### PR TITLE
[MRG] Add requires_positiv_X tag to AdditiveChi2Sampler

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -426,7 +426,8 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
         return sp.hstack(X_new)
 
     def _more_tags(self):
-        return {'stateless': True}
+        return {'stateless': True,
+                'requires_positive_X': True}
 
 
 class Nystroem(TransformerMixin, BaseEstimator):

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -19,6 +19,7 @@ from .utils import check_array, check_random_state, as_float_array
 from .utils.extmath import safe_sparse_dot
 from .utils.validation import check_is_fitted
 from .metrics.pairwise import pairwise_kernels, KERNEL_PARAMS
+from .utils.validation import check_non_negative
 
 
 class RBFSampler(TransformerMixin, BaseEstimator):
@@ -324,7 +325,9 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
         self : object
             Returns the transformer.
         """
-        check_array(X, accept_sparse='csr')
+        X = check_array(X, accept_sparse='csr')
+        check_non_negative(X, 'X in AdditiveChi2Sampler.fit')
+
         if self.sample_interval is None:
             # See reference, figure 2 c)
             if self.sample_steps == 1:
@@ -359,11 +362,9 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
         check_is_fitted(self, msg=msg)
 
         X = check_array(X, accept_sparse='csr')
+        check_non_negative(X, 'X in AdditiveChi2Sampler.transform')
         sparse = sp.issparse(X)
 
-        # check if X has negative values. Doesn't play well with np.log.
-        if ((X.data if sparse else X) < 0).any():
-            raise ValueError("Entries of X must be non-negative.")
         # zeroth component
         # 1/cosh = sech
         # cosh(0) = 1.0

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -120,16 +120,14 @@ def test_skewed_chi2_sampler():
 
 def test_additive_chi2_sampler_exceptions():
     """Ensures correct error message"""
-    transform = AdditiveChi2Sampler()
+    transformer = AdditiveChi2Sampler()
+    X_neg = X.copy()
+    X_neg[0, 0] = -1
     with pytest.raises(ValueError, match="X in AdditiveChi2Sampler.fit"):
-        X_neg = X.copy()
-        X_neg[0, 0] = -1
-        transform.fit(X_neg)
+        transformer.fit(X_neg)
     with pytest.raises(ValueError, match="X in AdditiveChi2Sampler.transform"):
-        transform.fit(X)
-        X_neg = X.copy()
-        X_neg[0, 0] = -1
-        transform.transform(X_neg)
+        transformer.fit(X)
+        transformer.transform(X_neg)
 
 
 def test_rbf_sampler():

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -118,6 +118,20 @@ def test_skewed_chi2_sampler():
     assert_raises(ValueError, transform.transform, Y_neg)
 
 
+def test_additive_chi2_sampler_exceptions():
+    """Ensures correct error message"""
+    transform = AdditiveChi2Sampler()
+    with pytest.raises(ValueError, match="X in AdditiveChi2Sampler.fit"):
+        X_neg = X.copy()
+        X_neg[0, 0] = -1
+        transform.fit(X_neg)
+    with pytest.raises(ValueError, match="X in AdditiveChi2Sampler.transform"):
+        transform.fit(X)
+        X_neg = X.copy()
+        X_neg[0, 0] = -1
+        transform.transform(X_neg)
+
+
 def test_rbf_sampler():
     # test that RBFSampler approximates kernel on random data
     # compute exact kernel


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
If given negative X values, AdditiveChi2Sampler raises a ValueError ("Entries of X must be non-negative.") on transform. 

#### Any other comments?

Part of Paris sprint.