### PR TITLE
API Deprecates the fit_grid_point function

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1608,5 +1608,5 @@ To be removed in 0.24
    :toctree: generated/
    :template: deprecated_function.rst
 
-	model_selection.fit_grid_point
-	utils.safe_indexing
+   model_selection.fit_grid_point
+   utils.safe_indexing

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1607,10 +1607,5 @@ To be removed in 0.24
    :toctree: generated/
    :template: deprecated_function.rst
 
-   utils.safe_indexing
-
-.. autosummary::
-   :toctree: generated/
-   :template: deprecated_function.rst
-
-   model_selection.fit_grid_point
+	model_selection.fit_grid_point
+	utils.safe_indexing

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1179,12 +1179,6 @@ Hyper-parameter optimizers
    model_selection.RandomizedSearchCV
 
 
-.. autosummary::
-   :toctree: generated/
-   :template: function.rst
-
-   model_selection.fit_grid_point
-
 Model validation
 ----------------
 
@@ -1614,3 +1608,9 @@ To be removed in 0.24
    :template: deprecated_function.rst
 
    utils.safe_indexing
+
+.. autosummary::
+   :toctree: generated/
+   :template: deprecated_function.rst
+
+   model_selection.fit_grid_point

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -215,8 +215,9 @@ Changelog
   when `y=None`.
   :pr:`15918` by :user:`Luca Kubin <lkubin>`.
 
-- |Fix| deprecate :func: `fit_grid_point`on 0.23, to be removed on 0.25.
-  :pr: `16401` by :user: `Arie Pratama Sutiono <ariepratama>`
+- |Fix| :func:`model_selection.fit_grid_point` is deprecated in 0.23 and will
+  be removed in 0.25. :pr: `16401` by
+  :user:`Arie Pratama Sutiono <ariepratama>`
 
 :mod:`sklearn.naive_bayes`
 .............................

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -190,6 +190,9 @@ Changelog
   when `y=None`.
   :pr:`15918` by :user:`Luca Kubin <lkubin>`.
 
+- |Fix| deprecate :func: `fit_grid_point`on 0.23, to be removed on 0.25.
+  :pr: `16401` by :user: `Arie Pratama Sutiono <ariepratama>`
+
 :mod:`sklearn.naive_bayes`
 .............................
 

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -216,7 +216,7 @@ Changelog
   :pr:`15918` by :user:`Luca Kubin <lkubin>`.
 
 - |Fix| :func:`model_selection.fit_grid_point` is deprecated in 0.23 and will
-  be removed in 0.25. :pr: `16401` by
+  be removed in 0.25. :pr:`16401` by
   :user:`Arie Pratama Sutiono <ariepratama>`
 
 :mod:`sklearn.naive_bayes`

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -300,6 +300,7 @@ class ParameterSampler:
         """Number of points that will be sampled."""
         return self.n_iter
 
+
 @deprecated(
     "Function fit_grid_point has never been used anywhere in code"
     "in version 0.22"

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -301,10 +301,10 @@ class ParameterSampler:
         return self.n_iter
 
 
+# FIXME Remove fit_grid_point in 0.24
 @deprecated(
-    "Function fit_grid_point has never been used anywhere in code"
-    "in version 0.22"
-    "and will be removed in release 0.24"
+    "fit_grid_point is deprecated in version 0.22 "
+    "and will be removed in version 0.24"
 )
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
                    verbose, error_score=np.nan, **fit_params):

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -301,10 +301,10 @@ class ParameterSampler:
         return self.n_iter
 
 
-# FIXME Remove fit_grid_point in 0.24
+# FIXME Remove fit_grid_point in 0.25
 @deprecated(
-    "fit_grid_point is deprecated in version 0.22 "
-    "and will be removed in version 0.24"
+    "fit_grid_point is deprecated in version 0.23 "
+    "and will be removed in version 0.25"
 )
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
                    verbose, error_score=np.nan, **fit_params):

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -37,7 +37,7 @@ from ..utils.validation import indexable, check_is_fitted, _check_fit_params
 from ..utils.metaestimators import if_delegate_has_method
 from ..metrics._scorer import _check_multimetric_scoring
 from ..metrics import check_scoring
