### PR TITLE
Add missing 'values_format' param to disp.plot() in plot_confusion_matrix

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -56,7 +56,7 @@ Changelog
   
 - |Fix| Fixed a bug in :func:`metrics.plot_confusion_matrix` to correctly
   pass the `values_format` parameter to the :class:`ConfusionMatrixDisplay`
-  plot() call. :pr:`15937` by :user: `Stephen Blystone <blynotes>`.
+  plot() call. :pr:`15937` by :user:`Stephen Blystone <blynotes>`.
 
 :mod:`sklearn.semi_supervised`
 ..............................

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -54,6 +54,10 @@ Changelog
   value of the ``zero_division`` keyword argument. :pr:`15879`
   by :user:`Bibhash Chandra Mitra <Bibyutatsu>`.
   
+- |Fix| Fixed a bug in :func:`metrics.plot_confusion_matrix` to correctly
+  pass the `values_format` parameter to the :class:`ConfusionMatrixDisplay`
+  plot() call. :pr:`15937` by :user: `Stephen Blystone <blynotes>`.
+
 :mod:`sklearn.semi_supervised`
 ..............................
 

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -197,4 +197,5 @@ def plot_confusion_matrix(estimator, X, y_true, labels=None,
     disp = ConfusionMatrixDisplay(confusion_matrix=cm,
                                   display_labels=display_labels)
     return disp.plot(include_values=include_values,
-                     cmap=cmap, ax=ax, xticks_rotation=xticks_rotation)
+                     cmap=cmap, ax=ax, xticks_rotation=xticks_rotation,
+                     values_format=values_format)

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -231,3 +231,22 @@ def test_confusion_matrix_pipeline(pyplot, clf, data, n_classes):
 
     assert_allclose(disp.confusion_matrix, cm)
     assert disp.text_.shape == (n_classes, n_classes)
+
+
+@pytest.mark.parametrize("values_format", ['e', 'n'])
+def test_confusion_matrix_text_format(pyplot, data, y_pred, n_classes,
+                                      fitted_clf, values_format):
+    # Make sure plot text is formatted with 'values_format'.
+    X, y = data
+    cm = confusion_matrix(y, y_pred)
+    disp = plot_confusion_matrix(fitted_clf, X, y,
+                                 include_values=True,
+                                 values_format=values_format)
+
+    assert disp.text_.shape == (n_classes, n_classes)
+
+    expected_text = np.array([format(v, values_format)
+                              for v in cm.ravel(order="C")])
+    text_text = np.array([
+        t.get_text() for t in disp.text_.ravel(order="C")])
+    assert_array_equal(expected_text, text_text)

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -260,7 +260,7 @@ def test_confusion_matrix_text_format(pyplot, data, y_pred, n_classes,
     assert disp.text_.shape == (n_classes, n_classes)
 
     expected_text = np.array([format(v, values_format)
-                              for v in cm.ravel(order="C")])
+                              for v in cm.ravel()])
     text_text = np.array([
-        t.get_text() for t in disp.text_.ravel(order="C")])
+        t.get_text() for t in disp.text_.ravel()])
     assert_array_equal(expected_text, text_text)


### PR DESCRIPTION
I added the missing 'values_format' parameter to the "disp.plot()" call in "plot_confusion_matrix".

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
No related issues found.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
__Problem Description__
- The class ConfusionMatrixDisplay's plot() function already has the values_format parameter.
- "plot_confusion_matrix" function also has the values_format parameter.
- However, "plot_confusion_matrix" was not passing it's values_format value when calling the ConfusionMatrixDisplay's plot().
- This resulted in being unable to change the format of the values in the confusion matrix when calling plot_confusion_matrix(), even when you passed a value for "values_format". The confusion matrix always displayed in scientific notation.

__My Solution__
- I fixed this by adding the missing parameter to the plot() call in "plot_confusion_matrix".

Simplified example of the code, for further clarification:
```python
   class ConfusionMatrixDisplay:
       ...__init__ function goes here...
       def plot(self, ..., values_format=None, ...):  # <-- values_format is already there.
           ...

   def plot_confusion_matrix(...,
                             values_format=None,  # <-- values_format is already there.
                             ...):
       ...
       disp = ConfusionMatrixDisplay(...)
       return disp.plot(...)  # <-- values_format is missing from here and NOT passed to plot.
```

#### Any other comments?
None. Thank you!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
