### PR TITLE
[MRG] Explicit conversion of ndarray to object dtype

### DIFF
--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -276,8 +276,8 @@ def _radius_neighbors_from_graph(graph, radius, return_distance):
     indices = indices.astype(np.intp, copy=no_filter_needed)
 
     if return_distance:
-        neigh_dist = np.array(np.split(data, indptr[1:-1]))
-    neigh_ind = np.array(np.split(indices, indptr[1:-1]))
+        neigh_dist = np.array(np.split(data, indptr[1:-1]), dtype=object)
+    neigh_ind = np.array(np.split(indices, indptr[1:-1]), dtype=object)
 
     if return_distance:
         return neigh_dist, neigh_ind


### PR DESCRIPTION
#### Reference Issues/PRs

Fix #15788.

#### What does this implement/fix? Explain your changes.

Recently, `numpy` deprecates automatic conversion of ragged arrays to object (see https://github.com/numpy/numpy/pull/14794 for details). Therefore, this kind of arrays must be explicitly created with the parameter `dtype=object` ([NEP 34 - Disallow inferring `dtype=object` for sequences](https://numpy.org/neps/nep-0034.html)).

This issue has been easily solved for the module `sklearn/neighbors/_base.py` (lines 279 and 280) since the returned array is always ragged.

However, also affects to methods like `is_multilabel` (line 138) and `target_type` (line 251) in module `sklearn/utils/multiclass` or `check_array` (line 515) in `sklearn/utils/validation.py` (among others) because the deprecation also affects to any call that internally calls `np.asarray` (for instance, the `assert_equal` family of functions calls `np.asarray`). Thus, these cases require more work, investigation and effort.

#### Any other comments?

The PR implementing the NEP 34 causes a lot of problems also in `NumPy` (https://github.com/numpy/numpy/pull/15053) `Pandas` (https://github.com/pandas-dev/pandas/pull/30035) and `Astropy` (https://github.com/astropy/astropy/issues/9716). Therefore, they reverse the PR (https://github.com/numpy/numpy/pull/15066) and leave it out of the 1.18.x and 1.19.x series and work on it in the master.

**Therefore, this issue should not cause more problems in the `travis` CRON (not for the moment).**

**Any comments will be appreciated, since the issue is causing more problems than expected.**