### PR TITLE
Adding lightweight random indexing

### DIFF
--- a/benchmarks/bench_text_vectorizers.py
+++ b/benchmarks/bench_text_vectorizers.py
@@ -16,8 +16,7 @@ import pandas as pd
 from memory_profiler import memory_usage
 
 from sklearn.datasets import fetch_20newsgroups
-from sklearn.feature_extraction.text import (CountVectorizer, TfidfVectorizer,
-                                             HashingVectorizer)
+import sklearn.feature_extraction.text as fet
 
 n_repeat = 3
 
@@ -39,7 +38,8 @@ print("This benchmarks runs in ~1 min ...")
 res = []
 
 for Vectorizer, (analyzer, ngram_range) in itertools.product(
-            [CountVectorizer, TfidfVectorizer, HashingVectorizer],
+            [fet.CountVectorizer, fet.TfidfVectorizer, fet.HashingVectorizer,
+             fet.LightweightRandomIndexingVectorizer],
             [('word', (1, 1)),
              ('word', (1, 2)),
              ('char', (4, 4)),

--- a/conftest.py
+++ b/conftest.py
@@ -36,9 +36,12 @@ def pytest_collection_modifyitems(config, items):
     # FeatureHasher is not compatible with PyPy
     if platform.python_implementation() == 'PyPy':
         skip_marker = pytest.mark.skip(
-            reason='FeatureHasher is not compatible with PyPy')
+            reason='FeatureHasher and FeatureLightweightRandomIndexing are '
+                   'not compatible with PyPy')
         for item in items:
-            if item.name.endswith(('_hash.FeatureHasher',
+            if item.name.endswith(('_hash.FeatureLightweightRandomIndexing',
+                                   'text.LightweightRandomIndexingVectorizer',
+                                   '_hash.FeatureHasher',
                                    'text.HashingVectorizer')):
                 item.add_marker(skip_marker)
 

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -479,6 +479,7 @@ Samples generator
 
    feature_extraction.DictVectorizer
    feature_extraction.FeatureHasher
+   feature_extraction.FeatureLightweightRandomIndexing
 
 From images
 -----------
@@ -519,6 +520,7 @@ From text
 
    feature_extraction.text.CountVectorizer
    feature_extraction.text.HashingVectorizer
+   feature_extraction.text.LightweightRandomIndexingVectorizer
    feature_extraction.text.TfidfTransformer
    feature_extraction.text.TfidfVectorizer
 

--- a/doc/modules/computing.rst
+++ b/doc/modules/computing.rst
@@ -47,6 +47,13 @@ use the so-called :ref:`hashing trick<feature_hashing>` as implemented by
 :class:`sklearn.feature_extraction.FeatureHasher` for datasets with categorical
 variables represented as list of Python dicts or
 :class:`sklearn.feature_extraction.text.HashingVectorizer` for text documents.
+Alternatively, a method based on the theory of
+:ref:`random indexing<feature_lri>` is implemented by
+:class:`sklearn.feature_extraction.FeatureLightweightRandomIndexing` for
+datasets with categorical variables represented as list of Python dicts or
+:class:`sklearn.feature_extraction.text.LightweightRandomIndexingVectorizer`
+for text documents.
+
 
 Incremental learning
 .....................

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -212,6 +212,47 @@ otherwise the features will not be mapped evenly to the columns.
  * `MurmurHash3 <https://github.com/aappleby/smhasher>`_.
 
 
+.. _feature_lri:
+
+Lightweight Random Indexing
+===============
+
+.. currentmodule:: sklearn.feature_extraction
+
+The class :class:`FeatureLightweightRandomIndexing` is a hash-based indexing
+ method that implements a
+`random indexing <https://en.wikipedia.org/wiki/Random_indexing>`_ technique
+called lightweight random indexing.
+:class:`FeatureLightweightRandomIndexing` represents every feature with
+a vector in which exactly two indices has non-zero value, randomly selected
+from the two possible values +1 and -1.
+This random indexing criteria has similar speed and reduced memory usage
+properties of :class:`FeatureHasher`, plus it gives to the indexing vectors
+good properties of quasiorthogonality, reducing the loss of information the
+the dimensionality of the indexing space (`n_feature`) is much smaller than
+the number of input features.
+
+The input and output data of :class:`FeatureLightweightRandomIndexing` are
+the same of :class:`FeatureHasher`.
+A dedicated :ref:`text vectorizer<lri_vectorizer>' that also includes the
+tokenization process is implemented by
+:class:`LightweightRandomIndexingVectorizer`.
+
+Implementation details
+----------------------
+
+The difference with respect to :class:`FeatureHasher` is that the MurmurHash3
+hashing function is invoked twice, using different seeds, checking for
+possible collisions between the two hashes, and eventually generating a second
+hash with a different seed until there is no collision.
+
+.. topic:: References:
+
+ * Alejandro Moreo, Andrea Esuli, Fabrizio Sebastiani (2016).
+   `Lightweight Random Indexing for Polylingual Text Classification
+   <https://www.jair.org/index.php/jair/article/view/11025>`_. JAIR
+
+
 .. _text_feature_extraction:
 
 Text feature extraction
@@ -872,6 +913,18 @@ time is often limited by the CPU time one wants to spend on the task.
 
 For a full-fledged example of out-of-core scaling in a text classification
 task see :ref:`sphx_glr_auto_examples_applications_plot_out_of_core_classification.py`.
+
+.. _lri_vectorizer:
+
+Stateless vectorization with lightweight random indexing
+------------------------------------------------------
+
+Another method that implements stateless vectorization of text is
+:ref:`lightweight random indexing<_feature_lri>`_.
+:class:`LightweightRandomIndexingVectorizer` is a subclass of
+:class:`HashingVectorizer` that differs only in the use of the method
+implemented by :class:`FeatureLightweightRandomIndexing` to perform indexing.
+
 
 Customizing the vectorizer classes
 ----------------------------------

--- a/sklearn/feature_extraction/__init__.py
+++ b/sklearn/feature_extraction/__init__.py
@@ -6,8 +6,9 @@ images.
 
 from ._dict_vectorizer import DictVectorizer
 from ._hash import FeatureHasher
+from ._lri import FeatureLightweightRandomIndexing
 from .image import img_to_graph, grid_to_graph
 from . import text
 
 __all__ = ['DictVectorizer', 'image', 'img_to_graph', 'grid_to_graph', 'text',
-           'FeatureHasher']
+           'FeatureHasher', 'FeatureLightweightRandomIndexing']

--- a/sklearn/feature_extraction/_lri.py
+++ b/sklearn/feature_extraction/_lri.py
@@ -1,0 +1,156 @@
+# Author: Lars Buitinck
+# License: BSD 3 clause
+
+import numbers
+
+import numpy as np
+import scipy.sparse as sp
+
+from ..utils import IS_PYPY
+from ..base import BaseEstimator, TransformerMixin
+
+if not IS_PYPY:
+    from ._lri_fast import transform as _lri_transform
+else:
+    def _lri_transform(*args, **kwargs):
+        raise NotImplementedError(
+                'FeatureLightweightRandomIndexing is not compatible with '
+                'PyPy (see '
+                'https://github.com/scikit-learn/scikit-learn/issues/11540 '
+                'for the status updates).')
+
+
+def _iteritems(d):
+    """Like d.iteritems, but accepts any collections.Mapping."""
+    return d.iteritems() if hasattr(d, "iteritems") else d.items()
+
+
+class FeatureLightweightRandomIndexing(TransformerMixin, BaseEstimator):
+    """Applies lightweight random indexing [1] to a collection of texts.
+
+    Derived from :ref:`FeatureHasher`, it computes two hashes for every
+    feature (avoiding collisions). The resulting indexing vectors for features
+    have good properties of orthogonality and information preservation in
+    reduced feature spaces.
+
+    Parameters
+    ----------
+    n_features : int, default=2**20
+        The number of features (columns) in the output matrices. Small numbers
+        of features are likely to cause hash collisions, but large numbers
+        will cause larger coefficient dimensions in linear learners.
+    input_type : {"dict", "pair"}, default="dict"
+        Either "dict" (the default) to accept dictionaries over
+        (feature_name, value); "pair" to accept pairs of (feature_name, value);
+        or "string" to accept single strings.
+        feature_name should be a string, while value should be a number.
+        In the case of "string", a value of 1 is implied.
+        The feature_name is hashed to find the appropriate column for the
+        feature. The value's sign might be flipped in the output (but see
+        non_negative, below).
+    dtype : numpy dtype, default=np.float64
+        The type of feature values. Passed to scipy.sparse matrix constructors
+        as the dtype argument. Do not set this to bool, np.boolean or any
+        unsigned integer type.
+
+    Examples
+    --------
+    >>> from sklearn.feature_extraction import FeatureLightweightRandomIndexing
+    >>> h = FeatureLightweightRandomIndexing(n_features=10)
+    >>> D = [{'dog': 1, 'cat':2, 'elephant':4},{'dog': 2, 'run': 5}]
+    >>> f = h.transform(D)
+    >>> f.toarray()
+    array([[ 0.,  2., -4., -1., -1.,  0.,  0.,  0., -4.,  2.],
+           [ 5.,  0.,  0., -2., -7.,  0.,  0.,  0.,  0.,  0.]])
+
+    See also
+    --------
+    DictVectorizer : vectorizes string-valued features using a hash table.
+    FeatureHasher : implements the hashing trick
+    sklearn.preprocessing.OneHotEncoder : handles nominal/categorical features.
+
+    References
+    ----------
+    .. [1] Lightweight random indexing for polylingual text classification,
+    A. Moreo, A. Esuli & F. Sebastiani, JAIR, 2016.
+    """
+
+    def __init__(self, n_features=(2 ** 20), input_type="dict",
+                 dtype=np.float64):
+        self._validate_params(n_features, input_type)
+
+        self.dtype = dtype
+        self.input_type = input_type
+        self.n_features = n_features
+
+    @staticmethod
+    def _validate_params(n_features, input_type):
+        # strangely, np.int16 instances are not instances of Integral,
+        # while np.int64 instances are...
+        if not isinstance(n_features, numbers.Integral):
+            raise TypeError("n_features must be integral, got %r (%s)."
+                            % (n_features, type(n_features)))
+        elif n_features < 1 or n_features >= np.iinfo(np.int32).max + 1:
+            raise ValueError("Invalid number of features (%d)." % n_features)
+
+        if input_type not in ("dict", "pair", "string"):
+            raise ValueError("input_type must be 'dict', 'pair' or 'string',"
+                             " got %r." % input_type)
+
+    def fit(self, X=None, y=None):
+        """No-op.
+
+        This method doesn't do anything. It exists purely for compatibility
+        with the scikit-learn transformer API.
+
+        Parameters
+        ----------
+        X : ndarray
+
+        Returns
+        -------
+        self : FeatureLightweightRandomIndexing
+
+        """
+        # repeat input validation for grid search (which calls set_params)
+        self._validate_params(self.n_features, self.input_type)
+        return self
+
+    def transform(self, raw_X):
+        """Transform a sequence of instances to a scipy.sparse matrix.
+
+        Parameters
+        ----------
+        raw_X : iterable over iterable over raw features, length = n_samples
+            Samples. Each sample must be iterable an (e.g., a list or tuple)
+            containing/generating feature names (and optionally values, see
+            the input_type constructor argument) which will be hashed.
+            raw_X need not support the len function, so it can be the result
+            of a generator; n_samples is determined on the fly.
+
+        Returns
+        -------
+        X : sparse matrix of shape (n_samples, n_features)
+            Feature matrix, for use with estimators or further transformers.
+
+        """
+        raw_X = iter(raw_X)
+        if self.input_type == "dict":
+            raw_X = (_iteritems(d) for d in raw_X)
+        elif self.input_type == "string":
+            raw_X = (((f, 1) for f in x) for x in raw_X)
+        indices, indptr, values = \
+            _lri_transform(raw_X, self.n_features, self.dtype, seed=0)
+        n_samples = indptr.shape[0] - 1
+
+        if n_samples == 0:
+            raise ValueError("Cannot vectorize empty sequence.")
+
+        X = sp.csr_matrix((values, indices, indptr), dtype=self.dtype,
+                          shape=(n_samples, self.n_features))
+        X.sum_duplicates()  # also sorts the indices
+
+        return X
+
+    def _more_tags(self):
+        return {'X_types': [self.input_type]}

--- a/sklearn/feature_extraction/_lri_fast.pyx
+++ b/sklearn/feature_extraction/_lri_fast.pyx
@@ -1,0 +1,124 @@
+# Author: Lars Buitinck
+# License: BSD 3 clause
+#
+# cython: boundscheck=False, cdivision=True
+
+import sys
+import array
+from cpython cimport array
+cimport cython
+from libc.stdlib cimport abs
+cimport numpy as np
+import numpy as np
+
+from ..utils.murmurhash cimport murmurhash3_bytes_s32
+from ..utils.fixes import sp_version
+
+np.import_array()
+
+
+def transform(raw_X, Py_ssize_t n_features, dtype, unsigned int seed=0):
+    """Guts of FeatureLightweightRandomIndexing.transform.
+
+    Returns
+    -------
+    n_samples : integer
+    indices, indptr, values : lists
+        For constructing a scipy.sparse.csr_matrix.
+
+    """
+    assert n_features > 0
+
+    cdef np.int32_t h
+    cdef double value
+
+    cdef array.array indices
+    cdef array.array indptr
+    indices = array.array("i")
+    indices_array_dtype = "q"
+    indices_np_dtype = np.longlong
+
+
+    indptr = array.array(indices_array_dtype, [0])
+
+    # Since Python array does not understand Numpy dtypes, we grow the indices
+    # and values arrays ourselves. Use a Py_ssize_t capacity for safety.
+    cdef Py_ssize_t capacity = 8192     # arbitrary
+    cdef np.int64_t size = 0
+    cdef np.ndarray values = np.empty(capacity, dtype=dtype)
+
+    for x in raw_X:
+        for f, v in x:
+            if isinstance(v, (str, unicode)):
+                f = "%s%s%s" % (f, '=', v)
+                value = 1
+            else:
+                value = v
+
+            if value == 0:
+                continue
+
+            if isinstance(f, unicode):
+                f = (<unicode>f).encode("utf-8")
+            # Need explicit type check because Murmurhash does not propagate
+            # all exceptions. Add "except *" there?
+            elif not isinstance(f, bytes):
+                raise TypeError("feature names must be strings")
+
+            h0 = murmurhash3_bytes_s32(<bytes>f, seed)
+
+            array.resize_smart(indices, len(indices) + 1)
+            indices[len(indices) - 1] = abs(h0) % n_features
+            # improve inner product preservation in the hashed space
+            value0 = value * ((h0 >= 0) * 2 - 1)
+            values[size] = value0
+            size += 1
+
+            if size == capacity:
+                capacity *= 2
+                # can't use resize member because there might be multiple
+                # references to the arrays due to Cython's error checking
+                values = np.resize(values, capacity)
+
+            h0 = abs(h0) % n_features
+
+            ih1 = h0
+            offset = 1
+            while ih1==h0:
+                h1 = murmurhash3_bytes_s32(<bytes>f, seed+offset)
+                ih1 = abs(h1) % n_features
+                offset += 1
+
+            array.resize_smart(indices, len(indices) + 1)
+            indices[len(indices) - 1] = ih1
+            # improve inner product preservation in the hashed space
+            value1 = value * ((h1 >= 0) * 2 - 1)
+            values[size] = value1
+            size += 1
+
+            if size == capacity:
+                capacity *= 2
+                # can't use resize member because there might be multiple
+                # references to the arrays due to Cython's error checking
+                values = np.resize(values, capacity)
+
+
+        array.resize_smart(indptr, len(indptr) + 1)
+        indptr[len(indptr) - 1] = size
+
+    indices_a = np.frombuffer(indices, dtype=np.int32)
+    indptr_a = np.frombuffer(indptr, dtype=indices_np_dtype)
+
+    if indptr[-1] > np.iinfo(np.int32).max:  # = 2**31 - 1
+        if sp_version < (0, 14):
+            raise ValueError(('sparse CSR array has {} non-zero '
+                              'elements and requires 64 bit indexing, '
+                              ' which is unsupported with scipy {}. '
+                              'Please upgrade to scipy >=0.14')
+                             .format(indptr[-1], '.'.join(sp_version)))
+        # both indices and indptr have the same dtype in CSR arrays
+        indices_a = indices_a.astype(np.int64, copy=False)
+    else:
+        indptr_a = indptr_a.astype(np.int32, copy=False)
+
+    return (indices_a, indptr_a, values[:size])

--- a/sklearn/feature_extraction/setup.py
+++ b/sklearn/feature_extraction/setup.py
@@ -16,6 +16,10 @@ def configuration(parent_package='', top_path=None):
                              sources=['_hashing_fast.pyx'],
                              include_dirs=[numpy.get_include()],
                              libraries=libraries)
+    config.add_extension('_lri_fast',
+                         sources=['_lri_fast.pyx'],
+                         include_dirs=[numpy.get_include()],
+                         libraries=libraries)
     config.add_subpackage("tests")
 
     return config

--- a/sklearn/feature_extraction/tests/test_feature_lri.py
+++ b/sklearn/feature_extraction/tests/test_feature_lri.py
@@ -86,7 +86,7 @@ def test_feature_lri_pairs_with_string_values():
                                        {"bax": "abc"}])
     x1, x2 = h.transform(raw_X).toarray()
     x1_nz = np.abs(x1[x1 != 0])
