### PR TITLE
MNT clarification on check_pca_float_dtype_preservation's new tol level.

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -532,6 +532,9 @@ def check_pca_float_dtype_preservation(svd_solver):
     assert pca_64.transform(X_64).dtype == np.float64
     assert pca_32.transform(X_32).dtype == np.float32
 
+    # the rtol is set such that the test passes on all platforms tested on
+    # conda-forge: PR#15775
+    # see: https://github.com/conda-forge/scikit-learn-feedstock/pull/113
     assert_allclose(pca_64.components_, pca_32.components_, rtol=2e-4)
 
 


### PR DESCRIPTION
#15775  adds a new `rtol` to a test, to pass tests on the archs not tested here but tested in `scikit-learn-feedstock`. This PR adds a comment to clarify that new tol.

@thomasjpfan sorry I wasn't available on that PR. I meant to add a comment in the code for future readers.