### PR TITLE
 Fixes #16065 Ignore weights equal zero in precision recall curve

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -668,11 +668,6 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
     array([0.35, 0.4 , 0.8 ])
 
     """
-    # ignore weights equal zero
-    indexes_zeros = sample_weight.index(0)
-    del y_true[indexes_zeros]
-    del probas_pred[indexes_zeros]
-    del sample_weight[indexes_zeros]
 
     fps, tps, thresholds = _binary_clf_curve(y_true, probas_pred,
                                              pos_label=pos_label,

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -27,6 +27,7 @@ from scipy.stats import rankdata
 
 from ..utils import assert_all_finite
 from ..utils import check_consistent_length
+from ..utils import _check_sample_weight
 from ..utils import column_or_1d, check_array
 from ..utils.multiclass import type_of_target
 from ..utils.extmath import stable_cumsum
@@ -534,6 +535,13 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     if not (y_type == "binary" or
             (y_type == "multiclass" and pos_label is not None)):
         raise ValueError("{0} format is not supported".format(y_type))
+
+    # Check to make sure sample_weight is strictly positive
+    _check_sample_weight(sample_weight, y_true, positive=True)
+    nonzero_weight_mask = sample_weight > 0
+    y_true = y_true[nonzero_mask]
+    probas_pred = probas_pred[nonzero_mask]
+    sample_weight = sample_weight[nonzero_mask]
 
     check_consistent_length(y_true, y_score, sample_weight)
     y_true = column_or_1d(y_true)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -668,6 +668,12 @@ def precision_recall_curve(y_true, probas_pred, pos_label=None,
     array([0.35, 0.4 , 0.8 ])
 
     """
+    # ignore weights equal zero
+    indexes_zeros = sample_weight.index(0)
+    del y_true[indexes_zeros]
+    del probas_pred[indexes_zeros]
+    del sample_weight[indexes_zeros]
+
     fps, tps, thresholds = _binary_clf_curve(y_true, probas_pred,
                                              pos_label=pos_label,
                                              sample_weight=sample_weight)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -27,7 +27,7 @@ from scipy.stats import rankdata
 
 from ..utils import assert_all_finite
 from ..utils import check_consistent_length
-from ..utils import _check_sample_weight
+from ..utils.validation import _check_sample_weight
 from ..utils import column_or_1d, check_array
 from ..utils.multiclass import type_of_target
 from ..utils.extmath import stable_cumsum
@@ -536,13 +536,6 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
             (y_type == "multiclass" and pos_label is not None)):
         raise ValueError("{0} format is not supported".format(y_type))
 
-    # Check to make sure sample_weight is strictly positive
-    _check_sample_weight(sample_weight, y_true, positive=True)
-    nonzero_weight_mask = sample_weight > 0
-    y_true = y_true[nonzero_mask]
-    probas_pred = probas_pred[nonzero_mask]
-    sample_weight = sample_weight[nonzero_mask]
-
     check_consistent_length(y_true, y_score, sample_weight)
     y_true = column_or_1d(y_true)
     y_score = column_or_1d(y_score)
@@ -552,6 +545,13 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     if sample_weight is not None:
         sample_weight = column_or_1d(sample_weight)
 
+    # Check to make sure sample_weight is strictly positive
+    _check_sample_weight(sample_weight, y_true, check_negative=True)
+    nonzero_weight_mask = sample_weight > 0
+    y_true = y_true[nonzero_weight_mask]
+    y_score = y_score[nonzero_weight_mask]
+    sample_weight = sample_weight[nonzero_weight_mask]
+    
     # ensure binary classification if pos_label is not specified
     # classes.dtype.kind in ('O', 'U', 'S') is required to avoid
     # triggering a FutureWarning by calling np.array_equal(a, b)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1172,7 +1172,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
     return lambdas
 
 
-def _check_sample_weight(sample_weight, X, dtype=None, positive=False):
+def _check_sample_weight(sample_weight, X, dtype=None, check_negative=False):
     """Validate sample weights.
 
     Note that passing sample_weight=None will output an array of ones.
@@ -1205,9 +1205,9 @@ def _check_sample_weight(sample_weight, X, dtype=None, positive=False):
     if dtype is not None and dtype not in [np.float32, np.float64]:
         dtype = np.float64
 
-    if sample_weight is not None and positive:
+    if sample_weight is not None and check_negative:
         if not np.all(sample_weight >= 0):
-            raise ValueError("negative values in sample_weight are invalid")
+            raise ValueError("Negative values in sample_weight are invalid")
 
     if sample_weight is None or isinstance(sample_weight, numbers.Number):
         if sample_weight is None:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1205,10 +1205,6 @@ def _check_sample_weight(sample_weight, X, dtype=None, check_negative=False):
     if dtype is not None and dtype not in [np.float32, np.float64]:
         dtype = np.float64
 
-    if sample_weight is not None and check_negative:
-        if not np.all(sample_weight >= 0):
-            raise ValueError("Negative values in sample_weight are invalid")
-
     if sample_weight is None or isinstance(sample_weight, numbers.Number):
         if sample_weight is None:
             sample_weight = np.ones(n_samples, dtype=dtype)
@@ -1228,6 +1224,11 @@ def _check_sample_weight(sample_weight, X, dtype=None, check_negative=False):
         if sample_weight.shape != (n_samples,):
             raise ValueError("sample_weight.shape == {}, expected {}!"
                              .format(sample_weight.shape, (n_samples,)))
+    
+    if sample_weight is not None and check_negative:
+        if not np.all(sample_weight >= 0):
+            raise ValueError("Negative values in sample_weight are invalid")
+
     return sample_weight
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1172,7 +1172,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
     return lambdas
 
 
-def _check_sample_weight(sample_weight, X, dtype=None):
+def _check_sample_weight(sample_weight, X, dtype=None, positive=False):
     """Validate sample weights.
 
     Note that passing sample_weight=None will output an array of ones.
@@ -1204,6 +1204,10 @@ def _check_sample_weight(sample_weight, X, dtype=None):
 
     if dtype is not None and dtype not in [np.float32, np.float64]:
         dtype = np.float64
+
+    if sample_weight is not None and positive:
+        if not np.all(sample_weight >= 0):
+            raise ValueError("negative values in sample_weight are invalid")
 
     if sample_weight is None or isinstance(sample_weight, numbers.Number):
         if sample_weight is None:


### PR DESCRIPTION
Fixes #16065. 

#### What does this implement/fix? Explain your changes.

It ignores weights equal to zero when called by precision_recall_curve function.

#### Any other comments?

I'm not sure if there is a more elegant solution.
