### PR TITLE
[DOC] Fix Typo in random_state for multioutput.py

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -548,7 +548,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
     random_state : int, RandomState instance or None, optional (default=None)
         If ``order='random'``, determines random number generation for the
-        chain orders.
+        chain order.
         In addition, it controls the random seed given at each `base_estimator`
         at each chaining iteration. Thus, it is only used when `base_estimator`
         exposes a `random_state`.
@@ -709,7 +709,7 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
 
     random_state : int, RandomState instance or None, optional (default=None)
         If ``order='random'``, determines random number generation for the
-        chain orders.
+        chain order.
         In addition, it controls the random seed given at each `base_estimator`
         at each chaining iteration. Thus, it is only used when `base_estimator`
         exposes a `random_state`.


### PR DESCRIPTION
Reference Issue/PR:
Addressed typo issue in #16291

Updated the documentation for random_state in sklearn/multioutput.py - 578, 738