### PR TITLE
[MRG+1] Better non-regression test for spectral embedding AMG solver issue

### DIFF
--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -230,6 +230,11 @@ def test_spectral_clustering_with_arpack_amg_solvers():
                                 random_state=0)
 
 
+# TODO: Remove filterwarnings when pyamg does replaces sp.rand call with
+# np.random.rand:
+# https://github.com/scikit-learn/scikit-learn/issues/15913
+@pytest.mark.filterwarnings(
+    "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")
 def test_spectral_clustering_amg_solver_failure():
     # Non-regression test for amg solver failure (issue #13393 on github)
     pytest.importorskip('pyamg')

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -230,6 +230,23 @@ def test_spectral_clustering_with_arpack_amg_solvers():
                                 random_state=0)
 
 
+def test_spectral_clustering_amg_solver_failure():
+    # Non-regression test for amg solver failure (issue #13393 on github)
+    pytest.importorskip('pyamg')
+    seed = 36
+    num_nodes = 1000
+    X = sparse.rand(num_nodes, num_nodes, density=0.1, random_state=seed)
+    upper = sparse.triu(X) - sparse.diags(X.diagonal())
+    sym_matrix = upper + upper.T
+    clustering = SpectralClustering(n_clusters=3,
+                                    eigen_solver='amg',
+                                    random_state=seed,
+                                    affinity='precomputed')
+
+    # Smoke test: underlying solver should not raise numpy.linalg.LinAlgError
+    clustering.fit(sym_matrix)
+
+
 def test_n_components():
     # Test that after adding n_components, result is different and
     # n_components = n_clusters by default

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -229,6 +229,7 @@ def test_spectral_clustering_with_arpack_amg_solvers():
             spectral_clustering(graph, n_clusters=2, eigen_solver='amg',
                                 random_state=0)
 
+
 def test_n_components():
     # Test that after adding n_components, result is different and
     # n_components = n_clusters by default

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -229,29 +229,6 @@ def test_spectral_clustering_with_arpack_amg_solvers():
             spectral_clustering(graph, n_clusters=2, eigen_solver='amg',
                                 random_state=0)
 
-
-# TODO: Remove filterwarnings when pyamg does replaces sp.rand call with
-# np.random.rand:
-# https://github.com/scikit-learn/scikit-learn/issues/15913
-@pytest.mark.filterwarnings(
-    "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")
-def test_spectral_clustering_amg_solver_failure():
-    # Non-regression test for amg solver failure (issue #13393 on github)
-    pytest.importorskip('pyamg')
-    seed = 36
-    num_nodes = 1000
-    X = sparse.rand(num_nodes, num_nodes, density=0.1, random_state=seed)
-    upper = sparse.triu(X) - sparse.diags(X.diagonal())
-    sym_matrix = upper + upper.T
-    clustering = SpectralClustering(n_clusters=3,
-                                    eigen_solver='amg',
-                                    random_state=seed,
-                                    affinity='precomputed')
-
-    # Smoke test: underlying solver should not raise numpy.linalg.LinAlgError
-    clustering.fit(sym_matrix)
-
-
 def test_n_components():
     # Test that after adding n_components, result is different and
     # n_components = n_clusters by default

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -224,7 +224,7 @@ def test_spectral_embedding_amg_solver_failure():
     # Non-regression test for amg solver failure (issue #13393 on github)
     pytest.importorskip('pyamg')
     seed = 36
-    num_nodes = 1000
+    num_nodes = 100
     X = sparse.rand(num_nodes, num_nodes, density=0.1, random_state=seed)
     upper = sparse.triu(X) - sparse.diags(X.diagonal())
     sym_matrix = upper + upper.T

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -228,18 +228,17 @@ def test_spectral_embedding_amg_solver_failure():
     X = sparse.rand(num_nodes, num_nodes, density=0.1, random_state=seed)
     upper = sparse.triu(X) - sparse.diags(X.diagonal())
     sym_matrix = upper + upper.T
-    embedder = SpectralEmbedding(n_components=10,
-                                 eigen_solver='amg',
-                                 random_state=0,
-                                 affinity='precomputed')
-
-    # Smoke test: underlying solver should not raise numpy.linalg.LinAlgError
-    embedding = embedder.fit_transform(sym_matrix)
+    embedding = spectral_embedding(sym_matrix,
+                                   n_components=10,
+                                   eigen_solver='amg',
+                                   random_state=0)
 
     # Check that the learned embedding is stable w.r.t. random solver init:
     for i in range(3):
-        embedder.set_params(random_state=i + 1)
-        new_embedding = embedder.fit_transform(sym_matrix)
+        new_embedding = spectral_embedding(sym_matrix,
+                                           n_components=10,
+                                           eigen_solver='amg',
+                                           random_state=i + 1)
         assert _check_with_col_sign_flipping(
             embedding, new_embedding, tol=0.05)
 

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -215,34 +215,6 @@ def test_spectral_embedding_amg_solver(seed=36):
     assert _check_with_col_sign_flipping(embed_amg, embed_arpack, 1e-5)
 
 
-# TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
-# https://github.com/scikit-learn/scikit-learn/issues/15913
-@pytest.mark.filterwarnings(
-    "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")
-def test_spectral_embedding_amg_solver_failure(seed=36):
-    # Test spectral embedding with amg solver failure, see issue #13393
-    pytest.importorskip('pyamg')
-
-    # The generated graph below is NOT fully connected if n_neighbors=3
-    n_samples = 200
-    n_clusters = 3
-    n_features = 3
-    centers = np.eye(n_clusters, n_features)
-    S, true_labels = make_blobs(n_samples=n_samples, centers=centers,
-                                cluster_std=1., random_state=42)
-
-    se_amg0 = SpectralEmbedding(n_components=3, affinity="nearest_neighbors",
-                                eigen_solver="amg", n_neighbors=3,
-                                random_state=np.random.RandomState(seed))
-    embed_amg0 = se_amg0.fit_transform(S)
-
-    for i in range(10):
-        se_amg0.set_params(random_state=np.random.RandomState(seed + 1))
-        embed_amg1 = se_amg0.fit_transform(S)
-
-        assert _check_with_col_sign_flipping(embed_amg0, embed_amg1, 0.05)
-
-
 @pytest.mark.filterwarnings("ignore:the behavior of nmi will "
                             "change in version 0.22")
 def test_pipeline_spectral_clustering(seed=36):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes:  #16011
Related to: #13393 which was fixed in PR #13707 that introduced the unstable test.

#### What does this implement/fix? Explain your changes.

Replace `test_spectral_embedding_amg_solver_failure` which is unstable and does not seem to test what it is supposed to test (the seed is kept fixed in the loop) by another test built from the original bug report (#13393).

#### Any other comments?

@whitews @lobpcg please let us know if you have any comment.