### PR TITLE
[WIP] cd_fast speedup

### DIFF
--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -174,12 +174,8 @@ def enet_coordinate_descent(floating[::1] w,
 
                 w_ii = w[ii]  # Store previous value
 
-                if w_ii != 0.0:
-                    # R += w_ii * X[:,ii]
-                    _axpy(n_samples, w_ii, &X[0, ii], 1, &R[0], 1)
-
-                # tmp = (X[:,ii]*R).sum()
-                tmp = _dot(n_samples, &X[0, ii], 1, &R[0], 1)
+                # tmp = (X[:,ii]*R).sum() + w_ii * norm_cols_X[ii]
+                tmp = _dot(n_samples, &X[0, ii], 1, &R[0], 1) + w_ii * norm_cols_X[ii]
 
                 if positive and tmp < 0:
                     w[ii] = 0.0
@@ -188,8 +184,8 @@ def enet_coordinate_descent(floating[::1] w,
                              / (norm_cols_X[ii] + beta))
 
                 if w[ii] != 0.0:
-                    # R -=  w[ii] * X[:,ii] # Update residual
-                    _axpy(n_samples, -w[ii], &X[0, ii], 1, &R[0], 1)
+                    # R +=  (w_ii - w[ii]) * X[:,ii] # Update residual
+                    _axpy(n_samples, w_ii - w[ii], &X[0, ii], 1, &R[0], 1)
 
                 # update the maximum absolute coefficient update
                 d_w_ii = fabs(w[ii] - w_ii)

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -183,7 +183,7 @@ def enet_coordinate_descent(floating[::1] w,
                     w[ii] = (fsign(tmp) * fmax(fabs(tmp) - alpha, 0)
                              / (norm_cols_X[ii] + beta))
 
-                if w[ii] != 0.0:
+                if (w_ii - w[ii]) != 0.0:
                     # R +=  (w_ii - w[ii]) * X[:,ii] # Update residual
                     _axpy(n_samples, w_ii - w[ii], &X[0, ii], 1, &R[0], 1)
 


### PR DESCRIPTION
Rewriting implementation to remove redundant calculations.
Old implementation:
1. R = R + w_ii * X[:,ii]
2. tmp = X[:,ii] dot R
3. f(tmp,...)
4. R = R - w[ii] * X[:,ii]

New implementation:
substitute R from 1 into 2 ->
tmp = X[:,ii] dot (R + w_ii * X[:,ii]) 
tmp = X[:,ii] dot R + w_ii * X[:,ii] dot X[:,ii]
2. tmp = X[:,ii] dot R + w_ii * norm_cols_X[ii]
Then to update R:
4. R = R + (w_ii - w[ii]) * X[:,ii]

This removes step one, and rewrites step 2 and 4, improving loop speed.
The method here is probably also extendable to the other 3 functions.

Sadly my python skills are not good enough to build and test this, I did however test this in C++, so everything should work.
Help with building, testing, and extending is very much appreciated.

Tasklist:
- [ ] Build and validate results.
- [ ] Extend to sparse, gram, and multi_task