### PR TITLE
DOC Rewrite user-guide to clarify feature_importance_ are impurity based

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -296,7 +296,7 @@ to the prediction function.
 
 The impurity-based feature importance for trees suffers from being computed
 on statistics derived from the training dataset
-and favor high cardinality features (typically numerical features). 
+and favors high cardinality features (typically numerical features). 
 :ref:`permutation_importance` is a nice alternative impurity-based feature importance.
 These two methods of obtaining feature importance are explored in:
 :ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance.py`.

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -294,9 +294,9 @@ In practice those estimates are stored as an attribute named
 the value, the more important is the contribution of the matching feature
 to the prediction function.
 
-But, the impurity-based feature importance suffers from being computed 
-on statistics derived from the training dataset. There is a nice alternative
-to the impurity-based feature importance which is :ref:`permutation_importance`.
+The impurity-based feature importance suffers from being computed 
+on statistics derived from the training dataset. 
+:ref:`permutation_importance` is a nice alternative impurity-based feature importance.
 These two methods of obtaining feature importance are explored in:
 :ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance.py`.
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -294,6 +294,12 @@ In practice those estimates are stored as an attribute named
 the value, the more important is the contribution of the matching feature
 to the prediction function.
 
+But, the impurity-based feature importance suffers from being computed 
+on statistics derived from the training dataset. There is a nice alternative
+to the impurity-based feature importance which is permutation feature importance.
+These two methods of obtaining feature importance are explored in:
+:ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance.py`.
+
 .. topic:: Examples:
 
  * :ref:`sphx_glr_auto_examples_ensemble_plot_forest_importances_faces.py`
@@ -540,8 +546,8 @@ of the gradient boosting model. The test error at each iterations can be obtaine
 via the :meth:`~GradientBoostingRegressor.staged_predict` method which returns a
 generator that yields the predictions at each stage. Plots like these can be used
 to determine the optimal number of trees (i.e. ``n_estimators``) by early stopping.
-The plot on the right shows the feature importances which can be obtained via
-the ``feature_importances_`` property.
+The plot on the right shows the impurity-based feature importances which can be
+obtained via the ``feature_importances_`` property.
 
 .. figure:: ../auto_examples/ensemble/images/sphx_glr_plot_gradient_boosting_regression_001.png
    :target: ../auto_examples/ensemble/plot_gradient_boosting_regression.html
@@ -798,7 +804,7 @@ appropriate split points. This information can be used to measure the
 importance of each feature; the basic idea is: the more often a
 feature is used in the split points of a tree the more important that
 feature is. This notion of importance can be extended to decision tree
-ensembles by simply averaging the feature importance of each tree (see
+ensembles by simply averaging the impurity-based feature importance of each tree (see
 :ref:`random_forest_feature_importance` for more details).
 
 The feature importance scores of a fit gradient boosting model can be

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -294,8 +294,9 @@ In practice those estimates are stored as an attribute named
 the value, the more important is the contribution of the matching feature
 to the prediction function.
 
-The impurity-based feature importance suffers from being computed 
-on statistics derived from the training dataset. 
+The impurity-based feature importance for trees suffers from being computed
+on statistics derived from the training dataset
+and favor high cardinality features (typically numerical features). 
 :ref:`permutation_importance` is a nice alternative impurity-based feature importance.
 These two methods of obtaining feature importance are explored in:
 :ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance.py`.

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -296,7 +296,7 @@ to the prediction function.
 
 But, the impurity-based feature importance suffers from being computed 
 on statistics derived from the training dataset. There is a nice alternative
-to the impurity-based feature importance which is permutation feature importance.
+to the impurity-based feature importance which is :ref:`permutation_importance`.
 These two methods of obtaining feature importance are explored in:
 :ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance.py`.
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -296,7 +296,7 @@ to the prediction function.
 
 The impurity-based feature importance for trees suffers from being computed
 on statistics derived from the training dataset
-and favors high cardinality features (typically numerical features). 
+and favors high cardinality features.
 :ref:`permutation_importance` is a nice alternative impurity-based feature importance.
 These two methods of obtaining feature importance are explored in:
 :ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance.py`.

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -232,7 +232,7 @@ Tree-based feature selection
 
 Tree-based estimators (see the :mod:`sklearn.tree` module and forest
 of trees in the :mod:`sklearn.ensemble` module) can be used to compute
