### PR TITLE
Release 0.22rc3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ scikit-learn requires:
 **Scikit-learn 0.20 was the last version to support Python 2.7 and Python 3.4.**
 scikit-learn 0.21 and later require Python 3.5 or newer.
 
-Scikit-learn plotting capabilities (i.e., functions start with "plot_"
+Scikit-learn plotting capabilities (i.e., functions start with ``plot_``
 and classes end with "Display") require Matplotlib (>= 1.5.1). For running the
 examples Matplotlib >= 1.5.1 is required. A few examples require
 scikit-image >= 0.12.3, a few examples require pandas >= 0.18.0.

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ SciPy and is distributed under the 3-Clause BSD license.
 
 The project was started in 2007 by David Cournapeau as a Google Summer
 of Code project, and since then many volunteers have contributed. See
-the `About us <http://scikit-learn.org/dev/about.html#authors>`_ page
+the `About us <http://scikit-learn.org/dev/about.html#authors>`__ page
 for a list of core contributors.
 
 It is currently maintained by a team of volunteers.
@@ -138,7 +138,7 @@ Project History
 
 The project was started in 2007 by David Cournapeau as a Google Summer
 of Code project, and since then many volunteers have contributed. See
-the  `About us <http://scikit-learn.org/dev/about.html#authors>`_ page
+the `About us <http://scikit-learn.org/dev/about.html#authors>`__ page
 for a list of core contributors.
 
 The project is currently maintained by a team of volunteers.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ jobs:
       pylatest_pip_openblas_pandas:
         DISTRIB: 'conda-pip-latest'
         # FIXME: pinned until SciPy wheels are available for Pyhon 3.8
-        PYTHON_VERSION: '3.7'
+        PYTHON_VERSION: '3.8'
         PYTEST_VERSION: '4.6.2'
         COVERAGE: 'true'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       pylatest_conda_mkl:
         DISTRIB: 'conda'
         PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
+        BLAS: 'mkl'
         NUMPY_VERSION: '*'
         SCIPY_VERSION: '*'
         CYTHON_VERSION: '*'
@@ -52,7 +52,7 @@ jobs:
       py35_conda_openblas:
         DISTRIB: 'conda'
         PYTHON_VERSION: '3.5'
-        INSTALL_MKL: 'false'
+        BLAS: 'openblas'
         NUMPY_VERSION: '1.11.0'
         SCIPY_VERSION: '0.17.0'
         PANDAS_VERSION: '*'
@@ -96,7 +96,7 @@ jobs:
       pylatest_conda_mkl:
         DISTRIB: 'conda'
         PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
+        BLAS: 'mkl'
         NUMPY_VERSION: '*'
         SCIPY_VERSION: '*'
         CYTHON_VERSION: '*'
@@ -107,7 +107,7 @@ jobs:
       pylatest_conda_mkl_no_openmp:
         DISTRIB: 'conda'
         PYTHON_VERSION: '*'
-        INSTALL_MKL: 'true'
+        BLAS: 'mkl'
         NUMPY_VERSION: '*'
         SCIPY_VERSION: '*'
         CYTHON_VERSION: '*'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,8 @@ jobs:
         SCIPY_VERSION: '0.17.0'
         PANDAS_VERSION: '*'
         CYTHON_VERSION: '*'
-        PYTEST_VERSION: '*'
+        # temporary pin pytest due to unknown failure with pytest 5.3
+        PYTEST_VERSION: '5.2'
         PILLOW_VERSION: '4.0.0'
         MATPLOTLIB_VERSION: '1.5.1'
         # later version of joblib are not packaged in conda for Python 3.5

--- a/benchmarks/bench_plot_hierarchical.py
+++ b/benchmarks/bench_plot_hierarchical.py
@@ -1,0 +1,85 @@
+from collections import defaultdict
+from time import time
+
+import numpy as np
+from numpy import random as nr
+
+from sklearn.cluster import AgglomerativeClustering
+
+
+def compute_bench(samples_range, features_range):
+
+    it = 0
+    results = defaultdict(lambda: [])
+
+    max_it = len(samples_range) * len(features_range)
+    for n_samples in samples_range:
+        for n_features in features_range:
+            it += 1
+            print('==============================')
+            print('Iteration %03d of %03d' % (it, max_it))
+            print('n_samples %05d; n_features %02d' % (n_samples, n_features))
+            print('==============================')
+            print()
+            data = nr.randint(-50, 51, (n_samples, n_features))
+
+            for linkage in ("single", "average", "complete", "ward"):
+                print(linkage.capitalize())
+                tstart = time()
+                AgglomerativeClustering(
+                    linkage=linkage,
+                    n_clusters=10
+                ).fit(data)
+
+                delta = time() - tstart
+                print("Speed: %0.3fs" % delta)
+                print()
+
+                results[linkage].append(delta)
+
+    return results
+
+
+if __name__ == '__main__':
+    import matplotlib.pyplot as plt
+
+    samples_range = np.linspace(1000, 15000, 8).astype(np.int)
+    features_range = np.array([2, 10, 20, 50])
+
+    results = compute_bench(samples_range, features_range)
+
+    max_time = max([max(i) for i in [t for (label, t) in results.items()]])
+
+    colors = plt.get_cmap('tab10')(np.linspace(0, 1, 10))[:4]
+    lines = {linkage: None for linkage in results.keys()}
+    fig, axs = plt.subplots(2, 2, sharex=True, sharey=True)
+    fig.suptitle(
+        'Scikit-learn agglomerative clustering benchmark results',
+        fontsize=16
+    )
+    for c, (label, timings) in zip(colors,
+                                   sorted(results.items())):
+        timing_by_samples = np.asarray(timings).reshape(
+            samples_range.shape[0],
+            features_range.shape[0]
+        )
+
+        for n in range(timing_by_samples.shape[1]):
+            ax = axs.flatten()[n]
+            lines[label], = ax.plot(
+                samples_range,
+                timing_by_samples[:, n],
+                color=c,
+                label=label
+            )
+            ax.set_title('n_features = %d' % features_range[n])
+            if n >= 2:
+                ax.set_xlabel('n_samples')
+            if n % 2 == 0:
+                ax.set_ylabel('time (s)')
+
+    fig.subplots_adjust(right=0.8)
+    fig.legend([lines[link] for link in sorted(results.keys())],
+               sorted(results.keys()), loc="center right", fontsize=8)
+
+    plt.show()

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -22,13 +22,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     TO_INSTALL="python=$PYTHON_VERSION pip \
                 numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION \
-                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION"
-
-    if [[ "$INSTALL_MKL" == "true" ]]; then
-        TO_INSTALL="$TO_INSTALL mkl"
-    else
-        TO_INSTALL="$TO_INSTALL nomkl"
-    fi
+                cython=$CYTHON_VERSION joblib=$JOBLIB_VERSION\
+                blas[build=$BLAS]"
 
     if [[ -n "$PANDAS_VERSION" ]]; then
         TO_INSTALL="$TO_INSTALL pandas=$PANDAS_VERSION"

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -172,8 +172,8 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   joblib memory_profiler packaging
 
 source activate testenv
-pip install sphinx-gallery==0.3.1
-pip install numpydoc==0.9
+pip install sphinx-gallery
+pip install numpydoc
 
 # Build and install scikit-learn in dev mode
 python setup.py build_ext --inplace -j 3

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -58,6 +58,44 @@ get_build_type() {
         return
     fi
     changed_examples=$(echo "$filenames" | grep -E "^examples/(.*/)*plot_")
+
+    # The following is used to extract the list of filenames of example python
+    # files that sphinx-gallery needs to run to generate png files used as
+    # figures or images in the .rst files  from the documentation.
+    # If the contributor changes a .rst file in a PR we need to run all
+    # the examples mentioned in that file to get sphinx build the
+    # documentation without generating spurious warnings related to missing
+    # png files.
+
+    if [[ -n "$filenames" ]]
+    then
+        # get rst files
+        rst_files="$(echo "$filenames" | grep -E "rst$")"
+
+        # get lines with figure or images
+        img_fig_lines="$(echo "$rst_files" | xargs grep -shE "(figure|image)::")"
+
+        # get only auto_examples
+        auto_example_files="$(echo "$img_fig_lines" | grep auto_examples | awk -F "/" '{print $NF}')"
+
+        # remove "sphx_glr_" from path and accept replace _(\d\d\d|thumb).png with .py
+        scripts_names="$(echo "$auto_example_files" | sed 's/sphx_glr_//' | sed -e 's/_([[:digit:]][[:digit:]][[:digit:]]|thumb).png/.py/')"
+
+        # get unique values
+        examples_in_rst="$(echo "$scripts_names" | uniq )"
+    fi
+
+    # executed only if there are examples in the modified rst files
+    if [[ -n "$examples_in_rst" ]]
+    then
+        if [[ -n "$changed_examples" ]]
+        then
+            changed_examples="$changed_examples|$examples_in_rst"
+        else
+            changed_examples="$examples_in_rst"
+        fi
+    fi
+
     if [[ -n "$changed_examples" ]]
     then
         echo BUILD: detected examples/ filename modified in $git_range: $changed_examples
@@ -204,5 +242,12 @@ then
     echo "$warnings" | sed 's/\/home\/circleci\/project\//<li>/g'
     echo '</ul></body></html>'
     ) > 'doc/_build/html/stable/_changed.html'
+
+    if [ "$warnings" != "/home/circleci/project/ no warnings" ]
+    then
+        echo "Sphinx generated warnings when building the documentation related to files modified in this PR."
+        echo "Please check doc/_build/html/stable/_changed.html"
+        exit 1
+    fi
 fi
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -225,9 +225,9 @@ to enable OpenMP support:
 macOS compilers from conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you use the conda package manager, you can install the ``compilers``
-meta-package from the conda-forge channel, which provides OpenMP-enabled C/C++
-compilers based on the llvm toolchain.
+If you use the conda package manager (version >= 4.7), you can install the
+``compilers`` meta-package from the conda-forge channel, which provides
+OpenMP-enabled C/C++ compilers based on the llvm toolchain.
 
 First install the macOS command line tools::
 
@@ -264,7 +264,8 @@ variables::
     echo $LDFLAGS
 
 They point to files and folders from your ``sklearn-dev`` conda environment
-(in particular in the bin/, include/ and lib/ subfolders).
+(in particular in the bin/, include/ and lib/ subfolders). For instance
+``-L/path/to/conda/envs/sklearn-dev/lib`` should appear in ``LDFLAGS``.
 
 In the log, you should see the compiled extension being built with the clang
 and clang++ compilers installed by conda with the ``-fopenmp`` command line

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -385,3 +385,23 @@ efficient to process for most operations. Extensive work would also be needed
 to support Pandas categorical types. Restricting input to homogeneous
 types therefore reduces maintenance cost and encourages usage of efficient
 data structures.
+
+Do you plan to implement transform for target y in a pipeline?
+----------------------------------------------------------------------------
+Currently transform only works for features X in a pipeline. 
+There's a long-standing discussion about 
+not being able to transform y in a pipeline.
+Follow on github issue
+`#4143<https://github.com/scikit-learn/scikit-learn/issues/4143>`_.
+Meanwhile check out
+:class:`sklearn.compose.TransformedTargetRegressor`,
+`pipegraph<https://github.com/mcasl/PipeGraph>`_,
+`imbalanced-learn<https://github.com/scikit-learn-contrib/imbalanced-learn>`_.
+Note that Scikit-learn solved for the case where y 
+has an invertible transformation applied before training 
+and inverted after prediction. Scikit-learn intends to solve for
+use cases where y should be transformed at training time 
+and not at test time, for resampling and similar uses, 
+like at imbalanced learn. 
+In general, these use cases can be solved 
+with a custom meta estimator rather than a Pipeline

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -392,11 +392,11 @@ Currently transform only works for features X in a pipeline.
 There's a long-standing discussion about 
 not being able to transform y in a pipeline.
 Follow on github issue
-`#4143<https://github.com/scikit-learn/scikit-learn/issues/4143>`_.
+`#4143 <https://github.com/scikit-learn/scikit-learn/issues/4143>`_.
 Meanwhile check out
 :class:`sklearn.compose.TransformedTargetRegressor`,
-`pipegraph<https://github.com/mcasl/PipeGraph>`_,
-`imbalanced-learn<https://github.com/scikit-learn-contrib/imbalanced-learn>`_.
+`pipegraph <https://github.com/mcasl/PipeGraph>`_,
+`imbalanced-learn <https://github.com/scikit-learn-contrib/imbalanced-learn>`_.
 Note that Scikit-learn solved for the case where y 
 has an invertible transformation applied before training 
 and inverted after prediction. Scikit-learn intends to solve for

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1082,6 +1082,7 @@ See the :ref:`visualizations` section of the user guide for further details.
    :toctree: generated/
    :template: function.rst
 
+   metrics.plot_confusion_matrix
    metrics.plot_precision_recall_curve
    metrics.plot_roc_curve
 
@@ -1089,6 +1090,7 @@ See the :ref:`visualizations` section of the user guide for further details.
    :toctree: generated/
    :template: class.rst
 
+   metrics.ConfusionMatrixDisplay
    metrics.PrecisionRecallDisplay
    metrics.RocCurveDisplay
 

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1687,6 +1687,7 @@ Drawbacks
 Calinski-Harabasz Index
 -----------------------
 
+
 If the ground truth labels are not known, the Calinski-Harabasz index
 (:func:`sklearn.metrics.calinski_harabasz_score`) - also known as the Variance 
 Ratio Criterion - can be used to evaluate the model, where a higher 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -895,12 +895,13 @@ generally recommended to use as many bins as possible, which is the default.
 The ``l2_regularization`` parameter is a regularizer on the loss function and
 corresponds to :math:`\lambda` in equation (2) of [XGBoost]_.
 
-Note that **early-stopping is enabled by default**. The early-stopping
-behaviour is controlled via the ``scoring``, ``validation_fraction``,
-``n_iter_no_change``, and ``tol`` parameters. It is possible to early-stop
-using an arbitrary :term:`scorer`, or just the training or validation loss. By
-default, early-stopping is performed using the default :term:`scorer` of
-the estimator on a validation set.
+The early-stopping behaviour is controlled via the ``scoring``,
+``validation_fraction``, ``n_iter_no_change``, and ``tol`` parameters. It is
+possible to early-stop using an arbitrary :term:`scorer`, or just the
+training or validation loss. By default, early-stopping is performed using
+the default :term:`scorer` of the estimator on a validation set but it is
+also possible to perform early-stopping based on the loss value, which is
+significantly faster.
 
 Missing values support
 ----------------------

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -573,8 +573,10 @@ predicted to be in group :math:`j`. Here is an example::
          [0, 0, 1],
          [1, 0, 2]])
 
-Here is a visual representation of such a confusion matrix (this figure comes
-from the :ref:`sphx_glr_auto_examples_model_selection_plot_confusion_matrix.py` example):
+:func:`plot_confusion_matrix` can be used to visually represent a confusion
+matrix as shown in the 
+:ref:`sphx_glr_auto_examples_model_selection_plot_confusion_matrix.py`
+example, which creates the following figure:
 
 .. image:: ../auto_examples/model_selection/images/sphx_glr_plot_confusion_matrix_001.png
    :target: ../auto_examples/model_selection/plot_confusion_matrix.html

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -574,7 +574,7 @@ predicted to be in group :math:`j`. Here is an example::
          [1, 0, 2]])
 
 :func:`plot_confusion_matrix` can be used to visually represent a confusion
-matrix as shown in the 
+matrix as shown in the
 :ref:`sphx_glr_auto_examples_model_selection_plot_confusion_matrix.py`
 example, which creates the following figure:
 
@@ -582,6 +582,17 @@ example, which creates the following figure:
    :target: ../auto_examples/model_selection/plot_confusion_matrix.html
    :scale: 75
    :align: center
+
+The parameter ``normalize`` allows to report ratios instead of counts. The
+confusion matrix can be normalized in 3 different ways: ``'pred'``, ``'true'``,
+and ``'all'`` which will divide the counts by the sum of each columns, rows, or
+the entire matrix, respectively.
+
+  >>> y_true = [0, 0, 0, 1, 1, 1, 1, 1]
+  >>> y_pred = [0, 1, 0, 1, 0, 1, 0, 1]
+  >>> confusion_matrix(y_true, y_pred, normalize='all')
+  array([[0.25 , 0.125],
+         [0.25 , 0.375]])
 
 For binary problems, we can get counts of true negatives, false positives,
 false negatives and true positives as follows::

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -8,7 +8,7 @@
         <h1 class="sk-landing-header text-white text-monospace">scikit-learn</h1>
         <h4 class="sk-landing-subheader text-white font-italic mb-3">Machine Learning in Python</h4>
         <a class="btn sk-landing-btn mb-1" href="{{ pathto('getting_started') }}" role="button">Getting Started</a>
-        <a class="btn sk-landing-btn mb-1" href="whats_new.html" role="button">Whats New in {{ version }}</a>
+        <a class="btn sk-landing-btn mb-1" href="whats_new/v{{ version }}.html" role="button">What's New in {{ version }}</a>
         <a class="btn sk-landing-btn mb-1" href="https://github.com/scikit-learn/scikit-learn" role="button">GitHub</a>
       </div>
       <div class="col-md-6 d-flex">

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -823,6 +823,10 @@ div.body img {
     height: unset!important; /* Needed because sphinx sets the height */
 }
 
