### PR TITLE
Confusion_matrix_plot fix of values_format

### DIFF
--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -89,7 +89,7 @@ class ConfusionMatrixDisplay:
         if include_values:
             self.text_ = np.empty_like(cm, dtype=object)
             if values_format is None:
-                values_format = lambda x: 'd' if (x <= 0 or log10(x) < 7) else '.2g'
+                values_format = lambda x: 'd' if (x == 0 or log10(x) < 7) else '.2g'
 
             # print text with appropriate color depending on background
             thresh = (cm.max() + cm.min()) / 2.0

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -89,7 +89,7 @@ class ConfusionMatrixDisplay:
         if include_values:
             self.text_ = np.empty_like(cm, dtype=object)
             if values_format is None:
-                values_format = lambda x: 'd' if (x == 0 or log10(x) < 7) else '.2g'
+                values_format = lambda x: 'd' if (x <= 0 or log10(x) < 7) else '.2g'
 
             # print text with appropriate color depending on background
             thresh = (cm.max() + cm.min()) / 2.0

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -61,7 +61,7 @@ class ConfusionMatrixDisplay:
 
         values_format : str, default=None
             Format specification for values in confusion matrix. If `None`,
-            the format specification is '.2g'.
+            the format specification is 'd' if < 1e7, '.2g' otherwise.
 
         ax : matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is
@@ -89,14 +89,14 @@ class ConfusionMatrixDisplay:
         if include_values:
             self.text_ = np.empty_like(cm, dtype=object)
             if values_format is None:
-                values_format = '.2g'
+                values_format = lambda x: '.2g' if (log10(x) > 7) else 'd'
 
             # print text with appropriate color depending on background
             thresh = (cm.max() + cm.min()) / 2.0
             for i, j in product(range(n_classes), range(n_classes)):
                 color = cmap_max if cm[i, j] < thresh else cmap_min
                 self.text_[i, j] = ax.text(j, i,
-                                           format(cm[i, j], values_format),
+                                           format(cm[i, j], values_format(cm[i, j])),
                                            ha="center", va="center",
                                            color=color)
 
