### PR TITLE
[MRG] Fix undesired warnings for identically constant columns and degrees of freedom less than one

### DIFF
--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -294,15 +294,34 @@ def f_regression(X, y, center=True):
     else:
         X_norms = row_norms(X.T)
 
+    # the Pearson correlation coefficient is undefined
+    # for random variables (regressors and target) with
+    # a standard deviation of zero
+    if np.any(X_norms == 0) or np.std(y) == 0:
+        raise ValueError("The correlation is undefined for "
+                         "regressors and target with "
+                         "identically constant values. "
+                         "Remove them before calling this method.")
+
     # compute the correlation
     corr = safe_sparse_dot(y, X)
     corr /= X_norms
     corr /= np.linalg.norm(y)
 
-    # convert to p-value
+    # compute degrees of freedom
     degrees_of_freedom = y.size - (2 if center else 1)
-    F = corr ** 2 / (1 - corr ** 2) * degrees_of_freedom
-    pv = stats.f.sf(F, 1, degrees_of_freedom)
+
+    # the degrees of freedom must be at least one for the F-test
+    if degrees_of_freedom < 1:
+        raise ValueError("The sample size must be greater than "
+                         "two if 'center=True'. Got n_samples={}."
+                         .format(n_samples))
+
+    # convert to F-score and then to p-value
+    with np.errstate(divide="ignore"):
+        F = corr ** 2 / (1 - corr ** 2) * degrees_of_freedom
+        pv = stats.f.sf(F, 1, degrees_of_freedom)
+
     return F, pv
 
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -11,6 +11,7 @@ import pytest
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
+from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._testing import assert_warns_message
@@ -125,6 +126,24 @@ def test_f_regression_center():
     F2, _ = f_regression(X, Y, center=False)
     assert_array_almost_equal(F1 * (n_samples - 1.) / (n_samples - 2.), F2)
     assert_almost_equal(F2[0], 0.232558139)  # value from statsmodels OLS
+
+
+def test_f_regression_gets_raised():
+    # Test whether f_regression gets raised when the standard deviation
+    # of the random variables (regressors and targets) is zero
+    X = np.array([[2, 2], [0, 1]])
+    y = np.array([0, 1])
+    assert_raises(ValueError, f_regression, X, y)
+
+    X = np.array([[0, 1], [0, 1]])
+    y = np.array([1, 1])
+    assert_raises(ValueError, f_regression, X, y)
+
+    # Test whether f_regression gets raised when the degrees
+    # of freedom employed for the F-test is less than one
+    X = np.array([[1, 0], [0, 1]])
+    y = np.array([1, 0])
+    assert_raises(ValueError, f_regression, X, y)
 
 
 def test_f_classif_multi_class():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #15672.

#### What does this implement/fix? Explain your changes.
* Fix `RuntimeWarning: divide by zero encountered in true_divide` arising when the standard deviation of some of the random variables (regressors and target) is zero. The Pearson correlation coefficient is undefined for those cases. To solve this issue, a `ValueError` is raised.

* Ensure that the degrees of freedom used for the F-tests is at least one (for degrees of freedom less than or equal zero, `np.nan` values were returned for the F-scores and p-values). To solve this issue, a `ValueError` is raised.

* Filter `RuntimeWarning: divide by zero encountered in true_divide` when computing the F-scores between random variables with maximum correlation (either -1 or 1). In that cases, the returned F-scores and p-values are `np.inf` and `0`, respectively (that is correct).