### PR TITLE
Tag "multioutput", described as 'unused'-removed, as it is being used in the code.

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -491,7 +491,7 @@ binary_only (default=``False``)
 multilabel (default=``False``)
     whether the estimator supports multilabel output
 
-multioutput - unused for now (default=``False``)
+multioutput (default=``False``)
     whether a regressor supports multi-target outputs or a classifier supports
     multi-class multi-output.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
I have removed "- unused for now", as requested, from the doc. Fixes #16357

#### What does this implement/fix? Explain your changes.
The above statement was deleted because multioutput is being used now.

#### Any other comments?
None.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
