### PR TITLE
Improve Elkan's algorithm

### DIFF
--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -245,7 +245,7 @@ def k_means_elkan(np.ndarray[floating, ndim=2, mode='c'] X_,
                     % (iteration, np.sum((X_ - centers_[labels]) ** 2 *
                                          sample_weight[:,np.newaxis])))
         center_shift_total = np.sum(center_shift ** 2)
-        if center_shift_total < tol:
+        if center_shift_total <= tol:
             if verbose:
                 print("center shift %e within tolerance %e"
                       % (center_shift_total, tol))

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -431,7 +431,7 @@ def _kmeans_single_lloyd(X, sample_weight, n_clusters, max_iter=300,
                                               n_clusters, distances)
 
         if verbose:
-            print("Iteration %2d, inertia %.3f" % (i, inertia))
+            print("Iteration %2d, inertia %.3f" % (i + 1, inertia))
 
         if best_inertia is None or inertia < best_inertia:
             best_labels = labels.copy()
@@ -443,7 +443,7 @@ def _kmeans_single_lloyd(X, sample_weight, n_clusters, max_iter=300,
             if verbose:
                 print("Converged at iteration %d: "
                       "center shift %e within tolerance %e"
-                      % (i, center_shift_total, tol))
+                      % (i + 1, center_shift_total, tol))
             break
 
     if center_shift_total > 0:

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -57,7 +57,8 @@ def test_kmeans_results(representation, algo, dtype):
     expected_labels = [0, 0, 1, 1]
     expected_inertia = 0.1875
     expected_centers = np.array([[0.125, 0], [0.875, 1]], dtype=dtype)
-    expected_n_iter = 2
+    # Elkan now frequently takes 1 less iteration because of hard convergence
+    expected_n_iter = 2 if algo != "elkan" else 1
 
     kmeans = KMeans(n_clusters=2, n_init=1, init=init_centers, algorithm=algo)
     kmeans.fit(X, sample_weight=sample_weight)
@@ -91,7 +92,8 @@ def test_elkan_results(distribution, tol):
 
     # The number of iterations and inertia should be close but not
     # necessarily exactly the same because of rounding errors.
-    assert km_elkan.n_iter_ == pytest.approx(km_full.n_iter_, rel=0.01)
+    # Elkan now frequently takes 1 less iteration because of hard convergence
+    assert km_elkan.n_iter_ == pytest.approx(km_full.n_iter_, rel=1.01)
     assert km_elkan.inertia_ == pytest.approx(km_full.inertia_, rel=1e-6)
 
 


### PR DESCRIPTION
The current implementation of Elkan's algorithms had several issues that negatively affected performance. This fixes several of them:

* lower_bounds were not always initialized, when left at 0, this would require additional distance computations, making the algorithm less effective
* points were reassigned first, then the means updated; but they were already assigned in the first iteration. So the entire pass in the first iteration was wasted.
* If no more cluster assignments change, the algorithm can terminate. This required changing some of the unit tests because the "full" algorithm does one unnecessary additional iteration, and hence the test that both need the *same* number of iterations fail. Here, the "full" algorithm needs to be improved, then the unit tests can be adjusted for it, too.
* When not converged, another additional assignment step was executed at the end.
* `verbose=True` causes expensive computations of inertia. Now only a bound for inertia is reported which is much cheaper. 
* `bounds_tight` is reduced from an array of size N to a single boolean, so this saves O(N) memory, too.

I also fix the iteration number reported in verbose mode, to begin with 1.