### PR TITLE
[MRG] MNT CI Pin version of compilers on macos

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,6 +104,7 @@ jobs:
         PYTEST_VERSION: '*'
         JOBLIB_VERSION: '*'
         COVERAGE: 'true'
+        SKLEARN_FAIL_NO_OPENMP: 'true'
       pylatest_conda_mkl_no_openmp:
         DISTRIB: 'conda'
         PYTHON_VERSION: '*'

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -46,7 +46,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
             # on macOS, install an OpenMP-enabled clang/llvm from conda-forge.
             # FIXME: temporary pin version of compilers, see
             # https://github.com/conda-forge/compilers-feedstock/issues/18
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers \
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers=1.0.4 \
                 conda-forge::llvm-openmp conda-forge::ld64=409.12"
         fi
     fi

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -46,7 +46,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
             # on macOS, install an OpenMP-enabled clang/llvm from conda-forge.
             # FIXME: temporary pin version of compilers, see
             # https://github.com/conda-forge/compilers-feedstock/issues/18
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers=1.0.3"
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers \
+                conda-forge::llvm-openmp conda-forge::ld64=409.12"
         fi
     fi
 

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -47,7 +47,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
             # FIXME: temporary pin version of compilers, see
             # https://github.com/conda-forge/compilers-feedstock/issues/18
             TO_INSTALL="$TO_INSTALL conda-forge::compilers=1.0.3 \
-                        conda-forge::llvm-openmp"
+                        conda-forge::llvm-openmp=8"
         fi
     fi
 

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -44,8 +44,11 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$SKLEARN_TEST_NO_OPENMP" != "true" ]]; then
             # on macOS, install an OpenMP-enabled clang/llvm from conda-forge.
-            # FIXME: temporary pin version of compilers, see
-            # https://github.com/conda-forge/compilers-feedstock/issues/18
+            # FIXME: temporary pin version of ld64 from compilers meta-package,
+            # see https://github.com/conda-forge/compilers-feedstock/issues/18
+            # When restoring, the command should be
+            # TO_INSTALL="$TO_INSTALL conda-forge::compilers \
+            #    conda-forge::llvm-openmp"
             TO_INSTALL="$TO_INSTALL conda-forge::compilers=1.0.4 \
                 conda-forge::llvm-openmp conda-forge::ld64=409.12"
         fi

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -46,8 +46,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
             # on macOS, install an OpenMP-enabled clang/llvm from conda-forge.
             # FIXME: temporary pin version of compilers, see
             # https://github.com/conda-forge/compilers-feedstock/issues/18
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers=1.0.3 \
-                        conda-forge::llvm-openmp=8"
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers=1.0.3"
         fi
     fi
 

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -44,7 +44,9 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$SKLEARN_TEST_NO_OPENMP" != "true" ]]; then
             # on macOS, install an OpenMP-enabled clang/llvm from conda-forge.
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers \
+            # FIXME: temporary pin version of compilers, see
+            # https://github.com/conda-forge/compilers-feedstock/issues/18
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers=1.0.3 \
                         conda-forge::llvm-openmp"
         fi
     fi


### PR DESCRIPTION
Fixes #15713

CI is failing on macOS, built with compilers 1.0.4.
I opened [https://github.com/conda-forge/compilers-feedstock/issues/18](https://github.com/conda-forge/compilers-feedstock/issues/18)

this PR temporary pins the version of compilers. Should be removed when fixed upstream.