### PR TITLE
Removed duplicate docstring for 'classes_' attribute in Naive Bayes

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -157,9 +157,6 @@ class GaussianNB(_BaseNB):
     epsilon_ : float
         absolute additive value to variances
 
-    classes_ : array-like, shape (n_classes,)
-        Unique class labels.
-
     Examples
     --------
     >>> import numpy as np
@@ -718,9 +715,6 @@ class MultinomialNB(_BaseDiscreteNB):
     n_features_ : int
         Number of features of each sample.
 
-    classes_ : array-like, shape (n_classes,)
-        Unique class labels.
-
     Examples
     --------
     >>> import numpy as np
@@ -827,9 +821,6 @@ class ComplementNB(_BaseDiscreteNB):
     feature_all_ : array, shape (n_features,)
         Number of samples encountered for each feature during fitting. This
         value is weighted by the sample weight when provided.
-
-    classes_ : array of shape (n_classes,)
-        The classes labels.
 
     Examples
     --------
@@ -938,9 +929,6 @@ class BernoulliNB(_BaseDiscreteNB):
 
     n_features_ : int
         Number of features of each sample.
-
-    classes_ : array of shape (n_classes,)
-        The classes labels.
 
     See Also
     ----------


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.

It removes some duplicate docstrings in the naive bayes documentation. The 'classes_' attribute was documented twice with slightly different wording. 

#### Any other comments?