+div.body dd > p {
+    hyphens: none;
+}
+
 img.align-center, .figure.align-center, object.align-center {
   display: block;
   margin-left: auto;

--- a/doc/visualizations.rst
+++ b/doc/visualizations.rst
@@ -72,6 +72,7 @@ Functions
 .. autosummary::
 
    inspection.plot_partial_dependence
+   metrics.plot_confusion_matrix
    metrics.plot_precision_recall_curve
    metrics.plot_roc_curve
 
@@ -84,5 +85,6 @@ Display Objects
 .. autosummary::
 
    inspection.PartialDependenceDisplay
+   metrics.ConfusionMatrixDisplay
    metrics.PrecisionRecallDisplay
    metrics.RocCurveDisplay

--- a/doc/whats_new/_contributors.rst
+++ b/doc/whats_new/_contributors.rst
@@ -175,3 +175,5 @@
 .. _Thomas Fan: https://github.com/thomasjpfan
 
 .. _Nicolas Hug: https://github.com/NicolasHug
+
+.. _Guillaume Lemaitre: https://github.com/glemaitre

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -829,7 +829,6 @@ Changelog
   :class:`ensemble.RandomForestRegressor`,
   :class:`ensemble.ExtraTreesClassifier`,
   :class:`ensemble.ExtraTreesRegressor`,
-  :class:`ensemble.RandomTreesEmbedding`,
   :class:`ensemble.GradientBoostingClassifier`,
   and :class:`ensemble.GradientBoostingRegressor`.
   :pr:`12887` by `Thomas Fan`_.

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -589,6 +589,9 @@ Changelog
 - |Feature| :func:`metrics.plot_precision_recall_curve` has been added to plot
   precision recall curves. :pr:`14936` by `Thomas Fan`_.
 
+- |Feature| :func:`metrics.plot_confusion_matrix` has been added to plot
+  confusion matrices. :pr:`15083` by `Thomas Fan`_.
+
 - |Feature| Added multiclass support to :func:`metrics.roc_auc_score` with
   corresponding scorers `'roc_auc_ovr'`, `'roc_auc_ovo'`,
   `'roc_auc_ovr_weighted'`, and `'roc_auc_ovo_weighted'`.

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -192,6 +192,13 @@ Changelog
 :mod:`sklearn.cross_decomposition`
 ..................................
 
+- |Enhancement| :class:`decomposition.KernelPCA` now properly checks the
+  eigenvalues found by the solver for numerical or conditioning issues. This
+  ensures consistency of results across solvers (different choices for
+  ``eigen_solver``), including approximate solvers such as ``'randomized'`` and
+  ``'lobpcg'`` (see :issue:`12068`).
+  :pr:`12145` by :user:`Sylvain Marié <smarie>`
+
 - |Fix| Fixed a bug where :class:`cross_decomposition.PLSCanonical` and
   :class:`cross_decomposition.PLSRegression` were raising an error when fitted
   with a target matrix `Y` in which the first column was constant.

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -744,7 +744,7 @@ Changelog
   :pr:`14336` by :user:`Gregory Dexter <gdex1>`.
 
 :mod:`sklearn.model_selection`
-..................
+..............................
 
 - |Fix| :class:`model_selection.GridSearchCV` and
   `model_selection.RandomizedSearchCV` now supports the

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -7,7 +7,7 @@
 Version 0.22.0
 ==============
 
-**In Development**
+**November 29 2019**
 
 For a short description of the main highlights of the release, please
 refer to
@@ -516,20 +516,20 @@ Changelog
 - |Fix| :class:`linear_model.LassoCV` no longer forces ``precompute=False``
   when fitting the final model. :pr:`14591` by `Andreas Müller`_.
 
-- |FIX| :class:`linear_model.RidgeCV` and :class:`linear_model.RidgeClassifierCV`
+- |Fix| :class:`linear_model.RidgeCV` and :class:`linear_model.RidgeClassifierCV`
   now correctly scores when `cv=None`.
   :pr:`14864` by :user:`Venkatachalam N <venkyyuvy>`.
 
-- |FIX| Fixed a bug in :class:`linear_model.LogisticRegressionCV` where the
+- |Fix| Fixed a bug in :class:`linear_model.LogisticRegressionCV` where the
   ``scores_``, ``n_iter_`` and ``coefs_paths_`` attribute would have a wrong
   ordering with ``penalty='elastic-net'``. :pr:`15044` by `Nicolas Hug`_
 
-- |FIX| :class:`linear_model.MultiTaskLassoCV` and
+- |Fix| :class:`linear_model.MultiTaskLassoCV` and
   :class:`linear_model.MultiTaskElasticNetCV` with X of dtype int
   and `fit_intercept=True`.
   :pr:`15086` by :user:`Alex Gramfort <agramfort>`.
 
-- |FIX| The liblinear solver now supports ``sample_weight``.
+- |Fix| The liblinear solver now supports ``sample_weight``.
   :pr:`15038` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.manifold`
@@ -804,7 +804,7 @@ Changelog
 - |Fix| fixed a bug in :class:`BaseLibSVM._sparse_fit` where n_SV=0 raised a
   ZeroDivisionError. :pr:`14894` by :user:`Danna Naser <danna-naser>`.
 
-- |FIX| The liblinear solver now supports ``sample_weight``.
+- |Fix| The liblinear solver now supports ``sample_weight``.
   :pr:`15038` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -631,6 +631,11 @@ Changelog
   used as the :term:`scoring` parameter of model-selection tools.
   :pr:`14417` by `Thomas Fan`_.
 
+- |Enhancement| :func:`metrics.confusion_matrix` accepts a parameters
+  `normalize` allowing to normalize the confusion matrix by column, rows, or
+  overall.
+  :pr:`15625` by `Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -168,6 +168,10 @@ Changelog
   `affinity='cosine'` and `X` has samples that are all-zeros. :pr:`7943` by
   :user:`mthorrell`.
 
+- |Enhancement| :class:`cluster.AgglomerativeClustering` has a faster and more
+  more memory efficient implementation of single linkage clustering.
+  :pr:`11514` by :user:`Leland McInnes <lmcinnes>`.
+
 :mod:`sklearn.compose`
 ......................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -182,7 +182,7 @@ Changelog
 - |Fix| Fixed a bug in :class:`compose.ColumnTransformer` which failed to
   select the proper columns when using a boolean list, with NumPy older than
   1.12.
-  :pr:`14510` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`14510` by `Guillaume Lemaitre`_.
 
 - |Fix| Fixed a bug in :class:`compose.TransformedTargetRegressor` which did not
   pass `**fit_params` to the underlying regressor.
@@ -197,6 +197,11 @@ Changelog
 :mod:`sklearn.cross_decomposition`
 ..................................
 
+- |Feature| :class:`cross_decomposition.PLSCanonical` and
+  :class:`cross_decomposition.PLSRegression` have a new function
+  ``inverse_transform`` to transform data to the original space.
+  :pr:`15304` by :user:`Jaime Ferrando Huertas <jiwidi>`.
+
 - |Enhancement| :class:`decomposition.KernelPCA` now properly checks the
   eigenvalues found by the solver for numerical or conditioning issues. This
   ensures consistency of results across solvers (different choices for
@@ -209,12 +214,7 @@ Changelog
   with a target matrix `Y` in which the first column was constant.
   :issue:`13609` by :user:`Camila Williamson <camilaagw>`.
 
-- |Feature| :class:`cross_decomposition.PLSCanonical` and
-  :class:`cross_decomposition.PLSRegression` have a new function
-  ``inverse_transform`` to transform data to the original space`.
-  :pr:`15304` by :user:`Jaime Ferrando Huertas <jiwidi>`.
-
-- |Fix| :class:`cross_decomposition.CCA` now produces the same results with 
+- |Fix| :class:`cross_decomposition.CCA` now produces the same results with
   scipy 1.3 and previous scipy versions. :pr:`15661` by `Thomas Fan`_.
 
 :mod:`sklearn.datasets`
@@ -234,16 +234,20 @@ Changelog
   `weights` parameter, i.e. list or numpy.array, instead of list only.
   :pr:`14764` by :user:`Cat Chenal <CatChenal>`.
 
+- |Enhancement| The parameter `normalize` was added to
+   :func:`datasets.fetch_20newsgroups_vectorized`.
+   :pr:`14740` by :user:`Stéphan Tulkens <stephantul>`
+
 - |Fix| Fixed a bug in :func:`datasets.fetch_openml`, which failed to load
   an OpenML dataset that contains an ignored feature.
   :pr:`14623` by :user:`Sarra Habchi <HabchiSarra>`.
 
- - |Enhancement| The parameter `normalize` was added to
-   :func:`datasets.fetch_20newsgroups_vectorized`.
-   :pr:`14740` by :user:`Stéphan Tulkens <stephantul>`
-
 :mod:`sklearn.decomposition`
 ............................
+
+- |Efficiency| :class:`decomposition.NMF(solver='mu')` fitted on sparse input
+  matrices now uses batching to avoid briefly allocating an array with size
+  (#non-zero elements, n_components). :pr:`15257` by `Mart Willocx <Maocx>`_.
 
 - |Enhancement| :func:`decomposition.dict_learning()` and
   :func:`decomposition.dict_learning_online()` now accept `method_max_iter` and
@@ -266,21 +270,17 @@ Changelog
   underlying :class:`linear_model.LassoLars` when `algorithm='lasso_lars'`.
   :issue:`12650` by `Adrin Jalali`_.
 
-- |Efficiency| :class:`decomposition.NMF(solver='mu')` fitted on sparse input
-  matrices now uses batching to avoid briefly allocating an array with size
-  (#non-zero elements, n_components). :pr:`15257` by `Mart Willocx <Maocx>`_.
-
 :mod:`sklearn.dummy`
 ....................
+
+- |Fix| :class:`dummy.DummyClassifier` now handles checking the existence
+  of the provided constant in multiouput cases.
+  :pr:`14908` by :user:`Martina G. Vilas <martinagvilas>`.
 
 - |API| The default value of the `strategy` parameter in
   :class:`dummy.DummyClassifier` will change from `'stratified'` in version
   0.22 to `'prior'` in 0.24. A FutureWarning is raised when the default value
   is used. :pr:`15382` by `Thomas Fan`_.
-
-- |Fix| :class:`dummy.DummyClassifier` now handles checking the existence
-  of the provided constant in multiouput cases.
-  :pr:`14908` by :user:`Martina G. Vilas <martinagvilas>`.
 
 - |API| The ``outputs_2d_`` attribute is deprecated in
   :class:`dummy.DummyClassifier` and :class:`dummy.DummyRegressor`. It is
@@ -305,24 +305,36 @@ Changelog
     and `Olivier Grisel`_.
   - |Feature| Estimators now have an additional `warm_start` parameter that
     enables warm starting. :pr:`14012` by :user:`Johann Faouzi <johannfaouzi>`.
+  - |Feature| :func:`inspection.partial_dependence` and
+    :func:`inspection.plot_partial_dependence` now support the fast 'recursion'
+    method for both estimators. :pr:`13769` by `Nicolas Hug`_.
   - |Enhancement| for :class:`ensemble.HistGradientBoostingClassifier` the
     training loss or score is now monitored on a class-wise stratified
     subsample to preserve the class balance of the original training set.
     :pr:`14194` by :user:`Johann Faouzi <johannfaouzi>`.
-  - |Feature| :func:`inspection.partial_dependence` and
-    :func:`inspection.plot_partial_dependence` now support the fast 'recursion'
-    method for both estimators. :pr:`13769` by `Nicolas Hug`_.
   - |Enhancement| :class:`ensemble.HistGradientBoostingRegressor` now supports
     the 'least_absolute_deviation' loss. :pr:`13896` by `Nicolas Hug`_.
   - |Fix| Estimators now bin the training and validation data separately to
     avoid any data leak. :pr:`13933` by `Nicolas Hug`_.
   - |Fix| Fixed a bug where early stopping would break with string targets.
-    :pr:`14710` by :user:`Guillaume Lemaitre <glemaitre>`.
+    :pr:`14710` by `Guillaume Lemaitre`_.
   - |Fix| :class:`ensemble.HistGradientBoostingClassifier` now raises an error
     if ``categorical_crossentropy`` loss is given for a binary classification
     problem. :pr:`14869` by `Adrin Jalali`_.
 
   Note that pickles from 0.21 will not work in 0.22.
+
+- |Enhancement| Addition of ``max_samples`` argument allows limiting
+  size of bootstrap samples to be less than size of dataset. Added to
+  :class:`ensemble.ForestClassifier`,
+  :class:`ensemble.ForestRegressor`,
+  :class:`ensemble.RandomForestClassifier`,
+  :class:`ensemble.RandomForestRegressor`,
+  :class:`ensemble.ExtraTreesClassifier`,
+  :class:`ensemble.ExtraTreesRegressor`,
+  :class:`ensemble.RandomTreesEmbedding`. :pr:`14682` by
+  :user:`Matt Hancock <notmatthancock>` and
+  :pr:`5963` by :user:`Pablo Duboue <DrDub>`.
 
 - |Fix| :func:`ensemble.VotingClassifier.predict_proba` will no longer be
   present when `voting='hard'`. :pr:`14287` by `Thomas Fan`_.
@@ -339,12 +351,23 @@ Changelog
   failing when the underlying estimators were not outputting consistent array
   dimensions. Note that it should be replaced by refactoring the common tests
   in the future.
-  :pr:`14305` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`14305` by `Guillaume Lemaitre`_.
 
 - |Fix| :class:`ensemble.AdaBoostClassifier` computes probabilities based on
   the decision function as in the literature. Thus, `predict` and
   `predict_proba` give consistent results.
-  :pr:`14114` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`14114` by `Guillaume Lemaitre`_.
+
+- |Fix| Stacking and Voting estimators now ensure that their underlying
+  estimators are either all classifiers or all regressors.
+  :class:`ensemble.StackingClassifier`, :class:`ensemble.StackingRegressor`,
+  and :class:`ensemble.VotingClassifier` and :class:`VotingRegressor`
+  now raise consistent error messages.
+  :pr:`15084` by `Guillaume Lemaitre`_.
+
+- |Fix| :class:`ensemble.AdaBoostRegressor` where the loss should be normalized
+  by the max of the samples with non-null weights only.
+  :pr:`14294` by `Guillaume Lemaitre`_.
 
 - |API| ``presort`` is now deprecated in
   :class:`ensemble.GradientBoostingClassifier` and
@@ -352,29 +375,6 @@ Changelog
   Users are recommended to use :class:`ensemble.HistGradientBoostingClassifier`
   and :class:`ensemble.HistGradientBoostingRegressor` instead.
   :pr:`14907` by `Adrin Jalali`_.
-
-- |Enhancement| Addition of ``max_samples`` argument allows limiting
-  size of bootstrap samples to be less than size of dataset. Added to
-  :class:`ensemble.ForestClassifier`,
-  :class:`ensemble.ForestRegressor`,
-  :class:`ensemble.RandomForestClassifier`,
-  :class:`ensemble.RandomForestRegressor`,
-  :class:`ensemble.ExtraTreesClassifier`,
-  :class:`ensemble.ExtraTreesRegressor`,
-  :class:`ensemble.RandomTreesEmbedding`. :pr:`14682` by
-  :user:`Matt Hancock <notmatthancock>` and
-  :pr:`5963` by :user:`Pablo Duboue <DrDub>`.
-
-- |Fix| Stacking and Voting estimators now ensure that their underlying
-  estimators are either all classifiers or all regressors.
-  :class:`ensemble.StackingClassifier`, :class:`ensemble.StackingRegressor`,
-  and :class:`ensemble.VotingClassifier` and :class:`VotingRegressor`
-  now raise consistent error messages.
-  :pr:`15084` by :user:`Guillaume Lemaitre <glemaitre>`.
-
-- |Fix| :class:`ensemble.AdaBoostRegressor` where the loss should be normalized
-  by the max of the samples with non-null weights only.
-  :pr:`14294` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.feature_extraction`
 .................................
@@ -390,11 +390,6 @@ Changelog
   :class:`feature_extraction.text.VectorizerMixin` can now be pickled.
   :pr:`14430` by :user:`Dillon Niederhut <deniederhut>`.
 
-- |API| Deprecated unused `copy` param for
-  :meth:`feature_extraction.text.TfidfVectorizer.transform` it will be
-  removed in v0.24. :pr:`14520` by
-  :user:`Guillem G. Subies <guillemgsubies>`.
-
 - |Fix| :func:`feature_extraction.text.strip_accents_unicode` now correctly
   removes accents from strings that are in NFKD normalized form. :pr:`15100` by
   :user:`Daniel Grady <DGrady>`.
@@ -402,6 +397,11 @@ Changelog
 - |Fix| Fixed a bug that caused :class:`feature_extraction.DictVectorizer` to raise
   an `OverflowError` during the `transform` operation when producing a `scipy.sparse`
   matrix on large input data. :pr:`15463` by :user:`Norvan Sahiner <norvan>`.
+
+- |API| Deprecated unused `copy` param for
+  :meth:`feature_extraction.text.TfidfVectorizer.transform` it will be
+  removed in v0.24. :pr:`14520` by
+  :user:`Guillem G. Subies <guillemgsubies>`.
 
 :mod:`sklearn.feature_selection`
 ................................
@@ -429,11 +429,6 @@ Changelog
   the kernel attribute is modified, but may result in a performance improvement.
   :pr:`14378` by :user:`Masashi Shibata <c-bata>`.
 
-- |API| From version 0.24 :meth:`gaussian_process.kernels.Kernel.get_params` will raise an
-  ``AttributeError`` rather than return ``None`` for parameters that are in the
-  estimator's constructor but not stored as attributes on the instance.
-  :pr:`14464` by `Joel Nothman`_.
-
 - |Feature| Gaussian process models on structured data: :class:`gaussian_process.GaussianProcessRegressor`
   and :class:`gaussian_process.GaussianProcessClassifier` can now accept a list
   of generic objects (e.g. strings, trees, graphs, etc.) as the ``X`` argument
@@ -443,27 +438,28 @@ Changelog
   to notify the GPR/GPC model that it handles non-vectorial samples.
   :pr:`15557` by :user:`Yu-Hang Tang <yhtang>`.
 
+- |API| From version 0.24 :meth:`gaussian_process.kernels.Kernel.get_params` will raise an
+  ``AttributeError`` rather than return ``None`` for parameters that are in the
+  estimator's constructor but not stored as attributes on the instance.
+  :pr:`14464` by `Joel Nothman`_.
+
 :mod:`sklearn.impute`
 .....................
 
 - |MajorFeature| Added :class:`impute.KNNImputer`, to impute missing values using
   k-Nearest Neighbors. :issue:`12852` by :user:`Ashim Bhattarai <ashimb9>` and
-  `Thomas Fan`_.
-
-- |Enhancement| Adds parameter `add_indicator` to :class:`impute.KNNImputer`
-  to get indicator of missing data.
-  :pr:`15010` by :user:`Guillaume Lemaitre <glemaitre>`.
+  `Thomas Fan`_ and :pr:`15010` by `Guillaume Lemaitre`_.
 
 - |Feature| :class:`impute.IterativeImputer` has new `skip_compute` flag that
   is False by default, which, when True, will skip computation on features that
   have no missing values during the fit phase. :issue:`13773` by
   :user:`Sergey Feldman <sergeyf>`.
 
-- |Fix| :class:`impute.IterativeImputer` now works when there is only one feature.
-  By :user:`Sergey Feldman <sergeyf>`.
-
 - |Efficiency| :meth:`impute.MissingIndicator.fit_transform` avoid repeated
   computation of the masked matrix. :pr:`14356` by :user:`Harsh Soni <harsh020>`.
+
+- |Fix| :class:`impute.IterativeImputer` now works when there is only one feature.
+  By :user:`Sergey Feldman <sergeyf>`.
 
 - |Fix| Fixed a bug in :class:`impute.IterativeImputer` where features where
   imputed in the reverse desired order with ``imputation_order`` either
@@ -491,7 +487,7 @@ Changelog
   and :class:`pipeline.Pipeline` containing :class:`compose.ColumnTransformer`.
   In addition :func:`inspection.plot_partial_dependence` will use the column
   names by default when a dataframe is passed.
-  :pr:`14028` and :pr:`15429` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`14028` and :pr:`15429` by `Guillaume Lemaitre`_.
 
 :mod:`sklearn.kernel_approximation`
 ...................................
@@ -503,14 +499,14 @@ Changelog
 :mod:`sklearn.linear_model`
 ...........................
 
+- |Efficiency| The 'liblinear' logistic regression solver is now faster and
+  requires less memory.
+  :pr:`14108`, :pr:`14170`, :pr:`14296` by :user:`Alex Henrie <alexhenrie>`.
+
 - |Enhancement| :class:`linear_model.BayesianRidge` now accepts hyperparameters
   ``alpha_init`` and ``lambda_init`` which can be used to set the initial value
   of the maximization procedure in :term:`fit`.
   :pr:`13618` by :user:`Yoshihiro Uchida <c56pony>`.
-
-- |Efficiency| The 'liblinear' logistic regression solver is now faster and
-  requires less memory.
-  :pr:`14108`, :pr:`14170`, :pr:`14296` by :user:`Alex Henrie <alexhenrie>`.
 
 - |Fix| :class:`linear_model.Ridge` now correctly fits an intercept when `X` is
   sparse, `solver="auto"` and `fit_intercept=True`, because the default solver
@@ -519,7 +515,7 @@ Changelog
 
 - |Fix| :class:`linear_model.Ridge` with `solver='sag'` now accepts F-ordered
   and non-contiguous arrays and makes a conversion instead of failing.
-  :pr:`14458` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`14458` by `Guillaume Lemaitre`_.
 
 - |Fix| :class:`linear_model.LassoCV` no longer forces ``precompute=False``
   when fitting the final model. :pr:`14591` by `Andreas Müller`_.
@@ -538,7 +534,7 @@ Changelog
   :pr:`15086` by :user:`Alex Gramfort <agramfort>`.
 
 - |Fix| The liblinear solver now supports ``sample_weight``.
-  :pr:`15038` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`15038` by `Guillaume Lemaitre`_.
 
 :mod:`sklearn.manifold`
 .......................
@@ -557,9 +553,6 @@ Changelog
   ``method="barnes-hut"`` by computing the gradient in parallel.
   :pr:`13213` by :user:`Thomas Moreau <tommoral>`
 
-- |API| Deprecate ``training_data_`` unused attribute in
-  :class:`manifold.Isomap`. :issue:`10482` by `Tom Dupre la Tour`_.
-
 - |Fix| Fixed a bug where :func:`manifold.spectral_embedding` (and therefore
   :class:`manifold.SpectralEmbedding` and :class:`cluster.SpectralClustering`)
   computed wrong eigenvalues with ``eigen_solver='amg'`` when
@@ -571,8 +564,15 @@ Changelog
   :issue:`13393` by :user:`Andrew Knyazev <lobpcg>`
   :pr:`13707` by :user:`Scott White <whitews>`
 
+- |API| Deprecate ``training_data_`` unused attribute in
+  :class:`manifold.Isomap`. :issue:`10482` by `Tom Dupre la Tour`_.
+
 :mod:`sklearn.metrics`
 ......................
+
+- |MajorFeature| :func:`metrics.plot_roc_curve` has been added to plot roc
+  curves. This function introduces the visualization API described in
+  the :ref:`User Guide <visualizations>`. :pr:`14357` by `Thomas Fan`_.
 
 - |Feature| Added a new parameter ``zero_division`` to multiple classification
   metrics: :func:`precision_score`, :func:`recall_score`, :func:`f1_score`,
@@ -580,10 +580,6 @@ Changelog
   :func:`classification_report`. This allows to set returned value for
   ill-defined metrics.
   :pr:`14900` by :user:`Marc Torrellas Socastro <marctorrellas>`.
-
-- |MajorFeature| :func:`metrics.plot_roc_curve` has been added to plot roc
-  curves. This function introduces the visualization API described in
-  the :ref:`User Guide <visualizations>`. :pr:`14357` by `Thomas Fan`_.
 
 - |Feature| Added the :func:`metrics.pairwise.nan_euclidean_distances` metric,
   which calculates euclidean distances in the presence of missing values.
@@ -615,6 +611,10 @@ Changelog
   :pr:`13938` by :user:`Christian Lorentzen <lorentzenchr>` and
   `Roman Yurchak`_.
 
+- |Efficiency| Improved performance of
+  :func:`metrics.pairwise.manhattan_distances` in the case of sparse matrices.
+  :pr:`15049` by `Paolo Toccaceli <ptocca>`.
+
 - |Enhancement| The parameter ``beta`` in :func:`metrics.fbeta_score` is
   updated to accept the zero and `float('+inf')` value.
   :pr:`13231` by :user:`Dong-hee Na <corona10>`.
@@ -626,22 +626,10 @@ Changelog
 - |Enhancement| Allow computing averaged metrics in the case of no true positives.
   :pr:`14595` by `Andreas Müller`_.
 
-- |Fix| Raise a ValueError in :func:`metrics.silhouette_score` when a
-  precomputed distance matrix contains non-zero diagonal entries.
-  :pr:`12258` by :user:`Stephen Tierney <sjtrny>`.
-
 - |Enhancement| Multilabel metrics now supports list of lists as input.
   :pr:`14865` :user:`Srivatsan Ramesh <srivatsan-ramesh>`,
   :user:`Herilalaina Rakotoarison <herilalaina>`,
   :user:`Léonard Binet <leonardbinet>`.
-
-- |API| ``scoring="neg_brier_score"`` should be used instead of
-  ``scoring="brier_score_loss"`` which is now deprecated.
-  :pr:`14898` by :user:`Stefan Matcovici <stefan-matcovici>`.
-
-- |Efficiency| Improved performance of
-  :func:`metrics.pairwise.manhattan_distances` in the case of sparse matrices.
-  :pr:`15049` by `Paolo Toccaceli <ptocca>`.
 
 - |Enhancement| :func:`metrics.median_absolute_error` now supports
   ``multioutput`` parameter.
@@ -655,6 +643,14 @@ Changelog
   `normalize` allowing to normalize the confusion matrix by column, rows, or
   overall.
   :pr:`15625` by `Guillaume Lemaitre <glemaitre>`.
+
+- |Fix| Raise a ValueError in :func:`metrics.silhouette_score` when a
+  precomputed distance matrix contains non-zero diagonal entries.
+  :pr:`12258` by :user:`Stephen Tierney <sjtrny>`.
+
+- |API| ``scoring="neg_brier_score"`` should be used instead of
+  ``scoring="brier_score_loss"`` which is now deprecated.
+  :pr:`14898` by :user:`Stefan Matcovici <stefan-matcovici>`.
 
 :mod:`sklearn.model_selection`
 ..............................
@@ -676,15 +672,15 @@ Changelog
   where one test set could be `n_classes` larger than another. Test sets should
   now be near-equally sized. :pr:`14704` by `Joel Nothman`_.
 
+- |Fix| The `cv_results_` attribute of :class:`model_selection.GridSearchCV`
+  and :class:`model_selection.RandomizedSearchCV` now only contains unfitted
+  estimators. This potentially saves a lot of memory since the state of the
+  estimators isn't stored. :pr:`#15096` by `Andreas Müller`_.
+
 - |API| :class:`model_selection.KFold` and
   :class:`model_selection.StratifiedKFold` now raise a warning if
   `random_state` is set but `shuffle` is False. This will raise an error in
   0.24.
-
-- |Fix| The `cv_results_` attribute of :class:`model_selection.GridSearchCV`
-  and :class:`model_selection.RandomizedSearchCV` now only contains unfitted
-  estimators. This potentially saves a lot of memory since the state of the
-  estimators isn't stored. :pr:`#15096` by :user:`Andreas Müller <amueller>`.
 
 :mod:`sklearn.multioutput`
 ..........................
@@ -752,12 +748,12 @@ Changelog
   the final estimator does.
   :pr:`13806` by :user:`Anaël Beaugnon <ab-anssi>`.
 
+- |Fix| The `fit` in :class:`~pipeline.FeatureUnion` now accepts `fit_params`
+  to pass to the underlying transformers. :pr:`15119` by `Adrin Jalali`_.
+
 - |API| `None` as a transformer is now deprecated in
   :class:`pipeline.FeatureUnion`. Please use `'drop'` instead. :pr:`15053` by
   `Thomas Fan`_.
-
-- |Fix| The `fit` in :class:`~pipeline.FeatureUnion` now accepts `fit_params`
-  to pass to the underlying transformers. :pr:`15119` by `Adrin Jalali`_.
 
 :mod:`sklearn.preprocessing`
 ............................
@@ -787,7 +783,6 @@ Changelog
   :pr:`13925` by :user:`Isaac S. Robson <isrobson>` and :pr:`15524` by
   :user:`Xun Tang <xun-tang>`.
 
-
 :mod:`sklearn.svm`
 ..................
 
@@ -816,7 +811,7 @@ Changelog
   ZeroDivisionError. :pr:`14894` by :user:`Danna Naser <danna-naser>`.
 
 - |Fix| The liblinear solver now supports ``sample_weight``.
-  :pr:`15038` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`15038` by `Guillaume Lemaitre`_.
 
 
 :mod:`sklearn.tree`
@@ -856,22 +851,7 @@ Changelog
   :func:`~utils.estimator_checks.parametrize_with_checks`, to parametrize
   estimator checks for a list of estimators. :pr:`14381` by `Thomas Fan`_.
 
-- |API| The following utils have been deprecated and are now private:
-
-  - ``utils.choose_check_classifiers_labels``
-  - ``utils.enforce_estimator_tags_y``
-  - ``utils.optimize.newton_cg``
-  - ``utils.random.random_choice_csc``
-  - ``utils.safe_indexing``
-  - ``utils.mocking``
-  - ``utils.fast_dict``
-  - ``utils.seq_dataset``
-  - ``utils.weight_vector``
-  - ``utils.fixes.parallel_helper`` (removed)
-  - All of ``utils.testing`` except for ``all_estimators`` which is now in
-    ``utils``.
-
-- A new random variable, :class:`utils.fixes.loguniform` implements a
+- |Feature| A new random variable, :class:`utils.fixes.loguniform` implements a
   log-uniform random variable (e.g., for use in RandomizedSearchCV).
   For example, the outcomes ``1``, ``10`` and ``100`` are all equally likely
   for ``loguniform(1, 100)``. See :issue:`11232` by
@@ -882,7 +862,7 @@ Changelog
   ``axis`` parameter to index array-like across rows and columns. The column
   indexing can be done on NumPy array, SciPy sparse matrix, and Pandas
   DataFrame. An additional refactoring was done. :pr:`14035` and :pr:`14475`
-  by :user:`Guillaume Lemaitre <glemaitre>`.
+  by `Guillaume Lemaitre`_.
 
 - |Enhancement| :func:`utils.extmath.safe_sparse_dot` works between 3D+ ndarray
   and sparse matrix.
@@ -904,6 +884,18 @@ Changelog
   - ``mocking.CheckingClassifier``
   - ``optimize.newton_cg``
   - ``random.random_choice_csc``
+  - ``utils.choose_check_classifiers_labels``
+  - ``utils.enforce_estimator_tags_y``
+  - ``utils.optimize.newton_cg``
+  - ``utils.random.random_choice_csc``
+  - ``utils.safe_indexing``
+  - ``utils.mocking``
+  - ``utils.fast_dict``
+  - ``utils.seq_dataset``
+  - ``utils.weight_vector``
+  - ``utils.fixes.parallel_helper`` (removed)
+  - All of ``utils.testing`` except for ``all_estimators`` which is now in
+    ``utils``.
 
 :mod:`sklearn.isotonic`
 ..................................
@@ -912,9 +904,12 @@ Changelog
   when `X.dtype == 'float32'` and `X.dtype != y.dtype`.
   :pr:`14902` by :user:`Lucas <lostcoaster>`.
 
-
 Miscellaneous
 .............
+
+- |Fix| Port `lobpcg` from SciPy which implement some bug fixes but only
+  available in 1.3+.
+  :pr:`13609` and :pr:`14971` by `Guillaume Lemaitre`_.
 
 - |API| Scikit-learn now converts any input data structure implementing a
   duck array to a numpy array (using ``__array__``) to ensure consistent
@@ -925,10 +920,6 @@ Miscellaneous
 - |API| Replace manual checks with ``check_is_fitted``. Errors thrown when
   using a non-fitted estimators are now more uniform.
   :pr:`13013` by :user:`Agamemnon Krasoulis <agamemnonc>`.
-
-- |Fix| Port `lobpcg` from SciPy which implement some bug fixes but only
-  available in 1.3+.
-  :pr:`13609` and :pr:`14971` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Changes to estimator checks
 ---------------------------
@@ -966,5 +957,4 @@ These changes mostly affect library developers.
 - |Fix| Added ``check_transformer_data_not_an_array`` to checks where missing
 
 - |Fix| The estimators tags resolution now follows the regular MRO. They used
-  to be overridable only once. :pr:`14884` by :user:`Andreas Müller
-  <amueller>`.
+  to be overridable only once. :pr:`14884` by `Andreas Müller`_.

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -101,6 +101,7 @@ random sampling procedures.
 - :class:`linear_model.Ridge` when `X` is sparse. |Fix|
 - :class:`model_selection.StratifiedKFold` and any use of `cv=int` with a
   classifier. |Fix|
+- :class:`cross_decomposition.CCA` when using scipy >= 1.3 |Fix|
 
 Details are listed in the changelog below.
 
@@ -208,6 +209,9 @@ Changelog
   :class:`cross_decomposition.PLSRegression` have a new function
   ``inverse_transform`` to transform data to the original space`.
   :pr:`15304` by :user:`Jaime Ferrando Huertas <jiwidi>`.
+
+- |Fix| :class:`cross_decomposition.CCA` now produces the same results with 
+  scipy 1.3 and previous scipy versions. :pr:`15661` by `Thomas Fan`_.
 
 :mod:`sklearn.datasets`
 .......................

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -426,6 +426,15 @@ Changelog
   estimator's constructor but not stored as attributes on the instance.
   :pr:`14464` by `Joel Nothman`_.
 
+- |Feature| Gaussian process models on structured data: :class:`gaussian_process.GaussianProcessRegressor`
+  and :class:`gaussian_process.GaussianProcessClassifier` can now accept a list
+  of generic objects (e.g. strings, trees, graphs, etc.) as the ``X`` argument
+  to their training/prediction methods.
+  A user-defined kernel should be provided for computing the kernel matrix among
+  the generic objects, and should inherit from :class:`gaussian_process.kernels.GenericKernelMixin`
+  to notify the GPR/GPC model that it handles non-vectorial samples.
+  :pr:`15557` by :user:`Yu-Hang Tang <yhtang>`.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/examples/classification/plot_digits_classification.py
+++ b/examples/classification/plot_digits_classification.py
@@ -31,12 +31,12 @@ digits = datasets.load_digits()
 # matplotlib.pyplot.imread.  Note that each image must have the same size. For these
 # images, we know which digit they represent: it is given in the 'target' of
 # the dataset.
+_, axes = plt.subplots(2, 4)
 images_and_labels = list(zip(digits.images, digits.target))
-for index, (image, label) in enumerate(images_and_labels[:4]):
-    plt.subplot(2, 4, index + 1)
-    plt.axis('off')
-    plt.imshow(image, cmap=plt.cm.gray_r, interpolation='nearest')
-    plt.title('Training: %i' % label)
+for ax, (image, label) in zip(axes[0, :], images_and_labels[:4]):
+    ax.set_axis_off()
+    ax.imshow(image, cmap=plt.cm.gray_r, interpolation='nearest')
+    ax.set_title('Training: %i' % label)
 
 # To apply a classifier on this data, we need to flatten the image, to
 # turn the data in a (samples, feature) matrix:
@@ -56,15 +56,16 @@ classifier.fit(X_train, y_train)
 # Now predict the value of the digit on the second half:
 predicted = classifier.predict(X_test)
 
+images_and_predictions = list(zip(digits.images[n_samples // 2:], predicted))
+for ax, (image, prediction) in zip(axes[1, :], images_and_predictions[:4]):
+    ax.set_axis_off()
+    ax.imshow(image, cmap=plt.cm.gray_r, interpolation='nearest')
+    ax.set_title('Prediction: %i' % prediction)
+
 print("Classification report for classifier %s:\n%s\n"
       % (classifier, metrics.classification_report(y_test, predicted)))
-print("Confusion matrix:\n%s" % metrics.confusion_matrix(y_test, predicted))
-
-images_and_predictions = list(zip(digits.images[n_samples // 2:], predicted))
-for index, (image, prediction) in enumerate(images_and_predictions[:4]):
-    plt.subplot(2, 4, index + 5)
-    plt.axis('off')
-    plt.imshow(image, cmap=plt.cm.gray_r, interpolation='nearest')
-    plt.title('Prediction: %i' % prediction)
+disp = metrics.plot_confusion_matrix(classifier, X_test, y_test)
+disp.figure_.suptitle("Confusion Matrix")
+print("Confusion matrix:\n%s" % disp.confusion_matrix)
 
 plt.show()

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -33,8 +33,8 @@ simply  whether there is at least one 'A' in the sequence. Here the model makes
 four correct classifications and fails on one.
 
 .. [1] Haussler, D. (1999). Convolution kernels on discrete structures
-(Vol. 646). Technical report, Department of Computer Science, University of
-California at Santa Cruz.
+       (Vol. 646). Technical report, Department of Computer Science, University
+       of California at Santa Cruz.
 """
 print(__doc__)
 

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -1,0 +1,174 @@
+"""
+==========================================================================
+Gaussian processes on discrete data structures
+==========================================================================
+
+This example illustrates the use of Gaussian processes for regression and
+classification tasks on data that are not in fixed-length feature vector form.
+This is achieved through the use of kernel functions that operates directly
+on discrete structures such as variable-length sequences, trees, and graphs.
+
+Specifically, here the input variables are some gene sequences stored as
+variable-length strings consisting of letters 'A', 'T', 'C', and 'G',
+while the output variables are floating point numbers and True/False labels
+in the regression and classification tasks, respectively.
+
+A kernel between the gene sequences is defined using R-convolution [1]_ by
+integrating a binary letter-wise kernel over all pairs of letters among a pair
+of strings.
+
+This example will generate three figures.
+
+In the first figure, we visualize the value of the kernel, i.e. the similarity
+of the sequences, using a colormap. Brighter color here indicates higher
+similarity.
+
+In the second figure, we show some regression result on a dataset of 6
+sequences. Here we use the 1st, 2nd, 4th, and 5th sequences as the training set
+to make predictions on the 3rd and 6th sequences.
+
+In the third figure, we demonstrate a classification model by training on 6
+sequences and make predictions on another 5 sequences. The ground truth here is
+simply  whether there is at least one 'A' in the sequence. Here the model makes
+four correct classifications and fails on one.
+
+.. [1] Haussler, D. (1999). Convolution kernels on discrete structures
+(Vol. 646). Technical report, Department of Computer Science, University of
+California at Santa Cruz.
+"""
+print(__doc__)
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.gaussian_process.kernels import Kernel, Hyperparameter
+from sklearn.gaussian_process.kernels import GenericKernelMixin
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process import GaussianProcessClassifier
+from sklearn.base import clone
+
+
+class SequenceKernel(GenericKernelMixin, Kernel):
+    '''
+    A minimal (but valid) convolutional kernel for sequences of variable
+    lengths.'''
+    def __init__(self,
+                 baseline_similarity=0.5,
+                 baseline_similarity_bounds=(1e-5, 1)):
+        self.baseline_similarity = baseline_similarity
+        self.baseline_similarity_bounds = baseline_similarity_bounds
+
+    @property
+    def hyperparameter_baseline_similarity(self):
+        return Hyperparameter("baseline_similarity",
+                              "numeric",
+                              self.baseline_similarity_bounds)
+
+    def _f(self, s1, s2):
+        '''
+        kernel value between a pair of sequences
+        '''
+        return sum([1.0 if c1 == c2 else self.baseline_similarity
+                   for c1 in s1
+                   for c2 in s2])
+
+    def _g(self, s1, s2):
+        '''
+        kernel derivative between a pair of sequences
+        '''
+        return sum([0.0 if c1 == c2 else 1.0
+                    for c1 in s1
+                    for c2 in s2])
+
+    def __call__(self, X, Y=None, eval_gradient=False):
+        if Y is None:
+            Y = X
+
+        if eval_gradient:
+            return (np.array([[self._f(x, y) for y in Y] for x in X]),
+                    np.array([[[self._g(x, y)] for y in Y] for x in X]))
+        else:
+            return np.array([[self._f(x, y) for y in Y] for x in X])
+
+    def diag(self, X):
+        return np.array([self._f(x, x) for x in X])
+
+    def is_stationary(self):
+        return False
+
+    def clone_with_theta(self, theta):
+        cloned = clone(self)
+        cloned.theta = theta
+        return cloned
+
+
+kernel = SequenceKernel()
+
+'''
+Sequence similarity matrix under the kernel
+===========================================
+'''
+
+X = np.array(['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA'])
+
+K = kernel(X)
+D = kernel.diag(X)
+
+plt.figure(figsize=(8, 5))
+plt.imshow(np.diag(D**-0.5).dot(K).dot(np.diag(D**-0.5)))
+plt.xticks(np.arange(len(X)), X)
+plt.yticks(np.arange(len(X)), X)
+plt.title('Sequence similarity under the kernel')
+
+'''
+Regression
+==========
+'''
+
+X = np.array(['AGCT', 'AGC', 'AACT', 'TAA', 'AAA', 'GAACA'])
+Y = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+
+training_idx = [0, 1, 3, 4]
+gp = GaussianProcessRegressor(kernel=kernel)
+gp.fit(X[training_idx], Y[training_idx])
+
+plt.figure(figsize=(8, 5))
+plt.bar(np.arange(len(X)), gp.predict(X), color='b', label='prediction')
+plt.bar(training_idx, Y[training_idx], width=0.2, color='r',
+        alpha=1, label='training')
+plt.xticks(np.arange(len(X)), X)
+plt.title('Regression on sequences')
+plt.legend()
+
+'''
+Classification
+==============
+'''
+
+X_train = np.array(['AGCT', 'CGA', 'TAAC', 'TCG', 'CTTT', 'TGCT'])
+# whether there are 'A's in the sequence
+Y_train = np.array([True, True, True, False, False, False])
+
+gp = GaussianProcessClassifier(kernel)
+gp.fit(X_train, Y_train)
+
+X_test = ['AAA', 'ATAG', 'CTC', 'CT', 'C']
+Y_test = [True, True, False, False, False]
+
+plt.figure(figsize=(8, 5))
+plt.scatter(np.arange(len(X_train)), [1.0 if c else -1.0 for c in Y_train],
+            s=100, marker='o', edgecolor='none', facecolor=(1, 0.75, 0),
+            label='training')
+plt.scatter(len(X_train) + np.arange(len(X_test)),
+            [1.0 if c else -1.0 for c in Y_test],
+            s=100, marker='o', edgecolor='none', facecolor='r', label='truth')
+plt.scatter(len(X_train) + np.arange(len(X_test)),
+            [1.0 if c else -1.0 for c in gp.predict(X_test)],
+            s=100, marker='x', edgecolor=(0, 1.0, 0.3), linewidth=2,
+            label='prediction')
+plt.xticks(np.arange(len(X_train) + len(X_test)),
+           np.concatenate((X_train, X_test)))
+plt.yticks([-1, 1], [False, True])
+plt.title('Classification on sequences')
+plt.legend()
+
+plt.show()

--- a/examples/model_selection/plot_confusion_matrix.py
+++ b/examples/model_selection/plot_confusion_matrix.py
@@ -31,8 +31,7 @@ import matplotlib.pyplot as plt
 
 from sklearn import svm, datasets
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import confusion_matrix
-from sklearn.utils.multiclass import unique_labels
+from sklearn.metrics import plot_confusion_matrix
 
 # import some data to play with
 iris = datasets.load_iris()
@@ -45,72 +44,21 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
 # Run classifier, using a model that is too regularized (C too low) to see
 # the impact on the results
-classifier = svm.SVC(kernel='linear', C=0.01)
-y_pred = classifier.fit(X_train, y_train).predict(X_test)
-
-
-def plot_confusion_matrix(y_true, y_pred, classes,
-                          normalize=False,
-                          title=None,
-                          cmap=plt.cm.Blues):
-    """
-    This function prints and plots the confusion matrix.
-    Normalization can be applied by setting `normalize=True`.
-    """
-    if not title:
-        if normalize:
-            title = 'Normalized confusion matrix'
-        else:
-            title = 'Confusion matrix, without normalization'
-
-    # Compute confusion matrix
-    cm = confusion_matrix(y_true, y_pred)
-    # Only use the labels that appear in the data
-    classes = classes[unique_labels(y_true, y_pred)]
-    if normalize:
-        cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
-        print("Normalized confusion matrix")
-    else:
-        print('Confusion matrix, without normalization')
-
-    print(cm)
-
-    fig, ax = plt.subplots()
-    im = ax.imshow(cm, interpolation='nearest', cmap=cmap)
-    ax.figure.colorbar(im, ax=ax)
-    # We want to show all ticks...
-    ax.set(xticks=np.arange(cm.shape[1]),
-           yticks=np.arange(cm.shape[0]),
-           # ... and label them with the respective list entries
-           xticklabels=classes, yticklabels=classes,
-           title=title,
-           ylabel='True label',
-           xlabel='Predicted label')
-
-    # Rotate the tick labels and set their alignment.
-    plt.setp(ax.get_xticklabels(), rotation=45, ha="right",
-             rotation_mode="anchor")
-
-    # Loop over data dimensions and create text annotations.
-    fmt = '.2f' if normalize else 'd'
-    thresh = cm.max() / 2.
-    for i in range(cm.shape[0]):
-        for j in range(cm.shape[1]):
-            ax.text(j, i, format(cm[i, j], fmt),
-                    ha="center", va="center",
-                    color="white" if cm[i, j] > thresh else "black")
-    fig.tight_layout()
-    return ax
-
+classifier = svm.SVC(kernel='linear', C=0.01).fit(X_train, y_train)
 
 np.set_printoptions(precision=2)
 
 # Plot non-normalized confusion matrix
-plot_confusion_matrix(y_test, y_pred, classes=class_names,
-                      title='Confusion matrix, without normalization')
+titles_options = [("Confusion matrix, without normalization", None),
+                  ("Normalized confusion matrix", 'true')]
+for title, normalize in titles_options:
+    disp = plot_confusion_matrix(classifier, X_test, y_test,
+                                 display_labels=class_names,
+                                 cmap=plt.cm.Blues,
+                                 normalize=normalize)
+    disp.ax_.set_title(title)
 
-# Plot normalized confusion matrix
-plot_confusion_matrix(y_test, y_pred, classes=class_names, normalize=True,
-                      title='Normalized confusion matrix')
+    print(title)
+    print(disp.confusion_matrix)
 
 plt.show()

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -246,11 +246,10 @@ def test_sklearn_compatible_estimator(estimator, check):
 # classification. Two averaging strategies are currently supported: the
 # one-vs-one algorithm computes the average of the pairwise ROC AUC scores, and
 # the one-vs-rest algorithm computes the average of the ROC AUC scores for each
-# class against all other classes. In both cases, the predicted labels are
-# provided in an array with values from 0 to ``n_classes``, and the scores
-# correspond to the probability estimates that a sample belongs to a particular
-# class. The OvO and OvR algorithms supports weighting uniformly
-# (``average='macro'``) and weighting by the prevalence
+# class against all other classes. In both cases, the multiclass ROC AUC scores
+# are computed from the probability estimates that a sample belongs to a
+# particular class according to the model. The OvO and OvR algorithms support
+# weighting uniformly (``average='macro'``) and weighting by the prevalence
 # (``average='weighted'``).
 #
 # Read more in the :ref:`User Guide <roc_metrics>`.

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -26,7 +26,12 @@ or with conda::
 # A new plotting API is available for creating visualizations. This new API
 # allows for quickly adjusting the visuals of a plot without involving any
 # recomputation. It is also possible to add different plots to the same
-# figure. See more examples in the :ref:`User Guide <visualizations>`.
+# figure. The following example illustrates :class:`~metrics.plot_roc_curve`,
+# but other plots utilities are supported like
+# :class:`~inspection.plot_partial_dependence`,
+# :class:`~metrics.plot_precision_recall_curve`, and
+# :class:`~metrics.plot_confusion_matrix`. Read more about this new API in the
+# :ref:`User Guide <visualizations>`.
 
 from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC

--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -39,6 +39,15 @@ DOCSTRING_WHITELIST = [
     "SGDClassifier.score",
     "SGDClassifier.sparsify",
     "SGDClassifier.densify",
+    "VotingClassifier.fit",
+    "VotingClassifier.transform",
+    "VotingClassifier.predict",
+    "VotingClassifier.score",
+    "VotingClassifier.predict_proba",
+    "VotingClassifier.set_params",
+    "VotingClassifier.get_params",
+    "VotingClassifier.named_estimators",
+    "VotingClassifier$",
 ]
 
 

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -90,6 +90,9 @@ else:
                'clone', 'get_config', 'set_config', 'config_context',
                'show_versions']
 
+    # Allow distributors to run custom init code
+    from . import _distributor_init  # noqa: F401
+
 
 def setup_module(module):
     """Fixture for the tests to assure globally controllable seeding of RNGs"""

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -40,7 +40,7 @@ logger.setLevel(logging.INFO)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.22.dev0'
+__version__ = '0.22rc1'
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -40,7 +40,7 @@ logger.setLevel(logging.INFO)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.22.dev0'
+__version__ = '0.22b1'
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -40,7 +40,7 @@ logger.setLevel(logging.INFO)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.22b1'
+__version__ = '0.22rc1'
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -40,7 +40,7 @@ logger.setLevel(logging.INFO)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.22rc2'
+__version__ = '0.22rc2.post1'
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -40,7 +40,7 @@ logger.setLevel(logging.INFO)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.22rc1'
+__version__ = '0.22rc2'
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded

--- a/sklearn/_distributor_init.py
+++ b/sklearn/_distributor_init.py
@@ -1,0 +1,10 @@
+""" Distributor init file
+
+Distributors: you can add custom code here to support particular distributions
+of scikit-learn.
+
+For example, this is a good place to put any checks for hardware requirements.
+
+The scikit-learn standard source distribution will not put code in this file,
+so you can safely replace this file with your own version.
+"""

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -383,8 +383,9 @@ class RegressorMixin:
         ----------
         X : array-like of shape (n_samples, n_features)
             Test samples. For some estimators this may be a
-            precomputed kernel matrix instead, shape = (n_samples,
-            n_samples_fitted], where n_samples_fitted is the number of
+            precomputed kernel matrix or a list of generic objects instead,
+            shape = (n_samples, n_samples_fitted),
+            where n_samples_fitted is the number of
             samples used in the fitting for the estimator.
 
         y : array-like of shape (n_samples,) or (n_samples, n_outputs)

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1,4 +1,8 @@
-"""Base classes for all estimators."""
+"""
+Base classes for all estimators.
+
+Used for VotingClassifier
+"""
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
 # License: BSD 3 clause
@@ -334,6 +338,7 @@ class BaseEstimator:
 
 class ClassifierMixin:
     """Mixin class for all classifiers in scikit-learn."""
+
     _estimator_type = "classifier"
 
     def score(self, X, y, sample_weight=None):

--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -388,25 +388,12 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
         if partial_fit is used instead of fit, they are assigned to the
         last batch of data.
 
-    Examples
+    See Also
     --------
-    >>> from sklearn.cluster import Birch
-    >>> X = [[0, 1], [0.3, 1], [-0.3, 1], [0, -1], [0.3, -1], [-0.3, -1]]
-    >>> brc = Birch(n_clusters=None)
-    >>> brc.fit(X)
-    Birch(n_clusters=None)
-    >>> brc.predict(X)
-    array([0, 0, 0, 1, 1, 1])
 
-    References
-    ----------
-    * Tian Zhang, Raghu Ramakrishnan, Maron Livny
-      BIRCH: An efficient data clustering method for large databases.
-      https://www.cs.sfu.ca/CourseCentral/459/han/papers/zhang96.pdf
-
-    * Roberto Perdisci
-      JBirch - Java implementation of BIRCH clustering algorithm
-      https://code.google.com/archive/p/jbirch
+    MiniBatchKMeans
+        Alternative  implementation that does incremental updates
+        of the centers' positions using mini-batches.
 
     Notes
     -----
@@ -421,6 +408,26 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
     to it and the linear sum, squared sum and the number of samples of that
     subcluster are updated. This is done recursively till the properties of
     the leaf node are updated.
+
+    References
+    ----------
+    * Tian Zhang, Raghu Ramakrishnan, Maron Livny
+      BIRCH: An efficient data clustering method for large databases.
+      https://www.cs.sfu.ca/CourseCentral/459/han/papers/zhang96.pdf
+
+    * Roberto Perdisci
+      JBirch - Java implementation of BIRCH clustering algorithm
+      https://code.google.com/archive/p/jbirch
+
+    Examples
+    --------
+    >>> from sklearn.cluster import Birch
+    >>> X = [[0, 1], [0.3, 1], [-0.3, 1], [0, -1], [0.3, -1], [-0.3, -1]]
+    >>> brc = Birch(n_clusters=None)
+    >>> brc.fit(X)
+    Birch(n_clusters=None)
+    >>> brc.predict(X)
+    array([0, 0, 0, 1, 1, 1])
     """
 
     def __init__(self, threshold=0.5, branching_factor=50, n_clusters=3,
@@ -441,7 +448,12 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
             Input data.
 
         y : Ignored
+            Not used, present here for API consistency by convention.
 
+        Returns
+        -------
+        self
+            Fitted estimator.
         """
         self.fit_, self.partial_fit_ = True, False
         return self._fit(X)
@@ -524,7 +536,12 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
             step is done.
 
         y : Ignored
+            Not used, present here for API consistency by convention.
 
+        Returns
+        -------
+        self
+            Fitted estimator.
         """
         self.partial_fit_, self.fit_ = True, False
         if X is None:

--- a/sklearn/cluster/_hierarchical_fast.pyx
+++ b/sklearn/cluster/_hierarchical_fast.pyx
@@ -13,6 +13,7 @@ ctypedef np.int8_t INT8
 
 np.import_array()
 
+from ..neighbors._dist_metrics cimport DistanceMetric
 from ..utils._fast_dict cimport IntFloatDict
 
 # C++
@@ -25,6 +26,8 @@ ctypedef np.float64_t DTYPE_t
 
 ITYPE = np.intp
 ctypedef np.intp_t ITYPE_t
+
+from numpy.math cimport INFINITY
 
 ###############################################################################
 # Utilities for computing the ward momentum
@@ -446,3 +449,89 @@ def single_linkage_label(L):
         raise ValueError("Input MST array must be sorted by weight")
 
     return _single_linkage_label(L)
+
+
+# Implements MST-LINKAGE-CORE from https://arxiv.org/abs/1109.2378
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+def mst_linkage_core(
+        DTYPE_t [:, ::1] raw_data,
+        DistanceMetric dist_metric):
+    """
+    Compute the necessary elements of a minimum spanning
+    tree for computation of single linkage clustering. This
+    represents the MST-LINKAGE-CORE algorithm (Figure 6) from
+    *Modern hierarchical, agglomerative clustering algorithms*
+    by Daniel Mullner (https://arxiv.org/abs/1109.2378).
+
+    In contrast to the scipy implementation is never computes
+    a full distance matrix, generating distances only as they
+    are needed and releasing them when no longer needed.
+
+    Parameters
+    ----------
+    raw_data: array of shape (n_samples, n_features)
+        The array of feature data to be clustered. Must be C-aligned
+
+    dist_metric: DistanceMetric
+        A DistanceMetric object conforming to the API from
+        ``sklearn.neighbors._dist_metrics.pxd`` that will be
+        used to compute distances.
+
+    Returns
+    -------
+    mst_core_data: array of shape (n_samples, 3)
+        An array providing information from which one
+        can either compute an MST, or the linkage hierarchy
+        very efficiently. See https://arxiv.org/abs/1109.2378
+        algorithm MST-LINKAGE-CORE for more details.
+    """
+    cdef:
+        ITYPE_t n_samples = raw_data.shape[0]
+        np.int8_t[:] in_tree = np.zeros(n_samples, dtype=np.int8)
+        DTYPE_t[:, ::1] result = np.zeros((n_samples - 1, 3))
+
+        np.ndarray label_filter
+
+        ITYPE_t current_node = 0
+        ITYPE_t new_node
+        ITYPE_t i
+        ITYPE_t j
+        ITYPE_t num_features = raw_data.shape[1]
+
+        DTYPE_t right_value
+        DTYPE_t left_value
+        DTYPE_t new_distance
+
+        DTYPE_t[:] current_distances = np.full(n_samples, INFINITY)
+
+    for i in range(n_samples - 1):
+
+        in_tree[current_node] = 1
+
+        new_distance = INFINITY
+        new_node = 0
+
+        for j in range(n_samples):
+            if in_tree[j]:
+                continue
+
+            right_value = current_distances[j]
+            left_value = dist_metric.dist(&raw_data[current_node, 0],
+                                          &raw_data[j, 0],
+                                          num_features)
+
+            if left_value < right_value:
+                current_distances[j] = left_value
+
+            if current_distances[j] < new_distance:
+                new_distance = current_distances[j]
+                new_node = j
+
+        result[i, 0] = current_node
+        result[i, 1] = new_node
+        result[i, 2] = new_distance
+        current_node = new_node
+
+    return np.array(result)
+

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -280,7 +280,7 @@ def assess_same_labelling(cut1, cut2):
     assert (co_clust[0] == co_clust[1]).all()
 
 
-def test_scikit_vs_scipy():
+def test_sparse_scikit_vs_scipy():
     # Test scikit linkage with full connectivity (i.e. unstructured) vs scipy
     n, p, k = 10, 5, 3
     rng = np.random.RandomState(0)
@@ -312,6 +312,33 @@ def test_scikit_vs_scipy():
     # Test error management in _hc_cut
     with pytest.raises(ValueError):
         _hc_cut(n_leaves + 1, children, n_leaves)
+
+
+# Make sure our custom mst_linkage_core gives
+# the same results as scipy's builtin
+@pytest.mark.parametrize('seed', range(5))
+def test_vector_scikit_single_vs_scipy_single(seed):
+    n_samples, n_features, n_clusters = 10, 5, 3
+    rng = np.random.RandomState(seed)
+    X = .1 * rng.normal(size=(n_samples, n_features))
+    X -= 4. * np.arange(n_samples)[:, np.newaxis]
+    X -= X.mean(axis=1)[:, np.newaxis]
+
+    out = hierarchy.linkage(X, method='single')
+    children_scipy = out[:, :2].astype(np.int)
+
+    children, _, n_leaves, _ = _TREE_BUILDERS['single'](X)
+
+    # Sort the order of child nodes per row for consistency
+    children.sort(axis=1)
+    assert_array_equal(children, children_scipy,
+                       'linkage tree differs'
+                       ' from scipy impl for'
+                       ' single linkage.')
+
+    cut = _hc_cut(n_clusters, children, n_leaves)
+    cut_scipy = _hc_cut(n_clusters, children_scipy, n_leaves)
+    assess_same_labelling(cut, cut_scipy)
 
 
 def test_identical_points():

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -40,6 +40,18 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
     ite = 1
     X_pinv = Y_pinv = None
     eps = np.finfo(X.dtype).eps
+
+    if mode == "B":
+        # Uses condition from scipy<1.3 in pinv2 which was changed in
+        # https://github.com/scipy/scipy/pull/10067. In scipy 1.3, the
+        # condition was changed to depend on the largest singular value
+        X_t = X.dtype.char.lower()
+        Y_t = Y.dtype.char.lower()
+        factor = {'f': 1E3, 'd': 1E6}
+
+        cond_X = factor[X_t] * eps
+        cond_Y = factor[Y_t] * eps
+
     # Inner loop of the Wold algo.
     while True:
         # 1.1 Update u: the X weights
@@ -47,7 +59,7 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
             if X_pinv is None:
                 # We use slower pinv2 (same as np.linalg.pinv) for stability
                 # reasons
-                X_pinv = pinv2(X, check_finite=False)
+                X_pinv = pinv2(X, check_finite=False, cond=cond_X)
             x_weights = np.dot(X_pinv, y_score)
         else:  # mode A
             # Mode A regress each X column on y_score
@@ -64,7 +76,8 @@ def _nipals_twoblocks_inner_loop(X, Y, mode="A", max_iter=500, tol=1e-06,
         # 2.1 Update y_weights
         if mode == "B":
             if Y_pinv is None:
-                Y_pinv = pinv2(Y, check_finite=False)  # compute once pinv(Y)
+                # compute once pinv(Y)
+                Y_pinv = pinv2(Y, check_finite=False, cond=cond_Y)
             y_weights = np.dot(Y_pinv, x_score)
         else:
             # Mode A regress each Y column on x_score

--- a/sklearn/datasets/tests/test_lfw.py
+++ b/sklearn/datasets/tests/test_lfw.py
@@ -24,10 +24,10 @@ from sklearn.utils._testing import SkipTest
 from sklearn.datasets.tests.test_common import check_return_X_y
 
 
-SCIKIT_LEARN_DATA = tempfile.mkdtemp(prefix="scikit_learn_lfw_test_")
-SCIKIT_LEARN_EMPTY_DATA = tempfile.mkdtemp(prefix="scikit_learn_empty_test_")
+SCIKIT_LEARN_DATA = None
+SCIKIT_LEARN_EMPTY_DATA = None
+LFW_HOME = None
 
-LFW_HOME = os.path.join(SCIKIT_LEARN_DATA, 'lfw_home')
 FAKE_NAMES = [
     'Abdelatif_Smith',
     'Abhati_Kepler',
@@ -43,6 +43,14 @@ def setup_module():
     """Test fixture run once and common to all tests of this module"""
     if not pillow_installed:
         raise SkipTest("PIL not installed.")
+
+    global SCIKIT_LEARN_DATA, SCIKIT_LEARN_EMPTY_DATA, LFW_HOME
+
+    SCIKIT_LEARN_DATA = tempfile.mkdtemp(prefix="scikit_learn_lfw_test_")
+    LFW_HOME = os.path.join(SCIKIT_LEARN_DATA, 'lfw_home')
+
+    SCIKIT_LEARN_EMPTY_DATA = tempfile.mkdtemp(
+        prefix="scikit_learn_empty_test_")
 
     if not os.path.exists(LFW_HOME):
         os.makedirs(LFW_HOME)

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -952,7 +952,7 @@ class SparseCoder(SparseCodingMixin, BaseEstimator):
         normalized to unit norm.
 
     transform_algorithm : {'lasso_lars', 'lasso_cd', 'lars', 'omp', \
-    'threshold'}
+    'threshold'}, default='omp'
         Algorithm used to transform the data:
         lars: uses the least angle regression method (linear_model.lars_path)
         lasso_lars: uses Lars to compute the Lasso solution
@@ -963,12 +963,12 @@ class SparseCoder(SparseCodingMixin, BaseEstimator):
         threshold: squashes to zero all coefficients less than alpha from
         the projection ``dictionary * X'``
 
-    transform_n_nonzero_coefs : int, ``0.1 * n_features`` by default
+    transform_n_nonzero_coefs : int, default=0.1*n_features
         Number of nonzero coefficients to target in each column of the
         solution. This is only used by `algorithm='lars'` and `algorithm='omp'`
         and is overridden by `alpha` in the `omp` case.
 
-    transform_alpha : float, 1. by default
+    transform_alpha : float, default=1.
         If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, `alpha` is the absolute value of the
@@ -977,23 +977,23 @@ class SparseCoder(SparseCodingMixin, BaseEstimator):
         the reconstruction error targeted. In this case, it overrides
         `n_nonzero_coefs`.
 
-    split_sign : bool, False by default
+    split_sign : bool, default=False
         Whether to split the sparse feature vector into the concatenation of
         its negative part and its positive part. This can improve the
         performance of downstream classifiers.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    positive_code : bool
+    positive_code : bool, default=False
         Whether to enforce positivity when finding the code.
 
         .. versionadded:: 0.20
 
-    transform_max_iter : int, optional (default=1000)
+    transform_max_iter : int, default=1000
         Maximum number of iterations to perform if `algorithm='lasso_cd'` or
         `lasso_lars`.
 

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -9,7 +9,8 @@ from scipy.sparse.linalg import eigsh
 
 from ..utils import check_random_state
 from ..utils.extmath import svd_flip
-from ..utils.validation import check_is_fitted, check_array
+from ..utils.validation import (check_is_fitted, check_array,
+                                _check_psd_eigenvalues)
 from ..exceptions import NotFittedError
 from ..base import BaseEstimator, TransformerMixin
 from ..preprocessing import KernelCenterer
@@ -210,6 +211,10 @@ class KernelPCA(TransformerMixin, BaseEstimator):
                                                 tol=self.tol,
                                                 maxiter=self.max_iter,
                                                 v0=v0)
+
+        # make sure that the eigenvalues are ok and fix numerical issues
+        self.lambdas_ = _check_psd_eigenvalues(self.lambdas_,
+                                               enable_warnings=False)
 
         # flip eigenvectors' sign to enforce deterministic output
         self.alphas_, _ = svd_flip(self.alphas_,

--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -1,6 +1,4 @@
-"""
-Base class for ensemble-based estimators.
-"""
+"""Base class for ensemble-based estimators."""
 
 # Authors: Gilles Louppe
 # License: BSD 3 clause
@@ -42,14 +40,13 @@ def _parallel_fit_estimator(estimator, X, y, sample_weight=None):
 
 
 def _set_random_states(estimator, random_state=None):
-    """Sets fixed random_state parameters for an estimator
+    """Set fixed random_state parameters for an estimator.
 
     Finds all parameters ending ``random_state`` and sets them to integers
     derived from ``random_state``.
 
     Parameters
     ----------
-
     estimator : estimator supporting get/set_params
         Estimator with potential randomness managed by random_state
         parameters.
@@ -106,6 +103,7 @@ class BaseEnsemble(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
     estimators_ : list of estimators
         The collection of fitted base estimators.
     """
+
     # overwrite _required_parameters from MetaEstimatorMixin
     _required_parameters = []
 
@@ -122,8 +120,10 @@ class BaseEnsemble(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         # self.estimators_ needs to be filled by the derived classes in fit.
 
     def _validate_estimator(self, default=None):
-        """Check the estimator and the n_estimator attribute, set the
-        `base_estimator_` attribute."""
+        """Check the estimator and the n_estimator attribute.
+
+        Sets the base_estimator_` attributes.
+        """
         if not isinstance(self.n_estimators, numbers.Integral):
             raise ValueError("n_estimators must be an integer, "
                              "got {0}.".format(type(self.n_estimators)))
@@ -159,15 +159,15 @@ class BaseEnsemble(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         return estimator
 
     def __len__(self):
-        """Returns the number of estimators in the ensemble."""
+        """Return the number of estimators in the ensemble."""
         return len(self.estimators_)
 
     def __getitem__(self, index):
-        """Returns the index'th estimator in the ensemble."""
+        """Return the index'th estimator in the ensemble."""
         return self.estimators_[index]
 
     def __iter__(self):
-        """Returns iterator over estimators in the ensemble."""
+        """Return iterator over estimators in the ensemble."""
         return iter(self.estimators_)
 
 
@@ -204,6 +204,7 @@ class _BaseHeterogeneousEnsemble(MetaEstimatorMixin, _BaseComposition,
         training data. If an estimator has been set to `'drop'`, it will not
         appear in `estimators_`.
     """
+
     _required_parameters = ['estimators']
 
     @property

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1563,6 +1563,7 @@ class ExtraTreesClassifier(ForestClassifier):
         - the sampling of the features to consider when looking for the best
           split at each node (if ``max_features < n_features``)
         - the draw of the splits for each of the `max_features`
+
         See :term:`Glossary <random_state>` for details.
 
     verbose : int, optional (default=0)
@@ -1871,6 +1872,7 @@ class ExtraTreesRegressor(ForestRegressor):
         - the sampling of the features to consider when looking for the best
           split at each node (if ``max_features < n_features``)
         - the draw of the splits for each of the `max_features`
+
         See :term:`Glossary <random_state>` for details.
 
     verbose : int, optional (default=0)

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -2112,14 +2112,6 @@ class RandomTreesEmbedding(BaseForest):
         and add more estimators to the ensemble, otherwise, just fit a whole
         new forest. See :term:`the Glossary <warm_start>`.
 
-    ccp_alpha : non-negative float, optional (default=0.0)
-        Complexity parameter used for Minimal Cost-Complexity Pruning. The
-        subtree with the largest cost complexity that is smaller than
-        ``ccp_alpha`` will be chosen. By default, no pruning is performed. See
-        :ref:`minimal_cost_complexity_pruning` for details.
-
-        .. versionadded:: 0.22
-
     max_samples : int or float, default=None
         If bootstrap is True, the number of samples to draw from X
         to train each base estimator.
@@ -2163,7 +2155,6 @@ class RandomTreesEmbedding(BaseForest):
                  random_state=None,
                  verbose=0,
                  warm_start=False,
-                 ccp_alpha=0.0,
                  max_samples=None):
         super().__init__(
             base_estimator=ExtraTreeRegressor(),
@@ -2172,7 +2163,7 @@ class RandomTreesEmbedding(BaseForest):
                               "min_samples_leaf", "min_weight_fraction_leaf",
                               "max_features", "max_leaf_nodes",
                               "min_impurity_decrease", "min_impurity_split",
-                              "random_state", "ccp_alpha"),
+                              "random_state"),
             bootstrap=False,
             oob_score=False,
             n_jobs=n_jobs,
@@ -2189,7 +2180,6 @@ class RandomTreesEmbedding(BaseForest):
         self.min_impurity_decrease = min_impurity_decrease
         self.min_impurity_split = min_impurity_split
         self.sparse_output = sparse_output
-        self.ccp_alpha = ccp_alpha
 
     def _set_oob_score(self, X, y):
         raise NotImplementedError("OOB score not supported by tree embedding")

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -962,10 +962,11 @@ class RandomForestClassifier(ForestClassifier):
         <n_jobs>` for more details.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Controls both the randomness of the bootstrapping of the samples used
+        when building trees (if ``bootstrap=True``) and the sampling of the
+        features to consider when looking for the best split at each node
+        (if ``max_features < n_features``).
+        See :term:`Glossary <random_state>` for details.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -1278,10 +1279,11 @@ class RandomForestRegressor(ForestRegressor):
         <n_jobs>` for more details.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Controls both the randomness of the bootstrapping of the samples used
+        when building trees (if ``bootstrap=True``) and the sampling of the
+        features to consider when looking for the best split at each node
+        (if ``max_features < n_features``).
+        See :term:`Glossary <random_state>` for details.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -1540,7 +1542,7 @@ class ExtraTreesClassifier(ForestClassifier):
 
     bootstrap : boolean, optional (default=False)
         Whether bootstrap samples are used when building trees. If False, the
-        whole datset is used to build each tree.
+        whole dataset is used to build each tree.
 
     oob_score : bool, optional (default=False)
         Whether to use out-of-bag samples to estimate
@@ -1554,10 +1556,14 @@ class ExtraTreesClassifier(ForestClassifier):
         <n_jobs>` for more details.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Controls 3 sources of randomness:
+
+        - the bootstrapping of the samples used when building trees
+          (if ``bootstrap=True``)
+        - the sampling of the features to consider when looking for the best
+          split at each node (if ``max_features < n_features``)
+        - the draw of the splits for each of the `max_features`
+        See :term:`Glossary <random_state>` for details.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -1845,7 +1851,7 @@ class ExtraTreesRegressor(ForestRegressor):
 
     bootstrap : boolean, optional (default=False)
         Whether bootstrap samples are used when building trees. If False, the
-        whole datset is used to build each tree.
+        whole dataset is used to build each tree.
 
     oob_score : bool, optional (default=False)
         Whether to use out-of-bag samples to estimate the R^2 on unseen data.
@@ -1858,10 +1864,14 @@ class ExtraTreesRegressor(ForestRegressor):
         <n_jobs>` for more details.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Controls 3 sources of randomness:
+
+        - the bootstrapping of the samples used when building trees
+          (if ``bootstrap=True``)
+        - the sampling of the features to consider when looking for the best
+          split at each node (if ``max_features < n_features``)
+        - the draw of the splits for each of the `max_features`
+        See :term:`Glossary <random_state>` for details.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.
@@ -2088,10 +2098,9 @@ class RandomTreesEmbedding(BaseForest):
         <n_jobs>` for more details.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Controls the generation of the random `y` used to fit the trees
+        and the draw of the splits for each feature at the trees' nodes.
+        See :term:`Glossary <random_state>` for details.
 
     verbose : int, optional (default=0)
         Controls the verbosity when fitting and predicting.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -270,6 +270,8 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
 
             # Compute raw predictions
             raw_predictions = self._raw_predict(X_binned_train)
+            if self.do_early_stopping_ and self._use_validation_data:
+                raw_predictions_val = self._raw_predict(X_binned_val)
 
             if self.do_early_stopping_ and self.scoring != 'loss':
                 # Compute the subsample set

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
@@ -93,14 +93,15 @@ def test_warm_start_max_depth(GradientBoosting, X, y):
     (HistGradientBoostingClassifier, X_classification, y_classification),
     (HistGradientBoostingRegressor, X_regression, y_regression)
 ])
-def test_warm_start_early_stopping(GradientBoosting, X, y):
+@pytest.mark.parametrize('scoring', (None, 'loss'))
+def test_warm_start_early_stopping(GradientBoosting, X, y, scoring):
     # Make sure that early stopping occurs after a small number of iterations
     # when fitting a second time with warm starting.
 
     n_iter_no_change = 5
     gb = GradientBoosting(
         n_iter_no_change=n_iter_no_change, max_iter=10000,
-        random_state=42, warm_start=True, tol=1e-3
+        random_state=42, warm_start=True, tol=1e-3, scoring=scoring,
     )
     gb.fit(X, y)
     n_iter_first_fit = gb.n_iter_

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -41,21 +41,19 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
 
     @property
     def _weights_not_none(self):
-        """Get the weights of not `None` estimators"""
+        """Get the weights of not `None` estimators."""
         if self.weights is None:
             return None
         return [w for est, w in zip(self.estimators, self.weights)
                 if est[1] not in (None, 'drop')]
 
     def _predict(self, X):
-        """Collect results from clf.predict calls. """
+        """Collect results from clf.predict calls."""
         return np.asarray([est.predict(X) for est in self.estimators_]).T
 
     @abstractmethod
     def fit(self, X, y, sample_weight=None):
-        """
-        common fit operations.
-        """
+        """Get common fit operations."""
         names, clfs = self._validate_estimators()
 
         if (self.weights is not None and
@@ -90,7 +88,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
 
     Parameters
     ----------
-    estimators : list of (string, estimator) tuples
+    estimators : list of (str, estimator) tuples
         Invoking the ``fit`` method on the ``VotingClassifier`` will fit clones
         of those original estimators that will be stored in the class attribute
         ``self.estimators_``. An estimator can be set to ``'drop'``
@@ -138,6 +136,10 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
     classes_ : array-like, shape (n_predictions,)
         The classes labels.
 
+    See Also
+    --------
+    VotingRegressor: Prediction voting regressor.
+
     Examples
     --------
     >>> import numpy as np
@@ -172,10 +174,6 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
     [1 1 1 2 2 2]
     >>> print(eclf3.transform(X).shape)
     (6, 6)
-
-    See also
-    --------
-    VotingRegressor: Prediction voting regressor.
     """
 
     def __init__(self, estimators, voting='hard', weights=None, n_jobs=None,
@@ -187,7 +185,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         self.flatten_transform = flatten_transform
 
     def fit(self, X, y, sample_weight=None):
-        """ Fit the estimators.
+        """Fit the estimators.
 
         Parameters
         ----------
@@ -206,6 +204,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         Returns
         -------
         self : object
+
         """
         check_classification_targets(y)
         if isinstance(y, np.ndarray) and len(y.shape) > 1 and y.shape[1] > 1:
@@ -223,7 +222,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         return super().fit(X, transformed_y, sample_weight)
 
     def predict(self, X):
-        """ Predict class labels for X.
+        """Predict class labels for X.
 
         Parameters
         ----------
@@ -235,7 +234,6 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         maj : array-like, shape (n_samples,)
             Predicted class labels.
         """
-
         check_is_fitted(self)
         if self.voting == 'soft':
             maj = np.argmax(self.predict_proba(X), axis=1)
@@ -252,11 +250,11 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         return maj
 
     def _collect_probas(self, X):
-        """Collect results from clf.predict calls. """
+        """Collect results from clf.predict calls."""
         return np.asarray([clf.predict_proba(X) for clf in self.estimators_])
 
     def _predict_proba(self, X):
-        """Predict class probabilities for X in 'soft' voting """
+        """Predict class probabilities for X in 'soft' voting."""
         check_is_fitted(self)
         avg = np.average(self._collect_probas(X), axis=0,
                          weights=self._weights_not_none)

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -224,7 +224,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
             Sample weights.
 
         Yields
-        -------
+        ------
         z : float
         """
         X = self._validate_data(X)
@@ -428,7 +428,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         Returns
         -------
         self : object
-            A fitted estimator.
+            Fitted estimator.
         """
         # Check that algorithm is supported
         if self.algorithm not in ('SAMME', 'SAMME.R'):
@@ -648,7 +648,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
             DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Yields
-        -------
+        ------
         y : generator of array, shape = [n_samples]
             The predicted classes.
         """
@@ -719,7 +719,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
             DOK, or LIL. COO, DOK, and LIL are converted to CSR.
 
         Yields
-        -------
+        ------
         score : generator of array, shape = [n_samples, k]
             The decision function of the input samples. The order of
             outputs is the same of that of the :term:`classes_` attribute.

--- a/sklearn/ensemble/tests/test_partial_dependence.py
+++ b/sklearn/ensemble/tests/test_partial_dependence.py
@@ -15,6 +15,12 @@ from sklearn import datasets
 from sklearn.utils._testing import ignore_warnings
 
 
+# TODO: Remove when https://github.com/numpy/numpy/issues/14397 is resolved
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:In future, it will be an error for 'np.bool_':DeprecationWarning:"
+    "matplotlib.*")
+
+
 # toy sample
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
 y = [-1, -1, -1, 1, 1, 1]

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -12,7 +12,8 @@ __all__ = ['NotFittedError',
            'FitFailedWarning',
            'NonBLASDotWarning',
            'SkipTestWarning',
-           'UndefinedMetricWarning']
+           'UndefinedMetricWarning',
+           'PositiveSpectrumWarning']
 
 
 class NotFittedError(ValueError, AttributeError):
@@ -170,4 +171,16 @@ class UndefinedMetricWarning(UserWarning):
 
     .. versionchanged:: 0.18
        Moved from sklearn.base.
+    """
+
+
+class PositiveSpectrumWarning(UserWarning):
+    """Warning raised when the eigenvalues of a PSD matrix have issues
+
+    This warning is typically raised by ``_check_psd_eigenvalues`` when the
+    eigenvalues of a positive semidefinite (PSD) matrix such as a gram matrix
+    (kernel) present significant negative eigenvalues, or bad conditioning i.e.
+    very small non-zero eigenvalues compared to the largest eigenvalue.
+
+    .. versionadded:: 0.22
     """

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -123,7 +123,7 @@ def strip_accents_unicode(s):
     s : string
         The string to strip
 
-    See also
+    See Also
     --------
     strip_accents_ascii
         Remove accentuated char for any unicode symbol that has a direct
@@ -150,7 +150,7 @@ def strip_accents_ascii(s):
     s : string
         The string to strip
 
-    See also
+    See Also
     --------
     strip_accents_unicode
         Remove accentuated char for any unicode symbol.
@@ -190,14 +190,19 @@ class _VectorizerMixin:
     _white_spaces = re.compile(r"\s\s+")
 
     def decode(self, doc):
-        """Decode the input into a string of unicode symbols
+        """Decode the input into a string of unicode symbols.
 
         The decoding strategy depends on the vectorizer parameters.
 
         Parameters
         ----------
-        doc : string
-            The string to decode
+        doc : str
+            The string to decode.
+
+        Returns
+        -------
+        doc: str
+            A string of unicode symbols.
         """
         if self.input == 'filename':
             with open(doc, 'rb') as fh:
@@ -298,7 +303,13 @@ class _VectorizerMixin:
         return ngrams
 
     def build_preprocessor(self):
-        """Return a function to preprocess the text before tokenization"""
+        """Return a function to preprocess the text before tokenization.
+
+        Returns
+        -------
+        preprocessor: callable
+              A function to preprocess the text before tokenization.
+        """
         if self.preprocessor is not None:
             return self.preprocessor
 
@@ -320,14 +331,26 @@ class _VectorizerMixin:
         )
 
     def build_tokenizer(self):
-        """Return a function that splits a string into a sequence of tokens"""
+        """Return a function that splits a string into a sequence of tokens.
+
+        Returns
+        -------
+        tokenizer: callable
+              A function to split a string into a sequence of tokens.
+        """
         if self.tokenizer is not None:
             return self.tokenizer
         token_pattern = re.compile(self.token_pattern)
         return token_pattern.findall
 
     def get_stop_words(self):
-        """Build or fetch the effective stop words list"""
+        """Build or fetch the effective stop words list.
+
+        Returns
+        -------
+        stop_words: list or None
+                A list of stop words.
+        """
         return _check_stop_list(self.stop_words)
 
     def _check_stop_words_consistency(self, stop_words, preprocess, tokenize):
@@ -391,8 +414,13 @@ class _VectorizerMixin:
 
     def build_analyzer(self):
         """Return a callable that handles preprocessing, tokenization
-
         and n-grams generation.
+
+        Returns
+        -------
+        analyzer: callable
+            A function to handle preprocessing, tokenization
+            and n-grams generation.
         """
 
         if callable(self.analyzer):
@@ -667,11 +695,12 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
     >>> print(X.shape)
     (4, 16)
 
-    See also
+    See Also
     --------
     CountVectorizer, TfidfVectorizer
 
     """
+
     def __init__(self, input='content', encoding='utf-8',
                  decode_error='strict', strip_accents=None,
                  lowercase=True, preprocessor=None, tokenizer=None,
@@ -982,7 +1011,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
      [1 0 0 1 0 0 0 0 1 1 0 1 0]
      [0 0 1 0 1 0 1 0 0 0 0 0 1]]
 
-    See also
+    See Also
     --------
     HashingVectorizer, TfidfVectorizer
 
@@ -1249,6 +1278,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Document-term matrix.
 
         Returns
         -------
@@ -1274,7 +1304,13 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
                 for i in range(n_samples)]
 
     def get_feature_names(self):
-        """Array mapping from feature integer indices to feature name"""
+        """Array mapping from feature integer indices to feature name.
+
+        Returns
+        -------
+        feature_names : list
+            A list of feature names.
+        """
 
         self._check_vocabulary()
 
@@ -1504,7 +1540,7 @@ class TfidfVectorizer(CountVectorizer):
 
     Parameters
     ----------
-    input : string {'filename', 'file', 'content'}
+    input : str {'filename', 'file', 'content'}
         If 'filename', the sequence passed as an argument to fit is
         expected to be a list of filenames that need reading to fetch
         the raw content to analyze.
@@ -1515,7 +1551,7 @@ class TfidfVectorizer(CountVectorizer):
         Otherwise the input is expected to be a sequence of items that
         can be of type string or byte.
 
-    encoding : string, 'utf-8' by default.
+    encoding : str, default='utf-8'
         If bytes or files are given to analyze, this encoding is used to
         decode.
 
@@ -1536,7 +1572,7 @@ class TfidfVectorizer(CountVectorizer):
         Both 'ascii' and 'unicode' use NFKD normalization from
         :func:`unicodedata.normalize`.
 
-    lowercase : boolean (default=True)
+    lowercase : bool (default=True)
         Convert all characters to lowercase before tokenizing.
 
     preprocessor : callable or None (default=None)
@@ -1549,7 +1585,7 @@ class TfidfVectorizer(CountVectorizer):
         preprocessing and n-grams generation steps.
         Only applies if ``analyzer == 'word'``.
 
-    analyzer : string, {'word', 'char', 'char_wb'} or callable
+    analyzer : str, {'word', 'char', 'char_wb'} or callable
         Whether the feature should be made of word or character n-grams.
         Option 'char_wb' creates character n-grams only from text inside
         word boundaries; n-grams at the edges of words are padded with space.
@@ -1563,7 +1599,7 @@ class TfidfVectorizer(CountVectorizer):
         first read from the file and then passed to the given callable
         analyzer.
 
-    stop_words : string {'english'}, list, or None (default=None)
+    stop_words : str {'english'}, list, or None (default=None)
         If a string, it is passed to _check_stop_list and the appropriate stop
         list is returned. 'english' is currently the only supported string
         value.
@@ -1578,7 +1614,7 @@ class TfidfVectorizer(CountVectorizer):
         in the range [0.7, 1.0) to automatically detect and filter stop
         words based on intra corpus document frequency of terms.
 
-    token_pattern : string
+    token_pattern : str
         Regular expression denoting what constitutes a "token", only used
         if ``analyzer == 'word'``. The default regexp selects tokens of 2
         or more alphanumeric characters (punctuation is completely ignored
@@ -1619,10 +1655,10 @@ class TfidfVectorizer(CountVectorizer):
         indices in the feature matrix, or an iterable over terms. If not
         given, a vocabulary is determined from the input documents.
 
-    binary : boolean (default=False)
+    binary : bool (default=False)
         If True, all non-zero term counts are set to 1. This does not mean
         outputs will have only 0/1 values, only that the tf term in tf-idf
-        is binary. (Set idf and normalization to False to get 0/1 outputs.)
+        is binary. (Set idf and normalization to False to get 0/1 outputs).
 
     dtype : type, optional (default=float64)
         Type of the matrix returned by fit_transform() or transform().
@@ -1633,17 +1669,17 @@ class TfidfVectorizer(CountVectorizer):
         similarity between two vectors is their dot product when l2 norm has
         been applied.
         * 'l1': Sum of absolute values of vector elements is 1.
-        See :func:`preprocessing.normalize`
+        See :func:`preprocessing.normalize`.
 
-    use_idf : boolean (default=True)
+    use_idf : bool (default=True)
         Enable inverse-document-frequency reweighting.
 
-    smooth_idf : boolean (default=True)
+    smooth_idf : bool (default=True)
         Smooth idf weights by adding one to document frequencies, as if an
         extra document was seen containing every term in the collection
         exactly once. Prevents zero divisions.
 
-    sublinear_tf : boolean (default=False)
+    sublinear_tf : bool (default=False)
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
     Attributes
@@ -1651,7 +1687,7 @@ class TfidfVectorizer(CountVectorizer):
     vocabulary_ : dict
         A mapping of terms to feature indices.
 
-    fixed_vocabulary_: boolean
+    fixed_vocabulary_: bool
         True if a fixed vocabulary of term to indices mapping
         is provided by the user
 
@@ -1668,6 +1704,19 @@ class TfidfVectorizer(CountVectorizer):
 
         This is only available if no vocabulary was given.
 
+    See Also
+    --------
+    CountVectorizer : Transforms text into a sparse matrix of n-gram counts.
+
+    TfidfTransformer : Performs the TF-IDF transformation from a provided
+        matrix of counts.
+
+    Notes
+    -----
+    The ``stop_words_`` attribute can get large and increase the model size
+    when pickling. This attribute is provided only for introspection and can
+    be safely removed using delattr or set to None before pickling.
+
     Examples
     --------
     >>> from sklearn.feature_extraction.text import TfidfVectorizer
@@ -1683,19 +1732,6 @@ class TfidfVectorizer(CountVectorizer):
     ['and', 'document', 'first', 'is', 'one', 'second', 'the', 'third', 'this']
     >>> print(X.shape)
     (4, 9)
-
-    See also
-    --------
-    CountVectorizer : Transforms text into a sparse matrix of n-gram counts.
-
-    TfidfTransformer : Performs the TF-IDF transformation from a provided
-        matrix of counts.
-
-    Notes
-    -----
-    The ``stop_words_`` attribute can get large and increase the model size
-    when pickling. This attribute is provided only for introspection and can
-    be safely removed using delattr or set to None before pickling.
     """
 
     def __init__(self, input='content', encoding='utf-8',
@@ -1782,11 +1818,14 @@ class TfidfVectorizer(CountVectorizer):
         Parameters
         ----------
         raw_documents : iterable
-            an iterable which yields either str, unicode or file objects
+            An iterable which yields either str, unicode or file objects.
+        y : None
+            This parameter is not needed to compute tfidf.
 
         Returns
         -------
-        self : TfidfVectorizer
+        self : object
+            Fitted vectorizer.
         """
         self._check_params()
         self._warn_for_unused_params()
@@ -1803,7 +1842,9 @@ class TfidfVectorizer(CountVectorizer):
         Parameters
         ----------
         raw_documents : iterable
-            an iterable which yields either str, unicode or file objects
+            An iterable which yields either str, unicode or file objects.
+        y : None
+            This parameter is ignored.
 
         Returns
         -------
@@ -1826,9 +1867,9 @@ class TfidfVectorizer(CountVectorizer):
         Parameters
         ----------
         raw_documents : iterable
-            an iterable which yields either str, unicode or file objects
+            An iterable which yields either str, unicode or file objects.
 
-        copy : boolean, default True
+        copy : bool, default True
             Whether to copy X and operate on the copy or perform in-place
             operations.
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -876,14 +876,15 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
 
     ngram_range : tuple (min_n, max_n), default=(1, 1)
         The lower and upper boundary of the range of n-values for different
-        n-grams to be extracted. All values of n such that min_n <= n <= max_n
-        will be used. For example an ``ngram_range`` of ``(1, 1)`` means only
-        unigrams, ``(1, 2)`` means unigrams and bigrams, and ``(2, 2)`` means
-        only bigrams.
+        word n-grams or char n-grams to be extracted. All values of n such
+        such that min_n <= n <= max_n will be used. For example an
+        ``ngram_range`` of ``(1, 1)`` means only unigrams, ``(1, 2)`` means
+        unigrams and bigrams, and ``(2, 2)`` means only bigrams.
         Only applies if ``analyzer is not callable``.
 
     analyzer : string, {'word', 'char', 'char_wb'} or callable
-        Whether the feature should be made of word or character n-grams.
+        Whether the feature should be made of word n-gram or character
+        n-grams.
         Option 'char_wb' creates character n-grams only from text inside
         word boundaries; n-grams at the edges of words are padded with space.
 
@@ -969,6 +970,17 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
      [0 2 0 1 0 1 1 0 1]
      [1 0 0 1 1 0 1 1 1]
      [0 1 1 1 0 0 1 0 1]]
+    >>> vectorizer2 = CountVectorizer(analyzer='word', ngram_range=(2, 2))
+    >>> X2 = vectorizer2.fit_transform(corpus)
+    >>> print(vectorizer2.get_feature_names())
+    ['and this', 'document is', 'first document', 'is the', 'is this',
+    'second document', 'the first', 'the second', 'the third', 'third one',
+     'this document', 'this is', 'this the']
+     >>> print(X2.toarray())
+     [[0 0 1 1 0 0 1 0 0 0 0 1 0]
+     [0 1 0 1 0 1 0 1 0 0 1 0 0]
+     [1 0 0 1 0 0 0 0 1 1 0 1 0]
+     [0 0 1 0 1 0 1 0 0 0 0 0 1]]
 
     See also
     --------

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -115,8 +115,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
     Attributes
     ----------
-    X_train_ : array-like of shape (n_samples, n_features)
-        Feature values in training data (also required for prediction)
+    X_train_ : sequence of length n_samples
+        Feature vectors or other representations of training data (also
+        required for prediction). Could either be array-like with shape =
+        (n_samples, n_features) or a list of objects.
 
     y_train_ : array-like of shape (n_samples,)
         Target values in training data (also required for prediction)
@@ -160,8 +162,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Training data
+        X : sequence of length n_samples
+            Feature vectors or other representations of training data.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         y : array-like of shape (n_samples,)
             Target values, must be binary
@@ -248,7 +252,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -270,7 +277,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -602,8 +612,10 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Training data
+        X : sequence of length n_samples
+            Feature vectors or other representations of training data.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         y : array-like of shape (n_samples,)
             Target values, must be binary
@@ -612,7 +624,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         -------
         self : returns an instance of self.
         """
-        X, y = check_X_y(X, y, multi_output=False)
+        if self.kernel is None or self.kernel.requires_vector_input:
+            X, y = check_X_y(X, y, multi_output=False,
+                             ensure_2d=True, dtype="numeric")
+        else:
+            X, y = check_X_y(X, y, multi_output=False,
+                             ensure_2d=False, dtype=None)
 
         self.base_estimator_ = _BinaryGaussianProcessClassifierLaplace(
             self.kernel, self.optimizer, self.n_restarts_optimizer,
@@ -656,7 +673,10 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -664,7 +684,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
             Predicted target values for X, values are from ``classes_``
         """
         check_is_fitted(self)
-        X = check_array(X)
+
+        if self.kernel is None or self.kernel.requires_vector_input:
+            X = check_array(X, ensure_2d=True, dtype="numeric")
+        else:
+            X = check_array(X, ensure_2d=False, dtype=None)
+
         return self.base_estimator_.predict(X)
 
     def predict_proba(self, X):
@@ -672,7 +697,10 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : sequence of length n_samples
+            Query points where the GP is evaluated for classification.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         Returns
         -------
@@ -686,7 +714,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
             raise ValueError("one_vs_one multi-class mode does not support "
                              "predicting probability estimates. Use "
                              "one_vs_rest mode instead.")
-        X = check_array(X)
+
+        if self.kernel is None or self.kernel.requires_vector_input:
+            X = check_array(X, ensure_2d=True, dtype="numeric")
+        else:
+            X = check_array(X, ensure_2d=False, dtype=None)
+
         return self.base_estimator_.predict_proba(X)
 
     @property

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -114,8 +114,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
     Attributes
     ----------
-    X_train_ : array-like of shape (n_samples, n_features)
-        Feature values in training data (also required for prediction)
+    X_train_ : sequence of length n_samples
+        Feature vectors or other representations of training data (also
+        required for prediction). Could either be array-like with shape =
+        (n_samples, n_features) or a list of objects.
 
     y_train_ : array-like of shape (n_samples,) or (n_samples, n_targets)
         Target values in training data (also required for prediction)
@@ -164,8 +166,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Training data
+        X : sequence of length n_samples
+            Feature vectors or other representations of training data.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Target values
@@ -182,7 +186,12 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         self._rng = check_random_state(self.random_state)
 
-        X, y = check_X_y(X, y, multi_output=True, y_numeric=True)
+        if self.kernel_.requires_vector_input:
+            X, y = check_X_y(X, y, multi_output=True, y_numeric=True,
+                             ensure_2d=True, dtype="numeric")
+        else:
+            X, y = check_X_y(X, y, multi_output=True, y_numeric=True,
+                             ensure_2d=False, dtype=None)
 
         # Normalize target value
         if self.normalize_y:
@@ -273,8 +282,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Query points where the GP is evaluated
+        X : sequence of length n_samples
+            Query points where the GP is evaluated.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         return_std : bool, default: False
             If True, the standard-deviation of the predictive distribution at
@@ -302,7 +313,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 "Not returning standard deviation of predictions when "
                 "returning full covariance.")
 
-        X = check_array(X)
+        if self.kernel is None or self.kernel.requires_vector_input:
+            X = check_array(X, ensure_2d=True, dtype="numeric")
+        else:
+            X = check_array(X, ensure_2d=False, dtype=None)
 
         if not hasattr(self, "X_train_"):  # Unfitted;predict based on GP prior
             if self.kernel is None:
@@ -357,8 +371,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples_X, n_features)
-            Query points where the GP samples are evaluated
+        X : sequence of length n_samples
+            Query points where the GP is evaluated.
+            Could either be array-like with shape = (n_samples, n_features)
+            or a list of objects.
 
         n_samples : int, default: 1
             The number of samples drawn from the Gaussian process

--- a/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
+++ b/sklearn/gaussian_process/tests/_mini_sequence_kernel.py
@@ -1,0 +1,51 @@
+from sklearn.gaussian_process.kernels import Kernel, Hyperparameter
+from sklearn.gaussian_process.kernels import GenericKernelMixin
+from sklearn.gaussian_process.kernels import StationaryKernelMixin
+import numpy as np
+from sklearn.base import clone
+
+
+class MiniSeqKernel(GenericKernelMixin,
+                    StationaryKernelMixin,
+                    Kernel):
+    '''
+    A minimal (but valid) convolutional kernel for sequences of variable
+    length.
+    '''
+    def __init__(self,
+                 baseline_similarity=0.5,
+                 baseline_similarity_bounds=(1e-5, 1)):
+        self.baseline_similarity = baseline_similarity
+        self.baseline_similarity_bounds = baseline_similarity_bounds
+
+    @property
+    def hyperparameter_baseline_similarity(self):
+        return Hyperparameter("baseline_similarity",
+                              "numeric",
+                              self.baseline_similarity_bounds)
+
+    def _f(self, s1, s2):
+        return sum([1.0 if c1 == c2 else self.baseline_similarity
+                   for c1 in s1
+                   for c2 in s2])
+
+    def _g(self, s1, s2):
+        return sum([0.0 if c1 == c2 else 1.0 for c1 in s1 for c2 in s2])
+
+    def __call__(self, X, Y=None, eval_gradient=False):
+        if Y is None:
+            Y = X
+
+        if eval_gradient:
+            return (np.array([[self._f(x, y) for y in Y] for x in X]),
+                    np.array([[[self._g(x, y)] for y in Y] for x in X]))
+        else:
+            return np.array([[self._f(x, y) for y in Y] for x in X])
+
+    def diag(self, X):
+        return np.array([self._f(x, x) for x in X])
+
+    def clone_with_theta(self, theta):
+        cloned = clone(self)
+        cloned.theta = theta
+        return cloned

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -11,12 +11,15 @@ import pytest
 
 from sklearn.gaussian_process import GaussianProcessClassifier
 from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C
+from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 
 from sklearn.utils._testing import assert_almost_equal, assert_array_equal
 
 
 def f(x):
     return np.sin(x)
+
+
 X = np.atleast_2d(np.linspace(0, 10, 30)).T
 X2 = np.atleast_2d([2., 4., 5.5, 6.5, 7.5]).T
 y = np.array(f(X).ravel() > 0, dtype=int)
@@ -44,12 +47,22 @@ def test_predict_consistent(kernel):
                        gpc.predict_proba(X)[:, 1] >= 0.5)
 
 
