### PR TITLE
Changed max number of iterations to ensure convergence

### DIFF
--- a/examples/neural_networks/plot_mlp_alpha.py
+++ b/examples/neural_networks/plot_mlp_alpha.py
@@ -28,6 +28,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 from sklearn.datasets import make_moons, make_circles, make_classification
 from sklearn.neural_network import MLPClassifier
+from sklearn.pipeline import make_pipeline
 
 h = .02  # step size in the mesh
 
@@ -36,9 +37,13 @@ names = ['alpha ' + str(i) for i in alphas]
 
 classifiers = []
 for i in alphas:
-    classifiers.append(MLPClassifier(solver='lbfgs', alpha=i,
+    classifiers.append(make_pipeline(
+                       StandardScaler(),
+                       MLPClassifier(solver='lbfgs', alpha=i,
                                      random_state=1, max_iter=2000,
-                                     hidden_layer_sizes=[100, 100]))
+                                     early_stopping=True,
+                                     hidden_layer_sizes=[100, 100])
+                       ))
 
 X, y = make_classification(n_features=2, n_redundant=0, n_informative=2,
                            random_state=0, n_clusters_per_class=1)

--- a/examples/neural_networks/plot_mlp_alpha.py
+++ b/examples/neural_networks/plot_mlp_alpha.py
@@ -37,7 +37,7 @@ names = ['alpha ' + str(i) for i in alphas]
 classifiers = []
 for i in alphas:
     classifiers.append(MLPClassifier(solver='lbfgs', alpha=i, random_state=1,
-                                     hidden_layer_sizes=[100, 100]))
+                                max_iter=2000, hidden_layer_sizes=[100, 100]))
 
 X, y = make_classification(n_features=2, n_redundant=0, n_informative=2,
                            random_state=0, n_clusters_per_class=1)
@@ -110,4 +110,4 @@ for X, y in datasets:
         i += 1
 
 figure.subplots_adjust(left=.02, right=.98)
-plt.show()
+# plt.show()

--- a/examples/neural_networks/plot_mlp_alpha.py
+++ b/examples/neural_networks/plot_mlp_alpha.py
@@ -36,8 +36,9 @@ names = ['alpha ' + str(i) for i in alphas]
 
 classifiers = []
 for i in alphas:
-    classifiers.append(MLPClassifier(solver='lbfgs', alpha=i, random_state=1,
-                                max_iter=2000, hidden_layer_sizes=[100, 100]))
+    classifiers.append(MLPClassifier(solver='lbfgs', alpha=i,
+                                     random_state=1, max_iter=2000,
+                                     hidden_layer_sizes=[100, 100]))
 
 X, y = make_classification(n_features=2, n_redundant=0, n_informative=2,
                            random_state=0, n_clusters_per_class=1)
@@ -110,4 +111,4 @@ for X, y in datasets:
         i += 1
 
 figure.subplots_adjust(left=.02, right=.98)
-# plt.show()
+plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Related to issue #14117 , fixes `examples/neural_networks/plot_mlp_alpha.py (ConvergenceWarning)` 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Increasing the maximum number of iterations to 2000 (instead of the default 1000) fixes the convergence warning.

#### Any other comments?

The running time is a bit slower but not so much, so it seems acceptable; since the actual number of iterations is usually less than max_iter, there is only one classifier for which 1932 iterations are needed before convergence.

With 1000 iterations: `python examples/neural_networks/plot_mlp_alpha.py  13,86s user 0,53s system 194% cpu 7,415 total`
With 2000 iterations: `python examples/neural_networks/plot_mlp_alpha.py  18,73s user 0,60s system 195% cpu 9,873 total`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
