### PR TITLE
COSMIT use np.iinfo to define the max int32

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -106,7 +106,7 @@ def setup_module(module):
     # Check if a random seed exists in the environment, if not create one.
     _random_seed = os.environ.get('SKLEARN_SEED', None)
     if _random_seed is None:
-        _random_seed = np.random.uniform() * (2 ** 31 - 1)
+        _random_seed = np.random.uniform() * np.iinfo(np.int32).max
     _random_seed = int(_random_seed)
     print("I: Seeding RNGs with %r" % _random_seed)
     np.random.seed(_random_seed)

--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -19,8 +19,6 @@ from ..utils import Bunch
 from ..utils import check_random_state
 from ..utils.metaestimators import _BaseComposition
 
-MAX_RAND_SEED = np.iinfo(np.int32).max
-
 
 def _parallel_fit_estimator(estimator, X, y, sample_weight=None):
     """Private function used to fit an estimator within a job."""
@@ -71,7 +69,7 @@ def _set_random_states(estimator, random_state=None):
     to_set = {}
     for key in sorted(estimator.get_params(deep=True)):
         if key == 'random_state' or key.endswith('__random_state'):
-            to_set[key] = random_state.randint(MAX_RAND_SEED)
+            to_set[key] = random_state.randint(np.iinfo(np.int32).max)
 
     if to_set:
         estimator.set_params(**to_set)

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -101,7 +101,7 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         if not isinstance(n_features, numbers.Integral):
             raise TypeError("n_features must be integral, got %r (%s)."
                             % (n_features, type(n_features)))
-        elif n_features < 1 or n_features >= 2 ** 31:
+        elif n_features < 1 or n_features >= np.iinfo(np.int32).max + 1:
             raise ValueError("Invalid number of features (%d)." % n_features)
 
         if input_type not in ("dict", "pair", "string"):

--- a/sklearn/feature_extraction/_hashing_fast.pyx
+++ b/sklearn/feature_extraction/_hashing_fast.pyx
@@ -88,7 +88,7 @@ def transform(raw_X, Py_ssize_t n_features, dtype,
     indices_a = np.frombuffer(indices, dtype=np.int32)
     indptr_a = np.frombuffer(indptr, dtype=indices_np_dtype)
 
-    if indptr[-1] > 2147483648:  # = 2**31
+    if indptr[-1] > np.iinfo(np.int32).max:  # = 2**31 - 1
         if sp_version < (0, 14):
             raise ValueError(('sparse CSR array has {} non-zero '
                               'elements and requires 64 bit indexing, '

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1150,7 +1150,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
                 raise ValueError("empty vocabulary; perhaps the documents only"
                                  " contain stop words")
 
-        if indptr[-1] > 2147483648:  # = 2**31 - 1
+        if indptr[-1] > np.iinfo(np.int32).max:  # = 2**31 - 1
             if _IS_32BIT:
                 raise ValueError(('sparse CSR array has {} non-zero '
                                   'elements and requires 64 bit indexing, '

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -197,7 +197,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             y = np.ascontiguousarray(y, dtype=DOUBLE)
 
         # Check parameters
-        max_depth = ((2 ** 31) - 1 if self.max_depth is None
+        max_depth = (np.iinfo(np.int32).max if self.max_depth is None
                      else self.max_depth)
         max_leaf_nodes = (-1 if self.max_leaf_nodes is None
                           else self.max_leaf_nodes)


### PR DESCRIPTION
In order to be explicit and homogeneous in scikit-learn, we use `np.iinfo` to find the max `int32` values required by some algorithm.