### PR TITLE
[MRG] CLN Remove the use of assert_raises in utils/

### DIFF
--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -1,15 +1,13 @@
 import numpy as np
+import pytest
 
-from sklearn.linear_model import LogisticRegression
 from sklearn.datasets import make_blobs
+from sklearn.linear_model import LogisticRegression
 
 from sklearn.utils.class_weight import compute_class_weight
 from sklearn.utils.class_weight import compute_sample_weight
-
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_almost_equal
-from sklearn.utils._testing import assert_raises
-from sklearn.utils._testing import assert_raise_message
 
 
 def test_compute_class_weight():
@@ -28,17 +26,19 @@ def test_compute_class_weight_not_present():
     # Raise error when y does not contain all class labels
     classes = np.arange(4)
     y = np.asarray([0, 0, 0, 1, 1, 2])
-    assert_raises(ValueError, compute_class_weight, "balanced", classes, y)
+    with pytest.raises(ValueError):
+        compute_class_weight("balanced", classes, y)
     # Fix exception in error message formatting when missing label is a string
     # https://github.com/scikit-learn/scikit-learn/issues/8312
-    assert_raise_message(ValueError,
-                         'Class label label_not_present not present',
-                         compute_class_weight,
-                         {'label_not_present': 1.}, classes, y)
+    with pytest.raises(ValueError,
+                       match="Class label label_not_present not present"):
+        compute_class_weight({"label_not_present": 1.}, classes, y)
     # Raise error when y has items not in classes
     classes = np.arange(2)
-    assert_raises(ValueError, compute_class_weight, "balanced", classes, y)
-    assert_raises(ValueError, compute_class_weight, {0: 1., 1: 2.}, classes, y)
+    with pytest.raises(ValueError):
+        compute_class_weight("balanced", classes, y)
+    with pytest.raises(ValueError):
+        compute_class_weight({0: 1., 1: 2.}, classes, y)
 
 
 def test_compute_class_weight_dict():
@@ -55,12 +55,13 @@ def test_compute_class_weight_dict():
     # should get raised
     msg = 'Class label 4 not present.'
     class_weights = {0: 1.0, 1: 2.0, 2: 3.0, 4: 1.5}
-    assert_raise_message(ValueError, msg, compute_class_weight, class_weights,
-                         classes, y)
+    with pytest.raises(ValueError, match=msg):
+        compute_class_weight(class_weights, classes, y)
+
     msg = 'Class label -1 not present.'
     class_weights = {-1: 5.0, 0: 1.0, 1: 2.0, 2: 3.0}
-    assert_raise_message(ValueError, msg, compute_class_weight, class_weights,
-                         classes, y)
+    with pytest.raises(ValueError, match=msg):
+        compute_class_weight(class_weights, classes, y)
 
 
 def test_compute_class_weight_invariance():
@@ -232,20 +233,27 @@ def test_compute_sample_weight_errors():
     # Invalid preset string
     y = np.asarray([1, 1, 1, 2, 2, 2])
     y_ = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1]])
-    assert_raises(ValueError, compute_sample_weight, "ni", y)
-    assert_raises(ValueError, compute_sample_weight, "ni", y, range(4))
-    assert_raises(ValueError, compute_sample_weight, "ni", y_)
-    assert_raises(ValueError, compute_sample_weight, "ni", y_, range(4))
+
+    with pytest.raises(ValueError):
+        compute_sample_weight("ni", y)
+    with pytest.raises(ValueError):
+        compute_sample_weight("ni", y, range(4))
+    with pytest.raises(ValueError):
+        compute_sample_weight("ni", y_)
+    with pytest.raises(ValueError):
+        compute_sample_weight("ni", y_, range(4))
 
     # Not "balanced" for subsample
-    assert_raises(ValueError,
-                  compute_sample_weight, {1: 2, 2: 1}, y, range(4))
+    with pytest.raises(ValueError):
+        compute_sample_weight({1: 2, 2: 1}, y, range(4))
 
     # Not a list or preset for multi-output
-    assert_raises(ValueError, compute_sample_weight, {1: 2, 2: 1}, y_)
+    with pytest.raises(ValueError):
+        compute_sample_weight({1: 2, 2: 1}, y_)
 
     # Incorrect length list for multi-output
-    assert_raises(ValueError, compute_sample_weight, [{1: 2, 2: 1}], y_)
+    with pytest.raises(ValueError):
+        compute_sample_weight([{1: 2, 2: 1}], y_)
 
 
 def test_compute_sample_weight_more_than_32():

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -2,6 +2,7 @@ import unittest
 import sys
 
 import numpy as np
+import pytest
 import scipy.sparse as sp
 import joblib
 
@@ -9,10 +10,7 @@ from io import StringIO
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils import deprecated
-from sklearn.utils._testing import (assert_raises_regex,
-                                   ignore_warnings,
-                                   assert_warns, assert_raises,
-                                   SkipTest)
+from sklearn.utils._testing import assert_warns, ignore_warnings, SkipTest
 from sklearn.utils.estimator_checks import check_estimator, _NotAnArray
 from sklearn.utils.estimator_checks \
     import check_class_weight_balanced_linear_classifier
