### PR TITLE
DOC relabel Feature -> Efficiency in change log

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -416,12 +416,6 @@ Changelog
 :mod:`sklearn.gaussian_process`
 ...............................
 
-- |Feature| :func:`gaussian_process.GaussianProcessClassifier.log_marginal_likelihood`
-  and :func:`gaussian_process.GaussianProcessRegressor.log_marginal_likelihood` now
-  accept a ``clone_kernel=True`` keyword argument. When set to ``False``,
-  the kernel attribute is modified, but may result in a performance improvement.
-  :pr:`14378` by :user:`Masashi Shibata <c-bata>`.
-
 - |Feature| Gaussian process models on structured data: :class:`gaussian_process.GaussianProcessRegressor`
   and :class:`gaussian_process.GaussianProcessClassifier` can now accept a list
   of generic objects (e.g. strings, trees, graphs, etc.) as the ``X`` argument
@@ -430,6 +424,12 @@ Changelog
   the generic objects, and should inherit from :class:`gaussian_process.kernels.GenericKernelMixin`
   to notify the GPR/GPC model that it handles non-vectorial samples.
   :pr:`15557` by :user:`Yu-Hang Tang <yhtang>`.
+
+- |Efficiency| :func:`gaussian_process.GaussianProcessClassifier.log_marginal_likelihood`
+  and :func:`gaussian_process.GaussianProcessRegressor.log_marginal_likelihood` now
+  accept a ``clone_kernel=True`` keyword argument. When set to ``False``,
+  the kernel attribute is modified, but may result in a performance improvement.
+  :pr:`14378` by :user:`Masashi Shibata <c-bata>`.
 
 - |API| From version 0.24 :meth:`gaussian_process.kernels.Kernel.get_params` will raise an
   ``AttributeError`` rather than return ``None`` for parameters that are in the


### PR DESCRIPTION
This was incorrectly classified as a Feature, when it is an efficiency tool.

I think this should be pulled into the 0.22.X branch to improve readability of change log highlights.