### PR TITLE
DOC Cleaning parameter spec in docstrings of base module

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -514,7 +514,7 @@ class BiclusterMixin:
 
         Returns
         -------
-        submatrix : array-like
+        submatrix : ndarray
             The submatrix corresponding to bicluster i.
 
         Notes

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -98,10 +98,10 @@ def _pprint(params, offset=0, printer=repr):
     params : dict
         The dictionary to pretty print
 
-    offset : int
+    offset : int, default=0
         The offset in characters to add at the begin of each line.
 
-    printer : callable
+    printer : callable, default=repr
         The function to convert entries to strings, typically
         the builtin str or repr
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -436,10 +436,10 @@ class ClusterMixin:
 
         Parameters
         ----------
-        X : ndarray of shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features)
             Input data.
 
-        y : Ignored, default=None
+        y : Ignored
             Not used, present for API consistency by convention.
 
         Returns
@@ -575,7 +575,7 @@ class DensityMixin:
         ----------
         X : array-like of shape (n_samples, n_features)
 
-        y : Ignored, default=None
+        y : Ignored
             Not used, present for API consistency by convention.
 
         Returns
@@ -599,7 +599,7 @@ class OutlierMixin:
         X : ndarray of shape (n_samples, n_features)
             Input data.
 
-        y : Ignored, default=None
+        y : Ignored
             Not used, present for API consistency by convention.
 
         Returns

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -48,7 +48,7 @@ def clone(estimator, safe=True):
     estimator : estimator object, or list, tuple or set of objects
         The estimator or group of estimators to be cloned
 
-    safe : boolean, optional
+    safe : bool, default=True
         If safe is false, clone will fall back to a deep copy on objects
         that are not estimators.
 
@@ -436,15 +436,15 @@ class ClusterMixin:
 
         Parameters
         ----------
-        X : ndarray, shape (n_samples, n_features)
+        X : ndarray of shape (n_samples, n_features)
             Input data.
 
-        y : Ignored
+        y : Ignored, default=None
             Not used, present for API consistency by convention.
 
         Returns
         -------
-        labels : ndarray, shape (n_samples,)
+        labels : ndarray of shape (n_samples,)
             Cluster labels.
         """
         # non-optimized default implementation; override when a better
@@ -476,9 +476,9 @@ class BiclusterMixin:
 
         Returns
         -------
-        row_ind : np.array, dtype=np.intp
+        row_ind : ndarray, dtype=np.intp
             Indices of rows in the dataset that belong to the bicluster.
-        col_ind : np.array, dtype=np.intp
+        col_ind : ndarray, dtype=np.intp
             Indices of columns in the dataset that belong to the bicluster.
 
         """
@@ -509,12 +509,12 @@ class BiclusterMixin:
         ----------
         i : int
             The index of the cluster.
-        data : array
+        data : array-like
             The data.
 
         Returns
         -------
-        submatrix : array
+        submatrix : array-like
             The submatrix corresponding to bicluster i.
 
         Notes
@@ -540,10 +540,10 @@ class TransformerMixin:
 
         Parameters
         ----------
-        X : numpy array of shape [n_samples, n_features]
+        X : ndarray of shape (n_samples, n_features)
             Training set.
 
-        y : numpy array of shape [n_samples]
+        y : ndarray of shape (n_samples,), default=None
             Target values.
 
         **fit_params : dict
@@ -551,7 +551,7 @@ class TransformerMixin:
 
         Returns
         -------
-        X_new : numpy array of shape [n_samples, n_features_new]
+        X_new : ndarray array of shape (n_samples, n_features_new)
             Transformed array.
         """
         # non-optimized default implementation; override when a better
@@ -575,6 +575,9 @@ class DensityMixin:
         ----------
         X : array-like of shape (n_samples, n_features)
 
+        y : Ignored, default=None
+            Not used, present for API consistency by convention.
+
         Returns
         -------
         score : float
@@ -593,15 +596,15 @@ class OutlierMixin:
 
         Parameters
         ----------
-        X : ndarray, shape (n_samples, n_features)
+        X : ndarray of shape (n_samples, n_features)
             Input data.
 
-        y : Ignored
+        y : Ignored, default=None
             Not used, present for API consistency by convention.
 
         Returns
         -------
-        y : ndarray, shape (n_samples,)
+        y : ndarray of shape (n_samples,)
             1 for inliers, -1 for outliers.
         """
         # override for transductive outlier detectors like LocalOulierFactor


### PR DESCRIPTION
#### Reference Issues/PRs

#15761

#### What does this implement/fix? Explain your changes.

Cleans up parameter spec in `base.py`, so it follows the convention outlined in Contributing Guide

Only changes in docstrings.

