### PR TITLE
[MRG] MNT Adds skip lint to azure pipeline CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
     - bash: conda create --name flake8_env --yes flake8
       displayName: Install flake8
     - bash: |
-        if [[ $BUILD_SOURCEVERSIONMESSAGE =~ /\[lint skip\]/ ]]; then
+        if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[lint\ skip\] ]]; then
           # skip linting
           echo "Skipping linting"
           exit 0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,14 @@ jobs:
     - bash: conda create --name flake8_env --yes flake8
       displayName: Install flake8
     - bash: |
-        source activate flake8_env
-        ./build_tools/circle/linting.sh
+        if [[ $BUILD_SOURCEVERSIONMESSAGE =~ /\[lint skip\]/ ]]; then
+          # skip linting
+          echo "Skipping linting"
+          exit 0
+        else
+          source activate flake8_env
+          ./build_tools/circle/linting.sh
+        fi
       displayName: Run linting
 
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -437,6 +437,7 @@ message, the following actions are taken.
     ---------------------- -------------------
     [scipy-dev]            Add a Travis build with our dependencies (numpy, scipy, etc ...) development builds
     [ci skip]              CI is skipped completely
+    [lint skip]            Azure pipeline skips linting
     [doc skip]             Docs are not built
     [doc quick]            Docs built, but excludes example gallery plots
     [doc build]            Docs built including example gallery plots


### PR DESCRIPTION
Adds `[lint skip]` marker to azure pipeline CI to run all the tests even if linting fails.