### PR TITLE
[MRG] MNT Updates pypy to use 7.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,28 +136,28 @@ workflows:
   version: 2
   build-doc-and-deploy:
     jobs:
-      # - lint
-      # - doc:
-      #     requires:
-      #       - lint
-      # - doc-min-dependencies:
-      #     requires:
-      #       - lint
-      - pypy3
-      #     filters:
-      #       branches:
-      #         only:
-      #           - 0.20.X
-      # - deploy:
-      #     requires:
-      #       - doc
-  # pypy:
-  #   triggers:
-  #     - schedule:
-  #         cron: "0 0 * * *"
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
+      - lint
+      - doc:
+          requires:
+            - lint
+      - doc-min-dependencies:
+          requires:
+            - lint
+      - pypy3:
+          filters:
+            branches:
+              only:
+                - 0.20.X
+      - deploy:
+          requires:
+            - doc
+  pypy:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - pypy3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
 
   pypy3:
     docker:
-      - image: pypy:3.6-7.1.1
+      - image: pypy:3.6-7.2.0
     steps:
       - restore_cache:
           keys:
@@ -136,28 +136,28 @@ workflows:
   version: 2
   build-doc-and-deploy:
     jobs:
-      - lint
-      - doc:
-          requires:
-            - lint
-      - doc-min-dependencies:
-          requires:
-            - lint
-      - pypy3:
-          filters:
-            branches:
-              only:
-                - 0.20.X
-      - deploy:
-          requires:
-            - doc
-  pypy:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+      # - lint
+      # - doc:
+      #     requires:
+      #       - lint
+      # - doc-min-dependencies:
+      #     requires:
+      #       - lint
+      - pypy3
+      #     filters:
+      #       branches:
+      #         only:
+      #           - 0.20.X
+      # - deploy:
+      #     requires:
+      #       - doc
+  # pypy:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0 0 * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
     jobs:
       - pypy3

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -18,10 +18,7 @@ source pypy-env/bin/activate
 python --version
 which python
 
-# XXX: numpy version pinning can be reverted once PyPy
-#      compatibility is resolved for numpy v1.6.x. For instance,
-#      when PyPy3 >6.0 is released (see numpy/numpy#12740)
-pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu numpy Cython pytest
+pip install --extra-index https://antocuni.github.io/pypy-wheels/manylinux2010 numpy Cython pytest
 pip install scipy sphinx numpydoc docutils joblib pillow
 
 ccache -M 512M

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -18,6 +18,7 @@ source pypy-env/bin/activate
 python --version
 which python
 
+pip install -U pip
 pip install --extra-index https://antocuni.github.io/pypy-wheels/manylinux2010 numpy Cython pytest
 pip install scipy sphinx numpydoc docutils joblib pillow
 

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -19,9 +19,12 @@ python --version
 which python
 
 pip install -U pip
-pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010 numpy
-pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010 scipy
-pip install --extra-index-url https://antocuni.github.io/pypy-wheels/ubuntu Cython
+
+# pins versions to install wheel from https://antocuni.github.io/pypy-wheels/manylinux2010
+pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010 numpy==1.18.0 scipy==1.3.2
+
+# Install Cython directly
+pip install https://antocuni.github.io/pypy-wheels/ubuntu/Cython/Cython-0.29.14-py3-none-any.whl
 pip install sphinx numpydoc docutils joblib pillow pytest
 
 ccache -M 512M

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -19,8 +19,10 @@ python --version
 which python
 
 pip install -U pip
-pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010 numpy Cython pytest scipy
-pip install sphinx numpydoc docutils joblib pillow
+pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010 numpy
+pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010 scipy
+pip install --extra-index-url https://antocuni.github.io/pypy-wheels/ubuntu Cython
+pip install sphinx numpydoc docutils joblib pillow pytest
 
 ccache -M 512M
 export CCACHE_COMPRESS=1

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -19,8 +19,8 @@ python --version
 which python
 
 pip install -U pip
-pip install --extra-index https://antocuni.github.io/pypy-wheels/manylinux2010 numpy Cython pytest
-pip install scipy sphinx numpydoc docutils joblib pillow
+pip install --extra-index https://antocuni.github.io/pypy-wheels/manylinux2010 numpy Cython pytest scipy
+pip install sphinx numpydoc docutils joblib pillow
 
 ccache -M 512M
 export CCACHE_COMPRESS=1

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -19,7 +19,7 @@ python --version
 which python
 
 pip install -U pip
-pip install --extra-index https://antocuni.github.io/pypy-wheels/manylinux2010 numpy Cython pytest scipy
+pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux2010 numpy Cython pytest scipy
 pip install sphinx numpydoc docutils joblib pillow
 
 ccache -M 512M

--- a/conftest.py
+++ b/conftest.py
@@ -37,7 +37,7 @@ def pytest_collection_modifyitems(config, items):
         skip_marker = pytest.mark.skip(
             reason='FeatureHasher is not compatible with PyPy')
         for item in items:
-            if item.name.endswith(('hashing.FeatureHasher',
+            if item.name.endswith(('_hash.FeatureHasher',
                                    'text.HashingVectorizer')):
                 item.add_marker(skip_marker)
 

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -140,7 +140,7 @@ class FitFailedWarning(RuntimeWarning):
     FitFailedWarning('Estimator fit failed. The score on this train-test
     partition for these parameters will be set to 0.000000.
     Details:...Traceback (most recent call last):...ValueError:
-    Penalty term must be positive; got (C=-2)\\n')
+    Penalty term must be positive; got (C=-2)...
 
 
     .. versionchanged:: 0.18

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -139,8 +139,7 @@ class FitFailedWarning(RuntimeWarning):
     ...     print(repr(w[-1].message))
     FitFailedWarning('Estimator fit failed. The score on this train-test
     partition for these parameters will be set to 0.000000.
-    Details:
-    \\nTraceback (most recent call last):...\\nValueError:
+    Details:...Traceback (most recent call last):...ValueError:
     Penalty term must be positive; got (C=-2)\\n')
 
 


### PR DESCRIPTION
Attempts to fix [pypy failure on master](https://circleci.com/gh/scikit-learn/scikit-learn/86859?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) by updating to 7.2.0 and updating the `--extra-index-url` according to the [pypy-wheels readme](https://github.com/antocuni/pypy-wheels).