### PR TITLE
[MRG] Make cross_val_predict support method="predict_proba" and y=None

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -94,6 +94,10 @@ Changelog
   type and details.
   :pr:`15622` by :user:`Gregory Morse <GregoryMorse>`.
 
+- |Fix| :func: `cross_val_predict` supports `method="predict_proba"`
+  when `y=None`.
+  :pr: `15918` by :user: `Luca Kubin <lkubin>`.
+
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -842,7 +842,11 @@ def _fit_and_predict(estimator, X, y, train, test, verbose, fit_params,
         estimator.fit(X_train, y_train, **fit_params)
     func = getattr(estimator, method)
     predictions = func(X_test)
-    if method in ['decision_function', 'predict_proba', 'predict_log_proba']:
+
+    encode = method in ['decision_function', 'predict_proba',
+                        'predict_log_proba'] and y is not None
+
+    if encode:
         if isinstance(predictions, list):
             predictions = [_enforce_prediction_order(
                 estimator.classes_[i_label], predictions[i_label],

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -734,7 +734,7 @@ def cross_val_predict(estimator, X, y=None, groups=None, cv=None,
     # If classification methods produce multiple columns of output,
     # we need to manually encode classes to ensure consistent column ordering.
     encode = method in ['decision_function', 'predict_proba',
-                        'predict_log_proba']
+                        'predict_log_proba'] and y is not None
     if encode:
         y = np.asarray(y)
         if y.ndim == 1:

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -978,13 +978,14 @@ def test_cross_val_predict_unbalanced():
 def test_cross_val_predict_y_none():
     # ensure that cross_val_predict works when y is None
     mock_classifier = MockClassifier()
-    X = np.random.random((100, 10))
+    rng = np.random.RandomState(42)
+    X = rng.random((100, 10))
     y_hat = cross_val_predict(mock_classifier, X, y=None, cv=5,
                               method='predict')
-    assert np.all(X[:, 0] == y_hat)
+    assert_allclose(X[:, 0], y_hat)
     y_hat_proba = cross_val_predict(mock_classifier, X, y=None, cv=5,
                                     method='predict_proba')
-    assert np.all(y_hat_proba == X)
+    assert_allclose(X, y_hat_proba)
 
 
 def test_cross_val_score_sparse_fit_params():

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -979,7 +979,7 @@ def test_cross_val_predict_y_none():
     # ensure that cross_val_predict works when y is None
     mock_classifier = MockClassifier()
     rng = np.random.RandomState(42)
-    X = rng.random((100, 10))
+    X = rng.rand(100, 10)
     y_hat = cross_val_predict(mock_classifier, X, y=None, cv=5,
                               method='predict')
     assert_allclose(X[:, 0], y_hat)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -214,6 +214,9 @@ class MockClassifier:
             T = T.reshape(len(T), -1)
         return T[:, 0]
 
+    def predict_proba(self, T):
+        return T
+
     def score(self, X=None, Y=None):
         return 1. / (1 + np.abs(self.a))
 
@@ -970,6 +973,18 @@ def test_cross_val_predict_unbalanced():
     assert np.all(yhat_proba[test[1]] > 0)
     assert_array_almost_equal(yhat_proba.sum(axis=1), np.ones(y.shape),
                               decimal=12)
+
+
+def test_cross_val_predict_y_none():
+    # ensure that cross_val_predict works when y is None
+    mock_classifier = MockClassifier(allow_nd=True)
+    X = np.random.random((100, 10))
+    y_hat = cross_val_predict(mock_classifier, X, y=None, cv=5,
+                              method='predict')
+    assert np.all(X[:, 0] == y_hat)
+    y_hat_proba = cross_val_predict(mock_classifier, X, y=None, cv=5,
+                                    method='predict_proba')
+    assert np.all(y_hat_proba == X)
 
 
 def test_cross_val_score_sparse_fit_params():

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -977,7 +977,7 @@ def test_cross_val_predict_unbalanced():
 
 def test_cross_val_predict_y_none():
     # ensure that cross_val_predict works when y is None
-    mock_classifier = MockClassifier(allow_nd=True)
+    mock_classifier = MockClassifier()
     X = np.random.random((100, 10))
     y_hat = cross_val_predict(mock_classifier, X, y=None, cv=5,
                               method='predict')


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #15855 

#### Description

`cross_val_predict` raises exception when passing `method="predict_proba"` and `y=None`

#### What does this implement/fix? Explain your changes.

The problem is due to the fact that when `method in ['decision_function', 'predict_proba', 'predict_log_proba']` y is cast to numpy array `y = np.asarray(y)` without checking if y is not None (when casting None to numpy array the singleton array `array(None, dtype=object)` is returned).
