### PR TITLE
Label spreading bug fix

### DIFF
--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -288,8 +288,8 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             )
             self.n_iter_ += 1
 
-        self.label_distributions_[np.sum(self.label_distributions_, 
-                                         axis=1) == 0, :] = 1
+        l_bool_zeros = np.sum(self.label_distributions_, axis=1) == 0
+        self.label_distributions_[l_bool_zeros, :] = 1
         normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
         self.label_distributions_ /= normalizer
 

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -288,6 +288,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             )
             self.n_iter_ += 1
 
+        self.label_distributions_[np.sum(self.label_distributions_, axis=1) == 0, :] = 1
         normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
         self.label_distributions_ /= normalizer
 

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -288,7 +288,8 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             )
             self.n_iter_ += 1
 
-        self.label_distributions_[np.sum(self.label_distributions_, axis=1) == 0, :] = 1
+        self.label_distributions_[np.sum(self.label_distributions_, 
+                                         axis=1) == 0, :] = 1
         normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
         self.label_distributions_ /= normalizer
 

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -289,9 +289,8 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             )
             self.n_iter_ += 1
 
-        l_bool_zeros = np.sum(self.label_distributions_, axis=1) == 0
-        self.label_distributions_[l_bool_zeros, :] = 1
         normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
+        normalizer = np.array([[1] if x[0] == 0 else x for x in normalizer])
         self.label_distributions_ /= normalizer
 
         # set the transduction item

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -290,7 +290,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             self.n_iter_ += 1
 
         normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
-        normalizer = np.array([[1] if x[0] == 0 else x for x in normalizer])
+        normalizer[normalizer == 0] = 1
         self.label_distributions_ /= normalizer
 
         # set the transduction item

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -166,7 +166,7 @@ def test_non_zero_normalizer():
                                            n_neighbors=1)
     assert_no_warnings(mdl.fit, X, y)
 
-    
+
 def test_predict_sparse_callable_kernel():
     # This is a non-regression test for #15866
 

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -152,12 +152,13 @@ def test_convergence_warning():
 
     mdl = label_propagation.LabelPropagation(kernel='rbf', max_iter=500)
     assert_no_warnings(mdl.fit, X, y)
-    
+
+
 def test_non_zero_normalizer():
     # This is a non-regression test for #15946
     X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
     y = np.array([0, 1, -1, -1])
-    mdl = label_propagation.LabelSpreading(kernel='knn', 
-                                           max_iter=100, 
+    mdl = label_propagation.LabelSpreading(kernel='knn',
+                                           max_iter=100,
                                            n_neighbors=1)
     assert_no_warnings(mdl.fit, X, y)

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -152,3 +152,10 @@ def test_convergence_warning():
 
     mdl = label_propagation.LabelPropagation(kernel='rbf', max_iter=500)
     assert_no_warnings(mdl.fit, X, y)
+    
+def test_non_zero_normalizer():
+    # This is a non-regression test for #15946
+    X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
+    y = np.array([0, 1, -1, -1])
+    mdl = label_propagation.LabelSpreading(kernel='knn', max_iter=100, n_neighbors=1)
+    assert_no_warnings(mdl.fit, X, y)

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -201,4 +201,3 @@ def test_predict_sparse_callable_kernel():
     model = label_propagation.LabelPropagation(kernel=topk_rbf)
     model.fit(X_train, y_train)
     assert model.score(X_test, y_test) >= 0.9
-

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -157,5 +157,7 @@ def test_non_zero_normalizer():
     # This is a non-regression test for #15946
     X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
     y = np.array([0, 1, -1, -1])
-    mdl = label_propagation.LabelSpreading(kernel='knn', max_iter=100, n_neighbors=1)
+    mdl = label_propagation.LabelSpreading(kernel='knn', 
+                                           max_iter=100, 
+                                           n_neighbors=1)
     assert_no_warnings(mdl.fit, X, y)

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -157,8 +157,10 @@ def test_convergence_warning():
     assert_no_warnings(mdl.fit, X, y)
 
 
-def test_non_zero_normalizer():
-    # This is a non-regression test for #15946
+def test_label_propagation_non_zero_normalizer():
+    # check that we don't divide by zero in case of null normalizer
+    # non-regression test for
+    # https://github.com/scikit-learn/scikit-learn/pull/15946
     X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
     y = np.array([0, 1, -1, -1])
     mdl = label_propagation.LabelSpreading(kernel='knn',


### PR DESCRIPTION
It can happen that the variable "normalizer" contains zeros and therefore the division below can fail. The line of the code added here avoids the division by zero and preserves the logic of the model.