### PR TITLE
DOC improve docstring random_state in cluster module

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -238,7 +238,7 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
     tol : float, optional
         The relative increment in the results before declaring convergence.
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance, default=None
         Determines random number generation for centroid initialization. Use
         an int to make the randomness deterministic.
         See :term:`Glossary <random_state>`.
@@ -377,7 +377,7 @@ def _kmeans_single_lloyd(X, sample_weight, n_clusters, max_iter=300,
     precompute_distances : boolean, default: True
         Precompute distances (faster but takes more memory).
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance, default=None
         Determines random number generation for centroid initialization. Use
         an int to make the randomness deterministic.
         See :term:`Glossary <random_state>`.
@@ -580,7 +580,7 @@ def _init_centroids(X, k, init, random_state=None, x_squared_norms=None,
     init : {'k-means++', 'random' or ndarray or callable} optional
         Method for initialization
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance, default=None
         Determines random number generation for centroid initialization. Use
         an int to make the randomness deterministic.
         See :term:`Glossary <random_state>`.
@@ -1147,7 +1147,7 @@ def _mini_batch_step(X, sample_weight, x_squared_norms, centers, weight_sums,
         the distances of each sample to its closest center.
         May not be None when random_reassign is True.
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance, default=None
         Determines random number generation for centroid initialization and to
         pick new clusters amongst observations with uniform probability. Use
         an int to make the randomness deterministic.

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -45,7 +45,7 @@ def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0,
     n_samples : int, optional
         The number of samples to use. If not given, all samples are used.
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance, default=None
         The generator used to randomly select the samples from input points
         for bandwidth estimation. Use an int to make the randomness
         deterministic.

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -38,7 +38,7 @@ def discretize(vectors, copy=True, max_svd_restarts=30, n_iter_max=20,
         Maximum number of iterations to attempt in rotation and partition
         matrix search if machine precision convergence is not reached
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance, default=None
         Determines random number generation for rotation matrix initialization.
         Use an int to make the randomness deterministic.
         See :term:`Glossary <random_state>`.
@@ -194,7 +194,7 @@ def spectral_clustering(affinity, n_clusters=8, n_components=None,
         to be installed. It can be faster on very large, sparse problems,
         but may also lead to instabilities
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance, default=None
         A pseudo random number generator used for the initialization of the
         lobpcg eigen vectors decomposition when eigen_solver == 'amg' and by
         the K-Means initialization. Use an int to make the randomness
@@ -310,7 +310,7 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
     n_components : integer, optional, default=n_clusters
         Number of eigen vectors to use for the spectral embedding
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance, default=None
         A pseudo random number generator used for the initialization of the
         lobpcg eigen vectors decomposition when ``eigen_solver='amg'`` and by
         the K-Means initialization. Use an int to make the randomness


### PR DESCRIPTION
This is a follow-up of #10548 where we did not decide yet the default style with None.
I updated the cluster module while I was giving a look at the PR touching the `random_state` docstring.