### PR TITLE
[MRG] Raise an error for categories unseen during training

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -1215,11 +1215,11 @@ class CategoricalNB(_BaseDiscreteNB):
         jll = np.zeros((X.shape[0], self.class_count_.shape[0]))
         for i in range(self.n_features_):
             indices = X[:, i]
-            num_categories = self.feature_log_prob_[i].shape[1]
-            if np.max(indices) >= num_categories:
+            try:
+                jll += self.feature_log_prob_[i][:, indices].T
+            except IndexError:
                 raise ValueError("A category unseen during training is present"
                                  " in feature %d" % i)
-            jll += self.feature_log_prob_[i][:, indices].T
         total_ll = jll + self.class_log_prior_
         return total_ll
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -1215,11 +1215,17 @@ class CategoricalNB(_BaseDiscreteNB):
         jll = np.zeros((X.shape[0], self.class_count_.shape[0]))
         for i in range(self.n_features_):
             indices = X[:, i]
-            try:
-                jll += self.feature_log_prob_[i][:, indices].T
-            except IndexError:
+            seen = True
+            for index in np.unique(indices):
+                if self.category_count_[i].shape[1] <= index or not np.any(
+                        self.category_count_[i][:, index]):
+                    seen = False
+                    break
+            if not seen:
                 raise ValueError("A category unseen during training is present"
                                  " in feature %d" % i)
+            jll += self.feature_log_prob_[i][:, indices].T
+
         total_ll = jll + self.class_log_prior_
         return total_ll
 

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -1215,6 +1215,10 @@ class CategoricalNB(_BaseDiscreteNB):
         jll = np.zeros((X.shape[0], self.class_count_.shape[0]))
         for i in range(self.n_features_):
             indices = X[:, i]
+            num_categories = self.feature_log_prob_[i].shape[1]
+            if np.max(indices) >= num_categories:
+                raise ValueError("A category unseen during training is present"
+                                 " in feature %d" % i)
             jll += self.feature_log_prob_[i][:, indices].T
         total_ll = jll + self.class_log_prior_
         return total_ll

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.sparse
 import pytest
 
-from sklearn.datasets import load_digits, load_iris
+from sklearn.datasets import load_digits, load_iris, make_classification
 
 from sklearn.model_selection import train_test_split
 from sklearn.model_selection import cross_val_score
@@ -693,6 +693,19 @@ def test_categoricalnb():
         clf = CategoricalNB(alpha=1, fit_prior=False)
         clf.fit(X, y, sample_weight=sample_weight)
         assert_array_equal(clf.predict(np.array([[0, 0]])), np.array([2]))
+
+
+def test_unseen_categories_at_predict():
+    X, y = make_classification(n_features=10, n_classes=3, n_samples=1000,
+                               random_state=42, n_redundant=0, n_informative=6)
+    X = np.abs(X.astype(np.int))
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5,
+                                                        random_state=42)
+    clf = CategoricalNB()
+    clf.fit(X_train, y_train)
+
+    expected_msg = "A category unseen during training is present in feature 0"
+    assert_raise_message(ValueError, expected_msg, clf.predict, X_test)
 
 
 def test_alpha():

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.sparse
 import pytest
 
-from sklearn.datasets import load_digits, load_iris, make_classification
+from sklearn.datasets import load_digits, load_iris
 
 from sklearn.model_selection import train_test_split
 from sklearn.model_selection import cross_val_score
@@ -696,11 +696,10 @@ def test_categoricalnb():
 
 
 def test_unseen_categories_at_predict():
-    X, y = make_classification(n_features=10, n_classes=3, n_samples=1000,
-                               random_state=42, n_redundant=0, n_informative=6)
-    X = np.abs(X.astype(np.int))
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5,
-                                                        random_state=42)
+    X_train = np.array([[0, 0], [0, 1], [0, 0], [1, 1]])
+    y_train = np.array([1, 1, 2, 2])
+    X_test = np.array([[2, 0]])
+
     clf = CategoricalNB()
     clf.fit(X_train, y_train)
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -696,7 +696,7 @@ def test_categoricalnb():
 
 
 def test_unseen_categories_at_predict():
-    X_train = np.array([[0, 0], [0, 1], [0, 0], [1, 1]])
+    X_train = np.array([[0, 0], [0, 1], [0, 0], [3, 1]])
     y_train = np.array([1, 1, 2, 2])
     X_test = np.array([[2, 0]])
 


### PR DESCRIPTION


#### Reference Issues/PRs
Fixes #16028

#### What does this implement/fix? Explain your changes.
Raises an error when CategoricalNB encounters new categories present during testing but never seen during training.

#### Any other comments?

