### PR TITLE
Simplify code of gallery example comparing different manifold methods

### DIFF
--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -23,6 +23,7 @@ representation of the data in the low-dimensional space.
 
 print(__doc__)
 
+from collections import OrderedDict
 from functools import partial
 from time import time
 
@@ -40,20 +41,25 @@ X, color = datasets.make_s_curve(n_points, random_state=0)
 n_neighbors = 10
 n_components = 2
 
-fig = plt.figure(figsize=(15, 8))
-plt.suptitle("Manifold Learning with %i points, %i neighbors"
+# Create figure
+fig, axis = plt.subplots(nrows=2, ncols=5, figsize=(15, 8))
+fig.suptitle("Manifold Learning with %i points, %i neighbors"
              % (1000, n_neighbors), fontsize=14)
 
-
-ax = fig.add_subplot(251, projection='3d')
+# Add 3d scatter plot
+axis[0, 0].remove()
+ax = fig.add_subplot(2, 5, 1, projection='3d')
 ax.scatter(X[:, 0], X[:, 1], X[:, 2], c=color, cmap=plt.cm.Spectral)
 ax.view_init(4, -72)
+
+# Hide axis for unused plot
+axis[1, 0].set_axis_off()
 
 # Set-up manifold methods
 LLE = partial(manifold.LocallyLinearEmbedding,
               n_neighbors, n_components, eigen_solver='auto')
 
-methods = dict()
+methods = OrderedDict()
 methods['LLE'] = LLE(method='standard')
 methods['LTSA'] = LLE(method='ltsa')
 methods['Hessian LLE'] = LLE(method='hessian')
@@ -71,11 +77,11 @@ for i, (label, method) in enumerate(methods.items()):
     Y = method.fit_transform(X)
     t1 = time()
     print("%s: %.2g sec" % (label, t1 - t0))
-    ax = fig.add_subplot(2, 5, 2 + i + (i > 3))
-    plt.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.Spectral)
-    plt.title("%s (%.2g sec)" % (label, t1 - t0))
+    ax = axis[1*(i > 3), (i % 4) + 1]  # fig.add_subplot(2, 5, 2 + i + (i > 3))
+    ax.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.Spectral)
+    ax.set_title("%s (%.2g sec)" % (label, t1 - t0))
     ax.xaxis.set_major_formatter(NullFormatter())
     ax.yaxis.set_major_formatter(NullFormatter())
-    plt.axis('tight')
+    ax.axis('tight')
 
 plt.show()

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -23,6 +23,7 @@ representation of the data in the low-dimensional space.
 
 print(__doc__)
 
+from functools import partial
 from time import time
 
 import matplotlib.pyplot as plt
@@ -48,72 +49,33 @@ ax = fig.add_subplot(251, projection='3d')
 ax.scatter(X[:, 0], X[:, 1], X[:, 2], c=color, cmap=plt.cm.Spectral)
 ax.view_init(4, -72)
 
-methods = ['standard', 'ltsa', 'hessian', 'modified']
-labels = ['LLE', 'LTSA', 'Hessian LLE', 'Modified LLE']
+# Set-up manifold methods
+LLE = partial(manifold.LocallyLinearEmbedding,
+              n_neighbors, n_components, eigen_solver='auto')
 
-for i, method in enumerate(methods):
+methods = dict()
+methods['LLE'] = LLE(method='standard')
+methods['LTSA'] = LLE(method='ltsa')
+methods['Hessian LLE'] = LLE(method='hessian')
+methods['Modified LLE'] = LLE(method='modified')
+methods['Isomap'] = manifold.Isomap(n_neighbors, n_components)
+methods['MDS'] = manifold.MDS(n_components, max_iter=100, n_init=1)
+methods['SE'] = manifold.SpectralEmbedding(n_components=n_components,
+                                           n_neighbors=n_neighbors)
+methods['t-SNE'] = manifold.TSNE(n_components=n_components, init='pca',
+                                 random_state=0)
+
+# Plot results
+for i, (label, method) in enumerate(methods.items()):
     t0 = time()
-    Y = manifold.LocallyLinearEmbedding(n_neighbors, n_components,
-                                        eigen_solver='auto',
-                                        method=method).fit_transform(X)
+    Y = method.fit_transform(X)
     t1 = time()
-    print("%s: %.2g sec" % (methods[i], t1 - t0))
-
-    ax = fig.add_subplot(252 + i)
+    print("%s: %.2g sec" % (label, t1 - t0))
+    ax = fig.add_subplot(2, 5, 2 + i + (i > 3))
     plt.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.Spectral)
-    plt.title("%s (%.2g sec)" % (labels[i], t1 - t0))
+    plt.title("%s (%.2g sec)" % (label, t1 - t0))
     ax.xaxis.set_major_formatter(NullFormatter())
     ax.yaxis.set_major_formatter(NullFormatter())
     plt.axis('tight')
-
-t0 = time()
-Y = manifold.Isomap(n_neighbors, n_components).fit_transform(X)
-t1 = time()
-print("Isomap: %.2g sec" % (t1 - t0))
-ax = fig.add_subplot(257)
-plt.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.Spectral)
-plt.title("Isomap (%.2g sec)" % (t1 - t0))
-ax.xaxis.set_major_formatter(NullFormatter())
-ax.yaxis.set_major_formatter(NullFormatter())
-plt.axis('tight')
-
-
-t0 = time()
-mds = manifold.MDS(n_components, max_iter=100, n_init=1)
-Y = mds.fit_transform(X)
-t1 = time()
-print("MDS: %.2g sec" % (t1 - t0))
-ax = fig.add_subplot(258)
-plt.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.Spectral)
-plt.title("MDS (%.2g sec)" % (t1 - t0))
-ax.xaxis.set_major_formatter(NullFormatter())
-ax.yaxis.set_major_formatter(NullFormatter())
-plt.axis('tight')
-
-
-t0 = time()
-se = manifold.SpectralEmbedding(n_components=n_components,
-                                n_neighbors=n_neighbors)
-Y = se.fit_transform(X)
-t1 = time()
-print("SpectralEmbedding: %.2g sec" % (t1 - t0))
-ax = fig.add_subplot(259)
-plt.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.Spectral)
-plt.title("SpectralEmbedding (%.2g sec)" % (t1 - t0))
-ax.xaxis.set_major_formatter(NullFormatter())
-ax.yaxis.set_major_formatter(NullFormatter())
-plt.axis('tight')
-
-t0 = time()
-tsne = manifold.TSNE(n_components=n_components, init='pca', random_state=0)
-Y = tsne.fit_transform(X)
-t1 = time()
-print("t-SNE: %.2g sec" % (t1 - t0))
-ax = fig.add_subplot(2, 5, 10)
-plt.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.Spectral)
-plt.title("t-SNE (%.2g sec)" % (t1 - t0))
-ax.xaxis.set_major_formatter(NullFormatter())
-ax.yaxis.set_major_formatter(NullFormatter())
-plt.axis('tight')
 
 plt.show()

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -42,18 +42,14 @@ n_neighbors = 10
 n_components = 2
 
 # Create figure
-fig, axis = plt.subplots(nrows=2, ncols=5, figsize=(15, 8))
+fig = plt.figure(figsize=(15, 8))
 fig.suptitle("Manifold Learning with %i points, %i neighbors"
              % (1000, n_neighbors), fontsize=14)
 
 # Add 3d scatter plot
-axis[0, 0].remove()
-ax = fig.add_subplot(2, 5, 1, projection='3d')
+ax = fig.add_subplot(251, projection='3d')
 ax.scatter(X[:, 0], X[:, 1], X[:, 2], c=color, cmap=plt.cm.Spectral)
 ax.view_init(4, -72)
-
-# Hide axis for unused plot
-axis[1, 0].set_axis_off()
 
 # Set-up manifold methods
 LLE = partial(manifold.LocallyLinearEmbedding,
@@ -77,7 +73,7 @@ for i, (label, method) in enumerate(methods.items()):
     Y = method.fit_transform(X)
     t1 = time()
     print("%s: %.2g sec" % (label, t1 - t0))
-    ax = axis[1*(i > 3), (i % 4) + 1]  # fig.add_subplot(2, 5, 2 + i + (i > 3))
+    ax = fig.add_subplot(2, 5, 2 + i + (i > 3))
     ax.scatter(Y[:, 0], Y[:, 1], c=color, cmap=plt.cm.Spectral)
     ax.set_title("%s (%.2g sec)" % (label, t1 - t0))
     ax.xaxis.set_major_formatter(NullFormatter())


### PR DESCRIPTION
#### Reference Issues/PRs

- None

#### What does this implement/fix? Explain your changes.

- The PR simplifies the existing gallery example comparing different manifold learning methods. 
- By defining and looping over a simple dictionary containing the compared methods, the PR removes around 40 lines of redundant code. 
- Moreover, when new methods are added to the sklearn.manifold module it will be easier to include them in the current gallery example.

#### Any other comments?

- While I think that the PR improves the readability/usability/expandability of examples/manifold/plot_compare_methods.py it does not address an existing issue. Please feel free to quickly reject the PR if it does not seem helpful. In any case, thanks for your great work!

- The committed changes pass all linting tests.
