### PR TITLE
DOC Incorrectly-rendered entries in what's new

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -79,7 +79,7 @@ Changelog
 ...............................
 
 - |Enhancement| :func:`gaussian_process.kernels.Matern` returns the RBF kernel when ``nu=np.inf``.
-  :pr: `15503` by :user:`Sam Dixon` <sam-dixon>.
+  :pr:`15503` by :user:`Sam Dixon <sam-dixon>`.
   
 :mod:`sklearn.linear_model`
 ...........................
@@ -111,7 +111,7 @@ Changelog
 
 - |Fix| :func: `cross_val_predict` supports `method="predict_proba"`
   when `y=None`.
-  :pr: `15918` by :user: `Luca Kubin <lkubin>`.
+  :pr:`15918` by :user:`Luca Kubin <lkubin>`.
 
 :mod:`sklearn.preprocessing`
 ............................


### PR DESCRIPTION
This quick PR fixes spacing issues in the what's new file for version 0.23 which currently makes some entries render incorrectly:
![render1](https://user-images.githubusercontent.com/11860098/72153930-e90a0080-33b7-11ea-8694-72f9a87b6c56.png)
![render2](https://user-images.githubusercontent.com/11860098/72153931-e90a0080-33b7-11ea-8e6e-041ee1d524f1.png)