-
+from ..utils import deprecated
 
 __all__ = ['GridSearchCV', 'ParameterGrid', 'fit_grid_point',
            'ParameterSampler', 'RandomizedSearchCV']
@@ -300,7 +300,11 @@ class ParameterSampler:
         """Number of points that will be sampled."""
         return self.n_iter
 
-
+@deprecated(
+    "Function fit_grid_point has never been used anywhere in code"
+    "in version 0.22"
+    "and will be removed in release 0.24"
+)
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
                    verbose, error_score=np.nan, **fit_params):
     """Run fit on one set of parameters.

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1340,19 +1340,15 @@ def test_fit_grid_point():
 # fit_grid_point will be removed on 0.25
 def test_fit_grid_point_deprecated():
     X, y = make_classification(random_state=0)
-    cv = StratifiedKFold()
     svc = LinearSVC(random_state=0)
     scorer = make_scorer(accuracy_score)
-    msg = (
-        "fit_grid_point is deprecated in version 0.23 "
-        "and will be removed in version 0.25")
+    msg = ("fit_grid_point is deprecated in version 0.23 "
+            "and will be removed in version 0.25")
     params = {'C': 0.1}
-    train, test = next(cv.split(X, y))
+    train, test = next(StratifiedKFold().split(X, y))
 
     with pytest.warns(FutureWarning, match=msg):
-        fit_grid_point(
-                X, y, svc, params, train, test,
-                scorer, verbose=False)
+        fit_grid_point(X, y, svc, params, train, test, scorer, verbose=False)
 
 
 def test_pickle():

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1310,8 +1310,7 @@ def test_fit_grid_point():
     X, y = make_classification(random_state=0)
     cv = StratifiedKFold()
     svc = LinearSVC(random_state=0)
-    scorer = make_scorer(accuracy_score)
-    
+    scorer = make_scorer(accuracy_score)    
     msg = (
         "fit_grid_point is deprecated in version 0.22 "
         "and will be removed in version 0.24")

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1343,7 +1343,7 @@ def test_fit_grid_point_deprecated():
     svc = LinearSVC(random_state=0)
     scorer = make_scorer(accuracy_score)
     msg = ("fit_grid_point is deprecated in version 0.23 "
-            "and will be removed in version 0.25")
+           "and will be removed in version 0.25")
     params = {'C': 0.1}
     train, test = next(StratifiedKFold().split(X, y))
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1306,6 +1306,7 @@ def test_grid_search_correct_score_results():
                 assert_almost_equal(correct_score, cv_scores[i])
 
 
+# FIXME remove test_fit_grid_point as the function will be removed on 0.25
 def test_fit_grid_point():
     X, y = make_classification(random_state=0)
     cv = StratifiedKFold()
@@ -1314,22 +1315,23 @@ def test_fit_grid_point():
     msg = (
         "fit_grid_point is deprecated in version 0.23 "
         "and will be removed in version 0.25")
-    with pytest.warns(FutureWarning, match=msg):
-        for params in ({'C': 0.1}, {'C': 0.01}, {'C': 0.001}):
-            for train, test in cv.split(X, y):
+    for params in ({'C': 0.1}, {'C': 0.01}, {'C': 0.001}):
+        for train, test in cv.split(X, y):
+            with pytest.warns(FutureWarning, match=msg):
                 this_scores, this_params, n_test_samples = fit_grid_point(
                     X, y, clone(svc), params, train, test,
                     scorer, verbose=False)
 
-                est = clone(svc).set_params(**params)
-                est.fit(X[train], y[train])
-                expected_score = scorer(est, X[test], y[test])
+            est = clone(svc).set_params(**params)
+            est.fit(X[train], y[train])
+            expected_score = scorer(est, X[test], y[test])
 
-                # Test the return values of fit_grid_point
-                assert_almost_equal(this_scores, expected_score)
-                assert params == this_params
-                assert n_test_samples == test.size
+            # Test the return values of fit_grid_point
+            assert_almost_equal(this_scores, expected_score)
+            assert params == this_params
+            assert n_test_samples == test.size
 
+    with pytest.warns(FutureWarning, match=msg):
         # Should raise an error upon multimetric scorer
         assert_raise_message(ValueError, "For evaluating multiple scores, use "
                              "sklearn.model_selection.cross_validate instead.",

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1311,12 +1311,17 @@ def test_fit_grid_point():
     cv = StratifiedKFold()
     svc = LinearSVC(random_state=0)
     scorer = make_scorer(accuracy_score)
+    
+    msg = (
+        "fit_grid_point is deprecated in version 0.22 "
+        "and will be removed in version 0.24")
 
     for params in ({'C': 0.1}, {'C': 0.01}, {'C': 0.001}):
         for train, test in cv.split(X, y):
-            this_scores, this_params, n_test_samples = fit_grid_point(
-                X, y, clone(svc), params, train, test,
-                scorer, verbose=False)
+            with pytest.warns(FutureWarning, match=msg):
+                this_scores, this_params, n_test_samples = fit_grid_point(
+                    X, y, clone(svc), params, train, test,
+                    scorer, verbose=False)
 
             est = clone(svc).set_params(**params)
             est.fit(X[train], y[train])

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1310,10 +1310,10 @@ def test_fit_grid_point():
     X, y = make_classification(random_state=0)
     cv = StratifiedKFold()
     svc = LinearSVC(random_state=0)
-    scorer = make_scorer(accuracy_score)    
+    scorer = make_scorer(accuracy_score)
     msg = (
-        "fit_grid_point is deprecated in version 0.22 "
-        "and will be removed in version 0.24")
+        "fit_grid_point is deprecated in version 0.23 "
+        "and will be removed in version 0.25")
 
     for params in ({'C': 0.1}, {'C': 0.01}, {'C': 0.001}):
         for train, test in cv.split(X, y):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1314,28 +1314,27 @@ def test_fit_grid_point():
     msg = (
         "fit_grid_point is deprecated in version 0.23 "
         "and will be removed in version 0.25")
-
-    for params in ({'C': 0.1}, {'C': 0.01}, {'C': 0.001}):
-        for train, test in cv.split(X, y):
-            with pytest.warns(FutureWarning, match=msg):
+    with pytest.warns(FutureWarning, match=msg):
+        for params in ({'C': 0.1}, {'C': 0.01}, {'C': 0.001}):
+            for train, test in cv.split(X, y):
                 this_scores, this_params, n_test_samples = fit_grid_point(
                     X, y, clone(svc), params, train, test,
                     scorer, verbose=False)
 
-            est = clone(svc).set_params(**params)
-            est.fit(X[train], y[train])
-            expected_score = scorer(est, X[test], y[test])
+                est = clone(svc).set_params(**params)
+                est.fit(X[train], y[train])
+                expected_score = scorer(est, X[test], y[test])
 
-            # Test the return values of fit_grid_point
-            assert_almost_equal(this_scores, expected_score)
-            assert params == this_params
-            assert n_test_samples == test.size
+                # Test the return values of fit_grid_point
+                assert_almost_equal(this_scores, expected_score)
+                assert params == this_params
+                assert n_test_samples == test.size
 
-    # Should raise an error upon multimetric scorer
-    assert_raise_message(ValueError, "For evaluating multiple scores, use "
-                         "sklearn.model_selection.cross_validate instead.",
-                         fit_grid_point, X, y, svc, params, train, test,
-                         {'score': scorer}, verbose=True)
+        # Should raise an error upon multimetric scorer
+        assert_raise_message(ValueError, "For evaluating multiple scores, use "
+                             "sklearn.model_selection.cross_validate instead.",
+                             fit_grid_point, X, y, svc, params, train, test,
+                             {'score': scorer}, verbose=True)
 
 
 def test_pickle():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #16391
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Add deprecation notice to `fit_grid_point` function because it is not used anywhere except test

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
