### PR TITLE
FIX  Elkan k-means does not stop if tol=0

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -50,6 +50,9 @@ Changelog
 - |Enhancement| :class:`cluster.AgglomerativeClustering` has a faster and more
   more memory efficient implementation of single linkage clustering.
   :pr:`11514` by :user:`Leland McInnes <lmcinnes>`.
+- |Fix| :class:`cluster.KMeans` with ``algorithm="elkan"`` now converges with
+  ``tol=0`` as with the default ``algorithm="full"``. :pr:`16075` by
+  :user:`Erich Schubert <kno10>`.
 
 :mod:`sklearn.datasets`
 .......................

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -245,7 +245,7 @@ def k_means_elkan(np.ndarray[floating, ndim=2, mode='c'] X_,
                     % (iteration, np.sum((X_ - centers_[labels]) ** 2 *
                                          sample_weight[:,np.newaxis])))
         center_shift_total = np.sum(center_shift ** 2)
-        if center_shift_total < tol:
+        if center_shift_total <= tol:
             if verbose:
                 print("center shift %e within tolerance %e"
                       % (center_shift_total, tol))

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -69,7 +69,7 @@ def test_kmeans_results(representation, algo, dtype):
 
 
 @pytest.mark.parametrize('distribution', ['normal', 'blobs'])
-@pytest.mark.parametrize('tol', [1e-2, 1e-4, 1e-8])
+@pytest.mark.parametrize('tol', [0, 1e-2, 1e-4, 1e-8])
 def test_elkan_results(distribution, tol):
     # check that results are identical between lloyd and elkan algorithms
     rnd = np.random.RandomState(0)


### PR DESCRIPTION
K-means convergence is still different between "full" k-means and "elkan" k-means.

The fix in #15831 is incomplete. Compare:

https://github.com/scikit-learn/scikit-learn/blob/4fe4d27eb1b88cc799199f2176ac734bbc16ca31/sklearn/cluster/_kmeans.py#L441-L442

and

https://github.com/scikit-learn/scikit-learn/blob/4fe4d27eb1b88cc799199f2176ac734bbc16ca31/sklearn/cluster/_k_means_elkan.pyx#L233
https://github.com/scikit-learn/scikit-learn/blob/4fe4d27eb1b88cc799199f2176ac734bbc16ca31/sklearn/cluster/_k_means_elkan.pyx#L249-L250

it should be noted that in the second version, it would likely make sense to first use `squared_norm`, and then separate the square root, rather than taking the square of the rooted values below.
But in this PR I'm just pointing to a single character. One tests `<=` and the other tests `<`.
With `tol=0` this means that "full" may stop when the clusters stop moving, while with `elkan` it *never* stops then, but always takes all iterations.

I do not think this is the best stopping criterion. If a numerical issue arises in computing the center shifts, this may cause the algorithm to always take the maximum number of iterations. The classic termination criterion for k-means is different: **stop if no object is relabeled**. That is more reliable.