### PR TITLE
[DOC] Update random_state descriptions for SVMs

### DIFF
--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -861,8 +861,7 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
         Stopping condition.
 
     random_state : int or RandomState instance, default=None
-        Controls the pseudo random number generator to use when shuffling the
-        data.
+        Controls the pseudo random number generation for shuffling the data.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -861,8 +861,8 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
         Stopping condition.
 
     random_state : int or RandomState instance, default=None
-        The seed of the pseudo random number generator to use when shuffling
-        the data.
+        Controls the pseudo random number generator to use when shuffling the
+        data.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -862,10 +862,9 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
 
     random_state : int or RandomState instance, default=None
         The seed of the pseudo random number generator to use when shuffling
-        the data.  If int, random_state is the seed used by the random number
-        generator; If RandomState instance, random_state is the random number
-        generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        the data.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     multi_class : {'ovr', 'crammer_singer'}, default='ovr'
         `ovr` trains n_classes one-vs-rest classifiers, while `crammer_singer`

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -92,11 +92,9 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         The seed of the pseudo random number generator to use when shuffling
         the data for the dual coordinate descent (if ``dual=True``). When
         ``dual=False`` the underlying implementation of :class:`LinearSVC`
-        is not random and ``random_state`` has no effect on the results. If
-        int, random_state is the seed used by the random number generator; If
-        RandomState instance, random_state is the random number generator; If
-        None, the random number generator is the RandomState instance used by
-        `np.random`.
+        is not random and ``random_state`` has no effect on the results.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     max_iter : int, default=1000
         The maximum number of iterations to be run.
@@ -301,10 +299,9 @@ class LinearSVR(RegressorMixin, LinearModel):
 
     random_state : int or RandomState instance, default=None
         The seed of the pseudo random number generator to use when shuffling
-        the data.  If int, random_state is the seed used by the random number
-        generator; If RandomState instance, random_state is the random number
-        generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        the data.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     max_iter : int, default=1000
         The maximum number of iterations to be run.
@@ -523,10 +520,9 @@ class SVC(BaseSVC):
 
     random_state : int or RandomState instance, default=None
         The seed of the pseudo random number generator used when shuffling
-        the data for probability estimates. If int, random_state is the
-        seed used by the random number generator; If RandomState instance,
-        random_state is the random number generator; If None, the random
-        number generator is the RandomState instance used by `np.random`.
+        the data for probability estimates.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------
@@ -729,10 +725,9 @@ class NuSVC(BaseSVC):
 
     random_state : int or RandomState instance, default=None
         The seed of the pseudo random number generator used when shuffling
-        the data for probability estimates. If int, random_state is the seed
-        used by the random number generator; If RandomState instance,
-        random_state is the random number generator; If None, the random
-        number generator is the RandomState instance used by `np.random`.
+        the data for probability estimates.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -89,7 +89,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         properly in a multithreaded context.
 
     random_state : int or RandomState instance, default=None
-        The seed of the pseudo random number generator to use when shuffling
+        Controls the pseudo random number generator to use when shuffling
         the data for the dual coordinate descent (if ``dual=True``). When
         ``dual=False`` the underlying implementation of :class:`LinearSVC`
         is not random and ``random_state`` has no effect on the results.
@@ -298,8 +298,8 @@ class LinearSVR(RegressorMixin, LinearModel):
         properly in a multithreaded context.
 
     random_state : int or RandomState instance, default=None
-        The seed of the pseudo random number generator to use when shuffling
-        the data.
+        Controls the pseudo random number generator to use when shuffling the
+        data.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
@@ -519,7 +519,7 @@ class SVC(BaseSVC):
         .. versionadded:: 0.22
 
     random_state : int or RandomState instance, default=None
-        The seed of the pseudo random number generator used when shuffling
+        Controls the pseudo random number generator used when shuffling
         the data for probability estimates.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
@@ -724,7 +724,7 @@ class NuSVC(BaseSVC):
         .. versionadded:: 0.22
 
     random_state : int or RandomState instance, default=None
-        The seed of the pseudo random number generator used when shuffling
+        Controls the pseudo random number generator used when shuffling
         the data for probability estimates.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -89,10 +89,10 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         properly in a multithreaded context.
 
     random_state : int or RandomState instance, default=None
-        Controls the pseudo random number generator to use when shuffling
-        the data for the dual coordinate descent (if ``dual=True``). When
-        ``dual=False`` the underlying implementation of :class:`LinearSVC`
-        is not random and ``random_state`` has no effect on the results.
+        Controls the pseudo random number generation for shuffling the data for
+        the dual coordinate descent (if ``dual=True``). When ``dual=False`` the
+        underlying implementation of :class:`LinearSVC` is not random and
+        ``random_state`` has no effect on the results.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
@@ -298,8 +298,7 @@ class LinearSVR(RegressorMixin, LinearModel):
         properly in a multithreaded context.
 
     random_state : int or RandomState instance, default=None
-        Controls the pseudo random number generator to use when shuffling the
-        data.
+        Controls the pseudo random number generation for shuffling the data.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
@@ -519,8 +518,8 @@ class SVC(BaseSVC):
         .. versionadded:: 0.22
 
     random_state : int or RandomState instance, default=None
-        Controls the pseudo random number generator used when shuffling
-        the data for probability estimates.
+        Controls the pseudo random number generation for shuffling the data for
+        probability estimates.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
@@ -724,8 +723,8 @@ class NuSVC(BaseSVC):
         .. versionadded:: 0.22
 
     random_state : int or RandomState instance, default=None
-        Controls the pseudo random number generator used when shuffling
-        the data for probability estimates.
+        Controls the pseudo random number generation for shuffling the data for
+        probability estimates.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 


### PR DESCRIPTION
Reference Issue/PR:
partially addressed #10548

Updated the documentation for random_state in :

sklearn/svm/_classes.py - 90, 312, 546, 752
sklearn/svm/_base.py - 853

Only added the key sentence :
Pass an int for reproducible output across multiple function calls.
See :term:`Glossary <random_state>`.