### PR TITLE
[NOMRG] test_stacking_cv_influence set tighter tol in LogisticRegression 

### DIFF
--- a/sklearn/ensemble/tests/test_stacking.py
+++ b/sklearn/ensemble/tests/test_stacking.py
@@ -443,9 +443,9 @@ def test_stacking_with_sample_weight(stacker, X, y):
 @pytest.mark.parametrize(
     "stacker, X, y",
     [(StackingClassifier(
-        estimators=[('lr', LogisticRegression()),
+        estimators=[('lr', LogisticRegression(tol=1e-6)),
                     ('svm', LinearSVC(random_state=42))],
-        final_estimator=LogisticRegression()),
+        final_estimator=LogisticRegression(tol=1e-6)),
       *load_breast_cancer(return_X_y=True)),
      (StackingRegressor(
          estimators=[('lr', LinearRegression()),


### PR DESCRIPTION
Setting tighter tolerance (`tol=1e-6`) allows the test to pass in daal4py, where computation of logistic/cross_entropy  loss and its gradient is performed using Intel DAAL.

With current test:

```
        for est_cv_3, est_cv_5 in zip(stacker_cv_3.estimators_,
                                      stacker_cv_5.estimators_):
>           assert_allclose(est_cv_3.coef_, est_cv_5.coef_)
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=0
E           
E           Mismatch: 100%
E           Max absolute difference: 0.53488994
E           Max relative difference: 2.78663169
E            x: array([[ 1.330649,  0.023872,  0.128831, -0.002925, -0.053261, -0.241014,
E                   -0.337852, -0.144228, -0.074394, -0.014633,  0.055071,  0.642667,
E                    0.242799, -0.109252, -0.004939, -0.048658, -0.069445, -0.018589,...
E            y: array([[ 1.839001,  0.088849, -0.072108,  0.002609, -0.076382, -0.341382,
E                   -0.477864, -0.204314, -0.106559, -0.021162,  0.077972,  0.911786,
E                    0.38237 , -0.115388, -0.007024, -0.068589, -0.097992, -0.026255,...

miniconda/envs/bld/lib/python3.6/site-packages/sklearn/ensemble/tests/test_stacking.py:474: AssertionError
```

as run on Travis CI in daal4py.