### PR TITLE
MNT Ignores warning in pyamg for deprecated scipy.random

### DIFF
--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -194,7 +194,7 @@ def test_discretize(n_samples):
 # TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
 # https://github.com/scikit-learn/scikit-learn/issues/15913
 @pytest.mark.filterwarnings(
-    "ignore:scipy.rand is deprecated:DeprecationWarning:scipy.*")
+    "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")
 def test_spectral_clustering_with_arpack_amg_solvers():
     # Test that spectral_clustering is the same for arpack and amg solver
     # Based on toy example from plot_segmentation_toy.py

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -191,6 +191,10 @@ def test_discretize(n_samples):
         assert adjusted_rand_score(y_true, y_pred) > 0.8
 
 
+# TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
+# https://github.com/scikit-learn/scikit-learn/issues/15913
+@pytest.mark.filterwarnings(
+    "ignore:scipy.rand is deprecated:DeprecationWarning:scipy.*")
 def test_spectral_clustering_with_arpack_amg_solvers():
     # Test that spectral_clustering is the same for arpack and amg solver
     # Based on toy example from plot_segmentation_toy.py

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -184,7 +184,7 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
 # TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
 # https://github.com/scikit-learn/scikit-learn/issues/15913
 @pytest.mark.filterwarnings(
-    "ignore:scipy.rand is deprecated:DeprecationWarning:scipy.*")
+    "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")
 def test_spectral_embedding_amg_solver(seed=36):
     # Test spectral embedding with amg solver
     pytest.importorskip('pyamg')
@@ -218,7 +218,7 @@ def test_spectral_embedding_amg_solver(seed=36):
 # TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
 # https://github.com/scikit-learn/scikit-learn/issues/15913
 @pytest.mark.filterwarnings(
-    "ignore:scipy.rand is deprecated:DeprecationWarning:scipy.*")
+    "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")
 def test_spectral_embedding_amg_solver_failure(seed=36):
     # Test spectral embedding with amg solver failure, see issue #13393
     pytest.importorskip('pyamg')

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -181,6 +181,10 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
     assert _check_with_col_sign_flipping(embed_rbf, embed_callable, 0.05)
 
 
+# TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
+# https://github.com/scikit-learn/scikit-learn/issues/15913
+@pytest.mark.filterwarnings(
+    "ignore:scipy.rand is deprecated:DeprecationWarning:scipy.*")
 def test_spectral_embedding_amg_solver(seed=36):
     # Test spectral embedding with amg solver
     pytest.importorskip('pyamg')
@@ -211,6 +215,10 @@ def test_spectral_embedding_amg_solver(seed=36):
     assert _check_with_col_sign_flipping(embed_amg, embed_arpack, 1e-5)
 
 
+# TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
+# https://github.com/scikit-learn/scikit-learn/issues/15913
+@pytest.mark.filterwarnings(
+    "ignore:scipy.rand is deprecated:DeprecationWarning:scipy.*")
 def test_spectral_embedding_amg_solver_failure(seed=36):
     # Test spectral embedding with amg solver failure, see issue #13393
     pytest.importorskip('pyamg')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Partially addresses https://github.com/scikit-learn/scikit-learn/issues/15913

#### What does this implement/fix? Explain your changes.
Filters warnings in tests that uses pyamg.

#### Any other comments?
This PR is a temporary solution. The correct fix is to update pyamg to use `numpy.random` instead of `scipy.random`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
