### PR TITLE
Filter empty samples after removing metadata from 20 newsgroup dataset

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -67,6 +67,10 @@ Changelog
   `ValueError` for arguments `n_classes < 1` OR `length < 1`.
   :pr:`16006` by :user:`Rushabh Vasani <rushabh-v>`.
 
+- |Enhancement| :func:`datasets.fetch_20newsgroups` now filters empty samples generated
+  by `remove` option by setting `clear_empty=True`.
+  :pr:`15985` by :user:`Hugo Abonizio <hugoabonizio>`.
+
 :mod:`sklearn.ensemble`
 .................................
 

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -284,6 +284,13 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
     if 'quotes' in remove:
         data.data = [strip_newsgroup_quoting(text) for text in data.data]
 
+    if len(remove) > 0:
+        empty_idxs = {i for (i, text) in enumerate(data.data) if len(text) == 0}
+        data.data = [text for (i, text) in enumerate(data.data) if i not in empty_idxs]
+        data.target = np.array(
+            [target for (i, target) in enumerate(data.target) if i not in empty_idxs]
+        )
+
     if categories is not None:
         labels = [(data.target_names.index(cat), cat) for cat in categories]
         # Sort the categories to have the ordering of the labels

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -285,11 +285,16 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
         data.data = [strip_newsgroup_quoting(text) for text in data.data]
 
     if len(remove) > 0:
-        empty_idxs = {i for (i, text) in enumerate(data.data) if len(text) == 0}
-        data.data = [text for (i, text) in enumerate(data.data) if i not in empty_idxs]
-        data.target = np.array(
-            [target for (i, target) in enumerate(data.target) if i not in empty_idxs]
-        )
+        empty_idxs = {
+            i for (i, text) in enumerate(data.data) if len(text) == 0
+        }
+        data.data = [
+            text for (i, text) in enumerate(data.data) if i not in empty_idxs
+        ]
+        data.target = np.array([
+            target for (i, target) in enumerate(data.target)
+            if i not in empty_idxs
+        ])
 
     if categories is not None:
         labels = [(data.target_names.index(cat), cat) for cat in categories]

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -148,7 +148,7 @@ def strip_newsgroup_footer(text):
 
 def fetch_20newsgroups(data_home=None, subset='train', categories=None,
                        shuffle=True, random_state=42,
-                       remove=(),
+                       remove=(), clear_empty=False,
                        download_if_missing=True, return_X_y=False):
     """Load the filenames and data from the 20 newsgroups dataset \
 (classification).
@@ -201,6 +201,13 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
 
         'headers' follows an exact standard; the other filters are not always
         correct.
+
+    clear_empty : bool, optional, False by default
+        Whether or not to remove the empty samples resulting from `remove`
+        option, which can remove the entire text if the sample is composed
+        only by metadata.
+
+        .. versionadded:: 0.23
 
     download_if_missing : optional, True by default
         If False, raise an IOError if the data is not locally available
@@ -277,24 +284,22 @@ def fetch_20newsgroups(data_home=None, subset='train', categories=None,
 
     data.DESCR = fdescr
 
-    if 'headers' in remove:
-        data.data = [strip_newsgroup_header(text) for text in data.data]
-    if 'footers' in remove:
-        data.data = [strip_newsgroup_footer(text) for text in data.data]
-    if 'quotes' in remove:
-        data.data = [strip_newsgroup_quoting(text) for text in data.data]
+    strip_funcs = {
+        "headers": strip_newsgroup_header,
+        "footers": strip_newsgroup_footer,
+        "quotes": strip_newsgroup_quoting,
+    }
 
-    if len(remove) > 0:
-        empty_idxs = {
-            i for (i, text) in enumerate(data.data) if len(text) == 0
-        }
-        data.data = [
-            text for (i, text) in enumerate(data.data) if i not in empty_idxs
-        ]
-        data.target = np.array([
-            target for (i, target) in enumerate(data.target)
-            if i not in empty_idxs
-        ])
+    for strip_type in remove:
+        tmp_target = []
+        tmp_data = []
+        for (label, text) in zip(data.target, data.data):
+            stripped_text = strip_funcs[strip_type](text)
+            if stripped_text or not clear_empty:
+                tmp_target.append(label)
+                tmp_data.append(stripped_text)
+        data.target = np.array(tmp_target)
+        data.data = tmp_data
 
     if categories is not None:
         labels = [(data.target_names.index(cat), cat) for cat in categories]


### PR DESCRIPTION
I was trying out some models on the 20 newsgroup dataset by using the `fetch_20newsgroups` method, but was geting some blank samples, which was causing my preprocessing and models to fail. Then I figured out that the `remove` option may remove all the content of some samples, as can be seen bellow. So I'm proposing to filter out those empty samples after removing the metadata to avoid silently generate blank samples.

```python
from sklearn.datasets import fetch_20newsgroups

full = fetch_20newsgroups(subset='train')
removed = fetch_20newsgroups(subset='train', remove=('headers', 'footers', 'quotes'))

print(len(full.data[155])) # => 849
print(len(removed.data[155])) # => 0
```