-    assert_array_equal([1,1], x1_nz)
+    assert_array_equal([1, 1], x1_nz)
     assert_array_equal(x1, x2)
 
 
@@ -94,7 +94,8 @@ def test_lri_empty_input():
     n_features = 16
     raw_X = [[], (), iter(range(0))]
 
-    h = FeatureLightweightRandomIndexing(n_features=n_features, input_type="string")
+    h = FeatureLightweightRandomIndexing(n_features=n_features,
+                                         input_type="string")
     X = h.transform(raw_X)
 
     assert_array_equal(X.A, np.zeros((len(raw_X), n_features)))

--- a/sklearn/feature_extraction/tests/test_feature_lri.py
+++ b/sklearn/feature_extraction/tests/test_feature_lri.py
@@ -1,0 +1,133 @@
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
+
+from sklearn.feature_extraction import FeatureLightweightRandomIndexing
+from sklearn.utils._testing import fails_if_pypy
+
+pytestmark = fails_if_pypy
+
+
+def test_feature_lri_dicts():
+    h = FeatureLightweightRandomIndexing(n_features=16)
+    assert "dict" == h.input_type
+
+    raw_X = [{"foo": "bar", "dada": 42, "tzara": 37},
+             {"foo": "baz", "gaga": "string1"}]
+    X1 = FeatureLightweightRandomIndexing(n_features=16).transform(raw_X)
+    gen = (iter(d.items()) for d in raw_X)
+    X2 = FeatureLightweightRandomIndexing(n_features=16,
+                                          input_type="pair").transform(gen)
+    assert_array_equal(X1.toarray(), X2.toarray())
+
+
+def test_feature_lri_strings():
+    # mix byte and Unicode strings; note that "foo" is a duplicate in row 0
+    raw_X = [["foo", "bar", "baz", "foo".encode("ascii")],
+             ["bar".encode("ascii"), "baz", "quux"]]
+
+    for lg_n_features in (7, 9, 11, 16, 22):
+        n_features = 2 ** lg_n_features
+
+        it = (x for x in raw_X)                 # iterable
+
+        h = FeatureLightweightRandomIndexing(n_features, input_type="string")
+        X = h.transform(it)
+
+        assert X.shape[0] == len(raw_X)
+        assert X.shape[1] == n_features
+
+
+def test_lri_transform_seed():
+    # check the influence of the seed when computing the hashes
+    # import is here to avoid importing on pypy
+    from sklearn.feature_extraction._lri_fast import (
+            transform as _lri_transform)
+    raw_X = [["foo", "bar", "baz", "foo".encode("ascii")],
+             ["bar".encode("ascii"), "baz", "quux"]]
+
+    raw_X_ = (((f, 1) for f in x) for x in raw_X)
+    indices, indptr, _ = _lri_transform(raw_X_, 2 ** 7, str)
+
+    raw_X_ = (((f, 1) for f in x) for x in raw_X)
+    indices_0, indptr_0, _ = _lri_transform(raw_X_, 2 ** 7, str, seed=0)
+    assert_array_equal(indices, indices_0)
+    assert_array_equal(indptr, indptr_0)
+
+    raw_X_ = (((f, 1) for f in x) for x in raw_X)
+    indices_1, _, _ = _lri_transform(raw_X_, 2 ** 7, str, seed=1)
+    with pytest.raises(AssertionError):
+        assert_array_equal(indices, indices_1)
+
+
+def test_feature_lri_pairs():
+    raw_X = (iter(d.items()) for d in [{"foo": 1, "bar": 2},
+                                       {"baz": 3, "quux": 4, "foo": -1}])
+    h = FeatureLightweightRandomIndexing(n_features=16, input_type="pair")
+    x1, x2 = h.transform(raw_X).toarray()
+    x1_nz = set(np.abs(x1[x1 != 0]))
+    x2_nz = set(np.abs(x2[x2 != 0]))
+    assert {1, 2} == x1_nz
+    assert {1, 3, 4} == x2_nz
+
+
+def test_feature_lri_pairs_with_string_values():
+    raw_X = (iter(d.items()) for d in [{"foo": 2, "bar": "a"},
+                                       {"baz": "abc", "quux": 4, "foo": -1}])
+    h = FeatureLightweightRandomIndexing(n_features=16, input_type="pair")
+    x1, x2 = h.transform(raw_X).toarray()
+    x1_nz = set(np.abs(x1[x1 != 0]))
+    x2_nz = set(np.abs(x2[x2 != 0]))
+    assert {1, 2} == x1_nz
+    assert {1, 4} == x2_nz
+
+    raw_X = (iter(d.items()) for d in [{"bax": "abc"},
+                                       {"bax": "abc"}])
+    x1, x2 = h.transform(raw_X).toarray()
+    x1_nz = np.abs(x1[x1 != 0])
+    assert_array_equal([1,1], x1_nz)
+    assert_array_equal(x1, x2)
+
+
+def test_lri_empty_input():
+    n_features = 16
+    raw_X = [[], (), iter(range(0))]
+
+    h = FeatureLightweightRandomIndexing(n_features=n_features, input_type="string")
+    X = h.transform(raw_X)
+
+    assert_array_equal(X.A, np.zeros((len(raw_X), n_features)))
+
+
+def test_lri_invalid_input():
+    with pytest.raises(ValueError):
+        FeatureLightweightRandomIndexing(input_type="gobbledygook")
+    with pytest.raises(ValueError):
+        FeatureLightweightRandomIndexing(n_features=-1)
+    with pytest.raises(ValueError):
+        FeatureLightweightRandomIndexing(n_features=0)
+    with pytest.raises(TypeError):
+        FeatureLightweightRandomIndexing(n_features='ham')
+
+    h = FeatureLightweightRandomIndexing(n_features=np.uint16(2 ** 6))
+    with pytest.raises(ValueError):
+        h.transform([])
+    with pytest.raises(Exception):
+        h.transform([[5.5]])
+    with pytest.raises(Exception):
+        h.transform([[None]])
+
+
+def test_lri_set_params():
+    # Test delayed input validation in fit (useful for grid search).
+    hasher = FeatureLightweightRandomIndexing()
+    hasher.set_params(n_features=np.inf)
+    with pytest.raises(TypeError):
+        hasher.fit()
+
+
+def test_lri_zeros():
+    # Assert that no zeros are materialized in the output.
+    X = FeatureLightweightRandomIndexing().transform([{'foo': 0}])
+    assert X.data.shape == (0,)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -25,6 +25,7 @@ import warnings
 import numpy as np
 import scipy.sparse as sp
 
