### PR TITLE
DOC Correct best_score_ doc in RidgeCV

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1696,7 +1696,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         Estimated regularization parameter.
 
     best_score_ : float
-        Mean cross-validated score of the estimator with the best alpha found.
+        Score of base estimator with best alpha.
 
     Examples
     --------
@@ -1803,7 +1803,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         Estimated regularization parameter.
 
     best_score_ : float
-        Mean cross-validated score of the estimator with the best alpha found.
+        Score of base estimator with best alpha.
 
     classes_ : array of shape (n_classes,)
         The classes labels.


### PR DESCRIPTION
See #15655
Sorry @glemaitre my review in that PR is wrong. best_score_ in RidgeCV is not the mean cross-validated score when ``cv is None`` and ``scoring is not None``. Instead, the score is obtained from the output of cross_val_predict.
I think this is annoying, i.e., ``RidgeCV(scoring="r2")`` is different from ``GridSearchCV(Ridge(), cv=LeaveOneOut(), scoring="r2")``.