### PR TITLE
Fix typos in doc/developers/develop.rst

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -74,7 +74,7 @@ multiple interfaces):
 Estimators
 ----------
 
-The API has one predominant object: the estimator. A estimator is an
+The API has one predominant object: the estimator. An estimator is an
 object that fits a model based on some training data and is capable of
 inferring some properties on new data. It can be, for instance, a
 classifier or a regressor. All estimators implement the fit method::
@@ -220,7 +220,7 @@ an integer called ``n_iter``.
 Pairwise Attributes
 ^^^^^^^^^^^^^^^^^^^
 
-An estimator that accept ``X`` of shape ``(n_samples, n_samples)`` and defines
+An estimator that accepts ``X`` of shape ``(n_samples, n_samples)`` and defines
 a :term:`_pairwise` property equal to ``True`` allows for cross-validation of
 the dataset, e.g. when ``X`` is a precomputed kernel matrix. Specifically,
 the :term:`_pairwise` property is used by ``utils.metaestimators._safe_split``

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -35,11 +35,11 @@ multiple interfaces):
 
     The base object, implements a ``fit`` method to learn from data, either::
 
-      estimator = estimator.fit(data, targets)
+      estimation = estimator.fit(data, targets)
 
     or::
 
-      estimator = estimator.fit(data)
+      estimation = estimator.fit(data)
 
 :Predictor:
 

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -35,11 +35,11 @@ multiple interfaces):
 
     The base object, implements a ``fit`` method to learn from data, either::
 
-      estimation = estimator.fit(data, targets)
+      estimator = estimator.fit(data, targets)
 
     or::
 
-      estimation = estimator.fit(data)
+      estimator = estimator.fit(data)
 
 :Predictor:
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Changes the variable name for result of `estimator.fit(data,targets)` from `estimator` to `estimation` for consistency with the `predictor` object. Other grammatical errors fixed as well.

#### Any other comments?

No