+from sklearn.feature_extraction._lri import FeatureLightweightRandomIndexing
 from ..base import BaseEstimator, TransformerMixin
 from ..preprocessing import normalize
 from ._hash import FeatureHasher
@@ -36,6 +37,7 @@ from ..exceptions import NotFittedError
 
 
 __all__ = ['HashingVectorizer',
+           'LightweightRandomIndexingVectorizer',
            'CountVectorizer',
            'ENGLISH_STOP_WORDS',
            'TfidfTransformer',
@@ -792,6 +794,38 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
 
     def _more_tags(self):
         return {'X_types': ['string']}
+
+
+class LightweightRandomIndexingVectorizer(HashingVectorizer):
+    """Applies lightweight random indexing [1] to a collection of texts.
+
+    It exploits the implementation of HashingVectorizer, changing hashing
+    object returned by _get_hasher(self).
+
+    Examples
+    --------
+    >>> from sklearn.feature_extraction.text import \
+            LightweightRandomIndexingVectorizer
+    >>> corpus = [
+    ...     'This is the first document.',
+    ...     'This document is the second document.',
+    ...     'And this is the third one.',
+    ...     'Is this the first document?',
+    ... ]
+    >>> vectorizer = LightweightRandomIndexingVectorizer(n_features=2**4)
+    >>> X = vectorizer.fit_transform(corpus)
+    >>> print(X.shape)
+    (4, 16)
+
+    See Also
+    --------
+    HashingVectorizer, CountVectorizer, TfidfVectorizer
+
+    """
+
+    def _get_hasher(self):
+        return FeatureLightweightRandomIndexing(n_features=self.n_features,
+                             input_type='string', dtype=self.dtype)
 
 
 def _document_frequency(X):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -825,7 +825,8 @@ class LightweightRandomIndexingVectorizer(HashingVectorizer):
 
     def _get_hasher(self):
         return FeatureLightweightRandomIndexing(n_features=self.n_features,
-                             input_type='string', dtype=self.dtype)
+                                                input_type='string',
+                                                dtype=self.dtype)
 
 
 def _document_frequency(X):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -1183,11 +1183,14 @@ def all_estimators(type_filter=None):
             classes = [(name, est_cls) for name, est_cls in classes
                        if not name.startswith("_")]
 