@@ -313,7 +311,8 @@ def test_not_an_array_array_function():
         raise SkipTest("array_function protocol not supported in numpy <1.17")
     not_array = _NotAnArray(np.ones(10))
     msg = "Don't want to call array_function sum!"
-    assert_raises_regex(TypeError, msg, np.sum, not_array)
+    with pytest.raises(TypeError, match=msg):
+        np.sum(not_array)
     # always returns True
     assert np.may_share_memory(not_array, None)
 
@@ -337,64 +336,82 @@ def test_check_estimator():
 
     # check that we have a set_params and can clone
     msg = "it does not implement a 'get_params' method"
-    assert_raises_regex(TypeError, msg, check_estimator, object)
-    assert_raises_regex(TypeError, msg, check_estimator, object())
+    with pytest.raises(TypeError, match=msg):
+        check_estimator(object)
+    with pytest.raises(TypeError, match=msg):
+        check_estimator(object())
+
     # check that values returned by get_params match set_params
     msg = "get_params result does not match what was passed to set_params"
-    assert_raises_regex(AssertionError, msg, check_estimator,
-                        ModifiesValueInsteadOfRaisingError())
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(ModifiesValueInsteadOfRaisingError())
+
     assert_warns(UserWarning, check_estimator, RaisesErrorInSetParams())
-    assert_raises_regex(AssertionError, msg, check_estimator,
-                        ModifiesAnotherValue())
+
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(ModifiesAnotherValue())
+
     # check that we have a fit method
     msg = "object has no attribute 'fit'"
-    assert_raises_regex(AttributeError, msg, check_estimator, BaseEstimator)
-    assert_raises_regex(AttributeError, msg, check_estimator, BaseEstimator())
+    with pytest.raises(AttributeError, match=msg):
+        check_estimator(BaseEstimator)
+    with pytest.raises(AttributeError, match=msg):
+        check_estimator(BaseEstimator())
+
     # check that fit does input validation
     msg = "ValueError not raised"
-    assert_raises_regex(AssertionError, msg, check_estimator,
-                        BaseBadClassifier)
-    assert_raises_regex(AssertionError, msg, check_estimator,
-                        BaseBadClassifier())
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(BaseBadClassifier)
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(BaseBadClassifier())
+
     # check that sample_weights in fit accepts pandas.Series type
     try:
         from pandas import Series  # noqa
         msg = ("Estimator NoSampleWeightPandasSeriesType raises error if "
                "'sample_weight' parameter is of type pandas.Series")
-        assert_raises_regex(
-            ValueError, msg, check_estimator, NoSampleWeightPandasSeriesType)
+        with pytest.raises(ValueError, match=msg):
+            check_estimator(NoSampleWeightPandasSeriesType)
+
     except ImportError:
         pass
     # check that predict does input validation (doesn't accept dicts in input)
     msg = "Estimator doesn't check for NaN and inf in predict"
-    assert_raises_regex(AssertionError, msg, check_estimator, NoCheckinPredict)
-    assert_raises_regex(AssertionError, msg, check_estimator,
-                        NoCheckinPredict())
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(NoCheckinPredict)
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(NoCheckinPredict())
+
     # check that estimator state does not change
     # at transform/predict/predict_proba time
     msg = 'Estimator changes __dict__ during predict'
-    assert_raises_regex(AssertionError, msg, check_estimator, ChangesDict)
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(ChangesDict)
+
     # check that `fit` only changes attribures that
     # are private (start with an _ or end with a _).
     msg = ('Estimator ChangesWrongAttribute should not change or mutate  '
            'the parameter wrong_attribute from 0 to 1 during fit.')
-    assert_raises_regex(AssertionError, msg,
-                        check_estimator, ChangesWrongAttribute)
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(ChangesWrongAttribute)
+
     check_estimator(ChangesUnderscoreAttribute)
     # check that `fit` doesn't add any public attribute
     msg = (r'Estimator adds public attribute\(s\) during the fit method.'
            ' Estimators are only allowed to add private attributes'
            ' either started with _ or ended'
            ' with _ but wrong_attribute added')
-    assert_raises_regex(AssertionError, msg,
-                        check_estimator, SetsWrongAttribute)
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(SetsWrongAttribute)
+
     # check for invariant method
     name = NotInvariantPredict.__name__
     method = 'predict'
     msg = ("{method} of {name} is not invariant when applied "
            "to a subset.").format(method=method, name=name)
-    assert_raises_regex(AssertionError, msg,
-                        check_estimator, NotInvariantPredict)
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(NotInvariantPredict)
+
     # check for sparse matrix input handling
     name = NoSparseClassifier.__name__
     msg = "Estimator %s doesn't seem to fail gracefully on sparse data" % name
@@ -415,13 +432,13 @@ def test_check_estimator():
     # Large indices test on bad estimator
     msg = ('Estimator LargeSparseNotSupportedClassifier doesn\'t seem to '
            r'support \S{3}_64 matrix, and is not failing gracefully.*')
-    assert_raises_regex(AssertionError, msg, check_estimator,
-                        LargeSparseNotSupportedClassifier)
+    with pytest.raises(AssertionError, match=msg):
+        check_estimator(LargeSparseNotSupportedClassifier)
 
     # does error on binary_only untagged estimator
     msg = 'Only 2 classes are supported'
