### PR TITLE
WIP Get column transform to accept other than strings

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -361,7 +361,7 @@ boolean mask array or callable
                 raise AttributeError("Transformer %s (type %s) does not "
                                      "provide get_feature_names."
                                      % (str(name), type(trans).__name__))
-            feature_names.extend([name + "__" + f for f in
+            feature_names.extend([name + "__" + str(f) for f in
                                   trans.get_feature_names()])
         return feature_names
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
WIP It tries to answer #16093
ColumnTransformer assumes elements of get_feature_names() will be strings



#### What does this implement/fix? Explain your changes.

It removes the assumption that the elements returned by get_feature_names() will be strings

#### Any other comments?

I tried to create a test with an error using both ColumnTransformer as well as DictVectorizer unsuccessfully 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
