### PR TITLE
[MRG] DOC remove caching in wikipedia_principal_eigenvector example

### DIFF
--- a/examples/applications/wikipedia_principal_eigenvector.py
+++ b/examples/applications/wikipedia_principal_eigenvector.py
@@ -42,8 +42,6 @@ import numpy as np
 
 from scipy import sparse
 
-from joblib import Memory
-
 from sklearn.decomposition import randomized_svd
 from urllib.request import urlopen
 
@@ -73,8 +71,6 @@ for url, filename in resources:
 
 # #############################################################################
 # Loading the redirect files
-
-memory = Memory(cachedir=".")
 
 
 def index(redirects, index_map, k):
@@ -124,8 +120,6 @@ def get_redirects(redirects_filename):
     return redirects
 
 
-# disabling joblib as the pickling of large dicts seems much too slow
-#@memory.cache
 def get_adjacency_matrix(redirects_filename, page_links_filename, limit=None):
     """Extract the adjacency graph as a scipy sparse matrix
 


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #14117
Fix DeprecationWarning in wikipedia_principal_eigenvector example

#### What does this implement/fix? Explain your changes.

`joblib.Memory` api changed the name of a parameter : `cachedir` => `location`, and deprecated the old version, hence the deprecation warning.

In this particular example, the memory was actually not used because 

> the pickling of large dicts seems much too slow

This PR removes the unused code, removing the warning along the way

#### Any other comments?

Nope
