### PR TITLE
CI: Action to auto assign issues

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,15 @@
+
+name: Assign
+on:
+  issue_comment:
+    types: created
+
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    steps:
+    - if: github.event.comment.body == 'take'
+      name:
+      run: |
+        echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -13,3 +13,4 @@ jobs:
       run: |
         echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
         curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/help%20wanted

--- a/.github/workflows/unassign.yml
+++ b/.github/workflows/unassign.yml
@@ -1,0 +1,14 @@
+name: Unassign
+#Runs when a contributor has unassigned themselves from the issue and adds 'help wanted' and 'stalled' tags
+on:
+  issues:
+    types: unassigned
+
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    steps:
+      name:
+      run: |
+        echo "Marking issue ${{ github.event.issue.number }} as stalled"
+        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["help wanted","Stalled"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels

--- a/.github/workflows/unassign.yml
+++ b/.github/workflows/unassign.yml
@@ -8,7 +8,7 @@ jobs:
   one:
     runs-on: ubuntu-latest
     steps:
-      name:
-      run: |
-        echo "Marking issue ${{ github.event.issue.number }} as stalled"
-        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["help wanted","Stalled"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels
+      - name:
+        run: |
+          echo "Marking issue ${{ github.event.issue.number }} as stalled"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["help wanted","Stalled"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -181,7 +181,12 @@ Contributing code
   If in doubt about duplicated work, or if you want to work on a non-trivial
   feature, it's recommended to first open an issue in
   the `issue tracker <https://github.com/scikit-learn/scikit-learn/issues>`_
-  to get some feedbacks from core developers.
+  to get some feedbacks from core developers. 
+  
+  One easy way to find an issue to work on is by applying the "help wanted" 
+  label in your search. This lists all the issues that have been unclaimed 
+  so far. In order to claim an issue for yourself, please comment exactly 
+  ``take`` on it for the CI to automatically assign the issue to you.  
 
 How to contribute
 -----------------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
ref #13188 
cc @thomasjpfan 


#### What does this implement/fix? Explain your changes.
Adds a Github action that auto-assigns a person and removes the help-wanted label. 
Needs documentation. The next step after this would be perhaps to add an action to mark issues as stalled.
Inspired by the pandas github action that does this.

#### Any other comments?
![image](https://user-images.githubusercontent.com/47963215/73115077-6fedcb80-3ed6-11ea-81fb-8d9c67abed87.png)

