### PR TITLE
Implement SVD algorithm in MDS

### DIFF
--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -439,6 +439,9 @@ should then correspond exactly to the distance between point :math:`i` and
 
 Most commonly, disparities are set to :math:`\hat{d}_{ij} = b S_{ij}`.
 
+If the metric of :math:`S` is Euclidean, user can choose to use faster and more accurate
+method of calculating results. See :ref:`multidimensional_scaling_method` for details.
+
 Nonmetric MDS
 -------------
 
@@ -457,6 +460,19 @@ order to avoid that, the disparities :math:`\hat{d}_{ij}` are normalized.
    :align: center
    :scale: 60
 
+.. _multidimensional_scaling_method:
+
+Method
+-------------
+
+Metric :class:`MDS` offers two different algorithms (methods) to calculate
+results: SMACOF and SVD-based. The SMACOF method (Scaling by MAjorizing a
+COmplicated Function) minimizes objective function (stress) in iterative
+manner. The SVD-based method performs series of transformations (including
+Singular Value Decomposition) to give exact result. The SVD-based method is
+thus much faster and more accurate, but also less general - it requires metric
+of :math:`S` to be Euclidean.
+
 
 .. topic:: References:
 
@@ -471,6 +487,11 @@ order to avoid that, the disparities :math:`\hat{d}_{ij}` are normalized.
   * `"Multidimensional scaling by optimizing goodness of fit to a nonmetric hypothesis"
     <https://link.springer.com/article/10.1007%2FBF02289565>`_
     Kruskal, J. Psychometrika, 29, (1964)
+
+  * `"An Introduction to MDS"
+    <https://www.researchgate.net/publication/228775338_An_introduction_to_MDS>`_
+    Florian Wickelmaier, Sound Quality Research Unit, Aalborg University, Denmark (2003)
+
 
 .. _t_sne:
 

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -440,18 +440,18 @@ should then correspond exactly to the distance between point :math:`i` and
 Most commonly, disparities are set to :math:`\hat{d}_{ij} = b S_{ij}`.
 
 If the metric of :math:`S` is Euclidean, user can choose to use faster and more accurate
-method of calculating results. See :ref:`multidimensional_scaling_method` for details.
+solver of calculating results. See :ref:`multidimensional_scaling_solver` for details.
 
-.. _multidimensional_scaling_method:
+.. _multidimensional_scaling_solver:
 
-Method
+Solver
 -------------
 