-feature importances, which in turn can be used to discard irrelevant
+impurity-based feature importances, which in turn can be used to discard irrelevant
 features (when coupled with the :class:`sklearn.feature_selection.SelectFromModel`
 meta-transformer)::
 

--- a/examples/ensemble/plot_forest_importances.py
+++ b/examples/ensemble/plot_forest_importances.py
@@ -4,8 +4,9 @@ Feature importances with forests of trees
 =========================================
 
 This examples shows the use of forests of trees to evaluate the importance of
-features on an artificial classification task. The red bars are the feature
-importances of the forest, along with their inter-trees variability.
+features on an artificial classification task. The red bars are
+the impurity-based feature importances of the forest,
+along with their inter-trees variability.
 
 As expected, the plot suggests that 3 features are informative, while the
 remaining are not.
@@ -28,7 +29,7 @@ X, y = make_classification(n_samples=1000,
                            random_state=0,
                            shuffle=False)
 
-# Build a forest and compute the feature importances
+# Build a forest and compute the impurity-based feature importances
 forest = ExtraTreesClassifier(n_estimators=250,
                               random_state=0)
 
@@ -44,7 +45,7 @@ print("Feature ranking:")
 for f in range(X.shape[1]):
     print("%d. feature %d (%f)" % (f + 1, indices[f], importances[indices[f]]))
 
