### PR TITLE
Deprecate unused 'rotate' parameter in tree.plot_tree.

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -56,3 +56,11 @@ Changelog
 
 - |Efficiency| :class:`preprocessing.OneHotEncoder` is now faster at
   transforming. :pr:`15762` by `Thomas Fan`_.
+
+:mod:`sklearn.tree`
+...................
+
+- |Fix| :func:`tree.plot_tree` `rotate` parameter was unused and has been
+  deprecated.
+  :pr:`15806` by :user:`Chiara Marmo <cmarmo>`.
+

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -132,10 +132,11 @@ def plot_tree(decision_tree, max_depth=None, feature_names=None,
         to be proportions and percentages respectively.
 
     rotate : bool, optional (default=False)
-        When set to ``True``, orient tree left to right rather than top-down.
+        This parameter has no effect on the matplotlib tree visualisation and
+        it is kept here for backward compatibility.
 
         .. deprecated:: 0.23
-           ``rotate`` will be removed in 0.25.
+           ``rotate`` is deprecated in 0.23 and will be removed in 0.25.
 
 
     rounded : bool, optional (default=False)
@@ -174,7 +175,7 @@ def plot_tree(decision_tree, max_depth=None, feature_names=None,
     """
 
     if rotate != 'deprecated':
-        warnings.warn("'rotate' will be removed in 0.25.",
+        warnings.warn("'rotate' is deprecated in 0.23 and will be removed in 0.25.",
                       FutureWarning)
 
     exporter = _MPLTreeExporter(

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -175,7 +175,8 @@ def plot_tree(decision_tree, max_depth=None, feature_names=None,
     """
 
     if rotate != 'deprecated':
-        warnings.warn("'rotate' is deprecated in 0.23 and will be removed in 0.25.",
+        warnings.warn("'rotate' has no effect and is deprecated in 0.23. \
+                       it will be removed in 0.25.",
                       FutureWarning)
 
     exporter = _MPLTreeExporter(

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -24,6 +24,7 @@ from . import _tree
 from ._reingold_tilford import buchheim, Tree
 from . import DecisionTreeClassifier
 
+import warnings
 
 def _color_brew(n):
     """Generate n colors with equally spaced hues.
@@ -78,7 +79,7 @@ SENTINEL = Sentinel()
 def plot_tree(decision_tree, max_depth=None, feature_names=None,
               class_names=None, label='all', filled=False,
               impurity=True, node_ids=False,
-              proportion=False, rotate=False, rounded=False,
+              proportion=False, rotate='deprecated', rounded=False,
               precision=3, ax=None, fontsize=None):
     """Plot a decision tree.
 
@@ -133,6 +134,10 @@ def plot_tree(decision_tree, max_depth=None, feature_names=None,
     rotate : bool, optional (default=False)
         When set to ``True``, orient tree left to right rather than top-down.
 
+        .. deprecated:: 0.23
+           ``rotate`` will be removed in 0.25.
+
+
     rounded : bool, optional (default=False)
         When set to ``True``, draw node boxes with rounded corners and use
         Helvetica fonts instead of Times-Roman.
@@ -167,6 +172,11 @@ def plot_tree(decision_tree, max_depth=None, feature_names=None,
     [Text(251.5,345.217,'X[3] <= 0.8...
 
     """
+
+    if rotate != 'deprecated':
+        warnings.warn("'rotate' will be removed in 0.25.",
+                      FutureWarning)
+
     exporter = _MPLTreeExporter(
         max_depth=max_depth, feature_names=feature_names,
         class_names=class_names, label=label, filled=filled,

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -175,8 +175,8 @@ def plot_tree(decision_tree, max_depth=None, feature_names=None,
     """
 
     if rotate != 'deprecated':
-        warnings.warn("'rotate' has no effect and is deprecated in 0.23. \
-                       it will be removed in 0.25.",
+        warnings.warn(("'rotate' has no effect and is deprecated in 0.23. "
+                       "It will be removed in 0.25."),
                       FutureWarning)
 
     exporter = _MPLTreeExporter(

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -455,7 +455,7 @@ def test_plot_tree_rotate_deprecation():
     tree = DecisionTreeClassifier()
     tree.fit(X, y)
     # test that a warning is raised when rotate is used.
-    match = "'rotate' has no effect and is deprecated in 0.23. \
-                       it will be removed in 0.25."
+    match = ("'rotate' has no effect and is deprecated in 0.23. "
+             "It will be removed in 0.25.")
     with pytest.warns(FutureWarning, match=match):
         plot_tree(tree, rotate=True)

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -454,6 +454,7 @@ def test_plot_tree_rotate_deprecation():
     tree = DecisionTreeClassifier()
     tree.fit(X, y)
     # test that a warning is raised when rotate is used.
-    match = "'rotate' is deprecated in 0.23 and will be removed in 0.25."
+    match = "'rotate' has no effect and is deprecated in 0.23. \
+                       it will be removed in 0.25."
     with pytest.warns(FutureWarning, match=match):
         plot_tree(tree, rotate=True)

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -449,6 +449,7 @@ def test_plot_tree_gini(pyplot):
     assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [3, 0]"
     assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"
 
+
 # FIXME: to be removed in 0.25
 def test_plot_tree_rotate_deprecation():
     tree = DecisionTreeClassifier()

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -448,3 +448,12 @@ def test_plot_tree_gini(pyplot):
                                    "samples = 6\nvalue = [3, 3]")
     assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [3, 0]"
     assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"
+
+# FIXME: to be removed in 0.25
+def test_plot_tree_rotate_deprecation():
+    tree = DecisionTreeClassifier()
+    tree.fit(X, y)
+    # test that a warning is raised when rotate is used.
+    match = "'rotate' is deprecated in 0.23 and will be removed in 0.25."
+    with pytest.warns(FutureWarning, match=match):
+        plot_tree(tree, rotate=True)

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -451,7 +451,7 @@ def test_plot_tree_gini(pyplot):
 
 
 # FIXME: to be removed in 0.25
-def test_plot_tree_rotate_deprecation():
+def test_plot_tree_rotate_deprecation(pyplot):
     tree = DecisionTreeClassifier()
     tree.fit(X, y)
     # test that a warning is raised when rotate is used.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #15694.
Originally reported in #13971. 

#### What does this implement/fix? Explain your changes.
As suggested in the corresponding issue and on the [discussion mailing list](https://mail.python.org/pipermail/scikit-learn/2019-December/003576.html), the `rotate` parameter is deprecated. Will be removed in 0.25