### PR TITLE
DOC adding CoC to the repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,16 @@
+# Code of Conduct
+
+We are a community based on openness and friendly, didactic, discussions.
+
+We aspire to treat everybody equally, and value their contributions.
+
+Decisions are made based on technical merit and consensus.
+
+Code is not the only way to help the project. Reviewing pull requests,
+answering questions to help others on mailing lists or issues, organizing and
+teaching tutorials, working on the website, improving the documentation, are
+all priceless contributions.
+
+We abide by the principles of openness, respect, and consideration of others of
+the Python Software Foundation: https://www.python.org/psf/codeofconduct/
+


### PR DESCRIPTION
This Fixes #16139. Adding what we have already under our contribution guide, as a separate file, which github expects and understands.

Note that I haven't copy/pasted the whole CoC, since it may change, and cpython itself doesn't have a copy under their repo.

CC @scikit-learn/core-devs 