### PR TITLE
DOC fix incorrect branch reference in contributing doc

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -251,7 +251,7 @@ modifying code and submitting a PR:
    to record your changes in Git, then push the changes to your GitHub
    account with::
 
-       $ git push -u origin my-feature
+       $ git push -u origin my_feature
 
 10. Follow `these
     <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_


### PR DESCRIPTION
#### Reference Issues/PRs
None, this is a very minor doc fix

#### What does this implement/fix? Explain your changes.
When looking at the documentation https://scikit-learn.org/stable/developers/contributing.html, in the "contributing code" section, number 8 creates a branch labeled 'my_feature' and number 9 pushes to a different branch 'my-feature'. I changed number 9 to 'my_feature' so that it is consistent with what is written in number 8. This will prevent errors from anyone who follows the code by a branch not existing when they push.