### PR TITLE
MNT Uploads coverage in pylatest_pip_openblas_pandas CI

### DIFF
--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -40,7 +40,7 @@ jobs:
     - script: |
         build_tools/azure/test_pytest_soft_dependency.sh
       displayName: 'Test Soft Dependency'
-      condition: and(eq(variables['CHECK_PYTEST_SOFT_DEPENDENCY'], 'true'), eq(variables['DISTRIB'], 'conda'))
+      condition: eq(variables['CHECK_PYTEST_SOFT_DEPENDENCY'], 'true')
     - task: PublishTestResults@2
       inputs:
         testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
@@ -49,7 +49,7 @@ jobs:
       condition: succeededOrFailed()
     - script: |
         build_tools/azure/upload_codecov.sh
-      condition: and(succeeded(), eq(variables['COVERAGE'], 'true'), eq(variables['DISTRIB'], 'conda'))
+      condition: and(succeeded(), eq(variables['COVERAGE'], 'true'))
       displayName: 'Upload To Codecov'
       env:
         CODECOV_TOKEN: $(CODECOV_TOKEN)


### PR DESCRIPTION
Allows coverage information to be uploaded for `pylatest_pip_openblas_pandas`. (It has a `DISTRIB=conda-pip-latest` which will cause the coverage to not upload.