### PR TITLE
[MRG] Allow plot_confusion_matrix to be called on predicted labels

### DIFF
--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -131,15 +131,13 @@ def plot_confusion_matrix(estimator=None, X=None, y_true=None, labels=None,
     Parameters
     ----------
     estimator : estimator instance, default=None
-        Trained classifier. Either `estimator` and `X` must be specified, or
-        `y_pred`.
+        Trained classifier. Must be None if `y_pred` is specified.
 
-    X : {array-like, sparse matrix} of shape (n_samples, n_features),
-        default=None
-        Input values. Either `estimator` and `X` must be specified, or
-        `y_pred`.
+    X : {array-like, sparse matrix} of shape (n_samples, n_features),\
+            default=None
+        Input values. Must be None if `y_pred` is specified.
 
-    y_true : array-like of shape (n_samples,), default=None
+    y_true : array-like of shape (n_samples,)
         Target values, must be specified.
 
     labels : array-like of shape (n_classes,), default=None
@@ -180,8 +178,7 @@ def plot_confusion_matrix(estimator=None, X=None, y_true=None, labels=None,
         created.
 
     y_pred : array-like of shape (n_samples,), default=None
-        Predicted labels. Either `estimator` and `X` must be specified, or
-        `y_pred`.
+        Predicted labels. Must be None if `estimator` and `X` are specified.
 
     Returns
     -------

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -205,7 +205,10 @@ def plot_confusion_matrix(estimator=None, X=None, y_true=None, labels=None,
 
     if display_labels is None:
         if labels is None:
-            display_labels = estimator.classes_
+            if estimator is None:
+                display_labels = sorted(set(y_true).union(y_pred))
+            else:
+                display_labels = estimator.classes_
         else:
             display_labels = labels
 

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -131,10 +131,13 @@ def plot_confusion_matrix(estimator=None, X=None, y_true=None, labels=None,
     Parameters
     ----------
     estimator : estimator instance, default=None
-        Trained classifier. Either `estimator` and `X` must be specified, or `y_pred`.
+        Trained classifier. Either `estimator` and `X` must be specified, or
+        `y_pred`.
 
-    X : {array-like, sparse matrix} of shape (n_samples, n_features), default=None
-        Input values. Either `estimator` and `X` must be specified, or `y_pred`.
+    X : {array-like, sparse matrix} of shape (n_samples, n_features),
+        default=None
+        Input values. Either `estimator` and `X` must be specified, or
+        `y_pred`.
 
     y_true : array-like of shape (n_samples,), default=None
         Target values, must be specified.
@@ -177,7 +180,8 @@ def plot_confusion_matrix(estimator=None, X=None, y_true=None, labels=None,
         created.
 
     y_pred : array-like of shape (n_samples,), default=None
-        Predicted labels. Either `estimator` and `X` must be specified, or `y_pred`.
+        Predicted labels. Either `estimator` and `X` must be specified, or
+        `y_pred`.
 
     Returns
     -------

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -192,7 +192,8 @@ def plot_confusion_matrix(estimator=None, X=None, y_true=None, labels=None,
     elif estimator is None and X is None and y_pred is not None:
         check_consistent_length(y_true, y_pred)
     else:
-        raise ValueError("Either 'estimator' and 'X' must be passed to plot_confusion_matrix or 'y_pred'")
+        raise ValueError("Either 'estimator' and 'X' must be passed to "
+                         "plot_confusion_matrix or 'y_pred'")
 
     if normalize not in {'true', 'pred', 'all', None}:
         raise ValueError("normalize must be one of {'true', 'pred', "

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -155,17 +155,16 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
         assert disp.text_ is None
 
 
-def test_plot_confusion_matrix_ypred(pyplot, data, y_pred,
-                                     fitted_clf):
+def test_plot_confusion_matrix_ypred(pyplot, data, y_pred, fitted_clf):
     X, y = data
     cmap = 'plasma'
     ax = pyplot.gca()
     cm_pred = plot_confusion_matrix(y_true=y, y_pred=y_pred,
-                                 cmap=cmap, ax=ax).confusion_matrix
+                                    cmap=cmap, ax=ax).confusion_matrix
 
     ax = pyplot.gca()
     cm_est = plot_confusion_matrix(fitted_clf, X, y,
-                                 cmap=cmap, ax=ax).confusion_matrix
+                                   cmap=cmap, ax=ax).confusion_matrix
 
     assert_allclose(cm_est, cm_pred)
 

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -155,6 +155,34 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
         assert disp.text_ is None
 
 
+def test_plot_confusion_matrix_ypred(pyplot, data, y_pred,
+                                     fitted_clf):
+    X, y = data
+    cmap = 'plasma'
+    ax = pyplot.gca()
+    cm_pred = plot_confusion_matrix(y_true=y, y_pred=y_pred,
+                                 cmap=cmap, ax=ax).confusion_matrix
+
+    ax = pyplot.gca()
+    cm_est = plot_confusion_matrix(fitted_clf, X, y,
+                                 cmap=cmap, ax=ax).confusion_matrix
+
+    assert_allclose(cm_est, cm_pred)
+
+    err_msg = "Either 'estimator' and 'X' must be passed to " \
+              "plot_confusion_matrix or 'y_pred'"
+
+    with pytest.raises(ValueError) as e:
+        plot_confusion_matrix(fitted_clf, X, y,
+                              cmap=cmap, ax=ax, y_pred=y_pred)
+    assert str(e.value) == err_msg
+
+    with pytest.raises(ValueError) as e:
+        plot_confusion_matrix(y, cmap=cmap, ax=ax)
+    assert str(e.value) == err_msg
+
+
+
 def test_confusion_matrix_display(pyplot, data, fitted_clf, y_pred, n_classes):
     X, y = data
 


### PR DESCRIPTION
Allow passing predicted labels `y_pred` to `plot_confusion_matrix` that will be used instead of `estimator` and `X`. In order to maintain backwards compatibility, `y_pred` is added as an optional keyword argument.
When both `estimator` and `X` aswell as `y_pred` are passed, a ValueError is raised since it is unclear which of both should be used.

For the discussion see #15880 