### PR TITLE
Managed the case where the sum by row is zero.

### DIFF
--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -288,6 +288,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             )
             self.n_iter_ += 1
 
+        self.label_distributions_[np.sum(self.label_distributions_, axis=1) == 0, :] = 1
         normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
         self.label_distributions_ /= normalizer
 


### PR DESCRIPTION
It can happen that the variable "normalizer" contains zeros and therefore the division below can fail. The line of the code added here avoids the division by zero and preserves the logic of the model. 