### PR TITLE
ENH CountVectorizer: sort features after pruning by frequency

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -58,6 +58,14 @@ Changelog
   :func:`datasets.make_moons` now accept two-element tuple.
   :pr:`15707` by :user:`Maciej J Mikulski <mjmikulski>`.
 
+:mod:`sklearn.feature_extraction`
+.................................
+
+- |Efficiency| :class:`feature_extraction.text.CountVectorizer` now sorts
+  features after pruning them by document frequency. This improves performances
+  for datasets with large vocabularies combined with ``min_df`` or ``max_df``.
+  :pr:`15834` by :user:`Santiago M. Mola <smola>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1223,8 +1223,6 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
             X.data.fill(1)
 
         if not self.fixed_vocabulary_:
-            X = self._sort_features(X, vocabulary)
-
             n_doc = X.shape[0]
             max_doc_count = (max_df
                              if isinstance(max_df, numbers.Integral)
@@ -1239,6 +1237,8 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
                                                        max_doc_count,
                                                        min_doc_count,
                                                        max_features)
+
+            X = self._sort_features(X, vocabulary)
 
             self.vocabulary_ = vocabulary
 


### PR DESCRIPTION
In CountVectorizer, sort features after pruning by frequency.
When using min_df or max_df with large vocabularies, this can
be a significant speed up.

Here's a simple benchmark:
```python
from sklearn.datasets import fetch_20newsgroups

dataset = fetch_20newsgroups(subset="all")

from time import time
from sklearn.feature_extraction.text import CountVectorizer

n_doc = 2000

for min_df in (1, 2, 3, 5, 8):
    for min_ngram_range in (1,):
        for max_ngram_range in (min_ngram_range + 5,):
            t0 = time()
            cv = CountVectorizer(
                input="content",
                analyzer="char",
                lowercase=False,
                ngram_range=(min_ngram_range, max_ngram_range),
                min_df=min_df,
            )
            cv.fit(dataset.data[:n_doc])
            print(
                "time=%f min_df=%d ngram_range=(%d, %d)"
                % (time() - t0, min_df, min_ngram_range, max_ngram_range)
```

and example results before the change:
```
time=20.674258 min_df=1 ngram_range=(1, 6)
time=21.181467 min_df=2 ngram_range=(1, 6)
time=21.105731 min_df=3 ngram_range=(1, 6)
time=21.049018 min_df=5 ngram_range=(1, 6)
time=21.095739 min_df=8 ngram_range=(1, 6)
```

and after the change:
```
time=20.434718 min_df=1 ngram_range=(1, 6)
time=17.153750 min_df=2 ngram_range=(1, 6)
time=16.405343 min_df=3 ngram_range=(1, 6)
time=16.040197 min_df=5 ngram_range=(1, 6)
time=15.901990 min_df=8 ngram_range=(1, 6)
```

