### PR TITLE
Fix warning in approximate_nearest_neighbors.py

### DIFF
--- a/examples/neighbors/approximate_nearest_neighbors.py
+++ b/examples/neighbors/approximate_nearest_neighbors.py
@@ -46,8 +46,6 @@ Sample output::
 # License: BSD 3 clause
 import time
 import sys
-import io
-import urllib
 
 try:
     import annoy
@@ -62,11 +60,9 @@ except ImportError:
     sys.exit()
 
 import numpy as np
-import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.ticker import NullFormatter
 from scipy.sparse import csr_matrix
-from scipy.io import arff
 
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.neighbors import KNeighborsTransformer
@@ -211,25 +207,19 @@ def test_transformers():
     assert_array_almost_equal(Xt0.toarray(), Xt2.toarray(), decimal=5)
 
 
-def load_mnist(n_samples_list):
+def load_mnist(n_samples):
     """Load MNIST, shuffle the data, and return only n_samples."""
-    url = 'https://www.openml.org/data/v1/download/18689782/MNIST.arff'
-    fstream = urllib.request.urlopen(url)
-    data, meta = arff.loadarff(io.StringIO(fstream.read().decode('utf-8')))
-    df = pd.DataFrame(np.array(data.tolist(), dtype=np.float64),
-                      columns=meta.names())
-    df_X = df.drop('class', axis=1)
-    df_y = df['class'].astype(int)
-    X, y = shuffle(df_X.to_numpy(), df_y.to_numpy(), random_state=42)
-    datasets = [
-        ('MINST_{}'.format(n_samples), (X[:n_samples], y[:n_samples]))
-        for n_samples in n_samples_list
-    ]
-    return datasets
+    mnist = fetch_openml("mnist_784")
+    X, y = shuffle(mnist.data[:60000], mnist.target[:60000],
+                   random_state=0)
+    return X[:n_samples] / 255, y[:n_samples]
 
 
 def run_benchmark():
-    datasets = load_mnist(n_samples_list=[2000, 10000])
+    datasets = [
+        ('MNIST_2000', load_mnist(n_samples=2000)),
+        ('MNIST_10000', load_mnist(n_samples=10000)),
+    ]
 
     n_iter = 500
     perplexity = 30
@@ -289,8 +279,8 @@ def run_benchmark():
             # plot TSNE embedding which should be very similar across methods
             if 'TSNE' in transformer_name:
                 axes[i_ax].set_title(transformer_name + '\non ' + dataset_name)
-                axes[i_ax].scatter(Xt[:, 0], Xt[:, 1], c=y, alpha=0.2,
-                                   cmap=plt.cm.viridis)
+                axes[i_ax].scatter(Xt[:, 0], Xt[:, 1], c=y.astype(np.int32),
+                                   alpha=0.2, cmap=plt.cm.viridis)
                 axes[i_ax].xaxis.set_major_formatter(NullFormatter())
                 axes[i_ax].yaxis.set_major_formatter(NullFormatter())
                 axes[i_ax].axis('tight')

--- a/examples/neighbors/approximate_nearest_neighbors.py
+++ b/examples/neighbors/approximate_nearest_neighbors.py
@@ -216,12 +216,10 @@ def load_mnist(n_samples_list):
     url = 'https://www.openml.org/data/v1/download/18689782/MNIST.arff'
     fstream = urllib.request.urlopen(url)
     data, meta = arff.loadarff(io.StringIO(fstream.read().decode('utf-8')))
-
     df = pd.DataFrame(np.array(data.tolist(), dtype=np.float64),
                       columns=meta.names())
     df_X = df.drop('class', axis=1)
     df_y = df['class'].astype(int)
-    
     X, y = shuffle(df_X.to_numpy(), df_y.to_numpy(), random_state=42)
     datasets = [
         ('MINST_{}'.format(n_samples), (X[:n_samples], y[:n_samples]))

--- a/examples/neighbors/approximate_nearest_neighbors.py
+++ b/examples/neighbors/approximate_nearest_neighbors.py
@@ -210,8 +210,7 @@ def test_transformers():
 def load_mnist(n_samples):
     """Load MNIST, shuffle the data, and return only n_samples."""
     mnist = fetch_openml("mnist_784")
-    X, y = shuffle(mnist.data[:60000], mnist.target[:60000],
-                   random_state=0)
+    X, y = shuffle(mnist.data, mnist.target, random_state=2)
     return X[:n_samples] / 255, y[:n_samples]
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#14117

#### What does this implement/fix? Explain your changes.
Fix warning in examples/neighbors/approximate_nearest_neighbors.py (UserWarning: Version 1 of dataset MNIST is inactive, meaning that issues have been found in the dataset. Try using a newer version from this URL: https://www.openml.org/data/v1/download/18689782/MNIST.arff)

#### Any other comments?
Though we can get MNIST dataset with 70000 samples by fetch_openml('mnist_784'), the example program does not succeed in the dataset.
So, I tried to avoid using fetch_openml and load the original data with 62000 samples directly from the URL: https://www.openml.org/data/v1/download/18689782/MNIST.arff via urllib.
Is it OK?

(as a part of Paris Sprint)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
