### PR TITLE
Release 0.22

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -230,6 +230,26 @@ library for Windows, Mac OSX and Linux.
 Anaconda offers scikit-learn as part of its free distribution.
 
 
+Intel conda channel
+-------------------
+
+Intel maintains a dedicated conda channel that ships scikit-learn::
+
+    $ conda install -c intel scikit-learn
+
+This version of scikit-learn comes with alternative solvers for some common
+estimators. Those solvers come from the DAAL C++ library and are optimized for
+multi-core Intel CPUs.
+
+Note that those solvers are not enabled by default, please refer to the
+`daal4py <https://intelpython.github.io/daal4py/sklearn.html>`_ documentation
+for more details.
+
+Compatibility with the standard scikit-learn solvers is checked by running the
+full scikit-learn test suite via automated continuous integration as reported
+on https://github.com/IntelPython/daal4py.
+
+
 WinPython for Windows
 -----------------------
 

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -156,6 +156,8 @@
         <li><strong>On-going development:</strong>
         <a href="https://scikit-learn.org/dev/whats_new.html"><strong>What's new</strong> (Changelog)</a>
         </li>
+        <li><strong>December 2019.</strong> scikit-learn 0.22 is available for download (<a href="whats_new/v0.22.html#version-0-22-0">Changelog</a>).
+        </li>
         <li><strong>Scikit-learn from 0.21 requires Python 3.5 or greater.</strong>
         </li>
         <li><strong>July 2019.</strong> scikit-learn 0.21.3 (<a href="whats_new/v0.21.html#version-0-21-3">Changelog</a>) and 0.20.4 (<a href="whats_new/v0.20.html#version-0-20-4">Changelog</a>) are available for download.

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -7,7 +7,7 @@
 Version 0.22.0
 ==============
 
-**November 29 2019**
+**December 3 2019**
 
 For a short description of the main highlights of the release, please
 refer to
@@ -951,3 +951,65 @@ These changes mostly affect library developers.
 
 - |Fix| The estimators tags resolution now follows the regular MRO. They used
   to be overridable only once. :pr:`14884` by `Andreas Müller`_.
