### PR TITLE
[MRG] MNT Only tweets on main repo

### DIFF
--- a/.github/workflows/twitter.yml
+++ b/.github/workflows/twitter.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Tweet URL of last commit as @sklearn_commits
+        if: github.repository == 'scikit-learn/scikit-learn'
         uses: xorilog/twitter-action@0.1
         with:
           args: "-message \"https://github.com/scikit-learn/scikit-learn/commit/${{ github.sha }}\""


### PR DESCRIPTION
Adjusts twitter github action to only tweet on main repo.

Reference:

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions
