### PR TITLE
[MRG] MNT Fixes link to whats new in front page

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,6 +88,7 @@ copyright = '2007 - 2019, scikit-learn developers (BSD License)'
 # The short X.Y version.
 import sklearn
 version = parse(sklearn.__version__).base_version
+version = ".".join(version.split(".")[:2])
 # The full version, including alpha/beta/rc tags.
 release = sklearn.__version__
 

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -156,6 +156,7 @@
         <li><strong>On-going development:</strong>
         <a href="https://scikit-learn.org/dev/whats_new.html"><strong>What's new</strong> (Changelog)</a>
         </li>
+        <li><strong>January 2020.</strong> scikit-learn 0.22.1 is available for download (<a href="whats_new/v0.22.html#version-0-22-1">Changelog</a>).
         <li><strong>December 2019.</strong> scikit-learn 0.22 is available for download (<a href="whats_new/v0.22.html#version-0-22-0">Changelog</a>).
         </li>
         <li><strong>Scikit-learn from 0.21 requires Python 3.5 or greater.</strong>

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -8,7 +8,7 @@
         <h1 class="sk-landing-header text-white text-monospace">scikit-learn</h1>
         <h4 class="sk-landing-subheader text-white font-italic mb-3">Machine Learning in Python</h4>
         <a class="btn sk-landing-btn mb-1" href="{{ pathto('getting_started') }}" role="button">Getting Started</a>
-        <a class="btn sk-landing-btn mb-1" href="whats_new/v{{ version }}.html" role="button">What's New in {{ version }}</a>
+        <a class="btn sk-landing-btn mb-1" href="whats_new/v{{ version }}.html" role="button">What's New in {{ release }}</a>
         <a class="btn sk-landing-btn mb-1" href="https://github.com/scikit-learn/scikit-learn" role="button">GitHub</a>
       </div>
       <div class="col-md-6 d-flex">

--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -77,7 +77,7 @@
         {%- if pagename != "install" %}
         <div class="alert alert-danger p-1 mb-2" role="alert">
           <p class="text-center mb-0">
-          <strong>scikit-learn {{ version }}</strong><br/>
+          <strong>scikit-learn {{ release }}</strong><br/>
           <a href="http://scikit-learn.org/dev/versions.html">Other versions</a>
           </p>
         </div>


### PR DESCRIPTION
Fixes #16024

Correctly sets the version to the the "short X.Y version" and uses the full release in the index page.