### PR TITLE
Use released scikit-learn==0.22 for binder.

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,8 +1,6 @@
---find-links https://sklearn-nightly.scdn8.secure.raxcdn.com scikit-learn
---pre
 matplotlib
 scikit-image
 pandas
 sphinx-gallery
-scikit-learn
+scikit-learn==0.22
 


### PR DESCRIPTION
Right now the scikit-learn dev version is used inside the binder image when clicking on a binder link from the stable documentation.

For example, if you click on the binder link at the bottom of https://scikit-learn.org/stable/auto_examples/plot_isotonic_regression.html#sphx-glr-auto-examples-plot-isotonic-regression-py and type this inside the notebook:
```py
import sklearn
sklearn.__version__
```
you'll get:
```
'0.23.dev0'
```