### PR TITLE
[DOC] Update random_state descriptions for mutual_info, unsupervised, .… (4)

### DIFF
--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -224,8 +224,8 @@ def _estimate_mi(X, y, discrete_features='auto', discrete_target=False,
         data will be overwritten.
 
     random_state : int, RandomState instance or None, optional, default None
-        The seed of the pseudo random number generator for adding small noise
-        to continuous variables in order to remove repeated values.
+        Determines random number generation for adding small noise to
+        continuous variables in order to remove repeated values.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.
 
@@ -331,8 +331,8 @@ def mutual_info_regression(X, y, discrete_features='auto', n_neighbors=3,
         data will be overwritten.
 
     random_state : int, RandomState instance or None, optional, default None
-        The seed of the pseudo random number generator for adding small noise
-        to continuous variables in order to remove repeated values.
+        Determines random number generation for adding small noise to
+        continuous variables in order to remove repeated values.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.
 
@@ -408,8 +408,8 @@ def mutual_info_classif(X, y, discrete_features='auto', n_neighbors=3,
         data will be overwritten.
 
     random_state : int, RandomState instance or None, optional, default None
-        The seed of the pseudo random number generator for adding small noise
-        to continuous variables in order to remove repeated values.
+        Determines random number generation for adding small noise to
+        continuous variables in order to remove repeated values.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.
 

--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -225,11 +225,9 @@ def _estimate_mi(X, y, discrete_features='auto', discrete_target=False,
 
     random_state : int, RandomState instance or None, optional, default None
         The seed of the pseudo random number generator for adding small noise
-        to continuous variables in order to remove repeated values.  If int,
-        random_state is the seed used by the random number generator; If
-        RandomState instance, random_state is the random number generator; If
-        None, the random number generator is the RandomState instance used by
-        `np.random`.
+        to continuous variables in order to remove repeated values.
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -335,10 +333,8 @@ def mutual_info_regression(X, y, discrete_features='auto', n_neighbors=3,
     random_state : int, RandomState instance or None, optional, default None
         The seed of the pseudo random number generator for adding small noise
         to continuous variables in order to remove repeated values.
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------
@@ -413,11 +409,9 @@ def mutual_info_classif(X, y, discrete_features='auto', n_neighbors=3,
 
     random_state : int, RandomState instance or None, optional, default None
         The seed of the pseudo random number generator for adding small noise
-        to continuous variables in order to remove repeated values.  If int,
-        random_state is the seed used by the random number generator; If
-        RandomState instance, random_state is the random number generator; If
-        None, the random number generator is the RandomState instance used by
-        `np.random`.
+        to continuous variables in order to remove repeated values.
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     Returns
     -------

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -78,11 +78,10 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
         If ``sample_size is None``, no sampling is used.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        The generator used to randomly select a subset of samples.  If int,
-        random_state is the seed used by the random number generator; If
-        RandomState instance, random_state is the random number generator; If
-        None, the random number generator is the RandomState instance used by
-        `np.random`. Used when ``sample_size is not None``.
+        The generator used to randomly select a subset of samples.
+        Used when ``sample_size is not None``.
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the distance function.

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -78,7 +78,7 @@ def silhouette_score(X, labels, metric='euclidean', sample_size=None,
         If ``sample_size is None``, no sampling is used.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        The generator used to randomly select a subset of samples.
+        Determines random number generation for selecting a subset of samples.
         Used when ``sample_size is not None``.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -476,7 +476,7 @@ def resample(*arrays, **options):
         arrays.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        Determines the pseudo random number generator to use when shuffling
+        Determines random number generation for shuffling
         the data.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -476,7 +476,7 @@ def resample(*arrays, **options):
         arrays.
 
     random_state : int, RandomState instance or None, optional (default=None)
-        The seed of the pseudo random number generator to use when shuffling
+        Determines the pseudo random number generator to use when shuffling
         the data.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.
@@ -620,7 +620,7 @@ def shuffle(*arrays, **options):
     Other Parameters
     ----------------
     random_state : int, RandomState instance or None, optional (default=None)
-        The seed of the pseudo random number generator to use when shuffling
+        Determines the pseudo random number generator to use when shuffling
         the data.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -477,10 +477,9 @@ def resample(*arrays, **options):
 
     random_state : int, RandomState instance or None, optional (default=None)
         The seed of the pseudo random number generator to use when shuffling
-        the data.  If int, random_state is the seed used by the random number
-        generator; If RandomState instance, random_state is the random number
-        generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        the data.
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     stratify : array-like or None (default=None)
         If not None, data is split in a stratified fashion, using this as
@@ -622,10 +621,9 @@ def shuffle(*arrays, **options):
     ----------------
     random_state : int, RandomState instance or None, optional (default=None)
         The seed of the pseudo random number generator to use when shuffling
-        the data.  If int, random_state is the seed used by the random number
-        generator; If RandomState instance, random_state is the random number
-        generator; If None, the random number generator is the RandomState
-        instance used by `np.random`.
+        the data.
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     n_samples : int, None by default
         Number of samples to generate. If left to None this is

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -620,7 +620,7 @@ def shuffle(*arrays, **options):
     Other Parameters
     ----------------
     random_state : int, RandomState instance or None, optional (default=None)
-        Determines the pseudo random number generator to use when shuffling
+        Determines random number generation for shuffling
         the data.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -519,10 +519,9 @@ def set_random_state(estimator, random_state=0):
     estimator : object
         The estimator
     random_state : int, RandomState instance or None, optional, default=0
-        Pseudo random number generator state.  If int, random_state is the seed
-        used by the random number generator; If RandomState instance,
-        random_state is the random number generator; If None, the random number
-        generator is the RandomState instance used by `np.random`.
+        Pseudo random number generator state.
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>`.
     """
     if "random_state" in estimator.get_params():
         estimator.set_params(random_state=random_state)


### PR DESCRIPTION
Reference Issue/PR:
partially addressed #10548

Updated the documentation for random_state in :

sklearn/feature_selection/_mutual_info.py - 226, 335, 414
sklearn/metrics/cluster/_unsupervised.py - 80
sklearn/utils/_testing.py - 521
sklearn/utils/init.py - 478, 623

Only added the key sentence :
Pass an int for reproducible output across multiple function calls.
See :term:Glossary <random_state>.