### PR TITLE
FIX use safe_sparse_dot for callable kernel in LabelSpreading (#15866)

### DIFF
--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -195,7 +195,8 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
                 for weight_matrix in weight_matrices])
         else:
             weight_matrices = weight_matrices.T
-            probabilities = np.dot(weight_matrices, self.label_distributions_)
+            probabilities = safe_sparse_dot(
+                    weight_matrices, self.label_distributions_)
         normalizer = np.atleast_2d(np.sum(probabilities, axis=1)).T
         probabilities /= normalizer
         return probabilities

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -3,10 +3,12 @@
 import numpy as np
 import pytest
 
+from scipy.sparse import csr_matrix
 from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_no_warnings
 from sklearn.semi_supervised import _label_propagation as label_propagation
 from sklearn.metrics.pairwise import rbf_kernel
+from sklearn.neighbors import NearestNeighbors
 from sklearn.datasets import make_classification
 from sklearn.exceptions import ConvergenceWarning
 from numpy.testing import assert_array_almost_equal
@@ -152,3 +154,40 @@ def test_convergence_warning():
 
     mdl = label_propagation.LabelPropagation(kernel='rbf', max_iter=500)
     assert_no_warnings(mdl.fit, X, y)
+
+
+def test_predict_sparse_callable_kernel():
+    # This is a non-regression test for #15866
+
+    # Custom sparse kernel (top-K RBF)
+    def topk_rbf(X, Y=None, n_neighbors=10, gamma=1e-5):
+        nn = NearestNeighbors(n_neighbors=10, metric='euclidean', n_jobs=-1)
+        nn.fit(X)
+        W = -1 * nn.kneighbors_graph(Y, mode='distance').power(2) * gamma
+        np.exp(W.data, out=W.data)
+        assert isinstance(W, csr_matrix)
+        return W.T
+
+    n_classes = 4
+    n_samples = 500
+    n_test = 10
+    X, Y = make_classification(n_classes=n_classes,
+                               n_samples=n_samples,
+                               n_features=20,
+                               n_informative=20,
+                               n_redundant=0,
+                               n_repeated=0,
+                               random_state=0)
+
+    Xtrain = X[:n_samples - n_test]
+    Ytrain = Y[:n_samples - n_test]
+    Xtest = X[n_samples - n_test:]
+    Ytest = Y[n_samples - n_test:]
+
+    model = label_propagation.LabelSpreading(kernel=topk_rbf)
+    model.fit(Xtrain, Ytrain)
+
+    Ypred = model.predict(Xtest)
+    n_correct = np.sum(Ypred == Ytest)
+
+    assert n_correct >= 0.9 * n_test


### PR DESCRIPTION
Fixes #15866

When using a callable kernel function that returns a sparse matrix, the probabilities calculated during `LabelSpreading.predict_proba()` use `np.dot()`, which behaves badly when one of the arguments is sparse.


As a follow-up, the kernel that I used as an example here was what I intuitively wanted when I began trying `LabelSpreading` (RBF weights, but only for a local neighborhood of each data point). It took me some time until I figured out how to calculate this kernel as a callable. Since computing a dense RBF kernel is not feasible for large datasets, this kernel might be useful as a built-in option for other users as well.

If this sounds like a useful addition, I'd be happy to add support and tests for this as a separate PR. For example, this might be provided via `kernel='sparse-rbf'`, `'topk-rbf'`, `'truncated-rbf'` or a similar name.
