### PR TITLE
test_svm_equivalent_sample_weight_C should use tighter tolerance

### DIFF
--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -485,12 +485,12 @@ def test_svm_regressor_sided_sample_weight(estimator):
 
 def test_svm_equivalence_sample_weight_C():
     # test that rescaling all samples is the same as changing C
-    clf = svm.SVC()
+    clf = svm.SVC(tol=1e-6)
     clf.fit(X, Y)
     dual_coef_no_weight = clf.dual_coef_
     clf.set_params(C=100)
     clf.fit(X, Y, sample_weight=np.repeat(0.01, len(X)))
-    assert_allclose(dual_coef_no_weight, clf.dual_coef_)
+    assert_allclose(dual_coef_no_weight, clf.dual_coef_, atol=1e-5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR tweaks ``sklearn/svm/tests/test_svm.py::test_svm_equivalence_sample_weight_C`` to specify tighter SVC tolerance parameter, specifically `tol=1e-6`, as well as absolute tolerance in `assert_allclose` to `atol=1e-5`.

This change fixes the failure of the test, when SVC class is patched to use DAAL in daal4py project.

```
_____________________ test_svm_equivalence_sample_weight_C _____________________

    def test_svm_equivalence_sample_weight_C():
        # test that rescaling all samples is the same as changing C
        clf = svm.SVC()
        clf.fit(X, Y)
        dual_coef_no_weight = clf.dual_coef_
        clf.set_params(C=100)
        clf.fit(X, Y, sample_weight=np.repeat(0.01, len(X)))
>       assert_allclose(dual_coef_no_weight, clf.dual_coef_)
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=0
E       
E       Mismatch: 100%
E       Max absolute difference: 0.00413014
E       Max relative difference: 0.01060894
E        x: array([[-0.44591 , -0.393437, -0.445884,  0.391153,  0.447039,  0.447039]])
E        y: array([[-0.448086, -0.389307, -0.447859,  0.387865,  0.448694,  0.448693]])

miniconda/envs/bld/lib/python3.6/site-packages/sklearn/svm/tests/test_svm.py:493: AssertionError
```
