### PR TITLE
BUG Adds attributes back to check_is_fitted

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -62,7 +62,7 @@ Changelog
 
 - |Fix| :func:`utils.check_is_fifted` accepts back an explicit ``attributes``
   argument to check for specific attributes as explicit markers of a fitted
-  estimator. When no explicit attributes are provided, only the attributes
+  estimator. When no explicit ``attributes`` are provided, only the attributes
   ending with a single "_" are used as "fitted" markers. This change is made to
   restore some backward compatibility with the behavior of this utility in
   version 0.21. :pr:`15947` by `Thomas Fan`_.

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -63,7 +63,8 @@ Changelog
 - |Fix| :func:`utils.check_is_fifted` accepts back an explicit ``attributes``
   argument to check for specific attributes as explicit markers of a fitted
   estimator. When no explicit ``attributes`` are provided, only the attributes
-  ending with a single "_" are used as "fitted" markers. This change is made to
+  ending with a single "_" are used as "fitted" markers. The ``all_or_any``
+  argument is also no longer deprecated. This change is made to
   restore some backward compatibility with the behavior of this utility in
   version 0.21. :pr:`15947` by `Thomas Fan`_.
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -28,6 +28,13 @@ Changelog
 - |Fix| :func:`utils.check_array` now correctly converts pandas DataFrame with
   boolean columns to floats. :pr:`15797` by `Thomas Fan`_.
 
+- |Fix| :func:`utils.check_is_fifted` accepts back an explicit ``attributes``
+  argument to check for specific attributes as explicit markers of a fitted
+  estimator. When no explicit attributes are provided, only the attributes
+  ending with a single "_" are used as "fitted" markers. This change is made to
+  restore some backward compatibility with the behavior of this utility in
+  version 0.21. :pr:`15947` by `Thomas Fan`_.
+
 :mod:`sklearn.inspection`
 .........................
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -60,7 +60,7 @@ Changelog
 - |Fix| :func:`utils.check_array` now correctly converts pandas DataFrame with
   boolean columns to floats. :pr:`15797` by `Thomas Fan`_.
 
-- |Fix| :func:`utils.check_is_fifted` accepts back an explicit ``attributes``
+- |Fix| :func:`utils.check_is_fitted` accepts back an explicit ``attributes``
   argument to check for specific attributes as explicit markers of a fitted
   estimator. When no explicit ``attributes`` are provided, only the attributes
   ending with a single "_" are used as "fitted" markers. The ``all_or_any``

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -67,13 +67,6 @@ Changelog
   restore some backward compatibility with the behavior of this utility in
   version 0.21. :pr:`15947` by `Thomas Fan`_.
 
-:mod:`sklearn.inspection`
-.........................
-
-- |Fix| :func:`inspection.plot_partial_dependence` and 
-  :meth:`inspection.PartialDependenceDisplay.plot` now consistently checks
-  the number of axes passed in. :pr:`15760` by `Thomas Fan`_.
-
 .. _changes_0_22:
 
 Version 0.22.0

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1099,6 +1099,7 @@ def test_vectorizer_string_object_as_input(Vectorizer):
     assert_raise_message(
             ValueError, message, vec.fit_transform, "hello world!")
     assert_raise_message(ValueError, message, vec.fit, "hello world!")
+    vec.fit(["some text", "some other text"])
     assert_raise_message(ValueError, message, vec.transform, "hello world!")
 
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1498,7 +1498,11 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
             X.data += 1
 
         if self.use_idf:
-            check_is_fitted(self, msg='idf vector is not fitted')
+            # idf_ being a property, the automatic attributes detection
+            # does not work as usual and we need to specify the attribute
+            # name:
+            check_is_fitted(self, attributes=["idf_"],
+                            msg='idf vector is not fitted')
 
             expected_n_features = self._idf_diag.shape[0]
             if n_features != expected_n_features:
@@ -1883,7 +1887,7 @@ class TfidfVectorizer(CountVectorizer):
         X : sparse matrix, [n_samples, n_features]
             Tf-idf-weighted document-term matrix.
         """
-        check_is_fitted(self, msg='The tfidf vector is not fitted')
+        check_is_fitted(self, msg='The TF-IDF vectorizer is not fitted')
 
         # FIXME Remove copy parameter support in 0.24
         if copy != "deprecated":

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -683,7 +683,6 @@ def test_check_is_fitted():
                          [itemgetter(0), list, tuple],
                          ids=["single", "list", "tuple"])
 def test_check_is_fitted_with_attributes(wrap):
-
     ard = ARDRegression()
     with pytest.raises(NotFittedError, match="is not fitted yet"):
         check_is_fitted(ard, wrap(["coef_"]))

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -5,6 +5,7 @@ import os
 
 from tempfile import NamedTemporaryFile
 from itertools import product
+from operator import itemgetter
 
 import pytest
 from pytest import importorskip
@@ -676,6 +677,25 @@ def test_check_is_fitted():
 
     assert check_is_fitted(ard) is None
     assert check_is_fitted(svr) is None
+
+
+@pytest.mark.parametrize("wrap",
+                         [itemgetter(0), list, tuple],
+                         ids=["single", "list", "tuple"])
+def test_check_is_fitted_with_attributes(wrap):
+
+    ard = ARDRegression()
+    with pytest.raises(NotFittedError, match="is not fitted yet"):
+        check_is_fitted(ard, wrap(["coef_"]))
+
+    ard.fit(*make_blobs())
+
+    # Does not raise
+    check_is_fitted(ard, wrap(["coef_"]))
+
+    # Raises when using attribute that is not defined
+    with pytest.raises(NotFittedError, match="is not fitted yet"):
+        check_is_fitted(ard, wrap(["coef_bad_"]))
 
 
 def test_check_consistent_length():

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -15,7 +15,6 @@ import scipy.sparse as sp
 from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_raises_regex
 from sklearn.utils._testing import assert_no_warnings
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._testing import SkipTest
@@ -51,7 +50,6 @@ from sklearn.utils.validation import (
 import sklearn
 
 from sklearn.exceptions import NotFittedError, PositiveSpectrumWarning
-from sklearn.exceptions import DataConversionWarning
 
 from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import TempMemmap
@@ -677,6 +675,34 @@ def test_check_is_fitted():
 
     assert check_is_fitted(ard) is None
     assert check_is_fitted(svr) is None
+
+
+def test_check_is_fitted_attributes():
+    class MyEstimator():
+        def fit(self, X, y):
+            return self
+
+    msg = "not fitted"
+    est = MyEstimator()
+
+    with pytest.raises(NotFittedError, match=msg):
+        check_is_fitted(est, attributes=["a_", "b_"])
+    with pytest.raises(NotFittedError, match=msg):
+        check_is_fitted(est, attributes=["a_", "b_"], all_or_any=all)
+    with pytest.raises(NotFittedError, match=msg):
+        check_is_fitted(est, attributes=["a_", "b_"], all_or_any=any)
+
+    est.a_ = "a"
+    with pytest.raises(NotFittedError, match=msg):
+        check_is_fitted(est, attributes=["a_", "b_"])
+    with pytest.raises(NotFittedError, match=msg):
+        check_is_fitted(est, attributes=["a_", "b_"], all_or_any=all)
+    check_is_fitted(est, attributes=["a_", "b_"], all_or_any=any)
+
+    est.b_ = "b"
+    check_is_fitted(est, attributes=["a_", "b_"])
+    check_is_fitted(est, attributes=["a_", "b_"], all_or_any=all)
+    check_is_fitted(est, attributes=["a_", "b_"], all_or_any=any)
 
 
 @pytest.mark.parametrize("wrap",

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -850,7 +850,7 @@ def check_symmetric(array, tol=1E-10, raise_warning=True,
     return array
 
 
-def check_is_fitted(estimator, msg=None):
+def check_is_fitted(estimator, attributes=None, msg=None):
     """Perform is_fitted validation for estimator.
 
     Checks if the estimator is fitted by verifying the presence of
@@ -861,6 +861,15 @@ def check_is_fitted(estimator, msg=None):
     ----------
     estimator : estimator instance.
         estimator instance for which the check is performed.
+
+    attributes : list or tuple of str or None, default=None
+        attribute name(s) given as string or a list/tuple of strings
+        Eg.:
+            ``["coef_", "estimator_", ...], "coef_"``
+
+        If None, `estimator` is considered fitted if there exist an attribute
+        that starts or ends with a underscore and does not start
+        with double underscore.
 
     msg : string
         The default error message is, "This %(name)s instance is not fitted
@@ -890,9 +899,14 @@ def check_is_fitted(estimator, msg=None):
     if not hasattr(estimator, 'fit'):
         raise TypeError("%s is not an estimator instance." % (estimator))
 
-    attrs = [v for v in vars(estimator)
-             if (v.endswith("_") or v.startswith("_"))
-             and not v.startswith("__")]
+    if attributes is not None:
+        if not isinstance(attributes, (list, tuple)):
+            attributes = [attributes]
+        attrs = all([hasattr(estimator, attr) for attr in attributes])
+    else:
+        attrs = [v for v in vars(estimator)
+                 if (v.endswith("_") or v.startswith("_"))
+                 and not v.startswith("__")]
 
     if not attrs:
         raise NotFittedError(msg % {'name': type(estimator).__name__})

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -872,8 +872,8 @@ def check_is_fitted(estimator, attributes=None, msg=None):
         Eg.: ``["coef_", "estimator_", ...], "coef_"``
 
         If `None`, `estimator` is considered fitted if there exist an