+def test_predict_consistent_structured():
+    # Check binary predict decision has also predicted probability above 0.5.
+    X = ['A', 'AB', 'B']
+    y = np.array([True, False, True])
+    kernel = MiniSeqKernel(baseline_similarity_bounds='fixed')
+    gpc = GaussianProcessClassifier(kernel=kernel).fit(X, y)
+    assert_array_equal(gpc.predict(X),
+                       gpc.predict_proba(X)[:, 1] >= 0.5)
+
+
 @pytest.mark.parametrize('kernel', non_fixed_kernels)
 def test_lml_improving(kernel):
     # Test that hyperparameter-tuning improves log-marginal likelihood.
     gpc = GaussianProcessClassifier(kernel=kernel).fit(X, y)
     assert (gpc.log_marginal_likelihood(gpc.kernel_.theta) >
-                   gpc.log_marginal_likelihood(kernel.theta))
+            gpc.log_marginal_likelihood(kernel.theta))
 
 
 @pytest.mark.parametrize('kernel', kernels)
@@ -139,7 +152,7 @@ def test_custom_optimizer(kernel):
     gpc.fit(X, y_mc)
     # Checks that optimizer improved marginal likelihood
     assert (gpc.log_marginal_likelihood(gpc.kernel_.theta) >
-                   gpc.log_marginal_likelihood(kernel.theta))
+            gpc.log_marginal_likelihood(kernel.theta))
 
 
 @pytest.mark.parametrize('kernel', kernels)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -13,6 +13,7 @@ from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels \
     import RBF, ConstantKernel as C, WhiteKernel
 from sklearn.gaussian_process.kernels import DotProduct
