### PR TITLE
[WIP] Add `sparse-rbf` kernel option for `semi_supervised.LabelSpreading`

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -795,6 +795,14 @@ Changelog
   :pr:`13925` by :user:`Isaac S. Robson <isrobson>` and :pr:`15524` by
   :user:`Xun Tang <xun-tang>`.
 
+:mod:`sklearn.semi_supervised`
+.............................
+
+- |Fix| :class:`semi_supervised.LabelPropagation` and
+  `semi_supervised.LabelSpreading` now allow callable kernel function to
+  return sparse weight matrix.
+  :pr:`15868` by :user:`Niklas Smedemark-Margulies <nik-sm>`.
+
 :mod:`sklearn.svm`
 ..................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -796,7 +796,7 @@ Changelog
   :user:`Xun Tang <xun-tang>`.
 
 :mod:`sklearn.semi_supervised`
-.............................
+..............................
 
 - |Fix| :class:`semi_supervised.LabelPropagation` and
   `semi_supervised.LabelSpreading` now allow callable kernel function to

--- a/examples/semi_supervised/compare_sparse_kernels_mnist.py
+++ b/examples/semi_supervised/compare_sparse_kernels_mnist.py
@@ -1,0 +1,169 @@
+"""
+=================================================
+Label Propagation MNIST: Comparing Sparse Kernels
+=================================================
+
+This example compares the runtime and performance of two sparse kernels for
+semisupervised learning on the MNIST digit dataset.
+
+The MNIST dataset consists of 28x28 pixel grayscale images. Here, we will use a
+subset of 10K images, reserving a fraction of these for testing.  We will
+compare the performance and runtime of two sparse kernels, across a range of
+low-supervision scenarios.
+
+In each scenario, we will run each model multiple times, to increase our
+confidence in the comparison between kernels.
+
+The models will be evaluated for their accuracy at spreading labels during
+training ("transductive learning"), as well as spreading labels to unseen
+points at test time ("inductive learning").
+
+The first kernel option produces a binary k-Nearest Neighbors adjacency matrix.
+The second produces a kernel which is also k-sparse, but contains the same
+weights as used in an RBF kernel.  
+
+Notice that the performance of the sparse-RBF kernel is very sensitive to
+parameters; the parameters used here were found by a quick manual search, so
+the model can likely be improved with further optimization, and using this
+kernel effectively on a new dataset requires hyperparameter tuning.
+"""
+import numpy as np
+from sklearn.datasets import fetch_openml
+from sklearn.semi_supervised import LabelSpreading
+from sklearn.metrics import classification_report, confusion_matrix
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import make_scorer
+import time
+
+Xorig, Yorig = fetch_openml('mnist_784', version=1, return_X_y=True)
+Yorig = Y.astype(int)
+
+# For a quick demonstration, use only a subset of the data
+n_total = 10000
+X = Xorig[:n_total, :]
+Y = Yorig[:n_total]
+
+# Save test set for inductive learning
+test_fraction = 0.333
+Xtrain, Xtest, Ytrain, Ytest = train_test_split(X, Y, test_size=test_fraction,
+                                                random_state=0)
+
+# Mask subset of train data for transductive learning
+n_train = len(Ytrain)
+#kwargs = {'gamma': 1e-9, 'n_neighbors': 50, 'n_jobs': -1, 'max_iter': 100}
+
+#models = [LabelSpreading(kernel='knn', **kwargs),
+#          LabelSpreading(kernel='sparse-rbf', **kwargs)]
+
+#supervision_fractions = [0.001, 0.005, 0.01, 0.05, 0.1]
+
+# First, we perform a grid search to optimize parameters for sparse-rbf kernel.
+# For this purpose, we use a smaller subset of the data.
+# Notice also that we 
+
+class WrapLabelSpreading(LabelSpreading):
+    """
+    In order to perform a grid search over this semi-supervised model,
+    we need to provide a thin wrapper that masks a subset of the data before 
+    `fit` is called.
+    """
+    def __init__(self, supervision_fraction, kernel='sparse-rbf', gamma=20,
+            n_neighbors=7, alpha=0.2, max_iter=30, tol=1e-3, n_jobs=None):
+
+        self.supervision_fraction = supervision_fraction
+
+        super().__init__(kernel=kernel, gamma=gamma,
+                         n_neighbors=n_neighbors, alpha=alpha,
+                         max_iter=max_iter, tol=tol, n_jobs=n_jobs)
+
+    def fit(self, X, y):
+        # mask a random subset of labels, based on self.supervision_fraction
+        n_total = len(y)
+        n_labeled = self.supervision_fraction * n_total
+
+        indices = np.arange(n_total)
+        np.random.seed(0)
+        np.random.shuffle(indices)
+        unlabeled_subset = indices[n_labeled:]
+
+        y[unlabeled_subset] = -1
+
+        super().fit(X,y)
+        return self
+
+
+# In all cases, we simply use max_iter=100
+sparse_rbf_model = GridSearchCV(WrapLabelSpreading(kernel='sparse-rbf'),
+                                param_grid= {
+                                    'gamma': np.logspace(-8, 1, 10),
+                                    'alpha': np.linspace(0, 1, 10),
+                                     'n_neighbors': list(range(5,55,5))})
+
+knn_model = GridSearchCV(WrapLabelSpreading(kernel='knn'),
+                         param_grid= {
+                             'n_neighbors': list(range(5,55,5))},
+                             'alpha': np.linspace(0, 1, 10),
+                            )
+
+
+# Then, we compare the performance of optimized sparse-rbf kernel to knn kernel
+supervision_fractions = [0.05, 0.1]
+accuracies = {
+        'transduction': { 'knn':[], 'sparse-rbf':[] }, 
+        'induction': { 'knn':[], 'sparse-rbf':[] }
+}
+for supervision_fraction in supervision_fractions:
+    supervision_fraction = 0.05
+    n_labeled = int(supervision_fraction * n_train)
+    indices = np.arange(n_train)
+    unlabeled_set = indices[n_labeled:]
+
+    Ymasked = np.copy(Ytrain)
+    Ymasked[unlabeled_set] = -1
+
+    for kernel_name, model in zip(['knn', 'sparse-rbf'], 
+                                  [knn_model, sparse_rbf_model]):
+        knn_acc_trans = []
+        knn_acc_ind = []
+        sparse_rbf_acc_trans = []
+        sparse_rbf_acc_ind = []
+        # Repeat each scenario 5 times to collect rough statistics
+    #    for _ in range(5):
+        print("="*80)
+        t0 = time.time()
+        print(f"MODEL: {model}")
+        model.fit(Xtrain, Ymasked)
+        t1 = time.time()
+
+        predicted_labels = model.transduction_[unlabeled_set]
+        true_labels = Ytrain[unlabeled_set]
+        acc = np.sum(predicted_labels == true_labels) / len(unlabeled_set)
+        print(f"accuracy: {acc}")
+
+
+
+        print("-"*80)
+        print(f"TRANSDUCTION: {n_labeled} labeled and " +
+              f"{n_train - n_labeled} unlabeled points ({n_train} total)")
+        print("-"*80)
+        print("Confusion Matrix:")
+        print(confusion_matrix(true_labels, predicted_labels,
+                               labels=model.classes_))
+        print("-"*80)
+        print("Classification Report:")
+        print(classification_report(true_labels, predicted_labels))
+        print("-"*80)
+
+        predicted_labels = model.predict(Xtest)
+        t2 = time.time()
+
+        print("-"*80)
+        print(f"INDUCTION: {int(test_fraction * n_total)} test points")
+        print("-"*80)
+        print("Confusion Matrix:")
+        print(confusion_matrix(Ytest, predicted_labels, labels=model.classes_))
+        print("-"*80)
+        print("Classification Report:")
+        print(classification_report(Ytest, predicted_labels))
+        print("-"*80)
+        print(f"Runtimes: Transduction: {t1 - t0:.2f}s. Induction: {t2 - t1:.2f}s")

