### PR TITLE
Except:pass is a bad programming practice. Must print error message.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -62,7 +62,7 @@ def pytest_collection_modifyitems(config, items):
                       '64 bits.')
             skip_doctests = True
     except ImportError:
-        pass
+        print("Import Error Raised.")
 
     if skip_doctests:
         skip_marker = pytest.mark.skip(reason=reason)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None

#### What does this implement/fix? Explain your changes.
It prints an error message saying that Import Error is raised. Because "Except: pass" is a bad programming practice.

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
