### PR TITLE
FIX support read only view for tree input

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -202,8 +202,13 @@ Changelog
 - |Fix| :func:`tree.plot_tree` `rotate` parameter was unused and has been
   deprecated.
   :pr:`15806` by :user:`Chiara Marmo <cmarmo>`.
-- |Fix| :func:`tree.predict`, :func:`tree.decision_path` and :func:`tree.apply`
-  can now be used with joblib based multiprocessing.
+
+- |Fix| Fix support of read-only float32 array input in ``predict``,
+  ``decision_path`` and ``predict_proba`` methods of
+  :class:`tree.DecisionTreeClassifier`, :class:`tree.ExtraTreeClassifier` and
+  :class:`ensemble.GradientBoostingClassifier` as well as ``predict`` method of
+  :class:`tree.DecisionTreeRegressor`, :class:`tree.ExtraTreeRegressor`, and
+  :class:`ensemble.GradientBoostingRegressor`.
   :pr:`16331` by :user:`Alexandre Batisse <batalex>`.
 
 :mod:`sklearn.utils`

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -202,6 +202,9 @@ Changelog
 - |Fix| :func:`tree.plot_tree` `rotate` parameter was unused and has been
   deprecated.
   :pr:`15806` by :user:`Chiara Marmo <cmarmo>`.
+- |Fix| :func:`tree.predict`, :func:`tree.decision_path` and :func:`tree.apply`
+  can now be used with joblib based multiprocessing.
+  :pr:`16331` by :user:`Alexandre Batisse <batalex>`.
 
 :mod:`sklearn.utils`
 ....................

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -792,7 +792,7 @@ cdef class Tree:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef DTYPE_t[:, :] X_ndarray = X
+        cdef const DTYPE_t[:, :] X_ndarray = X
         cdef SIZE_t n_samples = X.shape[0]
 
         # Initialize output

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -912,7 +912,7 @@ cdef class Tree:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef DTYPE_t[:, :] X_ndarray = X
+        cdef const DTYPE_t[:, :] X_ndarray = X
         cdef SIZE_t n_samples = X.shape[0]
 
         # Initialize output

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1824,15 +1824,6 @@ def test_empty_leaf_infinite_threshold():
         assert len(empty_leaf) == 0
 
 
-def test_decision_tree_memmap():
-    # check that decision trees supports read-only buffer (#13626)
-    X = np.random.RandomState(0).random_sample((10, 2)).astype(np.float32)
-    y = np.zeros(10)
-
-    with TempMemmap((X, y)) as (X_read_only, y_read_only):
-        DecisionTreeClassifier().fit(X_read_only, y_read_only)
-
-
 @pytest.mark.parametrize("criterion", CLF_CRITERIONS)
 @pytest.mark.parametrize(
     "dataset", sorted(set(DATASETS.keys()) - {"reg_small", "boston"}))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/15851.

#### What does this implement/fix? Explain your changes.

According to https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html#read-only-views
> Since Cython 0.28, the memoryview item type can be declared as const to support read-only buffers as input

This should be fine with scikit-learn since the minimal Cython version supported is 28.5. We could also check the input array for the `writeable` flag and make a copy instead of a view if needed but I figured this solution would be better.

#### Any other comments?
The benchmarks now work as expected.

```
python benchmarks\bench_mnist.py --classifiers RandomForest ExtraTrees CART
[...]
Classification performance:
===========================
Classifier               train-time   test-time   error-rate
------------------------------------------------------------
ExtraTrees                   45.16s       0.45s       0.0294
RandomForest                 40.51s       0.39s       0.0295
CART                         21.61s       0.06s       0.1221
```


2020 Paris Sprint
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
