### PR TITLE
DOC Improve random_state descriptions for GradientBoosting

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -887,7 +887,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
     random_state : int, RandomState instance or None, optional (default=None)
         Controls the random seed given to each Tree estimator at each
         boosting iteration.
-        In additions, it controls the random permutation of the features at
+        In addition, it controls the random permutation of the features at
         each split (see 'Notes' for more details).
         It also controls the random spliting of the training data to obtain a
         validation set if 'n_iter_no_change' is not None.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1364,7 +1364,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     random_state : int, RandomState instance or None, optional (default=None)
         Controls the random seed given to each Tree estimator at each
         boosting iteration.
-        In additions, it controls the random permutation of the features at
+        In addition, it controls the random permutation of the features at
         each split (see 'Notes' for more details).
         It also controls the random spliting of the training data to obtain a
         validation set if 'n_iter_no_change' is not None.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1365,7 +1365,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         Controls the random seed given to each Tree estimator at each
         boosting iteration.
         In addition, it controls the random permutation of the features at
-        each split (see 'Notes' for more details).
+        each split (see Notes for more details).
         It also controls the random spliting of the training data to obtain a
         validation set if 'n_iter_no_change' is not None.
         Pass an int for reproducible output across multiple function calls.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1362,7 +1362,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         (for loss='ls'), or a quantile for the other losses.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Controls the random seed given at each Tree estimator at each
+        Controls the random seed given to each Tree estimator at each
         boosting iteration.
         In additions, it controls the random permutation of the features at
         each split (see 'Notes' for more details).

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1367,7 +1367,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         In addition, it controls the random permutation of the features at
         each split (see Notes for more details).
         It also controls the random spliting of the training data to obtain a
-        validation set if 'n_iter_no_change' is not None.
+        validation set if `n_iter_no_change` is not None.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -888,7 +888,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         Controls the random seed given to each Tree estimator at each
         boosting iteration.
         In addition, it controls the random permutation of the features at
-        each split (see 'Notes' for more details).
+        each split (see Notes for more details).
         It also controls the random spliting of the training data to obtain a
         validation set if `n_iter_no_change` is not None.
         Pass an int for reproducible output across multiple function calls.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -885,10 +885,14 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         ``DummyEstimator`` predicting the classes priors is used.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Controls the random seed given at each Tree estimator at each
+        boosting iteration.
+        In additions, it controls the random permutation of the features at
+        each split (see 'Notes' for more details).
+        It also controls the random spliting of the training data to obtain a
+        validation set if 'n_iter_no_change' is not None.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:
@@ -1358,10 +1362,14 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         (for loss='ls'), or a quantile for the other losses.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Controls the random seed given at each Tree estimator at each
+        boosting iteration.
+        In additions, it controls the random permutation of the features at
+        each split (see 'Notes' for more details).
+        It also controls the random spliting of the training data to obtain a
+        validation set if 'n_iter_no_change' is not None.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     max_features : int, float, string or None, optional (default=None)
         The number of features to consider when looking for the best split:

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -885,7 +885,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         ``DummyEstimator`` predicting the classes priors is used.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Controls the random seed given at each Tree estimator at each
+        Controls the random seed given to each Tree estimator at each
         boosting iteration.
         In additions, it controls the random permutation of the features at
         each split (see 'Notes' for more details).

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -890,7 +890,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         In addition, it controls the random permutation of the features at
         each split (see 'Notes' for more details).
         It also controls the random spliting of the training data to obtain a
-        validation set if 'n_iter_no_change' is not None.
+        validation set if `n_iter_no_change` is not None.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 


### PR DESCRIPTION
Reference Issue/PR:
partially addressed #10548

Updated the documentation for random_state in sklearn/ensemble/_gb.py - 887, 1360
It now is more specific and refers to the glossary