### PR TITLE
MNT Get rid of temporary variables used only to compute field offsets

### DIFF
--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -181,13 +181,9 @@ cdef struct NodeHeapData_t:
 
 # build the corresponding numpy dtype for NodeHeapData
 # There is no offsetof() function in cython, so we hack it.
-# If we can ensure numpy 1.5 or greater, a cleaner way is to do
-#     cdef NodeHeapData_t nhd_tmp
-#     NodeHeapData = np.asarray(<NodeHeapData_t[:1]>(&nhd_tmp)).dtype
-cdef NodeHeapData_t nhd_tmp
-offsets = [<np.intp_t>&(nhd_tmp.val) - <np.intp_t>&nhd_tmp,
-           <np.intp_t>&(nhd_tmp.i1) - <np.intp_t>&nhd_tmp,
-           <np.intp_t>&(nhd_tmp.i2) - <np.intp_t>&nhd_tmp]
+offsets = [<np.intp_t>&((<NodeHeapData_t*>0).val),
+           <np.intp_t>&((<NodeHeapData_t*>0).i1),
+           <np.intp_t>&((<NodeHeapData_t*>0).i2)]
 NodeHeapData = np.dtype({'names': ['val', 'i1', 'i2'],
                          'formats': [DTYPE, ITYPE, ITYPE],
                          'offsets': offsets,
@@ -201,14 +197,10 @@ cdef struct NodeData_t:
 
 # build the corresponding numpy dtype for NodeData
 # There is no offsetof() function in cython, so we hack it.
-# If we can ensure numpy 1.5 or greater, a cleaner way is to do
-#     cdef NodeData_t nd_tmp
-#     NodeData = np.asarray(<NodeData_t[:1]>(&nd_tmp)).dtype
-cdef NodeData_t nd_tmp
-offsets = [<np.intp_t>&(nd_tmp.idx_start) - <np.intp_t>&nd_tmp,
-           <np.intp_t>&(nd_tmp.idx_end) - <np.intp_t>&nd_tmp,
-           <np.intp_t>&(nd_tmp.is_leaf) - <np.intp_t>&nd_tmp,
-           <np.intp_t>&(nd_tmp.radius) - <np.intp_t>&nd_tmp]
+offsets = [<np.intp_t>&((<NodeData_t*>0).idx_start),
+           <np.intp_t>&((<NodeData_t*>0).idx_end),
+           <np.intp_t>&((<NodeData_t*>0).is_leaf),
+           <np.intp_t>&((<NodeData_t*>0).radius)]
 NodeData = np.dtype({'names': ['idx_start', 'idx_end', 'is_leaf', 'radius'],
                      'formats': [ITYPE, ITYPE, ITYPE, DTYPE],
                      'offsets': offsets,


### PR DESCRIPTION
According to the section titled "Constant expressions" in the C language
standard, the computation of an offset from a null pointer is guaranteed
to not actually dereference the null pointer.

See also https://mail.python.org/pipermail/cython-devel/2013-April/003505.html