### PR TITLE
Make random_state descriptions for model selection validation, more informative and refer to Glossary towards #10548

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1007,8 +1007,8 @@ def permutation_test_score(estimator, X, y, groups=None, cv=None,
         for more details.
 
     random_state : int, RandomState instance or None, default=0
-        Pass an int for reproducible output for permutation of ``y`` values 
-        among samples.  
+        Pass an int for reproducible output for permutation of
+        ``y`` values among samples.  
         See :term:`Glossary <random_state>`.
 
     verbose : int, default=0

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1007,8 +1007,8 @@ def permutation_test_score(estimator, X, y, groups=None, cv=None,
         for more details.
 
     random_state : int, RandomState instance or None, default=0
-        Pass an int for reproducible output across multiple
-        function calls.
+        Pass an int for reproducible output for permutation of ``y`` values 
+        among samples.  
         See :term:`Glossary <random_state>`.
 
     verbose : int, default=0

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1008,8 +1008,7 @@ def permutation_test_score(estimator, X, y, groups=None, cv=None,
 
     random_state : int, RandomState instance or None, default=0
         Pass an int for reproducible output for permutation of
-        ``y`` values among samples.  
-        See :term:`Glossary <random_state>`.
+        ``y`` values among samples. See :term:`Glossary <random_state>`.
 
     verbose : int, default=0
         The verbosity level.
@@ -1176,9 +1175,8 @@ def learning_curve(estimator, X, y, groups=None,
         based on``train_sizes``.
 
     random_state : int or RandomState instance, default=None
-        Used when ``shuffle`` is True.
-        Pass an int for reproducible output across multiple
-        function calls.
+        Used when ``shuffle`` is True. Pass an int for reproducible
+        output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
     error_score : 'raise' or numeric, default=np.nan


### PR DESCRIPTION
Reference Issue/PR:
#10548

Updated the documentation for random_state in sklearn/model_selection/_validation.py - 1006, 1176
It now is more specific and refers to the glossary.  

Partial fix for issue #10548.

@noatamir
@adrinjalali
@WiMLDS

