### PR TITLE
Fix yticklabels order in permutation importances example

### DIFF
--- a/examples/inspection/plot_permutation_importance_multicollinear.py
+++ b/examples/inspection/plot_permutation_importance_multicollinear.py
@@ -60,11 +60,11 @@ tree_indices = np.arange(0, len(clf.feature_importances_)) + 0.5
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 8))
 ax1.barh(tree_indices,
          clf.feature_importances_[tree_importance_sorted_idx], height=0.7)
-ax1.set_yticklabels(data.feature_names)
+ax1.set_yticklabels(data.feature_names[tree_importance_sorted_idx])
 ax1.set_yticks(tree_indices)
 ax1.set_ylim((0, len(clf.feature_importances_)))
 ax2.boxplot(result.importances[perm_sorted_idx].T, vert=False,
-            labels=data.feature_names)
+            labels=data.feature_names[perm_sorted_idx])
 fig.tight_layout()
 plt.show()
 


### PR DESCRIPTION
The order of the yticklabels did not match the importance values (it was left to the original order of the source data columns).