### PR TITLE
Incremental weighted mean and var

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -707,6 +707,82 @@ def _safe_accumulator_op(op, x, *args, **kwargs):
     return result
 
 
+def _incremental_weighted_mean_and_var(X, sample_weight, last_weighted_mean,
+                                       last_weighted_variance,
+                                       last_weight_sum):
+    """Calculate weighted mean and variance batch update
+
+        last_weighted_mean and last_weighted_variance are statistics
+        computed at the last step by the function. Both must be
+        initialized to 0.0. In case no scaling is required
+        last_weighted_variance can be None. The weighted_mean is
+        always required and returned because necessary for the
+        calculation of the weighted_variance. last_weight sum is
+        the sum of weights encountered until now.
+
+        Derived from the paper "Incremental calculation of
+        weighted mean and variance",
+        by Tony Finch.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            Data to use for statistics update
+
+        sample_weight : array-like, shape (n_samples,)
+
+        last_weighted_mean : array-like, shape: (n_features,)
+
+        last_weighted_variance : array-like, shape: (n_features,)
+
+        last_weight_sum : array-like, shape (n_features,)
+
+        Returns
+        -------
+        updated_weighted_mean : array, shape (n_features,)
+
+        updated_weighted_variance : array, shape (n_features,)
+            If None, only weighted_mean is computed
+
+        updated_weight_sum : array, shape (n_features,)
+
+        Notes
+        -----
+        NaNs are forbidden.
+
+        References
+        ----------
+        Tony Finch
+        "Incremental calculation of weighted mean and variance"
+        University of Cambridge Computing Service, February 2009
+
+        """
+    # last = stats until now
+    # new = the current increment
+    # updated = the aggregated stats
+
+    new_weight_sum = np.sum(sample_weight, axis=0)
+    new_weighted_mean = np.average(X, weights=sample_weight, axis=0)
+    updated_weight_sum = last_weight_sum + new_weight_sum
+    updated_weighted_mean = (last_weight_sum * last_weighted_mean
+                             + new_weight_sum * new_weighted_mean) / updated_weight_sum
+
+    if last_weighted_variance is None:
+        updated_weighted_variance = None
+    else:
+        new_weighted_variance = np.average(
+            X ** 2, weights=sample_weight, axis=0) - new_weighted_mean ** 2
+        new_element = new_weight_sum * \
+            (new_weighted_variance + (new_weighted_mean - updated_weighted_mean) ** 2)
+        last_element = last_weight_sum * \
+            (last_weighted_variance + (last_weighted_mean - updated_weighted_mean) ** 2)
+        updated_weighted_variance = (
+            new_element + last_element) / updated_weight_sum
+
+    return updated_weighted_mean, updated_weighted_variance, updated_weight_sum
+
+
+
 def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
     """Calculate mean update and a Youngs and Cramer variance update.
 

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -491,6 +491,41 @@ def test_incremental_weighted_mean_and_variance():
         assert_almost_equal(last_var, var_exp)
 
 
+def test_incremental_weighted_mean_and_variance_ignore_nan():
+    old_means = np.array([535., 535., 535., 535.])
+    old_variances = np.array([4225., 4225., 4225., 4225.])
+    old_weight_sum = np.array([2, 2, 2, 2], dtype=np.int32)
+
+    sample_weights_X = np.ones(3)
+    sample_weights_X_nan = np.ones(4)
+
+    X = np.array([[170, 170, 170, 170],
+                  [430, 430, 430, 430],
+                  [300, 300, 300, 300]])
+
+    X_nan = np.array([[170, np.nan, 170, 170],
+                      [np.nan, 170, 430, 430],
+                      [430, 430, np.nan, 300],
+                      [300, 300, 300, np.nan]])
+
+    X_means, X_variances, X_count = \
+        _incremental_weighted_mean_and_var(X,
+                                           sample_weights_X,
+                                           old_means,
+                                           old_variances,
+                                           old_weight_sum)
+    X_nan_means, X_nan_variances, X_nan_count = \
+        _incremental_weighted_mean_and_var(X_nan,
+                                           sample_weights_X_nan,
+                                           old_means,
+                                           old_variances,
+                                           old_weight_sum)
+
+    assert_allclose(X_nan_means, X_means)
+    assert_allclose(X_nan_variances, X_variances)
+    assert_allclose(X_nan_count, X_count)
+
+
 def test_incremental_variance_update_formulas():
     # Test Youngs and Cramer incremental variance formulas.
     # Doggie data from https://www.mathsisfun.com/data/standard-deviation.html


### PR DESCRIPTION
#### Reference Issues/PRs
Partially adresses: #15601


#### What does this implement/fix? Explain your changes.
Method partial_fit in StandardScaler can be used multiple times to incrementally update mean and variance, but there was no proper method to do it with sample_weights. This PR introduce _incremental_weighted_mean_and_var, which does the exact thing we want. 

#### Any other comments?
1. Basic equations I used can be found [here](https://fanf2.user.srcf.net/hermes/doc/antiforgery/stats.pdf), but I haven't found any (free) papers with derivation leading to batch version of them. It's basic math, but code may seem confusing without that sort of explanation. If it's really necessary I can provide brief paper.
2. NaNs handling is somehow inelegant, but I haven't found any 'weighted' method similar to np.nanvar/np.nanmean.