### PR TITLE
Make random_state descriptions more informative and refer to Glossary for ensemble/_hist_gradient_boosting/binning towards  #10548

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/binning.py
@@ -34,9 +34,10 @@ def _find_binning_thresholds(data, max_bins, subsample, random_state):
         If ``n_samples > subsample``, then ``sub_samples`` samples will be
         randomly chosen to compute the quantiles. If ``None``, the whole data
         is used.
-    random_state: int, RandomState instance or None (default)
-        Determines random number generation for random sub-sampling.
-        Use an int to make randomness deterministic.
+    random_state: int, RandomState instance or None
+        Pseudo-random number generator to control the random sub-sampling.
+        Pass an int for reproducible output across multiple
+        function calls.
         See :term: `Glossary <random_state>`.
 
     Return
@@ -110,9 +111,10 @@ class _BinMapper(TransformerMixin, BaseEstimator):
         If ``n_samples > subsample``, then ``sub_samples`` samples will be
         randomly chosen to compute the quantiles. If ``None``, the whole data
         is used.
-    random_state: int, RandomState instance or None (default)
-        Determines random number generation for random sub-sampling.
-        Use an int to make randomness deterministic.
+    random_state: int, RandomState instance or None
+        Pseudo-random number generator to control the random sub-sampling.
+        Pass an int for reproducible output across multiple
+        function calls.
         See :term: `Glossary <random_state>`.
 
     Attributes

--- a/sklearn/ensemble/_hist_gradient_boosting/binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/binning.py
@@ -34,9 +34,10 @@ def _find_binning_thresholds(data, max_bins, subsample, random_state):
         If ``n_samples > subsample``, then ``sub_samples`` samples will be
         randomly chosen to compute the quantiles. If ``None``, the whole data
         is used.
-    random_state: int or numpy.random.RandomState or None
-        Pseudo-random number generator to control the random sub-sampling.
-        See :term:`random_state`.
+    random_state: int, RandomState instance or None (default)
+        Determines random number generation for random sub-sampling.
+        Use an int to make randomness deterministic.
+        See :term: `Glossary <random_state>`.
 
     Return
     ------
@@ -109,11 +110,11 @@ class _BinMapper(TransformerMixin, BaseEstimator):
         If ``n_samples > subsample``, then ``sub_samples`` samples will be
         randomly chosen to compute the quantiles. If ``None``, the whole data
         is used.
-    random_state: int or numpy.random.RandomState or None, \
-        optional (default=None)
-        Pseudo-random number generator to control the random sub-sampling.
-        See :term:`random_state`.
-
+    random_state: int, RandomState instance or None (default)
+        Determines random number generation for random sub-sampling.
+        Use an int to make randomness deterministic.
+        See :term: `Glossary <random_state>`.
+    
     Attributes
     ----------
     bin_thresholds_ : list of arrays

--- a/sklearn/ensemble/_hist_gradient_boosting/binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/binning.py
@@ -114,7 +114,7 @@ class _BinMapper(TransformerMixin, BaseEstimator):
         Determines random number generation for random sub-sampling.
         Use an int to make randomness deterministic.
         See :term: `Glossary <random_state>`.
-    
+
     Attributes
     ----------
     bin_thresholds_ : list of arrays


### PR DESCRIPTION
Reference Issue/PR:
#10548 

We (@mojc and me) updated the documentation for random_state in 'sklearn/ensemble/_hist_gradient_boosting/binning'. It now refers to the glossary. 

Partial fix for issue #10548.

@noatamir
@adrinjalali 
@WiMLDS
