### PR TITLE
Affinity propagation preference percentile

### DIFF
--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -62,12 +62,12 @@ def test_affinity_propagation():
     preference = '100%'
     af = AffinityPropagation(preference=preference, verbose=True)
     labels = af.fit(X).labels_
-    assert_equal(max(labels), n_samples-1)
+    assert max(labels) == n_samples-1
 
     preference = '0%'
     af = AffinityPropagation(preference=preference, verbose=True)
     labels = af.fit(X).labels_
-    assert_equal(max(labels), 2)
+    assert max(labels) == 2
 
     # Test input validation
     with pytest.raises(ValueError):

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -58,11 +58,28 @@ def test_affinity_propagation():
                                              copy=False)
     assert_array_equal(labels, labels_no_copy)
 
+    # Test preference string input
+    preference = '100%'
+    af = AffinityPropagation(preference=preference, verbose=True)
+    labels = af.fit(X).labels_
+    assert_equal(max(labels), n_samples-1)
+
+    preference = '0%'
+    af = AffinityPropagation(preference=preference, verbose=True)
+    labels = af.fit(X).labels_
+    assert_equal(max(labels), 2)
+
     # Test input validation
     with pytest.raises(ValueError):
         affinity_propagation(S[:, :-1])
     with pytest.raises(ValueError):
         affinity_propagation(S, damping=0)
+    with pytest.raises(ValueError):
+        affinity_propagation(S, preference='101%')
+    with pytest.raises(ValueError):
+        affinity_propagation(S, preference='-101.3%')
+    with pytest.raises(ValueError):
+        affinity_propagation(S, preference='42.0')
     af = AffinityPropagation(affinity="unknown")
     with pytest.raises(ValueError):
         af.fit(X)

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -62,7 +62,7 @@ def test_affinity_propagation():
     preference = '100%'
     af = AffinityPropagation(preference=preference, verbose=True)
     labels = af.fit(X).labels_
-    assert max(labels) == n_samples-1
+    assert max(labels) == X.shape[0]-1
 
     preference = '0%'
     af = AffinityPropagation(preference=preference, verbose=True)


### PR DESCRIPTION
Reference Issues/PRs
Note: Since my last pull request  for this feature was too old, I have redone it.
I would love if someone can guide me so I can finish this feature.

What does this implement/fix? Explain your changes.
This implements a preference_percentile parameter for the affinity propagation clustering module.
It gives control over the number of classes regardless of the size of the similarities.

Any other comments?
The authors of Affinity propagation suggest using a function to find the min and max of the similarities in order to compute the range of the preference parameter and thus controlling the number of clusters. implementing the preference_percentile allowing to change the preference variable within the range, without knowing computing the similarities matrix outside of the affinity propagation module.