-    assert_raises_regex(ValueError, msg, check_estimator,
-                        UntaggedBinaryClassifier)
+    with pytest.raises(ValueError, match=msg):
+        check_estimator(UntaggedBinaryClassifier)
 
     # non-regression test for estimators transforming to sparse data
     check_estimator(SparseTransformer())
@@ -437,14 +454,16 @@ def test_check_estimator():
 
     # Check regressor with requires_positive_y estimator tag
     msg = 'negative y values not supported!'
-    assert_raises_regex(ValueError, msg, check_estimator,
-                        RequiresPositiveYRegressor)
+    with pytest.raises(ValueError, match=msg):
+        check_estimator(RequiresPositiveYRegressor)
 
 
 def test_check_outlier_corruption():
     # should raise AssertionError
     decision = np.array([0., 1., 1.5, 2.])
-    assert_raises(AssertionError, check_outlier_corruption, 1, 2, decision)
+    with pytest.raises(AssertionError):
+        check_outlier_corruption(1, 2, decision)
+
     # should pass
     decision = np.array([0., 1., 1., 2.])
     check_outlier_corruption(1, 2, decision)
@@ -452,8 +471,8 @@ def test_check_outlier_corruption():
 
 def test_check_estimator_transformer_no_mixin():
     # check that TransformerMixin is not required for transformer tests to run
-    assert_raises_regex(AttributeError, '.*fit_transform.*',
-                        check_estimator, BadTransformerWithoutMixin())
+    with pytest.raises(AttributeError, match=".*fit_transform.*"):
+        check_estimator(BadTransformerWithoutMixin())
 
 
 def test_check_estimator_clones():
@@ -490,8 +509,8 @@ def test_check_estimators_unfitted():
     # check that a ValueError/AttributeError is raised when calling predict
     # on an unfitted estimator
     msg = "NotFittedError not raised by predict"
-    assert_raises_regex(AssertionError, msg, check_estimators_unfitted,
-                        "estimator", NoSparseClassifier())
+    with pytest.raises(AssertionError, match=msg):
+        check_estimators_unfitted("estimator", NoSparseClassifier())
 
     # check that CorrectNotFittedError inherit from either ValueError
     # or AttributeError
@@ -507,21 +526,20 @@ def test_check_no_attributes_set_in_init():
         def __init__(self, you_should_set_this_=None):
             pass
 
-    assert_raises_regex(AssertionError,
-                        "Estimator estimator_name should not set any"
-                        " attribute apart from parameters during init."
-                        r" Found attributes \['you_should_not_set_this_'\].",
-                        check_no_attributes_set_in_init,
-                        'estimator_name',
-                        NonConformantEstimatorPrivateSet())
-    assert_raises_regex(AssertionError,
-                        "Estimator estimator_name should store all "
-                        "parameters as an attribute during init. "
-                        "Did not find attributes "
-                        r"\['you_should_set_this_'\].",
-                        check_no_attributes_set_in_init,
-                        'estimator_name',
-                        NonConformantEstimatorNoParamSet())
+    msg = "Estimator estimator_name should not set any" \
+          " attribute apart from parameters during init." \
+          r" Found attributes \['you_should_not_set_this_'\]."
+    with pytest.raises(AssertionError, match=msg):
+        check_no_attributes_set_in_init("estimator_name",
+                                        NonConformantEstimatorPrivateSet())
+
+    msg = "Estimator estimator_name should store all " \
+          "parameters as an attribute during init. " \
+          "Did not find attributes " \
+          r"\['you_should_set_this_'\]."
+    with pytest.raises(AssertionError, match=msg):
+        check_no_attributes_set_in_init("estimator_name",
+                                        NonConformantEstimatorNoParamSet())
 
 
 def test_check_estimator_pairwise():
@@ -544,10 +562,11 @@ def test_check_estimator_required_parameters_skip():
         def __init__(self, special_parameter):
             self.special_parameter = special_parameter
 
-    assert_raises_regex(SkipTest, r"Can't instantiate estimator MyEstimator "
-                                  r"which requires parameters "
-                                  r"\['special_parameter'\]",
-                                  check_estimator, MyEstimator)
+    msg = r"Can't instantiate estimator MyEstimator "\
+          r"which requires parameters \['special_parameter'\]"
+
+    with pytest.raises(SkipTest, match=msg):
+        check_estimator(MyEstimator)
 
 
 def run_tests_without_pytest():
@@ -565,12 +584,12 @@ def run_tests_without_pytest():
 
 def test_check_class_weight_balanced_linear_classifier():
     # check that ill-computed balanced weights raises an exception
-    assert_raises_regex(AssertionError,
-                        "Classifier estimator_name is not computing"
-                        " class_weight=balanced properly.",
-                        check_class_weight_balanced_linear_classifier,
-                        'estimator_name',
-                        BadBalancedWeightsClassifier)
+    msg = "Classifier estimator_name is not computing"\
+          " class_weight=balanced properly."
+    with pytest.raises(AssertionError, match=msg):
+        check_class_weight_balanced_linear_classifier(
+            "estimator_name",
+            BadBalancedWeightsClassifier)
 
 
 def test_all_estimators_all_public():

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -10,7 +10,7 @@ from io import StringIO
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils import deprecated
-from sklearn.utils._testing import assert_warns, ignore_warnings, SkipTest
+from sklearn.utils._testing import ignore_warnings, SkipTest
 from sklearn.utils.estimator_checks import check_estimator, _NotAnArray
 from sklearn.utils.estimator_checks \
     import check_class_weight_balanced_linear_classifier
