### PR TITLE
Specify compilers version to work-around issues on MacOS

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -44,7 +44,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$SKLEARN_TEST_NO_OPENMP" != "true" ]]; then
             # on macOS, install an OpenMP-enabled clang/llvm from conda-forge.
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers'>=1.0.4' \
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers>=1.0.4 \
                         conda-forge::llvm-openmp"
         fi
     fi

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -44,7 +44,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$SKLEARN_TEST_NO_OPENMP" != "true" ]]; then
             # on macOS, install an OpenMP-enabled clang/llvm from conda-forge.
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers \
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers'>=1.0.4' \
                         conda-forge::llvm-openmp"
         fi
     fi

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -226,7 +226,7 @@ macOS compilers from conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you use the conda package manager (version >= 4.7), you can install the
-``compilers`` meta-package from the conda-forge channel which provides
+``compilers`` meta-package from the conda-forge channel, which provides
 OpenMP-enabled C/C++ compilers based on the llvm toolchain.
 
 First install the macOS command line tools::

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -226,8 +226,8 @@ macOS compilers from conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you use the conda package manager (version >= 4.7), you can install the
-``compilers`` meta-package from the conda-forge channel (use version >= 1.0.4)
-which provides OpenMP-enabled C/C++ compilers based on the llvm toolchain.
+``compilers`` meta-package from the conda-forge channel which provides
+OpenMP-enabled C/C++ compilers based on the llvm toolchain.
 
 First install the macOS command line tools::
 
@@ -237,7 +237,7 @@ It is recommended to use a dedicated `conda environment`_ to build
 scikit-learn from source::
 
     conda create -n sklearn-dev python numpy scipy cython joblib pytest \
-        conda-forge::compilers conda-forge::llvm-openmp
+        conda-forge::compilers">=1.0.4" conda-forge::llvm-openmp
     conda activate sklearn-dev
     make clean
     pip install --verbose --editable .

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -237,7 +237,7 @@ It is recommended to use a dedicated `conda environment`_ to build
 scikit-learn from source::
 
     conda create -n sklearn-dev python numpy scipy cython joblib pytest \
-        conda-forge::compilers">=1.0.4" conda-forge::llvm-openmp
+        "conda-forge::compilers>=1.0.4" conda-forge::llvm-openmp
     conda activate sklearn-dev
     make clean
     pip install --verbose --editable .

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -226,8 +226,8 @@ macOS compilers from conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you use the conda package manager (version >= 4.7), you can install the
-``compilers`` meta-package from the conda-forge channel, which provides
-OpenMP-enabled C/C++ compilers based on the llvm toolchain.
+``compilers`` meta-package from the conda-forge channel (use version >= 1.0.4)
+which provides OpenMP-enabled C/C++ compilers based on the llvm toolchain.
 
 First install the macOS command line tools::
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
No Open Issue on Github.
Paris Sprint 2020: Issue showed up when trying to use OpenMP when compiling sklearn.

#### What does this implement/fix? Explain your changes.
The commands shown in the advanced installation guide for MacOS do not work properly for some users.
The version of the `compilers` package downloaded from `conda-forge` was `1.0.3`
For some reasons, this version does not properly set up the linker flags ($LDFLAGS) and OpenMP is not used when sklearn is built.

By using the latest version of compilers `v1.0.4`, this problem is fixed.

#### Any other comments?
I don't understand why conda doesn't fetch the latest version of compilers from `conda-forge`.. 🤔 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
