### PR TITLE
Fixing document default values

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -72,21 +72,21 @@ def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
         Initialization value of the sparse code. Only used if
         `algorithm='lasso_cd'`.
 
-    max_iter : int, 1000 by default
+    max_iter : int, default=1000
         Maximum number of iterations to perform if `algorithm='lasso_cd'` or
         `lasso_lars`.
 
-    copy_cov : boolean, optional
+    copy_cov : boolean, default=True
         Whether to copy the precomputed covariance matrix; if False, it may be
         overwritten.
 
-    check_input : boolean, optional
+    check_input : boolean, default=True
         If False, the input arrays X and dictionary will not be checked.
 
-    verbose : int
+    verbose : int, default=0
         Controls the verbosity; the higher, the more messages. Defaults to 0.
 
-    positive: boolean
+    positive: bool, default=False
         Whether to enforce a positivity constraint on the sparse code.
 
         .. versionadded:: 0.20
@@ -224,12 +224,12 @@ def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
         threshold: squashes to zero all coefficients less than alpha from
         the projection dictionary * X'
 
-    n_nonzero_coefs : int, 0.1 * n_features by default
+    n_nonzero_coefs : int, default = 0.1 * n_features
         Number of nonzero coefficients to target in each column of the
         solution. This is only used by `algorithm='lars'` and `algorithm='omp'`
         and is overridden by `alpha` in the `omp` case.
 
-    alpha : float, 1. by default
+    alpha : float, default=1.
         If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, `alpha` is the absolute value of the
@@ -238,7 +238,7 @@ def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
         the reconstruction error targeted. In this case, it overrides
         `n_nonzero_coefs`.
 
-    copy_cov : boolean, optional
+    copy_cov : boolean, default=True
         Whether to copy the precomputed covariance matrix; if False, it may be
         overwritten.
 
@@ -246,23 +246,23 @@ def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
         Initialization value of the sparse codes. Only used if
         `algorithm='lasso_cd'`.
 
-    max_iter : int, 1000 by default
+    max_iter : int, default=1000
         Maximum number of iterations to perform if `algorithm='lasso_cd'` or
         `lasso_lars`.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    check_input : boolean, optional
+    check_input : boolean, default=True
         If False, the input arrays X and dictionary will not be checked.
 
-    verbose : int, optional
+    verbose : int, default=0
         Controls the verbosity; the higher, the more messages. Defaults to 0.
 
-    positive : boolean, optional
+    positive : boolean, default=False
         Whether to enforce positivity when finding the encoding.
 
         .. versionadded:: 0.20
@@ -361,13 +361,13 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
         Whether to compute and return the residual sum of squares corresponding
         to the computed solution.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    positive : boolean, optional
+    positive : boolean, default=False
         Whether to enforce positivity when finding the dictionary.
 
         .. versionadded:: 0.20
