### PR TITLE
[MRG] Ways to compute center_shift_total were different in "full" and "elkan" algorithms.

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -15,6 +15,13 @@ This is a bug-fix release to primarily resolve some packaging issues in version
 Changelog
 ---------
 
+:mod:`sklearn.cluster`
+......................
+
+- |Fix| :class:`KMeans` with ``algorithm="elkan"`` now uses the same stopping
+  criterion as with the default ``algorithm="full"``. :pr:`15930` by
+  :user:`inder128`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -246,8 +246,8 @@ def k_means_elkan(np.ndarray[floating, ndim=2, mode='c'] X_,
             print('Iteration %i, inertia %s'
                     % (iteration, np.sum((X_ - centers_[labels]) ** 2 *
                                          sample_weight[:,np.newaxis])))
-        center_shift_total = np.sum(center_shift)
-        if center_shift_total ** 2 < tol:
+        center_shift_total = np.sum(center_shift ** 2)
+        if center_shift_total < tol:
             if verbose:
                 print("center shift %e within tolerance %e"
                       % (center_shift_total, tol))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #15831 

changes in sklearn/cluster/_k_means_elkan.pyx in line 249 and 250.

Ways to compute center_shift_total were different if "full" and "alkan" algorithims.
center_shift_total is compared with value of tol to limit no. of iterations.
Thats why inertia and n_iter were different.

In "full" :      ( line 442 and 443 in sklearn/cluster/_k_means.py )
     It is computed as:
          center_shift_total = squared_norm(centers_old - centers) 
          if center_shift_total  <= tol:         #when compared with tol  

While in "alkan":      ( line 248 , 249 and 250 in sklearn/cluster/_k_means_elkan.pyx )
      It is computed as:
          center_shift = np.sqrt(np.sum((centers_ - new_centers) ** 2, axis=1))
          center_shift_total = np.sum(center_shift)
          if center_shift_total ** 2 < tol:        #when compared with tol


I changed above "alkan" code (so that it coputes center_shift_total insame as in "full" algorithm):
      It is computed as:
          center_shift = np.sqrt(np.sum((centers_ - new_centers) ** 2, axis=1))
          center_shift_total = np.sum(center_shift **2)
          if center_shift_total  < tol:        #when compared with tol

Above updated "alkan" code gives same value as "full".




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