+from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 
 from sklearn.utils._testing \
     import (assert_array_less,
@@ -53,12 +54,26 @@ def test_gpr_interpolation(kernel):
     assert_almost_equal(np.diag(y_cov), 0.)
 
 
+def test_gpr_interpolation_structured():
+    # Test the interpolating property for different kernels.
+    kernel = MiniSeqKernel(baseline_similarity_bounds='fixed')
+    X = ['A', 'B', 'C']
+    y = np.array([1, 2, 3])
+    gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
+    y_pred, y_cov = gpr.predict(X, return_cov=True)
+
+    assert_almost_equal(kernel(X, eval_gradient=True)[1].ravel(),
+                        (1 - np.eye(len(X))).ravel())
+    assert_almost_equal(y_pred, y)
+    assert_almost_equal(np.diag(y_cov), 0.)
+
+
 @pytest.mark.parametrize('kernel', non_fixed_kernels)
 def test_lml_improving(kernel):
     # Test that hyperparameter-tuning improves log-marginal likelihood.
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
     assert (gpr.log_marginal_likelihood(gpr.kernel_.theta) >
-                   gpr.log_marginal_likelihood(kernel.theta))
+            gpr.log_marginal_likelihood(kernel.theta))
 
 
 @pytest.mark.parametrize('kernel', kernels)
