### PR TITLE
Patch for floating point overrun in IncrementalPCA partial_fit

### DIFF
--- a/sklearn/decomposition/_incremental_pca.py
+++ b/sklearn/decomposition/_incremental_pca.py
@@ -270,7 +270,7 @@ class IncrementalPCA(_BasePCA):
             self.mean_ = .0
             self.var_ = .0
 
-        # Update stats - they are 0 if this is the first step
+        # Update stats - they are 0 if this is the fisrt step
         col_mean, col_var, n_total_samples = \
             _incremental_mean_and_var(
                 X, last_mean=self.mean_, last_variance=self.var_,
@@ -286,8 +286,8 @@ class IncrementalPCA(_BasePCA):
             X -= col_batch_mean
             # Build matrix of combined previous basis and new data
             mean_correction = \
-                np.sqrt((self.n_samples_seen_ * n_samples) /
-                        n_total_samples) * (self.mean_ - col_batch_mean)
+                np.sqrt((float(self.n_samples_seen_) * float(n_samples)) /
+                        float(n_total_samples)) * (self.mean_ - col_batch_mean)
             X = np.vstack((self.singular_values_.reshape((-1, 1)) *
                            self.components_, X, mean_correction))
 

--- a/sklearn/tests/test_ipca14851.py
+++ b/sklearn/tests/test_ipca14851.py
@@ -1,0 +1,25 @@
+
+import pandas as pd
+import numpy as np
+
+from sklearn.decomposition import IncrementalPCA
+
+
+def test_ipca14851():
+    #  PCA object
+    ipca = IncrementalPCA(n_components=16)
+
+    #  dummy data - row counts are from the run in the bug report
+    df1 = pd.DataFrame(np.random.rand(56320, 16))
+    df2 = pd.DataFrame(np.random.rand(58368, 16))
+
+    #  Fit the batch (original code had a text column)
+    X = df1.iloc[:, :].values
+    ipca.partial_fit(X)
+    assert ipca.n_samples_seen_ == 56320
+
+    X = df2.iloc[:, :].values
+    ipca.partial_fit(X)
+    assert ipca.n_samples_seen_ == 56320 + 58368
+
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs  Fixes #14851
<!--
Example: Fixes #14851 . See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Whitening transform in partial_fit() has integer overrun in calculation that causes NaN to be injected into the data.  See detail in the Issue.

#### Any other comments?  Patch as requested.  Also included is a small test case.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
