### PR TITLE
DOC Docstring improvements to confusion_matrix and splitters

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -232,7 +232,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
     Returns
     -------
     C : ndarray of shape (n_classes, n_classes)
-        Confusion matrix whose i-th row and j-th column entry corresponds to the number
+        Confusion matrix whose i-th row and j-th column entry indicates the number
         of samples with true labels in i-th class and the prediced labels in j-th class.
 
     References

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -232,8 +232,9 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
     Returns
     -------
     C : ndarray of shape (n_classes, n_classes)
-        Confusion matrix whose i-th row and j-th column entry indicates the number
-        of samples with true label being i-th class and prediced label being j-th class.
+        Confusion matrix whose i-th row and j-th column entry indicates
+        the number of samples with true label being i-th class and
+        prediced label being j-th class.
 
     References
     ----------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -233,7 +233,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
     -------
     C : ndarray of shape (n_classes, n_classes)
         Confusion matrix whose i-th row and j-th column entry indicates the number
-        of samples with true labels in i-th class and the prediced labels in j-th class.
+        of samples with true label being i-th class and prediced label being j-th class.
 
     References
     ----------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -232,9 +232,10 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
     Returns
     -------
     C : ndarray of shape (n_classes, n_classes)
-        Confusion matrix whose i-th row and j-th column entry indicates
-        the number of samples with true label being i-th class and
-        prediced label being j-th class.
+        Confusion matrix whose i-th row and j-th
+        column entry indicates the number of
+        samples with true label being i-th class
+        and prediced label being j-th class.
 
     References
     ----------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -233,7 +233,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
     -------
     C : ndarray of shape (n_classes, n_classes)
         Confusion matrix whose i-th row and j-th column entry corresponds to the number
-         of samples with true labels in i-th class and the prediced labels in j-th class.
+        of samples with true labels in i-th class and the prediced labels in j-th class.
 
     References
     ----------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -232,7 +232,8 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
     Returns
     -------
     C : ndarray of shape (n_classes, n_classes)
-        Confusion matrix.
+        Confusion matrix whose i-th row and j-th column entry corresponds to the number
+         of samples with true labels in i-th class and the prediced labels in j-th class.
 
     References
     ----------

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -204,13 +204,12 @@ class ParameterSampler:
     n_iter : integer
         Number of parameter settings that are produced.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, default=None
         Pseudo random number generator state used for random uniform sampling
         from lists of possible values instead of scipy.stats distributions.
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -1296,13 +1295,12 @@ class RandomizedSearchCV(BaseSearchCV):
     verbose : integer
         Controls the verbosity: the higher, the more messages.
 
-    random_state : int, RandomState instance or None, optional, default=None
+    random_state : int, RandomState instance or None, default=None
         Pseudo random number generator state used for random uniform sampling
         from lists of possible values instead of scipy.stats distributions.
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     error_score : 'raise' or numeric
         Value to assign to the score if an error occurs in estimator fitting.

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -380,12 +380,12 @@ class KFold(_BaseKFold):
         Whether to shuffle the data before splitting into batches.
         Note that the samples within each split will not be shuffled.
 
-    random_state : int, RandomState instance or None, optional, default=None
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`. Only used when ``shuffle`` is True. This should be left
+    random_state : int, RandomState instance or None, default=None
+        Only used when ``shuffle`` is True. This should be left
         to None if ``shuffle`` is False.
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -587,12 +587,12 @@ class StratifiedKFold(_BaseKFold):
         Whether to shuffle each class's samples before splitting into batches.
         Note that the samples within each split will not be shuffled.
 
-    random_state : int, RandomState instance or None, optional, default=None
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`. Only used when ``shuffle`` is True. This should be left
+    random_state : int, RandomState instance or None, default=None
+        Only used when ``shuffle`` is True. This should be left
         to None if ``shuffle`` is False.
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -1090,11 +1090,10 @@ class _RepeatedSplits(metaclass=ABCMeta):
     n_repeats : int, default=10
         Number of times cross-validator needs to be repeated.
 
-    random_state : int, RandomState instance or None, optional, default=None
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None, default=None
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     **cvargs : additional params
         Constructor parameters for cv. Must not contain random_state
@@ -1195,11 +1194,9 @@ class RepeatedKFold(_RepeatedSplits):
     n_repeats : int, default=10
         Number of times cross-validator needs to be repeated.
 
-    random_state : int, RandomState instance or None, optional, default=None
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None, default=None
+        Pass an int for reproducible output across multiple
+        function calls.See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -1249,9 +1246,10 @@ class RepeatedStratifiedKFold(_RepeatedSplits):
     n_repeats : int, default=10
         Number of times cross-validator needs to be repeated.
 
-    random_state : None, int or RandomState, default=None
-        Random state to be used to generate random state for each
-        repetition.
+    random_state : int, RandomState instance or None, default=None
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -1389,11 +1387,10 @@ class ShuffleSplit(BaseShuffleSplit):
         int, represents the absolute number of train samples. If None,
         the value is automatically set to the complement of the test size.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None, default=None
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -1491,11 +1488,10 @@ class GroupShuffleSplit(ShuffleSplit):
         int, represents the absolute number of train groups. If None,
         the value is automatically set to the complement of the test size.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None, default=None
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -1604,11 +1600,10 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         int, represents the absolute number of train samples. If None,
         the value is automatically set to the complement of the test size.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None, default=None
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -2048,11 +2043,10 @@ def train_test_split(*arrays, **options):
         int, represents the absolute number of train samples. If None,
         the value is automatically set to the complement of the test size.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None, default=None
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     shuffle : boolean, optional (default=True)
         Whether or not to shuffle the data before splitting. If shuffle=False

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1003,11 +1003,10 @@ def permutation_test_score(estimator, X, y, groups=None, cv=None,
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    random_state : int, RandomState instance or None, optional (default=0)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance or None, default=None
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     verbose : integer, optional
         The verbosity level.
@@ -1173,11 +1172,11 @@ def learning_curve(estimator, X, y, groups=None,
         Whether to shuffle training data before taking prefixes of it
         based on``train_sizes``.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`. Used when ``shuffle`` is True.
+    random_state : int, RandomState instance or None, default=None
+        Used when ``shuffle`` is True.
+        Pass an int for reproducible output across multiple
+        function calls.
+        See :term:`Glossary <random_state>`.
 
     error_score : 'raise' or numeric
         Value to assign to the score if an error occurs in estimator fitting.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->



#### What does this implement/fix? Explain your changes.
Fixes #16043 


add explanation :

> A confusion matrix whose i-th row and j-th column entry corresponds to the number of samples with true labels in i-th class and the prediced labels in j-th class.

The afterwards commitment Fixes #16096 
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
