### PR TITLE
[MRG] BLD Fixes bug when building with NO_MATHJAX=1

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,7 @@ numpydoc_class_members_toctree = False
 if os.environ.get('NO_MATHJAX'):
     extensions.append('sphinx.ext.imgmath')
     imgmath_image_format = 'svg'
+    mathjax_path = ''
 else:
     extensions.append('sphinx.ext.mathjax')
     mathjax_path = ('https://cdn.jsdelivr.net/npm/mathjax@3/es5/'


### PR DESCRIPTION
Fixes small bug when using `NO_MATHJAX=1` with doc building. When `mathjax_path=''` the mathjax script will not be inserted in the html.