-Metric :class:`MDS` offers two different algorithms (methods) to calculate
-results: SMACOF and SVD-based. The SMACOF method (Scaling by MAjorizing a
+Metric :class:`MDS` offers two different algorithms (solvers) to calculate
+results: SMACOF and SVD-based. The SMACOF solver (Scaling by MAjorizing a
 COmplicated Function) minimizes its objective function (stress) in an iterative
-manner. The SVD-based method performs series of transformations (including
-Singular Value Decomposition) to give exact result. The SVD-based method is
+manner. The SVD-based solver performs series of transformations (including
+Singular Value Decomposition) to give exact result. The SVD-based solver is
 thus much faster and more accurate, but also less general - it requires metric
 of :math:`S` to be Euclidean.
 

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -442,6 +442,19 @@ Most commonly, disparities are set to :math:`\hat{d}_{ij} = b S_{ij}`.
 If the metric of :math:`S` is Euclidean, user can choose to use faster and more accurate
 method of calculating results. See :ref:`multidimensional_scaling_method` for details.
 
+.. _multidimensional_scaling_method:
+
+Method
+-------------
+
+Metric :class:`MDS` offers two different algorithms (methods) to calculate
+results: SMACOF and SVD-based. The SMACOF method (Scaling by MAjorizing a
+COmplicated Function) minimizes its objective function (stress) in an iterative
+manner. The SVD-based method performs series of transformations (including
+Singular Value Decomposition) to give exact result. The SVD-based method is
+thus much faster and more accurate, but also less general - it requires metric
+of :math:`S` to be Euclidean.
+
 Nonmetric MDS
 -------------
 
@@ -459,19 +472,6 @@ order to avoid that, the disparities :math:`\hat{d}_{ij}` are normalized.
    :target: ../auto_examples/manifold/plot_mds.html
    :align: center
    :scale: 60
-
-.. _multidimensional_scaling_method:
-
-Method
--------------
-
-Metric :class:`MDS` offers two different algorithms (methods) to calculate
-results: SMACOF and SVD-based. The SMACOF method (Scaling by MAjorizing a
-COmplicated Function) minimizes objective function (stress) in iterative
-manner. The SVD-based method performs series of transformations (including
-Singular Value Decomposition) to give exact result. The SVD-based method is
-thus much faster and more accurate, but also less general - it requires metric
-of :math:`S` to be Euclidean.
 
 
 .. topic:: References:

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -262,10 +262,10 @@ Changelog
 :mod:`sklearn.manifold`
 ...........................
 
-- |Feature| Support of multidimensional scaling method,
+- |Feature| Support of multidimensional scaling solver,
   which uses Singular Value Decomposition (SVD) in :class:`manifold.MDS`.
-  User can choose whether to use SVD- or SMACOF-based method via parameter
-  `method`. The SVD-based method is faster and more accurate, but works
+  User can choose whether to use SVD- or SMACOF-based solver via parameter
+  `solver`. The SVD-based solver is faster and more accurate, but works
   only for euclidean dissimilarity matrices.
   :pr:`16067` by :user:`Piotr Gaiński <panpiort8>`.
 

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -259,6 +259,16 @@ Changelog
   of strictly inferior for maximum of `absgrad` and `tol` in `utils.optimize._newton_cg`.
   :pr:`16266` by :user:`Rushabh Vasani <rushabh-v>`.
 
+:mod:`sklearn.manifold`
+...........................
+
+- |Feature| Support of multidimensional scaling method,
+  which uses Singular Value Decomposition (SVD) in :class:`manifold.MDS`.
+  User can choose whether to use SVD- or SMACOF-based method via parameter
+  `method`. The SVD-based method is faster and more accurate, but works
+  only for euclidean dissimilarity matrices.
+  :pr:`16067` by :user:`Piotr Gaiński <panpiort8>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -352,19 +352,19 @@ class MDS(BaseEstimator):
     metric : boolean, optional, default: True
         If ``True``, perform metric MDS; otherwise, perform nonmetric MDS.
 
-        If  ``method=='svd'``, metric must be set to True.
+        If  ``solver=='svd'``, metric must be set to True.
 
     n_init : int, optional, default: 4
         Number of times the SMACOF algorithm will be run with different
         initializations. The final results will be the best output of the runs,
         determined by the run with the smallest final stress.
 
-        Ignored if  ``method=='svd'``.
+        Ignored if  ``solver=='svd'``.
 
     max_iter : int, optional, default: 300
         Maximum number of iterations of the SMACOF algorithm for a single run.
 
-        Ignored if  ``method=='svd'``.
+        Ignored if  ``solver=='svd'``.
 
     verbose : int, optional, default: 0
         Level of verbosity.
@@ -373,7 +373,7 @@ class MDS(BaseEstimator):
         Relative tolerance with respect to stress at which to declare
         convergence.
 
-        Ignored if  ``method=='svd'``.
+        Ignored if  ``solver=='svd'``.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to use for the computation. If multiple
@@ -384,7 +384,7 @@ class MDS(BaseEstimator):
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-        Ignored if  ``method=='svd'``.
+        Ignored if  ``solver=='svd'``.
 
     random_state : int, RandomState instance, default=None
         Determines the random number generator used to initialize the centers.
@@ -401,8 +401,8 @@ class MDS(BaseEstimator):
             Pre-computed dissimilarities are passed directly to ``fit`` and
             ``fit_transform``.
 
-    method : {'smacof', 'svd'}, default ='smacof'
-        The method used for solving the MDS problem.
+    solver : {'smacof', 'svd'}, default ='smacof'
+        The solver used for solving the MDS problem.
 
         .. versionadded:: 0.23
 
@@ -419,7 +419,7 @@ class MDS(BaseEstimator):
         The number of iterations of SMACOF algorithm corresponding
         to the best stress.
 
-        It is set to ``None`` if ``method=='svd'``.
+        It is set to ``None`` if ``solver=='svd'``.
 
     Examples
     --------
@@ -449,11 +449,11 @@ class MDS(BaseEstimator):
     def __init__(self, n_components=2, metric=True, n_init=4,
                  max_iter=300, verbose=0, eps=1e-3, n_jobs=None,
                  random_state=None, dissimilarity="euclidean",
-                 method="smacof"):
+                 solver="smacof"):
         self.n_components = n_components
         self.dissimilarity = dissimilarity
         self.metric = metric
-        self.method = method
+        self.solver = solver
         self.n_init = n_init
         self.max_iter = max_iter
         self.eps = eps
@@ -478,10 +478,11 @@ class MDS(BaseEstimator):
         y : Ignored
 
         init : ndarray, shape (n_samples,), optional, default: None
-            Ignored if  ``method=='svd'``.
             Starting configuration of the embedding to initialize the SMACOF
             algorithm. By default, the algorithm is initialized with a randomly
             chosen array.
+
+            Ignored if  ``solver=='svd'``.
         """
         self.fit_transform(X, init=init)
         return self
@@ -499,10 +500,11 @@ class MDS(BaseEstimator):
         y : Ignored
 
         init : ndarray, shape (n_samples,), optional, default: None
-            Ignored if  ``method=='svd'``.
             Starting configuration of the embedding to initialize the SMACOF
             algorithm. By default, the algorithm is initialized with a randomly
             chosen array.
+
+            Ignored if  ``solver=='svd'``.
         """
         X = self._validate_data(X)
         if X.shape[0] == X.shape[1] and self.dissimilarity != "precomputed":
@@ -520,7 +522,7 @@ class MDS(BaseEstimator):
                 "Dissimilarity matrix must be 'precomputed' or 'euclidean'."
                 " Got %s instead" % str(self.dissimilarity))
 
-        if self.method == "smacof":
+        if self.solver == "smacof":
             self.embedding_, self.stress_, self.n_iter_ = smacof(
                 self.dissimilarity_matrix_, metric=self.metric,
                 n_components=self.n_components, init=init,
@@ -528,14 +530,14 @@ class MDS(BaseEstimator):
                 max_iter=self.max_iter, verbose=self.verbose,
                 eps=self.eps, random_state=self.random_state,
                 return_n_iter=True)
-        elif self.method == "svd":
+        elif self.solver == "svd":
             if not self.metric:
                 raise ValueError("Using SVD requires metric=True")
             self.embedding_, self.stress_ = svd_scaler(
                 self.dissimilarity_matrix_, n_components=self.n_components)
             self.n_iter_ = None
         else:
-            raise ValueError("Method must be 'smacof' or 'svd'."
-                             " Got %s instead" % str(self.method))
+            raise ValueError("Solver must be 'smacof' or 'svd'."
+                             " Got %s instead" % str(self.solver))
 
         return self.embedding_

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -401,7 +401,7 @@ class MDS(BaseEstimator):
             Pre-computed dissimilarities are passed directly to ``fit`` and
             ``fit_transform``.
 
-    method: {'smacof', 'svd'}, default ='smacof'
+    method : {'smacof', 'svd'}, default ='smacof'
         The method used for solving the MDS problem.
 
         .. versionadded:: 0.23

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -55,30 +55,6 @@ def test_smacof_error():
         mds.smacof(sim, init=Z, n_init=1)
 
 
-def test_svd():
-    # Test svd using example data from "An Introduction to MDS"
-    # Florian Wickelmaier, p 11
-    sim = np.array([[0, 93, 82, 133],
-                    [93, 0, 52, 60],
-                    [82, 52, 0, 111],
-                    [133, 60, 111, 0]])
-
-    X, stress = mds.svd_scaler(sim, n_components=2)
-    X_true_1 = np.array([[-62.831, -32.97448],
-                         [18.403, 12.02697],
-                         [-24.960, 39.71091],
-                         [69.388, -18.76340]])
-    X_true_2 = np.copy(X_true_1)
-    X_true_2[:, 0] *= -1
-
-    # Signs of columns are dependent on signs of computed eigenvectors
-    # which are arbitrary and meaningless
-    assert(np.allclose(X, X_true_1)
-           or np.allclose(X, -X_true_1)
-           or np.allclose(X, X_true_2)
-           or np.allclose(X, -X_true_2))
-
-
 def test_svd_error():
     # Non symmetric (dis)similarity matrix:
     sim = np.array([[0, 5, 9, 4],
@@ -86,7 +62,7 @@ def test_svd_error():
                     [3, 2, 0, 1],
                     [4, 2, 1, 0]])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Array must be symmetric"):
         mds.svd_scaler(sim)
 
     # Non squared (dis)similarity matrix:
@@ -94,7 +70,8 @@ def test_svd_error():
                     [5, 0, 2, 2],
                     [4, 2, 1, 0]])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       match="array must be 2-dimensional and square"):
         mds.svd_scaler(sim)
 
     # Non Euclidean (dis)similarity matrix:
@@ -112,13 +89,13 @@ def test_MDS_error():
     # Bad solver name
     sim = np.ones((2, 2))
     mdc_clf = mds.MDS(solver='bad name')
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Solver must be 'smacof' or 'svd'"):
         mdc_clf.fit(sim)
 
     # SVD with metric=False
     sim = np.ones((2, 2))
     mdc_clf = mds.MDS(metric=False, solver='svd')
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Using SVD requires metric=True"):
         mdc_clf.fit(sim)
 
 

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -55,6 +55,73 @@ def test_smacof_error():
         mds.smacof(sim, init=Z, n_init=1)
 
 
+def test_svd():
+    # Test svd using example data from "An Introduction to MDS"
+    # Florian Wickelmaier, p 11
+    sim = np.array([[0, 93, 82, 133],
+                    [93, 0, 52, 60],
+                    [82, 52, 0, 111],
+                    [133, 60, 111, 0]])
+
+    X, stress = mds.svd_scaler(sim, n_components=2)
+    X_true_1 = np.array([[-62.831, -32.97448],
+                         [18.403, 12.02697],
+                         [-24.960, 39.71091],
+                         [69.388, -18.76340]])
+    X_true_2 = np.copy(X_true_1)
+    X_true_2[:, 0] *= -1
+
+    # Signs of columns are dependent on signs of computed eigenvectors
+    # which are arbitrary and meaningless
+    assert(np.allclose(X, X_true_1)
+           or np.allclose(X, -X_true_1)
+           or np.allclose(X, X_true_2)
+           or np.allclose(X, -X_true_2))
+
+
+def test_svd_error():
+    # Non symmetric (dis)similarity matrix:
+    sim = np.array([[0, 5, 9, 4],
+                    [5, 0, 2, 2],
+                    [3, 2, 0, 1],
+                    [4, 2, 1, 0]])
+
+    with pytest.raises(ValueError):
+        mds.svd_scaler(sim)
+
+    # Non squared (dis)similarity matrix:
+    sim = np.array([[0, 5, 9, 4],
+                    [5, 0, 2, 2],
+                    [4, 2, 1, 0]])
+
+    with pytest.raises(ValueError):
+        mds.svd_scaler(sim)
+
+    # Non Euclidean (dis)similarity matrix:
+    sim = np.array([[0, 12, 3, 4],
+                    [12, 0, 2, 2],
+                    [3, 2, 0, 1],
+                    [4, 2, 1, 0]])
+
+    with pytest.raises(ValueError,
+                       match="Dissimilarity matrix must be euclidean"):
+        mds.svd_scaler(sim)
+
+
+def test_MDS_error():
+    # Bad method name
+    sim = np.ones((2, 2))
+    mdc_clf = mds.MDS(method='bad name')
+    with pytest.raises(ValueError):
+        mdc_clf.fit(sim)
+
+    # SVD with metric=False
+    sim = np.ones((2, 2))
+    mdc_clf = mds.MDS(metric=False, method='svd')
+    with pytest.raises(ValueError):
+        mdc_clf.fit(sim)
+
+
 def test_MDS():
     sim = np.array([[0, 5, 3, 4],
                     [5, 0, 2, 2],
@@ -62,3 +129,29 @@ def test_MDS():
                     [4, 2, 1, 0]])
     mds_clf = mds.MDS(metric=False, n_jobs=3, dissimilarity="precomputed")
     mds_clf.fit(sim)
+
+
+def test_MDS_svd():
+    # Test svd using example data from "An Introduction to MDS"
+    # Florian Wickelmaier, p 11
+    sim = np.array([[0, 93, 82, 133],
+                    [93, 0, 52, 60],
+                    [82, 52, 0, 111],
+                    [133, 60, 111, 0]])
+
+    mds_clf = mds.MDS(metric=True, method="svd", dissimilarity='precomputed')
+    mds_clf.fit(sim)
+
+    X_true_1 = np.array([[-62.831, -32.97448],
+                         [18.403, 12.02697],
+                         [-24.960, 39.71091],
+                         [69.388, -18.76340]])
+    X_true_2 = np.copy(X_true_1)
+    X_true_2[:, 0] *= -1
+
+    # Signs of columns are dependent on signs of computed eigenvectors
+    # which are arbitrary and meaningless
+    assert (np.allclose(mds_clf.embedding_, X_true_1)
+            or np.allclose(mds_clf.embedding_, -X_true_1)
+            or np.allclose(mds_clf.embedding_, X_true_2)
+            or np.allclose(mds_clf.embedding_, -X_true_2))

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -109,15 +109,15 @@ def test_svd_error():
 
 
 def test_MDS_error():
-    # Bad method name
+    # Bad solver name
     sim = np.ones((2, 2))
-    mdc_clf = mds.MDS(method='bad name')
+    mdc_clf = mds.MDS(solver='bad name')
     with pytest.raises(ValueError):
         mdc_clf.fit(sim)
 
     # SVD with metric=False
     sim = np.ones((2, 2))
-    mdc_clf = mds.MDS(metric=False, method='svd')
+    mdc_clf = mds.MDS(metric=False, solver='svd')
     with pytest.raises(ValueError):
         mdc_clf.fit(sim)
 
@@ -139,7 +139,7 @@ def test_MDS_svd():
                     [82, 52, 0, 111],
                     [133, 60, 111, 0]])
 
-    mds_clf = mds.MDS(metric=True, method="svd", dissimilarity='precomputed')
+    mds_clf = mds.MDS(metric=True, solver="svd", dissimilarity='precomputed')
     mds_clf.fit(sim)
 
     X_true_1 = np.array([[-62.831, -32.97448],


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #15272

#### What does this implement/fix? Explain your changes.
Adds implementation of Multidimensional scaling (MDS), which uses Singular Value Decompostion (SVD) method. SVD works much faster and far more accurate for Euclidean matrixes than SMACOF algorithm (current implementation of MDS in sklearn/manifold module). 

#### Any other comments?
I'm putting simple benchmark script and it's results in comment (not sure if it's best practice).