+
+
+Code and Documentation Contributors
+-----------------------------------
+
+Thanks to everyone who has contributed to the maintenance and improvement of the
+project since version 0.20, including:
+
+Aaron Alphonsus, Abbie Popa, Abdur-Rahmaan Janhangeer, abenbihi, Abhinav Sagar,
+Abhishek Jana, Abraham K. Lagat, Adam J. Stewart, Aditya Vyas, Adrin Jalali,
+Agamemnon Krasoulis, Alec Peters, Alessandro Surace, Alexandre de Siqueira,
+Alexandre Gramfort, alexgoryainov, Alex Henrie, Alex Itkes, alexshacked, Allen
+Akinkunle, Anaël Beaugnon, Anders Kaseorg, Andrea Maldonado, Andrea Navarrete,
+Andreas Mueller, Andreas Schuderer, Andrew Nystrom, Angela Ambroz, Anisha
+Keshavan, Ankit Jha, Antonio Gutierrez, Anuja Kelkar, Archana Alva,
+arnaudstiegler, arpanchowdhry, ashimb9, Ayomide Bamidele, Baran Buluttekin,
+barrycg, Bharat Raghunathan, Bill Mill, Biswadip Mandal, blackd0t, Brian G.
+Barkley, Brian Wignall, Bryan Yang, c56pony, camilaagw, cartman_nabana,
+catajara, Cat Chenal, Cathy, cgsavard, Charles Vesteghem, Chiara Marmo, Chris
+Gregory, Christian Lorentzen, Christos Aridas, Dakota Grusak, Daniel Grady,
+Daniel Perry, Danna Naser, DatenBergwerk, David Dormagen, deeplook, Dillon
+Niederhut, Dong-hee Na, Dougal J. Sutherland, DrGFreeman, Dylan Cashman,
+edvardlindelof, Eric Larson, Eric Ndirangu, Eunseop Jeong, Fanny,
+federicopisanu, Felix Divo, flaviomorelli, FranciDona, Franco M. Luque, Frank
+Hoang, Frederic Haase, g0g0gadget, Gabriel Altay, Gabriel do Vale Rios, Gael
+Varoquaux, ganevgv, gdex1, getgaurav2, Gideon Sonoiya, Gordon Chen, gpapadok,
+Greg Mogavero, Grzegorz Szpak, Guillaume Lemaitre, Guillem García Subies,
+H4dr1en, hadshirt, Hailey Nguyen, Hanmin Qin, Hannah Bruce Macdonald, Harsh
+Mahajan, Harsh Soni, Honglu Zhang, Hossein Pourbozorg, Ian Sanders, Ingrid
+Spielman, J-A16, jaehong park, Jaime Ferrando Huertas, James Hill, James Myatt,
+Jay, jeremiedbb, Jérémie du Boisberranger, jeromedockes, Jesper Dramsch, Joan
+Massich, Joanna Zhang, Joel Nothman, Johann Faouzi, Jonathan Rahn, Jon Cusick,
+Jose Ortiz, Kanika Sabharwal, Katarina Slama, kellycarmody, Kennedy Kang'ethe,
+Kensuke Arai, Kesshi Jordan, Kevad, Kevin Loftis, Kevin Winata, Kevin Yu-Sheng
+Li, Kirill Dolmatov, Kirthi Shankar Sivamani, krishna katyal, Lakshmi Krishnan,
+Lakshya KD, LalliAcqua, lbfin, Leland McInnes, Léonard Binet, Loic Esteve,
+loopyme, lostcoaster, Louis Huynh, lrjball, Luca Ionescu, Lutz Roeder,
+MaggieChege, Maithreyi Venkatesh, Maltimore, Maocx, Marc Torrellas, Marie
+Douriez, Markus, Markus Frey, Martina G. Vilas, Martin Oywa, Martin Thoma,
+Masashi SHIBATA, Maxwell Aladago, mbillingr, m-clare, Meghann Agarwal, m.fab,
+Micah Smith, miguelbarao, Miguel Cabrera, Mina Naghshhnejad, Ming Li, motmoti,
+mschaffenroth, mthorrell, Natasha Borders, nezar-a, Nicolas Hug, Nidhin
+Pattaniyil, Nikita Titov, Nishan Singh Mann, Nitya Mandyam, norvan,
+notmatthancock, novaya, nxorable, Oleg Stikhin, Oleksandr Pavlyk, Olivier
+Grisel, Omar Saleem, Owen Flanagan, panpiort8, Paolo, Paolo Toccaceli, Paresh
+Mathur, Paula, Peng Yu, Peter Marko, pierretallotte, poorna-kumar, pspachtholz,
+qdeffense, Rajat Garg, Raphaël Bournhonesque, Ray, Ray Bell, Rebekah Kim, Reza
+Gharibi, Richard Payne, Richard W, rlms, Robert Juergens, Rok Mihevc, Roman
+Feldbauer, Roman Yurchak, R Sanjabi, RuchitaGarde, Ruth Waithera, Sackey, Sam
+Dixon, Samesh Lakhotia, Samuel Taylor, Sarra Habchi, Scott Gigante, Scott
+Sievert, Scott White, Sebastian Pölsterl, Sergey Feldman, SeWook Oh, she-dares,
+Shreya V, Shubham Mehta, Shuzhe Xiao, SimonCW, smarie, smujjiga, Sönke
+Behrends, Soumirai, Sourav Singh, stefan-matcovici, steinfurt, Stéphane
+Couvreur, Stephan Tulkens, Stephen Cowley, Stephen Tierney, SylvainLan,
+th0rwas, theoptips, theotheo, Thierno Ibrahima DIOP, Thomas Edwards, Thomas J
+Fan, Thomas Moreau, Thomas Schmitt, Tilen Kusterle, Tim Bicker, Timsaur, Tim
+Staley, Tirth Patel, Tola A, Tom Augspurger, Tom Dupré la Tour, topisan, Trevor
+Stephens, ttang131, Urvang Patel, Vathsala Achar, veerlosar, Venkatachalam N,
+Victor Luzgin, Vincent Jeanselme, Vincent Lostanlen, Vladimir Korolev,
+vnherdeiro, Wenbo Zhao, Wendy Hu, willdarnell, William de Vazelhes,
+wolframalpha, xavier dupré, xcjason, x-martian, xsat, xun-tang, Yinglr,
+yokasre, Yu-Hang "Maxin" Tang, Yulia Zamriy, Zhao Feng

