### PR TITLE
[MRG] DOC Updates kernel formulation to be consistent

### DIFF
--- a/doc/modules/density.rst
+++ b/doc/modules/density.rst
@@ -93,7 +93,7 @@ Given this kernel form, the density estimate at a point :math:`y` within
 a group of points :math:`x_i; i=1\cdots N` is given by:
 
 .. math::
-    \rho_K(y) = \sum_{i=1}^{N} K((y - x_i) / h)
+    \rho_K(y) = \sum_{i=1}^{N} K(y - x_i; h)
 
 The bandwidth here acts as a smoothing parameter, controlling the tradeoff
 between bias and variance in the result.  A large bandwidth leads to a very


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/13659
Closes https://github.com/scikit-learn/scikit-learn/pull/15457 (supersedes)

#### What does this implement/fix? Explain your changes.
The formula in https://scikit-learn.org/stable/modules/density.html#kernel-density-estimation includes the bandwidth parameter:

![Screen Shot 2020-01-10 at 3 36 49 PM](https://user-images.githubusercontent.com/5402633/72184710-0b534c80-33bf-11ea-8803-e844ed50f327.png)

The other way to fix this is to update rho to use the same `K(x;h)` notation:

![Untitled](https://user-images.githubusercontent.com/5402633/72210986-4756e200-3491-11ea-97c7-fc54deace9f6.png)

This way the kernel can still use `h` in its definition.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
