### PR TITLE
MAINT Unpin coverage package

### DIFF
--- a/build_tools/azure/install.cmd
+++ b/build_tools/azure/install.cmd
@@ -25,11 +25,7 @@ IF "%PYTHON_ARCH%"=="64" (
     pip install numpy scipy cython pytest wheel pillow joblib
 )
 if "%COVERAGE%" == "true" (
-    @rem Using coverage 5.0 will trigger relpath between 2 windows
-    @rem paths from different drives. Pinning can be removed when
-    @rem https://github.com/scikit-learn/scikit-learn/issues/15908
-    @rem is resolved.
-    pip install coverage==4.5.3 codecov pytest-cov
+    pip install coverage codecov pytest-cov
 )
 python --version
 pip --version


### PR DESCRIPTION
coverage 5.0.1 was released with a fix for: https://github.com/nedbat/coveragepy/issues/895

Let's see if our Windows tests pass as expected.