### PR TITLE
Mod: Modify silhouette_score(), calinski_harabasz_score() and davies_…

### DIFF
--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -19,20 +19,20 @@ from ...preprocessing import LabelEncoder
 from ...utils import deprecated
 
 
-def check_number_of_labels(n_labels, n_samples):
-    """Check that number of labels are valid.
-
-    Parameters
-    ----------
-    n_labels : int
-        Number of labels
-
-    n_samples : int
-        Number of samples
-    """
-    if not 1 < n_labels < n_samples:
-        raise ValueError("Number of labels is %d. Valid values are 2 "
-                         "to n_samples - 1 (inclusive)" % n_labels)
+# def check_number_of_labels(n_labels, n_samples):
+#     """Check that number of labels are valid.
+#
+#     Parameters
+#     ----------
+#     n_labels : int
+#         Number of labels
+#
+#     n_samples : int
+#         Number of samples
+#     """
+#     if not 1 < n_labels < n_samples:
+#         raise ValueError("Number of labels is %d. Valid values are 2 "
+#                          "to n_samples - 1 (inclusive)" % n_labels)
 
 
 def silhouette_score(X, labels, metric='euclidean', sample_size=None,

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -225,7 +225,12 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
     labels = le.fit_transform(labels)
     n_samples = len(labels)
     label_freqs = np.bincount(labels)
-    check_number_of_labels(len(le.classes_), n_samples)
+
+    # don't raise an error when le.classes_ =1 or cle.classes_ = n_samples
+    # instead return the worst score = -1
+    # check_number_of_labels(len(le.classes_), n_samples)
+    if len(le.classes_) == 1 or len(le.classes_) == n_samples:
+        return -1.0
 
     kwds['metric'] = metric
     reduce_func = functools.partial(_silhouette_reduce,
@@ -284,7 +289,11 @@ def calinski_harabasz_score(X, labels):
     n_samples, _ = X.shape
     n_labels = len(le.classes_)
 
-    check_number_of_labels(n_labels, n_samples)
+    # don't raise an error when le.classes_ = 1 or cle.classes_ = n_samples
+    # instead return the worst score = 0
+    # check_number_of_labels(n_labels, n_samples)
+    if len(le.classes_) == 1 or len(le.classes_) == n_samples:
+        return 0.0
 
     extra_disp, intra_disp = 0., 0.
     mean = np.mean(X, axis=0)
@@ -338,7 +347,16 @@ def davies_bouldin_score(X, labels):
     labels = le.fit_transform(labels)
     n_samples, _ = X.shape
     n_labels = len(le.classes_)
-    check_number_of_labels(n_labels, n_samples)
+
+    # don't raise an error when le.classes_ = 1 or cle.classes_ = n_samples
+    # instead return the worst score = np.inf
+    # this scorer does not follow the convention that higher return values
+    # are better than lower return values used along scikit-learn.
+    # It follow the opposite principle (lower return values are better than
+    # higher return values.
+    # check_number_of_labels(n_labels, n_samples)
+    if len(le.classes_) == 1 or len(le.classes_) == n_samples:
+        return np.inf
 
     intra_dists = np.zeros(n_labels)
     centroids = np.zeros((n_labels, len(X[0])), dtype=np.float)

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -19,22 +19,6 @@ from ...preprocessing import LabelEncoder
 from ...utils import deprecated
 
 
-# def check_number_of_labels(n_labels, n_samples):
-#     """Check that number of labels are valid.
-#
-#     Parameters
-#     ----------
-#     n_labels : int
-#         Number of labels
-#
-#     n_samples : int
-#         Number of samples
-#     """
-#     if not 1 < n_labels < n_samples:
-#         raise ValueError("Number of labels is %d. Valid values are 2 "
-#                          "to n_samples - 1 (inclusive)" % n_labels)
-
-
 def silhouette_score(X, labels, metric='euclidean', sample_size=None,
                      random_state=None, **kwds):
     """Compute the mean Silhouette Coefficient of all samples.
@@ -228,7 +212,6 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
 
     # don't raise an error when le.classes_ =1 or cle.classes_ = n_samples
     # instead return the worst score = -1
-    # check_number_of_labels(len(le.classes_), n_samples)
     if len(le.classes_) == 1 or len(le.classes_) == n_samples:
         return -1.0
 
@@ -291,7 +274,6 @@ def calinski_harabasz_score(X, labels):
 
     # don't raise an error when le.classes_ = 1 or cle.classes_ = n_samples
     # instead return the worst score = 0
-    # check_number_of_labels(n_labels, n_samples)
     if len(le.classes_) == 1 or len(le.classes_) == n_samples:
         return 0.0
 
@@ -350,11 +332,6 @@ def davies_bouldin_score(X, labels):
 
     # don't raise an error when le.classes_ = 1 or cle.classes_ = n_samples
     # instead return the worst score = np.inf
-    # this scorer does not follow the convention that higher return values
-    # are better than lower return values used along scikit-learn.
-    # It follow the opposite principle (lower return values are better than
-    # higher return values.
-    # check_number_of_labels(n_labels, n_samples)
     if len(le.classes_) == 1 or len(le.classes_) == n_samples:
         return np.inf
 

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -210,7 +210,7 @@ def silhouette_samples(X, labels, metric='euclidean', **kwds):
     n_samples = len(labels)
     label_freqs = np.bincount(labels)
 
-    # don't raise an error when le.classes_ =1 or cle.classes_ = n_samples
+    # don't raise an error when le.classes_ = 1 or le.classes_ = n_samples
     # instead return the worst score = -1
     if len(le.classes_) == 1 or len(le.classes_) == n_samples:
         return -1.0
@@ -272,7 +272,7 @@ def calinski_harabasz_score(X, labels):
     n_samples, _ = X.shape
     n_labels = len(le.classes_)
 
-    # don't raise an error when le.classes_ = 1 or cle.classes_ = n_samples
+    # don't raise an error when le.classes_ = 1 or le.classes_ = n_samples
     # instead return the worst score = 0
     if len(le.classes_) == 1 or len(le.classes_) == n_samples:
         return 0.0
@@ -330,7 +330,7 @@ def davies_bouldin_score(X, labels):
     n_samples, _ = X.shape
     n_labels = len(le.classes_)
 
-    # don't raise an error when le.classes_ = 1 or cle.classes_ = n_samples
+    # don't raise an error when le.classes_ = 1 or le.classes_ = n_samples
     # instead return the worst score = np.inf
     if len(le.classes_) == 1 or len(le.classes_) == n_samples:
         return np.inf

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -134,17 +134,10 @@ def test_correct_labelsize():
 
     # n_labels = n_samples
     y = np.arange(X.shape[0])
-    err_msg = (r'Number of labels is %d\. Valid values are 2 '
-               r'to n_samples - 1 \(inclusive\)' % len(np.unique(y)))
-    with pytest.raises(ValueError, match=err_msg):
-        silhouette_score(X, y)
-
+    assert -1.0 == silhouette_score(X, y)
     # n_labels = 1
     y = np.zeros(X.shape[0])
-    err_msg = (r'Number of labels is %d\. Valid values are 2 '
-               r'to n_samples - 1 \(inclusive\)' % len(np.unique(y)))
-    with pytest.raises(ValueError, match=err_msg):
-        silhouette_score(X, y)
+    assert -1.0 == silhouette_score(X, y)
 
 
 def test_non_encoded_labels():
@@ -185,24 +178,7 @@ def test_silhouette_nonzero_diag(dtype):
         silhouette_samples(dists, labels, metric='precomputed')
 
 
-def assert_raises_on_only_one_label(func):
-    """Assert message when there is only one label"""
-    rng = np.random.RandomState(seed=0)
-    with pytest.raises(ValueError, match="Number of labels is"):
-        func(rng.rand(10, 2), np.zeros(10))
-
-
-def assert_raises_on_all_points_same_cluster(func):
-    """Assert message when all point are in different clusters"""
-    rng = np.random.RandomState(seed=0)
-    with pytest.raises(ValueError, match="Number of labels is"):
-        func(rng.rand(10, 2), np.arange(10))
-
-
 def test_calinski_harabasz_score():
-    assert_raises_on_only_one_label(calinski_harabasz_score)
-
-    assert_raises_on_all_points_same_cluster(calinski_harabasz_score)
 
     # Assert the value is 1. when all samples are equals
     assert 1. == calinski_harabasz_score(np.ones((10, 2)),
@@ -221,8 +197,6 @@ def test_calinski_harabasz_score():
 
 
 def test_davies_bouldin_score():
-    assert_raises_on_only_one_label(davies_bouldin_score)
-    assert_raises_on_all_points_same_cluster(davies_bouldin_score)
 
     # Assert the value is 0. when all samples are equals
     assert davies_bouldin_score(np.ones((10, 2)),

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -127,8 +127,9 @@ def test_silhouette_paper_example():
                       abs=1e-2)
 
 
-def test_correct_labelsize():
-    # Assert 1 < n_labels < n_samples
+def test_worst_score_silhouette():
+    # Assert the worst score is returned
+    # when n_labels = 1 or n_labels = n_samples
     dataset = datasets.load_iris()
     X = dataset.data
 
@@ -138,6 +139,34 @@ def test_correct_labelsize():
     # n_labels = 1
     y = np.zeros(X.shape[0])
     assert -1.0 == silhouette_score(X, y)
+
+
+def test_worst_score_calinski_harabasz():
+    # Assert the worst score is returned
+    # when n_labels = 1 or n_labels = n_samples
+    dataset = datasets.load_iris()
+    X = dataset.data
+
+    # n_labels = n_samples
+    y = np.arange(X.shape[0])
+    assert 0.0 == calinski_harabasz_score(X, y)
+    # n_labels = 1
+    y = np.zeros(X.shape[0])
+    assert 0.0 == calinski_harabasz_score(X, y)
+
+
+def test_worst_score_davies_bouldin():
+    # Assert the worst score is returned
+    # when n_labels = 1 or n_labels = n_samples
+    dataset = datasets.load_iris()
+    X = dataset.data
+
+    # n_labels = n_samples
+    y = np.arange(X.shape[0])
+    assert np.inf == davies_bouldin_score(X, y)
+    # n_labels = 1
+    y = np.zeros(X.shape[0])
+    assert np.inf == davies_bouldin_score(X, y)
 
 
 def test_non_encoded_labels():


### PR DESCRIPTION
Modify `silhouette_score()`, `calinski_harabasz_score()` and `Davies-Bouldin Index()` to be compatible with GridSearchCv() when the numbers of clusters is equal to 1 or equal to n_samples.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
This pull request is to fix this issues https://github.com/scikit-learn/scikit-learn/issues/15717


#### What does this implement/fix? Explain your changes.
For `silhouette_score(X, y)`: instead of raise an `ValueError` when the len(classes_) = 1 or len(X), I return the min possible value = -1.

For `calinski_harabasz_score(X, y)`:  instead of raise an `ValueError` when the len(classes_) = 1 or len(X), I return the min possible value = 0.

For `Davies-Bouldin Index()`: instead of raise an `ValueError` when the len(classes_) = 1 or len(X), I return the max possible value = np.inf. This scorer does not follow the convention that higher return values are better than lower return values used along scikit-learn. It follows the opposite for that I return np.inf (could be fixed to a very big value)

I change few lines in sklearn/metrics/clusters/tests/test_unsupervised.py and passed all the tests.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
