### PR TITLE
WIP add score_samples method in base search CV and add tests

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -864,9 +864,9 @@ class GridSearchCV(BaseSearchCV):
     Important members are fit, predict.
 
     GridSearchCV implements a "fit" and a "score" method.
-    It also implements "score_samples", "predict", "predict_proba", "decision_function",
-    "transform" and "inverse_transform" if they are implemented in the
-    estimator used.
+    It also implements "score_samples", "predict", "predict_proba",
+    "decision_function", "transform" and "inverse_transform" if they are
+    implemented in the estimator used.
 
     The parameters of the estimator used to apply these methods are optimized
     by cross-validated grid-search over a parameter grid.
@@ -1175,9 +1175,9 @@ class RandomizedSearchCV(BaseSearchCV):
     """Randomized search on hyper parameters.
 
     RandomizedSearchCV implements a "fit" and a "score" method.
-    It also implements "score_samples", "predict", "predict_proba", "decision_function",
-    "transform" and "inverse_transform" if they are implemented in the
-    estimator used.
+    It also implements "score_samples", "predict", "predict_proba",
+    "decision_function", "transform" and "inverse_transform" if they are
+    implemented in the estimator used.
 
     The parameters of the estimator used to apply these methods are optimized
     by cross-validated search over parameter settings.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -464,12 +464,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         y_score : ndarray, shape (n_samples,)
         """
         self._check_is_fitted('score_samples')
-        if self.scorer_ is None:
-            raise ValueError("No score function explicitly defined, "
-                             "and the estimator doesn't provide one %s"
-                             % self.best_estimator_)
-        score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
-        return score(self.best_estimator_, X)
+        return self.best_estimator_.score_samples(X)
 
     def _check_is_fitted(self, method_name):
         if not self.refit:

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -447,6 +447,30 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
         return score(self.best_estimator_, X, y)
 