--- a/examples/semi_supervised/compare_sparse_kernels_mnist.py
+++ b/examples/semi_supervised/compare_sparse_kernels_mnist.py
@@ -163,6 +163,8 @@ def plot_results(supervision_fractions, results):
         ax[i].set_xlim([8e-4, 1.3e-1])
         ax[i].set_title(f'{label.capitalize()}')
         ax[i].set_xlabel('Supervision Fraction')
+        ax[i].set_ylabel(ylabel)
+        ax[i].legend()
         ax[i].fill_between(supervision_fractions,
                            [a - b for a, b in zip(S_avg, S_std)],
                            [a + b for a, b in zip(S_avg, S_std)],
@@ -213,7 +215,7 @@ if __name__ == '__main__':
     # Set the fraction of data to use for hyperparam tuning
     hyperp_tune_fraction = 0.1
     # Set the fraction of data to use for the final comparison
-    compare_fraction = 0.1
+    compare_fraction = 0.2
     # Set this flag to run the grid search, which takes several hours
     do_grid_search = False
 

--- a/examples/semi_supervised/compare_sparse_kernels_mnist.py
+++ b/examples/semi_supervised/compare_sparse_kernels_mnist.py
@@ -27,6 +27,7 @@ parameters; the parameters used here were found by a quick manual search, so
 the model can likely be improved with further optimization, and using this
 kernel effectively on a new dataset requires hyperparameter tuning.
 """
+import matplotlib.pyplot as plt
 import numpy as np
 from pprint import pprint
 from sklearn.datasets import fetch_openml
@@ -35,125 +36,166 @@ from sklearn.semi_supervised import LabelSpreading
 import time
 
 
-def run_comparison():
-    X_orig, y_orig = fetch_openml('mnist_784', version=1, return_X_y=True)
-    y_orig = y_orig.astype(int)
+def run_grid_search(X, y):
+    """
+    We perform a grid search to optimize parameters for sparse-rbf
+    kernel.  For this purpose, we use a smaller subset of the data.  In all
+    cases, we simply use max_iter=100 Notice that we are searching over the
+    inductive accuracy (accuracy on the test set) rather than the
+    transductive accuracy (on the masked training examples).  This keeps
+    things a bit simpler, though we could customize the score function and
+    the `WrapLabelSpreading` class further to also hyperparameter search over
+    the transductive accuracy.
+    """
 
     # First, we use a small subset of the data to tune hyperparameters
     n_total = 5000
-    X = X_orig[:n_total, :]
-    y = y_orig[:n_total]
+    X = X[:n_total, :]
+    y = y[:n_total]
 
     test_fraction = 0.333
     X_train, X_test, y_train, y_test = train_test_split(
             X, y, test_size=test_fraction, random_state=0)
 
-    # Mask subset of train data for transductive learning
-
-    # We perform a grid search to optimize parameters for sparse-rbf
-    # kernel.  For this purpose, we use a smaller subset of the data.  In all
-    # cases, we simply use max_iter=100 Notice that we are searching over the
-    # inductive accuracy (accuracy on the test set) rather than the
-    # transductive accuracy (on the masked training examples).  This keeps
-    # things a bit simpler, though we could customize the score function and
-    # the `WrapLabelSpreading` class further to also hyperparameter search over
-    # the transductive accuracy.
+    # In order to use GridSearchCV, we will use a thin wrapper class
+    # that masks a subset of our training labels.
     sparse_rbf_model = GridSearchCV(
             WrapLabelSpreading(kernel='sparse-rbf', supervision_fraction=0.05),
             param_grid={
                 'n_jobs': [-1],
                 'max_iter': [100],
-                'alpha': np.linspace(0.01, 0.50, 5),
-                'gamma': np.logspace(-8, 1, 20),
-                'n_neighbors': list(range(5, 60, 3))},
+                'alpha': np.linspace(0.01, 0.99, 10),
+                'gamma': np.logspace(-8, -4, 10),
+                'n_neighbors': list(range(6, 30, 2))},
             cv=3)
 
     sparse_rbf_model.fit(X, y)
     sparse_rbf_params = sparse_rbf_model.best_params_
     print(f"Optimal parameters for sparse RBF kernel: {sparse_rbf_params}")
 
-    knn_model = GridSearchCV(WrapLabelSpreading(kernel='knn',
-                                                supervision_fraction=0.05),
-                             param_grid={
-                                 'n_jobs': [-1],
-                                 'max_iter': [100],
-                                 'alpha': np.linspace(0.01, 0.50, 5),
-                                 'n_neighbors': list(range(5, 60, 3))},
-                             cv=3)
+    knn_model = GridSearchCV(
+            WrapLabelSpreading(kernel='knn', supervision_fraction=0.05),
+            param_grid={
+                'n_jobs': [-1],
+                'max_iter': [100],
+                'alpha': np.linspace(0.01, 0.99, 10),
+                'n_neighbors': list(range(6, 30, 2))},
+            cv=3)
 
     knn_model.fit(X, y)
     knn_params = knn_model.best_params_
     print(f"Optimal parameters for knn kernel: {knn_params}")
+    return n_total, sparse_rbf_params, knn_params
 
+
+def run_comparison(X, y, sparse_rbf_params, knn_params, n_skip):
+    print("Begin comparison...")
     # Next, we can compare our optimized models on a larger dataset.
-    n_total = 20000
-    X = X_orig[:n_total, :]
-    y = y_orig[:n_total]
+    n_total = 35000
+    X = X[n_skip:n_total+n_skip, :]
+    y = y[n_skip:n_total+n_skip]
     test_fraction = 0.333
+
+    print("Train/Test split...")
     X_train, X_test, y_train, y_test = train_test_split(
             X, y, test_size=test_fraction, random_state=0)
 
     supervision_fractions = [0.001, 0.003, 0.005, 0.01, 0.03, 0.05, 0.1]
     results = {
-            'transduction': {'knn': [], 'sparse-rbf': []},
-            'induction': {'knn': [], 'sparse-rbf': []},
-            'runtimes': {'knn': [], 'sparse-rbf': []}
+            'transduction': {
+                'knn': {'avg': [], 'std': []},
+                'sparse-rbf': {'avg': [], 'std': []}},
+            'induction': {
+                'knn': {'avg': [], 'std': []},
+                'sparse-rbf': {'avg': [], 'std': []}},
+            'runtimes': {
+                'knn': {'avg': [], 'std': []},
+                'sparse-rbf': {'avg': [], 'std': []}}
     }
+
+    rng = np.random.RandomState(0)
     for supervision_fraction in supervision_fractions:
-        n_train = len(y_train)
-        n_labeled = int(supervision_fraction * n_train)
-        indices = np.arange(n_train)
-        unlabeled_set = indices[n_labeled:]
-
-        y_masked = np.copy(y_train)
-        y_masked[unlabeled_set] = -1
-
         for kernel_name, params in zip(['knn', 'sparse-rbf'],
                                        [knn_params, sparse_rbf_params]):
             model = LabelSpreading(kernel=kernel_name, **params)
             print("="*80)
             print(f"Kernel: {kernel_name}, " +
                   f"Supervision fraction: {supervision_fraction}")
-            transductive_accs = []
-            inductive_accs = []
-            runtimes = []
 
             # Repeat each scenario several times to collect rough statistics
-            for _ in range(3):
+            t_accs = []
+            i_accs = []
+            runtimes = []
+            for _ in range(5):
+                n_train = len(y_train)
+                n_labeled = int(supervision_fraction * n_train)
+                indices = np.arange(n_train)
+                rng.shuffle(indices)
+                unlabeled_set = indices[n_labeled:]
+
+                y_masked = np.copy(y_train)
+                y_masked[unlabeled_set] = -1
+
                 t0 = time.time()
                 model.fit(X_train, y_masked)
 
                 predicted_labels = model.transduction_[unlabeled_set]
                 true_labels = y_train[unlabeled_set]
-                transductive_acc = (np.sum(predicted_labels == true_labels) /
-                                    len(unlabeled_set))
-                transductive_accs.append(transductive_acc)
-                inductive_acc = model.score(X_test, y_test)
-                inductive_accs.append(inductive_acc)
+                t_acc = (np.sum(predicted_labels == true_labels) /
+                         len(unlabeled_set))
+                t_accs.append(t_acc)
+                i_accs.append(model.score(X_test, y_test))
                 t1 = time.time()
                 runtimes.append(t1-t0)
 
-            mean_t_acc = np.mean(transductive_accs)
-            mean_i_acc = np.mean(inductive_accs)
-            mean_runtime = np.mean(runtimes)
-
-            print(f"Mean transductive accuracy: {100 * mean_t_acc:.2f}%, " +
-                  f"Mean inductive accuracy: {100 * mean_i_acc:.2f}%, " +
-                  f"Mean runtime: {mean_runtime:.2f}s")
-
-            results['transduction'][kernel_name].append(mean_t_acc)
-            results['induction'][kernel_name].append(mean_i_acc)
-            results['runtimes'][kernel_name].append(mean_runtime)
+            results['transduction'][kernel_name]['avg'].append(np.mean(t_accs))
+            results['transduction'][kernel_name]['std'].append(np.std(t_accs))
+            results['induction'][kernel_name]['avg'].append(np.mean(i_accs))
+            results['induction'][kernel_name]['std'].append(np.std(i_accs))
+            results['runtimes'][kernel_name]['avg'].append(np.mean(runtimes))
+            results['runtimes'][kernel_name]['std'].append(np.std(runtimes))
 
     print("="*80)
     print(f"supervision_fractions: {supervision_fractions}")
     pprint(results)
+    return supervision_fractions, results
+
+
+def plot_results(supervision_fractions, results):
+    fig, ax = plt.subplots(3, 1, figsize=(16, 9))
+    for i, (label, ylabel) in enumerate(zip(
+                ['induction', 'transduction', 'runtimes'],
+                ['% Accuracy', '% Accuracy', 'Duration (s)'])):
+
+        S_avg = results[label]['sparse-rbf']['avg']
+        S_std = results[label]['sparse-rbf']['std']
+
+        K_avg = results[label]['knn']['avg']
+        K_std = results[label]['knn']['std']
+
+        ax[i].scatter(supervision_fractions, S_avg, c='b', label='sparse-rbf')
+        ax[i].scatter(supervision_fractions, K_avg, c='r', label='knn')
+        ax[i].set_xscale('log')
+        ax[i].set_xlim([8e-4, 1.3e-1])
+        ax[i].set_title(f'{label.capitalize()}')
+        ax[i].set_xlabel('Supervision Fraction')
+        ax[i].fill_between(supervision_fractions,
+                           [a - b for a, b in zip(S_avg, S_std)],
+                           [a + b for a, b in zip(S_avg, S_std)],
+                           facecolor='b', alpha=0.2)
+        ax[i].fill_between(supervision_fractions,
+                           [a + b for a, b in zip(K_avg, K_std)],
+                           [a - b for a, b in zip(K_avg, K_std)],
+                           facecolor='r', alpha=0.2)
+
+    plt.tight_layout()
+    plt.savefig('sparse_kernel_comparison.png')
 
 
 class WrapLabelSpreading(LabelSpreading):
     """
     In order to perform a grid search over this semi-supervised model,
-    we need to provide a thin wrapper that masks a subset of the data before
+    we need to provide a wrapper that masks a subset of the data before
     `fit` is called.
     """
     def __init__(self, supervision_fraction, kernel='sparse-rbf', gamma=20,
@@ -182,4 +224,32 @@ class WrapLabelSpreading(LabelSpreading):
 
 
 if __name__ == '__main__':
-    run_comparison()
+    X, y = fetch_openml('mnist_784', version=1, return_X_y=True)
+    y = y.astype(int)
+
+    # Set this flag to run the grid search, which takes several hours
+    do_grid_search = False
+
+    if do_grid_search:
+        n_skip, sparse_rbf_params, knn_params = run_grid_search(X, y)
+    else:
+        # Values found from running grid search previously
+        sparse_rbf_params = {
+                'alpha': 0.663,
+                'gamma': 2.154e-7,
+                'max_iter': 100,
+                'n_jobs': -1,
+                'n_neighbors': 20}
+        knn_params = {
+                'alpha': 0.772,
+                'max_iter': 100,
+                'n_jobs': -1,
+                'n_neighbors': 6}
+        n_skip = 0
+
+    supervision_fractions, results = run_comparison(
+            X, y, sparse_rbf_params=sparse_rbf_params,
+            knn_params=knn_params,
+            n_skip=n_skip)
+
+    plot_results(supervision_fractions, results)

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -195,7 +195,8 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
                 for weight_matrix in weight_matrices])
         else:
             weight_matrices = weight_matrices.T
-            probabilities = np.dot(weight_matrices, self.label_distributions_)
+            probabilities = safe_sparse_dot(
+                    weight_matrices, self.label_distributions_)
         normalizer = np.atleast_2d(np.sum(probabilities, axis=1)).T
         probabilities /= normalizer
         return probabilities

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -136,7 +136,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             W = self.nn_fit.kneighbors_graph(y, mode='distance').T.power(2)
             W *= -1 * self.gamma
             np.exp(W.data, out=W.data)
-            # explicitly set diagonal, 
+            # explicitly set diagonal,
             # since np.exp(W.data) does not modify zeros on the diagonal
             W.setdiag(1)
             return W

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -18,10 +18,14 @@ ESTIMATORS = [
     (label_propagation.LabelPropagation, {'kernel': 'rbf'}),
     (label_propagation.LabelPropagation, {'kernel': 'knn', 'n_neighbors': 2}),
     (label_propagation.LabelPropagation, {
+        'kernel': 'sparse-rbf',  'gamma': 1e-4, 'n_neighbors': 2}),
+    (label_propagation.LabelPropagation, {
         'kernel': lambda x, y: rbf_kernel(x, y, gamma=20)
     }),
     (label_propagation.LabelSpreading, {'kernel': 'rbf'}),
     (label_propagation.LabelSpreading, {'kernel': 'knn', 'n_neighbors': 2}),
+    (label_propagation.LabelSpreading, {
+        'kernel': 'sparse-rbf',  'gamma': 1e-4, 'n_neighbors': 2}),
     (label_propagation.LabelSpreading, {
         'kernel': lambda x, y: rbf_kernel(x, y, gamma=20)
     }),
@@ -64,7 +68,7 @@ def test_predict_proba():
     for estimator, parameters in ESTIMATORS:
         clf = estimator(**parameters).fit(samples, labels)
         assert_array_almost_equal(clf.predict_proba([[1., 1.]]),
-                                  np.array([[0.5, 0.5]]))
+                                  np.array([[0.5, 0.5]]), 4)
 
 
 def test_label_spreading_closed_form():
@@ -199,3 +203,93 @@ def test_predict_sparse_callable_kernel():
     n_correct = np.sum(Ypred == Ytest)
 
     assert n_correct >= 0.9 * n_test
+
+
+def test_sparse_rbf_kernel():
+    n_classes = 4
+    n_samples = 500
+    n_test = 10
+    X, Y = make_classification(n_classes=n_classes,
+                               n_samples=n_samples,
+                               n_features=20,
+                               n_informative=20,
+                               n_redundant=0,
+                               n_repeated=0,
+                               random_state=0)
+
+    Xtrain = X[:n_samples - n_test]
+    Ytrain = Y[:n_samples - n_test]
+    Xtest = X[n_samples - n_test:]
+    Ytest = Y[n_samples - n_test:]
+
+    model = label_propagation.LabelSpreading(kernel='sparse-rbf', gamma=1e-5)
+    model.fit(Xtrain, Ytrain)
+
+    Ypred = model.predict(Xtest)
+    n_correct = np.sum(Ypred == Ytest)
+
+    assert n_correct >= 0.9 * n_test
+
+    model = label_propagation.LabelPropagation(kernel='sparse-rbf', gamma=1e-5)
+    model.fit(Xtrain, Ytrain)
+
+    Ypred = model.predict(Xtest)
+    n_correct = np.sum(Ypred == Ytest)
+
+    assert n_correct >= 0.9 * n_test
+
+
+def test_sparse_rbf_kernel_agrees_with_dense():
+
+    n_classes = 4
+    n_samples = 500
+    X, Y = make_classification(n_classes=n_classes,
+                               n_samples=n_samples,
+                               n_features=20,
+                               n_informative=20,
+                               n_redundant=0,
+                               n_repeated=0,
+                               random_state=0)
+
+    gamma = 1e-5
+    n_neighbors = 10
+
+    # Check LabelSpreading
+    # Make dense RBF kernel
+    dense_train = (label_propagation
+                   .LabelSpreading(kernel='rbf', gamma=gamma)
+                   ._get_kernel(X))
+    # Keep top k+1 per column. (k neighbors + 1 for self)
+    ind = np.argpartition(
+            dense_train, kth=-(n_neighbors+1), axis=0)[:-(n_neighbors+1), :]
+    np.put_along_axis(dense_train, ind, 0, axis=0)
+
+    # Make column-sparse RBF kernel
+    sparse_train = (label_propagation
+                    .LabelSpreading(kernel='sparse-rbf',
+                                    gamma=gamma,
+                                    n_neighbors=n_neighbors)
+                    ._get_kernel(X)
+                    .toarray())
+
+    assert_array_almost_equal(dense_train, sparse_train)
+
+    # Check LabelPropagation
+    # Make dense RBF kernel
+    dense_train = (label_propagation
+                   .LabelPropagation(kernel='rbf', gamma=gamma)
+                   ._get_kernel(X))
+    # Keep top k+1 per column. (k neighbors + 1 for self)
+    ind = np.argpartition(
+            dense_train, kth=-(n_neighbors+1), axis=0)[:-(n_neighbors+1), :]
+    np.put_along_axis(dense_train, ind, 0, axis=0)
+
+    # Make column-sparse RBF kernel
+    sparse_train = (label_propagation
+                    .LabelPropagation(kernel='sparse-rbf',
+                                      gamma=gamma,
+                                      n_neighbors=n_neighbors)
+                    ._get_kernel(X)
+                    .toarray())
+
+    assert_array_almost_equal(dense_train, sparse_train)

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -3,10 +3,12 @@
 import numpy as np
 import pytest
 
+from scipy.sparse import csr_matrix
 from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_no_warnings
 from sklearn.semi_supervised import _label_propagation as label_propagation
 from sklearn.metrics.pairwise import rbf_kernel
+from sklearn.neighbors import NearestNeighbors
 from sklearn.datasets import make_classification
 from sklearn.exceptions import ConvergenceWarning
 from numpy.testing import assert_array_almost_equal
@@ -152,3 +154,40 @@ def test_convergence_warning():
 
     mdl = label_propagation.LabelPropagation(kernel='rbf', max_iter=500)
     assert_no_warnings(mdl.fit, X, y)
+
+
+def test_predict_sparse_callable_kernel():
+    # This is a non-regression test for #15866
+
+    # Custom sparse kernel (top-K RBF)
+    def topk_rbf(X, Y=None, n_neighbors=10, gamma=1e-5):
+        nn = NearestNeighbors(n_neighbors=10, metric='euclidean', n_jobs=-1)
+        nn.fit(X)
+        W = -1 * nn.kneighbors_graph(Y, mode='distance').power(2) * gamma
+        np.exp(W.data, out=W.data)
+        assert isinstance(W, csr_matrix)
+        return W.T
+
+    n_classes = 4
+    n_samples = 500
+    n_test = 10
+    X, Y = make_classification(n_classes=n_classes,
+                               n_samples=n_samples,
+                               n_features=20,
+                               n_informative=20,
+                               n_redundant=0,
+                               n_repeated=0,
+                               random_state=0)
+
+    Xtrain = X[:n_samples - n_test]
+    Ytrain = Y[:n_samples - n_test]
+    Xtest = X[n_samples - n_test:]
+    Ytest = Y[n_samples - n_test:]
+
+    model = label_propagation.LabelSpreading(kernel=topk_rbf)
+    model.fit(Xtrain, Ytrain)
+
+    Ypred = model.predict(Xtest)
+    n_correct = np.sum(Ypred == Ytest)
+
+    assert n_correct >= 0.9 * n_test

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from scipy.sparse import csr_matrix
+from scipy.sparse import issparse
 from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_no_warnings
 from sklearn.semi_supervised import _label_propagation as label_propagation
@@ -165,7 +165,7 @@ def test_predict_sparse_callable_kernel():
         nn.fit(X)
         W = -1 * nn.kneighbors_graph(Y, mode='distance').power(2) * gamma
         np.exp(W.data, out=W.data)
-        assert isinstance(W, csr_matrix)
+        assert issparse(W)
         return W.T
 
     n_classes = 4
@@ -185,6 +185,14 @@ def test_predict_sparse_callable_kernel():
     Ytest = Y[n_samples - n_test:]
 
     model = label_propagation.LabelSpreading(kernel=topk_rbf)
+    model.fit(Xtrain, Ytrain)
+
+    Ypred = model.predict(Xtest)
+    n_correct = np.sum(Ypred == Ytest)
+
+    assert n_correct >= 0.9 * n_test
+
+    model = label_propagation.LabelPropagation(kernel=topk_rbf)
     model.fit(Xtrain, Ytrain)
 
     Ypred = model.predict(Xtest)


### PR DESCRIPTION
#### Reference Issues/PRs
This pull request adds another named kernel option, `sparse-rbf` for `semi_supervised.LabelSpreading`.

Loosely related to #15868.

#### Rationale
This kernel provides RBF weights for only the k-nearest-neighbors of each point.

Currently, the only kernel options are `knn` and `rbf` - but for a large dataset, the dense `rbf` kernel option is not feasible (for `N` items, we must compute a dense `NxN` matrix). For any non-trivial dataset, computing the dense kernel matrix will be infeasible, so my purpose here is to give a kernel that can perform better than `knn`, and still be feasible for a large dataset. 

The intuition is that a weighted adjacency matrix gives more information about the graph structure of our dataset, and therefore with appropriate parameter tuning, such a kernel should perform better than a binary adjacency matrix. Furthermore, filling with the RBF weights is cheap, once we have found the k-nearest-neighbors, so the additional runtime cost is minimal.

In particular, I believe that the performance difference will be more clear for datasets with more "difficult" structure; therefore I included CIFAR10 as an option for the example script (the easiest way I know to obtain this is via https://pytorch.org/docs/stable/torchvision/datasets.html#cifar), though I have not yet had time to experiment with a significant fraction of that dataset.

It might also be useful to try this on some toy datasets like https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_moons.html, but I have not experimented with this yet.

#### Notes and Questions
I included tests to show:
1. this kernel "works" (the learned classifier has high accuracy)
2. the weights found using `sparse-rbf` are indeed the same as the top-k entries of the kernel that you get using the dense `rbf` option

Since I am making a claim/intuition about performance, I also included an example that does a hyperparameter grid search for the two available sparse kernels (`knn`, already provided, and the new `sparse-rbf`), and then uses the optimal parameters across a range of % supervision to compare:

1. transductive accuracy (guessing labels for the unlabeled training data)
2. inductive accuracy (labeling test data)
3. runtime

I'm opening this PR to get some feedback on the following items:

1. Does this kernel seem helpful, and could I make it more helpful somehow?
2. Is the example I provided clear enough, and would other examples be useful to show the potential benefit of this kernel?
3. For sklearn examples in general, I'm not sure (practically speaking) how to get the results to be visible as embedded plots, so is there something I should do to structure my example appropriately?
4. Are there other experiments/examples that would be useful for evaluating this kernel that folks would like to see?

#### Caveats about the hyperparameter search
- The search is done using only the **inductive accuracy** because of the API used by `GridSearchCV`. It might be possible (with some headache) to run the grid search using transductive accuracy, but this also might not matter.
- The search is done at a fixed % supervision, again because of the API for `GridSearchCV`.
- Notice that the exact hyperparameters found depend on what dataset and what fraction of that dataset is used for the grid search.

#### Example results

Here are the results of using 20% of MNIST, with the fixed parameters included at the bottom of the example script.:
![sparse_kernel_comparison](https://user-images.githubusercontent.com/29764926/71132447-79905f00-21c5-11ea-9e7d-f3dc9b0abde7.png)


Please let me know if you need more info.
Thanks!
