### PR TITLE
ENH: Conditional Density Estimation Loss - New Decision Tree Criterion

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1178,11 +1178,12 @@ class RandomForestRegressor(ForestRegressor):
            The default value of ``n_estimators`` changed from 10 to 100
            in 0.22.
 
-    criterion : {"mse", "mae"}, default="mse"
+    criterion : {"mse", "mae", "cde_loss"}, default="mse"
         The function to measure the quality of a split. Supported criteria
         are "mse" for the mean squared error, which is equal to variance
-        reduction as feature selection criterion, and "mae" for the mean
-        absolute error.
+        reduction as feature selection criterion, "mae" for the mean
+        absolute error, and "cde_loss" which uses an approximation for the
+        conditional density estimation loss.
 
         .. versionadded:: 0.18
            Mean Absolute Error (MAE) criterion.

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -61,7 +61,7 @@ DOUBLE = _tree.DOUBLE
 
 CRITERIA_CLF = {"gini": _criterion.Gini, "entropy": _criterion.Entropy}
 CRITERIA_REG = {"mse": _criterion.MSE, "friedman_mse": _criterion.FriedmanMSE,
-                "mae": _criterion.MAE}
+                "mae": _criterion.MAE, "cde_loss": _criterion.CDELoss}
 
 DENSE_SPLITTERS = {"best": _splitter.BestSplitter,
                    "random": _splitter.RandomSplitter}
@@ -961,14 +961,15 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
 
     Parameters
     ----------
-    criterion : {"mse", "friedman_mse", "mae"}, default="mse"
+    criterion : {"mse", "friedman_mse", "mae", "cde_loss"}, default="mse"
         The function to measure the quality of a split. Supported criteria
         are "mse" for the mean squared error, which is equal to variance
         reduction as feature selection criterion and minimizes the L2 loss
         using the mean of each terminal node, "friedman_mse", which uses mean
         squared error with Friedman's improvement score for potential splits,
-        and "mae" for the mean absolute error, which minimizes the L1 loss
-        using the median of each terminal node.
+        "mae" for the mean absolute error, which minimizes the L1 loss
+        using the median of each terminal node, and "cde_loss" which uses
+        an approximation for the conditional density estimation loss.
 
         .. versionadded:: 0.18
            Mean Absolute Error (MAE) criterion.

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -983,7 +983,6 @@ cdef class CDELoss(MSE):
     cdef double node_impurity(self) nogil:
         """Evaluate the impurity of the current node, i.e. the impurity of
            samples[start:end]."""
-
         cdef double* sum_total = self.sum_total
         cdef double impurity
         cdef SIZE_t k

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -983,6 +983,7 @@ cdef class CDELoss(MSE):
     cdef double node_impurity(self) nogil:
         """Evaluate the impurity of the current node, i.e. the impurity of
            samples[start:end]."""
+
         cdef double* sum_total = self.sum_total
         cdef double impurity
         cdef SIZE_t k
@@ -1010,6 +1011,28 @@ cdef class CDELoss(MSE):
         for k in range(self.n_outputs):
             impurity_left[0] -= (sum_left[k] * sum_left[k] / self.weighted_n_left)
             impurity_right[0] -= (sum_right[k] * sum_right[k] / self.weighted_n_right)
+
+    cdef double impurity_improvement(self, double impurity) nogil:
+        """Compute the improvement in impurity
+
+        This method computes the improvement in impurity when a split occurs.
+
+        Parameters
+        ----------
+        impurity : double
+            The initial impurity of the node before the split
+
+        Return
+        ------
+        double : improvement in impurity after the split occurs
+        """
+
+        cdef double impurity_left
+        cdef double impurity_right
+
+        self.children_impurity(&impurity_left, &impurity_right)
+
+        return impurity - (impurity_left + impurity_right)
 
 cdef class MAE(RegressionCriterion):
     r"""Mean absolute error impurity criterion

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -450,8 +450,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
         is_leaf = (depth >= self.max_depth or
                    n_node_samples < self.min_samples_split or
                    n_node_samples < 2 * self.min_samples_leaf or
-                   weighted_n_node_samples < 2 * self.min_weight_leaf or
-                   impurity <= min_impurity_split)
+                   weighted_n_node_samples < 2 * self.min_weight_leaf)
 
         if not is_leaf:
             splitter.node_split(impurity, &split, &n_constant_features)

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -229,9 +229,6 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                     impurity = splitter.node_impurity()
                     first = 0
 
-                is_leaf = (is_leaf or
-                           (impurity <= min_impurity_split))
-
                 if not is_leaf:
                     splitter.node_split(impurity, &split, &n_constant_features)
                     # If EPSILON=0 in the below comparison, float precision


### PR DESCRIPTION
This PR implements conditional density estimation loss as described in T. Pospisil, and A. Lee, "RFCDE: Random Forests for Conditional Density Estimation", arXiv:1804.05753 [stat.ML], 2018. The key advantages of adding the CDE Loss criterion into sklearn is for making it easy for users to incorporate this algorithm in scikit-learn pipelines and serialize this estimator. 

Conditional Density Estimation is a useful branch of machine learning with many applications. The random forest implementation in scikit-learn is robust, in comparison to the C++ implementation provided by the authors of the above paper.

While users can easily implement their own cython class for CDE Loss, I believe this criterion is useful enough for CDE-type problems (and similar enough to the existing MSE criterion), that it should be supported within scikit-learn. 