### PR TITLE
DOC More explicit warnings about the misleading use of impurity-based feature_importances

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -279,6 +279,19 @@ for feature selection. This is known as the mean decrease in impurity, or MDI.
 Refer to [L2014]_ for more information on MDI and feature importance
 evaluation with Random Forests.
 
+.. warning::
+
+  The impurity-based feature importances computed on tree-based models suffer
+  from two flaws that can lead to misleading conclusions. First they are
+  computed on statistics derived from the training dataset and therefore **do
+  not necessarily inform us on which features are most important to make good
+  predictions on helf-out dataset**. Secondly, **they favor high cardinality
+  features**, that is feature with many unique values.
+  :ref:`permutation_importance` is an alternative to impurity-based feature
+  importance that does not suffer from these flaws. These two methods of
+  obtaining feature importance are explored in:
+  :ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance.py`.
+
 The following example shows a color-coded representation of the relative
 importances of each individual pixel for a face recognition task using
 a :class:`ExtraTreesClassifier` model.
@@ -293,13 +306,6 @@ In practice those estimates are stored as an attribute named
 ``(n_features,)`` whose values are positive and sum to 1.0. The higher
 the value, the more important is the contribution of the matching feature
 to the prediction function.
-
-The impurity-based feature importance for trees suffers from being computed
-on statistics derived from the training dataset
-and favors high cardinality features.
-:ref:`permutation_importance` is a nice alternative impurity-based feature importance.
-These two methods of obtaining feature importance are explored in:
-:ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance.py`.
 
 .. topic:: Examples:
 
@@ -329,8 +335,9 @@ trees and the maximum depth per tree. For each tree in the ensemble, the coding
 contains one entry of one. The size of the coding is at most ``n_estimators * 2
 ** max_depth``, the maximum number of leaves in the forest.
 
-As neighboring data points are more likely to lie within the same leaf of a tree,
-the transformation performs an implicit, non-parametric density estimation.
+As neighboring data points are more likely to lie within the same leaf of a
+tree, the transformation performs an implicit, non-parametric density
+estimation.
 
 .. topic:: Examples:
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -285,8 +285,8 @@ evaluation with Random Forests.
   from two flaws that can lead to misleading conclusions. First they are
   computed on statistics derived from the training dataset and therefore **do
   not necessarily inform us on which features are most important to make good
-  predictions on helf-out dataset**. Secondly, **they favor high cardinality
-  features**, that is feature with many unique values.
+  predictions on held-out dataset**. Secondly, **they favor high cardinality
+  features**, that is features with many unique values.
   :ref:`permutation_importance` is an alternative to impurity-based feature
   importance that does not suffer from these flaws. These two methods of
   obtaining feature importance are explored in:

--- a/doc/modules/permutation_importance.rst
+++ b/doc/modules/permutation_importance.rst
@@ -48,14 +48,14 @@ an arbitrary metric on the tree's predictions. These two methods of obtaining
 feature importance are explored in:
 :ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance.py`.
 
-Strongly correlated features
-----------------------------
+Misleading values on strongly correlated features
+-------------------------------------------------
 
 When two features are correlated and one of the features is permuted, the model
-will still have access to the feature through its correlated feature. This will 
+will still have access to the feature through its correlated feature. This will
 result in a lower importance for both features, where they might *actually* be
 important. One way  to handle this is to cluster features that are correlated
-and only keep one feature from each cluster. This use case is explored in: 
+and only keep one feature from each cluster. This use case is explored in:
 :ref:`sphx_glr_auto_examples_inspection_plot_permutation_importance_multicollinear.py`.
 
 .. topic:: Examples:

--- a/examples/ensemble/plot_forest_importances.py
+++ b/examples/ensemble/plot_forest_importances.py
@@ -10,6 +10,11 @@ along with their inter-trees variability.
 
 As expected, the plot suggests that 3 features are informative, while the
 remaining are not.
+
+Warning: impurity-based feature importances can be misleading for high
+cardinality features (many unique values). See
+:func:`sklearn.inspection.permutation_importance` as an alternative.
+
 """
 print(__doc__)
 
@@ -49,7 +54,7 @@ for f in range(X.shape[1]):
 plt.figure()
 plt.title("Feature importances")
 plt.bar(range(X.shape[1]), importances[indices],
-       color="r", yerr=std[indices], align="center")
+        color="r", yerr=std[indices], align="center")
 plt.xticks(range(X.shape[1]), indices)
 plt.xlim([-1, X.shape[1]])
 plt.show()

--- a/examples/ensemble/plot_gradient_boosting_regression.py
+++ b/examples/ensemble/plot_gradient_boosting_regression.py
@@ -63,6 +63,11 @@ plt.ylabel('Deviance')
 
 # #############################################################################
 # Plot impurity-based feature importance
+#
+# Warning: impurity-based feature importances can be misleading for
+# high cardinality features (many unique values). See
+# :func:`sklearn.inspection.permutation_importance` as an alternative.
+
 feature_importance = clf.feature_importances_
 # make importances relative to max importance
 feature_importance = 100.0 * (feature_importance / feature_importance.max())

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -422,6 +422,10 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
         Returns
         -------
         feature_importances_ : ndarray of shape (n_features,)
@@ -1056,6 +1060,10 @@ class RandomForestClassifier(ForestClassifier):
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
     oob_score_ : float
         Score of the training dataset obtained using an out-of-bag estimate.
         This attribute exists only when ``oob_score`` is True.
@@ -1078,8 +1086,6 @@ class RandomForestClassifier(ForestClassifier):
     >>> clf = RandomForestClassifier(max_depth=2, random_state=0)
     >>> clf.fit(X, y)
     RandomForestClassifier(max_depth=2, random_state=0)
-    >>> print(clf.feature_importances_)
-    [0.14205973 0.76664038 0.0282433  0.06305659]
     >>> print(clf.predict([[0, 0, 0, 0]]))
     [1]
 
@@ -1337,6 +1343,10 @@ class RandomForestRegressor(ForestRegressor):
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
     n_features_ : int
         The number of features when ``fit`` is performed.
 
@@ -1361,8 +1371,6 @@ class RandomForestRegressor(ForestRegressor):
     >>> regr = RandomForestRegressor(max_depth=2, random_state=0)
     >>> regr.fit(X, y)
     RandomForestRegressor(max_depth=2, random_state=0)
-    >>> print(regr.feature_importances_)
-    [0.18146984 0.81473937 0.00145312 0.00233767]
     >>> print(regr.predict([[0, 0, 0, 0]]))
     [-8.32987858]
 
@@ -1656,6 +1664,10 @@ class ExtraTreesClassifier(ForestClassifier):
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
     n_features_ : int
         The number of features when ``fit`` is performed.
 
@@ -1934,6 +1946,10 @@ class ExtraTreesRegressor(ForestRegressor):
         The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
+
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
 
     n_features_ : int
         The number of features.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -662,6 +662,10 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
         Returns
         -------
         feature_importances_ : array, shape (n_features,)
@@ -985,6 +989,10 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
+
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
 
     oob_improvement_ : ndarray of shape (n_estimators,)
         The improvement in loss (= deviance) on the out-of-bag samples
@@ -1463,6 +1471,10 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
+
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
 
     oob_improvement_ : ndarray of shape (n_estimators,)
         The improvement in loss (= deviance) on the out-of-bag samples

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -246,6 +246,10 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
         Returns
         -------
         feature_importances_ : ndarray of shape (n_features,)
@@ -356,7 +360,12 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         ensemble.
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances if supported by the ``base_estimator``.
+        The impurity-based feature importances if supported by the
+        ``base_estimator`` (when based on decision trees).
+
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
 
     See Also
     --------
@@ -394,8 +403,6 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
     >>> clf = AdaBoostClassifier(n_estimators=100, random_state=0)
     >>> clf.fit(X, y)
     AdaBoostClassifier(n_estimators=100, random_state=0)
-    >>> clf.feature_importances_
-    array([0.28..., 0.42..., 0.14..., 0.16...])
     >>> clf.predict([[0, 0, 0, 0]])
     array([1])
     >>> clf.score(X, y)
@@ -929,7 +936,12 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
         Regression error for each estimator in the boosted ensemble.
 
     feature_importances_ : ndarray of shape (n_features,)
-        The feature importances if supported by the ``base_estimator``.
+        The impurity-based feature importances if supported by the
+        ``base_estimator`` (when based on decision trees).
+
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
 
     Examples
     --------
@@ -940,8 +952,6 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
     >>> regr = AdaBoostRegressor(random_state=0, n_estimators=100)
     >>> regr.fit(X, y)
     AdaBoostRegressor(n_estimators=100, random_state=0)
-    >>> regr.feature_importances_
-    array([0.2788..., 0.7109..., 0.0065..., 0.0036...])
     >>> regr.predict([[0, 0, 0, 0]])
     array([4.7972...])
     >>> regr.score(X, y)

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -567,6 +567,10 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         reduction of the criterion brought by that feature.
         It is also known as the Gini importance.
 
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
         Returns
         -------
         feature_importances_ : ndarray of shape (n_features,)
@@ -741,6 +745,10 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
         The importance of a feature is computed as the (normalized)
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance [4]_.
+
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
 
     max_features_ : int
         The inferred value of max_features.
@@ -1097,6 +1105,10 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
         (normalized) total reduction of the criterion brought
         by that feature. It is also known as the Gini importance [4]_.
 
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
     max_features_ : int
         The inferred value of max_features.
 
@@ -1405,6 +1417,10 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
         total reduction of the criterion brought by that feature.  It is also
         known as the Gini importance.
 
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
     n_features_ : int
         The number of features when ``fit`` is performed.
 
@@ -1603,8 +1619,12 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
         The number of features when ``fit`` is performed.
 
     feature_importances_ : ndarray of shape (n_features,)
-        Return the feature importances (the higher, the more important the
-        feature).
+        Return impurity-based feature importances (the higher, the more
+        important the feature).
+
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
 
     n_outputs_ : int
         The number of outputs when ``fit`` is performed.


### PR DESCRIPTION
This builds on top of #16237 to better address #14528.

This PR focused on adding more explicit warnings while not changing the code of the examples.

Updating the examples to rewrite them to use permutation_importance can be done in another PR to be able to quickly merge this one.