### PR TITLE
Update docs to indicate shuffle=True still maintains sample order within each split

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -378,7 +378,7 @@ class KFold(_BaseKFold):
 
     shuffle : boolean, optional
         Whether to shuffle the data before splitting into batches.
-        Note that the sample order is maintained within each split.
+        Note that the samples within each split will not be shuffled.
 
     random_state : int, RandomState instance or None, optional, default=None
         If int, random_state is the seed used by the random number generator;
@@ -585,7 +585,7 @@ class StratifiedKFold(_BaseKFold):
 
     shuffle : boolean, optional
         Whether to shuffle each class's samples before splitting into batches.
-        Note that the sample order is maintained within each split.
+        Note that the samples within each split will not be shuffled.
 
     random_state : int, RandomState instance or None, optional, default=None
         If int, random_state is the seed used by the random number generator;

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -378,6 +378,7 @@ class KFold(_BaseKFold):
 
     shuffle : boolean, optional
         Whether to shuffle the data before splitting into batches.
+        Note that the sample order is maintained within each split.
 
     random_state : int, RandomState instance or None, optional, default=None
         If int, random_state is the seed used by the random number generator;
@@ -584,6 +585,7 @@ class StratifiedKFold(_BaseKFold):
 
     shuffle : boolean, optional
         Whether to shuffle each class's samples before splitting into batches.
+        Note that the sample order is maintained within each split.
 
     random_state : int, RandomState instance or None, optional, default=None
         If int, random_state is the seed used by the random number generator;


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #16068


#### What does this implement/fix? Explain your changes.
As suggested in #16068, updated the documentation to indicate shuffle=True still maintains sample order within each split

#### Any other comments?
