### PR TITLE
Remove abstractmethod that silently brake downstream packages

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -58,6 +58,13 @@ Changelog
   pass the `values_format` parameter to the :class:`ConfusionMatrixDisplay`
   plot() call. :pr:`15937` by :user:`Stephen Blystone <blynotes>`.
 
+:mod:`sklearn.naive_bayes`
+..........................
+
+- |Fix| removed abstract method `_check_X` from :class:`naive_bayes.BaseNB`
+  that could break downstream projects inheriting from this deprecated
+  public base class. :pr:`15996` by :user:`Brigitta Sipőcz <bsipocz>`.
+
 :mod:`sklearn.semi_supervised`
 ..............................
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -51,12 +51,6 @@ class _BaseNB(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         predict_proba and predict_log_proba.
         """
 
-    @abstractmethod
-    def _check_X(self, X):
-        """Validate input X
-        """
-        pass
-
     def predict(self, X):
         """
         Perform classification on an array of test vectors X.


### PR DESCRIPTION
This PR removes the abstractmethod `_check_X` that has been added silently in #12569, to be included in the next bugfix release 0.22.1

As the `BaseNB` class is going away anyway and downstream is not suppose to subclass private base classes, I suppose this can be a patch only for the bugfix, but not the next feature release.

cc @jnothman
