### PR TITLE
[MRG] BUG apply sample weights to RANSAC loss functions

### DIFF
--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -373,10 +373,8 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
 
             # residuals of all data for current random sample model
             y_pred = base_estimator.predict(X)
-            if sample_weight is None:
-                residuals_subset = loss_function(y, y_pred)
-            else:
-                residuals_subset = loss_function(y, y_pred) * sample_weight
+            sample_weight = _check_sample_weight(sample_weight, X)
+            residuals_subset = loss_function(y, y_pred) * sample_weight
 
             # classify data into inliers and outliers
             inlier_mask_subset = residuals_subset < residual_threshold

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -373,7 +373,10 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
 
             # residuals of all data for current random sample model
             y_pred = base_estimator.predict(X)
-            residuals_subset = loss_function(y, y_pred)
+            if sample_weight is None:
+                residuals_subset = loss_function(y, y_pred)
+            else:
+                residuals_subset = loss_function(y, y_pred) * sample_weight
 
             # classify data into inliers and outliers
             inlier_mask_subset = residuals_subset < residual_threshold


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #15836

#### What does this implement/fix? Explain your changes.
Ensures that `sample_weight` is applied to the output of the `loss_function` when determining inliers/outliers at each iteration.

#### Any other comments?
I'm not too sure of the best way to add a non-regression test for this behavior. I originally tried fitting two RANSAC estimators with/without weights and then compared their output coefficients (which were indeed different) but there was no way to know that the difference was from `sample_weight` being used during the underlying estimators' `.fit()` or if it was because of `sample_weight` being applied to the output of the `loss_function`.

Would it be useful to run an example with/without weights, checking the resulting `.inlier_mask_` (or something similar), and then writing a test that asserts the `.inlier_mask_` is the same?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
