### PR TITLE
[MRG] FIX add pos_label when computing AP in plot_precision_recall_curve

### DIFF
--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -161,6 +161,7 @@ def plot_precision_recall_curve(estimator, X, y,
                                                   pos_label=pos_label,
                                                   sample_weight=sample_weight)
     average_precision = average_precision_score(y, y_pred,
+                                                pos_label=pos_label,
                                                 sample_weight=sample_weight)
     viz = PrecisionRecallDisplay(precision, recall, average_precision,
                                  estimator.__class__.__name__)

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -7,6 +7,7 @@ from sklearn.metrics import plot_precision_recall_curve
 from sklearn.metrics import average_precision_score
 from sklearn.metrics import precision_recall_curve
 from sklearn.datasets import make_classification
+from sklearn.datasets import load_breast_cancer
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.linear_model import LogisticRegression
 from sklearn.exceptions import NotFittedError
@@ -132,3 +133,19 @@ def test_precision_recall_curve_pipeline(pyplot, clf):
     clf.fit(X, y)
     disp = plot_precision_recall_curve(clf, X, y)
     assert disp.estimator_name == clf.__class__.__name__
+
+
+def test_precision_recall_curve_string_labels():
+    # regression test #15738
+    cancer = load_breast_cancer()
+    X = cancer.data
+    y = np.array(
+        [cancer.target_names[i] for i in cancer.target],
+        dtype=object
+    )
+    lr = make_pipeline(StandardScaler(), LogisticRegression())
+    lr.fit(X, y)
+    for klass in cancer.target_names:
+        assert klass in lr.classes_
+    disp = plot_precision_recall_curve(lr, X, y)
+    assert disp.estimator_name == lr.__class__.__name__

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -135,7 +135,7 @@ def test_precision_recall_curve_pipeline(pyplot, clf):
     assert disp.estimator_name == clf.__class__.__name__
 
 
-def test_precision_recall_curve_string_labels():
+def test_precision_recall_curve_string_labels(pyplot):
     # regression test #15738
     cancer = load_breast_cancer()
     X = cancer.data

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -139,13 +139,17 @@ def test_precision_recall_curve_string_labels():
     # regression test #15738
     cancer = load_breast_cancer()
     X = cancer.data
-    y = np.array(
-        [cancer.target_names[i] for i in cancer.target],
-        dtype=object
-    )
+    y = cancer.target_names[cancer.target]
+
     lr = make_pipeline(StandardScaler(), LogisticRegression())
     lr.fit(X, y)
     for klass in cancer.target_names:
         assert klass in lr.classes_
     disp = plot_precision_recall_curve(lr, X, y)
+
+    y_pred = lr.predict_proba(X)[:, 1]
+    avg_prec = average_precision_score(y, y_pred,
+                                       pos_label=lr.classes_[1])
+
+    assert disp.average_precision == pytest.approx(avg_prec)
     assert disp.estimator_name == lr.__class__.__name__


### PR DESCRIPTION
closes #15738 

We need to pass `pos_label` into `average_precision_score`