### PR TITLE
fix space missing in documentation

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -46,11 +46,12 @@ class RBFSampler(TransformerMixin, BaseEstimator):
 
     Attributes
     ----------
-    random_offset_: ndarray of shape (n_components,), dtype=float64
+    random_offset_ : ndarray of shape (n_components,), dtype=float64
         Random offset used to compute the projection in the `n_components`
         dimensions of the feature space.
 
-    random_weights_: ndarray of shape (n_features, n_components), dtype=float64
+    random_weights_ : ndarray of shape (n_features, n_components),\
+        dtype=float64
         Random projection directions drawn from the Fourier transform
         of the RBF kernel.
 


### PR DESCRIPTION
corrects mistake introduced in #16276, and breaking #16286, because of missing space

