### PR TITLE
DOC improve random state docsting in permutation_importance

### DIFF
--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -79,8 +79,7 @@ def permutation_importance(estimator, X, y, scoring=None, n_repeats=5,
         for more details.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation to control the permutations
-        of each feature.
+        Pseudo-random number generator to control the permutations of each feature.
         See :term: `Glossary <random_state>`.
 
     Returns

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -79,7 +79,8 @@ def permutation_importance(estimator, X, y, scoring=None, n_repeats=5,
         for more details.
 
     random_state : int, RandomState instance or None (default)
-        Pseudo-random number generator to control the permutations of each feature. 
+        Pseudo-random number generator to control the permutations of each 
+        feature.
         Pass an int to get reproducible results across function calls.
         See :term: `Glossary <random_state>`.
 

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -78,9 +78,10 @@ def permutation_importance(estimator, X, y, scoring=None, n_repeats=5,
         `-1` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    random_state : int, RandomState instance, or None, default=None
-        Pseudo-random number generator to control the permutations of each
-        feature. See :term:`random_state`.
+    random_state : int, RandomState instance or None (default)
+        Determines random number generation to control the permutations 
+        of each feature.
+        See :term: `Glossary <random_state>`. 
 
     Returns
     -------

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -79,7 +79,8 @@ def permutation_importance(estimator, X, y, scoring=None, n_repeats=5,
         for more details.
 
     random_state : int, RandomState instance or None (default)
-        Pseudo-random number generator to control the permutations of each feature.
+        Pseudo-random number generator to control the permutations of each
+        feature.
         See :term: `Glossary <random_state>`.
 
     Returns

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -79,9 +79,9 @@ def permutation_importance(estimator, X, y, scoring=None, n_repeats=5,
         for more details.
 
     random_state : int, RandomState instance or None (default)
-        Determines random number generation to control the permutations 
+        Determines random number generation to control the permutations
         of each feature.
-        See :term: `Glossary <random_state>`. 
+        See :term: `Glossary <random_state>`.
 
     Returns
     -------

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -78,7 +78,7 @@ def permutation_importance(estimator, X, y, scoring=None, n_repeats=5,
         `-1` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance, default=None
         Pseudo-random number generator to control the permutations of each
         feature.
         Pass an int to get reproducible results across function calls.

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -79,8 +79,8 @@ def permutation_importance(estimator, X, y, scoring=None, n_repeats=5,
         for more details.
 
     random_state : int, RandomState instance or None (default)
-        Pseudo-random number generator to control the permutations of each
-        feature.
+        Pseudo-random number generator to control the permutations of each feature. 
+        Pass an int to get reproducible results across function calls.
         See :term: `Glossary <random_state>`.
 
     Returns

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -79,7 +79,7 @@ def permutation_importance(estimator, X, y, scoring=None, n_repeats=5,
         for more details.
 
     random_state : int, RandomState instance or None (default)
-        Pseudo-random number generator to control the permutations of each 
+        Pseudo-random number generator to control the permutations of each
         feature.
         Pass an int to get reproducible results across function calls.
         See :term: `Glossary <random_state>`.


### PR DESCRIPTION
Reference Issue/PR:
#10548

We (@Malesche and me) updated the documentation for random_state in 'sklearn/inspection/_permutation_importance.py'. It now refers to the glossary.

Partial fix for issue #10548.

@noatamir
@adrinjalali
@WiMLDS