### PR TITLE
[MRG] fixin random state doc in docstring in some files 

### DIFF
--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -56,11 +56,10 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
              Dummy Classifier now supports prior fitting strategy using
              parameter *prior*.
 
-    random_state : int, RandomState instance or None, optional, default=None
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance, default=None
+        Determines random choice of seed.
+        Use an int to use the randomness deterministic.
+        See :term:`Glossary <random_state>`.
 
     constant : int or str or array-like of shape (n_outputs,)
         The explicit constant as predicted by the "constant" strategy. This

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -38,11 +38,10 @@ class RBFSampler(TransformerMixin, BaseEstimator):
         Number of Monte Carlo samples per original feature.
         Equals the dimensionality of the computed feature space.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance, default=None
+        Determines random generator of number.
+        Pass an int for making it determenistic.
+        See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -140,11 +139,10 @@ class SkewedChi2Sampler(TransformerMixin, BaseEstimator):
         number of Monte Carlo samples per original feature.
         Equals the dimensionality of the computed feature space.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance, default=None
+        Determines random generator of number.
+        Pass an int for making it determenistic.
+        See :term:`Glossary <random_state>`.
 
     Examples
     --------
@@ -467,11 +465,10 @@ class Nystroem(TransformerMixin, BaseEstimator):
         Number of features to construct.
         How many data points will be used to construct the mapping.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+    random_state : int, RandomState instance, default=None
+        Determines random generator of number.
+        Pass an int for making it determenistic.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -684,11 +684,10 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         one-vs-the-rest. A number greater than 1 will require more classifiers
         than one-vs-the-rest.
 
-    random_state : int, RandomState instance or None, optional, default: None
-        The generator used to initialize the codebook.  If int, random_state is
-        the seed used by the random number generator; If RandomState instance,
-        random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`.
+    random_state : int, RandomState instance, default=None
+        Determines random choice for initializing the codebook.
+        Use an int to use the randomness deterministic.
+        See :term:`Glossary <random_state>`.
 
     n_jobs : int or None, optional (default=None)
         The number of jobs to use for the computation.

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -546,13 +546,10 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
-
-        The random number generator is used to generate random chain orders.
+    random_state : int, RandomState instance, default=None
+        Determines random generator for chain orders.
+        Pass an int for being more deterministic.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------
@@ -706,13 +703,10 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
-
-        The random number generator is used to generate random chain orders.
+    random_state : int, RandomState instance, default=None
+        Determines random generator for chain orders.
+        Pass an int for being more deterministc.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -175,12 +175,11 @@ def _gaussian_random_matrix(n_components, n_features, random_state=None):
     n_features : int,
         Dimensionality of the original source space.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        Control the pseudo random number generator used to generate the matrix
-        at fit time.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
-        number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`.
+    random_state : int, RandomState instance, default=None
+        Determines random number generator to generate the matrix at fit time.
+        Use an int to use the randomness deterministic.
+        See :term:`Glossary <random_state>`.
+
 
     Returns
     -------
@@ -242,12 +241,11 @@ def _sparse_random_matrix(n_components, n_features, density='auto',
         Use density = 1 / 3.0 if you want to reproduce the results from
         Achlioptas, 2001.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        Control the pseudo random number generator used to generate the matrix
-        at fit time.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
-        number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`.
+    random_state : int, RandomState instance, default=None
+        Determines pseudo random number generator used to generate the matrix at fit time.
+        Use an int to use the randomness deterministic.
+        See :term:`Glossary <random_state>`.
+
 
     Returns
     -------
@@ -461,12 +459,10 @@ class GaussianRandomProjection(BaseRandomProjection):
         Smaller values lead to better embedding and higher number of
         dimensions (n_components) in the target projection space.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        Control the pseudo random number generator used to generate the matrix
-        at fit time.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
-        number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`.
+    random_state : int, RandomState instance, default=None
+        Determines pseudo random number generator used to generate the matrix at fit time.
+        Use an int to use the randomness deterministic.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------
@@ -583,12 +579,10 @@ class SparseRandomProjection(BaseRandomProjection):
         If False, the projected data uses a sparse representation if
         the input is sparse.
 
-    random_state : int, RandomState instance or None, optional (default=None)
-        Control the pseudo random number generator used to generate the matrix
-        at fit time.  If int, random_state is the seed used by the random
-        number generator; If RandomState instance, random_state is the random
-        number generator; If None, the random number generator is the
-        RandomState instance used by `np.random`.
+    random_state : int, RandomState instance, default=None
+        Determines pseudo random number generator used to generate the matrix at fit time.
+        Use an int to use the randomness deterministic.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------


### PR DESCRIPTION
#10548 
fix docstrings for random_state in theses files:

sklearn/dummy.py 
sklearn/multioutput.py 
sklearn/kernel_approximation.py
sklearn/multiclass.py 
sklearn/random_projection.py