### PR TITLE
[DOC] Make random_state descriptions for AdaBoost

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -324,8 +324,9 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         achieving a lower test error with fewer boosting iterations.
 
     random_state : int, RandomState instance, default=None
-        For each iteration, controls the generation of the seed for
-        the base estimator, if it accepts a `random_state` attribute.
+        Controls the random seed given at each `base_estimator` at each
+        boosting iteration.
+        Thus, it is only used when `base_estimator` expose a `random_state`.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
@@ -901,9 +902,11 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
         boosting iteration.
 
     random_state : int, RandomState instance, default=None
-        For each iteration, controls the generation of the seed for the random
-        weighted sampling of the training set with replacement as well as for
-        the base estimator, if it accepts a `random_state` attribute.
+        Controls the random seed given at each `base_estimator` at each
+        boosting iteration.
+        Thus, it is only used when `base_estimator` expose a `random_state`.
+        In addition, it controls the bootstrap of the weights used to train the
+        `base_estimator` at each boosting iteration.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
@@ -1026,7 +1029,8 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
         random_state : RandomState
             The RandomState instance used if the base estimator accepts a
             `random_state` attribute.
-            Controls also the bootstrap of the weights used to train the weak learner.
+            Controls also the bootstrap of the weights used to train the weak
+            learner.
             replacement.
 
         Returns

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -1026,7 +1026,7 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
         random_state : RandomState
             The RandomState instance used if the base estimator accepts a
             `random_state` attribute.
-            Controls also the random weighted sampling of the training set with
+            Controls also the bootstrap of the weights used to train the weak learner.
             replacement.
 
         Returns

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -326,7 +326,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
     random_state : int, RandomState instance, default=None
         Controls the random seed given at each `base_estimator` at each
         boosting iteration.
-        Thus, it is only used when `base_estimator` expose a `random_state`.
+        Thus, it is only used when `base_estimator` exposes a `random_state`.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
@@ -904,7 +904,7 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
     random_state : int, RandomState instance, default=None
         Controls the random seed given at each `base_estimator` at each
         boosting iteration.
-        Thus, it is only used when `base_estimator` expose a `random_state`.
+        Thus, it is only used when `base_estimator` exposes a `random_state`.
         In addition, it controls the bootstrap of the weights used to train the
         `base_estimator` at each boosting iteration.
         Pass an int for reproducible output across multiple function calls.

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -131,6 +131,8 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         self.estimator_weights_ = np.zeros(self.n_estimators, dtype=np.float64)
         self.estimator_errors_ = np.ones(self.n_estimators, dtype=np.float64)
 
+        # Initializion of the random number instance that will be used to
+        # generate a seed at each iteration
         random_state = check_random_state(self.random_state)
 
         for iboost in range(self.n_estimators):
@@ -322,10 +324,10 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         achieving a lower test error with fewer boosting iterations.
 
     random_state : int, RandomState instance, default=None
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        For each iteration, controls the generation of the seed for
+        the base estimator, if it accepts a `random_state` attribute.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------
@@ -477,7 +479,8 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
             The current sample weights.
 
         random_state : RandomState
-            The current random number generator
+            The RandomState instance used if the base estimator accepts a
+            `random_state` attribute.
 
         Returns
         -------
@@ -898,10 +901,11 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
         boosting iteration.
 
     random_state : int, RandomState instance, default=None
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        For each iteration, controls the generation of the seed for the random
+        weighted sampling of the training set with replacement as well as for
+        the base estimator, if it accepts a `random_state` attribute.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------
@@ -1020,7 +1024,10 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
             The current sample weights.
 
         random_state : RandomState
-            The current random number generator
+            The RandomState instance used if the base estimator accepts a
+            `random_state` attribute.
+            Controls also the random weighted sampling of the training set with
+            replacement.
 
         Returns
         -------


### PR DESCRIPTION
Reference Issue/PR:
partially addressed #10548

Updated the documentation for random_state in sklearn/ensemble/_weight_boosting.py - 324, 479, 900, 1022
It now is more specific and refers to the glossary.