-        attribute that starts or ends with a underscore and does not start
-        with double underscore.
+        attribute that ends with a underscore and does not start with double
+        underscore.
 
     msg : string
         The default error message is, "This %(name)s instance is not fitted

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -852,7 +852,7 @@ def check_symmetric(array, tol=1E-10, raise_warning=True,
     return array
 
 
-def check_is_fitted(estimator, attributes=None, msg=None):
+def check_is_fitted(estimator, attributes=None, msg=None, all_or_any=all):
     """Perform is_fitted validation for estimator.
 
     Checks if the estimator is fitted by verifying the presence of
@@ -885,6 +885,9 @@ def check_is_fitted(estimator, attributes=None, msg=None):
 
         Eg. : "Estimator, %(name)s, must be fitted before sparsifying".
 
+    all_or_any : callable, {all, any}, default all
+        Specify whether all or any of the given attributes must exist.
+
     Returns
     -------
     None
@@ -906,7 +909,7 @@ def check_is_fitted(estimator, attributes=None, msg=None):
     if attributes is not None:
         if not isinstance(attributes, (list, tuple)):
             attributes = [attributes]
-        attrs = all([hasattr(estimator, attr) for attr in attributes])
+        attrs = all_or_any([hasattr(estimator, attr) for attr in attributes])
     else:
         attrs = [v for v in vars(estimator)
                  if v.endswith("_") and not v.startswith("__")]

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -862,7 +862,7 @@ def check_is_fitted(estimator, attributes=None, msg=None):
     estimator : estimator instance.
         estimator instance for which the check is performed.
 
-    attributes : list or tuple of str or None, default=None
+    attributes : str, list or tuple of str or None, default=None
         attribute name(s) given as string or a list/tuple of strings
         Eg.:
             ``["coef_", "estimator_", ...], "coef_"``

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -863,9 +863,8 @@ def check_is_fitted(estimator, attributes=None, msg=None):
         estimator instance for which the check is performed.
 
     attributes : str, list or tuple of str or None, default=None
-        attribute name(s) given as string or a list/tuple of strings
-        Eg.:
-            ``["coef_", "estimator_", ...], "coef_"``
+        Attribute name(s) given as string or a list/tuple of strings
+        Eg.: ``["coef_", "estimator_", ...], "coef_"``
 
         If None, `estimator` is considered fitted if there exist an attribute
         that starts or ends with a underscore and does not start

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -859,7 +859,7 @@ def check_is_fitted(estimator, attributes=None, msg=None, all_or_any=all):
     fitted attributes (ending with a trailing underscore) and otherwise
     raises a NotFittedError with the given message.
 
-    This utility is meant to be used internally by estimators them-selves,
+    This utility is meant to be used internally by estimators themselves,
     typically in their own predict / transform methods.
 
     Parameters

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -862,12 +862,12 @@ def check_is_fitted(estimator, attributes=None, msg=None):
     estimator : estimator instance.
         estimator instance for which the check is performed.
 
-    attributes : str, list or tuple of str or None, default=None
+    attributes : str, list or tuple of str, default=None
         Attribute name(s) given as string or a list/tuple of strings
         Eg.: ``["coef_", "estimator_", ...], "coef_"``
 
-        If None, `estimator` is considered fitted if there exist an attribute
-        that starts or ends with a underscore and does not start
+        If `None`, `estimator` is considered fitted if there exist an
+        attribute that starts or ends with a underscore and does not start
         with double underscore.
 
     msg : string
@@ -904,8 +904,7 @@ def check_is_fitted(estimator, attributes=None, msg=None):
         attrs = all([hasattr(estimator, attr) for attr in attributes])
     else:
         attrs = [v for v in vars(estimator)
-                 if (v.endswith("_") or v.startswith("_"))
-                 and not v.startswith("__")]
+                 if v.endswith("_") and not v.startswith("__")]
 
     if not attrs:
         raise NotFittedError(msg % {'name': type(estimator).__name__})

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -857,6 +857,9 @@ def check_is_fitted(estimator, attributes=None, msg=None):
     fitted attributes (ending with a trailing underscore) and otherwise
     raises a NotFittedError with the given message.
 
+    This utility is meant to be used internally by estimators them-selves,
+    typically in their own predict / transform methods.
+
     Parameters
     ----------
     estimator : estimator instance.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/15845 
Alternative to https://github.com/scikit-learn/scikit-learn/pull/15885

#### What does this implement/fix? Explain your changes.
Implements @jnothman's suggestion: https://github.com/scikit-learn/scikit-learn/issues/15845#issuecomment-566045018

#### Any other comments?
This PR adds `attributes` back in as an optional keyword to `check_is_fitted`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
