### PR TITLE
DOC add a coc reference to the main page

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -183,7 +183,7 @@
         <li><strong>Questions?</strong> See <a href="faq.html">FAQ</a> and <a href="https://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a></li>
         <li><strong>Mailing list:</strong> <a href="https://mail.python.org/mailman/listinfo/scikit-learn">scikit-learn@python.org</a></li>
         <li><strong>Gitter:</strong> <a href="https://gitter.im/scikit-learn/scikit-learn">gitter.im/scikit-learn</a></li>
-        <li>All communication on all channels should respect <a href="https://www.python.org/psf/conduct/">PSF's code of conduct</a></li>
+        <li>Communication on all channels should respect <a href="https://www.python.org/psf/conduct/">PSF's code of conduct.</a></li>
         </ul>
 
         <form target="_top" id="paypal-form" method="post" action="https://www.paypal.com/cgi-bin/webscr">

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -183,6 +183,7 @@
         <li><strong>Questions?</strong> See <a href="faq.html">FAQ</a> and <a href="https://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a></li>
         <li><strong>Mailing list:</strong> <a href="https://mail.python.org/mailman/listinfo/scikit-learn">scikit-learn@python.org</a></li>
         <li><strong>Gitter:</strong> <a href="https://gitter.im/scikit-learn/scikit-learn">gitter.im/scikit-learn</a></li>
+        <li>All communication on all channels should respect <a href="https://www.python.org/psf/conduct/">PSF's code of conduct</a></li>
         </ul>
 
         <form target="_top" id="paypal-form" method="post" action="https://www.paypal.com/cgi-bin/webscr">


### PR DESCRIPTION
This adds a link to psf's coc to the main page. Not sure about the wording, open to suggestions :)

Seems like having it on the website is the consensus from https://github.com/scikit-learn/scikit-learn/issues/16139

CC: @scikit-learn/core-devs 