### PR TITLE
[MRG] fixing doc for random-state of _unsupervised.py

### DIFF
--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -77,12 +77,10 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
         on a random subset of the data.
         If ``sample_size is None``, no sampling is used.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        The generator used to randomly select a subset of samples.  If int,
-        random_state is the seed used by the random number generator; If
-        RandomState instance, random_state is the random number generator; If
-        None, the random number generator is the RandomState instance used by
-        `np.random`. Used when ``sample_size is not None``.
+    random_state : int, RandomState instance, default=None
+        Determines random subset of of samples.
+        Use an int to use the randomness deterministic.
+        See :term: `Glossary <random_state>`
 
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the distance function.


### PR DESCRIPTION
Reference Issue/PR:
scikit-learn partial fix #10548

updated the documentation for random_state in ´´´metrics/cluster/_unsupervised.py´´´  It now refers to the glossary.


@noatamir
@adrinjalali
@WiMLDS