-# Plot the feature importances of the forest
+# Plot the impurity-based feature importances of the forest
 plt.figure()
 plt.title("Feature importances")
 plt.bar(range(X.shape[1]), importances[indices],

--- a/examples/ensemble/plot_forest_importances_faces.py
+++ b/examples/ensemble/plot_forest_importances_faces.py
@@ -3,9 +3,9 @@
 Pixel importances with a parallel forest of trees
 =================================================
 
-This example shows the use of forests of trees to evaluate the importance
-of the pixels in an image classification task (faces). The hotter the pixel,
-the more important.
+This example shows the use of forests of trees to evaluate the impurity-based
+importance of the pixels in an image classification task (faces).
+The hotter the pixel, the more important.
 
 The code below also illustrates how the construction and the computation
 of the predictions can be parallelized within multiple jobs.

--- a/examples/ensemble/plot_gradient_boosting_regression.py
+++ b/examples/ensemble/plot_gradient_boosting_regression.py
@@ -62,7 +62,7 @@ plt.xlabel('Boosting Iterations')
 plt.ylabel('Deviance')
 
 # #############################################################################
-# Plot feature importance
+# Plot impurity-based feature importance
 feature_importance = clf.feature_importances_
 # make importances relative to max importance
 feature_importance = 100.0 * (feature_importance / feature_importance.max())

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -420,7 +420,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         The higher, the more important the feature.
         The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
-        known as the Gini importance..
+        known as the Gini importance.
 
         Returns
         -------

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -416,6 +416,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
     def feature_importances_(self):
         """
         The impurity-based feature importances.
+
         The higher, the more important the feature.
         The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -415,8 +415,9 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
     @property
     def feature_importances_(self):
         """
-        The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance..
 
@@ -1048,8 +1049,9 @@ class RandomForestClassifier(ForestClassifier):
         The number of outputs when ``fit`` is performed.
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
@@ -1328,8 +1330,9 @@ class RandomForestRegressor(ForestRegressor):
         The collection of fitted sub-estimators.
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
@@ -1646,8 +1649,9 @@ class ExtraTreesClassifier(ForestClassifier):
         number of classes for each output (multi-output problem).
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
@@ -1924,8 +1928,9 @@ class ExtraTreesRegressor(ForestRegressor):
         The collection of fitted sub-estimators.
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -415,8 +415,10 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
     @property
     def feature_importances_(self):
         """
-        Return the feature importances (the higher, the more important the
-           feature).
+        The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance..
 
         Returns
         -------
@@ -1046,7 +1048,10 @@ class RandomForestClassifier(ForestClassifier):
         The number of outputs when ``fit`` is performed.
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances (the higher, the more important the feature).
+        The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance.
 
     oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
@@ -1323,7 +1328,10 @@ class RandomForestRegressor(ForestRegressor):
         The collection of fitted sub-estimators.
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances (the higher, the more important the feature).
+        The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance.
 
     n_features_ : int
         The number of features when ``fit`` is performed.
@@ -1638,7 +1646,10 @@ class ExtraTreesClassifier(ForestClassifier):
         number of classes for each output (multi-output problem).
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances (the higher, the more important the feature).
+        The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance.
 
     n_features_ : int
         The number of features when ``fit`` is performed.
@@ -1913,7 +1924,10 @@ class ExtraTreesRegressor(ForestRegressor):
         The collection of fitted sub-estimators.
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances (the higher, the more important the feature).
+        The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance.
 
     n_features_ : int
         The number of features.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -655,10 +655,11 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
 
     @property
     def feature_importances_(self):
-        """The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        """The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
-        known as the Gini importance..
+        known as the Gini importance.
 
         Returns
         -------
@@ -974,8 +975,9 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         .. versionadded:: 0.20
 
     feature_importances_ : array, shape (n_features,)
-        The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
@@ -1447,8 +1449,9 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     Attributes
     ----------
     feature_importances_ : array, shape (n_features,)
-        The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -656,6 +656,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
     @property
     def feature_importances_(self):
         """The impurity-based feature importances.
+
         The higher, the more important the feature.
         The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -655,8 +655,10 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
 
     @property
     def feature_importances_(self):
-        """Return the feature importances (the higher, the more important the
-           feature).
+        """The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance..
 
         Returns
         -------
@@ -972,7 +974,10 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         .. versionadded:: 0.20
 
     feature_importances_ : array, shape (n_features,)
-        The feature importances (the higher, the more important the feature).
+        The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance.
 
     oob_improvement_ : array, shape (n_estimators,)
         The improvement in loss (= deviance) on the out-of-bag samples
@@ -1442,7 +1447,10 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     Attributes
     ----------
     feature_importances_ : array, shape (n_features,)
-        The feature importances (the higher, the more important the feature).
+        The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance.
 
     oob_improvement_ : array, shape (n_estimators,)
         The improvement in loss (= deviance) on the out-of-bag samples

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -238,6 +238,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
     @property
     def feature_importances_(self):
         """The impurity-based feature importances.
+
         The higher, the more important the feature.
         The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -237,8 +237,10 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
 
     @property
     def feature_importances_(self):
-        """Return the feature importances (the higher, the more important the
-           feature).
+        """The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance.
 
         Returns
         -------

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -237,8 +237,9 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
 
     @property
     def feature_importances_(self):
-        """The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        """The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1398,8 +1398,10 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
         output (for multi-output problems).
 
     feature_importances_ : ndarray of shape (n_features,)
-        Return the feature importances (the higher, the more important the
-        feature).
+        The feature importances. The higher, the more important the
+        feature. The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance.
 
     n_features_ : int
         The number of features when ``fit`` is performed.

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -736,8 +736,9 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
         or a list of arrays of class labels (multi-output problem).
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance [4]_.
 
@@ -1398,8 +1399,9 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
         output (for multi-output problems).
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances. The higher, the more important the
-        feature. The importance of a feature is computed as the (normalized)
+        The impurity-based feature importances.
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #14528. See also #14530


#### What does this implement/fix? Explain your changes.
I clarify feature importance in every tree method by mentioning that is impurity-based. In User-guide, examples, and doc-string, it is now clear that feature importance comes from impurity concept. At some point, I mention [Permutation Importance vs Random Forest Feature Importance (MDI)](https://scikit-learn.org/stable/auto_examples/inspection/plot_permutation_importance.html#sphx-glr-auto-examples-inspection-plot-permutation-importance-py) to show impurity-based importance is not only choice but we have a good alternative.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
