### PR TITLE
[MRG] BUG Fixes division by zero in PCA get_precision

### DIFF
--- a/sklearn/decomposition/_base.py
+++ b/sklearn/decomposition/_base.py
@@ -56,12 +56,11 @@ class _BasePCA(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
             Estimated precision of data.
         """
         n_features = self.components_.shape[1]
-        n_samples = self.n_samples_
 
         # handle corner cases first
         if self.n_components_ == 0:
             return np.eye(n_features) / self.noise_variance_
-        if self.n_components_ == min(n_samples, n_features):
+        if self.n_components_ == min(self.explained_variance_.shape):
             return linalg.inv(self.get_covariance())
 
         # Get precision using matrix inversion lemma

--- a/sklearn/decomposition/_base.py
+++ b/sklearn/decomposition/_base.py
@@ -56,11 +56,12 @@ class _BasePCA(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
             Estimated precision of data.
         """
         n_features = self.components_.shape[1]
+        n_samples = self.n_samples_
 
         # handle corner cases first
         if self.n_components_ == 0:
             return np.eye(n_features) / self.noise_variance_
-        if self.n_components_ == n_features:
+        if self.n_components_ == min(n_samples, n_features):
             return linalg.inv(self.get_covariance())
 
         # Get precision using matrix inversion lemma

--- a/sklearn/decomposition/_base.py
+++ b/sklearn/decomposition/_base.py
@@ -60,8 +60,12 @@ class _BasePCA(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
         # handle corner cases first
         if self.n_components_ == 0:
             return np.eye(n_features) / self.noise_variance_
-        if self.n_components_ == min(self.n_samples_, n_features):
-            return linalg.inv(self.get_covariance())
+        if hasattr(self, 'n_samples_'):
+            if self.n_components_ == min(self.n_samples_, n_features):
+                return linalg.inv(self.get_covariance())
+        else:
+            if self.n_components == n_features:
+                return linalg.inv(self.get_covariance())
 
         # Get precision using matrix inversion lemma
         components_ = self.components_

--- a/sklearn/decomposition/_base.py
+++ b/sklearn/decomposition/_base.py
@@ -60,7 +60,7 @@ class _BasePCA(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
         # handle corner cases first
         if self.n_components_ == 0:
             return np.eye(n_features) / self.noise_variance_
-        if self.n_components_ == min(self.explained_variance_.shape):
+        if self.n_components_ == min(self.n_samples_, n_features):
             return linalg.inv(self.get_covariance())
 
         # Get precision using matrix inversion lemma

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -446,14 +446,17 @@ def test_pca_zero_noise_variance_edge_cases(svd_solver):
     # when n_components == min(n_samples, n_features)
     n, p = 100, 3
     rng = np.random.RandomState(0)
-    X = rng.randn(n, p) * .1 + np.array([3, 4, 5])
+    Xl = rng.randn(n, p) * .1 + np.array([3, 4, 5])
+    Xt = rng.randn(n, p) * .1 + np.array([3, 4, 5])
 
     pca = PCA(n_components=p, svd_solver=svd_solver)
-    pca.fit(X)
+    pca.fit(Xl)
     assert pca.noise_variance_ == 0
 
-    pca.fit(X.T)
+    pca.fit(Xl.T)
     assert pca.noise_variance_ == 0
+    # ensure pca.score works for n_components == n_samples < n_features
+    pca.score(Xt.T)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -446,17 +446,17 @@ def test_pca_zero_noise_variance_edge_cases(svd_solver):
     # when n_components == min(n_samples, n_features)
     n, p = 100, 3
     rng = np.random.RandomState(0)
-    Xl = rng.randn(n, p) * .1 + np.array([3, 4, 5])
-    Xt = rng.randn(n, p) * .1 + np.array([3, 4, 5])
+    X = rng.randn(n, p) * .1 + np.array([3, 4, 5])
 
     pca = PCA(n_components=p, svd_solver=svd_solver)
-    pca.fit(Xl)
+    pca.fit(X)
     assert pca.noise_variance_ == 0
 
-    pca.fit(Xl.T)
+    pca.fit(X.T)
     assert pca.noise_variance_ == 0
+    
     # ensure pca.score works for n_components == n_samples < n_features
-    pca.score(Xt.T)
+    pca.score(X.T)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -454,7 +454,6 @@ def test_pca_zero_noise_variance_edge_cases(svd_solver):
 
     pca.fit(X.T)
     assert pca.noise_variance_ == 0
-    
     # ensure pca.score works for n_components == n_samples < n_features
     pca.score(X.T)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #12489

#### What does this implement/fix? Explain your changes.

Calling get_precision in PCA uses a division by noise variance. When noise variance is 0, this causes a division by zero and raises an error. Noise variance is 0 when either n_components == n_features < n_samples or n_components == n_samples < n_features. The current code handled the first case, but not the second case. Checking for self.n_components == min(n_samples, n_features) solves the issue.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
