### PR TITLE
[DOC] ensure all attributes are documented for RBFSampler #14312

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -44,6 +44,17 @@ class RBFSampler(TransformerMixin, BaseEstimator):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
+    Attributes
+    ----------
+    random_offset_: ndarray of shape (n_components,), dtype=float64
+        Random offset used to compute the projection in the n_components
+        dimensions of the feature space.
+
+    random_weights_: ndarray of shape (n_features, n_components), dtype=float64
+        Random projection directions drawn from the Fourier transform
+        of the RBF kernel.
+
+
     Examples
     --------
     >>> from sklearn.kernel_approximation import RBFSampler

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -47,7 +47,7 @@ class RBFSampler(TransformerMixin, BaseEstimator):
     Attributes
     ----------
     random_offset_: ndarray of shape (n_components,), dtype=float64
-        Random offset used to compute the projection in the n_components
+        Random offset used to compute the projection in the `n_components`
         dimensions of the feature space.
 
     random_weights_: ndarray of shape (n_features, n_components), dtype=float64


### PR DESCRIPTION
adding documentation for all attributes of RBFSampler (random_offset_ and random_weights_)
contributes to #14312

