### PR TITLE
[MRG] TST Increases tol for check_pca_float_dtype_preservation assertion

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -532,7 +532,7 @@ def check_pca_float_dtype_preservation(svd_solver):
     assert pca_64.transform(X_64).dtype == np.float64
     assert pca_32.transform(X_32).dtype == np.float32
 
-    assert_allclose(pca_64.components_, pca_32.components_, rtol=1e-4)
+    assert_allclose(pca_64.components_, pca_32.components_, rtol=2e-4)
 
 
 def check_pca_int_dtype_upcast_to_double(svd_solver):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/15774


#### What does this implement/fix? Explain your changes.
I think we need to bump the `tol` to 2e-4. The `components_` are obtained directly from `linalg.svd` here:

https://github.com/scikit-learn/scikit-learn/blob/479548ac9b675dba10110e0ae7df2a9e1f73ade6/sklearn/decomposition/_pca.py#L447-L451

#### Any other comments?

The proper fix would be to dig into lapack and see why there is this difference between float32 and float64.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
