### PR TITLE
Fix restore BaseNB._check_X without abstractmethod decoration

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -61,9 +61,10 @@ Changelog
 :mod:`sklearn.naive_bayes`
 ..........................
 
-- |Fix| removed abstract method `_check_X` from :class:`naive_bayes.BaseNB`
-  that could break downstream projects inheriting from this deprecated
-  public base class. :pr:`15996` by :user:`Brigitta Sipőcz <bsipocz>`.
+- |Fix| removed `abstractmethod` decorator for the method `_check_X` in
+  :class:`naive_bayes.BaseNB` that could break downstream projects inheriting
+  from this deprecated public base class. :pr:`15996` by
+  :user:`Brigitta Sipőcz <bsipocz>`.
 
 :mod:`sklearn.semi_supervised`
 ..............................

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -61,7 +61,7 @@ Changelog
 :mod:`sklearn.naive_bayes`
 ..........................
 
-- |Fix| removed `abstractmethod` decorator for the method `_check_X` in
+- |Fix| Removed `abstractmethod` decorator for the method `_check_X` in
   :class:`naive_bayes.BaseNB` that could break downstream projects inheriting
   from this deprecated public base class. :pr:`15996` by
   :user:`Brigitta Sipőcz <bsipocz>`.

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -51,6 +51,14 @@ class _BaseNB(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         predict_proba and predict_log_proba.
         """
 
+    def _check_X(self, X):
+        """To be overridden in subclasses with the actual checks."""
+        # Note that this is not marked @abstractmethod as long as the
+        # deprecated public alias sklearn.naive_bayes.BayesNB exists
+        # (until 0.24) to preserve bacward compat for 3rd party projects
+        # with existing derived classes.
+        return X
+
     def predict(self, X):
         """
         Perform classification on an array of test vectors X.

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -55,7 +55,7 @@ class _BaseNB(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         """To be overridden in subclasses with the actual checks."""
         # Note that this is not marked @abstractmethod as long as the
         # deprecated public alias sklearn.naive_bayes.BayesNB exists
-        # (until 0.24) to preserve bacward compat for 3rd party projects
+        # (until 0.24) to preserve backward compat for 3rd party projects
         # with existing derived classes.
         return X
 


### PR DESCRIPTION
This is a follow-up on #15996 to fix the fact that this method is actually internally used by the other methods of the base class as remarked by @qinhanmin2014: https://github.com/scikit-learn/scikit-learn/pull/15996#issuecomment-569942569