@@ -66,7 +81,7 @@ def test_lml_precomputed(kernel):
     # Test that lml of optimized kernel is stored correctly.
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
     assert (gpr.log_marginal_likelihood(gpr.kernel_.theta) ==
-                 gpr.log_marginal_likelihood())
+            gpr.log_marginal_likelihood())
 
 
 @pytest.mark.parametrize('kernel', kernels)
@@ -179,7 +194,7 @@ def test_anisotropic_kernel():
     kernel = RBF([1.0, 1.0])
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
     assert (np.exp(gpr.kernel_.theta[1]) >
-                   np.exp(gpr.kernel_.theta[0]) * 5)
+            np.exp(gpr.kernel_.theta[0]) * 5)
 
 
 def test_random_starts():
@@ -297,7 +312,7 @@ def test_custom_optimizer(kernel):
     gpr.fit(X, y)
     # Checks that optimizer improved marginal likelihood
     assert (gpr.log_marginal_likelihood(gpr.kernel_.theta) >
-                   gpr.log_marginal_likelihood(gpr.kernel.theta))
+            gpr.log_marginal_likelihood(gpr.kernel.theta))
 
 
 def test_gpr_correct_error_message():

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -14,22 +14,22 @@ from sklearn.metrics.pairwise \
 from sklearn.gaussian_process.kernels \
     import (RBF, Matern, RationalQuadratic, ExpSineSquared, DotProduct,
             ConstantKernel, WhiteKernel, PairwiseKernel, KernelOperator,
-            Exponentiation, Kernel)
+            Exponentiation, Kernel, CompoundKernel)
 from sklearn.base import clone
 
 from sklearn.utils._testing import (assert_almost_equal, assert_array_equal,
-                                   assert_array_almost_equal,
-                                   assert_raise_message)
+                                    assert_array_almost_equal,
+                                    assert_raise_message)
 
 
 X = np.random.RandomState(0).normal(0, 1, (5, 2))
 Y = np.random.RandomState(0).normal(0, 1, (6, 2))
 
-kernel_white = RBF(length_scale=2.0) + WhiteKernel(noise_level=3.0)
+kernel_rbf_plus_white = RBF(length_scale=2.0) + WhiteKernel(noise_level=3.0)
 kernels = [RBF(length_scale=2.0), RBF(length_scale_bounds=(0.5, 2.0)),
            ConstantKernel(constant_value=10.0),
            2.0 * RBF(length_scale=0.33, length_scale_bounds="fixed"),
-           2.0 * RBF(length_scale=0.5), kernel_white,
+           2.0 * RBF(length_scale=0.5), kernel_rbf_plus_white,
            2.0 * RBF(length_scale=[0.5, 2.0]),
            2.0 * Matern(length_scale=0.33, length_scale_bounds="fixed"),
            2.0 * Matern(length_scale=0.5, nu=0.5),
@@ -92,8 +92,7 @@ def test_kernel_theta(kernel):
     # Check that values returned in theta are consistent with
     # hyperparameter values (being their logarithms)
     for i, hyperparameter in enumerate(kernel.hyperparameters):
-        assert (theta[i] ==
-                     np.log(getattr(kernel, hyperparameter.name)))
+        assert (theta[i] == np.log(getattr(kernel, hyperparameter.name)))
 
     # Fixed kernel parameters must be excluded from theta and gradient.
     for i, hyperparameter in enumerate(kernel.hyperparameters):
@@ -129,7 +128,7 @@ def test_kernel_theta(kernel):
 @pytest.mark.parametrize('kernel',
                          [kernel for kernel in kernels
                           # Identity is not satisfied on diagonal
-                          if kernel != kernel_white])
+                          if kernel != kernel_rbf_plus_white])
 def test_auto_vs_cross(kernel):
     # Auto-correlation and cross-correlation should be consistent.
     K_auto = kernel(X)
@@ -186,6 +185,27 @@ def test_kernel_stationary(kernel):
     assert_almost_equal(K[0, 0], np.diag(K))
 
 
+@pytest.mark.parametrize('kernel',  kernels)
+def test_kernel_input_type(kernel):
+    # Test whether kernels is for vectors or structured data
+    if isinstance(kernel, Exponentiation):
+        assert(kernel.requires_vector_input ==
+               kernel.kernel.requires_vector_input)
+    if isinstance(kernel, KernelOperator):
+        assert(kernel.requires_vector_input ==
+               (kernel.k1.requires_vector_input or
+                kernel.k2.requires_vector_input))
+
+
+def test_compound_kernel_input_type():
+    kernel = CompoundKernel([WhiteKernel(noise_level=3.0)])
+    assert not kernel.requires_vector_input
+
+    kernel = CompoundKernel([WhiteKernel(noise_level=3.0),
+                             RBF(length_scale=2.0)])
+    assert kernel.requires_vector_input
+
+
 def check_hyperparameters_equal(kernel1, kernel2):
     # Check that hyperparameters of two kernels are equal
     for attr in set(dir(kernel1) + dir(kernel2)):
@@ -236,8 +256,7 @@ def test_kernel_clone_after_set_params(kernel):
             params['length_scale_bounds'] = bounds * 2
         kernel_cloned.set_params(**params)
         kernel_cloned_clone = clone(kernel_cloned)
-        assert (kernel_cloned_clone.get_params() ==
-                     kernel_cloned.get_params())
+        assert (kernel_cloned_clone.get_params() == kernel_cloned.get_params())
         assert id(kernel_cloned_clone) != id(kernel_cloned)
         check_hyperparameters_equal(kernel_cloned, kernel_cloned_clone)
 
@@ -266,7 +285,7 @@ def test_kernel_versus_pairwise(kernel):
     # Check that GP kernels can also be used as pairwise kernels.
 
     # Test auto-kernel
-    if kernel != kernel_white:
+    if kernel != kernel_rbf_plus_white:
         # For WhiteKernel: k(X) != k(X,X). This is assumed by
         # pairwise_kernels
         K1 = kernel(X)

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -623,7 +623,8 @@ def plot_partial_dependence(estimator, X, features, feature_names=None,
         else:
             # define a list of numbered indices for a numpy array
             feature_names = [str(i) for i in range(n_features)]
-    elif isinstance(feature_names, np.ndarray):
+    elif hasattr(feature_names, "tolist"):
+        # convert numpy array or pandas index to a list
         feature_names = feature_names.tolist()
     if len(set(feature_names)) != len(feature_names):
         raise ValueError('feature_names should not contain duplicates.')

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -859,15 +859,14 @@ class PartialDependenceDisplay:
         n_features = len(self.features)
 
         if isinstance(ax, plt.Axes):
-            # If ax has visible==False, it has most likely been set to False
+            # If ax was set off, it has most likely been set to off
             # by a previous call to plot.
-            if not ax.get_visible():
+            if not ax.axison:
                 raise ValueError("The ax was already used in another plot "
                                  "function, please set ax=display.axes_ "
                                  "instead")
 
             ax.set_axis_off()
-            ax.set_visible(False)
             self.bounding_ax_ = ax
             self.figure_ = ax.figure
 

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -425,6 +425,22 @@ def plot_partial_dependence(estimator, X, features, feature_names=None,
     deciles of the feature values will be shown with tick marks on the x-axes
     for one-way plots, and on both axes for two-way plots.
 
+    .. note::
+
+        :func:`plot_partial_dependence` does not support using the same axes
+        with multiple calls. To plot the the partial dependence for multiple
+        estimators, please pass the axes created by the first call to the
+        second call::
+
+          >>> from sklearn.inspection import plot_partial_dependence
+          >>> from sklearn.datasets import make_friedman1
+          >>> from sklearn.linear_model import LinearRegression
+          >>> X, y = make_friedman1()
+          >>> est = LinearRegression().fit(X, y)
+          >>> disp1 = plot_partial_dependence(est, X)  # doctest: +SKIP
+          >>> disp2 = plot_partial_dependence(est, X,
+          ...                                 ax=disp1.axes_)  # doctest: +SKIP
+
     Read more in the :ref:`User Guide <partial_dependence>`.
 
     Parameters

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -933,8 +933,11 @@ class PartialDependenceDisplay:
             ylim = axi.get_ylim()
             axi.vlines(self.deciles[fx[0]], 0, 0.05, transform=trans,
                        color='k')
-            axi.set_xlabel(self.feature_names[fx[0]])
             axi.set_ylim(ylim)
+
+            # Set xlabel if it is not already set
+            if not axi.get_xlabel():
+                axi.set_xlabel(self.feature_names[fx[0]])
 
             if len(values) == 1:
                 if n_cols is None or i % n_cols == 0:

--- a/sklearn/inspection/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/tests/test_plot_partial_dependence.py
@@ -15,6 +15,12 @@ from sklearn.utils._testing import _convert_container
 from sklearn.inspection import plot_partial_dependence
 
 
+# TODO: Remove when https://github.com/numpy/numpy/issues/14397 is resolved
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:In future, it will be an error for 'np.bool_':DeprecationWarning:"
+    "matplotlib.*")
+
+
 @pytest.fixture(scope="module")
 def boston():
     return load_boston()

--- a/sklearn/inspection/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/tests/test_plot_partial_dependence.py
@@ -10,6 +10,8 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.linear_model import LinearRegression
+from sklearn.utils._testing import _convert_container
+
 from sklearn.inspection import plot_partial_dependence
 
 
@@ -86,12 +88,15 @@ def test_plot_partial_dependence(grid_resolution, pyplot, clf_boston, boston):
 
 
 @pytest.mark.parametrize(
-    "input_type, use_feature_names",
-    [('dataframe', False), ('dataframe', True),
-     ('list', True), ('array', True)]
+    "input_type, feature_names_type",
+    [('dataframe', None),
+     ('dataframe', 'list'), ('list', 'list'), ('array', 'list'),
+     ('dataframe', 'array'), ('list', 'array'), ('array', 'array'),
+     ('dataframe', 'series'), ('list', 'series'), ('array', 'series'),
+     ('dataframe', 'index'), ('list', 'index'), ('array', 'index')]
 )
 def test_plot_partial_dependence_str_features(pyplot, clf_boston, boston,
-                                              input_type, use_feature_names):
+                                              input_type, feature_names_type):
     if input_type == 'dataframe':
         pd = pytest.importorskip("pandas")
         X = pd.DataFrame(boston.data, columns=boston.feature_names)
@@ -99,7 +104,12 @@ def test_plot_partial_dependence_str_features(pyplot, clf_boston, boston,
         X = boston.data.tolist()
     else:
         X = boston.data
-    feature_names = boston.feature_names if use_feature_names else None
+
+    if feature_names_type is None:
+        feature_names = None
+    else:
+        feature_names = _convert_container(boston.feature_names,
+                                           feature_names_type)
 
     grid_resolution = 25
     # check with str features and array feature names and single column

--- a/sklearn/inspection/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/tests/test_plot_partial_dependence.py
@@ -256,6 +256,24 @@ def test_plot_partial_dependence_with_same_axes(pyplot, clf_boston, boston):
                                 feature_names=boston.feature_names, ax=ax)
 
 
+def test_plot_partial_dependence_feature_name_reuse(pyplot, clf_boston,
+                                                    boston):
+    # second call to plot does not change the feature names from the first
+    # call
+
+    feature_names = boston.feature_names
+    disp = plot_partial_dependence(clf_boston, boston.data,
+                                   [0, 1],
+                                   grid_resolution=10,
+                                   feature_names=feature_names)
+
+    plot_partial_dependence(clf_boston, boston.data, [0, 1],
+                            grid_resolution=10, ax=disp.axes_)
+
+    for i, ax in enumerate(disp.axes_.ravel()):
+        assert ax.get_xlabel() == feature_names[i]
+
+
 def test_plot_partial_dependence_multiclass(pyplot):
     grid_resolution = 25
     clf_int = GradientBoostingClassifier(n_estimators=10, random_state=1)

--- a/sklearn/inspection/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/tests/test_plot_partial_dependence.py
@@ -229,7 +229,16 @@ def test_plot_partial_dependence_incorrent_num_axes(pyplot, clf_boston,
 
 
 def test_plot_partial_dependence_with_same_axes(pyplot, clf_boston, boston):
-    # The first call to `plot_*` will plot the axes
+    # The first call to plot_partial_dependence will create two new axes to
+    # place in the space of the passed in axes, which results in a total of
+    # three axes in the figure.
+    # Currently the API does not allow for the second call to
+    # plot_partial_dependence to use the same axes again, because it will
+    # create two new axes in the space resulting in five axes. To get the
+    # expected behavior one needs to pass the generated axes into the second
+    # call:
+    # disp1 = plot_partial_dependence(...)
+    # disp2 = plot_partial_dependence(..., ax=disp1.axes_)
 
     grid_resolution = 25
     fig, ax = pyplot.subplots()

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -14,6 +14,7 @@ from ..base import RegressorMixin
 from ..utils.extmath import fast_logdet
 from ..utils import check_X_y
 from ..utils.fixes import pinvh
+from ..utils.validation import _check_sample_weight
 
 
 ###############################################################################
@@ -169,7 +170,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
 
         Parameters
         ----------
-        X : ndarray of shape (n_samples,n_features)
+        X : ndarray of shape (n_samples, n_features)
             Training data
         y : ndarray of shape (n_samples,)
             Target values. Will be cast to X's dtype if necessary
@@ -190,6 +191,11 @@ class BayesianRidge(RegressorMixin, LinearModel):
                              ' Got {!r}.'.format(self.n_iter))
 
         X, y = check_X_y(X, y, dtype=np.float64, y_numeric=True)
+
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X,
+                                                 dtype=X.dtype)
+
         X, y, X_offset_, y_offset_, X_scale_ = self._preprocess_data(
             X, y, self.fit_intercept, self.normalize, self.copy_X,
             sample_weight=sample_weight)

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -38,6 +38,12 @@ from ..model_selection import check_cv
 from ..metrics import get_scorer
 
 
+_LOGISTIC_SOLVER_CONVERGENCE_MSG = (
+    "Please also refer to the documentation for alternative solver options:\n"
+    "    https://scikit-learn.org/stable/modules/linear_model.html"
+    "#logistic-regression")
+
+
 # .. some helper functions for logistic_regression_path ..
 def _intercept_dot(w, X, y):
     """Computes y * np.dot(X, w).
@@ -928,7 +934,9 @@ def _logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
                 args=(X, target, 1. / C, sample_weight),
                 options={"iprint": iprint, "gtol": tol, "maxiter": max_iter}
             )
-            n_iter_i = _check_optimize_result(solver, opt_res, max_iter)
+            n_iter_i = _check_optimize_result(
+                solver, opt_res, max_iter,
+                extra_warning_msg=_LOGISTIC_SOLVER_CONVERGENCE_MSG)
             w0, loss = opt_res.x, opt_res.fun
         elif solver == 'newton-cg':
             args = (X, target, 1. / C, sample_weight)

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -320,7 +320,8 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
             raise ValueError("%s does not support sample_weight. Samples"
                              " weights are only used for the calibration"
                              " itself." % estimator_name)
-        sample_weight = _check_sample_weight(sample_weight, X)
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X)
 
         n_inliers_best = 1
         score_best = -np.inf

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -245,15 +245,14 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
     Parameters
     ----------
-    X : {array-like, sparse matrix, LinearOperator},
-        shape = [n_samples, n_features]
+    X : {array-like, sparse matrix, LinearOperator} of shape \
+        (n_samples, n_features)
         Training data
 
     y : array-like of shape (n_samples,) or (n_samples, n_targets)
         Target values
 
-    alpha : {float, array-like},
-        shape = [n_targets] if array-like
+    alpha : float or array-like of shape (n_targets,)
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.
@@ -262,8 +261,9 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         assumed to be specific to the targets. Hence they must correspond in
         number.
 
-    sample_weight : float or numpy array of shape (n_samples,), default=None
-        Individual weights for each sample. If sample_weight is not None and
+    sample_weight : float or array-like of shape (n_samples,), default=None
+        Individual weights for each sample. If given a float, every sample
+        will have the same weight. If sample_weight is not None and
         solver='auto', the solver will be set to 'cholesky'.
 
         .. versionadded:: 0.17
@@ -349,14 +349,14 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
 
     Returns
     -------
-    coef : array, shape = [n_features] or [n_targets, n_features]
+    coef : array of shape (n_features,) or (n_targets, n_features)
         Weight vector(s).
 
     n_iter : int, optional
         The actual number of iteration performed by the solver.
         Only returned if `return_n_iter` is True.
 
-    intercept : float or array, shape = [n_targets]
+    intercept : float or array of shape (n_targets,)
         The intercept of the model. Only returned if `return_intercept`
         is True and if X is a scipy sparse array.
 
@@ -364,7 +364,6 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     -----
     This function won't compute the intercept.
     """
-
     return _ridge_regression(X, y, alpha,
                              sample_weight=sample_weight,
                              solver=solver,
@@ -566,9 +565,9 @@ class _BaseRidge(LinearModel, metaclass=ABCMeta):
         else:
             solver = self.solver
 
-        if ((sample_weight is not None) and
-                np.asarray(sample_weight).ndim > 1):
-            raise ValueError("Sample weights must be 1D array or scalar")
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X,
+                                                 dtype=X.dtype)
 
         # when X is sparse we only remove offset from y
         X, y, X_offset, y_offset, X_scale = self._preprocess_data(
@@ -613,7 +612,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
     the linear least squares function and regularization is given by
     the l2-norm. Also known as Ridge Regression or Tikhonov regularization.
     This estimator has built-in support for multi-variate regression
-    (i.e., when y is a 2d-array of shape [n_samples, n_targets]).
+    (i.e., when y is a 2d-array of shape (n_samples, n_targets)).
 
     Read more in the :ref:`User Guide <ridge_regression>`.
 
@@ -701,14 +700,14 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
 
     Attributes
     ----------
-    coef_ : array, shape (n_features,) or (n_targets, n_features)
+    coef_ : array of shape (n_features,) or (n_targets, n_features)
         Weight vector(s).
 
-    intercept_ : float | array, shape = (n_targets,)
+    intercept_ : float or array of shape (n_targets,)
         Independent term in decision function. Set to 0.0 if
         ``fit_intercept = False``.
 
-    n_iter_ : array or None, shape (n_targets,)
+    n_iter_ : None or array of shape (n_targets,)
         Actual number of iterations for each target. Available only for
         sag and lsqr solvers. Other solvers will return None.
 
@@ -732,8 +731,8 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
     >>> clf = Ridge(alpha=1.0)
     >>> clf.fit(X, y)
     Ridge()
-
     """
+
     def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
                  copy_X=True, max_iter=None, tol=1e-3, solver="auto",
                  random_state=None):
@@ -744,7 +743,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
             random_state=random_state)
 
     def fit(self, X, y, sample_weight=None):
-        """Fit Ridge regression model
+        """Fit Ridge regression model.
 
         Parameters
         ----------
@@ -754,8 +753,9 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Target values
 
-        sample_weight : float or numpy array of shape [n_samples]
-            Individual weights for each sample
+        sample_weight : float or array-like of shape (n_samples,), default=None
+            Individual weights for each sample. If given a float, every sample
+            will have the same weight.
 
         Returns
         -------
@@ -856,16 +856,16 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
     Attributes
     ----------
-    coef_ : array, shape (1, n_features) or (n_classes, n_features)
+    coef_ : array of shape (1, n_features) or (n_classes, n_features)
         Coefficient of the features in the decision function.
 
         ``coef_`` is of shape (1, n_features) when the given problem is binary.
 
-    intercept_ : float | array, shape = (n_targets,)
+    intercept_ : float or array of shape (n_targets,)
         Independent term in decision function. Set to 0.0 if
         ``fit_intercept = False``.
 
-    n_iter_ : array or None, shape (n_targets,)
+    n_iter_ : None or array of shape (n_targets,)
         Actual number of iterations for each target. Available only for
         sag and lsqr solvers. Other solvers will return None.
 
@@ -903,7 +903,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         self.class_weight = class_weight
 
     def fit(self, X, y, sample_weight=None):
-        """Fit Ridge regression model.
+        """Fit Ridge classifier model.
 
         Parameters
         ----------
@@ -913,8 +913,9 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         y : array-like of shape (n_samples,)
             Target values.
 
-        sample_weight : {float, array-like of shape (n_samples,)}, default=None
-            Sample weight.
+        sample_weight : float or array-like of shape (n_samples,), default=None
+            Individual weights for each sample. If given a float, every sample
+            will have the same weight.
 
             .. versionadded:: 0.17
                *sample_weight* support to Classifier.
@@ -926,7 +927,9 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         """
         _accept_sparse = _get_valid_accept_sparse(sparse.issparse(X),
                                                   self.solver)
-        check_X_y(X, y, accept_sparse=_accept_sparse, multi_output=True)
+        X, y = check_X_y(X, y, accept_sparse=_accept_sparse, multi_output=True,
+                         y_numeric=False)
+        sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 
         self._label_binarizer = LabelBinarizer(pos_label=1, neg_label=-1)
         Y = self._label_binarizer.fit_transform(y)
@@ -939,8 +942,6 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
                     self.__class__.__name__))
 
         if self.class_weight:
-            if sample_weight is None:
-                sample_weight = 1.
             # modify the sample weights with the corresponding class weight
             sample_weight = (sample_weight *
                              compute_sample_weight(self.class_weight, y))
@@ -976,10 +977,10 @@ def _find_smallest_angle(query, vectors):
 
     Parameters
     ----------
-    query : ndarray, shape (n_samples,)
+    query : ndarray of shape (n_samples,)
         Normalized query vector.
 
-    vectors : ndarray, shape (n_samples, n_features)
+    vectors : ndarray of shape (n_samples, n_features)
         Vectors to which we compare query, as columns. Must be normalized.
     """
     abs_cosine = np.abs(query.dot(vectors))
@@ -1120,17 +1121,17 @@ class _RidgeGCV(LinearModel):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The preprocessed design matrix.
 
-        sqrt_sw : ndarray, shape (n_samples,)
+        sqrt_sw : ndarray of shape (n_samples,)
             square roots of sample weights
 
         Returns
         -------
-        gram : ndarray, shape (n_samples, n_samples)
+        gram : ndarray of shape (n_samples, n_samples)
             The Gram matrix.
-        X_mean : ndarray, shape (n_feature,)
+        X_mean : ndarray of shape (n_feature,)
             The weighted mean of ``X`` for each feature.
 
         Notes
@@ -1170,17 +1171,17 @@ class _RidgeGCV(LinearModel):
 
         Parameters
         ----------
-        X : sparse matrix, shape (n_samples, n_features)
+        X : sparse matrix of shape (n_samples, n_features)
             The preprocessed design matrix.
 
-        sqrt_sw : ndarray, shape (n_samples,)
+        sqrt_sw : ndarray of shape (n_samples,)
             square roots of sample weights
 
         Returns
         -------
-        covariance : ndarray, shape (n_features, n_features)
+        covariance : ndarray of shape (n_features, n_features)
             The covariance matrix.
-        X_mean : ndarray, shape (n_feature,)
+        X_mean : ndarray of shape (n_feature,)
             The weighted mean of ``X`` for each feature.
 
         Notes
@@ -1219,16 +1220,16 @@ class _RidgeGCV(LinearModel):
         ----------
         X : sparse matrix of shape (n_samples, n_features)
 
-        A : np.ndarray, shape = (n_features, n_features)
+        A : ndarray of shape (n_features, n_features)
 
-        X_mean : np.ndarray, shape = (n_features,)
+        X_mean : ndarray of shape (n_features,)
 
-        sqrt_sw : np.ndarray, shape = (n_features,)
+        sqrt_sw : ndarray of shape (n_features,)
             square roots of sample weights
 
         Returns
         -------
-        diag : np.ndarray, shape = (n_samples,)
+        diag : np.ndarray, shape (n_samples,)
             The computed diagonal.
         """
         intercept_col = scale = sqrt_sw
@@ -1249,7 +1250,7 @@ class _RidgeGCV(LinearModel):
         return diag
 
     def _eigen_decompose_gram(self, X, y, sqrt_sw):
-        """Eigendecomposition of X.X^T, used when n_samples <= n_features"""
+        """Eigendecomposition of X.X^T, used when n_samples <= n_features."""
         # if X is dense it has already been centered in preprocessing
         K, X_mean = self._compute_gram(X, sqrt_sw)
         if self.fit_intercept:
@@ -1263,7 +1264,7 @@ class _RidgeGCV(LinearModel):
         return X_mean, eigvals, Q, QT_y
 
     def _solve_eigen_gram(self, alpha, y, sqrt_sw, X_mean, eigvals, Q, QT_y):
-        """Compute dual coefficients and diagonal of G^-1
+        """Compute dual coefficients and diagonal of G^-1.
 
         Used when we have a decomposition of X.X^T (n_samples <= n_features).
         """
@@ -1329,7 +1330,7 @@ class _RidgeGCV(LinearModel):
 
     def _solve_eigen_covariance_intercept(
             self, alpha, y, sqrt_sw, X_mean, eigvals, V, X):
-        """Compute dual coefficients and diagonal of G^-1
+        """Compute dual coefficients and diagonal of G^-1.
 
         Used when we have a decomposition of X^T.X
         (n_samples > n_features and X is sparse),
@@ -1359,7 +1360,7 @@ class _RidgeGCV(LinearModel):
 
     def _solve_eigen_covariance(
             self, alpha, y, sqrt_sw, X_mean, eigvals, V, X):
-        """Compute dual coefficients and diagonal of G^-1
+        """Compute dual coefficients and diagonal of G^-1.
 
         Used when we have a decomposition of X^T.X
         (n_samples > n_features and X is sparse).
@@ -1386,7 +1387,7 @@ class _RidgeGCV(LinearModel):
 
     def _solve_svd_design_matrix(
             self, alpha, y, sqrt_sw, X_mean, singvals_sq, U, UT_y):
-        """Compute dual coefficients and diagonal of G^-1
+        """Compute dual coefficients and diagonal of G^-1.
 
         Used when we have an SVD decomposition of X
         (n_samples > n_features and X is dense).
@@ -1406,33 +1407,35 @@ class _RidgeGCV(LinearModel):
         return G_inverse_diag, c
 
     def fit(self, X, y, sample_weight=None):
-        """Fit Ridge regression model
+        """Fit Ridge regression model with gcv.
 
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Training data. Will be cast to float64 if necessary
+            Training data. Will be cast to float64 if necessary.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            Target values. Will be cast to float64 if necessary
+            Target values. Will be cast to float64 if necessary.
 
-        sample_weight : float or array-like of shape [n_samples]
-            Sample weight
+        sample_weight : float or array-like of shape (n_samples,), default=None
+            Individual weights for each sample. If given a float, every sample
+            will have the same weight.
 
         Returns
         -------
         self : object
         """
-        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'],
-                         dtype=[np.float64],
+        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=[np.float64],
                          multi_output=True, y_numeric=True)
+
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X,
+                                                 dtype=X.dtype)
 
         if np.any(self.alphas <= 0):
             raise ValueError(
                 "alphas must be positive. Got {} containing some "
                 "negative or null value instead.".format(self.alphas))
-
-        sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 
         n_samples, n_features = X.shape
 
@@ -1525,7 +1528,7 @@ class _BaseRidgeCV(LinearModel):
         self.store_cv_values = store_cv_values
 
     def fit(self, X, y, sample_weight=None):
-        """Fit Ridge regression model
+        """Fit Ridge regression model with cv.
 
         Parameters
         ----------
@@ -1534,10 +1537,11 @@ class _BaseRidgeCV(LinearModel):
             if necessary.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            Target values. Will be cast to X's dtype if necessary
+            Target values. Will be cast to X's dtype if necessary.
 
-        sample_weight : float or array-like of shape [n_samples]
-            Sample weight
+        sample_weight : float or array-like of shape (n_samples,), default=None
+            Individual weights for each sample. If given a float, every sample
+            will have the same weight.
 
         Returns
         -------
@@ -1595,7 +1599,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape (n_alphas,), default=(0.1, 1.0, 10.0)
+    alphas : ndarray of shape (n_alphas,), default=(0.1, 1.0, 10.0)
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
@@ -1661,17 +1665,17 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     Attributes
     ----------
-    cv_values_ : array, shape = [n_samples, n_alphas] or \
-        shape = [n_samples, n_targets, n_alphas], optional
+    cv_values_ : array of shape (n_samples, n_alphas) or \
+        shape (n_samples, n_targets, n_alphas), optional
         Cross-validation values for each alpha (if ``store_cv_values=True``\
         and ``cv=None``). After ``fit()`` has been called, this attribute \
         will contain the mean squared errors (by default) or the values \
         of the ``{loss,score}_func`` function (if provided in the constructor).
 
-    coef_ : array, shape = [n_features] or [n_targets, n_features]
+    coef_ : array of shape (n_features) or (n_targets, n_features)
         Weight vector(s).
 
-    intercept_ : float | array, shape = (n_targets,)
+    intercept_ : float or array of shape (n_targets,)
         Independent term in decision function. Set to 0.0 if
         ``fit_intercept = False``.
 
@@ -1709,7 +1713,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Parameters
     ----------
-    alphas : numpy array of shape (n_alphas,), default=(0.1, 1.0, 10.0)
+    alphas : ndarray of shape (n_alphas,), default=(0.1, 1.0, 10.0)
         Array of alpha values to try.
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
@@ -1763,19 +1767,19 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Attributes
     ----------
-    cv_values_ : array, shape = [n_samples, n_targets, n_alphas], optional
+    cv_values_ : array of shape (n_samples, n_targets, n_alphas), optional
         Cross-validation values for each alpha (if ``store_cv_values=True`` and
         ``cv=None``). After ``fit()`` has been called, this attribute will
         contain the mean squared errors (by default) or the values of the
         ``{loss,score}_func`` function (if provided in the constructor). This
         attribute exists only when ``store_cv_values`` is True.
 
-    coef_ : array, shape (1, n_features) or (n_targets, n_features)
+    coef_ : array of shape (1, n_features) or (n_targets, n_features)
         Coefficient of the features in the decision function.
 
         ``coef_`` is of shape (1, n_features) when the given problem is binary.
 
-    intercept_ : float | array, shape = (n_targets,)
+    intercept_ : float or array of shape (n_targets,)
         Independent term in decision function. Set to 0.0 if
         ``fit_intercept = False``.
 
@@ -1816,27 +1820,29 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         self.class_weight = class_weight
 
     def fit(self, X, y, sample_weight=None):
-        """Fit the ridge classifier.
+        """Fit Ridge classifier with cv.
 
         Parameters
         ----------
-        X : array-like, shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features)
             Training vectors, where n_samples is the number of samples
             and n_features is the number of features. When using GCV,
             will be cast to float64 if necessary.
 
-        y : array-like, shape (n_samples,)
-            Target values. Will be cast to X's dtype if necessary
+        y : array-like of shape (n_samples,)
+            Target values. Will be cast to X's dtype if necessary.
 
