### PR TITLE
[DOC] Add missing backquote in LogisticRegression docstring

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1157,7 +1157,7 @@ class LogisticRegression(BaseEstimator, LinearClassifierMixin,
 
     l1_ratio : float, default=None
         The Elastic-Net mixing parameter, with ``0 <= l1_ratio <= 1``. Only
-        used if ``penalty='elasticnet'`. Setting ``l1_ratio=0`` is equivalent
+        used if ``penalty='elasticnet'``. Setting ``l1_ratio=0`` is equivalent
         to using ``penalty='l2'``, while setting ``l1_ratio=1`` is equivalent
         to using ``penalty='l1'``. For ``0 < l1_ratio <1``, the penalty is a
         combination of L1 and L2.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Just add a missing backquote in the description of the `l1_ratio` parameter in [LogisticRegression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn-linear-model-logisticregression).

<img width="801" alt="Capture d’écran 2020-01-13 à 09 52 20" src="https://user-images.githubusercontent.com/17053934/72242709-5ef5ae00-35ea-11ea-88a1-01a6ad97768c.png">
