### PR TITLE
DOC/FIX indentation in deprecated estimators

### DIFF
--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -109,7 +109,7 @@ class deprecated:
         if self.extra:
             newdoc = "%s: %s" % (newdoc, self.extra)
         if olddoc:
-            newdoc = "%s\n\n%s" % (newdoc, olddoc)
+            newdoc = "%s\n\n    %s" % (newdoc, olddoc)
         return newdoc
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #15741 


#### What does this implement/fix? Explain your changes.

This small PR adds 4 whitespaces when the docstring is updated. Why? Because functions and classes are indented, so are their docstrings, thus a new paragraph must start with 4 whitespaces. `\t` does not work as good, because there are really 4 whitespaces in docstrings.

#### Any other comments?

I did not try on scikit-learn repository but on a project of mine (so that the documentation builds faster), I will try to have a look at the documentation from Circle CI to see if this works as expected.
