### PR TITLE
[MRG] Fix typo in docstring

### DIFF
--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -558,7 +558,7 @@ class KNeighborsMixin:
 
         Examples
         --------
-        In the following example, we construct a NeighborsClassifier
+        In the following example, we construct a NearestNeighbors
         class from an array representing our data set and ask who's
         the closest point to [1,1,1]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The **Examples** docstring part of `kneighbors` method constructs a `NearestNeighbors` class, rather than a `NeighborsClassifier` class. So I made this fix.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
