### PR TITLE
[MRG] BUG Fixes pandas dataframe bug with boolean dtypes

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -2,6 +2,25 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_0_22_1:
+
+Version 0.22.1
+==============
+
+**In Development**
+
+This is a bug-fix release to primarily resolve some packaging issues in version
+0.21.0. It also includes minor documentation improvements and some bug fixes.
+
+Changelog
+---------
+
+:mod:`sklearn.utils`
+....................
+
+- |Fix| :func:`utils.check_array` now correctly converts pandas DataFrame with
+  boolean columns to floats. :pr:`15797` by `Thomas Fan`_.
+
 .. _changes_0_22:
 
 Version 0.22.0

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -10,7 +10,7 @@ Version 0.22.1
 **In Development**
 
 This is a bug-fix release to primarily resolve some packaging issues in version
-0.21.0. It also includes minor documentation improvements and some bug fixes.
+0.22.0. It also includes minor documentation improvements and some bug fixes.
 
 Changelog
 ---------

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -56,9 +56,3 @@ Changelog
 
 - |Efficiency| :class:`preprocessing.OneHotEncoder` is now faster at
   transforming. :pr:`15762` by `Thomas Fan`_.
-
-:mod:`sklearn.utils`
-....................
-
-- |Fix| :func:`utils.check_array` now correctly converts pandas DataFrame with
-  boolean columns to floats. :pr:`15797` by `Thomas Fan`_.

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -56,3 +56,9 @@ Changelog
 
 - |Efficiency| :class:`preprocessing.OneHotEncoder` is now faster at
   transforming. :pr:`15762` by `Thomas Fan`_.
+
+:mod:`sklearn.utils`
+....................
+
+- |Fix| :func:`utils.check_array` now correctly converts pandas DataFrame with
+  boolean columns to floats. :pr:`15797` by `Thomas Fan`_.

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -840,12 +840,10 @@ def test_check_dataframe_mixed_float_dtypes():
         'bool': [True, False, True]})
 
     array = check_array(df, dtype=(np.float64, np.float32, np.float16))
-
     expected_array = np.array(
         [[1.0, 0.0, 1.0],
          [2.0, 0.1, 0.0],
          [3.0, 2.1, 1.0]], dtype=np.float)
-
     assert_allclose_dense_sparse(array, expected_array)
 
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -837,7 +837,7 @@ def test_check_dataframe_mixed_float_dtypes():
     df = pd.DataFrame({
         'int': [1, 2, 3],
         'float': [0, 0.1, 2.1],
-        'bool': [True, False, True]})
+        'bool': [True, False, True]}, columns=['int', 'float', 'bool'])
 
     array = check_array(df, dtype=(np.float64, np.float32, np.float16))
     expected_array = np.array(

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -826,6 +826,29 @@ def test_check_dataframe_warns_on_dtype():
     assert len(record) == 0
 
 
+def test_check_dataframe_mixed_float_dtypes():
+    # pandas dataframe will coerce a boolean into a object, this is a mismatch
+    # with np.result_type which will return a float
+    # check_array needs explicity check for bool dtype in a dataframe for this
+    # situation
+    # https://github.com/scikit-learn/scikit-learn/issues/15787
+
+    pd = importorskip("pandas")
+    df = pd.DataFrame({
+        'int': [1, 2, 3],
+        'float': [0, 0.1, 2.1],
+        'bool': [True, False, True]})
+
+    array = check_array(df, dtype=(np.float64, np.float32, np.float16))
+
+    expected_array = np.array(
+        [[1.0, 0.0, 1.0],
+         [2.0, 0.1, 0.0],
+         [3.0, 2.1, 1.0]], dtype=np.float)
+
+    assert_allclose_dense_sparse(array, expected_array)
+
+
 class DummyMemory:
     def cache(self, func):
         return func

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -829,8 +829,8 @@ def test_check_dataframe_warns_on_dtype():
 def test_check_dataframe_mixed_float_dtypes():
     # pandas dataframe will coerce a boolean into a object, this is a mismatch
     # with np.result_type which will return a float
-    # check_array needs explicity check for bool dtype in a dataframe for this
-    # situation
+    # check_array needs to explicitly check for bool dtype in a dataframe for
+    # this situation
     # https://github.com/scikit-learn/scikit-learn/issues/15787
 
     pd = importorskip("pandas")

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -454,9 +454,12 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     # DataFrame), and store them. If not, store None.
     dtypes_orig = None
     if hasattr(array, "dtypes") and hasattr(array.dtypes, '__array__'):
-        dtypes_orig = np.array(array.dtypes)
-        if all(isinstance(dtype, np.dtype) for dtype in dtypes_orig):
-            dtype_orig = np.result_type(*array.dtypes)
+        dtypes_orig = list(array.dtypes)
+        # pandas boolean dtype __array__ interface coerces bools to objects
+        if any(dtype.kind == 'b' for dtype in dtypes_orig):
+            dtypes_orig.append(np.object)
+        elif all(isinstance(dtype, np.dtype) for dtype in dtypes_orig):
+            dtype_orig = np.result_type(*dtypes_orig)
 
     if dtype_numeric:
         if dtype_orig is not None and dtype_orig.kind == "O":

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -456,9 +456,11 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     if hasattr(array, "dtypes") and hasattr(array.dtypes, '__array__'):
         dtypes_orig = list(array.dtypes)
         # pandas boolean dtype __array__ interface coerces bools to objects
-        if any(dtype.kind == 'b' for dtype in dtypes_orig):
-            dtypes_orig.append(np.object)
-        elif all(isinstance(dtype, np.dtype) for dtype in dtypes_orig):
+        for i, dtype_iter in enumerate(dtypes_orig):
+            if dtype_iter.kind == 'b':
+                dtypes_orig[i] = np.object
+
+        if all(isinstance(dtype, np.dtype) for dtype in dtypes_orig):
             dtype_orig = np.result_type(*dtypes_orig)
 
     if dtype_numeric:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/15787
Fixes #15795

#### What does this implement/fix? Explain your changes.
Adds a check for the boolean dtype and updates the dtype in the dtypes_org list.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