-            # TODO: Remove when FeatureHasher is implemented in PYPY
-            # Skips FeatureHasher for PYPY
+            # TODO: Remove when FeatureHasher and
+            #       FeatureLightweightRandomIndexing are implemented in PYPY
+            # Skips FeatureHasher and FeatureLightweightRandomIndexing
+            # for PYPY
             if IS_PYPY and 'feature_extraction' in modname:
                 classes = [(name, est_cls) for name, est_cls in classes
-                           if name == "FeatureHasher"]
+                           if name == "FeatureHasher" or
+                           name == "FeatureLightweightRandomIndexing"]
 
             all_classes.extend(classes)
 


### PR DESCRIPTION
This PR adds an implementation of lightweight random indexing (LRI) as a vectorization method.
LRI is a stateless indexing method based on hashing. It can be used in out-of-core scaling and in all the cases in which the feature set may not be entirely defined at the start of the indexing process (e.g. when repeatedly fitting with partial_fit).
LRI is based on random indexing theory, and it is more robust than the hashing trick in handling collisions.
The raw difference between hashing trick and LRI is that LRI uses two hashes to index a feature.
As detailed in this [paper](https://www.jair.org/index.php/jair/article/view/11025), the LRI hashing method supports the quasiorthogonality of the resulting vectors even when the indexing space is sensibly smaller than the original feature space.
The contributed code mainly consists of a modification of the `_hashing_fast.pyx` code so as to implement the LRI hashing method (`_lri_fast.pyx`). The two classes `FeatureLightweightRandomIndexing` and `LightweightRandomIndexingVectorizer` make the LRI method available similarly to the `FeatureHasher` and the `HashingVectorizer` classes for the hashing trick.