@@ -346,7 +346,8 @@ def test_check_estimator():
     with pytest.raises(AssertionError, match=msg):
         check_estimator(ModifiesValueInsteadOfRaisingError())
 
-    assert_warns(UserWarning, check_estimator, RaisesErrorInSetParams())
+    with pytest.warns(UserWarning):
+        check_estimator(RaisesErrorInSetParams())
 
     with pytest.raises(AssertionError, match=msg):
         check_estimator(ModifiesAnotherValue())

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -14,8 +14,6 @@ from scipy.sparse import lil_matrix
 
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import assert_raises
-from sklearn.utils._testing import assert_raises_regex
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils.estimator_checks import _NotAnArray
 
@@ -154,7 +152,8 @@ MULTILABEL_SEQUENCES = [
 
 def test_unique_labels():
     # Empty iterable
-    assert_raises(ValueError, unique_labels)
+    with pytest.raises(ValueError):
+        unique_labels()
 
     # Multiclass problem
     assert_array_equal(unique_labels(range(10)), np.arange(10))
@@ -178,8 +177,11 @@ def test_unique_labels():
                        np.arange(3))
 
     # Border line case with binary indicator matrix
-    assert_raises(ValueError, unique_labels, [4, 0, 2], np.ones((5, 5)))
-    assert_raises(ValueError, unique_labels, np.ones((5, 4)), np.ones((5, 5)))
+    with pytest.raises(ValueError):
+        unique_labels([4, 0, 2], np.ones((5, 5)))
+    with pytest.raises(ValueError):
+        unique_labels(np.ones((5, 4)), np.ones((5, 5)))
+
     assert_array_equal(unique_labels(np.ones((4, 5)), np.ones((5, 5))),
                        np.arange(5))
 
@@ -194,12 +196,14 @@ def test_unique_labels_non_specific():
 
     # We don't support those format at the moment
     for example in NON_ARRAY_LIKE_EXAMPLES:
-        assert_raises(ValueError, unique_labels, example)
+        with pytest.raises(ValueError):
+            unique_labels(example)
 
     for y_type in ["unknown", "continuous", 'continuous-multioutput',
                    'multiclass-multioutput']:
         for example in EXAMPLES[y_type]:
-            assert_raises(ValueError, unique_labels, example)
+            with pytest.raises(ValueError):
+                unique_labels(example)
 
 
 def test_unique_labels_mixed_types():
@@ -209,13 +213,22 @@ def test_unique_labels_mixed_types():
                              EXAMPLES["binary"])
 
     for y_multilabel, y_multiclass in mix_clf_format:
-        assert_raises(ValueError, unique_labels, y_multiclass, y_multilabel)
-        assert_raises(ValueError, unique_labels, y_multilabel, y_multiclass)
+        with pytest.raises(ValueError):
+            unique_labels(y_multiclass, y_multilabel)
+        with pytest.raises(ValueError):
+            unique_labels(y_multilabel, y_multiclass)
 
-    assert_raises(ValueError, unique_labels, [[1, 2]], [["a", "d"]])
-    assert_raises(ValueError, unique_labels, ["1", 2])
-    assert_raises(ValueError, unique_labels, [["1", 2], [1, 3]])
-    assert_raises(ValueError, unique_labels, [["1", "2"], [2, 3]])
+    with pytest.raises(ValueError):
+        unique_labels([[1, 2]], [["a", "d"]])
+
+    with pytest.raises(ValueError):
+        unique_labels(["1", 2])
+
+    with pytest.raises(ValueError):
+        unique_labels([["1", 2], [1, 3]])
+
+    with pytest.raises(ValueError):
+        unique_labels([["1", "2"], [2, 3]])
 
 
 def test_is_multilabel():
@@ -263,8 +276,8 @@ def test_check_classification_targets():
         if y_type in ["unknown", "continuous", 'continuous-multioutput']:
             for example in EXAMPLES[y_type]:
                 msg = 'Unknown label type: '
-                assert_raises_regex(ValueError, msg,
-                                    check_classification_targets, example)
+                with pytest.raises(ValueError, match=msg):
+                    check_classification_targets(example)
         else:
             for example in EXAMPLES[y_type]:
                 check_classification_targets(example)
@@ -280,13 +293,15 @@ def test_type_of_target():
 
     for example in NON_ARRAY_LIKE_EXAMPLES:
         msg_regex = r'Expected array-like \(array or non-string sequence\).*'
-        assert_raises_regex(ValueError, msg_regex, type_of_target, example)
+        with pytest.raises(ValueError, match=msg_regex):
+            type_of_target(example)
 
     for example in MULTILABEL_SEQUENCES:
         msg = ('You appear to be using a legacy multi-label data '
                'representation. Sequence of sequences are no longer supported;'
                ' use a binary array or sparse matrix instead.')
-        assert_raises_regex(ValueError, msg, type_of_target, example)
+        with pytest.raises(ValueError, match=msg):
+            type_of_target(example)
 
 
 def test_type_of_target_pandas_sparse():

