### PR TITLE
MNT remove tag help wanted in doc issue template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -2,7 +2,7 @@
 name: Documentation improvement
 about: Create a report to help us improve the documentation. Alternatively you can just open a pull request with the suggested change.
 title: ''
-labels: Documentation, help wanted
+labels: Documentation
 assignees: ''
 
 ---


### PR DESCRIPTION
Change the template of documentation issues by removing the tag "help wanted" which was assigned by default.

This concern was raised by @jnothman: https://github.com/scikit-learn/scikit-learn/issues/16113#issuecomment-574041360 which is valid in practice.