### PR TITLE
make docstring of confusion_matrix more clear

### DIFF
--- a/sklearn/metrics/classification.py
+++ b/sklearn/metrics/classification.py
@@ -217,7 +217,8 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None):
     Returns
     -------
     C : array, shape = [n_classes, n_classes]
-        Confusion matrix
+        A confusion matrix whose i-th row and j-th column entry corresponds to the number
+         of samples with true labels in i-th class and the prediced labels in j-th class.
 
     References
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Fixes #16043 
-->
Fixes #16043 


#### What does this implement/fix? Explain your changes.
add explanation :

> A confusion matrix whose i-th row and j-th column entry corresponds to the number of samples with true labels in i-th class and the prediced labels in j-th class.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