--- a/sklearn/utils/tests/test_random.py
+++ b/sklearn/utils/tests/test_random.py
@@ -1,18 +1,19 @@
 import numpy as np
+import pytest
 import scipy.sparse as sp
 from numpy.testing import assert_array_almost_equal
 
 from sklearn.utils.fixes import comb
 from sklearn.utils.random import _random_choice_csc, sample_without_replacement
 from sklearn.utils._random import _our_rand_r_py
-from sklearn.utils._testing import assert_raises
 
 
 ###############################################################################
 # test custom sampling without replacement algorithm
 ###############################################################################
 def test_invalid_sample_without_replacement_algorithm():
-    assert_raises(ValueError, sample_without_replacement, 5, 4, "unknown")
+    with pytest.raises(ValueError):
+        sample_without_replacement(5, 4, "unknown")
 
 
 def test_sample_without_replacement_algorithms():
@@ -33,8 +34,10 @@ def test_sample_without_replacement_algorithms():
 def check_edge_case_of_sample_int(sample_without_replacement):
 
     # n_population < n_sample
-    assert_raises(ValueError, sample_without_replacement, 0, 1)
-    assert_raises(ValueError, sample_without_replacement, 1, 2)
+    with pytest.raises(ValueError):
+        sample_without_replacement(0, 1)
+    with pytest.raises(ValueError):
+        sample_without_replacement(1, 2)
 
     # n_population == n_samples
     assert sample_without_replacement(0, 0).shape == (0, )
@@ -46,8 +49,10 @@ def check_edge_case_of_sample_int(sample_without_replacement):
     assert sample_without_replacement(5, 1).shape == (1, )
 
     # n_population < 0 or n_samples < 0
-    assert_raises(ValueError, sample_without_replacement, -1, 5)
-    assert_raises(ValueError, sample_without_replacement, 5, -1)
+    with pytest.raises(ValueError):
+        sample_without_replacement(-1, 5)
+    with pytest.raises(ValueError):
+        sample_without_replacement(5, -1)
 
 
 def check_sample_int(sample_without_replacement):
@@ -155,26 +160,26 @@ def test_random_choice_csc_errors():
     # the length of an array in classes and class_probabilities is mismatched
     classes = [np.array([0, 1]),  np.array([0, 1, 2, 3])]
     class_probabilities = [np.array([0.5, 0.5]), np.array([0.6, 0.1, 0.3])]
-    assert_raises(ValueError, _random_choice_csc, 4, classes,
-                  class_probabilities, 1)
+    with pytest.raises(ValueError):
+        _random_choice_csc(4, classes, class_probabilities, 1)
 
     # the class dtype is not supported
     classes = [np.array(["a", "1"]),  np.array(["z", "1", "2"])]
     class_probabilities = [np.array([0.5, 0.5]), np.array([0.6, 0.1, 0.3])]
-    assert_raises(ValueError, _random_choice_csc, 4, classes,
-                  class_probabilities, 1)
+    with pytest.raises(ValueError):
+        _random_choice_csc(4, classes, class_probabilities, 1)
 
     # the class dtype is not supported
     classes = [np.array([4.2, 0.1]),  np.array([0.1, 0.2, 9.4])]
     class_probabilities = [np.array([0.5, 0.5]), np.array([0.6, 0.1, 0.3])]
-    assert_raises(ValueError, _random_choice_csc, 4, classes,
-                  class_probabilities, 1)
+    with pytest.raises(ValueError):
+        _random_choice_csc(4, classes, class_probabilities, 1)
 
     # Given probabilities don't sum to 1
     classes = [np.array([0, 1]),  np.array([0, 1, 2])]
     class_probabilities = [np.array([0.5, 0.6]), np.array([0.6, 0.1, 0.3])]