+    @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))
+    def score_samples(self, X):
+        """Call score_samples on the estimator with the best found parameters.
+
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``score_samples``.
+
+        Parameters
+        ----------
+        X : iterable
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
+        Returns
+        -------
+        y_score : ndarray, shape (n_samples,)
+        """
+        self._check_is_fitted('score_samples')
+        if self.scorer_ is None:
+            raise ValueError("No score function explicitly defined, "
+                             "and the estimator doesn't provide one %s"
+                             % self.best_estimator_)
+        score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
+        return score(self.best_estimator_, X)
+
     def _check_is_fitted(self, method_name):
         if not self.refit:
             raise NotFittedError('This %s instance was initialized '
@@ -845,7 +869,7 @@ class GridSearchCV(BaseSearchCV):
     Important members are fit, predict.
 
     GridSearchCV implements a "fit" and a "score" method.
-    It also implements "predict", "predict_proba", "decision_function",
+    It also implements "score_samples", "predict", "predict_proba", "decision_function",
     "transform" and "inverse_transform" if they are implemented in the
     estimator used.
 
@@ -1156,7 +1180,7 @@ class RandomizedSearchCV(BaseSearchCV):
     """Randomized search on hyper parameters.
 
     RandomizedSearchCV implements a "fit" and a "score" method.
-    It also implements "predict", "predict_proba", "decision_function",
+    It also implements "score_samples", "predict", "predict_proba", "decision_function",
     "transform" and "inverse_transform" if they are implemented in the
     estimator used.
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -57,6 +57,7 @@ from sklearn.tree import DecisionTreeRegressor
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.cluster import KMeans
 from sklearn.neighbors import KernelDensity
+from sklearn.neighbors import LocalOutlierFactor
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.metrics import f1_score
 from sklearn.metrics import recall_score
@@ -102,13 +103,6 @@ class MockClassifier:
         else:
             score = 0.
         return score
-
-    def score_samples(self, X):
-        if self.foo_param > 1:
-            scores = [1.] * len(X)
-        else:
-            scores = [0.] * len(X)
-        return scores
 
     def get_params(self, deep=False):
         return {'foo_param': self.foo_param}
@@ -1208,15 +1202,68 @@ def compare_refit_methods_when_refit_with_acc(search_multi, search_acc, refit):
 
 @pytest.mark.filterwarnings("ignore:The parameter 'iid' is deprecated")  # 0.24
 @pytest.mark.parametrize('search_cv', [RandomizedSearchCV, GridSearchCV])
-def test_search_cv_score_samples_method(search_cv):
-    X, y = make_classification(n_samples=50, n_features=4, random_state=42)
-    clf = search_cv(MockClassifier(), {'foo_param': [0, 2]},
-                    scoring='precision', refit=True)
+def test_search_cv_score_samples_error(search_cv):
+    if search_cv == RandomizedSearchCV:
+        clf = search_cv(estimator=DecisionTreeClassifier(),
+                        param_distributions={'max_depth': [5, 10]})
+    else:
+        clf = search_cv(estimator=DecisionTreeClassifier(),
+                        param_grid={'max_depth': [5, 10]})
+
+    X, y = make_blobs(n_samples=100, n_features=4, random_state=42)
     clf.fit(X, y)
-    # Test that the score_samples method on *SearchCV yields same results as
-    # applying score_samples from the estimator itself directly (best param is
-    # foo_param=1)
-    assert_allclose(clf.score_samples(X), MockClassifier(foo_param=2).score_samples(X))
+
+    # Make sure to error out when underlying estimator does not implement
+    # the method `score_samples`
+    err_msg = "AttributeError: 'DecisionTreeClassifier' object has " \
+              "no attribute 'score_samples'"
+    assert_raise_message(AttributeError, err_msg, clf.score_samples, X)
+
+
+@pytest.mark.filterwarnings("ignore:The parameter 'iid' is deprecated")  # 0.24
+@pytest.mark.parametrize('search_cv', [RandomizedSearchCV, GridSearchCV])
+def test_search_cv_score_samples_method(search_cv):
+    # Set parameters
+    rng = np.random.RandomState(42)
+    n_samples = 300
+    outliers_fraction = 0.15
+    n_outliers = int(outliers_fraction * n_samples)
+    n_inliers = n_samples - n_outliers
+
+    # Create dataset
+    blobs_params = dict(random_state=0, n_samples=n_inliers, n_features=2)
+    X = make_blobs(centers=[[0, 0], [0, 0]], cluster_std=0.5,
+                   **blobs_params)[0]
+    # Add some noisy points
+    X = np.concatenate([X, rng.uniform(low=-6, high=6,
+                                       size=(n_outliers, 2))], axis=0)
+
+    # Define labels to be able to score the estimator with `search_cv`
+    y_true = np.array([1] * n_samples)
+    y_true[-n_outliers:] = [-1] * n_outliers
+
+    if search_cv == RandomizedSearchCV:
+        clf = search_cv(estimator=LocalOutlierFactor(novelty=True),
+                        param_distributions={'n_neighbors': [5, 10]},
+                        scoring="precision")
+    else:
+        clf = search_cv(estimator=LocalOutlierFactor(novelty=True),
+                        param_grid={'n_neighbors': [5, 10]},
+                        scoring="precision")
+    # Fit on data
+    clf.fit(X, y_true)
+
+    # Define estimator with the best params obtained in
+    # the *SearchCV
+    lof = LocalOutlierFactor(novelty=True,
+                             n_neighbors=clf.best_params_["n_neighbors"])
+
+    # Fit the estimator
+    lof.fit(X)
+
+    # Verify that the stand alone estimator yields the same results
+    # as the ones obtained with *SearchCV
+    assert_allclose(clf.score_samples(X), lof.score_samples(X))
 
 
 def test_search_cv_results_rank_tie_breaking():

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -103,6 +103,13 @@ class MockClassifier:
             score = 0.
         return score
 
+    def score_samples(self, X):
+        if self.foo_param > 1:
+            scores = [1.] * len(X)
+        else:
+            scores = [0.] * len(X)
+        return scores
+
     def get_params(self, deep=False):
         return {'foo_param': self.foo_param}
 
@@ -1197,6 +1204,19 @@ def compare_refit_methods_when_refit_with_acc(search_multi, search_acc, refit):
     assert_almost_equal(search_multi.score(X, y), search_acc.score(X, y))
     for key in ('best_index_', 'best_score_', 'best_params_'):
         assert getattr(search_multi, key) == getattr(search_acc, key)
+
+
+@pytest.mark.filterwarnings("ignore:The parameter 'iid' is deprecated")  # 0.24
+@pytest.mark.parametrize('search_cv', [RandomizedSearchCV, GridSearchCV])
+def test_search_cv_score_samples_method(search_cv):
+    X, y = make_classification(n_samples=50, n_features=4, random_state=42)
+    clf = search_cv(MockClassifier(), {'foo_param': [0, 2]},
+                    scoring='precision', refit=True)
+    clf.fit(X, y)
+    # Test that the score_samples method on *SearchCV yields same results as
+    # applying score_samples from the estimator itself directly (best param is
+    # foo_param=1)
+    assert_allclose(clf.score_samples(X), MockClassifier(foo_param=2).score_samples(X))
 
 
 def test_search_cv_results_rank_tie_breaking():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #12542 

#### What does this implement/fix? Explain your changes.
With the changes we'll be now able to call `score_samples` on the estimator with the best found parameters in *SearchCV instances.