-        sample_weight : {float, array-like of shape (n_samples,)}, default=None
-            Sample weight.
+        sample_weight : float or array-like of shape (n_samples,), default=None
+            Individual weights for each sample. If given a float, every sample
+            will have the same weight.
 
         Returns
         -------
         self : object
         """
-        check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
-                  multi_output=True)
+        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
+                         multi_output=True, y_numeric=False)
+        sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 
         self._label_binarizer = LabelBinarizer(pos_label=1, neg_label=-1)
         Y = self._label_binarizer.fit_transform(y)
@@ -1844,8 +1850,6 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
             y = column_or_1d(y, warn=True)
 
         if self.class_weight:
-            if sample_weight is None:
-                sample_weight = 1.
             # modify the sample weights with the corresponding class weight
             sample_weight = (sample_weight *
                              compute_sample_weight(self.class_weight, y))

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -209,7 +209,7 @@ def test_ard_accuracy_on_easy_problem():
     X = np.random.RandomState(seed=seed).normal(size=(250, 3))
     y = X[:, 1]
 
-    regressor = ARDRegression()
+    regressor = ARDRegression(n_iter=600)
     regressor.fit(X, y)
 
     abs_coef_error = np.abs(1 - regressor.coef_[1])

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -31,7 +31,6 @@ from sklearn.preprocessing import scale
 from sklearn.utils._testing import skip_if_no_parallel
 
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.exceptions import ChangedBehaviorWarning
 from sklearn.linear_model._logistic import (
     LogisticRegression,
     logistic_regression_path,
@@ -391,12 +390,19 @@ def test_logistic_regression_path_convergence_fail():
     y = [1] * 100 + [-1] * 100
     Cs = [1e3]
 
-    msg = (r"lbfgs failed to converge.+Increase the number of iterations or "
-           r"scale the data")
-
-    with pytest.warns(ConvergenceWarning, match=msg):
+    # Check that the convergence message points to both a model agnostic
+    # advice (scaling the data) and to the logistic regression specific
+    # documentation that includes hints on the solver configuration.
+    with pytest.warns(ConvergenceWarning) as record:
         _logistic_regression_path(
             X, y, Cs=Cs, tol=0., max_iter=1, random_state=0, verbose=0)
+
+    assert len(record) == 1
+    warn_msg = record[0].message.args[0]
+    assert "lbfgs failed to converge" in warn_msg
+    assert "Increase the number of iterations" in warn_msg
+    assert "scale the data" in warn_msg
+    assert "linear_model.html#logistic-regression" in warn_msg
 
 
 def test_liblinear_dual_random_state():

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -390,8 +390,13 @@ def test_logistic_regression_path_convergence_fail():
     X = np.concatenate((rng.randn(100, 2) + [1, 1], rng.randn(100, 2)))
     y = [1] * 100 + [-1] * 100
     Cs = [1e3]
-    assert_warns(ConvergenceWarning, _logistic_regression_path,
-                 X, y, Cs=Cs, tol=0., max_iter=1, random_state=0, verbose=1)
+
+    msg = (r"lbfgs failed to converge.+Increase the number of iterations or "
+           r"scale the data")
+
+    with pytest.warns(ConvergenceWarning, match=msg):
+        _logistic_regression_path(
+            X, y, Cs=Cs, tol=0., max_iter=1, random_state=0, verbose=0)
 
 
 def test_liblinear_dual_random_state():

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -82,6 +82,9 @@ from ._plot.roc_curve import RocCurveDisplay
 from ._plot.precision_recall_curve import plot_precision_recall_curve
 from ._plot.precision_recall_curve import PrecisionRecallDisplay
 
+from ._plot.confusion_matrix import plot_confusion_matrix
+from ._plot.confusion_matrix import ConfusionMatrixDisplay
+
 
 __all__ = [
     'accuracy_score',
@@ -97,6 +100,7 @@ __all__ = [
     'cluster',
     'cohen_kappa_score',
     'completeness_score',
+    'ConfusionMatrixDisplay',
     'confusion_matrix',
     'consensus_score',
     'coverage_error',
@@ -137,6 +141,7 @@ __all__ = [
     'pairwise_distances_argmin_min',
     'pairwise_distances_chunked',
     'pairwise_kernels',
+    'plot_confusion_matrix',
     'plot_precision_recall_curve',
     'plot_roc_curve',
     'PrecisionRecallDisplay',

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -117,9 +117,9 @@ class ConfusionMatrixDisplay:
         return self
 
 
-def plot_confusion_matrix(estimator, X, y_true, sample_weight=None,
-                          labels=None, display_labels=None,
-                          include_values=True, normalize=None,
+def plot_confusion_matrix(estimator, X, y_true, labels=None,
+                          sample_weight=None, normalize=None,
+                          display_labels=None, include_values=True,
                           xticks_rotation='horizontal',
                           values_format=None,
                           cmap='viridis', ax=None):
@@ -138,13 +138,18 @@ def plot_confusion_matrix(estimator, X, y_true, sample_weight=None,
     y : array-like of shape (n_samples,)
         Target values.
 
-    sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights.
-
     labels : array-like of shape (n_classes,), default=None
         List of labels to index the matrix. This may be used to reorder or
         select a subset of labels. If `None` is given, those that appear at
         least once in `y_true` or `y_pred` are used in sorted order.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    normalize : {'true', 'pred', 'all'}, default=None
+        Normalizes confusion matrix over the true (rows), predicted (columns)
+        conditions or all the population. If None, confusion matrix will not be
+        normalized.
 
     display_labels : array-like of shape (n_classes,), default=None
         Target names used for plotting. By default, `labels` will be used if
@@ -153,11 +158,6 @@ def plot_confusion_matrix(estimator, X, y_true, sample_weight=None,
 
     include_values : bool, default=True
         Includes values in confusion matrix.
-
-    normalize : {'true', 'pred', 'all'}, default=None
-        Normalizes confusion matrix over the true (rows), predicted (columns)
-        conditions or all the population. If None, confusion matrix will not be
-        normalized.
 
     xticks_rotation : {'vertical', 'horizontal'} or float, \
                         default='vertical'

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -1,0 +1,211 @@
+from itertools import product
+
+import numpy as np
+
+from .. import confusion_matrix
+from ...utils import check_matplotlib_support
+from ...base import is_classifier
+
+
+class ConfusionMatrixDisplay:
+    """Confusion Matrix visualization.
+
+    It is recommend to use :func:`~sklearn.metrics.plot_confusion_matrix` to
+    create a :class:`ConfusionMatrixDisplay`. All parameters are stored as
+    attributes.
+
+    Read more in the :ref:`User Guide <visualizations>`.
+
+    Parameters
+    ----------
+    confusion_matrix : ndarray of shape (n_classes, n_classes)
+        Confusion matrix.
+
+    display_labels : ndarray of shape (n_classes,)
+        Display labels for plot.
+
+    Attributes
+    ----------
+    im_ : matplotlib AxesImage
+        Image representing the confusion matrix.
+
+    text_ : ndarray of shape (n_classes, n_classes), dtype=matplotlib Text, \
+            or None
+        Array of matplotlib axes. `None` if `include_values` is false.
+
+    ax_ : matplotlib Axes
+        Axes with confusion matrix.
+
+    figure_ : matplotlib Figure
+        Figure containing the confusion matrix.
+    """
+    def __init__(self, confusion_matrix, display_labels):
+        self.confusion_matrix = confusion_matrix
+        self.display_labels = display_labels
+
+    def plot(self, include_values=True, cmap='viridis',
+             xticks_rotation='horizontal', values_format=None, ax=None):
+        """Plot visualization.
+
+        Parameters
+        ----------
+        include_values : bool, default=True
+            Includes values in confusion matrix.
+
+        cmap : str or matplotlib Colormap, default='viridis'
+            Colormap recognized by matplotlib.
+
+        xticks_rotation : {'vertical', 'horizontal'} or float, \
+                         default='vertical'
+            Rotation of xtick labels.
+
+        values_format : str, default=None
+            Format specification for values in confusion matrix. If `None`,
+            the format specification is '.2f' for a normalized matrix, and
+            'd' for a unnormalized matrix.
+
+        ax : matplotlib axes, default=None
+            Axes object to plot on. If `None`, a new figure and axes is
+            created.
+
+        Returns
+        -------
+        display : :class:`~sklearn.metrics.ConfusionMatrixDisplay`
+        """
+        check_matplotlib_support("ConfusionMatrixDisplay.plot")
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.figure
+
+        cm = self.confusion_matrix
+        n_classes = cm.shape[0]
+        self.im_ = ax.imshow(cm, interpolation='nearest', cmap=cmap)
+        self.text_ = None
+
+        cmap_min, cmap_max = self.im_.cmap(0), self.im_.cmap(256)
+
+        if include_values:
+            self.text_ = np.empty_like(cm, dtype=object)
+            if values_format is None:
+                values_format = '.2g'
+
+            # print text with appropriate color depending on background
+            thresh = (cm.max() - cm.min()) / 2.
+            for i, j in product(range(n_classes), range(n_classes)):
+                color = cmap_max if cm[i, j] < thresh else cmap_min
+                self.text_[i, j] = ax.text(j, i,
+                                           format(cm[i, j], values_format),
+                                           ha="center", va="center",
+                                           color=color)
+
+        fig.colorbar(self.im_, ax=ax)
+        ax.set(xticks=np.arange(n_classes),
+               yticks=np.arange(n_classes),
+               xticklabels=self.display_labels,
+               yticklabels=self.display_labels,
+               ylabel="True label",
+               xlabel="Predicted label")
+
+        ax.set_ylim((n_classes - 0.5, -0.5))
+        plt.setp(ax.get_xticklabels(), rotation=xticks_rotation)
+
+        self.figure_ = fig
+        self.ax_ = ax
+        return self
+
+
+def plot_confusion_matrix(estimator, X, y_true, sample_weight=None,
+                          labels=None, display_labels=None,
+                          include_values=True, normalize=None,
+                          xticks_rotation='horizontal',
+                          values_format=None,
+                          cmap='viridis', ax=None):
+    """Plot Confusion Matrix.
+
+    Read more in the :ref:`User Guide <confusion_matrix>`.
+
+    Parameters
+    ----------
+    estimator : estimator instance
+        Trained classifier.
+
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        Input values.
+
+    y : array-like of shape (n_samples,)
+        Target values.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    labels : array-like of shape (n_classes,), default=None
+        List of labels to index the matrix. This may be used to reorder or
+        select a subset of labels. If `None` is given, those that appear at
+        least once in `y_true` or `y_pred` are used in sorted order.
+
+    display_labels : array-like of shape (n_classes,), default=None
+        Target names used for plotting. By default, `labels` will be used if
+        it is defined, otherwise the unique labels of `y_true` and `y_pred`
+        will be used.
+
+    include_values : bool, default=True
+        Includes values in confusion matrix.
+
+    normalize : {'true', 'pred', 'all'}, default=None
+        Normalizes confusion matrix over the true (rows), predicited (columns)
+        conditions or all the population. If None, confusion matrix will not be
+        normalized.
+
+    xticks_rotation : {'vertical', 'horizontal'} or float, \
+                        default='vertical'
+        Rotation of xtick labels.
+
+    values_format : str, default=None
+        Format specification for values in confusion matrix. If `None`,
+        the format specification is '.2f' for a normalized matrix, and
+        'd' for a unnormalized matrix.
+
+    cmap : str or matplotlib Colormap, default='viridis'
+        Colormap recognized by matplotlib.
+
+    ax : matplotlib Axes, default=None
+        Axes object to plot on. If `None`, a new figure and axes is
+        created.
+
+    Returns
+    -------
+    display : :class:`~sklearn.metrics.ConfusionMatrixDisplay`
+    """
+    check_matplotlib_support("plot_confusion_matrix")
+
+    if not is_classifier(estimator):
+        raise ValueError("plot_confusion_matrix only supports classifiers")
+
+    if normalize not in {'true', 'pred', 'all', None}:
+        raise ValueError("normalize must be one of {'true', 'pred', "
+                         "'all', None}")
+
+    y_pred = estimator.predict(X)
+    cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight,
+                          labels=labels)
+
+    if normalize == 'true':
+        cm = cm / cm.sum(axis=1, keepdims=True)
+    elif normalize == 'pred':
+        cm = cm / cm.sum(axis=0, keepdims=True)
+    elif normalize == 'all':
+        cm = cm / cm.sum()
+
+    if display_labels is None:
+        if labels is None:
+            display_labels = estimator.classes_
+        else:
+            display_labels = labels
+
+    disp = ConfusionMatrixDisplay(confusion_matrix=cm,
+                                  display_labels=display_labels)
+    return disp.plot(include_values=include_values,
+                     cmap=cmap, ax=ax, xticks_rotation=xticks_rotation)

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -155,7 +155,7 @@ def plot_confusion_matrix(estimator, X, y_true, sample_weight=None,
         Includes values in confusion matrix.
 
     normalize : {'true', 'pred', 'all'}, default=None
-        Normalizes confusion matrix over the true (rows), predicited (columns)
+        Normalizes confusion matrix over the true (rows), predicted (columns)
         conditions or all the population. If None, confusion matrix will not be
         normalized.
 
@@ -190,14 +190,7 @@ def plot_confusion_matrix(estimator, X, y_true, sample_weight=None,
 
     y_pred = estimator.predict(X)
     cm = confusion_matrix(y_true, y_pred, sample_weight=sample_weight,
-                          labels=labels)
-
-    if normalize == 'true':
-        cm = cm / cm.sum(axis=1, keepdims=True)
-    elif normalize == 'pred':
-        cm = cm / cm.sum(axis=0, keepdims=True)
-    elif normalize == 'all':
-        cm = cm / cm.sum()
+                          labels=labels, normalize=normalize)
 
     if display_labels is None:
         if labels is None:

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -16,6 +16,11 @@ from sklearn.metrics import plot_confusion_matrix
 from sklearn.metrics import ConfusionMatrixDisplay
 
 
+# TODO: Remove when https://github.com/numpy/numpy/issues/14397 is resolved
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:In future, it will be an error for 'np.bool_':DeprecationWarning:"
+    "matplotlib.*")
+
 @pytest.fixture(scope="module")
 def n_classes():
     return 5

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -1,0 +1,228 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from numpy.testing import assert_array_equal
+
+from sklearn.compose import make_column_transformer
+from sklearn.datasets import make_classification
+from sklearn.exceptions import NotFittedError
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.svm import SVC, SVR
+
+from sklearn.metrics import confusion_matrix
+from sklearn.metrics import plot_confusion_matrix
+from sklearn.metrics import ConfusionMatrixDisplay
+
+
+@pytest.fixture(scope="module")
+def n_classes():
+    return 5
+
+
+@pytest.fixture(scope="module")
+def data(n_classes):
+    X, y = make_classification(n_samples=100, n_informative=5,
+                               n_classes=n_classes, random_state=0)
+    return X, y
+
+
+@pytest.fixture(scope="module")
+def fitted_clf(data):
+    return SVC(kernel='linear', C=0.01).fit(*data)
+
+
+@pytest.fixture(scope="module")
+def y_pred(data, fitted_clf):
+    X, _ = data
+    return fitted_clf.predict(X)
+
+
+def test_error_on_regressor(pyplot, data):
+    X, y = data
+    est = SVR().fit(X, y)
+
+    msg = "plot_confusion_matrix only supports classifiers"
+    with pytest.raises(ValueError, match=msg):
+        plot_confusion_matrix(est, X, y)
+
+
+def test_error_on_invalid_option(pyplot, fitted_clf, data):
+    X, y = data
+    msg = (r"normalize must be one of \{'true', 'pred', 'all', "
+           r"None\}")
+
+    with pytest.raises(ValueError, match=msg):
+        plot_confusion_matrix(fitted_clf, X, y, normalize='invalid')
+
+
+@pytest.mark.parametrize("with_labels", [True, False])
+@pytest.mark.parametrize("with_display_labels", [True, False])
+def test_plot_confusion_matrix_custom_labels(pyplot, data, y_pred, fitted_clf,
+                                             n_classes, with_labels,
+                                             with_display_labels):
+    X, y = data
+    ax = pyplot.gca()
+    labels = [2, 1, 0, 3, 4] if with_labels else None
+    display_labels = ['b', 'd', 'a', 'e', 'f'] if with_display_labels else None
+
+    cm = confusion_matrix(y, y_pred, labels=labels)
+    disp = plot_confusion_matrix(fitted_clf, X, y,
+                                 ax=ax, display_labels=display_labels,
+                                 labels=labels)
+
+    assert_allclose(disp.confusion_matrix, cm)
+
+    if with_display_labels:
+        expected_display_labels = display_labels
+    elif with_labels:
+        expected_display_labels = labels
+    else:
+        expected_display_labels = list(range(n_classes))
+
+    expected_display_labels_str = [str(name)
+                                   for name in expected_display_labels]
+
+    x_ticks = [tick.get_text() for tick in disp.ax_.get_xticklabels()]
+    y_ticks = [tick.get_text() for tick in disp.ax_.get_yticklabels()]
+
+    assert_array_equal(disp.display_labels, expected_display_labels)
+    assert_array_equal(x_ticks, expected_display_labels_str)
+    assert_array_equal(y_ticks, expected_display_labels_str)
+
+
+@pytest.mark.parametrize("normalize", ['true', 'pred', 'all', None])
+@pytest.mark.parametrize("include_values", [True, False])
+def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
+                               normalize, include_values):
+    X, y = data
+    ax = pyplot.gca()
+    cmap = 'plasma'
+    cm = confusion_matrix(y, y_pred)
+    disp = plot_confusion_matrix(fitted_clf, X, y,
+                                 normalize=normalize,
+                                 cmap=cmap, ax=ax,
+                                 include_values=include_values)
+
+    assert disp.ax_ == ax
+
+    if normalize == 'true':
+        cm = cm / cm.sum(axis=1, keepdims=True)
+    elif normalize == 'pred':
+        cm = cm / cm.sum(axis=0, keepdims=True)
+    elif normalize == 'all':
+        cm = cm / cm.sum()
+
+    assert_allclose(disp.confusion_matrix, cm)
+    import matplotlib as mpl
+    assert isinstance(disp.im_, mpl.image.AxesImage)
+    assert disp.im_.get_cmap().name == cmap
+    assert isinstance(disp.ax_, pyplot.Axes)
+    assert isinstance(disp.figure_, pyplot.Figure)
+
+    assert disp.ax_.get_ylabel() == "True label"
+    assert disp.ax_.get_xlabel() == "Predicted label"
+
+    x_ticks = [tick.get_text() for tick in disp.ax_.get_xticklabels()]
+    y_ticks = [tick.get_text() for tick in disp.ax_.get_yticklabels()]
+
+    expected_display_labels = list(range(n_classes))
+
+    expected_display_labels_str = [str(name)
+                                   for name in expected_display_labels]
+
+    assert_array_equal(disp.display_labels, expected_display_labels)
+    assert_array_equal(x_ticks, expected_display_labels_str)
+    assert_array_equal(y_ticks, expected_display_labels_str)
+
+    image_data = disp.im_.get_array().data
+    assert_allclose(image_data, cm)
+
+    if include_values:
+        assert disp.text_.shape == (n_classes, n_classes)
+        fmt = '.2g'
+        expected_text = np.array([format(v, fmt) for v in cm.ravel(order="C")])
+        text_text = np.array([
+            t.get_text() for t in disp.text_.ravel(order="C")])
+        assert_array_equal(expected_text, text_text)
+    else:
+        assert disp.text_ is None
+
+
+def test_confusion_matrix_display(pyplot, data, fitted_clf, y_pred, n_classes):
+    X, y = data
+
+    cm = confusion_matrix(y, y_pred)
+    disp = plot_confusion_matrix(fitted_clf, X, y, normalize=None,
+                                 include_values=True, cmap='viridis',
+                                 xticks_rotation=45.0)
+
+    assert_allclose(disp.confusion_matrix, cm)
+    assert disp.text_.shape == (n_classes, n_classes)
+
+    rotations = [tick.get_rotation() for tick in disp.ax_.get_xticklabels()]
+    assert_allclose(rotations, 45.0)
+
+    image_data = disp.im_.get_array().data
+    assert_allclose(image_data, cm)
+
+    disp.plot(cmap='plasma')
+    assert disp.im_.get_cmap().name == 'plasma'
+
+    disp.plot(include_values=False)
+    assert disp.text_ is None
+
+    disp.plot(xticks_rotation=90.0)
+    rotations = [tick.get_rotation() for tick in disp.ax_.get_xticklabels()]
+    assert_allclose(rotations, 90.0)
+
+    disp.plot(values_format='e')
+    expected_text = np.array([format(v, 'e') for v in cm.ravel(order="C")])
+    text_text = np.array([
+        t.get_text() for t in disp.text_.ravel(order="C")])
+    assert_array_equal(expected_text, text_text)
+
+
+def test_confusion_matrix_contrast(pyplot):
+    # make sure text color is appropriate depending on background
+
+    cm = np.eye(2) / 2
+    disp = ConfusionMatrixDisplay(cm, display_labels=[0, 1])
+
+    disp.plot(cmap=pyplot.cm.gray)
+    # diagonal text is black
+    assert_allclose(disp.text_[0, 0].get_color(), [0.0, 0.0, 0.0, 1.0])
+    assert_allclose(disp.text_[1, 1].get_color(), [0.0, 0.0, 0.0, 1.0])
+
+    # oof-diagonal text is white
+    assert_allclose(disp.text_[0, 1].get_color(), [1.0, 1.0, 1.0, 1.0])
+    assert_allclose(disp.text_[1, 0].get_color(), [1.0, 1.0, 1.0, 1.0])
+
+    disp.plot(cmap=pyplot.cm.gray_r)
+    # diagonal text is white
+    assert_allclose(disp.text_[0, 1].get_color(), [0.0, 0.0, 0.0, 1.0])
+    assert_allclose(disp.text_[1, 0].get_color(), [0.0, 0.0, 0.0, 1.0])
+
+    # oof-diagonal text is black
+    assert_allclose(disp.text_[0, 0].get_color(), [1.0, 1.0, 1.0, 1.0])
+    assert_allclose(disp.text_[1, 1].get_color(), [1.0, 1.0, 1.0, 1.0])
+
+
+@pytest.mark.parametrize(
+    "clf", [LogisticRegression(),
+            make_pipeline(StandardScaler(), LogisticRegression()),
+            make_pipeline(make_column_transformer((StandardScaler(), [0, 1])),
+                          LogisticRegression())])
+def test_confusion_matrix_pipeline(pyplot, clf, data, n_classes):
+    X, y = data
+    with pytest.raises(NotFittedError):
+        plot_confusion_matrix(clf, X, y)
+    clf.fit(X, y)
+    y_pred = clf.predict(X)
+
+    disp = plot_confusion_matrix(clf, X, y)
+    cm = confusion_matrix(y, y_pred)
+
+    assert_allclose(disp.confusion_matrix, cm)
+    assert disp.text_.shape == (n_classes, n_classes)

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -15,6 +15,12 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.compose import make_column_transformer
 
 
+# TODO: Remove when https://github.com/numpy/numpy/issues/14397 is resolved
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:In future, it will be an error for 'np.bool_':DeprecationWarning:"
+    "matplotlib.*")
+
+
 def test_errors(pyplot):
     X, y_multiclass = make_classification(n_classes=3, n_samples=50,
                                           n_informative=3,

--- a/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
+++ b/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
@@ -14,6 +14,12 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.compose import make_column_transformer
 
 
+# TODO: Remove when https://github.com/numpy/numpy/issues/14397 is resolved
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:In future, it will be an error for 'np.bool_':DeprecationWarning:"
+    "matplotlib.*")
+
+
 @pytest.fixture(scope="module")
 def data():
     return load_iris(return_X_y=True)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -525,14 +525,23 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
         sample_weight = column_or_1d(sample_weight)
 
     # ensure binary classification if pos_label is not specified
+    # classes.dtype.kind in ('O', 'U', 'S') is required to avoid
+    # triggering a FutureWarning by calling np.array_equal(a, b)
+    # when elements in the two arrays are not comparable.
     classes = np.unique(y_true)
-    if (pos_label is None and
-        not (np.array_equal(classes, [0, 1]) or
-             np.array_equal(classes, [-1, 1]) or
-             np.array_equal(classes, [0]) or
-             np.array_equal(classes, [-1]) or
-             np.array_equal(classes, [1]))):
-        raise ValueError("Data is not binary and pos_label is not specified")
+    if (pos_label is None and (
+            classes.dtype.kind in ('O', 'U', 'S') or
+            not (np.array_equal(classes, [0, 1]) or
+                 np.array_equal(classes, [-1, 1]) or
+                 np.array_equal(classes, [0]) or
+                 np.array_equal(classes, [-1]) or
+                 np.array_equal(classes, [1])))):
+        classes_repr = ", ".join(repr(c) for c in classes)
+        raise ValueError("y_true takes value in {{{classes_repr}}} and "
+                         "pos_label is not specified: either make y_true "
+                         "take integer value in {{0, 1}} or {{-1, 1}} or "
+                         "pass pos_label explicitly.".format(
+                             classes_repr=classes_repr))
     elif pos_label is None:
         pos_label = 1.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -406,20 +406,23 @@ def nan_euclidean_distances(X, Y=None, squared=False,
     distances -= np.dot(XX, missing_Y.T)
     distances -= np.dot(missing_X, YY.T)
 
-    present_coords_cnt = np.dot(1 - missing_X, 1 - missing_Y.T)
-    present_mask = (present_coords_cnt != 0)
-    distances[present_mask] *= (X.shape[1] / present_coords_cnt[present_mask])
-
     if X is Y:
         # Ensure that distances between vectors and themselves are set to 0.0.
         # This may not be the case due to floating point rounding errors.
         np.fill_diagonal(distances, 0.0)
 
+    present_X = 1 - missing_X
+    present_Y = present_X if Y is X else ~missing_Y
+    present_count = np.dot(present_X, present_Y.T)
+    distances[present_count == 0] = np.nan
+    # avoid divide by zero
+    np.maximum(1, present_count, out=present_count)
+    distances /= present_count
+    distances *= X.shape[1]
+
     if not squared:
         np.sqrt(distances, out=distances)
 
-    # coordinates with no common coordinates have a nan distance
-    distances[~present_mask] = np.nan
     return distances
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -406,6 +406,8 @@ def nan_euclidean_distances(X, Y=None, squared=False,
     distances -= np.dot(XX, missing_Y.T)
     distances -= np.dot(missing_X, YY.T)
 
+    np.clip(distances, 0, None, out=distances)
+
     if X is Y:
         # Ensure that distances between vectors and themselves are set to 0.0.
         # This may not be the case due to floating point rounding errors.

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1,6 +1,8 @@
 
 from functools import partial
 from itertools import product
+from itertools import chain
+from itertools import permutations
 import warnings
 import re
 
@@ -17,6 +19,7 @@ from sklearn.utils.validation import check_random_state
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
+from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_warns_div0
 from sklearn.utils._testing import assert_no_warnings
@@ -507,6 +510,39 @@ def test_multilabel_confusion_matrix_errors():
     with pytest.raises(ValueError, match=err_msg):
         multilabel_confusion_matrix([[0, 1, 2], [2, 1, 0]],
                                     [[1, 2, 0], [1, 0, 2]])
+
+
+@pytest.mark.parametrize(
+    "normalize, cm_dtype, expected_results",
+    [('true', 'f', 0.333333333),
+     ('pred', 'f', 0.333333333),
+     ('all', 'f', 0.1111111111),
+     (None, 'i', 2)]
+)
+def test_confusion_matrix_normalize(normalize, cm_dtype, expected_results):
+    y_test = [0, 1, 2] * 6
+    y_pred = list(chain(*permutations([0, 1, 2])))
+    cm = confusion_matrix(y_test, y_pred, normalize=normalize)
+    assert_allclose(cm, expected_results)
+    assert cm.dtype.kind == cm_dtype
+
+
+def test_confusion_matrix_normalize_single_class():
+    y_test = [0, 0, 0, 0, 1, 1, 1, 1]
+    y_pred = [0, 0, 0, 0, 0, 0, 0, 0]
+
+    cm_true = confusion_matrix(y_test, y_pred, normalize='true')
+    assert cm_true.sum() == pytest.approx(2.0)
+
+    # additionally check that no warnings are raised due to a division by zero
+    with pytest.warns(None) as rec:
+        cm_pred = confusion_matrix(y_test, y_pred, normalize='pred')
+    assert not rec
+    assert cm_pred.sum() == pytest.approx(1.0)
+
+    with pytest.warns(None) as rec:
+        cm_pred = confusion_matrix(y_pred, y_test, normalize='true')
+    assert not rec
 
 
 def test_cohen_kappa():

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -871,6 +871,23 @@ def test_nan_euclidean_distances_not_trival(missing_value):
     assert_allclose(D6, D7)
 
 
+@pytest.mark.parametrize("missing_value", [np.nan, -1])
+def test_nan_euclidean_distances_one_feature_match_positive(missing_value):
+    # First feature is the only feature that is non-nan and in both
+    # samples. The result of `nan_euclidean_distances` with squared=True
+    # should be non-negative. The non-squared version should all be close to 0.
+    X = np.array([[-122.27, 648., missing_value, 37.85],
+                  [-122.27, missing_value, 2.34701493, missing_value]])
+
+    dist_squared = nan_euclidean_distances(X, missing_values=missing_value,
+                                           squared=True)
+    assert np.all(dist_squared >= 0)
+
+    dist = nan_euclidean_distances(X, missing_values=missing_value,
+                                   squared=False)
+    assert_allclose(dist, 0.0)
+
+
 def test_cosine_distances():
     # Check the pairwise Cosine distances computation
     rng = np.random.RandomState(1337)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -662,13 +662,52 @@ def test_auc_score_non_binary_class():
             roc_auc_score(y_true, y_pred)
 
 
-def test_binary_clf_curve():
+def test_binary_clf_curve_multiclass_error():
     rng = check_random_state(404)
     y_true = rng.randint(0, 3, size=10)
     y_pred = rng.rand(10)
     msg = "multiclass format is not supported"
+
     with pytest.raises(ValueError, match=msg):
         precision_recall_curve(y_true, y_pred)
+
+    with pytest.raises(ValueError, match=msg):
+        roc_curve(y_true, y_pred)
+
+
+@pytest.mark.parametrize("curve_func", [
+    precision_recall_curve,
+    roc_curve,
+])
+def test_binary_clf_curve_implicit_pos_label(curve_func):
+    # Check that using string class labels raises an informative
+    # error for any supported string dtype:
+    msg = ("y_true takes value in {'a', 'b'} and pos_label is "
+           "not specified: either make y_true take integer "
+           "value in {0, 1} or {-1, 1} or pass pos_label "
+           "explicitly.")
+    with pytest.raises(ValueError, match=msg):
+        roc_curve(np.array(["a", "b"], dtype='<U1'), [0., 1.])
+
+    with pytest.raises(ValueError, match=msg):
+        roc_curve(np.array(["a", "b"], dtype=object), [0., 1.])
+
+    # The error message is slightly different for bytes-encoded
+    # class labels, but otherwise the behavior is the same:
+    msg = ("y_true takes value in {b'a', b'b'} and pos_label is "
+           "not specified: either make y_true take integer "
+           "value in {0, 1} or {-1, 1} or pass pos_label "
+           "explicitly.")
+    with pytest.raises(ValueError, match=msg):
+        roc_curve(np.array([b"a", b"b"], dtype='<S1'), [0., 1.])
+
+    # Check that it is possible to use floating point class labels
+    # that are interpreted similarly to integer class labels:
+    y_pred = [0., 1., 0.2, 0.42]
+    int_curve = roc_curve([0, 1, 1, 0], y_pred)
+    float_curve = roc_curve([0., 1., 1., 0.], y_pred)
+    for int_curve_part, float_curve_part in zip(int_curve, float_curve):
+        np.testing.assert_allclose(int_curve_part, float_curve_part)
 
 
 def test_precision_recall_curve():
@@ -1077,8 +1116,8 @@ def check_alternative_lrap_implementation(lrap_score, n_classes=5,
 
     # Score with ties
     y_score = _sparse_random_matrix(n_components=y_true.shape[0],
-                                   n_features=y_true.shape[1],
-                                   random_state=random_state)
+                                    n_features=y_true.shape[1],
+                                    random_state=random_state)
 
     if hasattr(y_score, "toarray"):
         y_score = y_score.toarray()

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -262,7 +262,7 @@ def _radius_neighbors_from_graph(graph, radius, return_distance):
     """
     assert graph.format == 'csr'
 