-    assert_raises(ValueError, _random_choice_csc, 4, classes,
-                  class_probabilities, 1)
+    with pytest.raises(ValueError):
+        _random_choice_csc(4, classes, class_probabilities, 1)
 
 
 def test_our_rand_r():

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -17,7 +17,6 @@ from sklearn.utils.sparsefuncs import (mean_variance_axis,
 from sklearn.utils.sparsefuncs_fast import (assign_rows_csr,
                                             inplace_csr_row_normalize_l1,
                                             inplace_csr_row_normalize_l2)
-from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_allclose
 
 
@@ -31,7 +30,8 @@ def test_mean_variance_axis0():
     X_lil[1, 0] = 0
     X[1, 0] = 0
 
-    assert_raises(TypeError, mean_variance_axis, X_lil, axis=0)
+    with pytest.raises(TypeError):
+        mean_variance_axis(X_lil, axis=0)
 
     X_csr = sp.csr_matrix(X_lil)
     X_csc = sp.csc_matrix(X_lil)
@@ -62,7 +62,8 @@ def test_mean_variance_axis1():
     X_lil[1, 0] = 0
     X[1, 0] = 0
 
-    assert_raises(TypeError, mean_variance_axis, X_lil, axis=1)
+    with pytest.raises(TypeError):
+        mean_variance_axis(X_lil, axis=1)
 
     X_csr = sp.csr_matrix(X_lil)
     X_csc = sp.csc_matrix(X_lil)
@@ -101,12 +102,11 @@ def test_incr_mean_variance_axis():
         X = np.atleast_2d(X)
         X_lil = sp.lil_matrix(X)
         X_csr = sp.csr_matrix(X_lil)
-        assert_raises(TypeError, incr_mean_variance_axis, axis,
-                      last_mean, last_var, last_n)
-        assert_raises(TypeError, incr_mean_variance_axis, axis,
-                      last_mean, last_var, last_n)
-        assert_raises(TypeError, incr_mean_variance_axis, X_lil, axis,
-                      last_mean, last_var, last_n)
+
+        with pytest.raises(TypeError):
+            incr_mean_variance_axis(axis, last_mean, last_var, last_n)
+        with pytest.raises(TypeError):
+            incr_mean_variance_axis(X_lil, axis, last_mean, last_var, last_n)
 
         # Test _incr_mean_and_var with a 1 row input
         X_means, X_vars = mean_variance_axis(X_csr, axis)
@@ -194,16 +194,24 @@ def test_mean_variance_illegal_axis():
     X[2, 1] = 0
     X[4, 3] = 0
     X_csr = sp.csr_matrix(X)
-    assert_raises(ValueError, mean_variance_axis, X_csr, axis=-3)
-    assert_raises(ValueError, mean_variance_axis, X_csr, axis=2)
-    assert_raises(ValueError, mean_variance_axis, X_csr, axis=-1)
+    with pytest.raises(ValueError):
+        mean_variance_axis(X_csr, axis=-3)
+    with pytest.raises(ValueError):
+        mean_variance_axis(X_csr, axis=2)
+    with pytest.raises(ValueError):
+        mean_variance_axis(X_csr, axis=-1)
 
-    assert_raises(ValueError, incr_mean_variance_axis, X_csr, axis=-3,
-                  last_mean=None, last_var=None, last_n=None)
-    assert_raises(ValueError, incr_mean_variance_axis, X_csr, axis=2,
-                  last_mean=None, last_var=None, last_n=None)
-    assert_raises(ValueError, incr_mean_variance_axis, X_csr, axis=-1,
-                  last_mean=None, last_var=None, last_n=None)
+    with pytest.raises(ValueError):
+        incr_mean_variance_axis(X_csr, axis=-3, last_mean=None, last_var=None,
+                                last_n=None)
+
+    with pytest.raises(ValueError):
+        incr_mean_variance_axis(X_csr, axis=2, last_mean=None, last_var=None,
+                                last_n=None)
+
+    with pytest.raises(ValueError):
+        incr_mean_variance_axis(X_csr, axis=-1, last_mean=None, last_var=None,
+                                last_n=None)
 
 
 def test_densify_rows():
@@ -238,7 +246,8 @@ def test_inplace_column_scale():
     assert_array_almost_equal(Xr.toarray(), Xc.toarray())
     assert_array_almost_equal(XA, Xc.toarray())
     assert_array_almost_equal(XA, Xr.toarray())
-    assert_raises(TypeError, inplace_column_scale, X.tolil(), scale)
+    with pytest.raises(TypeError):
+        inplace_column_scale(X.tolil(), scale)
 
     X = X.astype(np.float32)
     scale = scale.astype(np.float32)
@@ -251,7 +260,8 @@ def test_inplace_column_scale():
     assert_array_almost_equal(Xr.toarray(), Xc.toarray())
     assert_array_almost_equal(XA, Xc.toarray())
     assert_array_almost_equal(XA, Xr.toarray())
-    assert_raises(TypeError, inplace_column_scale, X.tolil(), scale)
+    with pytest.raises(TypeError):
+        inplace_column_scale(X.tolil(), scale)
 
 
 def test_inplace_row_scale():
@@ -268,7 +278,8 @@ def test_inplace_row_scale():
     assert_array_almost_equal(Xr.toarray(), Xc.toarray())
     assert_array_almost_equal(XA, Xc.toarray())
     assert_array_almost_equal(XA, Xr.toarray())
-    assert_raises(TypeError, inplace_column_scale, X.tolil(), scale)
+    with pytest.raises(TypeError):
+        inplace_column_scale(X.tolil(), scale)
 
     X = X.astype(np.float32)
     scale = scale.astype(np.float32)
@@ -281,7 +292,8 @@ def test_inplace_row_scale():
     assert_array_almost_equal(Xr.toarray(), Xc.toarray())
     assert_array_almost_equal(XA, Xc.toarray())
     assert_array_almost_equal(XA, Xr.toarray())
-    assert_raises(TypeError, inplace_column_scale, X.tolil(), scale)
+    with pytest.raises(TypeError):
+        inplace_column_scale(X.tolil(), scale)
 
 
 def test_inplace_swap_row():
@@ -308,7 +320,8 @@ def test_inplace_swap_row():
     assert_array_equal(X_csr.toarray(), X_csc.toarray())
     assert_array_equal(X, X_csc.toarray())
     assert_array_equal(X, X_csr.toarray())
-    assert_raises(TypeError, inplace_swap_row, X_csr.tolil())
+    with pytest.raises(TypeError):
+        inplace_swap_row(X_csr.tolil())
 
     X = np.array([[0, 3, 0],
                   [2, 4, 0],
@@ -331,7 +344,8 @@ def test_inplace_swap_row():
     assert_array_equal(X_csr.toarray(), X_csc.toarray())
     assert_array_equal(X, X_csc.toarray())
     assert_array_equal(X, X_csr.toarray())
-    assert_raises(TypeError, inplace_swap_row, X_csr.tolil())
+    with pytest.raises(TypeError):
+        inplace_swap_row(X_csr.tolil())
 
 
 def test_inplace_swap_column():
@@ -358,7 +372,8 @@ def test_inplace_swap_column():
     assert_array_equal(X_csr.toarray(), X_csc.toarray())
     assert_array_equal(X, X_csc.toarray())
     assert_array_equal(X, X_csr.toarray())
-    assert_raises(TypeError, inplace_swap_column, X_csr.tolil())
+    with pytest.raises(TypeError):
+        inplace_swap_column(X_csr.tolil())
 
     X = np.array([[0, 3, 0],
                   [2, 4, 0],
@@ -381,7 +396,8 @@ def test_inplace_swap_column():
     assert_array_equal(X_csr.toarray(), X_csc.toarray())
     assert_array_equal(X, X_csc.toarray())
     assert_array_equal(X, X_csr.toarray())
-    assert_raises(TypeError, inplace_swap_column, X_csr.tolil())
+    with pytest.raises(TypeError):
+        inplace_swap_column(X_csr.tolil())
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -419,9 +435,12 @@ def test_min_max_axis_errors():
                   [4, 0, 5]], dtype=np.float64)
     X_csr = sp.csr_matrix(X)
     X_csc = sp.csc_matrix(X)
-    assert_raises(TypeError, min_max_axis, X_csr.tolil(), axis=0)
-    assert_raises(ValueError, min_max_axis, X_csr, axis=2)
-    assert_raises(ValueError, min_max_axis, X_csc, axis=-3)
+    with pytest.raises(TypeError):
+        min_max_axis(X_csr.tolil(), axis=0)
+    with pytest.raises(ValueError):
+        min_max_axis(X_csr, axis=2)
+    with pytest.raises(ValueError):
+        min_max_axis(X_csc, axis=-3)
 
 
 def test_count_nonzero():
@@ -443,8 +462,10 @@ def test_count_nonzero():
                                                 sample_weight=sample_weight),
                                   X_nonzero_weighted.sum(axis=axis))
 
-    assert_raises(TypeError, count_nonzero, X_csc)
-    assert_raises(ValueError, count_nonzero, X_csr, axis=2)
+    with pytest.raises(TypeError):
+        count_nonzero(X_csc)
+    with pytest.raises(ValueError):
+        count_nonzero(X_csr, axis=2)
 
     assert (count_nonzero(X_csr, axis=0).dtype ==
             count_nonzero(X_csr, axis=1).dtype)
@@ -500,7 +521,8 @@ def test_csc_row_median():
     assert_array_equal(csc_median_axis_0(csc), np.array([0., -3]))
 
     # Test that it raises an Error for non-csc matrices.
-    assert_raises(TypeError, csc_median_axis_0, sp.csr_matrix(X))
+    with pytest.raises(TypeError):
+        csc_median_axis_0(sp.csr_matrix(X))
 
 
 def test_inplace_normalize():

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -44,14 +44,16 @@ from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
                             category=FutureWarning)  # 0.24
 def test_assert_less():
     assert 0 < 1
