### PR TITLE
DOC Format docstrings in _coordinate_descent.py

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1432,7 +1432,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : True | False | 'auto' | array-like, default='auto'
+    precompute : 'auto', bool or array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -594,7 +594,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     coef_ : array of shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
-    sparse_coef_ : scipy.sparse matrix of shape (n_features, 1) or \
+    sparse_coef_ : sparse matrix of shape (n_features, 1) or \
             (n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -43,7 +43,7 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
     y : ndarray of shape (n_samples,)
         Target values
 
-    Xy : array-like, default=None
+    Xy : array-like of shape (n_features,), default=None
         Xy = np.dot(X.T, y) that can be precomputed.
 
     l1_ratio : float, default=1.0
@@ -165,12 +165,12 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
         List of alphas where to compute the models.
         If ``None`` alphas are set automatically
 
-    precompute : "auto", bool or array-like, default='auto'
+    precompute : 'auto', bool or array-like of shape (n_features, n_features), default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    Xy : array-like, default=None
+    Xy : array-like of shape (n_features,) or (n_features, n_outputs), default=None
         Xy = np.dot(X.T, y) that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
@@ -317,12 +317,12 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         List of alphas where to compute the models.
         If None alphas are set automatically.
 
-    precompute : "auto", bool or array-like, default='auto'
+    precompute : 'auto', bool or array-like of shape (n_features, n_features), default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    Xy : array-like, default=None
+    Xy : array-like of shape (n_features,) or (n_features, n_outputs), default=None
         Xy = np.dot(X.T, y) that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
@@ -552,7 +552,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : bool or array-like, default=False
+    precompute : bool or array-like of shape (n_features, n_features), default=False
         Whether to use a precomputed Gram matrix to speed up
         calculations. The Gram matrix can also be passed as argument.
         For sparse input this option is always ``True`` to preserve sparsity.
@@ -829,7 +829,7 @@ class Lasso(ElasticNet):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : True | False | array-like, default=False
+    precompute : 'auto', bool or array-like of shape (n_features, n_features), default=False
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument. For sparse input
@@ -1260,7 +1260,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : 'auto', bool or array-like, default='auto'
+    precompute : 'auto', bool or array-like of shape (n_features, n_features), default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
@@ -1432,7 +1432,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : 'auto', bool or array-like, default='auto'
+    precompute : 'auto', bool or array-like of shape (n_features, n_features), default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -885,7 +885,7 @@ class Lasso(ElasticNet):
     intercept_ : float or array of shape (n_targets,)
         independent term in decision function.
 
-    n_iter_ : int or array-like of shape (n_targets,)
+    n_iter_ : int or list of int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1277,7 +1277,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
     copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    cv : int, cross-validation generator or an iterable, default=None
+    cv : int, cross-validation generator or iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -151,7 +151,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
         unnecessary memory duplication. If ``y`` is mono-output then ``X``
         can be sparse.
 
-    y : ndarray of shape (n_samples,) or (n_samples, n_outputs)
+    y : {array-like, sparse matrix} of shape (n_samples,) or (n_samples, n_outputs)
         Target values
 
     eps : float, default=1e-3

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -179,7 +179,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
     copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    coef_init : array of shape (n_features, ), default=None
+    coef_init : ndarray of shape (n_features, ), default=None
         The initial values of the coefficients.
 
     verbose : bool or int, default=False

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2033,7 +2033,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
     alpha_ : float
         The amount of penalization chosen by cross validation
 
-    mse_path_ : array of shape (n_alphas, n_folds) or \
+    mse_path_ : ndarray of shape (n_alphas, n_folds) or \
                 (n_l1_ratio, n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -355,7 +355,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     Returns
     -------
-    alphas : array of shape (n_alphas,)
+    alphas : ndarray of shape (n_alphas,)
         The alphas along the path where models are computed.
 
     coefs : array of shape (n_features, n_alphas) or \

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1336,7 +1336,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
     intercept_ : float or array of shape (n_targets,)
         independent term in decision function.
 
-    mse_path_ : array of shape (n_alphas, n_folds)
+    mse_path_ : ndarray of shape (n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
     alphas_ : ndarray of shape (n_alphas,)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -204,7 +204,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
             (n_outputs, n_features, n_alphas)
         Coefficients along the path.
 
-    dual_gaps : array of shape (n_alphas,)
+    dual_gaps : ndarray of shape (n_alphas,)
         The dual gaps at the end of the optimization for each alpha.
 
     n_iters : array-like of shape (n_alphas,)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1864,7 +1864,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
         Parameter vector (W in the cost function formula).
         Note that ``coef_`` stores the transpose of ``W``, ``W.T``.
 
-    intercept_ : array of shape (n_tasks,)
+    intercept_ : ndarray of shape (n_tasks,)
         independent term in decision function.
 
     n_iter_ : int

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1403,7 +1403,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
     Parameters
     ----------
-    l1_ratio : float or array of floats, default=0.5
+    l1_ratio : float or list of float, default=0.5
         float between 0 and 1 passed to ElasticNet (scaling between
         l1 and l2 penalties). For ``l1_ratio = 0``
         the penalty is an L2 penalty. For ``l1_ratio = 1`` it is an L1 penalty.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1415,7 +1415,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
     n_alphas : int, default=100
         Number of alphas along the regularization path, used for each l1_ratio.
 
-    alphas : numpy array, default=None
+    alphas : ndarray, default=None
         List of alphas where to compute the models.
         If None alphas are set automatically
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -207,7 +207,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
     dual_gaps : ndarray of shape (n_alphas,)
         The dual gaps at the end of the optimization for each alpha.
 
-    n_iters : array-like of shape (n_alphas,)
+    n_iters : list of int
         The number of iterations taken by the coordinate descent optimizer to
         reach the specified tolerance for each alpha.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2026,7 +2026,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
     intercept_ : ndarray of shape (n_tasks,)
         Independent term in decision function.
 
-    coef_ : array of shape (n_tasks, n_features)
+    coef_ : ndarray of shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula).
         Note that ``coef_`` stores the transpose of ``W``, ``W.T``.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -151,7 +151,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
         unnecessary memory duplication. If ``y`` is mono-output then ``X``
         can be sparse.
 
-    y : ndarray of shape (n_samples,), or (n_samples, n_outputs)
+    y : ndarray of shape (n_samples,) or (n_samples, n_outputs)
         Target values
 
     eps : float, default=1e-3

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -786,7 +786,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
         Returns
         -------
-        T : array of shape (n_samples,)
+        T : ndarray of shape (n_samples,)
             The predicted decision function
         """
         check_is_fitted(self)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1513,7 +1513,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
     intercept_ : float or array of shape (n_targets, n_features)
         Independent term in the decision function.
 
-    mse_path_ : array of shape (n_l1_ratio, n_alpha, n_folds)
+    mse_path_ : ndarray of shape (n_l1_ratio, n_alpha, n_folds)
         Mean square error for the test set on each fold, varying l1_ratio and
         alpha.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -606,7 +606,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     intercept_ : float or ndarray of shape (n_targets,)
         independent term in decision function.
 
-    n_iter_ : array-like of shape (n_targets,)
+    n_iter_ : list of int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2210,7 +2210,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
     mse_path_ : ndarray of shape (n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
-    alphas_ : numpy array of shape (n_alphas,)
+    alphas_ : ndarray of shape (n_alphas,)
         The grid of alphas used for fitting.
 
     n_iter_ : int

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -875,7 +875,7 @@ class Lasso(ElasticNet):
 
     Attributes
     ----------
-    coef_ : array of shape (n_features,) or (n_targets, n_features)
+    coef_ : ndarray of shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
     sparse_coef_ : sparse matrix of shape (n_features, 1) or \

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -933,7 +933,7 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
 
     Parameters
     ----------
-    X : array-like or sparse matrix of shape (n_samples, n_features)
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
         Training data.
 
     y : array-like of shape (n_samples,) or (n_samples, n_targets)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1679,7 +1679,7 @@ class MultiTaskElasticNet(Lasso):
     intercept_ : ndarray of shape (n_tasks,)
         Independent term in decision function.
 
-    coef_ : array of shape (n_tasks, n_features)
+    coef_ : ndarray of shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula). If a 1D y is
         passed in at fit (non multi-task usage), ``coef_`` is then a 1D array.
         Note that ``coef_`` stores the transpose of ``W``, ``W.T``.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -317,7 +317,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         List of alphas where to compute the models.
         If None alphas are set automatically.
 
-    precompute : True | False | 'auto' | array-like, default='auto'
+    precompute : "auto", bool or array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -596,7 +596,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     Attributes
     ----------
-    coef_ : array of shape (n_features,) or (n_targets, n_features)
+    coef_ : ndarray of shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
     sparse_coef_ : sparse matrix of shape (n_features, 1) or \

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -146,7 +146,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
 
     Parameters
     ----------
-    X : array-like or sparse matrix of shape (n_samples, n_features)
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
         Training data. Pass directly as Fortran-contiguous data to avoid
         unnecessary memory duplication. If ``y`` is mono-output then ``X``
         can be sparse.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1335,7 +1335,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
     alphas_ : ndarray of shape (n_alphas,)
         The grid of alphas used for fitting
 
-    dual_gap_ : ndarray of shape ()
+    dual_gap_ : float or ndarray of shape (n_targets,)
         The dual gap at the end of the optimization for the optimal alpha
         (``alpha_``).
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2200,7 +2200,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
     intercept_ : ndarray of shape (n_tasks,)
         Independent term in decision function.
 
-    coef_ : array of shape (n_tasks, n_features)
+    coef_ : ndarray of shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula).
         Note that ``coef_`` stores the transpose of ``W``, ``W.T``.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1507,7 +1507,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         The compromise between l1 and l2 penalization chosen by
         cross validation
 
-    coef_ : array of shape (n_features,) or (n_targets, n_features)
+    coef_ : ndarray of shape (n_features,) or (n_targets, n_features)
         Parameter vector (w in the cost function formula),
 
     intercept_ : float or array of shape (n_targets, n_features)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -872,7 +872,7 @@ class Lasso(ElasticNet):
     coef_ : array of shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
-    sparse_coef_ : scipy.sparse matrix of shape (n_features, 1) or \
+    sparse_coef_ : sparse matrix of shape (n_features, 1) or \
             (n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1247,7 +1247,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         List of alphas where to compute the models.
         If ``None`` alphas are set automatically
 
-    fit_intercept : bool, default True
+    fit_intercept : bool, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -362,7 +362,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
             (n_outputs, n_features, n_alphas)
         Coefficients along the path.
 
-    dual_gaps : array of shape (n_alphas,)
+    dual_gaps : ndarray of shape (n_alphas,)
         The dual gaps at the end of the optimization for each alpha.
 
     n_iters : array-like of shape (n_alphas,)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1509,7 +1509,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         Mean square error for the test set on each fold, varying l1_ratio and
         alpha.
 
-    alphas_ : numpy array of shape (n_alphas,) or (n_l1_ratio, n_alphas)
+    alphas_ : ndarray of shape (n_alphas,) or (n_l1_ratio, n_alphas)
         The grid of alphas used for fitting, for each l1_ratio.
 
     n_iter_ : int

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -165,7 +165,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
         List of alphas where to compute the models.
         If ``None`` alphas are set automatically
 
-    precompute : True | False | 'auto' | array-like, default='auto'
+    precompute : "auto", bool or array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -603,7 +603,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
             (n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 
-    intercept_ : float or array of shape (n_targets,)
+    intercept_ : float or ndarray of shape (n_targets,)
         independent term in decision function.
 
     n_iter_ : array-like of shape (n_targets,)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -358,7 +358,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     alphas : ndarray of shape (n_alphas,)
         The alphas along the path where models are computed.
 
-    coefs : array of shape (n_features, n_alphas) or \
+    coefs : ndarray of shape (n_features, n_alphas) or \
             (n_outputs, n_features, n_alphas)
         Coefficients along the path.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1446,7 +1446,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    cv : int, cross-validation generator or an iterable, default=None
+    cv : int, cross-validation generator or iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2023,7 +2023,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
 
     Attributes
     ----------
-    intercept_ : array of shape (n_tasks,)
+    intercept_ : ndarray of shape (n_tasks,)
         Independent term in decision function.
 
     coef_ : array of shape (n_tasks, n_features)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -552,7 +552,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : True | False | array-like, default=False
+    precompute : bool or array-like, default=False
         Whether to use a precomputed Gram matrix to speed up
         calculations. The Gram matrix can also be passed as argument.
         For sparse input this option is always ``True`` to preserve sparsity.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1971,7 +1971,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    cv : int, cross-validation generator or an iterable, default=None
+    cv : int, cross-validation generator or iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1243,7 +1243,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
     n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    alphas : numpy array, default=None
+    alphas : ndarray, default=None
         List of alphas where to compute the models.
         If ``None`` alphas are set automatically
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -165,12 +165,14 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
         List of alphas where to compute the models.
         If ``None`` alphas are set automatically
 
-    precompute : 'auto', bool or array-like of shape (n_features, n_features), default='auto'
+    precompute : 'auto', bool or array-like of shape (n_features, n_features),\
+                 default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    Xy : array-like of shape (n_features,) or (n_features, n_outputs), default=None
+    Xy : array-like of shape (n_features,) or (n_features, n_outputs),\
+         default=None
         Xy = np.dot(X.T, y) that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
@@ -317,12 +319,14 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         List of alphas where to compute the models.
         If None alphas are set automatically.
 
-    precompute : 'auto', bool or array-like of shape (n_features, n_features), default='auto'
+    precompute : 'auto', bool or array-like of shape (n_features, n_features),\
+                 default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    Xy : array-like of shape (n_features,) or (n_features, n_outputs), default=None
+    Xy : array-like of shape (n_features,) or (n_features, n_outputs),\
+         default=None
         Xy = np.dot(X.T, y) that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
@@ -552,7 +556,8 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : bool or array-like of shape (n_features, n_features), default=False
+    precompute : bool or array-like of shape (n_features, n_features),\
+                 default=False
         Whether to use a precomputed Gram matrix to speed up
         calculations. The Gram matrix can also be passed as argument.
         For sparse input this option is always ``True`` to preserve sparsity.
@@ -829,7 +834,8 @@ class Lasso(ElasticNet):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : 'auto', bool or array-like of shape (n_features, n_features), default=False
+    precompute : 'auto', bool or array-like of shape (n_features, n_features),\
+                 default=False
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument. For sparse input
@@ -1260,7 +1266,8 @@ class LassoCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : 'auto', bool or array-like of shape (n_features, n_features), default='auto'
+    precompute : 'auto', bool or array-like of shape (n_features, n_features),\
+                 default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
@@ -1432,7 +1439,8 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : 'auto', bool or array-like of shape (n_features, n_features), default='auto'
+    precompute : 'auto', bool or array-like of shape (n_features, n_features),\
+                 default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -659,7 +659,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
         Parameters
         ----------
-        X : ndarray or scipy.sparse matrix of (n_samples, n_features)
+        X : {ndarray, sparse matrix} of (n_samples, n_features)
             Data
 
         y : ndarray of shape (n_samples,) or (n_samples, n_targets)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1934,7 +1934,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
 
     Parameters
     ----------
-    l1_ratio : float or array of floats, default=0.5
+    l1_ratio : float or list of float, default=0.5
         The ElasticNet mixing parameter, with 0 < l1_ratio <= 1.
         For l1_ratio = 1 the penalty is an L1/L2 penalty. For l1_ratio = 0 it
         is an L2 penalty.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2197,7 +2197,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
 
     Attributes
     ----------
-    intercept_ : array of shape (n_tasks,)
+    intercept_ : ndarray of shape (n_tasks,)
         Independent term in decision function.
 
     coef_ : array of shape (n_tasks, n_features)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2207,7 +2207,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
     alpha_ : float
         The amount of penalization chosen by cross validation
 
-    mse_path_ : array of shape (n_alphas, n_folds)
+    mse_path_ : ndarray of shape (n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
     alphas_ : numpy array of shape (n_alphas,)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1676,7 +1676,7 @@ class MultiTaskElasticNet(Lasso):
 
     Attributes
     ----------
-    intercept_ : array of shape (n_tasks,)
+    intercept_ : ndarray of shape (n_tasks,)
         Independent term in decision function.
 
     coef_ : array of shape (n_tasks, n_features)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -151,7 +151,8 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
         unnecessary memory duplication. If ``y`` is mono-output then ``X``
         can be sparse.
 
-    y : {array-like, sparse matrix} of shape (n_samples,) or (n_samples, n_outputs)
+    y : {array-like, sparse matrix} of shape (n_samples,) or \
+        (n_samples, n_outputs)
         Target values
 
     eps : float, default=1e-3
@@ -301,7 +302,8 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         unnecessary memory duplication. If ``y`` is mono-output then ``X``
         can be sparse.
 
-    y : {array-like, sparse matrix} of shape (n_samples,) or (n_samples, n_outputs)
+    y : {array-like, sparse matrix} of shape (n_samples,) or \
+        (n_samples, n_outputs)
         Target values.
 
     l1_ratio : float, default=0.5
@@ -667,7 +669,8 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         X : {ndarray, sparse matrix} of (n_samples, n_features)
             Data
 
-        y : ndarray of shape (n_samples,) or (n_samples, n_targets)
+        y : {ndarray, sparse matrix} of shape (n_samples,) or \
+            (n_samples, n_targets)
             Target. Will be cast to X's dtype if necessary
 
         check_input : bool, default=True
@@ -882,7 +885,7 @@ class Lasso(ElasticNet):
             (n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 
-    intercept_ : float or array of shape (n_targets,)
+    intercept_ : float or ndarray of shape (n_targets,)
         independent term in decision function.
 
     n_iter_ : int or list of int
@@ -1061,7 +1064,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Training data. Pass directly as Fortran-contiguous data
             to avoid unnecessary memory duplication. If y is mono-output,
             X can be sparse.
@@ -1333,7 +1336,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
     coef_ : ndarray of shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
-    intercept_ : float or array of shape (n_targets,)
+    intercept_ : float or ndarray of shape (n_targets,)
         independent term in decision function.
 
     mse_path_ : ndarray of shape (n_alphas, n_folds)
@@ -1510,7 +1513,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
     coef_ : ndarray of shape (n_features,) or (n_targets, n_features)
         Parameter vector (w in the cost function formula),
 
-    intercept_ : float or array of shape (n_targets, n_features)
+    intercept_ : float or ndarray of shape (n_targets, n_features)
         Independent term in the decision function.
 
     mse_path_ : ndarray of shape (n_l1_ratio, n_alpha, n_folds)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -200,7 +200,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
     alphas : ndarray of shape (n_alphas,)
         The alphas along the path where models are computed.
 
-    coefs : array of shape (n_features, n_alphas) or \
+    coefs : ndarray of shape (n_features, n_alphas) or \
             (n_outputs, n_features, n_alphas)
         Coefficients along the path.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2148,7 +2148,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
     copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    cv : int, cross-validation generator or an iterable, default=None
+    cv : int, cross-validation generator or iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2037,7 +2037,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
                 (n_l1_ratio, n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
-    alphas_ : numpy array of shape (n_alphas,) or (n_l1_ratio, n_alphas)
+    alphas_ : ndarray of shape (n_alphas,) or (n_l1_ratio, n_alphas)
         The grid of alphas used for fitting, for each l1_ratio
 
     l1_ratio_ : float

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -36,11 +36,11 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
 
     Parameters
     ----------
-    X : {array-like, sparse matrix}, shape (n_samples, n_features)
+    X : array-like or sparse matrix of shape (n_samples, n_features)
         Training data. Pass directly as Fortran-contiguous data to avoid
         unnecessary memory duplication
 
-    y : ndarray, shape (n_samples,)
+    y : ndarray of shape (n_samples,)
         Target values
 
     Xy : array-like, default=None
@@ -59,10 +59,10 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
     n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    fit_intercept : boolean, default=True
+    fit_intercept : bool, default=True
         Whether to fit an intercept or not
 
-    normalize : boolean, default=False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -70,7 +70,7 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default=True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
     """
     if l1_ratio == 0:
@@ -146,47 +146,47 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
 
     Parameters
     ----------
-    X : {array-like, sparse matrix}, shape (n_samples, n_features)
+    X : array-like or sparse matrix of shape (n_samples, n_features)
         Training data. Pass directly as Fortran-contiguous data to avoid
         unnecessary memory duplication. If ``y`` is mono-output then ``X``
         can be sparse.
 
-    y : ndarray, shape (n_samples,), or (n_samples, n_outputs)
+    y : ndarray of shape (n_samples,), or (n_samples, n_outputs)
         Target values
 
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    alphas : ndarray, optional
+    alphas : ndarray, default=None
         List of alphas where to compute the models.
         If ``None`` alphas are set automatically
 
-    precompute : True | False | 'auto' | array-like
+    precompute : True | False | 'auto' | array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    Xy : array-like, optional
+    Xy : array-like, default=None
         Xy = np.dot(X.T, y) that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
-    copy_X : boolean, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    coef_init : array, shape (n_features, ) | None
+    coef_init : array of shape (n_features, ), default=None
         The initial values of the coefficients.
 
-    verbose : bool or integer
+    verbose : bool or int, default=False
         Amount of verbosity.
 
-    return_n_iter : bool
+    return_n_iter : bool, default=False
         whether to return the number of iterations or not.
 
-    positive : bool, default False
+    positive : bool, default=False
         If set to True, forces coefficients to be positive.
         (Only allowed when ``y.ndim == 1``).
 
@@ -195,17 +195,17 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
 
     Returns
     -------
-    alphas : array, shape (n_alphas,)
+    alphas : array of shape (n_alphas,)
         The alphas along the path where models are computed.
 
-    coefs : array, shape (n_features, n_alphas) or \
+    coefs : array of shape (n_features, n_alphas) or \
             (n_outputs, n_features, n_alphas)
         Coefficients along the path.
 
-    dual_gaps : array, shape (n_alphas,)
+    dual_gaps : array of shape (n_alphas,)
         The dual gaps at the end of the optimization for each alpha.
 
-    n_iters : array-like, shape (n_alphas,)
+    n_iters : array-like of shape (n_alphas,)
         The number of iterations taken by the coordinate descent optimizer to
         reach the specified tolerance for each alpha.
 
@@ -294,55 +294,55 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     Parameters
     ----------
-    X : {array-like}, shape (n_samples, n_features)
+    X : array-like of shape (n_samples, n_features)
         Training data. Pass directly as Fortran-contiguous data to avoid
         unnecessary memory duplication. If ``y`` is mono-output then ``X``
         can be sparse.
 
-    y : ndarray, shape (n_samples,) or (n_samples, n_outputs)
+    y : ndarray of shape (n_samples,) or (n_samples, n_outputs)
         Target values.
 
-    l1_ratio : float, optional
+    l1_ratio : float, default=0.5
         Number between 0 and 1 passed to elastic net (scaling between
         l1 and l2 penalties). ``l1_ratio=1`` corresponds to the Lasso.
 
-    eps : float
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path.
 
-    alphas : ndarray, optional
+    alphas : ndarray, default=None
         List of alphas where to compute the models.
         If None alphas are set automatically.
 
-    precompute : True | False | 'auto' | array-like
+    precompute : True | False | 'auto' | array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    Xy : array-like, optional
+    Xy : array-like, default=None
         Xy = np.dot(X.T, y) that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
-    copy_X : bool, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    coef_init : array, shape (n_features, ) | None
+    coef_init : array of shape (n_features, ), default=None
         The initial values of the coefficients.
 
-    verbose : bool or int
+    verbose : bool or int, default=False
         Amount of verbosity.
 
-    return_n_iter : bool
+    return_n_iter : bool, default=False
         Whether to return the number of iterations or not.
 
-    positive : bool, default False
+    positive : bool, default=False
         If set to True, forces coefficients to be positive.
         (Only allowed when ``y.ndim == 1``).
 
-    check_input : bool, default True
+    check_input : bool, default=True
         Skip input validation checks, including the Gram matrix when provided
         assuming there are handled by the caller when check_input=False.
 
@@ -351,17 +351,17 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     Returns
     -------
-    alphas : array, shape (n_alphas,)
+    alphas : array of shape (n_alphas,)
         The alphas along the path where models are computed.
 
-    coefs : array, shape (n_features, n_alphas) or \
+    coefs : array of shape (n_features, n_alphas) or \
             (n_outputs, n_features, n_alphas)
         Coefficients along the path.
 
-    dual_gaps : array, shape (n_alphas,)
+    dual_gaps : array of shape (n_alphas,)
         The dual gaps at the end of the optimization for each alpha.
 
-    n_iters : array-like, shape (n_alphas,)
+    n_iters : array-like of shape (n_alphas,)
         The number of iterations taken by the coordinate descent optimizer to
         reach the specified tolerance for each alpha.
         (Is returned when ``return_n_iter`` is set to True).
@@ -526,7 +526,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float, default=1.0
         Constant that multiplies the penalty terms. Defaults to 1.0.
         See the notes for the exact mathematical meaning of this
         parameter. ``alpha = 0`` is equivalent to an ordinary least square,
@@ -534,17 +534,17 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         reasons, using ``alpha = 0`` with the ``Lasso`` object is not advised.
         Given this, you should use the :class:`LinearRegression` object.
 
-    l1_ratio : float
+    l1_ratio : float, default=0.5
         The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``. For
         ``l1_ratio = 0`` the penalty is an L2 penalty. ``For l1_ratio = 1`` it
         is an L1 penalty.  For ``0 < l1_ratio < 1``, the penalty is a
         combination of L1 and L2.
 
-    fit_intercept : bool
+    fit_intercept : bool, default=True
         Whether the intercept should be estimated or not. If ``False``, the
         data is assumed to be already centered.
 
-    normalize : boolean, optional, default False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -552,29 +552,29 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : True | False | array-like
+    precompute : True | False | array-like, default=False
         Whether to use a precomputed Gram matrix to speed up
         calculations. The Gram matrix can also be passed as argument.
         For sparse input this option is always ``True`` to preserve sparsity.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    copy_X : boolean, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    warm_start : bool, optional
+    warm_start : bool, default=False
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
 
-    positive : bool, optional
+    positive : bool, default=False
         When set to ``True``, forces the coefficients to be positive.
 
     random_state : int, RandomState instance, default=None
@@ -583,7 +583,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    selection : str, default 'cyclic'
+    selection : {'cyclic', 'random'}, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -591,17 +591,17 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     Attributes
     ----------
-    coef_ : array, shape (n_features,) | (n_targets, n_features)
+    coef_ : array of shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
-    sparse_coef_ : scipy.sparse matrix, shape (n_features, 1) | \
+    sparse_coef_ : scipy.sparse matrix of shape (n_features, 1) or \
             (n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 
-    intercept_ : float | array, shape (n_targets,)
+    intercept_ : float or array of shape (n_targets,)
         independent term in decision function.
 
-    n_iter_ : array-like, shape (n_targets,)
+    n_iter_ : array-like of shape (n_targets,)
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
@@ -659,13 +659,13 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
         Parameters
         ----------
-        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+        X : ndarray or scipy.sparse matrix of (n_samples, n_features)
             Data
 
-        y : ndarray, shape (n_samples,) or (n_samples, n_targets)
+        y : ndarray of shape (n_samples,) or (n_samples, n_targets)
             Target. Will be cast to X's dtype if necessary
 
-        check_input : boolean, (default=True)
+        check_input : bool, default=True
             Allow to bypass several input checking.
             Don't use this parameter unless you know what you do.
 
@@ -781,7 +781,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
         Returns
         -------
-        T : array, shape (n_samples,)
+        T : array of shape (n_samples,)
             The predicted decision function
         """
         check_is_fitted(self)
@@ -809,19 +809,19 @@ class Lasso(ElasticNet):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float, default=1.0
         Constant that multiplies the L1 term. Defaults to 1.0.
         ``alpha = 0`` is equivalent to an ordinary least square, solved
         by the :class:`LinearRegression` object. For numerical
         reasons, using ``alpha = 0`` with the ``Lasso`` object is not advised.
         Given this, you should use the :class:`LinearRegression` object.
 
-    fit_intercept : boolean, optional, default True
+    fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set
         to False, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -835,24 +835,24 @@ class Lasso(ElasticNet):
         matrix can also be passed as argument. For sparse input
         this option is always ``True`` to preserve sparsity.
 
-    copy_X : boolean, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    warm_start : bool, optional
+    warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
 
-    positive : bool, optional
+    positive : bool, default=False
         When set to ``True``, forces the coefficients to be positive.
 
     random_state : int, RandomState instance, default=None
@@ -861,7 +861,7 @@ class Lasso(ElasticNet):
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    selection : str, default 'cyclic'
+    selection : {'cyclic', 'random'}, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -869,17 +869,17 @@ class Lasso(ElasticNet):
 
     Attributes
     ----------
-    coef_ : array, shape (n_features,) | (n_targets, n_features)
+    coef_ : array of shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
-    sparse_coef_ : scipy.sparse matrix, shape (n_features, 1) | \
+    sparse_coef_ : scipy.sparse matrix of shape (n_features, 1) or \
             (n_targets, n_features)
         ``sparse_coef_`` is a readonly property derived from ``coef_``
 
-    intercept_ : float | array, shape (n_targets,)
+    intercept_ : float or array of shape (n_targets,)
         independent term in decision function.
 
-    n_iter_ : int | array-like, shape (n_targets,)
+    n_iter_ : int or array-like of shape (n_targets,)
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
@@ -933,10 +933,10 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
 
     Parameters
     ----------
-    X : {array-like, sparse matrix}, shape (n_samples, n_features)
+    X : array-like or sparse matrix of shape (n_samples, n_features)
         Training data.
 
-    y : array-like, shape (n_samples,) or (n_samples, n_targets)
+    y : array-like of shape (n_samples,) or (n_samples, n_targets)
         Target values
 
     train : list of indices
@@ -952,21 +952,21 @@ def _path_residuals(X, y, train, test, path, path_params, alphas=None,
     path_params : dictionary
         Parameters passed to the path function
 
-    alphas : array-like, optional
+    alphas : array-like, default=None
         Array of float that is used for cross-validation. If not
         provided, computed using 'path'.
 
-    l1_ratio : float, optional
+    l1_ratio : float, default=1
         float between 0 and 1 passed to ElasticNet (scaling between
         l1 and l2 penalties). For ``l1_ratio = 0`` the penalty is an
         L2 penalty. For ``l1_ratio = 1`` it is an L1 penalty. For ``0
         < l1_ratio < 1``, the penalty is a combination of L1 and L2.
 
-    X_order : {'F', 'C', or None}, optional
+    X_order : {'F', 'C'}, default=None
         The order of the arrays expected by the path function to
         avoid memory copies
 
-    dtype : a numpy dtype or None
+    dtype : a numpy dtype, default=None
         The dtype of the arrays expected by the path function to
         avoid memory copies
     """
@@ -1055,12 +1055,12 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : {array-like}, shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features)
             Training data. Pass directly as Fortran-contiguous data
             to avoid unnecessary memory duplication. If y is mono-output,
             X can be sparse.
 
-        y : array-like, shape (n_samples,) or (n_samples, n_targets)
+        y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Target values
         """
         y = check_array(y, copy=False, dtype=[np.float64, np.float32],
@@ -1236,23 +1236,23 @@ class LassoCV(RegressorMixin, LinearModelCV):
 
     Parameters
     ----------
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    alphas : numpy array, optional
+    alphas : numpy array, default=None
         List of alphas where to compute the models.
         If ``None`` alphas are set automatically
 
-    fit_intercept : boolean, default True
+    fit_intercept : bool, default True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1260,33 +1260,33 @@ class LassoCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : True | False | 'auto' | array-like
+    precompute : True | False | 'auto' | array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    copy_X : boolean, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
         - None, to use the default 5-fold cross-validation,
-        - integer, to specify the number of folds.
+        - int, to specify the number of folds.
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For integer/None inputs, :class:`KFold` is used.
+        For int/None inputs, :class:`KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
@@ -1294,16 +1294,16 @@ class LassoCV(RegressorMixin, LinearModelCV):
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    verbose : bool or integer
+    verbose : bool or int, default=False
         Amount of verbosity.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int, default=None
         Number of CPUs to use during the cross validation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    positive : bool, optional
+    positive : bool, default=False
         If positive, restrict regression coefficients to be positive
 
     random_state : int, RandomState instance, default=None
@@ -1312,7 +1312,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    selection : str, default 'cyclic'
+    selection : {'cyclic', 'random'}, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -1323,19 +1323,19 @@ class LassoCV(RegressorMixin, LinearModelCV):
     alpha_ : float
         The amount of penalization chosen by cross validation
 
-    coef_ : array, shape (n_features,) | (n_targets, n_features)
+    coef_ : array of shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
-    intercept_ : float | array, shape (n_targets,)
+    intercept_ : float or array of shape (n_targets,)
         independent term in decision function.
 
-    mse_path_ : array, shape (n_alphas, n_folds)
+    mse_path_ : array of shape (n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
-    alphas_ : numpy array, shape (n_alphas,)
+    alphas_ : numpy array of shape (n_alphas,)
         The grid of alphas used for fitting
 
-    dual_gap_ : ndarray, shape ()
+    dual_gap_ : ndarray of shape ()
         The dual gap at the end of the optimization for the optimal alpha
         (``alpha_``).
 
@@ -1396,7 +1396,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
     Parameters
     ----------
-    l1_ratio : float or array of floats, optional
+    l1_ratio : float or array of floats, default=0.5
         float between 0 and 1 passed to ElasticNet (scaling between
         l1 and l2 penalties). For ``l1_ratio = 0``
         the penalty is an L2 penalty. For ``l1_ratio = 1`` it is an L1 penalty.
@@ -1408,23 +1408,23 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         (i.e. Lasso) and less close to 0 (i.e. Ridge), as in ``[.1, .5, .7,
         .9, .95, .99, 1]``
 
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path, used for each l1_ratio.
 
-    alphas : numpy array, optional
+    alphas : numpy array, default=None
         List of alphas where to compute the models.
         If None alphas are set automatically
 
-    fit_intercept : boolean
+    fit_intercept : bool, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1432,30 +1432,30 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : True | False | 'auto' | array-like
+    precompute : True | False | 'auto' | array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
         - None, to use the default 5-fold cross-validation,
-        - integer, to specify the number of folds.
+        - int, to specify the number of folds.
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For integer/None inputs, :class:`KFold` is used.
+        For int/None inputs, :class:`KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
@@ -1463,19 +1463,19 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    copy_X : boolean, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    verbose : bool or integer
+    verbose : bool or int, default=0
         Amount of verbosity.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int, default=None
         Number of CPUs to use during the cross validation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    positive : bool, optional
+    positive : bool, default=False
         When set to ``True``, forces the coefficients to be positive.
 
     random_state : int, RandomState instance, default=None
@@ -1484,7 +1484,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    selection : str, default 'cyclic'
+    selection : {'cyclic', 'random'}, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -1499,17 +1499,17 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         The compromise between l1 and l2 penalization chosen by
         cross validation
 
-    coef_ : array, shape (n_features,) | (n_targets, n_features)
+    coef_ : array of shape (n_features,) or (n_targets, n_features)
         Parameter vector (w in the cost function formula),
 
-    intercept_ : float | array, shape (n_targets, n_features)
+    intercept_ : float or array of shape (n_targets, n_features)
         Independent term in the decision function.
 
-    mse_path_ : array, shape (n_l1_ratio, n_alpha, n_folds)
+    mse_path_ : array of shape (n_l1_ratio, n_alpha, n_folds)
         Mean square error for the test set on each fold, varying l1_ratio and
         alpha.
 
-    alphas_ : numpy array, shape (n_alphas,) or (n_l1_ratio, n_alphas)
+    alphas_ : numpy array of shape (n_alphas,) or (n_l1_ratio, n_alphas)
         The grid of alphas used for fitting, for each l1_ratio.
 
     n_iter_ : int
@@ -1615,21 +1615,21 @@ class MultiTaskElasticNet(Lasso):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float, default=1.0
         Constant that multiplies the L1/L2 term. Defaults to 1.0
 
-    l1_ratio : float
+    l1_ratio : float, default=0.5
         The ElasticNet mixing parameter, with 0 < l1_ratio <= 1.
         For l1_ratio = 1 the penalty is an L1/L2 penalty. For l1_ratio = 0 it
         is an L2 penalty.
         For ``0 < l1_ratio < 1``, the penalty is a combination of L1/L2 and L2.
 
-    fit_intercept : boolean
+    fit_intercept : bool, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1637,19 +1637,19 @@ class MultiTaskElasticNet(Lasso):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    warm_start : bool, optional
+    warm_start : bool, default=False
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
@@ -1660,7 +1660,7 @@ class MultiTaskElasticNet(Lasso):
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    selection : str, default 'cyclic'
+    selection : {'cyclic', 'random'}, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -1668,10 +1668,10 @@ class MultiTaskElasticNet(Lasso):
 
     Attributes
     ----------
-    intercept_ : array, shape (n_tasks,)
+    intercept_ : array of shape (n_tasks,)
         Independent term in decision function.
 
-    coef_ : array, shape (n_tasks, n_features)
+    coef_ : array of shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula). If a 1D y is
         passed in at fit (non multi-task usage), ``coef_`` is then a 1D array.
         Note that ``coef_`` stores the transpose of ``W``, ``W.T``.
@@ -1725,9 +1725,9 @@ class MultiTaskElasticNet(Lasso):
 
         Parameters
         ----------
-        X : ndarray, shape (n_samples, n_features)
+        X : ndarray of shape (n_samples, n_features)
             Data
-        y : ndarray, shape (n_samples, n_tasks)
+        y : ndarray of shape (n_samples, n_tasks)
             Target. Will be cast to X's dtype if necessary
 
         Notes
@@ -1805,15 +1805,15 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
     Parameters
     ----------
-    alpha : float, optional
+    alpha : float, default=1.0
         Constant that multiplies the L1/L2 term. Defaults to 1.0
 
-    fit_intercept : boolean
+    fit_intercept : bool, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1821,19 +1821,19 @@ class MultiTaskLasso(MultiTaskElasticNet):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    copy_X : boolean, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    warm_start : bool, optional
+    warm_start : bool, default=False
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
         See :term:`the Glossary <warm_start>`.
@@ -1844,7 +1844,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    selection : str, default 'cyclic'
+    selection : {'cyclic', 'random'}, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -1852,11 +1852,11 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
     Attributes
     ----------
-    coef_ : array, shape (n_tasks, n_features)
+    coef_ : array of shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula).
         Note that ``coef_`` stores the transpose of ``W``, ``W.T``.
 
-    intercept_ : array, shape (n_tasks,)
+    intercept_ : array of shape (n_tasks,)
         independent term in decision function.
 
     n_iter_ : int
@@ -1926,7 +1926,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
 
     Parameters
     ----------
-    l1_ratio : float or array of floats
+    l1_ratio : float or array of floats, default=0.5
         The ElasticNet mixing parameter, with 0 < l1_ratio <= 1.
         For l1_ratio = 1 the penalty is an L1/L2 penalty. For l1_ratio = 0 it
         is an L2 penalty.
@@ -1938,23 +1938,23 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         (i.e. Lasso) and less close to 0 (i.e. Ridge), as in ``[.1, .5, .7,
         .9, .95, .99, 1]``
 
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    alphas : array-like, optional
+    alphas : array-like, default=None
         List of alphas where to compute the models.
         If not provided, set automatically.
 
-    fit_intercept : boolean
+    fit_intercept : bool, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -1962,25 +1962,25 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
         - None, to use the default 5-fold cross-validation,
-        - integer, to specify the number of folds.
+        - int, to specify the number of folds.
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For integer/None inputs, :class:`KFold` is used.
+        For int/None inputs, :class:`KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
@@ -1988,13 +1988,13 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    copy_X : boolean, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    verbose : bool or integer
+    verbose : bool or int, default=0
         Amount of verbosity.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int, default=None
         Number of CPUs to use during the cross validation. Note that this is
         used only if multiple values for l1_ratio are given.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
@@ -2007,7 +2007,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    selection : str, default 'cyclic'
+    selection : {'cyclic', 'random'}, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -2015,21 +2015,21 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
 
     Attributes
     ----------
-    intercept_ : array, shape (n_tasks,)
+    intercept_ : array of shape (n_tasks,)
         Independent term in decision function.
 
-    coef_ : array, shape (n_tasks, n_features)
+    coef_ : array of shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula).
         Note that ``coef_`` stores the transpose of ``W``, ``W.T``.
 
     alpha_ : float
         The amount of penalization chosen by cross validation
 
-    mse_path_ : array, shape (n_alphas, n_folds) or \
+    mse_path_ : array of shape (n_alphas, n_folds) or \
                 (n_l1_ratio, n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
-    alphas_ : numpy array, shape (n_alphas,) or (n_l1_ratio, n_alphas)
+    alphas_ : numpy array of shape (n_alphas,) or (n_l1_ratio, n_alphas)
         The grid of alphas used for fitting, for each l1_ratio
 
     l1_ratio_ : float
@@ -2112,23 +2112,23 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
 
     Parameters
     ----------
-    eps : float, optional
+    eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
         ``alpha_min / alpha_max = 1e-3``.
 
-    n_alphas : int, optional
+    n_alphas : int, default=100
         Number of alphas along the regularization path
 
-    alphas : array-like, optional
+    alphas : array-like, default=None
         List of alphas where to compute the models.
         If not provided, set automatically.
 
-    fit_intercept : boolean
+    fit_intercept : bool, default=True
         whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
-    normalize : boolean, optional, default False
+    normalize : bool, default=False
         This parameter is ignored when ``fit_intercept`` is set to False.
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
@@ -2136,28 +2136,28 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    max_iter : int, optional
+    max_iter : int, default=1000
         The maximum number of iterations.
 
-    tol : float, optional
+    tol : float, default=1e-4
         The tolerance for the optimization: if the updates are
         smaller than ``tol``, the optimization code checks the
         dual gap for optimality and continues until it is smaller
         than ``tol``.
 
-    copy_X : boolean, optional, default True
+    copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
         - None, to use the default 5-fold cross-validation,
-        - integer, to specify the number of folds.
+        - int, to specify the number of folds.
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For integer/None inputs, :class:`KFold` is used.
+        For int/None inputs, :class:`KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
@@ -2165,10 +2165,10 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         .. versionchanged:: 0.22
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
-    verbose : bool or integer
+    verbose : bool or int, default=False
         Amount of verbosity.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int, default=None
         Number of CPUs to use during the cross validation. Note that this is
         used only if multiple values for l1_ratio are given.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
@@ -2181,7 +2181,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    selection : str, default 'cyclic'
+    selection : {'cyclic', 'random'}, default='cyclic'
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
@@ -2189,20 +2189,20 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
 
     Attributes
     ----------
-    intercept_ : array, shape (n_tasks,)
+    intercept_ : array of shape (n_tasks,)
         Independent term in decision function.
 
-    coef_ : array, shape (n_tasks, n_features)
+    coef_ : array of shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula).
         Note that ``coef_`` stores the transpose of ``W``, ``W.T``.
 
     alpha_ : float
         The amount of penalization chosen by cross validation
 
-    mse_path_ : array, shape (n_alphas, n_folds)
+    mse_path_ : array of shape (n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
-    alphas_ : numpy array, shape (n_alphas,)
+    alphas_ : numpy array of shape (n_alphas,)
         The grid of alphas used for fitting.
 
     n_iter_ : int

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -197,7 +197,7 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
 
     Returns
     -------
-    alphas : array of shape (n_alphas,)
+    alphas : ndarray of shape (n_alphas,)
         The alphas along the path where models are computed.
 
     coefs : array of shape (n_features, n_alphas) or \

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1332,7 +1332,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
     mse_path_ : array of shape (n_alphas, n_folds)
         mean square error for the test set on each fold, varying alpha
 
-    alphas_ : numpy array of shape (n_alphas,)
+    alphas_ : ndarray of shape (n_alphas,)
         The grid of alphas used for fitting
 
     dual_gap_ : ndarray of shape ()

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -301,7 +301,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         unnecessary memory duplication. If ``y`` is mono-output then ``X``
         can be sparse.
 
-    y : ndarray of shape (n_samples,) or (n_samples, n_outputs)
+    y : {array-like, sparse matrix} of shape (n_samples,) or (n_samples, n_outputs)
         Target values.
 
     l1_ratio : float, default=0.5

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -36,7 +36,7 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
 
     Parameters
     ----------
-    X : array-like or sparse matrix of shape (n_samples, n_features)
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
         Training data. Pass directly as Fortran-contiguous data to avoid
         unnecessary memory duplication
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1260,7 +1260,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : True | False | 'auto' | array-like, default='auto'
+    precompute : 'auto', bool or array-like, default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -296,7 +296,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
 
     Parameters
     ----------
-    X : array-like of shape (n_samples, n_features)
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
         Training data. Pass directly as Fortran-contiguous data to avoid
         unnecessary memory duplication. If ``y`` is mono-output then ``X``
         can be sparse.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -333,7 +333,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 
-    coef_init : array of shape (n_features, ), default=None
+    coef_init : ndarray of shape (n_features, ), default=None
         The initial values of the coefficients.
 
     verbose : bool or int, default=False

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1860,7 +1860,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
     Attributes
     ----------
-    coef_ : array of shape (n_tasks, n_features)
+    coef_ : ndarray of shape (n_tasks, n_features)
         Parameter vector (W in the cost function formula).
         Note that ``coef_`` stores the transpose of ``W``, ``W.T``.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1330,7 +1330,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
     alpha_ : float
         The amount of penalization chosen by cross validation
 
-    coef_ : array of shape (n_features,) or (n_targets, n_features)
+    coef_ : ndarray of shape (n_features,) or (n_targets, n_features)
         parameter vector (w in the cost function formula)
 
     intercept_ : float or array of shape (n_targets,)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -365,7 +365,7 @@ def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
     dual_gaps : ndarray of shape (n_alphas,)
         The dual gaps at the end of the optimization for each alpha.
 
-    n_iters : array-like of shape (n_alphas,)
+    n_iters : list of int
         The number of iterations taken by the coordinate descent optimizer to
         reach the specified tolerance for each alpha.
         (Is returned when ``return_n_iter`` is set to True).


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #15761 

#### What does this implement/fix? Explain your changes.
Improves docstrings (mainly default values) in all classes and function under sklearn/linear_model/_coordinate_descent.py

#### Any other comments?
As a part of the Paris Sprint

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