-    no_filter_needed = graph.data.max() <= radius
+    no_filter_needed = bool(graph.data.max() <= radius)
 
     if no_filter_needed:
         data, indices, indptr = graph.data, graph.indices, graph.indptr

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -30,6 +30,8 @@ class KNeighborsRegressor(NeighborsBase, KNeighborsMixin,
 
     Read more in the :ref:`User Guide <regression>`.
 
+    .. versionadded:: 0.9
+
     Parameters
     ----------
     n_neighbors : int, optional (default = 5)
@@ -202,6 +204,8 @@ class RadiusNeighborsRegressor(NeighborsBase, RadiusNeighborsMixin,
     associated of the nearest neighbors in the training set.
 
     Read more in the :ref:`User Guide <regression>`.
+
+    .. versionadded:: 0.9
 
     Parameters
     ----------

--- a/sklearn/neighbors/_unsupervised.py
+++ b/sklearn/neighbors/_unsupervised.py
@@ -11,6 +11,8 @@ class NearestNeighbors(NeighborsBase, KNeighborsMixin,
 
     Read more in the :ref:`User Guide <unsupervised_neighbors>`.
 
+    .. versionadded:: 0.9
+
     Parameters
     ----------
     n_neighbors : int, optional (default = 5)

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -365,8 +365,8 @@ class MinMaxScaler(TransformerMixin, BaseEstimator):
                              " than maximum. Got %s." % str(feature_range))
 
         if sparse.issparse(X):
-            raise TypeError("MinMaxScaler does no support sparse input. "
-                            "You may consider to use MaxAbsScaler instead.")
+            raise TypeError("MinMaxScaler does not support sparse input. "
+                            "Consider using MaxAbsScaler instead.")
 
         X = check_array(X,
                         estimator=self, dtype=FLOAT_DTYPES,

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -171,6 +171,8 @@ class OneHotEncoder(_BaseEncoder):
 
     Read more in the :ref:`User Guide <preprocessing_categorical_features>`.
 
+    .. versionchanged:: 0.20
+
     Parameters
     ----------
     categories : 'auto' or a list of array-like, default='auto'
@@ -550,6 +552,8 @@ class OrdinalEncoder(_BaseEncoder):
     a single column of integers (0 to n_categories - 1) per feature.
 
     Read more in the :ref:`User Guide <preprocessing_categorical_features>`.
+
+    .. versionchanged:: 0.20.1
 
     Parameters
     ----------

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -176,6 +176,8 @@ class LabelEncoder(TransformerMixin, BaseEstimator):
 
     Read more in the :ref:`User Guide <preprocessing_targets>`.
 
+    .. versionadded:: 0.12
+
     Attributes
     ----------
     classes_ : array of shape (n_class,)

--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -515,6 +515,7 @@ Solver_MCSVM_CS::~Solver_MCSVM_CS()
 {
 	delete[] B;
 	delete[] G;
+	delete[] C;
 }
 
 int compare_double(const void *a, const void *b)

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1631,6 +1631,21 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
 
     .. [1] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized trees",
            Machine Learning, 63(1), 3-42, 2006.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import load_boston
+    >>> from sklearn.model_selection import train_test_split
+    >>> from sklearn.ensemble import BaggingRegressor
+    >>> from sklearn.tree import ExtraTreeRegressor
+    >>> X, y = load_boston(return_X_y=True)
+    >>> X_train, X_test, y_train, y_test = train_test_split(
+    ...     X, y, random_state=0)
+    >>> extra_tree = ExtraTreeRegressor(random_state=0)
+    >>> reg = BaggingRegressor(extra_tree, random_state=0).fit(
+    ...     X_train, y_train)
+    >>> reg.score(X_test, y_test)
+    0.7823...
     """
     def __init__(self,
                  criterion="mse",

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -912,3 +912,25 @@ def assert_run_python_script(source_code, timeout=60):
                                % e.output.decode('utf-8'))
     finally:
         os.unlink(source_file)
+
+
+def _convert_container(container, constructor_name, columns_name=None):
+    if constructor_name == 'list':
+        return list(container)
+    elif constructor_name == 'tuple':
+        return tuple(container)
+    elif constructor_name == 'array':
+        return np.asarray(container)
+    elif constructor_name == 'sparse':
+        return sp.sparse.csr_matrix(container)
+    elif constructor_name == 'dataframe':
+        pd = pytest.importorskip('pandas')
+        return pd.DataFrame(container, columns=columns_name)
+    elif constructor_name == 'series':
+        pd = pytest.importorskip('pandas')
+        return pd.Series(container)
+    elif constructor_name == 'index':
+        pd = pytest.importorskip('pandas')
+        return pd.Index(container)
+    elif constructor_name == 'slice':
+        return slice(container[0], container[1])

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -213,7 +213,8 @@ def _newton_cg(grad_hess, func, grad, x0, args=(), tol=1e-4,
     return xk, k
 
 
-def _check_optimize_result(solver, result, max_iter=None):
+def _check_optimize_result(solver, result, max_iter=None,
+                           extra_warning_msg=None):
     """Check the OptimizeResult for successful convergence
 
     Parameters
@@ -233,12 +234,16 @@ def _check_optimize_result(solver, result, max_iter=None):
     # handle both scipy and scikit-learn solver names
     if solver == "lbfgs":
         if result.status != 0:
-            warnings.warn("{} failed to converge (status={}): {}. "
-                          "Increase the number of iterations or scale the "
-                          "data as shown in https://scikit-learn.org/stable/"
-                          "modules/preprocessing.html"
-                          .format(solver, result.status, result.message),
-                          ConvergenceWarning, stacklevel=2)
+            warning_msg = (
+                "{} failed to converge (status={}):\n{}.\n\n"
+                "Increase the number of iterations (max_iter) "
+                "or scale the data as shown in:\n"
+                "    https://scikit-learn.org/stable/modules/"
+                "preprocessing.html."
+            ).format(solver, result.status, result.message.decode("latin1"))
+            if extra_warning_msg is not None:
+                warning_msg += "\n" + extra_warning_msg
+            warnings.warn(warning_msg, ConvergenceWarning, stacklevel=2)
         if max_iter is not None:
             # In scipy <= 1.0.0, nit may exceed maxiter for lbfgs.
             # See https://github.com/scipy/scipy/issues/7854

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -234,7 +234,9 @@ def _check_optimize_result(solver, result, max_iter=None):
     if solver == "lbfgs":
         if result.status != 0:
             warnings.warn("{} failed to converge (status={}): {}. "
-                          "Increase the number of iterations."
+                          "Increase the number of iterations or scale the "
+                          "data as shown in https://scikit-learn.org/stable/"
+                          "modules/preprocessing.html"
                           .format(solver, result.status, result.message),
                           ConvergenceWarning, stacklevel=2)
         if max_iter is not None:

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -32,7 +32,8 @@ from sklearn.utils._testing import (
     assert_raises_regex,
     TempMemmap,
     create_memmap_backed_data,
-    _delete_folder)
+    _delete_folder,
+    _convert_container)
 
 from sklearn.utils._testing import SkipTest
 from sklearn.tree import DecisionTreeClassifier
@@ -674,3 +675,20 @@ def test_deprecated_helpers(callable, args):
            '0.24. Please use "assert" instead')
     with pytest.warns(FutureWarning, match=msg):
         callable(*args)
+
+
+@pytest.mark.parametrize(
+    "constructor_name, container_type",
+    [('list', list),
+     ('tuple', tuple),
+     ('array', np.ndarray),
+     ('sparse', sparse.csr_matrix),
+     ('dataframe', pytest.importorskip('pandas').DataFrame),
+     ('series', pytest.importorskip('pandas').Series),
+     ('index', pytest.importorskip('pandas').Index),
+     ('slice', slice)]
+)
+def test_convert_container(constructor_name, container_type):
+    container = [0, 1]
+    assert isinstance(_convert_container(container, constructor_name),
+                      container_type)

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -9,10 +9,12 @@ import numpy as np
 import scipy.sparse as sp
 
 from sklearn.utils._testing import (assert_raises,
-                                   assert_array_equal,
-                                   assert_allclose_dense_sparse,
-                                   assert_raises_regex,
-                                   assert_warns_message, assert_no_warnings)
+                                    assert_array_equal,
+                                    assert_allclose_dense_sparse,
+                                    assert_raises_regex,
+                                    assert_warns_message,
+                                    assert_no_warnings,
+                                    _convert_container)
 from sklearn.utils import check_random_state
 from sklearn.utils import _determine_key_type
 from sklearn.utils import deprecated
@@ -234,25 +236,6 @@ def test_determine_key_type_error():
 def test_determine_key_type_slice_error():
     with pytest.raises(TypeError, match="Only array-like or scalar are"):
         _determine_key_type(slice(0, 2, 1), accept_slice=False)
-
-
-def _convert_container(container, constructor_name, columns_name=None):
-    if constructor_name == 'list':
-        return list(container)
-    elif constructor_name == 'tuple':
-        return tuple(container)
-    elif constructor_name == 'array':
-        return np.asarray(container)
-    elif constructor_name == 'sparse':
-        return sp.csr_matrix(container)
-    elif constructor_name == 'dataframe':
-        pd = pytest.importorskip('pandas')
-        return pd.DataFrame(container, columns=columns_name)
-    elif constructor_name == 'series':
-        pd = pytest.importorskip('pandas')
-        return pd.Series(container)
-    elif constructor_name == 'slice':
-        return slice(container[0], container[1])
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -41,13 +41,15 @@ from sklearn.utils.validation import (
     check_non_negative,
     _num_samples,
     check_scalar,
+    _check_psd_eigenvalues,
     _deprecate_positional_args,
     _check_sample_weight,
     _allclose_dense_sparse,
     FLOAT_DTYPES)
+
 import sklearn
 
-from sklearn.exceptions import NotFittedError
+from sklearn.exceptions import NotFittedError, PositiveSpectrumWarning
 from sklearn.exceptions import DataConversionWarning
 
 from sklearn.utils._testing import assert_raise_message
@@ -935,6 +937,81 @@ def test_check_scalar_invalid(x, target_name, target_type, min_val, max_val,
                      min_val=min_val, max_val=max_val)
     assert str(raised_error.value) == str(err_msg)
     assert type(raised_error.value) == type(err_msg)
+
+
+_psd_cases_valid = {
+    'nominal': ((1, 2), np.array([1, 2]), None, ""),
+    'nominal_np_array': (np.array([1, 2]), np.array([1, 2]), None, ""),
+    'insignificant_imag': ((5, 5e-5j), np.array([5, 0]),
+                           PositiveSpectrumWarning,
+                           "There are imaginary parts in eigenvalues "
+                           "\\(1e\\-05 of the maximum real part"),
+    'insignificant neg': ((5, -5e-5), np.array([5, 0]),
+                          PositiveSpectrumWarning, ""),
+    'insignificant neg float32': (np.array([1, -1e-6], dtype=np.float32),
+                                  np.array([1, 0], dtype=np.float32),
+                                  PositiveSpectrumWarning,
+                                  "There are negative eigenvalues \\(1e\\-06 "
+                                  "of the maximum positive"),
+    'insignificant neg float64': (np.array([1, -1e-10], dtype=np.float64),
+                                  np.array([1, 0], dtype=np.float64),
+                                  PositiveSpectrumWarning,
+                                  "There are negative eigenvalues \\(1e\\-10 "
+                                  "of the maximum positive"),
+    'insignificant pos': ((5, 4e-12), np.array([5, 0]),
+                          PositiveSpectrumWarning,
+                          "the largest eigenvalue is more than 1e\\+12 "
+                          "times the smallest"),
+}
+
+
+@pytest.mark.parametrize("lambdas, expected_lambdas, w_type, w_msg",
+                         list(_psd_cases_valid.values()),
+                         ids=list(_psd_cases_valid.keys()))
+@pytest.mark.parametrize("enable_warnings", [True, False])
+def test_check_psd_eigenvalues_valid(lambdas, expected_lambdas, w_type, w_msg,
+                                     enable_warnings):
+    # Test that ``_check_psd_eigenvalues`` returns the right output for valid
+    # input, possibly raising the right warning
+
+    if not enable_warnings:
+        w_type = None
+        w_msg = ""
+
+    with pytest.warns(w_type, match=w_msg) as w:
+        assert_array_equal(
+            _check_psd_eigenvalues(lambdas, enable_warnings=enable_warnings),
+            expected_lambdas
+        )
+    if w_type is None:
+        assert not w
+
+
+_psd_cases_invalid = {
+    'significant_imag': ((5, 5j), ValueError,
+                         "There are significant imaginary parts in eigenv"),
+    'all negative': ((-5, -1), ValueError,
+                     "All eigenvalues are negative \\(maximum is -1"),
+    'significant neg': ((5, -1), ValueError,
+                        "There are significant negative eigenvalues"),
+    'significant neg float32': (np.array([3e-4, -2e-6], dtype=np.float32),
+                                ValueError,
+                                "There are significant negative eigenvalues"),
+    'significant neg float64': (np.array([1e-5, -2e-10], dtype=np.float64),
+                                ValueError,
+                                "There are significant negative eigenvalues"),
+}
+
+
+@pytest.mark.parametrize("lambdas, err_type, err_msg",
+                         list(_psd_cases_invalid.values()),
+                         ids=list(_psd_cases_invalid.keys()))
+def test_check_psd_eigenvalues_invalid(lambdas, err_type, err_msg):
+    # Test that ``_check_psd_eigenvalues`` raises the right error for invalid
+    # input
+
+    with pytest.raises(err_type, match=err_msg):
+        _check_psd_eigenvalues(lambdas)
 
 
 def test_check_sample_weight():

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -6,6 +6,7 @@
 #          Lars Buitinck
 #          Alexandre Gramfort
 #          Nicolas Tresegnie
+#          Sylvain Marie
 # License: BSD 3 clause
 
 from functools import wraps
@@ -22,7 +23,7 @@ import joblib
 
 from .fixes import _object_dtype_isnan
 from .. import get_config as _get_config
-from ..exceptions import NonBLASDotWarning
+from ..exceptions import NonBLASDotWarning, PositiveSpectrumWarning
 from ..exceptions import NotFittedError
 from ..exceptions import DataConversionWarning
 
@@ -1018,6 +1019,169 @@ def check_scalar(x, name, target_type, min_val=None, max_val=None):
 
     if max_val is not None and x > max_val:
         raise ValueError('`{}`= {}, must be <= {}.'.format(name, x, max_val))
+
+
+def _check_psd_eigenvalues(lambdas, enable_warnings=False):
+    """Check the eigenvalues of a positive semidefinite (PSD) matrix.
+
+    Checks the provided array of PSD matrix eigenvalues for numerical or
+    conditioning issues and returns a fixed validated version. This method
+    should typically be used if the PSD matrix is user-provided (e.g. a
+    Gram matrix) or computed using a user-provided dissimilarity metric
+    (e.g. kernel function), or if the decomposition process uses approximation
+    methods (randomized SVD, etc.).
+
+    It checks for three things:
+
+    - that there are no significant imaginary parts in eigenvalues (more than
+      1e-5 times the maximum real part). If this check fails, it raises a
+      ``ValueError``. Otherwise all non-significant imaginary parts that may
+      remain are set to zero. This operation is traced with a
+      ``PositiveSpectrumWarning`` when ``enable_warnings=True``.
+
+    - that eigenvalues are not all negative. If this check fails, it raises a
+      ``ValueError``
+
+    - that there are no significant negative eigenvalues with absolute value
+      more than 1e-10 (1e-6) and more than 1e-5 (5e-3) times the largest
+      positive eigenvalue in double (simple) precision. If this check fails,
+      it raises a ``ValueError``. Otherwise all negative eigenvalues that may
+      remain are set to zero. This operation is traced with a
+      ``PositiveSpectrumWarning`` when ``enable_warnings=True``.
+
+    Finally, all the positive eigenvalues that are too small (with a value
+    smaller than the maximum eigenvalue divided by 1e12) are set to zero.
+    This operation is traced with a ``PositiveSpectrumWarning`` when
+    ``enable_warnings=True``.
+
+    Parameters
+    ----------
+    lambdas : array-like of shape (n_eigenvalues,)
+        Array of eigenvalues to check / fix.
+
+    enable_warnings : bool, default=False
+        When this is set to ``True``, a ``PositiveSpectrumWarning`` will be
+        raised when there are imaginary parts, negative eigenvalues, or
+        extremely small non-zero eigenvalues. Otherwise no warning will be
+        raised. In both cases, imaginary parts, negative eigenvalues, and
+        extremely small non-zero eigenvalues will be set to zero.
+
+    Returns
+    -------
+    lambdas_fixed : ndarray of shape (n_eigenvalues,)
+        A fixed validated copy of the array of eigenvalues.
+
+    Examples
+    --------
+    >>> _check_psd_eigenvalues([1, 2])      # nominal case
+    array([1, 2])
+    >>> _check_psd_eigenvalues([5, 5j])     # significant imag part
+    Traceback (most recent call last):
+        ...
+    ValueError: There are significant imaginary parts in eigenvalues (1
+        of the maximum real part). Either the matrix is not PSD, or there was
+        an issue while computing the eigendecomposition of the matrix.
+    >>> _check_psd_eigenvalues([5, 5e-5j])  # insignificant imag part
+    array([5., 0.])
+    >>> _check_psd_eigenvalues([-5, -1])    # all negative
+    Traceback (most recent call last):
+        ...
+    ValueError: All eigenvalues are negative (maximum is -1). Either the
+        matrix is not PSD, or there was an issue while computing the
+        eigendecomposition of the matrix.
+    >>> _check_psd_eigenvalues([5, -1])     # significant negative
+    Traceback (most recent call last):
+        ...
+    ValueError: There are significant negative eigenvalues (0.2 of the
+        maximum positive). Either the matrix is not PSD, or there was an issue
+        while computing the eigendecomposition of the matrix.
+    >>> _check_psd_eigenvalues([5, -5e-5])  # insignificant negative
+    array([5., 0.])
+    >>> _check_psd_eigenvalues([5, 4e-12])  # bad conditioning (too small)
+    array([5., 0.])
+
+    """
+
+    lambdas = np.array(lambdas)
+    is_double_precision = lambdas.dtype == np.float64
+
+    # note: the minimum value available is
+    #  - single-precision: np.finfo('float32').eps = 1.2e-07
+    #  - double-precision: np.finfo('float64').eps = 2.2e-16
+
+    # the various thresholds used for validation
+    # we may wish to change the value according to precision.
+    significant_imag_ratio = 1e-5
+    significant_neg_ratio = 1e-5 if is_double_precision else 5e-3
+    significant_neg_value = 1e-10 if is_double_precision else 1e-6
+    small_pos_ratio = 1e-12
+
+    # Check that there are no significant imaginary parts
+    if not np.isreal(lambdas).all():
+        max_imag_abs = np.abs(np.imag(lambdas)).max()
+        max_real_abs = np.abs(np.real(lambdas)).max()
+        if max_imag_abs > significant_imag_ratio * max_real_abs:
+            raise ValueError(
+                "There are significant imaginary parts in eigenvalues (%g "
+                "of the maximum real part). Either the matrix is not PSD, or "
+                "there was an issue while computing the eigendecomposition "
+                "of the matrix."
+                % (max_imag_abs / max_real_abs))
+
+        # warn about imaginary parts being removed
+        if enable_warnings:
+            warnings.warn("There are imaginary parts in eigenvalues (%g "
+                          "of the maximum real part). Either the matrix is not"
+                          " PSD, or there was an issue while computing the "
+                          "eigendecomposition of the matrix. Only the real "
+                          "parts will be kept."
+                          % (max_imag_abs / max_real_abs),
+                          PositiveSpectrumWarning)
+
+    # Remove all imaginary parts (even if zero)
+    lambdas = np.real(lambdas)
+
+    # Check that there are no significant negative eigenvalues
+    max_eig = lambdas.max()
+    if max_eig < 0:
+        raise ValueError("All eigenvalues are negative (maximum is %g). "
+                         "Either the matrix is not PSD, or there was an "
+                         "issue while computing the eigendecomposition of "
+                         "the matrix." % max_eig)
+
+    else:
+        min_eig = lambdas.min()
+        if (min_eig < -significant_neg_ratio * max_eig
+                and min_eig < -significant_neg_value):
+            raise ValueError("There are significant negative eigenvalues (%g"
+                             " of the maximum positive). Either the matrix is "
+                             "not PSD, or there was an issue while computing "
+                             "the eigendecomposition of the matrix."
+                             % (-min_eig / max_eig))
+        elif min_eig < 0:
+            # Remove all negative values and warn about it
+            if enable_warnings:
+                warnings.warn("There are negative eigenvalues (%g of the "
+                              "maximum positive). Either the matrix is not "
+                              "PSD, or there was an issue while computing the"
+                              " eigendecomposition of the matrix. Negative "
+                              "eigenvalues will be replaced with 0."
+                              % (-min_eig / max_eig),
+                              PositiveSpectrumWarning)
+            lambdas[lambdas < 0] = 0
+
+    # Check for conditioning (small positive non-zeros)
+    too_small_lambdas = (0 < lambdas) & (lambdas < small_pos_ratio * max_eig)
+    if too_small_lambdas.any():
+        if enable_warnings:
+            warnings.warn("Badly conditioned PSD matrix spectrum: the largest "
+                          "eigenvalue is more than %g times the smallest. "
+                          "Small eigenvalues will be replaced with 0."
+                          "" % (1 / small_pos_ratio),
+                          PositiveSpectrumWarning)
+        lambdas[too_small_lambdas] = 0
+
+    return lambdas
 
 
 def _check_sample_weight(sample_weight, X, dtype=None):


### PR DESCRIPTION
I've included the doc changes, and the ones which were suggested to be included.

The only one I was a bit surprised about is #11514 which I've included since it touches the whats_new, but it's not a very minor change.

It'd be also nice to have https://github.com/scikit-learn/scikit-learn/pull/15626 here.

```
drop 947f37e3a1 MNT bump version to 0.23.dev0 and add new whats_new (#15631)
pick 9dcdb8789a DOC Adds confusion matrix to whats new (#15656)
pick f7ed72aa44 ENH reduce memory consumption in nan_euclidean_distances (#15615)
pick 60248946bd EXA Adds example for tree.ExtraTreeRegressor (#15213)
pick e254b30b6e MAINT run latest CI on Python 3.8 (#15637)
drop b6f124c848 MAINT Improve variable order in BaseDecisionTree (#15664)
pick a723bea9c9 [MRG] Enables CircleCI to fail when sphinx warns (#15633)
pick 663d052d3c [MRG] documentation for random_state in forest.py (#15516)
pick 43d8dee07b MNT improve the convergence warning message for LogisticRegression (#15665)
pick 6231d5ae51 MAINT Add _distributor_init.py (#15570)
drop 12196dab9b MNT replaced check_consistent_length, etc with _check_sample_weight in BaseGradientBoosting (#15478)
pick e81884f919 TST Fix leak in tmp folders in LFW test when pillow is missing (#15676)
pick ce1b171e39 MNT pin pytest in failing job on azure (#15677)
pick 0831dfbe95 [MRG] BUG Fixes test_scale_and_stability in windows (#15661)
drop 641b863188 MNT fix filtering of examples file to run by sphinx (#15680)
pick 10b8bf7c54 [MRG] Improve error message with implicit pos_label in _binary_clf_curve (#15562)
pick cc9066f964 DOC add transform y section to faq.rst (#15484)
pick ccac637855 FIX Clip distances below 0 (#15683)
drop 1c546cd9b1 CLN Move gradient and hessian closer to for loop in hist GBDT (#15686)
pick 6b8e545293 MNT bump the version of numpydoc and sphinx gallery (#15681)
pick 2151b79a91 FIX Releases memory in liblinear (#15687)
pick e06cc9e3fe MNT Better error message for MinMaxScaler and sparse data (#15695)
pick 0c2da0cb48 DOC Fix various sphinx warnings. (#15692)
pick db59dd74df [MRG] Fast, low memory, single linkage implementation (#11514)
pick 308a54e3ae CI Use new conda syntax to select blas (#15705)
pick c1ba7bfe43 DOC versionadded labels for NearestNeighbors, KNeighborsRegressor and RadiusNeighborsRegressor (#15688)
pick 9f5b97119b CLN Removes ccp_alpha from RandomTreesEmbedding (#15708)
pick fc46a13d57 DOC Wrong statement in release highlight (#15704)
pick 4f97facc3a DOC Further 0.22 whats_new cleanup (#15675)
```