### PR TITLE
TST Specify random_state in test_cv_iterable_wrapper

### DIFF
--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1344,16 +1344,6 @@ def test_cv_iterable_wrapper():
     np.testing.assert_equal(list(kf_randomized_iter_wrapped.split(X, y)),
                             list(kf_randomized_iter_wrapped.split(X, y)))
 
-    try:
-        np.testing.assert_equal(list(kf_iter_wrapped.split(X, y)),
-                                list(kf_randomized_iter_wrapped.split(X, y)))
-        splits_are_equal = True
-    except AssertionError:
-        splits_are_equal = False
-    assert not splits_are_equal, (
-        "If the splits are randomized, "
-        "successive calls to split should yield different results")
-
 
 def test_group_kfold():
     rng = np.random.RandomState(0)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1338,7 +1338,7 @@ def test_cv_iterable_wrapper():
                             list(kf_iter_wrapped.split(X, y)))
     # If the splits are randomized, successive calls to split yields different
     # results
-    kf_randomized_iter = KFold(shuffle=True).split(X, y)
+    kf_randomized_iter = KFold(shuffle=True, random_state=0).split(X, y)
     kf_randomized_iter_wrapped = check_cv(kf_randomized_iter)
     # numpy's assert_array_equal properly compares nested lists
     np.testing.assert_equal(list(kf_randomized_iter_wrapped.split(X, y)),

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1344,6 +1344,16 @@ def test_cv_iterable_wrapper():
     np.testing.assert_equal(list(kf_randomized_iter_wrapped.split(X, y)),
                             list(kf_randomized_iter_wrapped.split(X, y)))
 
+    try:
+        np.testing.assert_equal(list(kf_iter_wrapped.split(X, y)),
+                                list(kf_randomized_iter_wrapped.split(X, y)))
+        splits_are_equal = True
+    except AssertionError:
+        splits_are_equal = False
+    assert not splits_are_equal, (
+        "If the splits are randomized, "
+        "successive calls to split should yield different results")
+
 
 def test_group_kfold():
     rng = np.random.RandomState(0)


### PR DESCRIPTION
Fixes #15784 
This test checks whether ``KFold(shuffle=False)`` produces different splits compared with ``KFold(shuffle=True, random_state=None)``. I think we can remove it because this test will sometimes fail.
ping @thomasjpfan