-    assert_raises(AssertionError, assert_less, 1, 0)
+    with pytest.raises(AssertionError):
+        assert_less(1, 0)
 
 
 @pytest.mark.filterwarnings("ignore",
                             category=FutureWarning)  # 0.24
 def test_assert_greater():
     assert 1 > 0
-    assert_raises(AssertionError, assert_greater, 0, 1)
+    with pytest.raises(AssertionError):
+        assert_greater(0, 1)
 
 
 @pytest.mark.filterwarnings("ignore",
@@ -59,7 +61,8 @@ def test_assert_greater():
 def test_assert_less_equal():
     assert 0 <= 1
     assert 1 <= 1
-    assert_raises(AssertionError, assert_less_equal, 1, 0)
+    with pytest.raises(AssertionError):
+        assert_less_equal(1, 0)
 
 
 @pytest.mark.filterwarnings("ignore",
@@ -67,7 +70,8 @@ def test_assert_less_equal():
 def test_assert_greater_equal():
     assert 1 >= 0
     assert 1 >= 1
-    assert_raises(AssertionError, assert_greater_equal, 0, 1)
+    with pytest.raises(AssertionError):
+        assert_greater_equal(0, 1)
 
 
 def test_set_random_state():
@@ -85,18 +89,17 @@ def test_assert_allclose_dense_sparse():
     y = sparse.csc_matrix(x)
     for X in [x, y]:
         # basic compare
-        assert_raise_message(AssertionError, msg, assert_allclose_dense_sparse,
-                             X, X * 2)
+        with pytest.raises(AssertionError, match=msg):
+            assert_allclose_dense_sparse(X, X*2)
         assert_allclose_dense_sparse(X, X)
 
-    assert_raise_message(ValueError, "Can only compare two sparse",
-                         assert_allclose_dense_sparse, x, y)
+    with pytest.raises(ValueError, match="Can only compare two sparse"):
+        assert_allclose_dense_sparse(x, y)
 
     A = sparse.diags(np.ones(5), offsets=0).tocsr()
     B = sparse.csr_matrix(np.ones((1, 5)))
-
-    assert_raise_message(AssertionError, "Arrays are not equal",
-                         assert_allclose_dense_sparse, B, A)
+    with pytest.raises(AssertionError, match="Arrays are not equal"):
+        assert_allclose_dense_sparse(B, A)
 
 
 def test_assert_raises_msg():
@@ -252,8 +255,8 @@ class TestWarns(unittest.TestCase):
             # test that assert_warns doesn't have side effects on warnings
             # filters
             assert warnings.filters == filters_orig
-
-        assert_raises(AssertionError, assert_no_warnings, f)
+        with pytest.raises(AssertionError):
+            assert_no_warnings(f)
         assert assert_no_warnings(lambda x: x, 1) == 1
 
     def test_warn_wrong_warning(self):
@@ -265,6 +268,9 @@ class TestWarns(unittest.TestCase):
         try:
             try:
                 # Should raise an AssertionError
+
+                # assert_warns has a special handling of "FutureWarning" that
+                # pytest.warns does not have
                 assert_warns(UserWarning, f)
                 failed = True
             except AssertionError:
@@ -492,10 +498,10 @@ def test_check_docstring_parameters():
     assert incorrect == []
     incorrect = check_docstring_parameters(f_missing, ignore=['b'])
     assert incorrect == []
-    assert_raise_message(RuntimeError, 'Unknown section Results',
-                         check_docstring_parameters, f_bad_sections)
-    assert_raise_message(RuntimeError, 'Unknown section Parameter',
-                         check_docstring_parameters, Klass.f_bad_sections)
+    with pytest.raises(RuntimeError, match="Unknown section Results"):
+        check_docstring_parameters(f_bad_sections)
+    with pytest.raises(RuntimeError, match="Unknown section Parameter"):
+        check_docstring_parameters(Klass.f_bad_sections)
 
     incorrect = check_docstring_parameters(f_check_param_definition)
     assert (

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -8,10 +8,8 @@ import pytest
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils._testing import (assert_raises,
-                                    assert_array_equal,
+from sklearn.utils._testing import (assert_array_equal,
                                     assert_allclose_dense_sparse,
-                                    assert_raises_regex,
                                     assert_warns_message,
                                     assert_no_warnings,
                                     _convert_container)
@@ -51,7 +49,8 @@ def test_make_rng():
     rng_42 = np.random.RandomState(42)
     assert check_random_state(43).randint(100) != rng_42.randint(100)
 
-    assert_raises(ValueError, check_random_state, "some invalid seed")
+    with pytest.raises(ValueError):
+        check_random_state("some invalid seed")
 
 
 def test_gen_batches():
@@ -112,10 +111,13 @@ def test_resample():
     assert resample() is None
 
     # Check that invalid arguments yield ValueError
-    assert_raises(ValueError, resample, [0], [0, 1])
-    assert_raises(ValueError, resample, [0, 1], [0, 1],
-                  replace=False, n_samples=3)
-    assert_raises(ValueError, resample, [0, 1], [0, 1], meaning_of_life=42)
+    with pytest.raises(ValueError):
+        resample([0], [0, 1])
+    with pytest.raises(ValueError):
+        resample([0, 1], [0, 1], replace=False, n_samples=3)
+
+    with pytest.raises(ValueError):
+        resample([0, 1], [0, 1], meaning_of_life=42)
     # Issue:6581, n_samples can be more when replace is True (default).
     assert len(resample([1, 2], n_samples=5)) == 5
 
@@ -214,7 +216,8 @@ def test_column_or_1d():
         if y_type in ["binary", 'multiclass', "continuous"]:
             assert_array_equal(column_or_1d(y), np.ravel(y))
         else:
-            assert_raises(ValueError, column_or_1d, y)
+            with pytest.raises(ValueError):
+                column_or_1d(y)
 
 
 @pytest.mark.parametrize(
@@ -539,8 +542,9 @@ def test_gen_even_slices():
 
     # check that passing negative n_chunks raises an error
     slices = gen_even_slices(10, -1)
-    assert_raises_regex(ValueError, "gen_even_slices got n_packs=-1, must be"
-                        " >=1", next, slices)
+    with pytest.raises(ValueError, match="gen_even_slices got n_packs=-1,"
+                                         " must be >=1"):
+        next(slices)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/issues/14216

#### What does this implement/fix? Explain your changes.

Replace occurences of `assert_raises` & `assert_raises_regex ` in the following files:

- [x] sklearn/utils/tests/test_class_weight.py
- [ ] ~~sklearn/utils/tests/test_estimator_checks.py~~
- [x] sklearn/utils/tests/test_multiclass.py
- [x] sklearn/utils/tests/test_random.py
- [x] sklearn/utils/tests/test_sparsefuncs.py
- [x] sklearn/utils/tests/test_testing.py
- [x] sklearn/utils/tests/test_utils.py
- [x] sklearn/utils/tests/test_validation.py

#### Any other comments?

1. Should we replace `assert_warns` with `pytest.warns` context manager?
2. It seems that `assert_raises` is also used outside test files (namely, `sklearn/utils/_testing.py` and
`sklearn/utils/estimator_checks.py` for simple checks. Is that normal? Does it not risk to produce errors with the python `-O` flag?


Edit: test_estimator_checks.py has been reverted to its prior state because it should run even without pytest.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
