### PR TITLE
Configure twitter-action for @sklearn_commits

### DIFF
--- a/.github/workflows/twitter.yml
+++ b/.github/workflows/twitter.yml
@@ -1,0 +1,25 @@
+# Tweet the URL of a commit on @sklearn_commits whenever a push event
+# happens on the master branch
+name: Twitter Push Notification
+
+
+on:
+  push:
+    branches:
+      - master
+
+
+jobs:
+  tweet:
+    name: Twitter Notification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tweet URL of last commit as @sklearn_commits
+        uses: xorilog/twitter-action@0.1
+        with:
+          args: "-message \"https://github.com/scikit-learn/scikit-learn/commit/${{ github.sha }}\""
+        env:
+          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_SECRET: ${{ secrets.TWITTER_ACCESS_SECRET }}


### PR DESCRIPTION
This registers a new github actions workflow to tweet the last commit of any push to master on https://twitter.com/sklearn_commits.

I have registered the necessary secrent API keys and token on https://github.com/scikit-learn/scikit-learn/settings/secrets/ and I have also tested from my own github fork and it seem to work as expected.

The ultimate test would be to merge this PR though :)