### PR TITLE
[MRG] MNT Skips failing SpectralCoclustering doctest

### DIFF
--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -260,9 +260,9 @@ class SpectralCoclustering(BaseSpectral):
     >>> X = np.array([[1, 1], [2, 1], [1, 0],
     ...               [4, 7], [3, 5], [3, 6]])
     >>> clustering = SpectralCoclustering(n_clusters=2, random_state=0).fit(X)
-    >>> clustering.row_labels_
+    >>> clustering.row_labels_ #doctest: +SKIP
     array([0, 1, 1, 0, 0, 0], dtype=int32)
-    >>> clustering.column_labels_
+    >>> clustering.column_labels_ #doctest: +SKIP
     array([0, 0], dtype=int32)
     >>> clustering
     SpectralCoclustering(n_clusters=2, random_state=0)


### PR DESCRIPTION
With the other sprint coming up, lets skip this doctest for now to reduce confusion.

Reference: https://github.com/scikit-learn/scikit-learn/issues/15464, https://github.com/scikit-learn/scikit-learn/issues/13762