### PR TITLE
BUG splitting out clone error message

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -62,7 +62,8 @@ def clone(estimator, safe=True):
             return copy.deepcopy(estimator)
         else:
             if isinstance(estimator, type):
-                raise TypeError("You should provide an instance of " +
+                raise TypeError("Cannot clone object " +
+                                "You should provide an instance of " +
                                 "scikit-learn estimator instead of a class.")
             else:
                 raise TypeError("Cannot clone object '%s' (type %s): "

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -65,11 +65,12 @@ def clone(estimator, safe=True):
                 raise TypeError("You should provide an instance of " +
                                 "scikit-learn estimator instead of a class.")
             else:
-                raise  TypeError("Cannot clone object '%s' (type %s): "
-                            "it does not seem to be a scikit-learn estimator "
-                            "as it does not implement a 'get_params' methods."
-                            % (repr(estimator), type(estimator)))
-                            
+                raise TypeError("Cannot clone object '%s' (type %s): "
+                                "it does not seem to be a scikit-learn "
+                                "estimator as it does not implement a "
+                                "'get_params' method."
+                                % (repr(estimator), type(estimator)))
+
     klass = estimator.__class__
     new_object_params = estimator.get_params(deep=False)
     for name, param in new_object_params.items():

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -65,10 +65,11 @@ def clone(estimator, safe=True):
                 raise TypeError("You should provide an instance of " +
                                 "scikit-learn estimator instead of a class.")
             else:
-                raise TypeError("Cannot clone object '%s': "
-                                "it is a class rather than an instance."
-                                % (repr(estimator)))
-
+                raise  TypeError("Cannot clone object '%s' (type %s): "
+                            "it does not seem to be a scikit-learn estimator "
+                            "as it does not implement a 'get_params' methods."
+                            % (repr(estimator), type(estimator)))
+                            
     klass = estimator.__class__
     new_object_params = estimator.get_params(deep=False)
     for name, param in new_object_params.items():

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -57,7 +57,7 @@ def clone(estimator, safe=True):
     # XXX: not handling dictionaries
     if estimator_type in (list, tuple, set, frozenset):
         return estimator_type([clone(e, safe=safe) for e in estimator])
-    elif not hasattr(estimator, 'get_params') or isinstance(estimator, type):
+    elif not hasattr(estimator, 'get_params'):
         if not safe:
             return copy.deepcopy(estimator)
         else:
@@ -65,6 +65,14 @@ def clone(estimator, safe=True):
                             "it does not seem to be a scikit-learn estimator "
                             "as it does not implement a 'get_params' methods."
                             % (repr(estimator), type(estimator)))
+    elif isinstance(estimator, type):
+        if not safe:
+            return copy.deepcopy(estimator)
+        else:
+            raise TypeError("Cannot clone object '%s' "
+                            "it is a class rather than instance of a class "
+                            % (repr(estimator)))
+
     klass = estimator.__class__
     new_object_params = estimator.get_params(deep=False)
     for name, param in new_object_params.items():

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -69,7 +69,7 @@ def clone(estimator, safe=True):
         if not safe:
             return copy.deepcopy(estimator)
         else:
-            raise TypeError("Cannot clone object '%s' "
+            raise TypeError("Cannot clone object '%s': "
                             "it is a class rather than instance of a class "
                             % (repr(estimator)))
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -62,7 +62,7 @@ def clone(estimator, safe=True):
             return copy.deepcopy(estimator)
         else:
             if isinstance(estimator, type):
-                raise TypeError("Cannot clone object " +
+                raise TypeError("Cannot clone object. " +
                                 "You should provide an instance of " +
                                 "scikit-learn estimator instead of a class.")
             else:

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -61,7 +61,7 @@ def clone(estimator, safe=True):
         if not safe:
             return copy.deepcopy(estimator)
         else:
-            if issubclass(estimator, BaseEstimator):
+            if isinstance(estimator, type):
                 raise TypeError("You should provide an instance of " +
                                 "scikit-learn estimator instead of a class.")
             else:

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -70,7 +70,7 @@ def clone(estimator, safe=True):
             return copy.deepcopy(estimator)
         else:
             raise TypeError("Cannot clone object '%s': "
-                            "it is a class rather than instance of a class "
+                            "it is a class rather than an instance."
                             % (repr(estimator)))
 
     klass = estimator.__class__

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -62,7 +62,8 @@ def clone(estimator, safe=True):
             return copy.deepcopy(estimator)
         else:
             if issubclass(estimator, BaseEstimator):
-                raise TypeError("You should provide an instance of scikit-learn estimator instead of a class.")
+                raise TypeError("You should provide an instance of " +
+                                "scikit-learn estimator instead of a class.")
             else:
                 raise TypeError("Cannot clone object '%s': "
                                 "it is a class rather than an instance."

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -57,21 +57,16 @@ def clone(estimator, safe=True):
     # XXX: not handling dictionaries
     if estimator_type in (list, tuple, set, frozenset):
         return estimator_type([clone(e, safe=safe) for e in estimator])
-    elif not hasattr(estimator, 'get_params'):
+    elif not hasattr(estimator, 'get_params') or isinstance(estimator, type):
         if not safe:
             return copy.deepcopy(estimator)
         else:
-            raise TypeError("Cannot clone object '%s' (type %s): "
-                            "it does not seem to be a scikit-learn estimator "
-                            "as it does not implement a 'get_params' methods."
-                            % (repr(estimator), type(estimator)))
-    elif isinstance(estimator, type):
-        if not safe:
-            return copy.deepcopy(estimator)
-        else:
-            raise TypeError("Cannot clone object '%s': "
-                            "it is a class rather than an instance."
-                            % (repr(estimator)))
+            if issubclass(estimator, BaseEstimator):
+                raise TypeError("You should provide an instance of scikit-learn estimator instead of a class.")
+            else:
+                raise TypeError("Cannot clone object '%s': "
+                                "it is a class rather than an instance."
+                                % (repr(estimator)))
 
     klass = estimator.__class__
     new_object_params = estimator.get_params(deep=False)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -198,7 +198,8 @@ def test_clone_estimator_types():
 def test_clone_class_rather_than_instance():
     # Check that clone raises expected error message when cloning class rather than instance
     clf_class = MyEstimator
-    with pytest.raises(TypeError): 
+    msg = "You should provide an instance of scikit-learn estimator instead of a class."
+    with pytest.raises(TypeError, match=msg): 
         clone(clf_class)
 
 def test_repr():

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -199,10 +199,9 @@ def test_clone_estimator_types():
 def test_clone_class_rather_than_instance():
     # Check that clone raises expected error message when
     # cloning class rather than instance
-    clf_class = MyEstimator
     msg = "You should provide an instance of scikit-learn estimator"
     with pytest.raises(TypeError, match=msg):
-        clone(clf_class)
+        clone(MyEstimator)
 
 
 def test_repr():

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -195,6 +195,11 @@ def test_clone_estimator_types():
 
     assert clf.empty is clf2.empty
 
+def test_clone_class_rather_than_instance():
+    # Check that clone raises expected error message when cloning class rather than instance
+    clf_class = MyEstimator
+    with pytest.raises(TypeError): 
+        clone(clf_class)
 
 def test_repr():
     # Smoke test the repr of the base estimator.

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -195,12 +195,15 @@ def test_clone_estimator_types():
 
     assert clf.empty is clf2.empty
 
+
 def test_clone_class_rather_than_instance():
-    # Check that clone raises expected error message when cloning class rather than instance
+    # Check that clone raises expected error message when
+    # cloning class rather than instance
     clf_class = MyEstimator
-    msg = "You should provide an instance of scikit-learn estimator instead of a class."
-    with pytest.raises(TypeError, match=msg): 
+    msg = "You should provide an instance of scikit-learn estimator"
+    with pytest.raises(TypeError, match=msg):
         clone(clf_class)
+
 
 def test_repr():
     # Smoke test the repr of the base estimator.

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -336,7 +336,7 @@ def test_check_estimator():
     # not a complete test of all checks, which are very extensive.
 
     # check that we have a set_params and can clone
-    msg = "it does not implement a 'get_params' methods"
+    msg = "it does not implement a 'get_params' method"
     assert_raises_regex(TypeError, msg, check_estimator, object)
     assert_raises_regex(TypeError, msg, check_estimator, object())
     # check that values returned by get_params match set_params


### PR DESCRIPTION

#### Reference Issue 
Example: Fixes #16170 - sklearn.base.clone - incorrect/unclear error about 'get_params'

#### What does this implement/fix? Explain your changes.

This makes the error message when passing a class, rather than instance of a class, into sklearn.base.clone more clear. Current message states that get_params is not implemented, rather than the true source of the issue. 