### PR TITLE
[MRG] More explicit binder requirements for 0.22

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,6 +1,9 @@
-matplotlib
-scikit-image
-pandas
-sphinx-gallery
-scikit-learn==0.22.*
+# Dependencies version were set to roughly the latest available version at the
+# time of the scikit-learn major release
+matplotlib==3.1.2
+scikit-image==0.16.2
+pandas==0.25.3
+sphinx-gallery==0.5.0
+# Need to update the scikit-learn version on each 0.22 minor release
+scikit-learn==0.22
 

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -2,5 +2,5 @@ matplotlib
 scikit-image
 pandas
 sphinx-gallery
-scikit-learn==0.22
+scikit-learn==0.22.*
 


### PR DESCRIPTION
Follow-up on https://github.com/scikit-learn/scikit-learn/pull/15840.

This avoids having to change the binder requirements on each minor release.