@@ -164,7 +164,7 @@ def plot_confusion_matrix(estimator, X, y_true, labels=None,
 
     values_format : str, default=None
         Format specification for values in confusion matrix. If `None`,
-        the format specification is '.2g'.
+        the format specification is 'd' if < 1e7, '.2g' otherwise.
 
     cmap : str or matplotlib Colormap, default='viridis'
         Colormap recognized by matplotlib.

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -73,6 +73,7 @@ class ConfusionMatrixDisplay:
         """
         check_matplotlib_support("ConfusionMatrixDisplay.plot")
         import matplotlib.pyplot as plt
+        from math import log10
 
         if ax is None:
             fig, ax = plt.subplots()
@@ -94,7 +95,9 @@ class ConfusionMatrixDisplay:
             for i, j in product(range(n_classes), range(n_classes)):
                 color = cmap_max if cm[i, j] < thresh else cmap_min
                 if values_format is None:
-                    values_format = 'd' if (cm[i, j] <= 1e7) else '.2g'
+                    values_format = 'd' if (
+                        cm[i, j] == 0 or log10(cm[i, j]) < 7
+                        ) else '.2g'
                 self.text_[i, j] = ax.text(
                     j, i, format(cm[i, j], values_format),
                     ha="center", va="center",

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -84,6 +84,8 @@ class ConfusionMatrixDisplay:
         n_classes = cm.shape[0]
         self.im_ = ax.imshow(cm, interpolation='nearest', cmap=cmap)
         self.text_ = None
+        if (values_format is None and cm.dtype.kind == "f"):
+            values_format = '.2g'
 
         cmap_min, cmap_max = self.im_.cmap(0), self.im_.cmap(256)
 

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -61,7 +61,7 @@ class ConfusionMatrixDisplay:
 
         values_format : str, default=None
             Format specification for values in confusion matrix. If `None`,
-            the format specification is 'd' if < 1e7, '.2g' otherwise.
+            the format specification is 'd' or '.2g', whichever is shorter. 
 
         ax : matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is
@@ -89,7 +89,7 @@ class ConfusionMatrixDisplay:
         if include_values:
             self.text_ = np.empty_like(cm, dtype=object)
             if values_format is None:
-                values_format = lambda x: '.2g' if (log10(x) > 7) else 'd'
+                values_format = lambda x: 'd' if (x == 0 or log10(x) < 7) else '.2g'
 
             # print text with appropriate color depending on background
             thresh = (cm.max() + cm.min()) / 2.0
@@ -164,7 +164,7 @@ def plot_confusion_matrix(estimator, X, y_true, labels=None,
 
     values_format : str, default=None
         Format specification for values in confusion matrix. If `None`,
-        the format specification is 'd' if < 1e7, '.2g' otherwise.
+        the format specification is 'd' or '.2g', whichever is shorter. 
 
     cmap : str or matplotlib Colormap, default='viridis'
         Colormap recognized by matplotlib.

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -61,7 +61,7 @@ class ConfusionMatrixDisplay:
 
         values_format : str, default=None
             Format specification for values in confusion matrix. If `None`,
-            the format specification is 'd' or '.2g', whichever is shorter. 
+            the format specification is 'd' or '.2g' whichever is shorter.
 
         ax : matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is
@@ -73,7 +73,6 @@ class ConfusionMatrixDisplay:
         """
         check_matplotlib_support("ConfusionMatrixDisplay.plot")
         import matplotlib.pyplot as plt
-        from math import log10
 
         if ax is None:
             fig, ax = plt.subplots()
@@ -89,17 +88,17 @@ class ConfusionMatrixDisplay:
 
         if include_values:
             self.text_ = np.empty_like(cm, dtype=object)
-            if values_format is None:
-                values_format = lambda x: 'd' if (x == 0 or log10(x) < 7) else '.2g'
 
             # print text with appropriate color depending on background
             thresh = (cm.max() + cm.min()) / 2.0
             for i, j in product(range(n_classes), range(n_classes)):
                 color = cmap_max if cm[i, j] < thresh else cmap_min
-                self.text_[i, j] = ax.text(j, i,
-                                           format(cm[i, j], values_format(cm[i, j])),
-                                           ha="center", va="center",
-                                           color=color)
+                if values_format is None:
+                    values_format = 'd' if (cm[i, j] <= 1e7) else '.2g'
+                self.text_[i, j] = ax.text(
+                    j, i, format(cm[i, j], values_format),
+                    ha="center", va="center",
+                    color=color)
 
         fig.colorbar(self.im_, ax=ax)
         ax.set(xticks=np.arange(n_classes),
@@ -165,7 +164,7 @@ def plot_confusion_matrix(estimator, X, y_true, labels=None,
 
     values_format : str, default=None
         Format specification for values in confusion matrix. If `None`,
-        the format specification is 'd' or '.2g', whichever is shorter. 
+        the format specification is 'd' or '.2g' whichever is shorter.
 
     cmap : str or matplotlib Colormap, default='viridis'
         Colormap recognized by matplotlib.

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -73,6 +73,7 @@ class ConfusionMatrixDisplay:
         """
         check_matplotlib_support("ConfusionMatrixDisplay.plot")
         import matplotlib.pyplot as plt
+        from math import log10
 
         if ax is None:
             fig, ax = plt.subplots()


### PR DESCRIPTION
Changes to the values_format for plotting the confusion_matrix. This fix will now show values up to 1e7 in integer values, and afterwards
in .2g"

#### What does this implement/fix? Explain your changes.
Fix to change the format of the values in the confusion_matrix_plot as specified:
https://github.com/scikit-learn/scikit-learn/issues/16127