### PR TITLE
[MRG] Import sklearn._distributor_init first

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -70,11 +70,17 @@ if __SKLEARN_SETUP__:
     # We are not importing the rest of scikit-learn during the build
     # process, as it may not be compiled yet
 else:
-    from . import __check_build
+    # `_distributor_init` allows distributors to run custom init code.
+    # For instance, for the Windows wheel, this is used to pre-load the
+    # vcomp shared library runtime for OpenMP embedded in the sklearn/.libs
+    # sub-folder.
+    # It is necessary to do this prior to importing show_versions as the
+    # later is linked to the OpenMP runtime to make it possible to introspect
+    # it and importing it first would fail if the OpenMP dll cannot be found.
+    from . import _distributor_init  # noqa: F401
+    from . import __check_build  # noqa: F401
     from .base import clone
     from .utils._show_versions import show_versions
-
-    __check_build  # avoid flakes unused variable error
 
     __all__ = ['calibration', 'cluster', 'covariance', 'cross_decomposition',
                'datasets', 'decomposition', 'dummy', 'ensemble', 'exceptions',
@@ -89,9 +95,6 @@ else:
                # Non-modules:
                'clone', 'get_config', 'set_config', 'config_context',
                'show_versions']
-
-    # Allow distributors to run custom init code
-    from . import _distributor_init  # noqa: F401
 
 
 def setup_module(module):


### PR DESCRIPTION
This change is required by https://github.com/MacPython/scikit-learn-wheels/pull/43 to be able to properly fix #15899.

Based on local tests on a Windows VM it seems to work as expected: importing sklearn works and links to the vendored DLL:

```
C:\Users\olivi>.\AppData\Local\Programs\Python\Python37\python.exe -c "import sklearn; from pprint import pprint; from threadpoolctl import threadpool_info; pprint(threadpool_info())"
[{'filepath': 'C:\\Users\\olivi\\AppData\\Local\\Programs\\Python\\Python37\\lib\\site-packages\\sklearn\\.libs\\vcomp140.dll',
  'internal_api': 'openmp',
  'num_threads': 2,
  'prefix': 'vcomp',
  'user_api': 'openmp',
  'version': None},
 {'filepath': 'C:\\Users\\olivi\\AppData\\Local\\Programs\\Python\\Python37\\lib\\site-packages\\numpy\\.libs\\libopenblas.TXA6YQSD3GCQQC22GEQ54J2UDCXDXHWN.gfortran-win_amd64.dll',
  'internal_api': 'openblas',
  'num_threads': 2,
  'prefix': 'libopenblas',
  'threading_layer': 'pthreads',
  'user_api': 'blas',
  'version': '0.3.7.dev'}]
```

The Windows wheels that leverage the branch of scikit-learn of this PR are being generated by the appveyor workers linked to https://github.com/MacPython/scikit-learn-wheels/pull/43 and should be soon be ready for testing (look at the "artifacts" tab of each build).