### PR TITLE
[MRG] Fix FutureWarning in plot_partial_dependence_visualization_api.py

### DIFF
--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -25,7 +25,7 @@ from ..utils import _safe_indexing
 from ..utils import _determine_key_type
 from ..utils import _get_column_indices
 from ..utils.validation import check_is_fitted
-from ..tree._tree import DTYPE
+from ..tree import DecisionTreeRegressor
 from ..exceptions import NotFittedError
 from ..ensemble._gb import BaseGradientBoosting
 from sklearn.ensemble._hist_gradient_boosting.gradient_boosting import (
@@ -590,9 +590,11 @@ def plot_partial_dependence(estimator, X, features, feature_names=None,
     from matplotlib import transforms  # noqa
     from matplotlib.ticker import MaxNLocator  # noqa
     from matplotlib.ticker import ScalarFormatter  # noqa
-
     # set target_idx for multi-class estimators
-    if hasattr(estimator, 'classes_') and np.size(estimator.classes_) > 2:
+    # TODO: Remove isinstance check in 0.24
+    if (not isinstance(estimator, DecisionTreeRegressor) and
+            hasattr(estimator, 'classes_') and
+            np.size(estimator.classes_) > 2):
         if target is None:
             raise ValueError('target must be specified for multi-class')
         target_idx = np.searchsorted(estimator.classes_, target)

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -25,7 +25,6 @@ from ..utils import _safe_indexing
 from ..utils import _determine_key_type
 from ..utils import _get_column_indices
 from ..utils.validation import check_is_fitted
-from ..tree import DecisionTreeRegressor
 from ..exceptions import NotFittedError
 from ..ensemble._gb import BaseGradientBoosting
 from sklearn.ensemble._hist_gradient_boosting.gradient_boosting import (
@@ -590,15 +589,9 @@ def plot_partial_dependence(estimator, X, features, feature_names=None,
     from matplotlib import transforms  # noqa
     from matplotlib.ticker import MaxNLocator  # noqa
     from matplotlib.ticker import ScalarFormatter  # noqa
-    # set target_idx for multi-class estimators
 
-    # Attribute classes_ in DecisionTreeRegressor has been moved to super class
-    # BaseDecisionTree and is deprecated.
-    # The isinstance(estimator, DecisionTreeRegressor)
-    # check is used to prevent raising a spurious warning.
-    # TODO: Remove isinstance check in 0.24 when the `classes_`
-    # attribute is actually removed from the DecisionTreeRegressor class.
-    if (not isinstance(estimator, DecisionTreeRegressor) and
+    # set target_idx for multi-class estimators
+    if (is_classifier(estimator) and
             hasattr(estimator, 'classes_') and
             np.size(estimator.classes_) > 2):
         if target is None:

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -591,7 +591,13 @@ def plot_partial_dependence(estimator, X, features, feature_names=None,
     from matplotlib.ticker import MaxNLocator  # noqa
     from matplotlib.ticker import ScalarFormatter  # noqa
     # set target_idx for multi-class estimators
-    # TODO: Remove isinstance check in 0.24
+
+    # Attribute classes_ in DecisionTreeRegressor has been moved to super class
+    # BaseDecisionTree and is deprecated.
+    # The isinstance(estimator, DecisionTreeRegressor)
+    # check is used to prevent raising a spurious warning.
+    # TODO: Remove isinstance check in 0.24 when the `classes_`
+    # attribute is actually removed from the DecisionTreeRegressor class.
     if (not isinstance(estimator, DecisionTreeRegressor) and
             hasattr(estimator, 'classes_') and
             np.size(estimator.classes_) > 2):


### PR DESCRIPTION
#### Reference Issues/PRs
This PR fixes a Warning in of the examples of #14117. 
Specifically `examples/plot_partial_dependence_visualization_api.py (FutureWarning)`.

#### What does this implement/fix? Explain your changes.
Attribute classes_ in DecisionTreeRegressor has been moved to super class BaseDecisionTree and is deprecated. With version 0.24 it will be removed. With an isintance check a hasattr call is prevented and solves the warning, which can be removed in version 0.24.

#### Any other comments?
Removed also `from ..tree._tree import DTYPE` as it's unused and causes a linting complain.