### PR TITLE
[DOC] Make random_state descriptions for Mixture Models

### DIFF
--- a/sklearn/mixture/_base.py
+++ b/sklearn/mixture/_base.py
@@ -137,7 +137,8 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         X : array-like, shape  (n_samples, n_features)
 
         random_state : RandomState
-            A random number generator instance.
+            A random number generator instance that controls the random seed
+            used for the method chosen to initialize the parameters.
         """
         n_samples, _ = X.shape
 

--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -167,7 +167,7 @@ class BayesianGaussianMixture(BaseMixture):
         Controls the random seed given to the method chosen to initialize the
         parameters (see `init_params`).
         In addition, it controls the generation of random samples from the
-        fitted distribution (see the function `sample`).
+        fitted distribution (see the method `sample`).
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 

--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -164,10 +164,12 @@ class BayesianGaussianMixture(BaseMixture):
                 float                    if 'spherical'
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Controls the random seed given to the method chosen to initialize the
+        parameters (see `init_params`).
+        In addition, it controls the generation of random samples from the
+        fitted distribution (see the function `sample`).
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     warm_start : bool, default to False.
         If 'warm_start' is True, the solution of the last fitting is used as

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -505,7 +505,7 @@ class GaussianMixture(BaseMixture):
         Controls the random seed given to the method chosen to initialize the
         parameters (see `init_params`).
         In addition, it controls the generation of random samples from the
-        fitted distribution (see the function `sample`).
+        fitted distribution (see the method `sample`).
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -502,10 +502,12 @@ class GaussianMixture(BaseMixture):
             (n_components, n_features, n_features) if 'full'
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Controls the random seed given to the method chosen to initialize the
+        parameters (see `init_params`).
+        In addition, it controls the generation of random samples from the
+        fitted distribution (see the function `sample`).
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     warm_start : bool, default to False.
         If 'warm_start' is True, the solution of the last fitting is used as


### PR DESCRIPTION
Reference Issue/PR:
partially addressed #10548

Updated the documentation for random_state in : 

sklearn/mixture/_bayesian_mixture.py - 166
sklearn/mixture/_base.py - 139
sklearn/mixture/_gaussian_mixture.py - 504

It now is more specific and refers to the glossary.