### PR TITLE
[MRG] MNT create issue templates with automatic tagging

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_template.md
+++ b/.github/ISSUE_TEMPLATE/blank_template.md
@@ -1,0 +1,10 @@
+--
+name: Other (blank template)
+about: For all other issues to reach the community...
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/blank_template.md
+++ b/.github/ISSUE_TEMPLATE/blank_template.md
@@ -1,4 +1,4 @@
---
+---
 name: Other (blank template)
 about: For all other issues to reach the community...
 title: ''

--- a/.github/ISSUE_TEMPLATE/blank_template.md
+++ b/.github/ISSUE_TEMPLATE/blank_template.md
@@ -1,5 +1,5 @@
 ---
-name: Other (blank template)
+name: Other
 about: For all other issues to reach the community...
 title: ''
 labels: ''

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,59 @@
+---
+name: Bug report
+about: Create a report to help us reproduce and correct the bug
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+#### Describe the bug
+A clear and concise description of what the bug is.
+
+#### Steps/Code to Reproduce
+<!--
+Example:
+```python
+from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.decomposition import LatentDirichletAllocation
+docs = ["Help I have a bug" for i in range(1000)]
+vectorizer = CountVectorizer(input=docs, analyzer='word')
+lda_features = vectorizer.fit_transform(docs)
+lda_model = LatentDirichletAllocation(
+    n_topics=10,
+    learning_method='online',
+    evaluate_every=10,
+    n_jobs=4,
+)
+model = lda_model.fit(lda_features)
+```
+If the code is too long, feel free to put it in a public gist and link
+it in the issue: https://gist.github.com
+-->
+
+```
+Sample code to reproduce the problem
+```
+
+#### Expected Results
+<!-- Example: No error is thrown. Please paste or describe the expected results.-->
+
+#### Actual Results
+<!-- Please paste or specifically describe the actual output or traceback. -->
+
+#### Versions
+<!--
+Please run the following snippet and paste the output below.
+For scikit-learn >= 0.20:
+import sklearn; sklearn.show_versions()
+For scikit-learn < 0.20:
+import platform; print(platform.platform())
+import sys; print("Python", sys.version)
+import numpy; print("NumPy", numpy.__version__)
+import scipy; print("SciPy", scipy.__version__)
+import sklearn; print("Scikit-Learn", sklearn.__version__)
+import imblearn; print("Imbalanced-Learn", imblearn.__version__)
+-->
+
+
+<!-- Thanks for contributing! -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us reproduce and correct the bug
-title: "[BUG]"
+title: ''
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,8 +13,8 @@ A clear and concise description of what the bug is.
 #### Steps/Code to Reproduce
 Please add a minimal example that we can reproduce the error by running the
 code. Be as succint as possible, do not depend on external data. In short, we
-are going to copy-paste your code in `IPython` and we expect to get the same
-result than you.
+are going to copy-paste your code and we expect to get the same
+result as you.
 <!--
 Example:
 ```python

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,9 @@ assignees: ''
 
 ---
 
+Before submitting a bug, please make sure the issue hasn't been already
+addressed by searching through the past issues.
+
 #### Describe the bug
 <!--
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us reproduce and correct the bug
 title: ''
-labels: bug
+labels: Bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,10 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 #### Steps/Code to Reproduce
+Please add a minimal example that we can reproduce the error by running the
+code. Be as succint as possible, do not depend on external data. In short, we
+are going to copy-paste your code in `IPython` and we expect to get the same
+result than you.
 <!--
 Example:
 ```python

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ A clear and concise description of what the bug is.
 #### Steps/Code to Reproduce
 <!--
 Please add a minimal example that we can reproduce the error by running the
-code. Be as succint as possible, do not depend on external data. In short, we
+code. Be as succinct as possible, do not depend on external data. In short, we
 are going to copy-paste your code and we expect to get the same
 result as you.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,14 +8,17 @@ assignees: ''
 ---
 
 #### Describe the bug
+<!--
 A clear and concise description of what the bug is.
+-->
 
 #### Steps/Code to Reproduce
