### PR TITLE
[MRG] OPTICS Benchmark and improve the performance

### DIFF
--- a/benchmarks/bench_optics.py
+++ b/benchmarks/bench_optics.py
@@ -1,0 +1,93 @@
+"""
+To run this, you'll need to have installed.
+  * scikit-learn
+Does two benchmarks
+First, we fix a training set, increase the number of
+samples to cluster and plot number of clustered samples as a
+function of time.
+In the second benchmark, we increase the number of dimensions of the
+training set, cluster a sample and plot the time taken as a function
+of the number of dimensions.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+import gc
+from datetime import datetime
+
+# to store the results
+scikit_cluster_results = []
+
+mu_second = 0.0 + 10 ** 6  # number of microseconds in a second
+
+
+def bench_scikit_OPTICS(X, Y):
+    """Benchmark with scikit-learn OPTICS"""
+
+    from sklearn.cluster import OPTICS
+    gc.collect()
+
+    # start time
+    tstart = datetime.now()
+    clf = OPTICS()
+    clf.fit(X, Y)
+    delta = (datetime.now() - tstart)
+    # stop time
+
+    scikit_cluster_results.append(
+        delta.seconds + delta.microseconds / mu_second)
+
+
+if __name__ == '__main__':
+
+    print('============================================')
+    print('Warning: this is going to take a looong time')
+    print('============================================')
+
+    n = 10
+    step = 1000
+    n_samples = 20000
+    dim = 10
+    n_classes = 10
+    for i in range(n):
+        print('============================================')
+        print('Entering iteration %s of %s' % (i, n))
+        print('============================================')
+        n_samples += step
+        X = np.random.randn(n_samples, dim)
+        Y = np.random.randint(0, n_classes, (n_samples,))
+        bench_scikit_OPTICS(X, Y)
+
+    xx = range(0, n * step, step)
+    plt.figure('scikit-learn OPTICS benchmark results')
+    plt.subplot(211)
+    plt.title('Learning with varying number of samples')
+    plt.plot(xx, scikit_cluster_results, 'g-', label='OPTICS')
+    plt.legend(loc='upper left')
+    plt.xlabel('number of samples')
+    plt.ylabel('Time (s)')
+
+    scikit_cluster_results = []
+    n = 10
+    step = 500
+    start_dim = 500
+    n_classes = 10
+
+    dim = start_dim
+    for i in range(0, n):
+        print('============================================')
+        print('Entering iteration %s of %s' % (i, n))
+        print('============================================')
+        dim += step
+        X = np.random.randn(100, dim)
+        Y = np.random.randint(0, n_classes, (100,))
+        bench_scikit_OPTICS(X, Y)
+
+    xx = np.arange(start_dim, start_dim + n * step, step)
+    plt.subplot(212)
+    plt.title('OPTICS in high dimensional spaces')
+    plt.plot(xx, scikit_cluster_results, 'g-', label='classification')
+    plt.legend(loc='upper left')
+    plt.xlabel('number of dimensions')
+    plt.ylabel('Time (s)')
+    plt.axis('tight')
+    plt.show()

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -13,7 +13,7 @@ License: BSD 3 clause
 
 import warnings
 import numpy as np
-from heapq import *
+import heapq
 
 from ..utils import check_array
 from ..utils import gen_batches, get_chunk_n_rows
@@ -483,15 +483,15 @@ if metric=’precomputed’.
     for ordering_idx in range(X.shape[0]):
         Heap.append((np.inf, ordering_idx))
 
-    heapify(Heap)
+    heapq.heapify(Heap)
     processed = np.zeros(X.shape[0], dtype=bool)
     ordering = np.zeros(X.shape[0], dtype=int)
     for ordering_idx in range(X.shape[0]):
         # Choose next based on smallest reachability distance
         # (And prefer smaller ids on ties, possibly np.inf!)
-        (val, point) = heappop(Heap)
-        while (processed[point] == True):
-            (val,point) = heappop(Heap)
+        (val, point) = heapq.heappop(Heap)
+        while processed[point]:
+            (val, point) = heapq.heappop(Heap)
 
         processed[point] = True
         ordering[ordering_idx] = point
@@ -541,10 +541,9 @@ def _set_reach_dist(core_distances_, reachability_, predecessor_,
 
     rdists = np.maximum(dists, core_distances_[point_index])
     improved = np.where(rdists < np.take(reachability_, unproc))
-    for arr in improved:
-        for idx in arr:
-            heappush(Heap, (rdists[idx], unproc[idx]))
-    
+    for idx in improved[0]:
+        heapq.heappush(Heap, (rdists[idx], unproc[idx]))
+
     reachability_[unproc[improved]] = rdists[improved]
     predecessor_[unproc[improved]] = point_index
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See #12442 

#### What does this implement/fix? Explain your changes.
This add OPTICS benchmark. See #12442. I used heap to manage expansion candidates in OPTICS algorithm.

#### Any other comments?
On test with 10000 samples current OPTICS run about 15s. I think it is possible to improve this using heap. I will try to run test with larger number of samples.
EDIT: New code run few seconds faster. Locally on tests with 20000 samples previous code run 36s and new code 28s. Please note that running on different computers may get different results.
When profiling code I noticed that pairwise distance function takes a lot of time (about 1/3). I am not familiar with code of pairwise distance function. Could someone tell me if it is possible to speed up it?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