--- a/setup.py
+++ b/setup.py
@@ -247,6 +247,7 @@ def setup_package():
                                  'Programming Language :: Python :: 3.5',
                                  'Programming Language :: Python :: 3.6',
                                  'Programming Language :: Python :: 3.7',
+                                 'Programming Language :: Python :: 3.8',
                                  ('Programming Language :: Python :: '
                                   'Implementation :: CPython'),
                                  ('Programming Language :: Python :: '

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -40,7 +40,7 @@ logger.setLevel(logging.INFO)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.22rc3'
+__version__ = '0.22'
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -161,6 +161,7 @@ def plot_precision_recall_curve(estimator, X, y,
                                                   pos_label=pos_label,
                                                   sample_weight=sample_weight)
     average_precision = average_precision_score(y, y_pred,
+                                                pos_label=pos_label,
                                                 sample_weight=sample_weight)
     viz = PrecisionRecallDisplay(precision, recall, average_precision,
                                  estimator.__class__.__name__)

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -7,6 +7,7 @@ from sklearn.metrics import plot_precision_recall_curve
 from sklearn.metrics import average_precision_score
 from sklearn.metrics import precision_recall_curve
 from sklearn.datasets import make_classification
+from sklearn.datasets import load_breast_cancer
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.linear_model import LogisticRegression
 from sklearn.exceptions import NotFittedError
@@ -132,3 +133,23 @@ def test_precision_recall_curve_pipeline(pyplot, clf):
     clf.fit(X, y)
     disp = plot_precision_recall_curve(clf, X, y)
     assert disp.estimator_name == clf.__class__.__name__
+
+
+def test_precision_recall_curve_string_labels(pyplot):
+    # regression test #15738
+    cancer = load_breast_cancer()
+    X = cancer.data
+    y = cancer.target_names[cancer.target]
+
+    lr = make_pipeline(StandardScaler(), LogisticRegression())
+    lr.fit(X, y)
+    for klass in cancer.target_names:
+        assert klass in lr.classes_
+    disp = plot_precision_recall_curve(lr, X, y)
+
+    y_pred = lr.predict_proba(X)[:, 1]
+    avg_prec = average_precision_score(y, y_pred,
+                                       pos_label=lr.classes_[1])
+
+    assert disp.average_precision == pytest.approx(avg_prec)
+    assert disp.estimator_name == lr.__class__.__name__


### PR DESCRIPTION
This only adds the `pos_label` fix the 0.22 related doc fixes.
```
drop 947f37e3a1 MNT bump version to 0.23.dev0 and add new whats_new (#15631)
drop b6f124c848 MAINT Improve variable order in BaseDecisionTree (#15664)
drop 12196dab9b MNT replaced check_consistent_length, etc with _check_sample_weight in BaseGradientBoosting (#15478)
drop 1c546cd9b1 CLN Move gradient and hessian closer to for loop in hist GBDT (#15686)
pick f4da713c44 FIX add pos_label when computing AP in plot_precision_recall_curve (#15739)
drop a117db5755 MNT Activates github actions (#15746)
pick a91304ecd7 DOC Pre 0.22 release (#15735)
```