### PR TITLE
[MRG] Fix documentation of the tol parameter of kmeans

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -236,7 +236,9 @@ def k_means(X, n_clusters, sample_weight=None, init='k-means++',
         Verbosity mode.
 
     tol : float, optional
-        The relative increment in the results before declaring convergence.
+        Relative tolerance with regards to Frobenius norm of the difference
+        in the cluster centers of two consecutive iterations to declare
+        convergence.
 
     random_state : int, RandomState instance, default=None
         Determines random number generation for centroid initialization. Use

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -681,7 +681,9 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         single run.
 
     tol : float, default=1e-4
-        Relative tolerance with regards to inertia to declare convergence.
+        Relative tolerance with regards to Frobenius norm of the difference
+        in the cluster centers of two consecutive iterations to declare
+        convergence.
 
     precompute_distances : 'auto' or bool, default='auto'
         Precompute distances (faster but takes more memory).


### PR DESCRIPTION

#### Reference Issues/PRs
Fixes #16058 

#### What does this implement/fix? Explain your changes.
Fix documentation of the `tol` parameter. Tolerance in KMeans is with respect to the norm of the difference of centres.


#### Any other comments?