+<!--
 Please add a minimal example that we can reproduce the error by running the
 code. Be as succint as possible, do not depend on external data. In short, we
 are going to copy-paste your code and we expect to get the same
 result as you.
-<!--
+
 Example:
 ```python
 from sklearn.feature_extraction.text import CountVectorizer

--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -1,0 +1,16 @@
+---
+name: Documentation improvement
+about: Create a report to help us improve the documentation
+title: "[DOC]"
+labels: Documentation, help wanted, good first issue
+assignees: ''
+
+---
+
+#### Describe the issue linked to the documentation
+
+Tell us about the confusion introduce in the documentation.
+
+#### Suggest a potential alternative/fix
+
+Tell us how we could improve the documentation in this regard.

--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -9,7 +9,7 @@ assignees: ''
 
 #### Describe the issue linked to the documentation
 
-Tell us about the confusion introduce in the documentation.
+Tell us about the confusion introduced in the documentation.
 
 #### Suggest a potential alternative/fix
 

--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -1,6 +1,6 @@
 ---
 name: Documentation improvement
-about: Create a report to help us improve the documentation
+about: Create a report to help us improve the documentation. Alternatively you can just open a pull request with the suggested change.
 title: ''
 labels: Documentation, help wanted
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -1,7 +1,7 @@
 ---
 name: Documentation improvement
 about: Create a report to help us improve the documentation
-title: "[DOC]"
+title: ''
 labels: Documentation, help wanted, good first issue
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -9,8 +9,12 @@ assignees: ''
 
 #### Describe the issue linked to the documentation
 
+<!--
 Tell us about the confusion introduced in the documentation.
+-->
 
 #### Suggest a potential alternative/fix
 
+<!--
 Tell us how we could improve the documentation in this regard.
+-->

--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -2,7 +2,7 @@
 name: Documentation improvement
 about: Create a report to help us improve the documentation
 title: ''
-labels: Documentation, help wanted, good first issue
+labels: Documentation, help wanted
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an new algorithm, enhancement to an existing algorithm, etc.
+title: "[ENH]"
+labels: enhancement
+assignees: ''
+
+---
+
+<--
+If you want to propose a new algorithm, please refer first to the scikit-learn
+inclusion criterion:
+https://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new-algorithms
+-->
+
+#### Is your feature request related to a problem? Please describe
+
+#### Describe the solution you'd like
+
+#### Describe alternatives you've considered
+
+#### Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,13 +1,13 @@
 ---
 name: Feature request
-about: Suggest an new algorithm, enhancement to an existing algorithm, etc.
+about: Suggest a new algorithm, enhancement to an existing algorithm, etc.
 title: ''
 labels: enhancement
 assignees: ''
 
 ---
 
-<--
+<!--
 If you want to propose a new algorithm, please refer first to the scikit-learn
 inclusion criterion:
 https://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new-algorithms
@@ -15,7 +15,7 @@ https://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new
 
 #### Is your feature request related to a problem? Please describe
 
-#### Describe the solution you'd like
+#### Describe your proposed solution
 
 #### Describe alternatives you've considered
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a new algorithm, enhancement to an existing algorithm, etc.
 title: ''
-labels: Enhancement, New Feature
+labels: New Feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a new algorithm, enhancement to an existing algorithm, etc.
 title: ''
-labels: enhancement
+labels: Enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a new algorithm, enhancement to an existing algorithm, etc.
 title: ''
-labels: Enhancement
+labels: Enhancement, New Feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,7 +15,6 @@ https://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new
 
 #### Describe the workflow you want to enable
 
-
 #### Describe your proposed solution
 
 #### Describe alternatives you've considered, if relevant

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an new algorithm, enhancement to an existing algorithm, etc.
-title: "[ENH]"
+title: ''
 labels: enhancement
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,10 +13,11 @@ inclusion criterion:
 https://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new-algorithms
 -->
 
-#### Is your feature request related to a problem? Please describe
+#### Describe the workflow you want to enable
+
 
 #### Describe your proposed solution
 
-#### Describe alternatives you've considered
+#### Describe alternatives you've considered, if relevant
 
 #### Additional context

--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -1,8 +1,0 @@
----
-name: Request for Comments or Changes
-about: Open discussion regarding API or algorithms.
-title: ''
-labels: RFC
-assignees: ''
-
----

--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -1,0 +1,8 @@
+---
+name: Request for Comments or Changes
+about: Open discussion regarding API or algorithms.
+title: ''
+labels: RFC
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -1,0 +1,17 @@
+---
+name: Usage question
+about: If you have a usage question
+title: "[SO]"
+labels: question
+assignees: ''
+
+---
+
+** If your issue is a usage question, submit it here instead:**
+- **StackOverflow with the scikit-learn tag: https://stackoverflow.com/questions/tagged/scikit-learn**
+- **Gitter: https://gitter.im/scikit-learn/scikit-learn**
+- **Mailing List: https://mail.python.org/mailman/listinfo/scikit-learn**
+- **For more information, see User Questions: http://scikit-learn.org/stable/support.html#user-question**
+
+We are going to automatically close this issue if this is not link to a bug or
+an enhancement.

--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-** If your issue is a usage question, submit it here instead:**
+**If your issue is a usage question, submit it here instead:**
 - **StackOverflow with the scikit-learn tag: https://stackoverflow.com/questions/tagged/scikit-learn**
 - **Mailing List: https://mail.python.org/mailman/listinfo/scikit-learn**
 - **Gitter: https://gitter.im/scikit-learn/scikit-learn**

--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -13,5 +13,6 @@ assignees: ''
 - **Gitter: https://gitter.im/scikit-learn/scikit-learn**
 - **For more information, see User Questions: http://scikit-learn.org/stable/support.html#user-question**
 
-We are going to automatically close this issue if this is not link to a bug or
-an enhancement.
+The issue tracker is used only to report issues and feature requests. For
+questions, please use either of the above platforms. Most question issues are
+closed without an answer on this issue tracker. Thanks for your understanding.

--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -1,7 +1,7 @@
 ---
 name: Usage question
 about: If you have a usage question
-title: "[SO]"
+title: ''
 labels: question
 assignees: ''
 
@@ -9,8 +9,8 @@ assignees: ''
 
 ** If your issue is a usage question, submit it here instead:**
 - **StackOverflow with the scikit-learn tag: https://stackoverflow.com/questions/tagged/scikit-learn**
-- **Gitter: https://gitter.im/scikit-learn/scikit-learn**
 - **Mailing List: https://mail.python.org/mailman/listinfo/scikit-learn**
+- **Gitter: https://gitter.im/scikit-learn/scikit-learn**
 - **For more information, see User Questions: http://scikit-learn.org/stable/support.html#user-question**
 
 We are going to automatically close this issue if this is not link to a bug or

--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -2,7 +2,7 @@
 name: Usage question
 about: If you have a usage question
 title: ''
-labels: question
+labels: Question
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -7,6 +7,7 @@ assignees: ''
 
 ---
 
+<!--
 **If your issue is a usage question, please submit it in one of these other channels instead:**
 - **StackOverflow with the scikit-learn tag: https://stackoverflow.com/questions/tagged/scikit-learn**
 - **Mailing List: https://mail.python.org/mailman/listinfo/scikit-learn**
@@ -16,3 +17,4 @@ assignees: ''
 The issue tracker is used only to report issues and feature requests. For
 questions, please use either of the above platforms. Most question issues are
 closed without an answer on this issue tracker. Thanks for your understanding.
+-->

--- a/.github/ISSUE_TEMPLATE/usage_question.md
+++ b/.github/ISSUE_TEMPLATE/usage_question.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**If your issue is a usage question, submit it here instead:**
+**If your issue is a usage question, please submit it in one of these other channels instead:**
 - **StackOverflow with the scikit-learn tag: https://stackoverflow.com/questions/tagged/scikit-learn**
 - **Mailing List: https://mail.python.org/mailman/listinfo/scikit-learn**
 - **Gitter: https://gitter.im/scikit-learn/scikit-learn**


### PR DESCRIPTION
closes #14881

Add a couple of issue template which can help for automatically labelling some issues and sometimes redirect users.