### PR TITLE
Permutation importance fail fix

### DIFF
--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -116,7 +116,8 @@ def permutation_importance(estimator, X, y, scoring=None, n_repeats=5,
     baseline_score = scorer(estimator, X, y)
     scores = np.zeros((X.shape[1], n_repeats))
 
-    scores = Parallel(n_jobs=n_jobs)(delayed(_calculate_permutation_scores)(
+    scores = Parallel(n_jobs=n_jobs, max_nbytes=None)(delayed(
+        _calculate_permutation_scores)(
         estimator, X, y, col_idx, random_state, n_repeats, scorer
     ) for col_idx in range(X.shape[1]))
 

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -56,7 +56,7 @@ class ConfusionMatrixDisplay:
             Colormap recognized by matplotlib.
 
         xticks_rotation : {'vertical', 'horizontal'} or float, \
-                         default='vertical'
+                         default='horizontal'
             Rotation of xtick labels.
 
         values_format : str, default=None
@@ -160,7 +160,7 @@ def plot_confusion_matrix(estimator, X, y_true, labels=None,
         Includes values in confusion matrix.
 
     xticks_rotation : {'vertical', 'horizontal'} or float, \
-                        default='vertical'
+                        default='horizontal'
         Rotation of xtick labels.
 
     values_format : str, default=None


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#15810
#### What does this implement/fix? Explain your changes.

 When using permutation_importance with a large enough pandas DataFrame and n_jobs > 0, joblib switches to read-only memmap mode, which proceeds to raise, as permutation_importance tries to assign to the DataFrame.
The bug was fixed by setting the bug by setting max_nbytes to None.


#### Any other comments?
Verified using below snippet
`
import pandas as pd
from sklearn.datasets import load_iris
from sklearn.ensemble import RandomForestClassifier
from sklearn.inspection import permutation_importance

data = load_iris()
df = pd.DataFrame(data=data.data.repeat(1000, axis=0))
y = data.target.repeat(1000)

clf = RandomForestClassifier()
clf.fit(df, y)

r = permutation_importance(clf, df, y, n_jobs=-1)
`
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->