### PR TITLE
[MRG] Adds XFAIL/XPASS to common tests

### DIFF
--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -101,6 +101,8 @@ Other `pytest` options that may become useful include:
   - ``-s`` so that pytest does not capture the output of ``print()``
     statements
   - ``--tb=short`` or ``--tb=line`` to control the length of the logs
+  - ``--runxfail`` also run tests marked as a known failure (XFAIL) and report
+    errors.
 
 Since our continuous integration tests will error if
 ``FutureWarning`` isn't properly caught,

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ addopts =
     --ignore maint_tools
     --doctest-modules
     --disable-pytest-warnings
-    -rs
+    -rxXs
 
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -104,16 +104,17 @@ _xfail_checks.update({
 
 @parametrize_with_checks(_tested_estimators())
 def test_estimators(estimator, check, request):
+    with suppress(KeyError):
+        start = len(request.node.originalname) + 1
+        name = request.node.name[start:-1]
+        reason = _xfail_checks[name]
+        request.applymarker(pytest.mark.xfail(run=True, reason=reason))
+
     # Common tests for estimator instances
     with ignore_warnings(category=(FutureWarning,
                                    ConvergenceWarning,
                                    UserWarning, FutureWarning)):
         _set_checking_parameters(estimator)
-        with suppress(KeyError):
-            start = len(request.node.originalname) + 1
-            name = request.node.name[start:-1]
-            reason = _xfail_checks[name]
-            request.applymarker(pytest.mark.xfail(run=True, reason=reason))
         check(estimator)
 
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -97,7 +97,7 @@ _xfail_checks["NuSVC()-check_class_weight_classifiers"] = \
 
 # check_methods_subset_invariance
 _xfail_checks.update({
-    "{}()-check_class_weight_classifiers".format(name):
+    "{}()-check_methods_subset_invariance".format(name):
         "{} fails for check_methods_subset_invariance".format(name)
         for name in ['DummyClassifier', 'BernoulliRBM']})
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -92,12 +92,12 @@ def _tested_estimators():
 _xfail_checks = {}
 
 # check_class_weight_classifiers
-_xfail_checks[(check_class_weight_classifiers, 'NuSVC')] = \
+_xfail_checks["NuSVC()-check_class_weight_classifiers"] = \
     "Not testing NuSVC class weight as it is ignored."
 
 # check_methods_subset_invariance
 _xfail_checks.update({
-    (check_methods_subset_invariance, name):
+    "{}()-check_class_weight_classifiers".format(name):
         "{} fails for check_methods_subset_invariance".format(name)
         for name in ['DummyClassifier', 'BernoulliRBM']})
 
@@ -109,9 +109,10 @@ def test_estimators(estimator, check, request):
                                    ConvergenceWarning,
                                    UserWarning, FutureWarning)):
         _set_checking_parameters(estimator)
-        print(_xfail_checks)
         with suppress(KeyError):
-            reason = _xfail_checks[(check.func, check.args[0])]
+            start = len(request.node.originalname) + 1
+            name = request.node.name[start:-1]
+            reason = _xfail_checks[name]
             request.applymarker(pytest.mark.xfail(run=True, reason=reason))
         check(estimator)
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1028,13 +1028,6 @@ def check_methods_subset_invariance(name, estimator_orig):
 
         msg = ("{method} of {name} is not invariant when applied "
                "to a subset.").format(method=method, name=name)
-        # TODO remove cases when corrected
-        if (name, method) in [('NuSVC', 'decision_function'),
-                              ('SparsePCA', 'transform'),
-                              ('MiniBatchSparsePCA', 'transform'),
-                              ('DummyClassifier', 'predict'),
-                              ('BernoulliRBM', 'score_samples')]:
-            raise SkipTest(msg)
 
         if hasattr(estimator, method):
             result_full, result_by_batch = _apply_on_subsets(
@@ -2235,14 +2228,6 @@ def check_regressors_no_decision_function(name, regressor_orig):
 
 @ignore_warnings(category=FutureWarning)
 def check_class_weight_classifiers(name, classifier_orig):
-    if name == "NuSVC":
-        # the sparse version has a parameter that doesn't do anything
-        raise SkipTest("Not testing NuSVC class weight as it is ignored.")
-    if name.endswith("NB"):
-        # NaiveBayes classifiers have a somewhat different interface.
-        # FIXME SOON!
-        raise SkipTest
-
     if _safe_tags(classifier_orig, 'binary_only'):
         problems = [2]
     else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Alternative to #16306

#### What does this implement/fix? Explain your changes.
Places the xfail into the test themselves.

#### Any other comments?
`check_methods_subset_invariance` feels like it should be broken down into multiple tests - one for each method.

CC @rth 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
