### PR TITLE
Make random_state descriptions more informative and refer to Glossary #10548

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -185,10 +185,9 @@ def randomized_range_finder(A, size, n_iter,
     random_state : int, RandomState instance or None, optional (default=None)
         The seed of the pseudo random number generator to use when shuffling
         the data, i.e. getting the random vectors to initialize the algorithm.
-        Pass an int for reproducible results across multiple function 
+        Pass an int for reproducible results across multiple function
         calls.
         See :term:`Glossary <random_state>`.
-
 
     Returns
     -------
@@ -298,10 +297,10 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
     random_state : int, RandomState instance or None, optional (default=None)
         The seed of the pseudo random number generator to use when shuffling
         the data, i.e. getting the random vectors to initialize the algorithm.
-        Pass an int for reproducible results across multiple function 
+        Pass an int for reproducible results across multiple function
         calls.
         See :term:`Glossary <random_state>`.
-
+        
     Notes
     -----
     This algorithm finds a (usually very good) approximate truncated

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -181,13 +181,14 @@ def randomized_range_finder(A, size, n_iter,
         normalization if `n_iter` <= 2 and switches to LU otherwise.
 
         .. versionadded:: 0.18
-
+    
     random_state : int, RandomState instance or None, optional (default=None)
         The seed of the pseudo random number generator to use when shuffling
-        the data.  If int, random_state is the seed used by the random number
-        generator; If RandomState instance, random_state is the random number
-        generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        the data, i.e. getting the random vectors to initialize the algorithm.
+        Pass an int for reproducible results across multiple function 
+        calls.
+        See :term:`Glossary <random_state>`.
+
 
     Returns
     -------
@@ -296,10 +297,10 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
 
     random_state : int, RandomState instance or None, optional (default=None)
         The seed of the pseudo random number generator to use when shuffling
-        the data.  If int, random_state is the seed used by the random number
-        generator; If RandomState instance, random_state is the random number
-        generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        the data, i.e. getting the random vectors to initialize the algorithm.
+        Pass an int for reproducible results across multiple function 
+        calls.
+        See :term:`Glossary <random_state>`.
 
     Notes
     -----


### PR DESCRIPTION
Reference Issue/PR:
#10548

We (@Olks  and me) updated the documentation for random_state in 'sklearn/utils/extmath.py - 185, 297'. It now refers to the glossary.

Partial fix for issue #10548.

@noatamir
@adrinjalali
@WiMLDS