### PR TITLE
Correct numpy docstring guide link in Coding Guidelines page

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -601,7 +601,7 @@ In addition, we add the following guidelines:
   find bugs in scikit-learn.
 
 * Use the `numpy docstring standard
-  <https://numpy.readthedocs.io/en/latest/format.html>`_ in all your docstrings.
+  <https://numpydoc.readthedocs.io/en/latest/format.html#numpydoc-docstring-guide>`_ in all your docstrings.
 
 
 A good example of code that we like can be found `here


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #16038

#### What does this implement/fix? Explain your changes.
Corrects the link that otherwise reaches to Permission Denied Page