@@ -464,7 +464,7 @@ def dict_learning(X, n_components, alpha, max_iter=100, tol=1e-8,
         Lasso solution (linear_model.Lasso). Lars will be faster if
         the estimated components are sparse.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -476,13 +476,13 @@ def dict_learning(X, n_components, alpha, max_iter=100, tol=1e-8,
     code_init : array of shape (n_samples, n_components),
         Initial value for the sparse code for warm restart scenarios.
 
-    callback : callable or None, optional (default: None)
+    callback : callable or None, default=None
         Callable that gets invoked every five iterations
 
-    verbose : bool, optional (default: False)
+    verbose : bool, default=False
         To control the verbosity of the procedure.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -501,7 +501,7 @@ def dict_learning(X, n_components, alpha, max_iter=100, tol=1e-8,
 
         .. versionadded:: 0.20
 
-    method_max_iter : int, optional (default=1000)
+    method_max_iter : int, default=1000
         Maximum number of iterations to perform.
 
         .. versionadded:: 0.22
@@ -660,19 +660,19 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
     dict_init : array of shape (n_components, n_features),
         Initial value for the dictionary for warm restart scenarios.
 
-    callback : callable or None, optional (default: None)
+    callback : callable or None, default=None
         callable that gets invoked every five iterations
 
     batch_size : int,
         The number of samples to take in each batch.
 
-    verbose : bool, optional (default: False)
+    verbose : bool, default=False
         To control the verbosity of the procedure.
 
     shuffle : boolean,
         Whether to shuffle the data before splitting it in batches.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -685,17 +685,17 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
         Lasso solution (linear_model.Lasso). Lars will be faster if
         the estimated components are sparse.
 
-    iter_offset : int, default 0
+    iter_offset : int, default=0
         Number of previous iterations completed on the dictionary used for
         initialization.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    return_inner_stats : boolean, optional
+    return_inner_stats : boolean, default=False
         Return the inner statistics A (dictionary covariance) and B
         (data approximation). Useful to restart the algorithm in an
         online setting. If return_inner_stats is True, return_code is
@@ -721,7 +721,7 @@ def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
 
         .. versionadded:: 0.20
 
-    method_max_iter : int, optional (default=1000)
+    method_max_iter : int, default=1000
         Maximum number of iterations to perform when solving the lasso problem.
 
         .. versionadded:: 0.22
@@ -1273,7 +1273,7 @@ class MiniBatchDictionaryLearning(SparseCodingMixin, BaseEstimator):
         Lasso solution (linear_model.Lasso). Lars will be faster if
         the estimated components are sparse.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -1300,12 +1300,12 @@ class MiniBatchDictionaryLearning(SparseCodingMixin, BaseEstimator):
         threshold: squashes to zero all coefficients less than alpha from
         the projection dictionary * X'
 
-    transform_n_nonzero_coefs : int, ``0.1 * n_features`` by default
+    transform_n_nonzero_coefs : int, default=0.1 * n_features
         Number of nonzero coefficients to target in each column of the
         solution. This is only used by `algorithm='lars'` and `algorithm='omp'`
         and is overridden by `alpha` in the `omp` case.
 
-    transform_alpha : float, 1. by default
+    transform_alpha : float, default=1.
         If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, `alpha` is the absolute value of the
@@ -1314,15 +1314,15 @@ class MiniBatchDictionaryLearning(SparseCodingMixin, BaseEstimator):
         the reconstruction error targeted. In this case, it overrides
         `n_nonzero_coefs`.
 
-    verbose : bool, optional (default: False)
+    verbose : bool, default=False
         To control the verbosity of the procedure.
 
-    split_sign : bool, False by default
+    split_sign : bool, default=False
         Whether to split the sparse feature vector into the concatenation of
         its negative part and its positive part. This can improve the
         performance of downstream classifiers.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -1338,7 +1338,7 @@ class MiniBatchDictionaryLearning(SparseCodingMixin, BaseEstimator):
 
         .. versionadded:: 0.20
 
-    transform_max_iter : int, optional (default=1000)
+    transform_max_iter : int, default=1000
         Maximum number of iterations to perform if `algorithm='lasso_cd'` or
         `lasso_lars`.
 
@@ -1455,7 +1455,7 @@ class MiniBatchDictionaryLearning(SparseCodingMixin, BaseEstimator):
 
         y : Ignored
 
-        iter_offset : integer, optional
+        iter_offset : integer, default=None
             The number of iteration on data batches that has been
             performed before this call to partial_fit. This is optional:
             if no number is passed, the memory of the object is

--- a/sklearn/decomposition/_factor_analysis.py
+++ b/sklearn/decomposition/_factor_analysis.py
@@ -85,11 +85,11 @@ class FactorAnalysis(TransformerMixin, BaseEstimator):
         `iterated_power`. If this is not sufficient, for maximum precision
         you should choose 'lapack'.
 
-    iterated_power : int, optional
+    iterated_power : int, default=3
         Number of iterations for the power method. 3 by default. Only used
         if ``svd_method`` equals 'randomized'
 
-    random_state : int, RandomState instance or None, optional (default=0)
+    random_state : int, RandomState instance or None, default=0
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used

--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -160,21 +160,21 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         Training vector, where n_samples is the number of samples and
         n_features is the number of features.
 
-    n_components : int, optional
+    n_components : int, default=None
         Number of components to extract. If None no dimension reduction
         is performed.
 
-    algorithm : {'parallel', 'deflation'}, optional
+    algorithm : {'parallel', 'deflation'}, default='parallel'
         Apply a parallel or deflational FASTICA algorithm.
 
-    whiten : boolean, optional
+    whiten : boolean, default=True
         If True perform an initial whitening of the data.
         If False, the data is assumed to have already been
         preprocessed: it should be centered, normed and white.
         Otherwise you will get incorrect results.
         In this case the parameter n_components will be ignored.
 
-    fun : string or function, optional. Default: 'logcosh'
+    fun : string or function, default='logcosh'
         The functional form of the G function used in the
         approximation to neg-entropy. Could be either 'logcosh', 'exp',
         or 'cube'.
@@ -186,36 +186,36 @@ def fastica(X, n_components=None, algorithm="parallel", whiten=True,
         def my_g(x):
             return x ** 3, np.mean(3 * x ** 2, axis=-1)
 
-    fun_args : dictionary, optional
+    fun_args : dictionary, default=None
         Arguments to send to the functional form.
         If empty or None and if fun='logcosh', fun_args will take value
         {'alpha' : 1.0}
 
-    max_iter : int, optional
+    max_iter : int, default=200
         Maximum number of iterations to perform.
 
-    tol : float, optional
+    tol : float, default=1e-4
         A positive scalar giving the tolerance at which the
         un-mixing matrix is considered to have converged.
 
-    w_init : (n_components, n_components) array, optional
+    w_init : (n_components, n_components) array, default=None
         Initial un-mixing array of dimension (n.comp,n.comp).
         If None (default) then an array of normal r.v.'s is used.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    return_X_mean : bool, optional
+    return_X_mean : bool, default=False
         If True, X_mean is returned too.
 
-    compute_sources : bool, optional
+    compute_sources : bool, default=True
         If False, sources are not computed, but only the rotation matrix.
         This can save memory when working with big data. Defaults to True.
 
-    return_n_iter : bool, optional
+    return_n_iter : bool, default=False
         Whether or not to return the number of iterations.
 
     Returns
@@ -306,17 +306,17 @@ class FastICA(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_components : int, optional
+    n_components : int, default=None
         Number of components to use. If none is passed, all are used.
 
-    algorithm : {'parallel', 'deflation'}
+    algorithm : {'parallel', 'deflation'}, default='parallel'
         Apply parallel or deflational algorithm for FastICA.
 
-    whiten : boolean, optional
+    whiten : boolean, default=True
         If whiten is false, the data is already considered to be
         whitened, and no whitening is performed.
 
-    fun : string or function, optional. Default: 'logcosh'
+    fun : string or function, default='logcosh'
         The functional form of the G function used in the
         approximation to neg-entropy. Could be either 'logcosh', 'exp',
         or 'cube'.
@@ -327,21 +327,21 @@ class FastICA(TransformerMixin, BaseEstimator):
         def my_g(x):
             return x ** 3, (3 * x ** 2).mean(axis=-1)
 
-    fun_args : dictionary, optional
+    fun_args : dictionary, default=None
         Arguments to send to the functional form.
         If empty and if fun='logcosh', fun_args will take value
         {'alpha' : 1.0}.
 
-    max_iter : int, optional
+    max_iter : int, default=200
         Maximum number of iterations during fit.
 
-    tol : float, optional
+    tol : float, defaul1e-4
         Tolerance on update at each iteration.
 
     w_init : None of an (n_components, n_components) ndarray
         The mixing matrix to be used to initialize the algorithm.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -585,7 +585,7 @@ class FastICA(TransformerMixin, BaseEstimator):
             Data to transform, where n_samples is the number of samples
             and n_features is the number of features.
 
-        copy : bool (optional)
+        copy : bool, default=True
             If False, data passed to fit are overwritten. Defaults to True.
 
         Returns
@@ -608,7 +608,7 @@ class FastICA(TransformerMixin, BaseEstimator):
         X : array-like, shape (n_samples, n_components)
             Sources, where n_samples is the number of samples
             and n_components is the number of components.
-        copy : bool (optional)
+        copy : bool, default=True
             If False, data passed to fit are overwritten. Defaults to True.
 
         Returns

--- a/sklearn/decomposition/_incremental_pca.py
+++ b/sklearn/decomposition/_incremental_pca.py
@@ -41,12 +41,12 @@ class IncrementalPCA(_BasePCA):
 
     Parameters
     ----------
-    n_components : int or None, (default=None)
+    n_components : int or None, default=None
         Number of components to keep. If ``n_components `` is ``None``,
         then ``n_components`` is set to ``min(n_samples, n_features)``.
 
-    whiten : bool, optional
-        When True (False by default) the ``components_`` vectors are divided
+    whiten : bool, default=False
+        When True the ``components_`` vectors are divided
         by ``n_samples`` times ``components_`` to ensure uncorrelated outputs
         with unit component-wise variances.
 
@@ -55,11 +55,11 @@ class IncrementalPCA(_BasePCA):
         improve the predictive accuracy of the downstream estimators by
         making data respect some hard-wired assumptions.
 
-    copy : bool, (default=True)
+    copy : bool, default=True
         If False, X will be overwritten. ``copy=False`` can be used to
         save memory but is unsafe for general use.
 
-    batch_size : int or None, (default=None)
+    batch_size : int or None, default=None
         The number of samples to use for each batch. Only used when calling
         ``fit``. If ``batch_size`` is ``None``, then ``batch_size``
         is inferred from the data and set to ``5 * n_features``, to provide a

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -76,7 +76,7 @@ class KernelPCA(TransformerMixin, BaseEstimator):
         When n_components is None, this parameter is ignored and components
         with zero eigenvalues are removed regardless.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -84,14 +84,14 @@ class KernelPCA(TransformerMixin, BaseEstimator):
 
         .. versionadded:: 0.18
 
-    copy_X : boolean, default=True
+    copy_X : bool, default=True
         If True, input X is copied and stored by the model in the `X_fit_`
         attribute. If no further changes will be done to X, setting
         `copy_X=False` saves memory by storing a reference.
 
         .. versionadded:: 0.18
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         The number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`

--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -141,15 +141,15 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_components : int, optional (default=10)
+    n_components : int, default=10
         Number of topics.
 
-    doc_topic_prior : float, optional (default=None)
+    doc_topic_prior : float, default=None
         Prior of document topic distribution `theta`. If the value is None,
         defaults to `1 / n_components`.
         In [1]_, this is called `alpha`.
 
-    topic_word_prior : float, optional (default=None)
+    topic_word_prior : float, default=None
         Prior of topic word distribution `beta`. If the value is None, defaults
         to `1 / n_components`.
         In [1]_, this is called `eta`.
@@ -172,26 +172,26 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
         .. versionchanged:: 0.20
             The default learning method is now ``"batch"``.
 
-    learning_decay : float, optional (default=0.7)
+    learning_decay : float, default=0.7
         It is a parameter that control learning rate in the online learning
         method. The value should be set between (0.5, 1.0] to guarantee
         asymptotic convergence. When the value is 0.0 and batch_size is
         ``n_samples``, the update method is same as batch learning. In the
         literature, this is called kappa.
 
-    learning_offset : float, optional (default=10.)
+    learning_offset : float, default=10.
         A (positive) parameter that downweights early iterations in online
         learning.  It should be greater than 1.0. In the literature, this is
         called tau_0.
 
-    max_iter : integer, optional (default=10)
+    max_iter : integer, default=10
         The maximum number of iterations.
 
-    batch_size : int, optional (default=128)
+    batch_size : int, default=128
         Number of documents to use in each EM iteration. Only used in online
         learning.
 
-    evaluate_every : int, optional (default=0)
+    evaluate_every : int, default=0
         How often to evaluate perplexity. Only used in `fit` method.
         set it to 0 or negative number to not evaluate perplexity in
         training at all. Evaluating perplexity can help you check convergence
@@ -199,30 +199,30 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
         Evaluating perplexity in every iteration might increase training time
         up to two-fold.
 
-    total_samples : int, optional (default=1e6)
+    total_samples : int, default=1e6
         Total number of documents. Only used in the :meth:`partial_fit` method.
 
-    perp_tol : float, optional (default=1e-1)
+    perp_tol : float, default=1e-1
         Perplexity tolerance in batch learning. Only used when
         ``evaluate_every`` is greater than 0.
 
-    mean_change_tol : float, optional (default=1e-3)
+    mean_change_tol : float, default=1e-3
         Stopping tolerance for updating document topic distribution in E-step.
 
-    max_doc_update_iter : int (default=100)
+    max_doc_update_iter : int, default=100
         Max number of iterations for updating document topic distribution in
         the E-step.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         The number of jobs to use in the E-step.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    verbose : int, optional (default=0)
+    verbose : int, default=0
         Verbosity level.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -370,7 +370,7 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
             distribution randomly in the E-step. Set it to True in training
             steps.
 
-        parallel : joblib.Parallel (optional)
+        parallel : joblib.Parallel, default=None
             Pre-initialized instance of joblib.Parallel.
 
         Returns
@@ -660,7 +660,7 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
             Document topic distribution. In the literature, this is called
             gamma.
 
-        sub_sampling : boolean, optional, (default=False)
+        sub_sampling : boolean, default=False
             Compensate for subsampling of documents.
             It is used in calculate bound in online learning.
 

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -77,7 +77,7 @@ def _beta_divergence(X, W, H, beta, square_root=False):
         If beta == 0, this is the Itakura-Saito divergence.
         Else, this is the general beta-divergence.
 
-    square_root : boolean, default False
+    square_root : bool, default=False
         If True, return np.sqrt(2 * res)
         For beta == 2, it corresponds to the Frobenius norm.
 
@@ -287,7 +287,7 @@ def _initialize_nmf(X, n_components, init=None, eps=1e-6,
     eps : float
         Truncate all values less then this in output to zero.
 
-    random_state : int, RandomState instance or None, optional, default: None
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -444,35 +444,35 @@ def _fit_coordinate_descent(X, W, H, tol=1e-4, max_iter=200, l1_reg_W=0,
     H : array-like, shape (n_components, n_features)
         Initial guess for the solution.
 
-    tol : float, default: 1e-4
+    tol : float, default=1e-4
         Tolerance of the stopping condition.
 
-    max_iter : integer, default: 200
+    max_iter : integer, default=200
         Maximum number of iterations before timing out.
 
-    l1_reg_W : double, default: 0.
+    l1_reg_W : double, default=0.
         L1 regularization parameter for W.
 
-    l1_reg_H : double, default: 0.
+    l1_reg_H : double, default=0.
         L1 regularization parameter for H.
 
-    l2_reg_W : double, default: 0.
+    l2_reg_W : double, default=0.
         L2 regularization parameter for W.
 
-    l2_reg_H : double, default: 0.
+    l2_reg_H : double, default=0.
         L2 regularization parameter for H.
 
-    update_H : boolean, default: True
+    update_H : boolean, default=True
         Set to True, both W and H will be estimated from initial guesses.
         Set to False, only W will be estimated.
 
-    verbose : integer, default: 0
+    verbose : integer, default=0
         The verbosity level.
 
-    shuffle : boolean, default: False
+    shuffle : boolean, default=False
         If true, randomize the order of coordinates in the CD solver.
 
-    random_state : int, RandomState instance or None, optional, default: None
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -728,7 +728,7 @@ def _fit_multiplicative_update(X, W, H, beta_loss='frobenius',
     H : array-like, shape (n_components, n_features)
         Initial guess for the solution.
 
-    beta_loss : float or string, default 'frobenius'
+    beta_loss : float or string, default='frobenius'
         String must be in {'frobenius', 'kullback-leibler', 'itakura-saito'}.
         Beta divergence to be minimized, measuring the distance between X
         and the dot product WH. Note that values different from 'frobenius'
@@ -736,29 +736,29 @@ def _fit_multiplicative_update(X, W, H, beta_loss='frobenius',
         fits. Note that for beta_loss <= 0 (or 'itakura-saito'), the input
         matrix X cannot contain zeros.
 
-    max_iter : integer, default: 200
+    max_iter : integer, default=200
         Number of iterations.
 
-    tol : float, default: 1e-4
+    tol : float, default=1e-4
         Tolerance of the stopping condition.
 
-    l1_reg_W : double, default: 0.
+    l1_reg_W : double, default=0.
         L1 regularization parameter for W.
 
-    l1_reg_H : double, default: 0.
+    l1_reg_H : double, default=0.
         L1 regularization parameter for H.
 
-    l2_reg_W : double, default: 0.
+    l2_reg_W : double, default=0.
         L2 regularization parameter for W.
 
-    l2_reg_H : double, default: 0.
+    l2_reg_H : double, default=0.
         L2 regularization parameter for H.
 
-    update_H : boolean, default: True
+    update_H : boolean, default=True
         Set to True, both W and H will be estimated from initial guesses.
         Set to False, only W will be estimated.
 
-    verbose : integer, default: 0
+    verbose : integer, default=0
         The verbosity level.
 
     Returns
@@ -915,7 +915,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
         .. versionchanged:: 0.23
             The default value of `init` changed from 'random' to None in 0.23.
 
-    update_H : boolean, default: True
+    update_H : boolean, default=True
         Set to True, both W and H will be estimated from initial guesses.
         Set to False, only W will be estimated.
 
@@ -933,7 +933,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
         .. versionadded:: 0.19
            Multiplicative Update solver.
 
-    beta_loss : float or string, default 'frobenius'
+    beta_loss : float or string, default='frobenius'
         String must be in {'frobenius', 'kullback-leibler', 'itakura-saito'}.
         Beta divergence to be minimized, measuring the distance between X
         and the dot product WH. Note that values different from 'frobenius'
@@ -943,16 +943,16 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
 
         .. versionadded:: 0.19
 
-    tol : float, default: 1e-4
+    tol : float, default=1e-4
         Tolerance of the stopping condition.
 
-    max_iter : integer, default: 200
+    max_iter : integer, default=200
         Maximum number of iterations before timing out.
 
-    alpha : double, default: 0.
+    alpha : double, default=0.
         Constant that multiplies the regularization terms.
 
-    l1_ratio : double, default: 0.
+    l1_ratio : double, default=0.
         The regularization mixing parameter, with 0 <= l1_ratio <= 1.
         For l1_ratio = 0 the penalty is an elementwise L2 penalty
         (aka Frobenius Norm).
@@ -963,16 +963,16 @@ def non_negative_factorization(X, W=None, H=None, n_components=None,
         Select whether the regularization affects the components (H), the
         transformation (W), both or none of them.
 
-    random_state : int, RandomState instance or None, optional, default: None
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    verbose : integer, default: 0
+    verbose : integer, default=0
         The verbosity level.
 
-    shuffle : boolean, default: False
+    shuffle : boolean, default=False
         If true, randomize the order of coordinates in the CD solver.
 
     Returns
@@ -1140,7 +1140,7 @@ class NMF(TransformerMixin, BaseEstimator):
         .. versionadded:: 0.19
            Multiplicative Update solver.
 
-    beta_loss : float or string, default 'frobenius'
+    beta_loss : float or string, default='frobenius'
         String must be in {'frobenius', 'kullback-leibler', 'itakura-saito'}.
         Beta divergence to be minimized, measuring the distance between X
         and the dot product WH. Note that values different from 'frobenius'
@@ -1150,26 +1150,26 @@ class NMF(TransformerMixin, BaseEstimator):
 
         .. versionadded:: 0.19
 
-    tol : float, default: 1e-4
+    tol : float, default=1e-4
         Tolerance of the stopping condition.
 
-    max_iter : integer, default: 200
+    max_iter : integer, default=200
         Maximum number of iterations before timing out.
 
-    random_state : int, RandomState instance or None, optional, default: None
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    alpha : double, default: 0.
+    alpha : double, default=0.
         Constant that multiplies the regularization terms. Set it to zero to
         have no regularization.
 
         .. versionadded:: 0.17
            *alpha* used in the Coordinate Descent solver.
 
-    l1_ratio : double, default: 0.
+    l1_ratio : double, default=0.
         The regularization mixing parameter, with 0 <= l1_ratio <= 1.
         For l1_ratio = 0 the penalty is an elementwise L2 penalty
         (aka Frobenius Norm).
@@ -1183,7 +1183,7 @@ class NMF(TransformerMixin, BaseEstimator):
     verbose : bool, default=False
         Whether to be verbose.
 
-    shuffle : boolean, default: False
+    shuffle : boolean, default=False
         If true, randomize the order of coordinates in the CD solver.
 
         .. versionadded:: 0.17

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -148,7 +148,7 @@ class PCA(_BasePCA):
         fit(X).transform(X) will not yield the expected results,
         use fit_transform(X) instead.
 
-    whiten : bool, optional (default False)
+    whiten : bool, default=False
         When True (False by default) the `components_` vectors are multiplied
         by the square root of n_samples and then divided by the singular values
         to ensure uncorrelated outputs with unit component-wise variances.
@@ -158,7 +158,7 @@ class PCA(_BasePCA):
         improve the predictive accuracy of the downstream estimators by
         making their data respect some hard-wired assumptions.
 
-    svd_solver : str {'auto', 'full', 'arpack', 'randomized'}
+    svd_solver : str {'auto', 'full', 'arpack', 'randomized'}, default='auto'
         If auto :
             The solver is selected by a default policy based on `X.shape` and
             `n_components`: if the input data is larger than 500x500 and the
@@ -178,18 +178,18 @@ class PCA(_BasePCA):
 
         .. versionadded:: 0.18.0
 
-    tol : float >= 0, optional (default .0)
+    tol : float >= 0, default=.0
         Tolerance for singular values computed by svd_solver == 'arpack'.
 
         .. versionadded:: 0.18.0
 
-    iterated_power : int >= 0, or 'auto', (default 'auto')
+    iterated_power : int >= 0, or 'auto', default='auto'
         Number of iterations for the power method computed by
         svd_solver == 'randomized'.
 
         .. versionadded:: 0.18.0
 
-    random_state : int, RandomState instance or None, optional (default None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -64,7 +64,7 @@ class SparsePCA(TransformerMixin, BaseEstimator):
         Lasso solution (linear_model.Lasso). Lars will be faster if
         the estimated components are sparse.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -79,7 +79,7 @@ class SparsePCA(TransformerMixin, BaseEstimator):
     verbose : int
         Controls the verbosity; the higher, the more messages. Defaults to 0.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -257,7 +257,7 @@ class MiniBatchSparsePCA(SparsePCA):
     n_iter : int,
         number of iterations to perform for each mini batch
 
-    callback : callable or None, optional (default: None)
+    callback : callable or None, default=None
         callable that gets invoked every five iterations
 
     batch_size : int,
@@ -269,7 +269,7 @@ class MiniBatchSparsePCA(SparsePCA):
     shuffle : boolean,
         whether to shuffle the data before splitting it in batches
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -282,7 +282,7 @@ class MiniBatchSparsePCA(SparsePCA):
         Lasso solution (linear_model.Lasso). Lars will be faster if
         the estimated components are sparse.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used

--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -50,19 +50,19 @@ class TruncatedSVD(TransformerMixin, BaseEstimator):
         (scipy.sparse.linalg.svds), or "randomized" for the randomized
         algorithm due to Halko (2009).
 
-    n_iter : int, optional (default 5)
+    n_iter : int, default=5
         Number of iterations for randomized SVD solver. Not used by ARPACK. The
         default is larger than the default in
         `~sklearn.utils.extmath.randomized_svd` to handle sparse matrices that
         may have large slowly decaying spectrum.
 
-    random_state : int, RandomState instance or None, optional, default = None
+    random_state : int, RandomState instance or None, default = None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    tol : float, optional
+    tol : float, default=0.0
         Tolerance for ARPACK. 0 means machine precision. Ignored by randomized
         SVD solver.
 

--- a/sklearn/feature_extraction/_dict_vectorizer.py
+++ b/sklearn/feature_extraction/_dict_vectorizer.py
@@ -47,18 +47,17 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    dtype : callable, optional
+    dtype : callable, default=np.float64
         The type of feature values. Passed to Numpy array/scipy.sparse matrix
         constructors as the dtype argument.
-    separator : string, optional
+    separator : string, default="="
         Separator string used when constructing new features for one-hot
         coding.
-    sparse : boolean, optional.
+    sparse : bool, default=true.
         Whether transform should produce scipy.sparse matrices.
-        True by default.
-    sort : boolean, optional.
+    sort : bool, default=True.
         Whether ``feature_names_`` and ``vocabulary_`` should be
-        sorted when fitting. True by default.
+        sorted when fitting.
 
     Attributes
     ----------
@@ -241,7 +240,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Sample matrix.
-        dict_type : callable, optional
+        dict_type : callable, default=dict
             Constructor for feature mappings. Must conform to the
             collections.Mapping API.
 
@@ -324,7 +323,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
         support : array-like
             Boolean mask or list of indices (as returned by the get_support
             member of feature selectors).
-        indices : boolean, optional
+        indices : bool, default=False
             Whether support is a list of indices.
 
         Returns

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -51,7 +51,7 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-    input_type : string, optional, default "dict"
+    input_type : string, default="dict"
         Either "dict" (the default) to accept dictionaries over
         (feature_name, value); "pair" to accept pairs of (feature_name, value);
         or "string" to accept single strings.
@@ -60,11 +60,11 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         The feature_name is hashed to find the appropriate column for the
         feature. The value's sign might be flipped in the output (but see
         non_negative, below).
-    dtype : numpy type, optional, default np.float64
+    dtype : numpy type, default=np.float64
         The type of feature values. Passed to scipy.sparse matrix constructors
         as the dtype argument. Do not set this to bool, np.boolean or any
         unsigned integer type.
-    alternate_sign : boolean, optional, default True
+    alternate_sign : bool, default=True
         When True, an alternating sign is added to the features as to
         approximately conserve the inner product in the hashed space even for
         small n_features. This approach is similar to sparse random projection.

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -38,7 +38,7 @@ def _make_edges_3d(n_x, n_y, n_z=1):
     n_y : integer
         The size of the grid in the y direction.
     n_z : integer, optional
-        The size of the grid in the z direction, defaults to 1
+        The size of the grid in the z direction, defaults=1
     """
     vertices = np.arange(n_x * n_y * n_z).reshape((n_x, n_y, n_z))
     edges_deep = np.vstack((vertices[:, :, :-1].ravel(),
@@ -145,9 +145,8 @@ def img_to_graph(img, mask=None, return_as=sparse.coo_matrix, dtype=None):
         pixels.
     return_as : np.ndarray or a sparse matrix class, optional
         The class to use to build the returned adjacency matrix.
-    dtype : None or dtype, optional
-        The data of the returned sparse matrix. By default it is the
-        dtype of img
+    dtype : None or dtype, default=None
+        The data of the returned sparse matrix.
 
     Notes
     -----
@@ -175,14 +174,14 @@ def grid_to_graph(n_x, n_y, n_z=1, mask=None, return_as=sparse.coo_matrix,
         Dimension in x axis
     n_y : int
         Dimension in y axis
-    n_z : int, optional, default 1
+    n_z : int, default=1
         Dimension in z axis
     mask : ndarray of booleans, optional
         An optional mask of the image, to consider only part of the
         pixels.
     return_as : np.ndarray or a sparse matrix class, optional
         The class to use to build the returned adjacency matrix.
-    dtype : dtype, optional, default int
+    dtype : dtype, default=int
         The data of the returned sparse matrix. By default it is int
 
     Notes
@@ -216,7 +215,7 @@ def _compute_n_patches(i_h, i_w, p_h, p_w, max_patches=None):
         The height of a patch
     p_w : int
         The width of a patch
-    max_patches : integer or float, optional default is None
+    max_patches : integer or float, default=None
         The maximum number of patches to extract. If max_patches is a float
         between 0 and 1, it is taken to be a proportion of the total number
         of patches.
@@ -357,12 +356,12 @@ def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
     patch_size : tuple of ints (patch_height, patch_width)
         the dimensions of one patch
 
-    max_patches : integer or float, optional default is None
+    max_patches : integer or float, default=None
         The maximum number of patches to extract. If max_patches is a float
         between 0 and 1, it is taken to be a proportion of the total number
         of patches.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         Determines the random number generator used for random sampling when
         `max_patches` is not None. Use an int to make the randomness
         deterministic.
@@ -491,12 +490,12 @@ class PatchExtractor(BaseEstimator):
     patch_size : tuple of ints (patch_height, patch_width)
         the dimensions of one patch
 
-    max_patches : integer or float, optional default is None
+    max_patches : integer or float, default=None
         The maximum number of patches per image to extract. If max_patches is a
         float in (0, 1), it is taken to mean a proportion of the total number
         of patches.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         Determines the random number generator used for random sampling when
         `max_patches` is not None. Use an int to make the randomness
         deterministic.

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -591,19 +591,19 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         If bytes or files are given to analyze, this encoding is used to
         decode.
 
-    decode_error : {'strict', 'ignore', 'replace'}
+    decode_error : {'strict', 'ignore', 'replace'}, default='strict'
         Instruction on what to do if a byte sequence is given to analyze that
         contains characters not of the given `encoding`. By default, it is
         'strict', meaning that a UnicodeDecodeError will be raised. Other
         values are 'ignore' and 'replace'.
 
-    strip_accents : {'ascii', 'unicode', None}
+    strip_accents : {'ascii', 'unicode', None}, default=None
         Remove accents and perform other character normalization
         during the preprocessing step.
         'ascii' is a fast method that only works on characters that have
         an direct ASCII mapping.
         'unicode' is a slightly slower method that works on any characters.
-        None (default) does nothing.
+        None does nothing.
 
         Both 'ascii' and 'unicode' use NFKD normalization from
         :func:`unicodedata.normalize`.
@@ -611,17 +611,17 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
     lowercase : boolean, default=True
         Convert all characters to lowercase before tokenizing.
 
-    preprocessor : callable or None (default)
+    preprocessor : callable or None, default=None
         Override the preprocessing (string transformation) stage while
         preserving the tokenizing and n-grams generation steps.
         Only applies if ``analyzer is not callable``.
 
-    tokenizer : callable or None (default)
+    tokenizer : callable or None, default=None
         Override the string tokenization step while preserving the
         preprocessing and n-grams generation steps.
         Only applies if ``analyzer == 'word'``.
 
-    stop_words : string {'english'}, list, or None (default)
+    stop_words : string {'english'}, list, or None, default=None
         If 'english', a built-in stop word list for English is used.
         There are several known issues with 'english' and you should
         consider an alternative (see :ref:`stop_words`).
@@ -644,7 +644,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         only bigrams.
         Only applies if ``analyzer is not callable``.
 
-    analyzer : string, {'word', 'char', 'char_wb'} or callable
+    analyzer : string, {'word', 'char', 'char_wb'} or callable, default='word'
         Whether the feature should be made of word or character n-grams.
         Option 'char_wb' creates character n-grams only from text inside
         word boundaries; n-grams at the edges of words are padded with space.
@@ -668,17 +668,17 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         probabilistic models that model binary events rather than integer
         counts.
 
-    norm : 'l1', 'l2' or None, optional
+    norm : 'l1', 'l2' or None, default='l2'
         Norm used to normalize term vectors. None for no normalization.
 
-    alternate_sign : boolean, optional, default True
+    alternate_sign : bool, default=True
         When True, an alternating sign is added to the features as to
         approximately conserve the inner product in the hashed space even for
         small n_features. This approach is similar to sparse random projection.
 
         .. versionadded:: 0.19
 
-    dtype : type, optional
+    dtype : type, default=np.float64
         Type of the matrix returned by fit_transform() or transform().
 
     Examples
@@ -850,41 +850,41 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         Otherwise the input is expected to be a sequence of items that
         can be of type string or byte.
 
-    encoding : string, 'utf-8' by default.
+    encoding : string, default='utf-8'
         If bytes or files are given to analyze, this encoding is used to
         decode.
 
-    decode_error : {'strict', 'ignore', 'replace'}
+    decode_error : {'strict', 'ignore', 'replace'}, default='strict'
         Instruction on what to do if a byte sequence is given to analyze that
         contains characters not of the given `encoding`. By default, it is
         'strict', meaning that a UnicodeDecodeError will be raised. Other
         values are 'ignore' and 'replace'.
 
-    strip_accents : {'ascii', 'unicode', None}
+    strip_accents : {'ascii', 'unicode', None}, default=None
         Remove accents and perform other character normalization
         during the preprocessing step.
         'ascii' is a fast method that only works on characters that have
         an direct ASCII mapping.
         'unicode' is a slightly slower method that works on any characters.
-        None (default) does nothing.
+        None does nothing.
 
         Both 'ascii' and 'unicode' use NFKD normalization from
         :func:`unicodedata.normalize`.
 
-    lowercase : boolean, True by default
+    lowercase : bool, default=None
         Convert all characters to lowercase before tokenizing.
 
-    preprocessor : callable or None (default)
+    preprocessor : callable or None, default=None
         Override the preprocessing (string transformation) stage while
         preserving the tokenizing and n-grams generation steps.
         Only applies if ``analyzer is not callable``.
 
-    tokenizer : callable or None (default)
+    tokenizer : callable or None, default=None
         Override the string tokenization step while preserving the
         preprocessing and n-grams generation steps.
         Only applies if ``analyzer == 'word'``.
 
-    stop_words : string {'english'}, list, or None (default)
+    stop_words : string {'english'}, list, default=None
         If 'english', a built-in stop word list for English is used.
         There are several known issues with 'english' and you should
         consider an alternative (see :ref:`stop_words`).
@@ -911,7 +911,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         unigrams and bigrams, and ``(2, 2)`` means only bigrams.
         Only applies if ``analyzer is not callable``.
 
-    analyzer : string, {'word', 'char', 'char_wb'} or callable
+    analyzer : string, {'word', 'char', 'char_wb'} or callable, default='word'
         Whether the feature should be made of word n-gram or character
         n-grams.
         Option 'char_wb' creates character n-grams only from text inside
@@ -948,7 +948,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
 
         This parameter is ignored if vocabulary is not None.
 
-    vocabulary : Mapping or iterable, optional
+    vocabulary : Mapping or iterable, default=None
         Either a Mapping (e.g., a dict) where keys are terms and values are
         indices in the feature matrix, or an iterable over terms. If not
         given, a vocabulary is determined from the input documents. Indices
@@ -960,7 +960,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         probabilistic models that model binary events rather than integer
         counts.
 
-    dtype : type, optional
+    dtype : type, default=np.int64
         Type of the matrix returned by fit_transform() or transform().
 
     Attributes
@@ -1371,7 +1371,7 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    norm : 'l1', 'l2' or None, optional (default='l2')
+    norm : 'l1', 'l2' or None, default='l2'
         Each output row will have unit norm, either:
         * 'l2': Sum of squares of vector elements is 1. The cosine
         similarity between two vectors is their dot product when l2 norm has
@@ -1379,15 +1379,15 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
         * 'l1': Sum of absolute values of vector elements is 1.
         See :func:`preprocessing.normalize`
 
-    use_idf : boolean (default=True)
+    use_idf : bool, default=True
         Enable inverse-document-frequency reweighting.
 
-    smooth_idf : boolean (default=True)
+    smooth_idf : bool, default=True
         Smooth idf weights by adding one to document frequencies, as if an
         extra document was seen containing every term in the collection
         exactly once. Prevents zero divisions.
 
-    sublinear_tf : boolean (default=False)
+    sublinear_tf : bool, default=False
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
     Attributes
@@ -1479,7 +1479,7 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
         X : sparse matrix, [n_samples, n_features]
             a matrix of term/token counts
 
-        copy : boolean, default True
+        copy : bool, default=True
             Whether to copy X and operate on the copy or perform in-place
             operations.
 
@@ -1555,32 +1555,32 @@ class TfidfVectorizer(CountVectorizer):
         If bytes or files are given to analyze, this encoding is used to
         decode.
 
-    decode_error : {'strict', 'ignore', 'replace'} (default='strict')
+    decode_error : {'strict', 'ignore', 'replace'}, default='strict'
         Instruction on what to do if a byte sequence is given to analyze that
         contains characters not of the given `encoding`. By default, it is
         'strict', meaning that a UnicodeDecodeError will be raised. Other
         values are 'ignore' and 'replace'.
 
-    strip_accents : {'ascii', 'unicode', None} (default=None)
+    strip_accents : {'ascii', 'unicode', None}, default=None
         Remove accents and perform other character normalization
         during the preprocessing step.
         'ascii' is a fast method that only works on characters that have
         an direct ASCII mapping.
         'unicode' is a slightly slower method that works on any characters.
-        None (default) does nothing.
+        None does nothing.
 
         Both 'ascii' and 'unicode' use NFKD normalization from
         :func:`unicodedata.normalize`.
 
-    lowercase : bool (default=True)
+    lowercase : bool,d efault=True
         Convert all characters to lowercase before tokenizing.
 
-    preprocessor : callable or None (default=None)
+    preprocessor : callable or None,d efault=None
         Override the preprocessing (string transformation) stage while
         preserving the tokenizing and n-grams generation steps.
         Only applies if ``analyzer is not callable``.
 
-    tokenizer : callable or None (default=None)
+    tokenizer : callable or None, default=None
         Override the string tokenization step while preserving the
         preprocessing and n-grams generation steps.
         Only applies if ``analyzer == 'word'``.
@@ -1599,7 +1599,7 @@ class TfidfVectorizer(CountVectorizer):
         first read from the file and then passed to the given callable
         analyzer.
 
-    stop_words : str {'english'}, list, or None (default=None)
+    stop_words : str {'english'}, list, or None, default=None
         If a string, it is passed to _check_stop_list and the appropriate stop
         list is returned. 'english' is currently the only supported string
         value.
@@ -1628,7 +1628,7 @@ class TfidfVectorizer(CountVectorizer):
         only bigrams.
         Only applies if ``analyzer is not callable``.
 
-    max_df : float in range [0.0, 1.0] or int (default=1.0)
+    max_df : float in range [0.0, 1.0] or int, default=1.0
         When building the vocabulary ignore terms that have a document
         frequency strictly higher than the given threshold (corpus-specific
         stop words).
@@ -1636,7 +1636,7 @@ class TfidfVectorizer(CountVectorizer):
         absolute counts.
         This parameter is ignored if vocabulary is not None.
 
-    min_df : float in range [0.0, 1.0] or int (default=1)
+    min_df : float in range [0.0, 1.0] or int, default=1
         When building the vocabulary ignore terms that have a document
         frequency strictly lower than the given threshold. This value is also
         called cut-off in the literature.
@@ -1644,26 +1644,26 @@ class TfidfVectorizer(CountVectorizer):
         absolute counts.
         This parameter is ignored if vocabulary is not None.
 
-    max_features : int or None (default=None)
+    max_features : int or None, default=None
         If not None, build a vocabulary that only consider the top
         max_features ordered by term frequency across the corpus.
 
         This parameter is ignored if vocabulary is not None.
 
-    vocabulary : Mapping or iterable, optional (default=None)
+    vocabulary : Mapping or iterable, default=None
         Either a Mapping (e.g., a dict) where keys are terms and values are
         indices in the feature matrix, or an iterable over terms. If not
         given, a vocabulary is determined from the input documents.
 
-    binary : bool (default=False)
+    binary : bool, default=False
         If True, all non-zero term counts are set to 1. This does not mean
         outputs will have only 0/1 values, only that the tf term in tf-idf
         is binary. (Set idf and normalization to False to get 0/1 outputs).
 
-    dtype : type, optional (default=float64)
+    dtype : type, default=float64
         Type of the matrix returned by fit_transform() or transform().
 
-    norm : 'l1', 'l2' or None, optional (default='l2')
+    norm : 'l1', 'l2' or None, default='l2'
         Each output row will have unit norm, either:
         * 'l2': Sum of squares of vector elements is 1. The cosine
         similarity between two vectors is their dot product when l2 norm has
@@ -1671,15 +1671,15 @@ class TfidfVectorizer(CountVectorizer):
         * 'l1': Sum of absolute values of vector elements is 1.
         See :func:`preprocessing.normalize`.
 
-    use_idf : bool (default=True)
+    use_idf : bool, default=True
         Enable inverse-document-frequency reweighting.
 
-    smooth_idf : bool (default=True)
+    smooth_idf : bool, default=True
         Smooth idf weights by adding one to document frequencies, as if an
         extra document was seen containing every term in the collection
         exactly once. Prevents zero divisions.
 
-    sublinear_tf : bool (default=False)
+    sublinear_tf : bool, default=False
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
     Attributes
@@ -1869,7 +1869,7 @@ class TfidfVectorizer(CountVectorizer):
         raw_documents : iterable
             An iterable which yields either str, unicode or file objects.
 
-        copy : bool, default True
+        copy : bool, default=True
             Whether to copy X and operate on the copy or perform in-place
             operations.
 

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -59,10 +59,10 @@ def make_dataset(X, y, sample_weight, random_state=None):
     y : array_like, shape (n_samples, )
         Target values.
 
-    sample_weight : numpy array of shape (n_samples,)
+    sample_weight : numpy array of shape (n_samples,), default=None
         The weight of each sample
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance or None, default=None
         Determines random number generation for dataset shuffling and noise.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
@@ -382,12 +382,12 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
 
     Parameters
     ----------
-    fit_intercept : bool, optional, default True
+    fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set
         to False, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : bool, optional, default False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -395,10 +395,10 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit`` on
         an estimator with ``normalize=False``.
 
-    copy_X : bool, optional, default True
+    copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         The number of jobs to use for the computation. This will only provide
         speedup for n_targets > 1 and sufficient large problems.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -70,7 +70,7 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default=True
+    copy_X : boolean, default=True
         If ``True``, X will be copied; else, it may be overwritten.
     """
     if l1_ratio == 0:
@@ -154,39 +154,39 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
     y : ndarray, shape (n_samples,), or (n_samples, n_outputs)
         Target values
 
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    alphas : ndarray, optional
+    alphas : ndarray, default=None
         List of alphas where to compute the models.
         If ``None`` alphas are set automatically
 
-    precompute : True | False | 'auto' | array-like
+    precompute : True | False | 'auto' | array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    Xy : array-like, optional
+    Xy : array-like, default=None
         Xy = np.dot(X.T, y) that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    coef_init : array, shape (n_features, ) | None
+    coef_init : array, shape (n_features, ) | None, default=None
         The initial values of the coefficients.
 
-    verbose : bool or integer
+    verbose : bool or integer, default=False
         Amount of verbosity.
 
-    return_n_iter : bool
+    return_n_iter : bool, default=False
         whether to return the number of iterations or not.
 
-    positive : bool, default False
+    positive : bool, default=False
         If set to True, forces coefficients to be positive.
         (Only allowed when ``y.ndim == 1``).
 
@@ -302,7 +302,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     y : ndarray, shape (n_samples,) or (n_samples, n_outputs)
         Target values.
 
-    l1_ratio : float, optional
+    l1_ratio : float, default=0.5
         Number between 0 and 1 passed to elastic net (scaling between
         l1 and l2 penalties). ``l1_ratio=1`` corresponds to the Lasso.
 
@@ -310,10 +310,10 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path.
 
-    alphas : ndarray, optional
+    alphas : ndarray, default=None
         List of alphas where to compute the models.
         If None alphas are set automatically.
 
@@ -322,27 +322,27 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    Xy : array-like, optional
+    Xy : array-like, default=None
         Xy = np.dot(X.T, y) that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
-    copy_X : bool, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    coef_init : array, shape (n_features, ) | None
+    coef_init : array, shape (n_features, ) | None, default=None
         The initial values of the coefficients.
 
-    verbose : bool or int
+    verbose : bool or int, default=False
         Amount of verbosity.
 
-    return_n_iter : bool
+    return_n_iter : bool, default=False
         Whether to return the number of iterations or not.
 
-    positive : bool, default False
+    positive : bool, default=False
         If set to True, forces coefficients to be positive.
         (Only allowed when ``y.ndim == 1``).
 
-    check_input : bool, default True
+    check_input : bool, default=True
         Skip input validation checks, including the Gram matrix when provided
         assuming there are handled by the caller when check_input=False.
 
@@ -526,7 +526,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float, default=1.0
         Constant that multiplies the penalty terms. Defaults to 1.0.
         See the notes for the exact mathematical meaning of this
         parameter. ``alpha = 0`` is equivalent to an ordinary least square,
@@ -534,17 +534,17 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         reasons, using ``alpha = 0`` with the ``Lasso`` object is not advised.
         Given this, you should use the :class:`LinearRegression` object.
 
-    l1_ratio : float
+    l1_ratio : float, default=0.5
         The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``. For
         ``l1_ratio = 0`` the penalty is an L2 penalty. ``For l1_ratio = 1`` it
         is an L1 penalty.  For ``0 < l1_ratio < 1``, the penalty is a
         combination of L1 and L2.
 
-    fit_intercept : bool
+    fit_intercept : bool, default=True
         Whether the intercept should be estimated or not. If ``False``, the
         data is assumed to be already centered.
 
-    normalize : boolean, optional, default False
+    normalize : boolean, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -557,27 +557,27 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         calculations. The Gram matrix can also be passed as argument.
         For sparse input this option is always ``True`` to preserve sparsity.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    warm_start : bool, optional
+    warm_start : bool, default=False
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
 
-    positive : bool, optional
+    positive : bool, default=False
         When set to ``True``, forces the coefficients to be positive.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
@@ -585,7 +585,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         RandomState instance used by `np.random`. Used when ``selection`` ==
         'random'.
 
-    selection : str, default 'cyclic'
+    selection : str, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -811,19 +811,19 @@ class Lasso(ElasticNet):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float, default=1.0
         Constant that multiplies the L1 term. Defaults to 1.0.
         ``alpha = 0`` is equivalent to an ordinary least square, solved
         by the :class:`LinearRegression` object. For numerical
         reasons, using ``alpha = 0`` with the ``Lasso`` object is not advised.
         Given this, you should use the :class:`LinearRegression` object.
 
-    fit_intercept : boolean, optional, default True
+    fit_intercept : boolean, default=True
         Whether to calculate the intercept for this model. If set
         to False, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -837,27 +837,27 @@ class Lasso(ElasticNet):
         matrix can also be passed as argument. For sparse input
         this option is always ``True`` to preserve sparsity.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    warm_start : bool, optional
+    warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
 
-    positive : bool, optional
+    positive : bool, default=False
         When set to ``True``, forces the coefficients to be positive.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
@@ -865,7 +865,7 @@ class Lasso(ElasticNet):
         RandomState instance used by `np.random`. Used when ``selection`` ==
         'random'.
 
-    selection : str, default 'cyclic'
+    selection : str, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -956,21 +956,21 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
     path_params : dictionary
         Parameters passed to the path function
 
-    alphas : array-like, optional
+    alphas : array-like, default=None
         Array of float that is used for cross-validation. If not
         provided, computed using 'path'.
 
-    l1_ratio : float, optional
+    l1_ratio : float, default=1
         float between 0 and 1 passed to ElasticNet (scaling between
         l1 and l2 penalties). For ``l1_ratio = 0`` the penalty is an
         L2 penalty. For ``l1_ratio = 1`` it is an L1 penalty. For ``0
         < l1_ratio < 1``, the penalty is a combination of L1 and L2.
 
-    X_order : {'F', 'C', or None}, optional
+    X_order : {'F', 'C', or None}, default=None
         The order of the arrays expected by the path function to
         avoid memory copies
 
-    dtype : a numpy dtype or None
+    dtype : a numpy dtype or None, default=None
         The dtype of the arrays expected by the path function to
         avoid memory copies
     """
@@ -1240,23 +1240,23 @@ class LassoCV(RegressorMixin, LinearModelCV):
 
     Parameters
     ----------
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    alphas : numpy array, optional
+    alphas : numpy array, default=None
         List of alphas where to compute the models.
         If ``None`` alphas are set automatically
 
-    fit_intercept : boolean, default True
+    fit_intercept : boolean, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1264,24 +1264,24 @@ class LassoCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : True | False | 'auto' | array-like
+    precompute : True | False | 'auto' | array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
@@ -1298,19 +1298,19 @@ class LassoCV(RegressorMixin, LinearModelCV):
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    verbose : bool or integer
+    verbose : bool or integer, default=False
         Amount of verbosity.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of CPUs to use during the cross validation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    positive : bool, optional
+    positive : bool, default=False
         If positive, restrict regression coefficients to be positive
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
@@ -1318,7 +1318,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         RandomState instance used by `np.random`. Used when ``selection`` ==
         'random'.
 
-    selection : str, default 'cyclic'
+    selection : str, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -1402,7 +1402,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
     Parameters
     ----------
-    l1_ratio : float or array of floats, optional
+    l1_ratio : float or array of floats, default=0.5
         float between 0 and 1 passed to ElasticNet (scaling between
         l1 and l2 penalties). For ``l1_ratio = 0``
         the penalty is an L2 penalty. For ``l1_ratio = 1`` it is an L1 penalty.
@@ -1414,23 +1414,23 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         (i.e. Lasso) and less close to 0 (i.e. Ridge), as in ``[.1, .5, .7,
         .9, .95, .99, 1]``
 
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path, used for each l1_ratio.
 
-    alphas : numpy array, optional
+    alphas : numpy array, default=None
         List of alphas where to compute the models.
         If None alphas are set automatically
 
-    fit_intercept : boolean
+    fit_intercept : boolean, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1438,21 +1438,21 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : True | False | 'auto' | array-like
+    precompute : True | False | 'auto' | array-like, default=False
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
@@ -1469,22 +1469,22 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default True
         If ``True``, X will be copied; else, it may be overwritten.
 
     verbose : bool or integer
         Amount of verbosity.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of CPUs to use during the cross validation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    positive : bool, optional
+    positive : bool, default=False
         When set to ``True``, forces the coefficients to be positive.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
@@ -1492,7 +1492,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         RandomState instance used by `np.random`. Used when ``selection`` ==
         'random'.
 
-    selection : str, default 'cyclic'
+    selection : str, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -1623,21 +1623,21 @@ class MultiTaskElasticNet(Lasso):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float, default=None
         Constant that multiplies the L1/L2 term. Defaults to 1.0
 
-    l1_ratio : float
+    l1_ratio : float, default=0.5
         The ElasticNet mixing parameter, with 0 < l1_ratio <= 1.
         For l1_ratio = 1 the penalty is an L1/L2 penalty. For l1_ratio = 0 it
         is an L2 penalty.
         For ``0 < l1_ratio < 1``, the penalty is a combination of L1/L2 and L2.
 
-    fit_intercept : boolean
+    fit_intercept : boolean, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1645,24 +1645,24 @@ class MultiTaskElasticNet(Lasso):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    warm_start : bool, optional
+    warm_start : bool, default=False
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
@@ -1670,7 +1670,7 @@ class MultiTaskElasticNet(Lasso):
         RandomState instance used by `np.random`. Used when ``selection`` ==
         'random'.
 
-    selection : str, default 'cyclic'
+    selection : str, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -1815,7 +1815,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float, default=None
         Constant that multiplies the L1/L2 term. Defaults to 1.0
 
     fit_intercept : boolean
@@ -1823,7 +1823,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1831,24 +1831,24 @@ class MultiTaskLasso(MultiTaskElasticNet):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    warm_start : bool, optional
+    warm_start : bool, default=None
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
@@ -1856,7 +1856,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
         RandomState instance used by `np.random`. Used when ``selection`` ==
         'random'.
 
-    selection : str, default 'cyclic'
+    selection : str, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -1950,23 +1950,23 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         (i.e. Lasso) and less close to 0 (i.e. Ridge), as in ``[.1, .5, .7,
         .9, .95, .99, 1]``
 
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    alphas : array-like, optional
+    alphas : array-like, default=None
         List of alphas where to compute the models.
         If not provided, set automatically.
 
-    fit_intercept : boolean
+    fit_intercept : boolean, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1974,16 +1974,16 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
@@ -2000,20 +2000,20 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
     verbose : bool or integer
         Amount of verbosity.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of CPUs to use during the cross validation. Note that this is
         used only if multiple values for l1_ratio are given.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
@@ -2021,7 +2021,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         RandomState instance used by `np.random`. Used when ``selection`` ==
         'random'.
 
-    selection : str, default 'cyclic'
+    selection : str, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -2126,23 +2126,23 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
 
     Parameters
     ----------
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    alphas : array-like, optional
+    alphas : array-like, default=None
         List of alphas where to compute the models.
         If not provided, set automatically.
 
-    fit_intercept : boolean
+    fit_intercept : boolean, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : boolean, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -2150,19 +2150,19 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations.
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
@@ -2179,17 +2179,17 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    verbose : bool or integer
+    verbose : bool or integer, default=False
         Amount of verbosity.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of CPUs to use during the cross validation. Note that this is
         used only if multiple values for l1_ratio are given.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator that selects a random
         feature to update.  If int, random_state is the seed used by the random
         number generator; If RandomState instance, random_state is the random
@@ -2197,7 +2197,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         RandomState instance used by `np.random`. Used when ``selection`` ==
         'random'
 
-    selection : str, default 'cyclic'
+    selection : str, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -37,7 +37,7 @@ def _huber_loss_and_gradient(w, X, y, epsilon, alpha, sample_weight=None):
     alpha : float
         Regularization parameter.
 
-    sample_weight : ndarray, shape (n_samples,), optional
+    sample_weight : ndarray, shape (n_samples,), default=None
         Weight assigned to each sample.
 
     Returns
@@ -142,29 +142,29 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
 
     Parameters
     ----------
-    epsilon : float, greater than 1.0, default 1.35
+    epsilon : float, greater than 1.0, default=1.35
         The parameter epsilon controls the number of samples that should be
         classified as outliers. The smaller the epsilon, the more robust it is
         to outliers.
 
-    max_iter : int, default 100
+    max_iter : int, default=100
         Maximum number of iterations that
         ``scipy.optimize.minimize(method="L-BFGS-B")`` should run for.
 
-    alpha : float, default 0.0001
+    alpha : float, default=0.0001
         Regularization parameter.
 
-    warm_start : bool, default False
+    warm_start : bool, default=False
         This is useful if the stored attributes of a previously used model
         has to be reused. If set to False, then the coefficients will
         be rewritten for every call to fit.
         See :term:`the Glossary <warm_start>`.
 
-    fit_intercept : bool, default True
+    fit_intercept : bool, default=True
         Whether or not to fit the intercept. This can be set to False
         if the data is already centered around the origin.
 
-    tol : float, default 1e-5
+    tol : float, default=1e-5
         The iteration will stop when
         ``max{|proj g_i | i = 1, ..., n}`` <= ``tol``
         where pg_i is the i-th component of the projected gradient.
@@ -245,7 +245,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         y : array-like, shape (n_samples,)
             Target vector relative to X.
 
-        sample_weight : array-like, shape (n_samples,)
+        sample_weight : array-like, shape (n_samples,), default=None
             Weight given to each sample.
 
         Returns

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -86,7 +86,7 @@ def lars_path(X, y, Xy=None, Gram=None, max_iter=500, alpha_min=0,
     copy_X : bool, default=True
         If ``False``, ``X`` is overwritten.
 
-    eps : float, optional
+    eps : float, default=np.finfo(np.float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. By default, ``np.finfo(np.float).eps`` is used.
@@ -205,7 +205,7 @@ def lars_path_gram(Xy, Gram, n_samples, max_iter=500, alpha_min=0,
     copy_X : bool, default=True
         If ``False``, ``X`` is overwritten.
 
-    eps : float, optional
+    eps : float, default=np.finfo(np.float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. By default, ``np.finfo(np.float).eps`` is used.
@@ -333,7 +333,7 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
     copy_X : bool, default=True
         If ``False``, ``X`` is overwritten.
 
-    eps : float, optional
+    eps : float, default=np.finfo(np.float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. By default, ``np.finfo(np.float).eps`` is used
@@ -792,7 +792,7 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
     n_nonzero_coefs : int, default=500
         Target number of non-zero coefficients. Use ``np.inf`` for no limit.
 
-    eps : float, optional
+    eps : float, default=np.finfo(np.float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. Unlike the ``tol`` parameter in some iterative
@@ -1013,7 +1013,7 @@ class LassoLars(Lars):
     max_iter : int, default=500
         Maximum number of iterations to perform.
 
-    eps : float, optional
+    eps : float, default=np.finfo(np.float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. Unlike the ``tol`` parameter in some iterative
@@ -1174,7 +1174,7 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
     max_iter : int, default=500
         Maximum number of iterations to perform.
 
-    eps : float, optional
+    eps : float, default=np.finfo(np.float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. Unlike the ``tol`` parameter in some iterative
@@ -1289,7 +1289,7 @@ class LarsCV(Lars):
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    eps : float, optional
+    eps : float, default=np.finfo(np.float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. By default, ``np.finfo(np.float).eps`` is used.
@@ -1506,7 +1506,7 @@ class LassoLarsCV(LarsCV):
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    eps : float, optional
+    eps : float, default=np.finfo(np.float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. By default, ``np.finfo(np.float).eps`` is used.
@@ -1649,7 +1649,7 @@ class LassoLarsIC(LassoLars):
         Maximum number of iterations to perform. Can be used for
         early stopping.
 
-    eps : float, optional
+    eps : float, default=np.finfo(np.float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. Unlike the ``tol`` parameter in some iterative

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -529,7 +529,8 @@ def _logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
 
-    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}, default='lbfgs'
+    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}, \
+            default='lbfgs'
         Numerical solver to use.
 
     coef : array-like, shape (n_features,), default=None
@@ -888,7 +889,8 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
 
-    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}, default='lbfgs'
+    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}, \
+            default='lbfgs'
         Decides which solver to use.
 
     penalty : str, 'l1', 'l2', or 'elasticnet', default='l2'

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -100,7 +100,7 @@ def _logistic_loss_and_grad(w, X, y, alpha, sample_weight=None):
     alpha : float
         Regularization parameter. alpha is equal to 1 / C.
 
-    sample_weight : array-like, shape (n_samples,) optional
+    sample_weight : array-like, shape (n_samples,) default=None
         Array of weights that are assigned to individual samples.
         If not provided, then each sample is given unit weight.
 
@@ -151,7 +151,7 @@ def _logistic_loss(w, X, y, alpha, sample_weight=None):
     alpha : float
         Regularization parameter. alpha is equal to 1 / C.
 
-    sample_weight : array-like, shape (n_samples,) optional
+    sample_weight : array-like, shape (n_samples,) default=None
         Array of weights that are assigned to individual samples.
         If not provided, then each sample is given unit weight.
 
@@ -187,7 +187,7 @@ def _logistic_grad_hess(w, X, y, alpha, sample_weight=None):
     alpha : float
         Regularization parameter. alpha is equal to 1 / C.
 
-    sample_weight : array-like, shape (n_samples,) optional
+    sample_weight : array-like, shape (n_samples,) default=None
         Array of weights that are assigned to individual samples.
         If not provided, then each sample is given unit weight.
 
@@ -503,40 +503,40 @@ def _logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     y : array-like, shape (n_samples,) or (n_samples, n_targets)
         Input data, target values.
 
-    pos_class : int, None
+    pos_class : int, default=None
         The class with respect to which we perform a one-vs-all fit.
         If None, then it is assumed that the given problem is binary.
 
-    Cs : int | array-like, shape (n_cs,)
+    Cs : int | array-like, shape (n_cs,), default=10
         List of values for the regularization parameter or integer specifying
         the number of regularization parameters that should be used. In this
         case, the parameters will be chosen in a logarithmic scale between
         1e-4 and 1e4.
 
-    fit_intercept : bool
+    fit_intercept : bool, default=True
         Whether to fit an intercept for the model. In this case the shape of
         the returned array is (n_cs, n_features + 1).
 
-    max_iter : int
+    max_iter : int, default=100
         Maximum number of iterations for the solver.
 
-    tol : float
+    tol : float, default=1e-4
         Stopping criterion. For the newton-cg and lbfgs solvers, the iteration
         will stop when ``max{|g_i | i = 1, ..., n} <= tol``
         where ``g_i`` is the i-th component of the gradient.
 
-    verbose : int
+    verbose : int, default=0
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
 
-    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}
+    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}, default='lbfgs'
         Numerical solver to use.
 
-    coef : array-like, shape (n_features,), default None
+    coef : array-like, shape (n_features,), default=None
         Initialization value for coefficients of logistic regression.
         Useless for liblinear solver.
 
-    class_weight : dict or 'balanced', optional
+    class_weight : dict or 'balanced', default=None
         Weights associated with classes in the form ``{class_label: weight}``.
         If not given, all classes are supposed to have weight one.
 
@@ -547,17 +547,17 @@ def _logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         Note that these weights will be multiplied with sample_weight (passed
         through the fit method) if sample_weight is specified.
 
-    dual : bool
+    dual : bool, default=False
         Dual or primal formulation. Dual formulation is only implemented for
         l2 penalty with liblinear solver. Prefer dual=False when
         n_samples > n_features.
 
-    penalty : str, 'l1', 'l2', or 'elasticnet'
+    penalty : str, 'l1', 'l2', or 'elasticnet', default='l2'
         Used to specify the norm used in the penalization. The 'newton-cg',
         'sag' and 'lbfgs' solvers support only l2 penalties. 'elasticnet' is
         only supported by the 'saga' solver.
 
-    intercept_scaling : float, default 1.
+    intercept_scaling : float, default=1.
         Useful only when the solver 'liblinear' is used
         and self.fit_intercept is set to True. In this case, x becomes
         [x, self.intercept_scaling],
@@ -583,7 +583,7 @@ def _logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         .. versionchanged:: 0.22
             Default changed from 'ovr' to 'auto' in 0.22.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
@@ -591,19 +591,19 @@ def _logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         instance used by `np.random`. Used when ``solver`` == 'sag' or
         'liblinear'.
 
-    check_input : bool, default True
+    check_input : bool, default=True
         If False, the input arrays X and y will not be checked.
 
-    max_squared_sum : float, default None
+    max_squared_sum : float, default=None
         Maximum squared sum of X over samples. Used only in SAG solver.
         If None, it will be computed, going through all the samples.
         The value should be precomputed to speed up cross validation.
 
-    sample_weight : array-like, shape(n_samples,) optional
+    sample_weight : array-like, shape(n_samples,) default=None
         Array of weights that are assigned to individual samples.
         If not provided, then each sample is given unit weight.
 
-    l1_ratio : float or None, optional (default=None)
+    l1_ratio : float or None, default=None
         The Elastic-Net mixing parameter, with ``0 <= l1_ratio <= 1``. Only
         used if ``penalty='elasticnet'``. Setting ``l1_ratio=0`` is equivalent
         to using ``penalty='l2'``, while setting ``l1_ratio=1`` is equivalent
@@ -846,34 +846,34 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
     test : list of indices
         The indices of the test set.
 
-    pos_class : int, None
+    pos_class : int, default=None
         The class with respect to which we perform a one-vs-all fit.
         If None, then it is assumed that the given problem is binary.
 
-    Cs : list of floats | int
+    Cs : list of floats | int, default=10
         Each of the values in Cs describes the inverse of
         regularization strength. If Cs is as an int, then a grid of Cs
         values are chosen in a logarithmic scale between 1e-4 and 1e4.
         If not provided, then a fixed set of values for Cs are used.
 
-    scoring : callable or None, optional, default: None
+    scoring : callable or None, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``. For a list of scoring functions
         that can be used, look at :mod:`sklearn.metrics`. The
         default scoring option used is accuracy_score.
 
-    fit_intercept : bool
+    fit_intercept : bool, default=False
         If False, then the bias term is set to zero. Else the last
         term of each coef_ gives us the intercept.
 
-    max_iter : int
+    max_iter : int, default=100
         Maximum number of iterations for the solver.
 
-    tol : float
+    tol : float, default=1e-4
         Tolerance for stopping criteria.
 
-    class_weight : dict or 'balanced', optional
+    class_weight : dict or 'balanced', default=None
         Weights associated with classes in the form ``{class_label: weight}``.
         If not given, all classes are supposed to have weight one.
 
@@ -884,24 +884,24 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         Note that these weights will be multiplied with sample_weight (passed
         through the fit method) if sample_weight is specified.
 
-    verbose : int
+    verbose : int, default=0
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
 
-    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}
+    solver : {'lbfgs', 'newton-cg', 'liblinear', 'sag', 'saga'}, default='lbfgs'
         Decides which solver to use.
 
-    penalty : str, 'l1', 'l2', or 'elasticnet'
+    penalty : str, 'l1', 'l2', or 'elasticnet', default='l2'
         Used to specify the norm used in the penalization. The 'newton-cg',
         'sag' and 'lbfgs' solvers support only l2 penalties. 'elasticnet' is
         only supported by the 'saga' solver.
 
-    dual : bool
+    dual : bool, default=False
         Dual or primal formulation. Dual formulation is only implemented for
         l2 penalty with liblinear solver. Prefer dual=False when
         n_samples > n_features.
 
-    intercept_scaling : float, default 1.
+    intercept_scaling : float, default=1.
         Useful only when the solver 'liblinear' is used
         and self.fit_intercept is set to True. In this case, x becomes
         [x, self.intercept_scaling],
@@ -913,13 +913,13 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         To lessen the effect of regularization on synthetic feature weight
         (and therefore on the intercept) intercept_scaling has to be increased.
 
-    multi_class : {'ovr', 'multinomial'}
+    multi_class : {'ovr', 'multinomial'}, default='auto'
         If the option chosen is 'ovr', then a binary problem is fit for each
         label. For 'multinomial' the loss minimised is the multinomial loss fit
         across the entire probability distribution, *even when the data is
         binary*. 'multinomial' is unavailable when solver='liblinear'.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
@@ -927,16 +927,16 @@ def _log_reg_scoring_path(X, y, train, test, pos_class=None, Cs=10,
         instance used by `np.random`. Used when ``solver`` == 'sag' and
         'liblinear'.
 
-    max_squared_sum : float, default None
+    max_squared_sum : float, default=None
         Maximum squared sum of X over samples. Used only in SAG solver.
         If None, it will be computed, going through all the samples.
         The value should be precomputed to speed up cross validation.
 
-    sample_weight : array-like, shape(n_samples,) optional
+    sample_weight : array-like, shape(n_samples,) default=None
         Array of weights that are assigned to individual samples.
         If not provided, then each sample is given unit weight.
 
-    l1_ratio : float or None, optional (default=None)
+    l1_ratio : float or None, default=None
         The Elastic-Net mixing parameter, with ``0 <= l1_ratio <= 1``. Only
         used if ``penalty='elasticnet'``. Setting ``l1_ratio=0`` is equivalent
         to using ``penalty='l2'``, while setting ``l1_ratio=1`` is equivalent
@@ -1042,7 +1042,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
 
     Parameters
     ----------
-    penalty : str, 'l1', 'l2', 'elasticnet' or 'none', optional (default='l2')
+    penalty : str, 'l1', 'l2', 'elasticnet' or 'none', default='l2'
         Used to specify the norm used in the penalization. The 'newton-cg',
         'sag' and 'lbfgs' solvers support only l2 penalties. 'elasticnet' is
         only supported by the 'saga' solver. If 'none' (not supported by the
@@ -1051,24 +1051,24 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         .. versionadded:: 0.19
            l1 penalty with SAGA solver (allowing 'multinomial' + L1)
 
-    dual : bool, optional (default=False)
+    dual : bool, default=False
         Dual or primal formulation. Dual formulation is only implemented for
         l2 penalty with liblinear solver. Prefer dual=False when
         n_samples > n_features.
 
-    tol : float, optional (default=1e-4)
+    tol : float, default=1e-4
         Tolerance for stopping criteria.
 
-    C : float, optional (default=1.0)
+    C : float, default=1.0
         Inverse of regularization strength; must be a positive float.
         Like in support vector machines, smaller values specify stronger
         regularization.
 
-    fit_intercept : bool, optional (default=True)
+    fit_intercept : bool, default=True
         Specifies if a constant (a.k.a. bias or intercept) should be
         added to the decision function.
 
-    intercept_scaling : float, optional (default=1)
+    intercept_scaling : float, default=1
         Useful only when the solver 'liblinear' is used
         and self.fit_intercept is set to True. In this case, x becomes
         [x, self.intercept_scaling],
@@ -1081,7 +1081,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         To lessen the effect of regularization on synthetic feature weight
         (and therefore on the intercept) intercept_scaling has to be increased.
 
-    class_weight : dict or 'balanced', optional (default=None)
+    class_weight : dict or 'balanced', default=None
         Weights associated with classes in the form ``{class_label: weight}``.
         If not given, all classes are supposed to have weight one.
 
@@ -1095,7 +1095,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         .. versionadded:: 0.17
            *class_weight='balanced'*
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
@@ -1104,7 +1104,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         'liblinear'.
 
     solver : str, {'newton-cg', 'lbfgs', 'liblinear', 'sag', 'saga'}, \
-             optional (default='lbfgs')
+            default='lbfgs'
 
         Algorithm to use in the optimization problem.
 
@@ -1129,7 +1129,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         .. versionchanged:: 0.22
             The default solver changed from 'liblinear' to 'lbfgs' in 0.22.
 
-    max_iter : int, optional (default=100)
+    max_iter : int, default=100
         Maximum number of iterations taken for the solvers to converge.
 
     multi_class : {'ovr', 'multinomial', 'auto'}, default='auto'
@@ -1145,11 +1145,11 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         .. versionchanged:: 0.22
             Default changed from 'ovr' to 'auto' in 0.22.
 
-    verbose : int, optional (default=0)
+    verbose : int, default=0
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
 
-    warm_start : bool, optional (default=False)
+    warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         Useless for liblinear solver. See :term:`the Glossary <warm_start>`.
@@ -1157,7 +1157,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         .. versionadded:: 0.17
            *warm_start* to support *lbfgs*, *newton-cg*, *sag*, *saga* solvers.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of CPU cores used when parallelizing over classes if
         multi_class='ovr'". This parameter is ignored when the ``solver`` is
         set to 'liblinear' regardless of whether 'multi_class' is specified or
@@ -1165,7 +1165,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         context. ``-1`` means using all processors.
         See :term:`Glossary <n_jobs>` for more details.
 
-    l1_ratio : float or None, optional (default=None)
+    l1_ratio : float or None, default=None
         The Elastic-Net mixing parameter, with ``0 <= l1_ratio <= 1``. Only
         used if ``penalty='elasticnet'`. Setting ``l1_ratio=0`` is equivalent
         to using ``penalty='l2'``, while setting ``l1_ratio=1`` is equivalent
@@ -1295,7 +1295,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
         y : array-like, shape (n_samples,)
             Target vector relative to X.
 
-        sample_weight : array-like, shape (n_samples,) optional
+        sample_weight : array-like, shape (n_samples,) default=None
             Array of weights that are assigned to individual samples.
             If not provided, then each sample is given unit weight.
 
@@ -1529,18 +1529,18 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
 
     Parameters
     ----------
-    Cs : list of floats or int, optional (default=10)
+    Cs : list of floats or int, default=10
         Each of the values in Cs describes the inverse of regularization
         strength. If Cs is as an int, then a grid of Cs values are chosen
         in a logarithmic scale between 1e-4 and 1e4.
         Like in support vector machines, smaller values specify stronger
         regularization.
 
-    fit_intercept : bool, optional (default=True)
+    fit_intercept : bool, default=True
         Specifies if a constant (a.k.a. bias or intercept) should be
         added to the decision function.
 
-    cv : int or cross-validation generator, optional (default=None)
+    cv : int or cross-validation generator, default=None
         The default cross-validation generator used is Stratified K-Folds.
         If an integer is provided, then it is the number of folds used.
         See the module :mod:`sklearn.model_selection` module for the
@@ -1549,17 +1549,17 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    dual : bool, optional (default=False)
+    dual : bool, default=False
         Dual or primal formulation. Dual formulation is only implemented for
         l2 penalty with liblinear solver. Prefer dual=False when
         n_samples > n_features.
 
-    penalty : str, 'l1', 'l2', or 'elasticnet', optional (default='l2')
+    penalty : str, 'l1', 'l2', or 'elasticnet', default='l2'
         Used to specify the norm used in the penalization. The 'newton-cg',
         'sag' and 'lbfgs' solvers support only l2 penalties. 'elasticnet' is
         only supported by the 'saga' solver.
 
-    scoring : string, callable, or None, optional (default=None)
+    scoring : string, callable, or None, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``. For a list of scoring functions
@@ -1567,7 +1567,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         default scoring option used is 'accuracy'.
 
     solver : str, {'newton-cg', 'lbfgs', 'liblinear', 'sag', 'saga'}, \
-             optional (default='lbfgs')
+            default='lbfgs'
 
         Algorithm to use in the optimization problem.
 
@@ -1590,13 +1590,13 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         .. versionadded:: 0.19
            SAGA solver.
 
-    tol : float, optional (default=1e-4)
+    tol : float, default=1e-4
         Tolerance for stopping criteria.
 
-    max_iter : int, optional (default=100)
+    max_iter : int, default=100
         Maximum number of iterations of the optimization algorithm.
 
-    class_weight : dict or 'balanced', optional (default=None)
+    class_weight : dict or 'balanced', default=None
         Weights associated with classes in the form ``{class_label: weight}``.
         If not given, all classes are supposed to have weight one.
 
@@ -1610,24 +1610,24 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         .. versionadded:: 0.17
            class_weight == 'balanced'
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of CPU cores used during the cross-validation loop.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    verbose : int, optional (default=0)
+    verbose : int, default=0
         For the 'liblinear', 'sag' and 'lbfgs' solvers set verbose to any
         positive number for verbosity.
 
-    refit : bool, optional (default=True)
+    refit : bool, default=True
         If set to True, the scores are averaged across all folds, and the
         coefs and the C that corresponds to the best score is taken, and a
         final refit is done using these parameters.
         Otherwise the coefs, intercepts and C that correspond to the
         best scores across folds are averaged.
 
-    intercept_scaling : float, optional (default=1)
+    intercept_scaling : float, default=1
         Useful only when the solver 'liblinear' is used
         and self.fit_intercept is set to True. In this case, x becomes
         [x, self.intercept_scaling],
@@ -1653,7 +1653,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         .. versionchanged:: 0.22
             Default changed from 'ovr' to 'auto' in 0.22.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -1661,7 +1661,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         Note that this only applies to the solver and not the cross-validation
         generator.
 
-    l1_ratios : list of float or None, optional (default=None)
+    l1_ratios : list of float or None, default=None
         The list of Elastic-Net mixing parameter, with ``0 <= l1_ratio <= 1``.
         Only used if ``penalty='elasticnet'``. A value of 0 is equivalent to
         using ``penalty='l2'``, while 1 is equivalent to using
@@ -1787,7 +1787,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
         y : array-like, shape (n_samples,)
             Target vector relative to X.
 
-        sample_weight : array-like, shape (n_samples,) optional
+        sample_weight : array-like, shape (n_samples,) default=None
             Array of weights that are assigned to individual samples.
             If not provided, then each sample is given unit weight.
 

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -38,15 +38,15 @@ def _cholesky_omp(X, y, n_nonzero_coefs, tol=None, copy_X=True,
     n_nonzero_coefs : int
         Targeted number of non-zero elements
 
-    tol : float
+    tol : float, default=None
         Targeted squared error, if not None overrides n_nonzero_coefs.
 
-    copy_X : bool, optional
+    copy_X : bool, default=True
         Whether the design matrix X must be copied by the algorithm. A false
         value is only helpful if X is already Fortran-ordered, otherwise a
         copy is made anyway.
 
-    return_path : bool, optional. Default: False
+    return_path : bool, default=False
         Whether to return every value of the nonzero coefficients along the
         forward path. Useful for cross-validation.
 
@@ -153,22 +153,22 @@ def _gram_omp(Gram, Xy, n_nonzero_coefs, tol_0=None, tol=None,
     n_nonzero_coefs : int
         Targeted number of non-zero elements
 
-    tol_0 : float
+    tol_0 : float, default=None
         Squared norm of y, required if tol is not None.
 
-    tol : float
+    tol : float, default=None
         Targeted squared error, if not None overrides n_nonzero_coefs.
 
-    copy_Gram : bool, optional
+    copy_Gram : bool, default=True
         Whether the gram matrix must be copied by the algorithm. A false
         value is only helpful if it is already Fortran-ordered, otherwise a
         copy is made anyway.
 
-    copy_Xy : bool, optional
+    copy_Xy : bool, default=True
         Whether the covariance vector Xy must be copied by the algorithm.
         If False, it may be overwritten.
 
-    return_path : bool, optional. Default: False
+    return_path : bool, default=False
         Whether to return every value of the nonzero coefficients along the
         forward path. Useful for cross-validation.
 
@@ -291,23 +291,23 @@ def orthogonal_mp(X, y, n_nonzero_coefs=None, tol=None, precompute=False,
         Desired number of non-zero entries in the solution. If None (by
         default) this value is set to 10% of n_features.
 
-    tol : float
+    tol : float, default=None
         Maximum norm of the residual. If not None, overrides n_nonzero_coefs.
 
-    precompute : {True, False, 'auto'},
+    precompute : {True, False, 'auto'}, default=False
         Whether to perform precomputations. Improves performance when n_targets
         or n_samples is very large.
 
-    copy_X : bool, optional
+    copy_X : bool, default=True
         Whether the design matrix X must be copied by the algorithm. A false
         value is only helpful if X is already Fortran-ordered, otherwise a
         copy is made anyway.
 
-    return_path : bool, optional. Default: False
+    return_path : bool, default=False
         Whether to return every value of the nonzero coefficients along the
         forward path. Useful for cross-validation.
 
-    return_n_iter : bool, optional default False
+    return_n_iter : bool, default=False
         Whether or not to return the number of iterations.
 
     Returns
@@ -427,26 +427,26 @@ def orthogonal_mp_gram(Gram, Xy, n_nonzero_coefs=None, tol=None,
         Desired number of non-zero entries in the solution. If None (by
         default) this value is set to 10% of n_features.
 
-    tol : float
+    tol : float, default=None
         Maximum norm of the residual. If not None, overrides n_nonzero_coefs.
 
-    norms_squared : array-like, shape (n_targets,)
+    norms_squared : array-like, shape (n_targets,), default=None
         Squared L2 norms of the lines of y. Required if tol is not None.
 
-    copy_Gram : bool, optional
+    copy_Gram : bool, default=True
         Whether the gram matrix must be copied by the algorithm. A false
         value is only helpful if it is already Fortran-ordered, otherwise a
         copy is made anyway.
 
-    copy_Xy : bool, optional
+    copy_Xy : bool, default=True
         Whether the covariance vector Xy must be copied by the algorithm.
         If False, it may be overwritten.
 
-    return_path : bool, optional. Default: False
+    return_path : bool, default=False
         Whether to return every value of the nonzero coefficients along the
         forward path. Useful for cross-validation.
 
-    return_n_iter : bool, optional default False
+    return_n_iter : bool, default=False
         Whether or not to return the number of iterations.
 
     Returns
@@ -550,15 +550,15 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
         Desired number of non-zero entries in the solution. If None (by
         default) this value is set to 10% of n_features.
 
-    tol : float, optional
+    tol : float, default=None
         Maximum norm of the residual. If not None, overrides n_nonzero_coefs.
 
-    fit_intercept : boolean, optional
+    fit_intercept : boolean, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default True
+    normalize : boolean, default=True
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -566,7 +566,7 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : {True, False, 'auto'}, default 'auto'
+    precompute : {True, False, 'auto'}, default='auto'
         Whether to use a precomputed Gram and Xy matrix to speed up
         calculations. Improves performance when :term:`n_targets` or
         :term:`n_samples` is very large. Note that if you already have such
@@ -694,16 +694,16 @@ def _omp_path_residues(X_train, y_train, X_test, y_test, copy=True,
     y_test : array, shape (n_samples)
         The target variable to compute the residues on
 
-    copy : boolean, optional
+    copy : boolean, default=True
         Whether X_train, X_test, y_train and y_test should be copied.  If
         False, they may be overwritten.
 
-    fit_intercept : boolean
+    fit_intercept : boolean, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default True
+    normalize : boolean, default=True
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -711,7 +711,7 @@ def _omp_path_residues(X_train, y_train, X_test, y_test, copy=True,
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    max_iter : integer, optional
+    max_iter : integer, default=100
         Maximum numbers of iterations to perform, therefore maximum features
         to include. 100 by default.
 
@@ -762,17 +762,17 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
 
     Parameters
     ----------
-    copy : bool, optional
+    copy : bool, default=True
         Whether the design matrix X must be copied by the algorithm. A false
         value is only helpful if X is already Fortran-ordered, otherwise a
         copy is made anyway.
 
-    fit_intercept : boolean, optional
+    fit_intercept : boolean, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default True
+    normalize : boolean, default=True
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -780,11 +780,11 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    max_iter : integer, optional
+    max_iter : integer, default=None
         Maximum numbers of iterations to perform, therefore maximum features
         to include. 10% of ``n_features`` but at least 5 if available.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
@@ -801,13 +801,13 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of CPUs to use during the cross validation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    verbose : boolean or integer, optional
+    verbose : boolean or integer, default=False
         Sets the verbosity amount
 
     Attributes

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -14,21 +14,21 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     Parameters
     ----------
 
-    C : float
+    C : float, default=1.0
         Maximum step size (regularization). Defaults to 1.0.
 
     fit_intercept : bool, default=False
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered.
 
-    max_iter : int, optional (default=1000)
+    max_iter : int, default=1000
         The maximum number of passes over the training data (aka epochs).
         It only impacts the behavior in the ``fit`` method, and not the
         :meth:`partial_fit` method.
 
         .. versionadded:: 0.19
 
-    tol : float or None, optional (default=1e-3)
+    tol : float or None, default=1e-3
         The stopping criterion. If it is not None, the iterations will stop
         when (loss > previous_loss - tol).
 
@@ -58,29 +58,29 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     shuffle : bool, default=True
         Whether or not the training data should be shuffled after each epoch.
 
-    verbose : integer, optional
+    verbose : integer, default=0
         The verbosity level
 
-    loss : string, optional
+    loss : string, default='hinge'
         The loss function to be used:
         hinge: equivalent to PA-I in the reference paper.
         squared_hinge: equivalent to PA-II in the reference paper.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         The number of CPUs to use to do the OVA (One Versus All, for
         multi-class problems) computation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    random_state : int, RandomState instance or None, optional, default=None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
         instance used by `np.random`.
 
-    warm_start : bool, optional
+    warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
@@ -89,7 +89,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         result in a different solution than when calling fit a single time
         because of the way the data is shuffled.
 
-    class_weight : dict, {class_label: weight} or "balanced" or None, optional
+    class_weight : dict, {class_label: weight} or "balanced" or None, default=None
         Preset for the class_weight fit parameter.
 
         Weights associated with classes. If not given, all classes
@@ -102,7 +102,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         .. versionadded:: 0.17
            parameter *class_weight* to automatically weight samples.
 
-    average : bool or int, optional
+    average : bool or int, default=False
         When set to True, computes the averaged SGD weights and stores the
         result in the ``coef_`` attribute. If set to an int greater than 1,
         averaging will begin once the total number of samples seen reaches
@@ -262,21 +262,21 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     Parameters
     ----------
 
-    C : float
+    C : float, default=1.0
         Maximum step size (regularization). Defaults to 1.0.
 
-    fit_intercept : bool
+    fit_intercept : bool, default=True
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered. Defaults to True.
 
-    max_iter : int, optional (default=1000)
+    max_iter : int, default=1000
         The maximum number of passes over the training data (aka epochs).
         It only impacts the behavior in the ``fit`` method, and not the
         :meth:`partial_fit` method.
 
         .. versionadded:: 0.19
 
-    tol : float or None, optional (default=1e-3)
+    tol : float or None, default=1e-3
         The stopping criterion. If it is not None, the iterations will stop
         when (loss > previous_loss - tol).
 
@@ -306,10 +306,10 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     shuffle : bool, default=True
         Whether or not the training data should be shuffled after each epoch.
 
-    verbose : integer, optional
+    verbose : integer, default=0
         The verbosity level
 
-    loss : string, optional
+    loss : string, default='epsilon_insensitive'
         The loss function to be used:
         epsilon_insensitive: equivalent to PA-I in the reference paper.
         squared_epsilon_insensitive: equivalent to PA-II in the reference
@@ -319,14 +319,14 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
         If the difference between the current prediction and the correct label
         is below this threshold, the model is not updated.
 
-    random_state : int, RandomState instance or None, optional, default=None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
         instance used by `np.random`.
 
-    warm_start : bool, optional
+    warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
@@ -335,7 +335,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
         result in a different solution than when calling fit a single time
         because of the way the data is shuffled.
 
-    average : bool or int, optional
+    average : bool or int, default=False
         When set to True, computes the averaged SGD weights and stores the
         result in the ``coef_`` attribute. If set to an int greater than 1,
         averaging will begin once the total number of samples seen reaches

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -1,3 +1,4 @@
+
 # Authors: Rob Zinkov, Mathieu Blondel
 # License: BSD 3 clause
 
@@ -89,7 +90,8 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         result in a different solution than when calling fit a single time
         because of the way the data is shuffled.
 
-    class_weight : dict, {class_label: weight} or "balanced" or None, default=None
+    class_weight : dict, {class_label: weight} or "balanced" or None, \
+            default=None
         Preset for the class_weight fit parameter.
 
         Weights associated with classes. If not given, all classes

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -12,25 +12,25 @@ class Perceptron(BaseSGDClassifier):
     Parameters
     ----------
 
-    penalty : None, 'l2' or 'l1' or 'elasticnet'
+    penalty : None, 'l2' or 'l1' or 'elasticnet', default=None
         The penalty (aka regularization term) to be used. Defaults to None.
 
-    alpha : float
+    alpha : float, default=0.0001
         Constant that multiplies the regularization term if regularization is
         used. Defaults to 0.0001
 
-    fit_intercept : bool
+    fit_intercept : bool, default=True
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered. Defaults to True.
 
-    max_iter : int, optional (default=1000)
+    max_iter : int, default=1000
         The maximum number of passes over the training data (aka epochs).
         It only impacts the behavior in the ``fit`` method, and not the
         :meth:`partial_fit` method.
 
         .. versionadded:: 0.19
 
-    tol : float or None, optional (default=1e-3)
+    tol : float or None, default=1e-3
         The stopping criterion. If it is not None, the iterations will stop
         when (loss > previous_loss - tol).
 
@@ -45,14 +45,14 @@ class Perceptron(BaseSGDClassifier):
     eta0 : double
         Constant by which the updates are multiplied. Defaults to 1.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         The number of CPUs to use to do the OVA (One Versus All, for
         multi-class problems) computation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
@@ -80,7 +80,7 @@ class Perceptron(BaseSGDClassifier):
 
         .. versionadded:: 0.20
 
-    class_weight : dict, {class_label: weight} or "balanced" or None, optional
+    class_weight : dict, {class_label: weight} or "balanced" or None, default=None
         Preset for the class_weight fit parameter.
 
         Weights associated with classes. If not given, all classes

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -80,7 +80,8 @@ class Perceptron(BaseSGDClassifier):
 
         .. versionadded:: 0.20
 
-    class_weight : dict, {class_label: weight} or "balanced" or None, default=None
+    class_weight : dict, {class_label: weight} or "balanced" or None, \
+            default=None
         Preset for the class_weight fit parameter.
 
         Weights associated with classes. If not given, all classes

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -64,7 +64,7 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
 
     Parameters
     ----------
-    base_estimator : object, optional
+    base_estimator : object, default=None
         Base estimator object which implements the following methods:
 
          * `fit(X, y)`: Fit model to given training data and target values.
@@ -82,7 +82,7 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
         Note that the current implementation only supports regression
         estimators.
 
-    min_samples : int (>= 1) or float ([0, 1]), optional
+    min_samples : int (>= 1) or float ([0, 1]), default=None
         Minimum number of samples chosen randomly from original data. Treated
         as an absolute number of samples for `min_samples >= 1`, treated as a
         relative number `ceil(min_samples * X.shape[0]`) for
@@ -91,17 +91,17 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
         ``sklearn.linear_model.LinearRegression()`` estimator is assumed and
         `min_samples` is chosen as ``X.shape[1] + 1``.
 
-    residual_threshold : float, optional
+    residual_threshold : float, default=None
         Maximum residual for a data sample to be classified as an inlier.
         By default the threshold is chosen as the MAD (median absolute
         deviation) of the target values `y`.
 
-    is_data_valid : callable, optional
+    is_data_valid : callable, default=None
         This function is called with the randomly selected data before the
         model is fitted to it: `is_data_valid(X, y)`. If its return value is
         False the current randomly chosen sub-sample is skipped.
 
-    is_model_valid : callable, optional
+    is_model_valid : callable, default=None
         This function is called with the estimated model and the randomly
         selected data: `is_model_valid(model, X, y)`. If its return value is
         False the current randomly chosen sub-sample is skipped.
@@ -109,23 +109,23 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
         with `is_data_valid`. `is_model_valid` should therefore only be used if
         the estimated model is needed for making the rejection decision.
 
-    max_trials : int, optional
+    max_trials : int, default=100
         Maximum number of iterations for random sample selection.
 
-    max_skips : int, optional
+    max_skips : int, default=np.inf
         Maximum number of iterations that can be skipped due to finding zero
         inliers or invalid data defined by ``is_data_valid`` or invalid models
         defined by ``is_model_valid``.
 
         .. versionadded:: 0.19
 
-    stop_n_inliers : int, optional
+    stop_n_inliers : int, default=np.inf
         Stop iteration if at least this number of inliers are found.
 
-    stop_score : float, optional
+    stop_score : float, default=np.inf
         Stop iteration if score is greater equal than this threshold.
 
-    stop_probability : float in range [0, 1], optional
+    stop_probability : float in range [0, 1], default=0.99
         RANSAC iteration stops if at least one outlier-free set of the training
         data is sampled in RANSAC. This requires to generate at least N
         samples (iterations)::
@@ -136,7 +136,7 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
         as 0.99 (the default) and e is the current fraction of inliers w.r.t.
         the total number of samples.
 
-    loss : string, callable, optional, default "absolute_loss"
+    loss : string, callable, default="absolute_loss"
         String inputs, "absolute_loss" and "squared_loss" are supported which
         find the absolute loss and squared loss per sample
         respectively.
@@ -149,7 +149,7 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
         If the loss on a sample is greater than the ``residual_threshold``,
         then this sample is classified as an outlier.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The generator used to initialize the centers.  If int, random_state is
         the seed used by the random number generator; If RandomState instance,
         random_state is the random number generator; If None, the random number

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -308,7 +308,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         .. versionadded:: 0.19
            SAGA solver.
 
-    max_iter : int, optional
+    max_iter : int, default=None
         Maximum number of iterations for conjugate gradient solver.
         For the 'sparse_cg' and 'lsqr' solvers, the default value is determined
         by scipy.sparse.linalg. For 'sag' and saga solver, the default value is
@@ -321,7 +321,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         Verbosity level. Setting verbose > 0 will display additional
         information depending on the solver used.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
@@ -352,7 +352,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     coef : array of shape (n_features,) or (n_targets, n_features)
         Weight vector(s).
 
-    n_iter : int, optional
+    n_iter : int, default=None
         The actual number of iteration performed by the solver.
         Only returned if `return_n_iter` is True.
 
@@ -643,7 +643,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
     copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.
 
-    max_iter : int, optional
+    max_iter : int, default=None
         Maximum number of iterations for conjugate gradient solver.
         For 'sparse_cg' and 'lsqr' solvers, the default value is determined
         by scipy.sparse.linalg. For 'sag' solver, the default value is 1000.
@@ -688,7 +688,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         .. versionadded:: 0.19
            SAGA solver.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
@@ -798,14 +798,14 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
     copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.
 
-    max_iter : int, optional
+    max_iter : int, default=None
         Maximum number of iterations for conjugate gradient solver.
         The default value is determined by scipy.sparse.linalg.
 
     tol : float, default=1e-3
         Precision of the solution.
 
-    class_weight : dict or 'balanced', optional
+    class_weight : dict or 'balanced', default=None
         Weights associated with classes in the form ``{class_label: weight}``.
         If not given, all classes are supposed to have weight one.
 
@@ -1641,7 +1641,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         If None, the negative mean squared error if cv is 'auto' or None
         (i.e. when using generalized cross-validation), and r2 score otherwise.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
@@ -1658,7 +1658,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
 
-    gcv_mode : {None, 'auto', 'svd', eigen'}, optional
+    gcv_mode : {None, 'auto', 'svd', eigen'}, default='auto'
         Flag indicating which strategy to use when performing
         Generalized Cross-Validation. Options are::
 
@@ -1679,7 +1679,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     Attributes
     ----------
     cv_values_ : array of shape (n_samples, n_alphas) or \
-        shape (n_samples, n_targets, n_alphas), optional
+        shape (n_samples, n_targets, n_alphas), default=None
         Cross-validation values for each alpha (if ``store_cv_values=True``\
         and ``cv=None``). After ``fit()`` has been called, this attribute \
         will contain the mean squared errors (by default) or the values \
@@ -1755,7 +1755,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
@@ -1767,7 +1767,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
 
-    class_weight : dict or 'balanced', optional
+    class_weight : dict or 'balanced', default=None
         Weights associated with classes in the form ``{class_label: weight}``.
         If not given, all classes are supposed to have weight one.
 
@@ -1783,7 +1783,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     Attributes
     ----------
-    cv_values_ : array of shape (n_samples, n_targets, n_alphas), optional
+    cv_values_ : array of shape (n_samples, n_targets, n_alphas), default=None
         Cross-validation values for each alpha (if ``store_cv_values=True`` and
         ``cv=None``). After ``fit()`` has been called, this attribute will
         contain the mean squared errors (by default) or the values of the

--- a/sklearn/linear_model/_sag.py
+++ b/sklearn/linear_model/_sag.py
@@ -40,10 +40,10 @@ def get_auto_step_size(max_squared_sum, alpha_scaled, loss, fit_intercept,
         Specifies if a constant (a.k.a. bias or intercept) will be
         added to the decision function.
 
-    n_samples : int, optional
+    n_samples : int, default=None
         Number of rows in X. Useful if is_saga=True.
 
-    is_saga : boolean, optional
+    is_saga : boolean, default=False
         Whether to return step size for the SAGA algorithm or the SAG
         algorithm.
 
@@ -118,10 +118,10 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
         Target values. With loss='multinomial', y must be label encoded
         (see preprocessing.LabelEncoder).
 
-    sample_weight : array-like, shape (n_samples,), optional
+    sample_weight : array-like, shape (n_samples,), default=None
         Weights applied to individual samples (1. for unweighted).
 
-    loss : 'log' | 'squared' | 'multinomial'
+    loss : 'log' | 'squared' | 'multinomial', default='log'
         Loss function that will be optimized:
         -'log' is the binary logistic loss, as used in LogisticRegression.
         -'squared' is the squared loss, as used in Ridge.
@@ -131,42 +131,42 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
         .. versionadded:: 0.18
            *loss='multinomial'*
 
-    alpha : float, optional
+    alpha : float, default=1.
         L2 regularization term in the objective function
         ``(0.5 * alpha * || W ||_F^2)``. Defaults to 1.
 
-    beta : float, optional
+    beta : float, default=0.
         L1 regularization term in the objective function
         ``(beta * || W ||_1)``. Only applied if ``is_saga`` is set to True.
         Defaults to 0.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The max number of passes over the training data if the stopping
         criteria is not reached. Defaults to 1000.
 
-    tol : double, optional
+    tol : double, default=.001
         The stopping criteria for the weights. The iterations will stop when
         max(change in weights) / max(weights) < tol. Defaults to .001
 
-    verbose : integer, optional
+    verbose : integer, default=0
         The verbosity level.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
         instance used by `np.random`.
 
-    check_input : bool, default True
+    check_input : bool, default=True
         If False, the input arrays X and y will not be checked.
 
-    max_squared_sum : float, default None
+    max_squared_sum : float, default=None
         Maximum squared sum of X over samples. If None, it will be computed,
         going through all the samples. The value should be precomputed
         to speed up cross validation.
 
-    warm_start_mem : dict, optional
+    warm_start_mem : dict, default=False
         The initialization parameters used for warm starting. Warm starting is
         currently used in LogisticRegression but not in Ridge.
         It contains:
@@ -180,7 +180,7 @@ def sag_solver(X, y, sample_weight=None, loss='log', alpha=1., beta=0.,
             - 'seen': array of boolean describing the seen samples.
             - 'num_seen': the number of seen samples.
 
-    is_saga : boolean, optional
+    is_saga : boolean, default=False
         Whether to use the SAGA algorithm or the SAG algorithm. SAGA behaves
         better in the first epochs, and allow for l1 regularisation.
 

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -861,7 +861,8 @@ class SGDClassifier(BaseSGDClassifier):
 
         .. versionadded:: 0.20
 
-    class_weight : dict, {class_label: weight} or "balanced" or None, default=None
+    class_weight : dict, {class_label: weight} or "balanced" or None, \
+            default=None
         Preset for the class_weight fit parameter.
 
         Weights associated with classes. If not given, all classes

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -366,7 +366,7 @@ def fit_binary(est, i, X, y, alpha, C, learning_rate, max_iter,
         Precomputed validation mask in case _fit_binary is called in the
         context of a one-vs-rest reduction.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
@@ -652,7 +652,7 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
             and can be omitted in the subsequent calls.
             Note that y doesn't need to contain all labels in `classes`.
 
-        sample_weight : array-like, shape (n_samples,), optional
+        sample_weight : array-like, shape (n_samples,), default=None
             Weights applied to individual samples.
             If not provided, uniform weights are assumed.
 
@@ -694,7 +694,7 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
         intercept_init : array, shape (n_classes,)
             The initial intercept to warm-start the optimization.
 
-        sample_weight : array-like, shape (n_samples,), optional
+        sample_weight : array-like, shape (n_samples,), default=None
             Weights applied to individual samples.
             If not provided, uniform weights are assumed. These weights will
             be multiplied with class_weight (passed through the
@@ -738,7 +738,7 @@ class SGDClassifier(BaseSGDClassifier):
 
     Parameters
     ----------
-    loss : str, default: 'hinge'
+    loss : str, default='hinge'
         The loss function to be used. Defaults to 'hinge', which gives a
         linear SVM.
 
@@ -754,40 +754,40 @@ class SGDClassifier(BaseSGDClassifier):
         The other losses are designed for regression but can be useful in
         classification as well; see SGDRegressor for a description.
 
-    penalty : str, 'none', 'l2', 'l1', or 'elasticnet'
+    penalty : str, 'none', 'l2', 'l1', or 'elasticnet', default="l2"
         The penalty (aka regularization term) to be used. Defaults to 'l2'
         which is the standard regularizer for linear SVM models. 'l1' and
         'elasticnet' might bring sparsity to the model (feature selection)
         not achievable with 'l2'.
 
-    alpha : float
+    alpha : float, default=0.0001
         Constant that multiplies the regularization term. Defaults to 0.0001.
         Also used to compute learning_rate when set to 'optimal'.
 
-    l1_ratio : float
+    l1_ratio : float, default=0.15
         The Elastic Net mixing parameter, with 0 <= l1_ratio <= 1.
         l1_ratio=0 corresponds to L2 penalty, l1_ratio=1 to L1.
         Defaults to 0.15.
 
-    fit_intercept : bool
+    fit_intercept : bool, default=True
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered. Defaults to True.
 
-    max_iter : int, optional (default=1000)
+    max_iter : int, default=1000
         The maximum number of passes over the training data (aka epochs).
         It only impacts the behavior in the ``fit`` method, and not the
         :meth:`partial_fit` method.
 
         .. versionadded:: 0.19
 
-    tol : float or None, optional (default=1e-3)
+    tol : float or None, default=1e-3
         The stopping criterion. If it is not None, the iterations will stop
         when (loss > best_loss - tol) for ``n_iter_no_change`` consecutive
         epochs.
 
         .. versionadded:: 0.19
 
-    shuffle : bool, optional
+    shuffle : bool, default=True
         Whether or not the training data should be shuffled after each epoch.
         Defaults to True.
 
@@ -802,21 +802,21 @@ class SGDClassifier(BaseSGDClassifier):
         For epsilon-insensitive, any differences between the current prediction
         and the correct label are ignored if they are less than this threshold.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         The number of CPUs to use to do the OVA (One Versus All, for
         multi-class problems) computation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
         instance used by `np.random`.
 
-    learning_rate : str, optional
+    learning_rate : str, default="optimal"
         The learning rate schedule:
 
         'constant':
@@ -832,12 +832,12 @@ class SGDClassifier(BaseSGDClassifier):
             training loss by tol or fail to increase validation score by tol if
             early_stopping is True, the current learning rate is divided by 5.
 
-    eta0 : double
+    eta0 : double, default=0.0
         The initial learning rate for the 'constant', 'invscaling' or
         'adaptive' schedules. The default value is 0.0 as eta0 is not used by
         the default schedule 'optimal'.
 
-    power_t : double
+    power_t : double, default=0.5
         The exponent for inverse scaling learning rate [default 0.5].
 
     early_stopping : bool, default=False
@@ -861,7 +861,7 @@ class SGDClassifier(BaseSGDClassifier):
 
         .. versionadded:: 0.20
 
-    class_weight : dict, {class_label: weight} or "balanced" or None, optional
+    class_weight : dict, {class_label: weight} or "balanced" or None, default=None
         Preset for the class_weight fit parameter.
 
         Weights associated with classes. If not given, all classes
@@ -1140,7 +1140,7 @@ class BaseSGDRegressor(RegressorMixin, BaseSGD):
         y : numpy array of shape (n_samples,)
             Subset of target values
 
-        sample_weight : array-like, shape (n_samples,), optional
+        sample_weight : array-like, shape (n_samples,), default=None
             Weights applied to individual samples.
             If not provided, uniform weights are assumed.
 
@@ -1207,7 +1207,7 @@ class BaseSGDRegressor(RegressorMixin, BaseSGD):
         intercept_init : array, shape (1,)
             The initial intercept to warm-start the optimization.
 
-        sample_weight : array-like, shape (n_samples,), optional
+        sample_weight : array-like, shape (n_samples,), default=None
             Weights applied to individual samples (1. for unweighted).
 
         Returns
@@ -1359,7 +1359,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     Parameters
     ----------
-    loss : str, default: 'squared_loss'
+    loss : str, default='squared_loss'
         The loss function to be used. The possible values are 'squared_loss',
         'huber', 'epsilon_insensitive', or 'squared_epsilon_insensitive'
 
@@ -1371,40 +1371,40 @@ class SGDRegressor(BaseSGDRegressor):
         'squared_epsilon_insensitive' is the same but becomes squared loss past
         a tolerance of epsilon.
 
-    penalty : str, 'none', 'l2', 'l1', or 'elasticnet'
+    penalty : str, 'none', 'l2', 'l1', or 'elasticnet', default="l2"
         The penalty (aka regularization term) to be used. Defaults to 'l2'
         which is the standard regularizer for linear SVM models. 'l1' and
         'elasticnet' might bring sparsity to the model (feature selection)
         not achievable with 'l2'.
 
     alpha : float
-        Constant that multiplies the regularization term. Defaults to 0.0001
+        Constant that multiplies the regularization term. Defaults=0.0001
         Also used to compute learning_rate when set to 'optimal'.
 
-    l1_ratio : float
+    l1_ratio : float, default=0.15
         The Elastic Net mixing parameter, with 0 <= l1_ratio <= 1.
         l1_ratio=0 corresponds to L2 penalty, l1_ratio=1 to L1.
         Defaults to 0.15.
 
-    fit_intercept : bool
+    fit_intercept : bool, default=True
         Whether the intercept should be estimated or not. If False, the
         data is assumed to be already centered. Defaults to True.
 
-    max_iter : int, optional (default=1000)
+    max_iter : int, default=1000
         The maximum number of passes over the training data (aka epochs).
         It only impacts the behavior in the ``fit`` method, and not the
         :meth:`partial_fit` method.
 
         .. versionadded:: 0.19
 
-    tol : float or None, optional (default=1e-3)
+    tol : float or None, default=1e-3
         The stopping criterion. If it is not None, the iterations will stop
         when (loss > best_loss - tol) for ``n_iter_no_change`` consecutive
         epochs.
 
         .. versionadded:: 0.19
 
-    shuffle : bool, optional
+    shuffle : bool, default=True
         Whether or not the training data should be shuffled after each epoch.
         Defaults to True.
 
@@ -1419,14 +1419,14 @@ class SGDRegressor(BaseSGDRegressor):
         For epsilon-insensitive, any differences between the current prediction
         and the correct label are ignored if they are less than this threshold.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
         instance used by `np.random`.
 
-    learning_rate : string, optional
+    learning_rate : string, default='optimal'
         The learning rate schedule:
 
         'constant':
@@ -1442,11 +1442,11 @@ class SGDRegressor(BaseSGDRegressor):
             training loss by tol or fail to increase validation score by tol if
             early_stopping is True, the current learning rate is divided by 5.
 
-    eta0 : double
+    eta0 : double, default=0.01
         The initial learning rate for the 'constant', 'invscaling' or
         'adaptive' schedules. The default value is 0.01.
 
-    power_t : double
+    power_t : double, default=0.25
         The exponent for inverse scaling learning rate [default 0.25].
 
     early_stopping : bool, default=False

--- a/sklearn/linear_model/_theil_sen.py
+++ b/sklearn/linear_model/_theil_sen.py
@@ -88,10 +88,10 @@ def _spatial_median(X, max_iter=300, tol=1.e-3):
         Training vector, where n_samples is the number of samples and
         n_features is the number of features.
 
-    max_iter : int, optional
+    max_iter : int, default=300
         Maximum number of iterations.  Default is 300.
 
-    tol : float, optional
+    tol : float, default=1.e-3
         Stop the algorithm if spatial_median has converged. Default is 1.e-3.
 
     Returns
@@ -209,14 +209,14 @@ class TheilSenRegressor(RegressorMixin, LinearModel):
 
     Parameters
     ----------
-    fit_intercept : boolean, optional, default True
+    fit_intercept : boolean, default=True
         Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations.
 
-    copy_X : boolean, optional, default True
+    copy_X : boolean, default=True
         If True, X will be copied; else, it may be overwritten.
 
-    max_subpopulation : int, optional, default 1e4
+    max_subpopulation : int, default=1e4
         Instead of computing with a set of cardinality 'n choose k', where n is
         the number of samples and k is the number of subsamples (at least
         number of features), consider only a stochastic subpopulation of a
@@ -224,7 +224,7 @@ class TheilSenRegressor(RegressorMixin, LinearModel):
         For other than small problem sizes this parameter will determine
         memory usage and runtime if n_subsamples is not changed.
 
-    n_subsamples : int, optional, default None
+    n_subsamples : int, default=None
         Number of samples to calculate the parameters. This is at least the
         number of features (plus 1 if fit_intercept=True) and the number of
         samples as a maximum. A lower number leads to a higher breakdown
@@ -234,26 +234,26 @@ class TheilSenRegressor(RegressorMixin, LinearModel):
         If n_subsamples is set to n_samples, Theil-Sen is identical to least
         squares.
 
-    max_iter : int, optional, default 300
+    max_iter : int, default=300
         Maximum number of iterations for the calculation of spatial median.
 
-    tol : float, optional, default 1.e-3
+    tol : float, default=1.e-3
         Tolerance when calculating spatial median.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         A random number generator instance to define the state of the random
         permutations generator.  If int, random_state is the seed used by the
         random number generator; If RandomState instance, random_state is the
         random number generator; If None, the random number generator is the
         RandomState instance used by `np.random`.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         Number of CPUs to use during the cross validation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    verbose : boolean, optional, default False
+    verbose : boolean, default=False
         Verbose mode when fitting the model.
 
     Attributes

--- a/sklearn/metrics/_base.py
+++ b/sklearn/metrics/_base.py
@@ -156,7 +156,7 @@ def _average_multiclass_ovo_score(binary_metric, y_true, y_score,
         Target scores corresponding to probability estimates of a sample
         belonging to a particular class
 
-    average : 'macro' or 'weighted', optional (default='macro')
+    average : 'macro' or 'weighted', default='macro'
         Determines the type of averaging performed on the pairwise binary
         metric scores
         ``'macro'``:

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -138,7 +138,7 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
     y_pred : 1d array-like, or label indicator array / sparse matrix
         Predicted labels, as returned by a classifier.
 
-    normalize : bool, optional (default=True)
+    normalize : bool, default=True
         If ``False``, return the number of correctly classified samples.
         Otherwise, return the fraction of correctly classified samples.
 
@@ -633,7 +633,7 @@ def jaccard_score(y_true, y_pred, labels=None, pos_label=1,
         labels are column indices. By default, all labels in ``y_true`` and
         ``y_pred`` are used in sorted order.
 
-    pos_label : str or int, 1 by default
+    pos_label : str or int, default=1
         The class to report if ``average='binary'`` and the data is binary.
         If the data are multiclass or multilabel, this will be ignored;
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
@@ -848,7 +848,7 @@ def zero_one_loss(y_true, y_pred, normalize=True, sample_weight=None):
     y_pred : 1d array-like, or label indicator array / sparse matrix
         Predicted labels, as returned by a classifier.
 
-    normalize : bool, optional (default=True)
+    normalize : bool, default=True
         If ``False``, return the number of misclassifications.
         Otherwise, return the fraction of misclassifications.
 
@@ -938,7 +938,7 @@ def f1_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
         .. versionchanged:: 0.17
            parameter *labels* improved for multiclass problem.
 
-    pos_label : str or int, 1 by default
+    pos_label : str or int, default=1
         The class to report if ``average='binary'`` and the data is binary.
         If the data are multiclass or multilabel, this will be ignored;
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
@@ -1062,7 +1062,7 @@ def fbeta_score(y_true, y_pred, beta, labels=None, pos_label=1,
         .. versionchanged:: 0.17
            parameter *labels* improved for multiclass problem.
 
-    pos_label : str or int, 1 by default
+    pos_label : str or int, default=1
         The class to report if ``average='binary'`` and the data is binary.
         If the data are multiclass or multilabel, this will be ignored;
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
@@ -1288,7 +1288,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
     y_pred : 1d array-like, or label indicator array / sparse matrix
         Estimated targets as returned by a classifier.
 
-    beta : float, 1.0 by default
+    beta : float, default=1.0
         The strength of recall versus precision in the F-score.
 
     labels : list, optional
@@ -1300,7 +1300,7 @@ def precision_recall_fscore_support(y_true, y_pred, beta=1.0, labels=None,
         labels are column indices. By default, all labels in ``y_true`` and
         ``y_pred`` are used in sorted order.
 
-    pos_label : str or int, 1 by default
+    pos_label : str or int, default=1
         The class to report if ``average='binary'`` and the data is binary.
         If the data are multiclass or multilabel, this will be ignored;
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
@@ -1514,7 +1514,7 @@ def precision_score(y_true, y_pred, labels=None, pos_label=1,
         .. versionchanged:: 0.17
            parameter *labels* improved for multiclass problem.
 
-    pos_label : str or int, 1 by default
+    pos_label : str or int, default=1
         The class to report if ``average='binary'`` and the data is binary.
         If the data are multiclass or multilabel, this will be ignored;
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
@@ -1631,7 +1631,7 @@ def recall_score(y_true, y_pred, labels=None, pos_label=1, average='binary',
         .. versionchanged:: 0.17
            parameter *labels* improved for multiclass problem.
 
-    pos_label : str or int, 1 by default
+    pos_label : str or int, default=1
         The class to report if ``average='binary'`` and the data is binary.
         If the data are multiclass or multilabel, this will be ignored;
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
@@ -1822,7 +1822,7 @@ def classification_report(y_true, y_pred, labels=None, target_names=None,
         When ``output_dict`` is ``True``, this will be ignored and the
         returned values will not be rounded.
 
-    output_dict : bool (default = False)
+    output_dict : bool, default=False
         If True, return output as dict
 
     zero_division : "warn", 0 or 1, default="warn"
@@ -2114,14 +2114,14 @@ def log_loss(y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None,
         Log loss is undefined for p=0 or p=1, so probabilities are
         clipped to max(eps, min(1 - eps, p)).
 
-    normalize : bool, optional (default=True)
+    normalize : bool, default=True
         If true, return the mean loss per sample.
         Otherwise, return the sum of the per-sample losses.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
 
-    labels : array-like, optional (default=None)
+    labels : array-like, default=None
         If not provided, labels will be inferred from y_true. If ``labels``
         is ``None`` and ``y_pred`` has shape (n_samples,) the labels are
         assumed to be binary and are inferred from ``y_true``.
@@ -2232,7 +2232,7 @@ def hinge_loss(y_true, pred_decision, labels=None, sample_weight=None):
     pred_decision : array, shape = [n_samples] or [n_samples, n_classes]
         Predicted decisions, as output by decision_function (floats).
 
-    labels : array, optional, default None
+    labels : array, default=None
         Contains all the labels for the problem. Used in multiclass hinge loss.
 
     sample_weight : array-like of shape (n_samples,), default=None

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -151,7 +151,7 @@ def average_precision_score(y_true, y_score, average="macro", pos_label=1,
 
         Will be ignored when ``y_true`` is binary.
 
-    pos_label : int or str (default=1)
+    pos_label : int or str, default=1
         The label of the positive class. Only applied to binary ``y_true``.
         For multilabel-indicator ``y_true``, ``pos_label`` is fixed to 1.
 
@@ -408,7 +408,7 @@ def _multiclass_roc_auc_score(y_true, y_score, labels,
         Target scores corresponding to probability estimates of a sample
         belonging to a particular class
 
-    labels : array, shape = [n_classes] or None, optional (default=None)
+    labels : array, shape = [n_classes] or None, default=None
         List of labels to index ``y_score`` used for multiclass. If ``None``,
         the lexical order of ``y_true`` is used to index ``y_score``.
 
@@ -421,7 +421,7 @@ def _multiclass_roc_auc_score(y_true, y_score, labels,
             Calculate metrics for the multiclass case using the one-vs-one
             approach.
 
-    average : 'macro' or 'weighted', optional (default='macro')
+    average : 'macro' or 'weighted', default='macro'
         Determines the type of averaging performed on the pairwise binary
         metric scores
         ``'macro'``:
@@ -711,7 +711,7 @@ def roc_curve(y_true, y_score, pos_label=None, sample_weight=None,
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
 
-    drop_intermediate : boolean, optional (default=True)
+    drop_intermediate : boolean, default=True
         Whether to drop some suboptimal thresholds which would not appear
         on a plotted ROC curve. This is useful in order to create lighter
         ROC curves.
@@ -1064,15 +1064,15 @@ def _dcg_sample_scores(y_true, y_score, k=None,
         or non-thresholded measure of decisions (as returned by
         "decision_function" on some classifiers).
 
-    k : int, optional (default=None)
+    k : int, default=None
         Only consider the highest k scores in the ranking. If None, use all
         outputs.
 
-    log_base : float, optional (default=2)
+    log_base : float, default=2
         Base of the logarithm used for the discount. A low value means a
         sharper discount (top results are more important).
 
-    ignore_ties : bool, optional (default=False)
+    ignore_ties : bool, default=False
         Assume that there are no ties in y_score (which is likely to be the
         case if y_score is continuous) for efficiency gains.
 
@@ -1187,18 +1187,18 @@ def dcg_score(y_true, y_score, k=None,
         or non-thresholded measure of decisions (as returned by
         "decision_function" on some classifiers).
 
-    k : int, optional (default=None)
+    k : int, default=None
         Only consider the highest k scores in the ranking. If None, use all
         outputs.
 
-    log_base : float, optional (default=2)
+    log_base : float, default=2
         Base of the logarithm used for the discount. A low value means a
         sharper discount (top results are more important).
 
-    sample_weight : ndarray, shape (n_samples,), optional (default=None)
+    sample_weight : ndarray, shape (n_samples,), default=None
         Sample weights. If None, all samples are given the same weight.
 
-    ignore_ties : bool, optional (default=False)
+    ignore_ties : bool, default=False
         Assume that there are no ties in y_score (which is likely to be the
         case if y_score is continuous) for efficiency gains.
 
@@ -1291,11 +1291,11 @@ def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
         or non-thresholded measure of decisions (as returned by
         "decision_function" on some classifiers).
 
-    k : int, optional (default=None)
+    k : int, default=None
         Only consider the highest k scores in the ranking. If None, use all
         outputs.
 
-    ignore_ties : bool, optional (default=False)
+    ignore_ties : bool, default=False
         Assume that there are no ties in y_score (which is likely to be the
         case if y_score is continuous) for efficiency gains.
 
@@ -1342,14 +1342,14 @@ def ndcg_score(y_true, y_score, k=None, sample_weight=None, ignore_ties=False):
         or non-thresholded measure of decisions (as returned by
         "decision_function" on some classifiers).
 
-    k : int, optional (default=None)
+    k : int, default=None
         Only consider the highest k scores in the ranking. If None, use all
         outputs.
 
-    sample_weight : ndarray, shape (n_samples,), optional (default=None)
+    sample_weight : ndarray, shape (n_samples,), default=None
         Sample weights. If None, all samples are given the same weight.
 
-    ignore_ties : bool, optional (default=False)
+    ignore_ties : bool, default=False
         Assume that there are no ties in y_score (which is likely to be the
         case if y_score is continuous) for efficiency gains.
 

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -191,7 +191,8 @@ def mean_absolute_error(y_true, y_pred,
 
 def mean_squared_error(y_true, y_pred,
                        sample_weight=None,
-                       multioutput='uniform_average', squared=True):
+                       multioutput='uniform_average', 
+                       squared=True):
     """Mean squared error regression loss
 
     Read more in the :ref:`User Guide <mean_squared_error>`.
@@ -218,7 +219,7 @@ def mean_squared_error(y_true, y_pred,
         'uniform_average' :
             Errors of all outputs are averaged with uniform weight.
 
-    squared : boolean value, optional (default = True)
+    squared : boolean value, default=True
         If True returns MSE value, if False returns RMSE value.
 
     Returns

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -191,7 +191,7 @@ def mean_absolute_error(y_true, y_pred,
 
 def mean_squared_error(y_true, y_pred,
                        sample_weight=None,
-                       multioutput='uniform_average', 
+                       multioutput='uniform_average',
                        squared=True):
     """Mean squared error regression loss
 

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -153,7 +153,7 @@ class _BaseScorer:
         y_true : array-like
             Gold standard target values for X.
 
-        sample_weight : array-like, optional (default=None)
+        sample_weight : array-like, default=None
             Sample weights.
 
         Returns
@@ -193,7 +193,7 @@ class _PredictScorer(_BaseScorer):
         y_true : array-like
             Gold standard target values for X.
 
-        sample_weight : array-like, optional (default=None)
+        sample_weight : array-like, default=None
             Sample weights.
 
         Returns
@@ -233,7 +233,7 @@ class _ProbaScorer(_BaseScorer):
             Gold standard target values for X. These must be class labels,
             not probabilities.
 
-        sample_weight : array-like, optional (default=None)
+        sample_weight : array-like, default=None
             Sample weights.
 
         Returns
@@ -286,7 +286,7 @@ class _ThresholdScorer(_BaseScorer):
             Gold standard target values for X. These must be class labels,
             not decision function values.
 
-        sample_weight : array-like, optional (default=None)
+        sample_weight : array-like, default=None
             Sample weights.
 
         Returns
@@ -381,12 +381,12 @@ def check_scoring(estimator, scoring=None, allow_none=False):
     estimator : estimator object implementing 'fit'
         The object to use to fit the data.
 
-    scoring : string, callable or None, optional, default: None
+    scoring : string, callable or None, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
 
-    allow_none : boolean, optional, default: False
+    allow_none : boolean, default=False
         If no scoring is specified and the estimator has no score function, we
         can either return None or raise an exception.
 
@@ -441,7 +441,7 @@ def _check_multimetric_scoring(estimator, scoring=None):
     estimator : sklearn estimator instance
         The estimator for which the scoring will be applied.
 
-    scoring : string, callable, list/tuple, dict or None, default: None
+    scoring : string, callable, list/tuple, dict or None, default=None
         A single string (see :ref:`scoring_parameter`) or a callable
         (see :ref:`scoring`) to evaluate the predictions on the test set.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -84,7 +84,7 @@ def check_pairwise_arrays(X, Y, precomputed=False, dtype=None,
         True if X is to be treated as precomputed distances to the samples in
         Y.
 
-    dtype : string, type, list of types or None (default=None)
+    dtype : string, type, list of types or None, default=None
         Data type required for X and Y. If None, the dtype will be an
         appropriate float type selected by _return_float_dtype.
 
@@ -97,7 +97,7 @@ def check_pairwise_arrays(X, Y, precomputed=False, dtype=None,
         to be any format. False means that a sparse matrix input will
         raise an error.
 
-    force_all_finite : boolean or 'allow-nan', (default=True)
+    force_all_finite : boolean or 'allow-nan', default=True
         Whether to raise an error on np.inf and np.nan in array. The
         possibilities are:
 
@@ -220,15 +220,15 @@ def euclidean_distances(X, Y=None, Y_norm_squared=None, squared=False,
 
     Y : {array-like, sparse matrix}, shape (n_samples_2, n_features)
 
-    Y_norm_squared : array-like, shape (n_samples_2, ), optional
+    Y_norm_squared : array-like, shape (n_samples_2, ), default=None
         Pre-computed dot-products of vectors in Y (e.g.,
         ``(Y**2).sum(axis=1)``)
         May be ignored in some cases, see the note below.
 
-    squared : boolean, optional
+    squared : bool, default=False
         Return squared Euclidean distances.
 
-    X_norm_squared : array-like of shape (n_samples,), optional
+    X_norm_squared : array-like of shape (n_samples,), default=None
         Pre-computed dot-products of vectors in X (e.g.,
         ``(X**2).sum(axis=1)``)
         May be ignored in some cases, see the note below.
@@ -526,10 +526,10 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
     Y : {array-like, sparse matrix}, shape (n_samples2, n_features)
         Arrays containing points.
 
-    axis : int, optional, default 1
+    axis : int, default=1
         Axis along which the argmin and distances are to be computed.
 
-    metric : string or callable, default 'euclidean'
+    metric : string or callable, default='euclidean'
         metric to use for distance computation. Any metric from scikit-learn
         or scipy.spatial.distance can be used.
 
@@ -555,7 +555,7 @@ def pairwise_distances_argmin_min(X, Y, axis=1, metric="euclidean",
         See the documentation for scipy.spatial.distance for details on these
         metrics.
 
-    metric_kwargs : dict, optional
+    metric_kwargs : dict, default=None
         Keyword arguments to pass to specified metric function.
 
     Returns
@@ -614,7 +614,7 @@ def pairwise_distances_argmin(X, Y, axis=1, metric="euclidean",
         Arrays containing points. Respective shapes (n_samples1, n_features)
         and (n_samples2, n_features)
 
-    axis : int, optional, default 1
+    axis : int, default=1
         Axis along which the argmin and distances are to be computed.
 
     metric : string or callable
@@ -679,7 +679,7 @@ def haversine_distances(X, Y=None):
     ----------
     X : array_like, shape (n_samples_1, 2)
 
-    Y : array_like, shape (n_samples_2, 2), optional
+    Y : array_like, shape (n_samples_2, 2), default=None
 
     Returns
     -------
@@ -724,7 +724,7 @@ def manhattan_distances(X, Y=None, sum_over_features=True):
     X : array_like
         An array with shape (n_samples_X, n_features).
 
-    Y : array_like, optional
+    Y : array_like, default=None
         An array with shape (n_samples_Y, n_features).
 
     sum_over_features : bool, default=True
@@ -804,7 +804,7 @@ def cosine_distances(X, Y=None):
     X : array_like, sparse matrix
         with shape (n_samples_X, n_features).
 
-    Y : array_like, sparse matrix (optional)
+    Y : array_like, sparse matrix, default=None
         with shape (n_samples_Y, n_features).
 
     Returns
@@ -978,7 +978,7 @@ def linear_kernel(X, Y=None, dense_output=True):
 
     Y : array of shape (n_samples_2, n_features)
 
-    dense_output : boolean (optional), default True
+    dense_output : bool, default=True
         Whether to return dense output even when the input is sparse. If
         ``False``, the output is sparse if both input arrays are sparse.
 
@@ -1006,12 +1006,12 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
 
     Y : ndarray of shape (n_samples_2, n_features)
 
-    degree : int, default 3
+    degree : int, default=3
 
-    gamma : float, default None
+    gamma : float, default=None
         if None, defaults to 1.0 / n_features
 
-    coef0 : float, default 1
+    coef0 : float, default=1
 
     Returns
     -------
@@ -1042,10 +1042,10 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
 
     Y : ndarray of shape (n_samples_2, n_features)
 
-    gamma : float, default None
+    gamma : float, default=None
         If None, defaults to 1.0 / n_features
 
-    coef0 : float, default 1
+    coef0 : float, default=1
 
     Returns
     -------
@@ -1078,7 +1078,7 @@ def rbf_kernel(X, Y=None, gamma=None):
 
     Y : array of shape (n_samples_Y, n_features)
 
-    gamma : float, default None
+    gamma : float, default=None
         If None, defaults to 1.0 / n_features
 
     Returns
@@ -1113,7 +1113,7 @@ def laplacian_kernel(X, Y=None, gamma=None):
 
     Y : array of shape (n_samples_Y, n_features)
 
-    gamma : float, default None
+    gamma : float, default=None
         If None, defaults to 1.0 / n_features
 
     Returns
@@ -1150,7 +1150,7 @@ def cosine_similarity(X, Y=None, dense_output=True):
         Input data. If ``None``, the output will be the pairwise
         similarities between all samples in ``X``.
 
-    dense_output : boolean (optional), default True
+    dense_output : bool, default=True
         Whether to return dense output even when the input is sparse. If
         ``False``, the output is sparse if both input arrays are sparse.
 
@@ -1459,11 +1459,11 @@ def pairwise_distances_chunked(X, Y=None, reduce_func=None,
         [n_samples_a, n_features] otherwise
         Array of pairwise distances between samples, or a feature array.
 
-    Y : array [n_samples_b, n_features], optional
+    Y : array [n_samples_b, n_features], default=None
         An optional second feature array. Only allowed if
         metric != "precomputed".
 
-    reduce_func : callable, optional
+    reduce_func : callable, default=None
         The function which is applied on each chunk of the distance matrix,
         reducing it to needed values.  ``reduce_func(D_chunk, start)``
         is called repeatedly, where ``D_chunk`` is a contiguous vertical
@@ -1485,7 +1485,7 @@ def pairwise_distances_chunked(X, Y=None, reduce_func=None,
         should take two arrays from X as input and return a value indicating
         the distance between them.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         The number of jobs to use for the computation. This works by breaking
         down the pairwise matrix into n_jobs even slices and computing them in
         parallel.
@@ -1494,7 +1494,7 @@ def pairwise_distances_chunked(X, Y=None, reduce_func=None,
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    working_memory : int, optional
+    working_memory : int, default=None
         The sought maximum memory for temporary distance matrix chunks.
         When None (default), the value of
         ``sklearn.get_config()['working_memory']`` is used.
@@ -1647,7 +1647,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None,
              [n_samples_a, n_features] otherwise
         Array of pairwise distances between samples, or a feature array.
 
-    Y : array [n_samples_b, n_features], optional
+    Y : array [n_samples_b, n_features], default=None
         An optional second feature array. Only allowed if
         metric != "precomputed".
 
@@ -1662,7 +1662,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None,
         should take two arrays from X as input and return a value indicating
         the distance between them.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         The number of jobs to use for the computation. This works by breaking
         down the pairwise matrix into n_jobs even slices and computing them in
         parallel.
@@ -1671,7 +1671,7 @@ def pairwise_distances(X, Y=None, metric="euclidean", n_jobs=None,
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    force_all_finite : boolean or 'allow-nan', (default=True)
+    force_all_finite : bool or 'allow-nan', default=True
         Whether to raise an error on np.inf and np.nan in array. The
         possibilities are:
 
@@ -1863,7 +1863,7 @@ def pairwise_kernels(X, Y=None, metric="linear", filter_params=False,
     filter_params : boolean
         Whether to filter invalid parameters or not.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, default=None
         The number of jobs to use for the computation. This works by breaking
         down the pairwise matrix into n_jobs even slices and computing them in
         parallel.

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -698,11 +698,11 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
 
     Parameters
     ----------
-    hidden_layer_sizes : tuple, length = n_layers - 2, default (100,)
+    hidden_layer_sizes : tuple, length = n_layers - 2, default=(100,)
         The ith element represents the number of neurons in the ith
         hidden layer.
 
-    activation : {'identity', 'logistic', 'tanh', 'relu'}, default 'relu'
+    activation : {'identity', 'logistic', 'tanh', 'relu'}, default='relu'
         Activation function for the hidden layer.
 
         - 'identity', no-op activation, useful to implement linear bottleneck,
@@ -717,7 +717,7 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         - 'relu', the rectified linear unit function,
           returns f(x) = max(0, x)
 
-    solver : {'lbfgs', 'sgd', 'adam'}, default 'adam'
+    solver : {'lbfgs', 'sgd', 'adam'}, default='adam'
         The solver for weight optimization.
 
         - 'lbfgs' is an optimizer in the family of quasi-Newton methods.
@@ -733,15 +733,15 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         For small datasets, however, 'lbfgs' can converge faster and perform
         better.
 
-    alpha : float, optional, default 0.0001
+    alpha : float, default=0.0001
         L2 penalty (regularization term) parameter.
 
-    batch_size : int, optional, default 'auto'
+    batch_size : int, default='auto'
         Size of minibatches for stochastic optimizers.
         If the solver is 'lbfgs', the classifier will not use minibatch.
         When set to "auto", `batch_size=min(200, n_samples)`
 
-    learning_rate : {'constant', 'invscaling', 'adaptive'}, default 'constant'
+    learning_rate : {'constant', 'invscaling', 'adaptive'}, default='constant'
         Learning rate schedule for weight updates.
 
         - 'constant' is a constant learning rate given by
@@ -759,55 +759,55 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
 
         Only used when ``solver='sgd'``.
 
-    learning_rate_init : double, optional, default 0.001
+    learning_rate_init : double, default=0.001
         The initial learning rate used. It controls the step-size
         in updating the weights. Only used when solver='sgd' or 'adam'.
 
-    power_t : double, optional, default 0.5
+    power_t : double, default=0.5
         The exponent for inverse scaling learning rate.
         It is used in updating effective learning rate when the learning_rate
         is set to 'invscaling'. Only used when solver='sgd'.
 
-    max_iter : int, optional, default 200
+    max_iter : int, default=200
         Maximum number of iterations. The solver iterates until convergence
         (determined by 'tol') or this number of iterations. For stochastic
         solvers ('sgd', 'adam'), note that this determines the number of epochs
         (how many times each data point will be used), not the number of
         gradient steps.
 
-    shuffle : bool, optional, default True
+    shuffle : bool, default=True
         Whether to shuffle samples in each iteration. Only used when
         solver='sgd' or 'adam'.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    tol : float, optional, default 1e-4
+    tol : float, default=1e-4
         Tolerance for the optimization. When the loss or score is not improving
         by at least ``tol`` for ``n_iter_no_change`` consecutive iterations,
         unless ``learning_rate`` is set to 'adaptive', convergence is
         considered to be reached and training stops.
 
-    verbose : bool, optional, default False
+    verbose : bool, default=False
         Whether to print progress messages to stdout.
 
-    warm_start : bool, optional, default False
+    warm_start : bool, default=False
         When set to True, reuse the solution of the previous
         call to fit as initialization, otherwise, just erase the
         previous solution. See :term:`the Glossary <warm_start>`.
 
-    momentum : float, default 0.9
+    momentum : float, default=0.9
         Momentum for gradient descent update. Should be between 0 and 1. Only
         used when solver='sgd'.
 
-    nesterovs_momentum : boolean, default True
+    nesterovs_momentum : bool, default=True
         Whether to use Nesterov's momentum. Only used when solver='sgd' and
         momentum > 0.
 
-    early_stopping : bool, default False
+    early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation
         score is not improving. If set to true, it will automatically set
         aside 10% of training data as validation and terminate training when
@@ -816,29 +816,29 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         except in a multilabel setting.
         Only effective when solver='sgd' or 'adam'
 
-    validation_fraction : float, optional, default 0.1
+    validation_fraction : float, default=0.1
         The proportion of training data to set aside as validation set for
         early stopping. Must be between 0 and 1.
         Only used if early_stopping is True
 
-    beta_1 : float, optional, default 0.9
+    beta_1 : float, default=0.9
         Exponential decay rate for estimates of first moment vector in adam,
         should be in [0, 1). Only used when solver='adam'
 
-    beta_2 : float, optional, default 0.999
+    beta_2 : float, default=0.999
         Exponential decay rate for estimates of second moment vector in adam,
         should be in [0, 1). Only used when solver='adam'
 
-    epsilon : float, optional, default 1e-8
+    epsilon : float, default=1e-8
         Value for numerical stability in adam. Only used when solver='adam'
 
-    n_iter_no_change : int, optional, default 10
+    n_iter_no_change : int, default=10
         Maximum number of epochs to not meet ``tol`` improvement.
         Only effective when solver='sgd' or 'adam'
 
         .. versionadded:: 0.20
 
-    max_fun : int, optional, default 15000
+    max_fun : int, default=15000
         Only used when solver='lbfgs'. Maximum number of loss function calls.
         The solver iterates until convergence (determined by 'tol'), number
         of iterations reaches max_iter, or this number of loss function calls.
@@ -1006,7 +1006,7 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         y : array-like, shape (n_samples,)
             The target values.
 
-        classes : array, shape (n_classes), default None
+        classes : array, shape (n_classes), default=None
             Classes across all calls to partial_fit.
             Can be obtained via `np.unique(y_all)`, where y_all is the
             target vector of the entire dataset.
@@ -1090,11 +1090,11 @@ class MLPRegressor(RegressorMixin, BaseMultilayerPerceptron):
 
     Parameters
     ----------
-    hidden_layer_sizes : tuple, length = n_layers - 2, default (100,)
+    hidden_layer_sizes : tuple, length = n_layers - 2, default=(100,)
         The ith element represents the number of neurons in the ith
         hidden layer.
 
-    activation : {'identity', 'logistic', 'tanh', 'relu'}, default 'relu'
+    activation : {'identity', 'logistic', 'tanh', 'relu'}, default='relu'
         Activation function for the hidden layer.
 
         - 'identity', no-op activation, useful to implement linear bottleneck,
@@ -1109,7 +1109,7 @@ class MLPRegressor(RegressorMixin, BaseMultilayerPerceptron):
         - 'relu', the rectified linear unit function,
           returns f(x) = max(0, x)
 
-    solver : {'lbfgs', 'sgd', 'adam'}, default 'adam'
+    solver : {'lbfgs', 'sgd', 'adam'}, default='adam'
         The solver for weight optimization.
 
         - 'lbfgs' is an optimizer in the family of quasi-Newton methods.
@@ -1125,15 +1125,15 @@ class MLPRegressor(RegressorMixin, BaseMultilayerPerceptron):
         For small datasets, however, 'lbfgs' can converge faster and perform
         better.
 
-    alpha : float, optional, default 0.0001
+    alpha : float, default=0.0001
         L2 penalty (regularization term) parameter.
 
-    batch_size : int, optional, default 'auto'
+    batch_size : int, default='auto'
         Size of minibatches for stochastic optimizers.
         If the solver is 'lbfgs', the classifier will not use minibatch.
         When set to "auto", `batch_size=min(200, n_samples)`
 
-    learning_rate : {'constant', 'invscaling', 'adaptive'}, default 'constant'
+    learning_rate : {'constant', 'invscaling', 'adaptive'}, default='constant'
         Learning rate schedule for weight updates.
 
         - 'constant' is a constant learning rate given by
@@ -1151,55 +1151,55 @@ class MLPRegressor(RegressorMixin, BaseMultilayerPerceptron):
 
         Only used when solver='sgd'.
 
-    learning_rate_init : double, optional, default 0.001
+    learning_rate_init : double, default=0.001
         The initial learning rate used. It controls the step-size
         in updating the weights. Only used when solver='sgd' or 'adam'.
 
-    power_t : double, optional, default 0.5
+    power_t : double, default=0.5
         The exponent for inverse scaling learning rate.
         It is used in updating effective learning rate when the learning_rate
         is set to 'invscaling'. Only used when solver='sgd'.
 
-    max_iter : int, optional, default 200
+    max_iter : int, default=200
         Maximum number of iterations. The solver iterates until convergence
         (determined by 'tol') or this number of iterations. For stochastic
         solvers ('sgd', 'adam'), note that this determines the number of epochs
         (how many times each data point will be used), not the number of
         gradient steps.
 
-    shuffle : bool, optional, default True
+    shuffle : bool, default=True
         Whether to shuffle samples in each iteration. Only used when
         solver='sgd' or 'adam'.
 
-    random_state : int, RandomState instance or None, optional, default None
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    tol : float, optional, default 1e-4
+    tol : float, default=1e-4
         Tolerance for the optimization. When the loss or score is not improving
         by at least ``tol`` for ``n_iter_no_change`` consecutive iterations,
         unless ``learning_rate`` is set to 'adaptive', convergence is
         considered to be reached and training stops.
 
-    verbose : bool, optional, default False
+    verbose : bool, default=False
         Whether to print progress messages to stdout.
 
-    warm_start : bool, optional, default False
+    warm_start : bool, default=False
         When set to True, reuse the solution of the previous
         call to fit as initialization, otherwise, just erase the
         previous solution. See :term:`the Glossary <warm_start>`.
 
-    momentum : float, default 0.9
+    momentum : float, default=0.9
         Momentum for gradient descent update.  Should be between 0 and 1. Only
         used when solver='sgd'.
 
-    nesterovs_momentum : boolean, default True
+    nesterovs_momentum : boolean, default=True
         Whether to use Nesterov's momentum. Only used when solver='sgd' and
         momentum > 0.
 
-    early_stopping : bool, default False
+    early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation
         score is not improving. If set to true, it will automatically set
         aside 10% of training data as validation and terminate training when
@@ -1207,29 +1207,29 @@ class MLPRegressor(RegressorMixin, BaseMultilayerPerceptron):
         ``n_iter_no_change`` consecutive epochs.
         Only effective when solver='sgd' or 'adam'
 
-    validation_fraction : float, optional, default 0.1
+    validation_fraction : float, default=0.1
         The proportion of training data to set aside as validation set for
         early stopping. Must be between 0 and 1.
         Only used if early_stopping is True
 
-    beta_1 : float, optional, default 0.9
+    beta_1 : float, default=0.9
         Exponential decay rate for estimates of first moment vector in adam,
         should be in [0, 1). Only used when solver='adam'
 
-    beta_2 : float, optional, default 0.999
+    beta_2 : float, default=0.999
         Exponential decay rate for estimates of second moment vector in adam,
         should be in [0, 1). Only used when solver='adam'
 
-    epsilon : float, optional, default 1e-8
+    epsilon : float, default=1e-8
         Value for numerical stability in adam. Only used when solver='adam'
 
-    n_iter_no_change : int, optional, default 10
+    n_iter_no_change : int, default=10
         Maximum number of epochs to not meet ``tol`` improvement.
         Only effective when solver='sgd' or 'adam'
 
         .. versionadded:: 0.20
 
-    max_fun : int, optional, default 15000
+    max_fun : int, default=15000
         Only used when solver='lbfgs'. Maximum number of function calls.
         The solver iterates until convergence (determined by 'tol'), number
         of iterations reaches max_iter, or this number of function calls.

--- a/sklearn/neural_network/_rbm.py
+++ b/sklearn/neural_network/_rbm.py
@@ -38,25 +38,25 @@ class BernoulliRBM(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_components : int, optional
+    n_components : int, default=256
         Number of binary hidden units.
 
-    learning_rate : float, optional
+    learning_rate : float, default=0.1
         The learning rate for weight updates. It is *highly* recommended
         to tune this hyper-parameter. Reasonable values are in the
         10**[0., -3.] range.
 
-    batch_size : int, optional
+    batch_size : int, default=10
         Number of examples per minibatch.
 
-    n_iter : int, optional
+    n_iter : int, default=10
         Number of iterations/sweeps over the training dataset to perform
         during training.
 
-    verbose : int, optional
+    verbose : int, default=0
         The verbosity level. The default, zero, means silent mode.
 
-    random_state : integer or RandomState, optional
+    random_state : integer or RandomState, default=None
         A random number generator instance to define the state of the
         random permutations generator. If an integer is given, it fixes the
         seed. Defaults to the global numpy random number generator.

--- a/sklearn/neural_network/_stochastic_optimizers.py
+++ b/sklearn/neural_network/_stochastic_optimizers.py
@@ -16,7 +16,7 @@ class BaseOptimizer:
         The concatenated list containing coefs_ and intercepts_ in MLP model.
         Used for initializing velocities and updating params
 
-    learning_rate_init : float, optional, default 0.1
+    learning_rate_init : float, default=0.1
         The initial learning rate used. It controls the step-size in updating
         the weights
 
@@ -80,11 +80,11 @@ class SGDOptimizer(BaseOptimizer):
         The concatenated list containing coefs_ and intercepts_ in MLP model.
         Used for initializing velocities and updating params
 
-    learning_rate_init : float, optional, default 0.1
+    learning_rate_init : float, default=0.1
         The initial learning rate used. It controls the step-size in updating
         the weights
 
-    lr_schedule : {'constant', 'adaptive', 'invscaling'}, default 'constant'
+    lr_schedule : {'constant', 'adaptive', 'invscaling'}, default='constant'
         Learning rate schedule for weight updates.
 
         -'constant', is a constant learning rate given by
@@ -100,10 +100,10 @@ class SGDOptimizer(BaseOptimizer):
          tol, or fail to increase validation score by tol if 'early_stopping'
          is on, the current learning rate is divided by 5.
 
-    momentum : float, optional, default 0.9
+    momentum : float, default=0.9
         Value of momentum used, must be larger than or equal to 0
 
-    nesterov : bool, optional, default True
+    nesterov : bool, default=True
         Whether to use nesterov's momentum or not. Use nesterov's if True
 
     Attributes
@@ -192,19 +192,19 @@ class AdamOptimizer(BaseOptimizer):
         The concatenated list containing coefs_ and intercepts_ in MLP model.
         Used for initializing velocities and updating params
 
-    learning_rate_init : float, optional, default 0.1
+    learning_rate_init : float, default=0.1
         The initial learning rate used. It controls the step-size in updating
         the weights
 
-    beta_1 : float, optional, default 0.9
+    beta_1 : float, default=0.9
         Exponential decay rate for estimates of first moment vector, should be
         in [0, 1)
 
-    beta_2 : float, optional, default 0.999
+    beta_2 : float, default=0.999
         Exponential decay rate for estimates of second moment vector, should be
         in [0, 1)
 
-    epsilon : float, optional, default 1e-8
+    epsilon : float, default=1e-8
         Value for numerical stability
 
     Attributes

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -90,19 +90,19 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     X : {array-like, sparse matrix}
         The data to center and scale.
 
-    axis : int (0 by default)
+    axis : int, default=0
         axis used to compute the means and standard deviations along. If 0,
         independently standardize each feature, otherwise (if 1) standardize
         each sample.
 
-    with_mean : boolean, True by default
+    with_mean : bool, default=True
         If True, center the data before scaling.
 
-    with_std : boolean, True by default
+    with_std : bool, default=True
         If True, scale the data to unit variance (or equivalently,
         unit standard deviation).
 
-    copy : boolean, optional, default True
+    copy : bool, default=True
         set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array or a scipy.sparse
         CSC matrix and if axis is 1).
@@ -553,20 +553,20 @@ class StandardScaler(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    copy : boolean, optional, default True
+    copy : bool, default=True
         If False, try to avoid a copy and do inplace scaling instead.
         This is not guaranteed to always work inplace; e.g. if the data is
         not a NumPy array or scipy.sparse CSR matrix, a copy may still be
         returned.
 
-    with_mean : boolean, True by default
+    with_mean : boolean, default=True
         If True, center the data before scaling.
         This does not work (and will raise an exception) when attempted on
         sparse matrices, because centering them entails building a dense
         matrix which in common use cases is likely to be too large to fit in
         memory.
 
-    with_std : boolean, True by default
+    with_std : boolean, default=True
         If True, scale the data to unit variance (or equivalently,
         unit standard deviation).
 
@@ -784,7 +784,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
         ----------
         X : array-like, shape [n_samples, n_features]
             The data used to scale along the features axis.
-        copy : bool, optional (default: None)
+        copy : bool, default=None
             Copy the input X or not.
         """
         check_is_fitted(self)
@@ -815,7 +815,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
         ----------
         X : array-like, shape [n_samples, n_features]
             The data used to scale along the features axis.
-        copy : bool, optional (default: None)
+        copy : bool, default=None
             Copy the input X or not.
 
         Returns
@@ -866,7 +866,7 @@ class MaxAbsScaler(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    copy : boolean, optional, default is True
+    copy : bool, default=True
         Set to False to perform inplace scaling and avoid a copy (if the input
         is already a numpy array).
 
@@ -1043,11 +1043,11 @@ def maxabs_scale(X, axis=0, copy=True):
     X : array-like, shape (n_samples, n_features)
         The data.
 
-    axis : int (0 by default)
+    axis : int, default=0
         axis used to scale along. If 0, independently scale each feature,
         otherwise (if 1) scale each sample.
 
-    copy : boolean, optional, default is True
+    copy : boolean, default=True
         Set to False to perform inplace scaling and avoid a copy (if the input
         is already a numpy array).
 
@@ -1113,14 +1113,14 @@ class RobustScaler(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    with_centering : boolean, True by default
+    with_centering : boolean, default=True
         If True, center the data before scaling.
         This will cause ``transform`` to raise an exception when attempted on
         sparse matrices, because centering them entails building a dense
         matrix which in common use cases is likely to be too large to fit in
         memory.
 
-    with_scaling : boolean, True by default
+    with_scaling : boolean, default=True
         If True, scale the data to interquartile range.
 
     quantile_range : tuple (q_min, q_max), 0.0 < q_min < q_max < 100.0
@@ -1129,7 +1129,7 @@ class RobustScaler(TransformerMixin, BaseEstimator):
 
         .. versionadded:: 0.18
 
-    copy : boolean, optional, default is True
+    copy : bool, default=True
         If False, try to avoid a copy and do inplace scaling instead.
         This is not guaranteed to always work inplace; e.g. if the data is
         not a NumPy array or scipy.sparse CSR matrix, a copy may still be
@@ -1300,15 +1300,15 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
     X : array-like
         The data to center and scale.
 
-    axis : int (0 by default)
+    axis : int, default=0
         axis used to compute the medians and IQR along. If 0,
         independently scale each feature, otherwise (if 1) scale
         each sample.
 
-    with_centering : boolean, True by default
+    with_centering : boolean, default=True
         If True, center the data before scaling.
 
-    with_scaling : boolean, True by default
+    with_scaling : boolean, default=True
         If True, scale the data to unit variance (or equivalently,
         unit standard deviation).
 
@@ -1318,7 +1318,7 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
 
         .. versionadded:: 0.18
 
-    copy : boolean, optional, default is True
+    copy : bool, default=True
         set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array or a scipy.sparse
         CSR matrix and if axis is 1).
@@ -1376,20 +1376,20 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    degree : integer
+    degree : integer, default=2
         The degree of the polynomial features. Default = 2.
 
-    interaction_only : boolean, default = False
+    interaction_only : boolean, default=False
         If true, only interaction features are produced: features that are
         products of at most ``degree`` *distinct* input features (so not
         ``x[1] ** 2``, ``x[0] * x[2] ** 3``, etc.).
 
-    include_bias : boolean
-        If True (default), then include a bias column, the feature in which
+    include_bias : boolean, default=True
+        If True, then include a bias column, the feature in which
         all polynomial powers are zero (i.e. a column of ones - acts as an
         intercept term in a linear model).
 
-    order : str in {'C', 'F'}, default 'C'
+    order : str in {'C', 'F'}, default='C'
         Order of output array in the dense case. 'F' order is faster to
         compute, but may slow down subsequent estimators.
 
@@ -1467,7 +1467,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        input_features : list of string, length n_features, optional
+        input_features : list of string, length n_features, default=None
             String names for input features if available. By default,
             "x0", "x1", ... "xn_features" is used.
 
@@ -1653,20 +1653,20 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         scipy.sparse matrices should be in CSR format to avoid an
         un-necessary copy.
 
-    norm : 'l1', 'l2', or 'max', optional ('l2' by default)
+    norm : 'l1', 'l2', or 'max', default='l2'
         The norm to use to normalize each non zero sample (or each non-zero
         feature if axis is 0).
 
-    axis : 0 or 1, optional (1 by default)
+    axis : 0 or 1, default=1
         axis used to normalize the data along. If 1, independently normalize
         each sample, otherwise (if 0) normalize each feature.
 
-    copy : boolean, optional, default True
+    copy : bool, default=True
         set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array or a scipy.sparse
         CSR matrix and if axis is 1).
 
-    return_norm : boolean, default False
+    return_norm : bool, default=False
         whether to return the computed norms
 
     Returns
@@ -1760,10 +1760,10 @@ class Normalizer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    norm : 'l1', 'l2', or 'max', optional ('l2' by default)
+    norm : 'l1', 'l2', or 'max', default='l2'
         The norm to use to normalize each non zero sample.
 
-    copy : boolean, optional, default True
+    copy : boolean, default=True
         set to False to perform inplace row normalization and avoid a
         copy (if the input is already a numpy array or a scipy.sparse
         CSR matrix).
@@ -1822,7 +1822,7 @@ class Normalizer(TransformerMixin, BaseEstimator):
         X : {array-like, sparse matrix}, shape [n_samples, n_features]
             The data to normalize, row by row. scipy.sparse matrices should be
             in CSR format to avoid an un-necessary copy.
-        copy : bool, optional (default: None)
+        copy : bool, default=None
             Copy the input X or not.
         """
         copy = copy if copy is not None else self.copy
@@ -1845,11 +1845,11 @@ def binarize(X, threshold=0.0, copy=True):
         scipy.sparse matrices should be in CSR or CSC format to avoid an
         un-necessary copy.
 
-    threshold : float, optional (0.0 by default)
+    threshold : float, default=0.0
         Feature values below or equal to this are replaced by 0, above it by 1.
         Threshold may not be less than 0 for operations on sparse matrices.
 
-    copy : boolean, optional, default True
+    copy : boolean, default=True
         set to False to perform inplace binarization and avoid a copy
         (if the input is already a numpy array or a scipy.sparse CSR / CSC
         matrix and if axis is 1).
@@ -1896,11 +1896,11 @@ class Binarizer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    threshold : float, optional (0.0 by default)
+    threshold : float, default0.0
         Feature values below or equal to this are replaced by 0, above it by 1.
         Threshold may not be less than 0 for operations on sparse matrices.
 
-    copy : boolean, optional, default True
+    copy : boolean, default=True
         set to False to perform inplace binarization and avoid a copy (if
         the input is already a numpy array or a scipy.sparse CSR matrix).
 
@@ -2045,7 +2045,7 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
         K : numpy array of shape [n_samples1, n_samples2]
             Kernel matrix.
 
-        copy : boolean, optional, default True
+        copy : boolean, default=True
             Set to False to perform inplace computation.
 
         Returns
@@ -2153,7 +2153,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_quantiles : int, optional (default=1000 or n_samples)
+    n_quantiles : int, default=1000 or n_samples
         Number of quantiles to be computed. It corresponds to the number
         of landmarks used to discretize the cumulative distribution function.
         If n_quantiles is larger than the number of samples, n_quantiles is set
@@ -2161,28 +2161,28 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         a better approximation of the cumulative distribution function
         estimator.
 
-    output_distribution : str, optional (default='uniform')
+    output_distribution : str, default='uniform'
         Marginal distribution for the transformed data. The choices are
         'uniform' (default) or 'normal'.
 
-    ignore_implicit_zeros : bool, optional (default=False)
+    ignore_implicit_zeros : bool, default=False
         Only applies to sparse matrices. If True, the sparse entries of the
         matrix are discarded to compute the quantile statistics. If False,
         these entries are treated as zeros.
 
-    subsample : int, optional (default=1e5)
+    subsample : int, default=1e5
         Maximum number of samples used to estimate the quantiles for
         computational efficiency. Note that the subsampling procedure may
         differ for value-identical sparse and dense matrices.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by np.random. Note that this is used by subsampling and smoothing
         noise.
 
-    copy : boolean, optional, (default=True)
+    copy : boolean, default=True
         Set to False to perform inplace transformation and avoid a copy (if the
         input is already a numpy array).
 
@@ -2477,7 +2477,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         X : ndarray, shape (n_samples, n_features)
             The data used to scale along the features axis.
 
-        inverse : bool, optional (default=False)
+        inverse : bool, default=False
             If False, apply forward transform. If True, apply
             inverse transform.
 
@@ -2578,11 +2578,11 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
     X : array-like, sparse matrix
         The data to transform.
 
-    axis : int, (default=0)
+    axis : int, default=0
         Axis used to compute the means and standard deviations along. If 0,
         transform each feature, otherwise (if 1) transform each sample.
 
-    n_quantiles : int, optional (default=1000 or n_samples)
+    n_quantiles : int, default=1000 or n_samples
         Number of quantiles to be computed. It corresponds to the number
         of landmarks used to discretize the cumulative distribution function.
         If n_quantiles is larger than the number of samples, n_quantiles is set
@@ -2590,28 +2590,28 @@ def quantile_transform(X, axis=0, n_quantiles=1000,
         a better approximation of the cumulative distribution function
         estimator.
 
-    output_distribution : str, optional (default='uniform')
+    output_distribution : str, default='uniform'
         Marginal distribution for the transformed data. The choices are
         'uniform' (default) or 'normal'.
 
-    ignore_implicit_zeros : bool, optional (default=False)
+    ignore_implicit_zeros : bool, default=False
         Only applies to sparse matrices. If True, the sparse entries of the
         matrix are discarded to compute the quantile statistics. If False,
         these entries are treated as zeros.
 
-    subsample : int, optional (default=1e5)
+    subsample : int, default=1e5
         Maximum number of samples used to estimate the quantiles for
         computational efficiency. Note that the subsampling procedure may
         differ for value-identical sparse and dense matrices.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by np.random. Note that this is used by subsampling and smoothing
         noise.
 
-    copy : boolean, optional, (default=True)
+    copy : boolean, default=True
         Set to False to perform inplace transformation and avoid a copy (if the
         input is already a numpy array). If True, a copy of `X` is transformed,
         leaving the original `X` unchanged
@@ -2693,17 +2693,17 @@ class PowerTransformer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    method : str, (default='yeo-johnson')
+    method : str, default='yeo-johnson'
         The power transform method. Available methods are:
 
         - 'yeo-johnson' [1]_, works with positive and negative values
         - 'box-cox' [2]_, only works with strictly positive values
 
-    standardize : boolean, default=True
+    standardize : bool, default=True
         Set to True to apply zero-mean, unit-variance normalization to the
         transformed output.
 
-    copy : boolean, optional, default=True
+    copy : bool, default=True
         Set to False to perform inplace computation during transformation.
 
     Attributes
@@ -3058,7 +3058,7 @@ def power_transform(X, method='yeo-johnson', standardize=True, copy=True):
         Set to True to apply zero-mean, unit-variance normalization to the
         transformed output.
 
-    copy : boolean, optional, default=True
+    copy : bool, default=True
         Set to False to perform inplace computation during transformation.
 
     Returns

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -26,10 +26,10 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_bins : int or array-like, shape (n_features,) (default=5)
+    n_bins : int or array-like, shape (n_features,) default=5
         The number of bins to produce. Raises ValueError if ``n_bins < 2``.
 
-    encode : {'onehot', 'onehot-dense', 'ordinal'}, (default='onehot')
+    encode : {'onehot', 'onehot-dense', 'ordinal'}, default='onehot'
         Method used to encode the transformed result.
 
         onehot
@@ -43,7 +43,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         ordinal
             Return the bin identifier encoded as an integer value.
 
-    strategy : {'uniform', 'quantile', 'kmeans'}, (default='quantile')
+    strategy : {'uniform', 'quantile', 'kmeans'}, default='quantile'
         Strategy used to define the widths of the bins.
 
         uniform

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -569,7 +569,7 @@ class OrdinalEncoder(_BaseEncoder):
 
         The used categories can be found in the ``categories_`` attribute.
 
-    dtype : number type, default np.float64
+    dtype : number type, default=np.float64
         Desired dtype of output.
 
     Attributes

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -28,18 +28,18 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    func : callable, optional default=None
+    func : callable, default=None
         The callable to use for the transformation. This will be passed
         the same arguments as transform, with args and kwargs forwarded.
         If func is None, then func will be the identity function.
 
-    inverse_func : callable, optional default=None
+    inverse_func : callable, default=None
         The callable to use for the inverse transformation. This will be
         passed the same arguments as inverse transform, with args and
         kwargs forwarded. If inverse_func is None, then inverse_func
         will be the identity function.
 
-    validate : bool, optional default=False
+    validate : bool, default=False
         Indicate that the input X array should be checked before calling
         ``func``. The possibilities are:
 
@@ -51,7 +51,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         .. versionchanged:: 0.22
            The default of ``validate`` changed from True to False.
 
-    accept_sparse : boolean, optional
+    accept_sparse : boolean, default=False
         Indicate that func accepts a sparse matrix as input. If validate is
         False, this has no effect. Otherwise, if accept_sparse is false,
         sparse matrix inputs will cause an exception to be raised.
@@ -63,10 +63,10 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
 
        .. versionadded:: 0.20
 
-    kw_args : dict, optional
+    kw_args : dict, default=None
         Dictionary of additional keyword arguments to pass to func.
 
-    inv_kw_args : dict, optional
+    inv_kw_args : dict, default=None
         Dictionary of additional keyword arguments to pass to inverse_func.
 
     Examples

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -85,13 +85,13 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
     ----------
     values : array
         Values to factorize or encode.
-    uniques : array, optional
+    uniques : array, default=None
         If passed, uniques are not determined from passed values (this
         can be because the user specified categories, or because they
         already have been determined in fit).
-    encode : bool, default False
+    encode : bool, default=False
         If True, also encode the values into integer codes based on `uniques`.
-    check_unknown : bool, default True
+    check_unknown : bool, default=True
         If True, check for values in ``values`` that are not in ``unique``
         and raise an error. This is ignored for object dtype, and treated as
         True in this case. This parameter is useful for
@@ -131,7 +131,7 @@ def _encode_check_unknown(values, uniques, return_mask=False):
         Values to check for unknowns.
     uniques : array
         Allowed uniques values.
-    return_mask : bool, default False
+    return_mask : bool, default=False
         If True, return a mask of the same shape as `values` indicating
         the valid values.
 
@@ -325,13 +325,13 @@ class LabelBinarizer(TransformerMixin, BaseEstimator):
     Parameters
     ----------
 
-    neg_label : int (default: 0)
+    neg_label : int, default=0
         Value with which negative labels must be encoded.
 
-    pos_label : int (default: 1)
+    pos_label : int, default=1
         Value with which positive labels must be encoded.
 
-    sparse_output : boolean (default: False)
+    sparse_output : bool, default=False
         True if the returned array from transform is desired to be in sparse
         CSR format.
 
@@ -347,7 +347,7 @@ class LabelBinarizer(TransformerMixin, BaseEstimator):
         'continuous-multioutput', 'binary', 'multiclass',
         'multiclass-multioutput', 'multilabel-indicator', and 'unknown'.
 
-    sparse_input_ : boolean,
+    sparse_input_ : bool,
         True if the input data to transform is given as a sparse matrix, False
         otherwise.
 
@@ -557,13 +557,13 @@ def label_binarize(y, classes, neg_label=0, pos_label=1, sparse_output=False):
     classes : array-like of shape [n_classes]
         Uniquely holds the label for each class.
 
-    neg_label : int (default: 0)
+    neg_label : int, default=0
         Value with which negative labels must be encoded.
 
-    pos_label : int (default: 1)
+    pos_label : int, default=1
         Value with which positive labels must be encoded.
 
-    sparse_output : boolean (default: False),
+    sparse_output : bool, default=False,
         Set to true if output binary array is desired in CSR sparse format
 
     Returns
@@ -796,11 +796,11 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    classes : array-like of shape [n_classes] (optional)
+    classes : array-like of shape [n_classes], default=None
         Indicates an ordering for the class labels.
         All entries should be unique (cannot contain duplicate classes).
 
-    sparse_output : boolean (default: False),
+    sparse_output : bool, default=False,
         Set to true if output binary array is desired in CSR sparse format
 
     Attributes

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -825,7 +825,7 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
         In order to avoid this, one should increase the intercept_scaling.
         such that the feature vector becomes [x, intercept_scaling].
 
-    class_weight : {dict, 'balanced'}, optional
+    class_weight : {dict, 'balanced'}, default=None
         Weights associated with classes in the form ``{class_label: weight}``.
         If not given, all classes are supposed to have weight one. For
         multi-output problems, a list of dicts can be provided in the same
@@ -850,7 +850,7 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
     tol : float
         Stopping condition.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
@@ -870,12 +870,12 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
                  'epsilon_insensitive', 'squared_epsilon_insensitive}
         The loss function used to fit the model.
 
-    epsilon : float, optional (default=0.1)
+    epsilon : float, default=0.1
         Epsilon parameter in the epsilon-insensitive loss function. Note
         that the value of this parameter depends on the scale of the target
         variable y. If unsure, set epsilon=0.
 
-    sample_weight : array-like, optional
+    sample_weight : array-like, default=None
         Weights assigned to each sample.
 
     Returns

--- a/sklearn/svm/_bounds.py
+++ b/sklearn/svm/_bounds.py
@@ -28,16 +28,16 @@ def l1_min_c(X, y, loss='squared_hinge', fit_intercept=True,
     y : array, shape = [n_samples]
         Target vector relative to X
 
-    loss : {'squared_hinge', 'log'}, default 'squared_hinge'
+    loss : {'squared_hinge', 'log'}, default='squared_hinge'
         Specifies the loss function.
         With 'squared_hinge' it is the squared hinge loss (a.k.a. L2 loss).
         With 'log' it is the loss of logistic regression models.
 
-    fit_intercept : bool, default: True
+    fit_intercept : bool, default=True
         Specifies if the intercept should be fitted by the model.
         It must match the fit() method parameter.
 
-    intercept_scaling : float, default: 1
+    intercept_scaling : float, default=1
         when fit_intercept is True, instance vector x becomes
         [x, intercept_scaling],
         i.e. a "synthetic" feature with constant value equals to

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -26,28 +26,28 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
 
     Parameters
     ----------
-    penalty : str, 'l1' or 'l2' (default='l2')
+    penalty : str, 'l1' or 'l2', default='l2'
         Specifies the norm used in the penalization. The 'l2'
         penalty is the standard used in SVC. The 'l1' leads to ``coef_``
         vectors that are sparse.
 
-    loss : str, 'hinge' or 'squared_hinge' (default='squared_hinge')
+    loss : str, 'hinge' or 'squared_hinge', default='squared_hinge'
         Specifies the loss function. 'hinge' is the standard SVM loss
         (used e.g. by the SVC class) while 'squared_hinge' is the
         square of the hinge loss.
 
-    dual : bool, (default=True)
+    dual : bool, default=True
         Select the algorithm to either solve the dual or primal
         optimization problem. Prefer dual=False when n_samples > n_features.
 
-    tol : float, optional (default=1e-4)
+    tol : float, default=1e-4
         Tolerance for stopping criteria.
 
-    C : float, optional (default=1.0)
+    C : float, default=1.0
         Regularization parameter. The strength of the regularization is
         inversely proportional to C. Must be strictly positive.
 
-    multi_class : str, 'ovr' or 'crammer_singer' (default='ovr')
+    multi_class : str, 'ovr' or 'crammer_singer', default='ovr'
         Determines the multi-class strategy if `y` contains more than
         two classes.
         ``"ovr"`` trains n_classes one-vs-rest classifiers, while
@@ -58,12 +58,12 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         If ``"crammer_singer"`` is chosen, the options loss, penalty and dual
         will be ignored.
 
-    fit_intercept : bool, optional (default=True)
+    fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be already centered).
 
-    intercept_scaling : float, optional (default=1)
+    intercept_scaling : float, default=1
         When self.fit_intercept is True, instance vector x becomes
         ``[x, self.intercept_scaling]``,
         i.e. a "synthetic" feature with constant value equals to
@@ -74,7 +74,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         To lessen the effect of regularization on synthetic feature weight
         (and therefore on the intercept) intercept_scaling has to be increased.
 
-    class_weight : {dict, 'balanced'}, optional
+    class_weight : {dict, 'balanced'}, default=None
         Set the parameter C of class i to ``class_weight[i]*C`` for
         SVC. If not given, all classes are supposed to have
         weight one.
@@ -82,12 +82,12 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         weights inversely proportional to class frequencies in the input data
         as ``n_samples / (n_classes * np.bincount(y))``.
 
-    verbose : int, (default=0)
+    verbose : int, default=0
         Enable verbose output. Note that this setting takes advantage of a
         per-process runtime setting in liblinear that, if enabled, may not work
         properly in a multithreaded context.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data for the dual coordinate descent (if ``dual=True``). When
         ``dual=False`` the underlying implementation of :class:`LinearSVC`
@@ -97,7 +97,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         None, the random number generator is the RandomState instance used by
         `np.random`.
 
-    max_iter : int, (default=1000)
+    max_iter : int, default=1000
         The maximum number of iterations to be run.
 
     Attributes
@@ -267,29 +267,29 @@ class LinearSVR(RegressorMixin, LinearModel):
 
     Parameters
     ----------
-    epsilon : float, optional (default=0.0)
+    epsilon : float, default=0.0
         Epsilon parameter in the epsilon-insensitive loss function. Note
         that the value of this parameter depends on the scale of the target
         variable y. If unsure, set ``epsilon=0``.
 
-    tol : float, optional (default=1e-4)
+    tol : float, default=1e-4
         Tolerance for stopping criteria.
 
-    C : float, optional (default=1.0)
+    C : float, default=1.0
         Regularization parameter. The strength of the regularization is
         inversely proportional to C. Must be strictly positive.
 
-    loss : string, optional (default='epsilon_insensitive')
+    loss : string, default='epsilon_insensitive'
         Specifies the loss function. The epsilon-insensitive loss
         (standard SVR) is the L1 loss, while the squared epsilon-insensitive
         loss ('squared_epsilon_insensitive') is the L2 loss.
 
-    fit_intercept : boolean, optional (default=True)
+    fit_intercept : boolean, default=True
         Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be already centered).
 
-    intercept_scaling : float, optional (default=1)
+    intercept_scaling : float, default=1
         When self.fit_intercept is True, instance vector x becomes
         [x, self.intercept_scaling],
         i.e. a "synthetic" feature with constant value equals to
@@ -300,23 +300,23 @@ class LinearSVR(RegressorMixin, LinearModel):
         To lessen the effect of regularization on synthetic feature weight
         (and therefore on the intercept) intercept_scaling has to be increased.
 
-    dual : bool, (default=True)
+    dual : bool, default=True
         Select the algorithm to either solve the dual or primal
         optimization problem. Prefer dual=False when n_samples > n_features.
 
-    verbose : int, (default=0)
+    verbose : int, default=0
         Enable verbose output. Note that this setting takes advantage of a
         per-process runtime setting in liblinear that, if enabled, may not work
         properly in a multithreaded context.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
         generator; If RandomState instance, random_state is the random number
         generator; If None, the random number generator is the RandomState
         instance used by `np.random`.
 
-    max_iter : int, (default=1000)
+    max_iter : int, default=1000
         The maximum number of iterations to be run.
 
     Attributes
@@ -456,12 +456,12 @@ class SVC(BaseSVC):
 
     Parameters
     ----------
-    C : float, optional (default=1.0)
+    C : float, default=1.0
         Regularization parameter. The strength of the regularization is
         inversely proportional to C. Must be strictly positive. The penalty
         is a squared l2 penalty.
 
-    kernel : string, optional (default='rbf')
+    kernel : string, default='rbf'
         Specifies the kernel type to be used in the algorithm.
         It must be one of 'linear', 'poly', 'rbf', 'sigmoid', 'precomputed' or
         a callable.
@@ -469,11 +469,11 @@ class SVC(BaseSVC):
         used to pre-compute the kernel matrix from data matrices; that matrix
         should be an array of shape ``(n_samples, n_samples)``.
 
-    degree : int, optional (default=3)
+    degree : int, default=3
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : {'scale', 'auto'} or float, optional (default='scale')
+    gamma : {'scale', 'auto'} or float, default='scale'
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         - if ``gamma='scale'`` (default) is passed then it uses
@@ -483,20 +483,20 @@ class SVC(BaseSVC):
         .. versionchanged:: 0.22
            The default value of ``gamma`` changed from 'auto' to 'scale'.
 
-    coef0 : float, optional (default=0.0)
+    coef0 : float, default=0.0
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
 
-    shrinking : boolean, optional (default=True)
+    shrinking : boolean, default=True
         Whether to use the shrinking heuristic.
 
-    probability : boolean, optional (default=False)
+    probability : bool, default=False
         Whether to enable probability estimates. This must be enabled prior
         to calling `fit`, will slow down that method as it internally uses
         5-fold cross-validation, and `predict_proba` may be inconsistent with
         `predict`. Read more in the :ref:`User Guide <scores_probabilities>`.
 
-    tol : float, optional (default=1e-3)
+    tol : float, default=1e-3
         Tolerance for stopping criterion.
 
     cache_size : float, optional
@@ -510,12 +510,12 @@ class SVC(BaseSVC):
         weights inversely proportional to class frequencies in the input data
         as ``n_samples / (n_classes * np.bincount(y))``
 
-    verbose : bool, default: False
+    verbose : bool, default=False
         Enable verbose output. Note that this setting takes advantage of a
         per-process runtime setting in libsvm that, if enabled, may not work
         properly in a multithreaded context.
 
-    max_iter : int, optional (default=-1)
+    max_iter : int, default=-1
         Hard limit on iterations within solver, or -1 for no limit.
 
     decision_function_shape : 'ovo', 'ovr', default='ovr'
@@ -534,7 +534,7 @@ class SVC(BaseSVC):
         .. versionchanged:: 0.17
            Deprecated *decision_function_shape='ovo' and None*.
 
-    break_ties : bool, optional (default=False)
+    break_ties : bool, default=False
         If true, ``decision_function_shape='ovr'``, and number of classes > 2,
         :term:`predict` will break ties according to the confidence values of
         :term:`decision_function`; otherwise the first class among the tied
@@ -543,7 +543,7 @@ class SVC(BaseSVC):
 
         .. versionadded:: 0.22
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator used when shuffling
         the data for probability estimates. If int, random_state is the
         seed used by the random number generator; If RandomState instance,
@@ -665,23 +665,23 @@ class NuSVC(BaseSVC):
 
     Parameters
     ----------
-    nu : float, optional (default=0.5)
+    nu : float, default=0.5
         An upper bound on the fraction of training errors and a lower
         bound of the fraction of support vectors. Should be in the
         interval (0, 1].
 
-    kernel : string, optional (default='rbf')
+    kernel : string, default='rbf'
          Specifies the kernel type to be used in the algorithm.
          It must be one of 'linear', 'poly', 'rbf', 'sigmoid', 'precomputed' or
          a callable.
          If none is given, 'rbf' will be used. If a callable is given it is
          used to precompute the kernel matrix.
 
-    degree : int, optional (default=3)
+    degree : int, default=3
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : {'scale', 'auto'} or float, optional (default='scale')
+    gamma : {'scale', 'auto'} or float, default='scale'
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         - if ``gamma='scale'`` (default) is passed then it uses
@@ -691,38 +691,38 @@ class NuSVC(BaseSVC):
         .. versionchanged:: 0.22
            The default value of ``gamma`` changed from 'auto' to 'scale'.
 
-    coef0 : float, optional (default=0.0)
+    coef0 : float, default=0.0
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
 
-    shrinking : boolean, optional (default=True)
+    shrinking : boolean, default=True
         Whether to use the shrinking heuristic.
 
-    probability : boolean, optional (default=False)
+    probability : boolean, default=False
         Whether to enable probability estimates. This must be enabled prior
         to calling `fit`, will slow down that method as it internally uses
         5-fold cross-validation, and `predict_proba` may be inconsistent with
         `predict`. Read more in the :ref:`User Guide <scores_probabilities>`.
 
-    tol : float, optional (default=1e-3)
+    tol : float, default=1e-3
         Tolerance for stopping criterion.
 
     cache_size : float, optional
         Specify the size of the kernel cache (in MB).
 
-    class_weight : {dict, 'balanced'}, optional
+    class_weight : {dict, 'balanced'}, default=None
         Set the parameter C of class i to class_weight[i]*C for
         SVC. If not given, all classes are supposed to have
         weight one. The "balanced" mode uses the values of y to automatically
         adjust weights inversely proportional to class frequencies as
         ``n_samples / (n_classes * np.bincount(y))``
 
-    verbose : bool, default: False
+    verbose : bool, default=False
         Enable verbose output. Note that this setting takes advantage of a
         per-process runtime setting in libsvm that, if enabled, may not work
         properly in a multithreaded context.
 
-    max_iter : int, optional (default=-1)
+    max_iter : int, default=-1
         Hard limit on iterations within solver, or -1 for no limit.
 
     decision_function_shape : 'ovo', 'ovr', default='ovr'
@@ -740,7 +740,7 @@ class NuSVC(BaseSVC):
         .. versionchanged:: 0.17
            Deprecated *decision_function_shape='ovo' and None*.
 
-    break_ties : bool, optional (default=False)
+    break_ties : bool, default=False
         If true, ``decision_function_shape='ovr'``, and number of classes > 2,
         :term:`predict` will break ties according to the confidence values of
         :term:`decision_function`; otherwise the first class among the tied
@@ -749,7 +749,7 @@ class NuSVC(BaseSVC):
 
         .. versionadded:: 0.22
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator used when shuffling
         the data for probability estimates. If int, random_state is the seed
         used by the random number generator; If RandomState instance,
@@ -873,18 +873,18 @@ class SVR(RegressorMixin, BaseLibSVM):
 
     Parameters
     ----------
-    kernel : string, optional (default='rbf')
+    kernel : string, default='rbf'
          Specifies the kernel type to be used in the algorithm.
          It must be one of 'linear', 'poly', 'rbf', 'sigmoid', 'precomputed' or
          a callable.
          If none is given, 'rbf' will be used. If a callable is given it is
          used to precompute the kernel matrix.
 
-    degree : int, optional (default=3)
+    degree : int, default=3
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : {'scale', 'auto'} or float, optional (default='scale')
+    gamma : {'scale', 'auto'} or float, default='scale'
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         - if ``gamma='scale'`` (default) is passed then it uses
@@ -894,36 +894,36 @@ class SVR(RegressorMixin, BaseLibSVM):
         .. versionchanged:: 0.22
            The default value of ``gamma`` changed from 'auto' to 'scale'.
 
-    coef0 : float, optional (default=0.0)
+    coef0 : float, default=0.0
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
 
-    tol : float, optional (default=1e-3)
+    tol : float, default=1e-3
         Tolerance for stopping criterion.
 
-    C : float, optional (default=1.0)
+    C : float, default=1.0
         Regularization parameter. The strength of the regularization is
         inversely proportional to C. Must be strictly positive.
         The penalty is a squared l2 penalty.
 
-    epsilon : float, optional (default=0.1)
+    epsilon : float, default=0.1
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube
          within which no penalty is associated in the training loss function
          with points predicted within a distance epsilon from the actual
          value.
 
-    shrinking : boolean, optional (default=True)
+    shrinking : boolean, default=True
         Whether to use the shrinking heuristic.
 
     cache_size : float, optional
         Specify the size of the kernel cache (in MB).
 
-    verbose : bool, default: False
+    verbose : bool, default=False
         Enable verbose output. Note that this setting takes advantage of a
         per-process runtime setting in libsvm that, if enabled, may not work
         properly in a multithreaded context.
 
-    max_iter : int, optional (default=-1)
+    max_iter : int, default=-1
         Hard limit on iterations within solver, or -1 for no limit.
 
     Attributes
@@ -1005,26 +1005,26 @@ class NuSVR(RegressorMixin, BaseLibSVM):
 
     Parameters
     ----------
-    nu : float, optional
+    nu : float, default=0.5
         An upper bound on the fraction of training errors and a lower bound of
         the fraction of support vectors. Should be in the interval (0, 1].  By
         default 0.5 will be taken.
 
-    C : float, optional (default=1.0)
+    C : float, default=1.0
         Penalty parameter C of the error term.
 
-    kernel : string, optional (default='rbf')
+    kernel : string, default='rbf'
          Specifies the kernel type to be used in the algorithm.
          It must be one of 'linear', 'poly', 'rbf', 'sigmoid', 'precomputed' or
          a callable.
          If none is given, 'rbf' will be used. If a callable is given it is
          used to precompute the kernel matrix.
 
-    degree : int, optional (default=3)
+    degree : int, default=3
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : {'scale', 'auto'} or float, optional (default='scale')
+    gamma : {'scale', 'auto'} or float, default='scale')
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         - if ``gamma='scale'`` (default) is passed then it uses
@@ -1034,25 +1034,25 @@ class NuSVR(RegressorMixin, BaseLibSVM):
         .. versionchanged:: 0.22
            The default value of ``gamma`` changed from 'auto' to 'scale'.
 
-    coef0 : float, optional (default=0.0)
+    coef0 : float, default=0.0)
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
 
-    shrinking : boolean, optional (default=True)
+    shrinking : boolean, default=True)
         Whether to use the shrinking heuristic.
 
-    tol : float, optional (default=1e-3)
+    tol : float, default=1e-3
         Tolerance for stopping criterion.
 
     cache_size : float, optional
         Specify the size of the kernel cache (in MB).
 
-    verbose : bool, default: False
+    verbose : bool, default=False
         Enable verbose output. Note that this setting takes advantage of a
         per-process runtime setting in libsvm that, if enabled, may not work
         properly in a multithreaded context.
 
-    max_iter : int, optional (default=-1)
+    max_iter : int, default=-1
         Hard limit on iterations within solver, or -1 for no limit.
 
     Attributes
@@ -1128,18 +1128,18 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
 
     Parameters
     ----------
-    kernel : string, optional (default='rbf')
+    kernel : string, default='rbf'
          Specifies the kernel type to be used in the algorithm.
          It must be one of 'linear', 'poly', 'rbf', 'sigmoid', 'precomputed' or
          a callable.
          If none is given, 'rbf' will be used. If a callable is given it is
          used to precompute the kernel matrix.
 
-    degree : int, optional (default=3)
+    degree : int, default=3
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
 
-    gamma : {'scale', 'auto'} or float, optional (default='scale')
+    gamma : {'scale', 'auto'} or float, default='scale'
         Kernel coefficient for 'rbf', 'poly' and 'sigmoid'.
 
         - if ``gamma='scale'`` (default) is passed then it uses
@@ -1149,31 +1149,31 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
         .. versionchanged:: 0.22
            The default value of ``gamma`` changed from 'auto' to 'scale'.
 
-    coef0 : float, optional (default=0.0)
+    coef0 : float, default=0.0
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
 
-    tol : float, optional
+    tol : float, default=1e-3
         Tolerance for stopping criterion.
 
-    nu : float, optional
+    nu : float, default=0.5
         An upper bound on the fraction of training
         errors and a lower bound of the fraction of support
         vectors. Should be in the interval (0, 1]. By default 0.5
         will be taken.
 
-    shrinking : boolean, optional
+    shrinking : boolean, default=True
         Whether to use the shrinking heuristic.
 
-    cache_size : float, optional
+    cache_size : float, default=200
         Specify the size of the kernel cache (in MB).
 
-    verbose : bool, default: False
+    verbose : bool, default=False
         Enable verbose output. Note that this setting takes advantage of a
         per-process runtime setting in libsvm that, if enabled, may not work
         properly in a multithreaded context.
 
-    max_iter : int, optional (default=-1)
+    max_iter : int, default=-1
         Hard limit on iterations within solver, or -1 for no limit.
 
     Attributes


### PR DESCRIPTION
This commits Fixes ##15761 , the optional keyword and default value for following classes:
`Neural Network`, `Decomposition`, `Feature Extraction`, `Metrics`, `svm` and `Preprocess`

