### PR TITLE
DOC add Bunch to public docs and API

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -74,9 +74,9 @@ See :ref:`model_persistence`.
 How can I create a bunch object?
 ------------------------------------------------
 
-:class:`~utils.Bunch` objects are used either as an output in certain functions
-and methods, or are used to store certain information in several attributes of
-objects throughout the API.
+:class:`~utils.Bunch` objects are sometimes used as an output in certain
+functions and methods, and also sometimes used to store certain information in
+several attributes of objects throughout the API.
 
 They should not be used as an input; therefore you almost never need to create
 a ``Bunch`` object, unless you are extending the scikit-learn's API.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -74,14 +74,12 @@ See :ref:`model_persistence`.
 How can I create a bunch object?
 ------------------------------------------------
 
-Don't make a bunch object! They are not part of the scikit-learn API. Bunch
-objects are just a way to package some numpy arrays. As a scikit-learn user you
-only ever need numpy arrays to feed your model with data.
+:class:`~utils.Bunch` objects are used either as an output in certain functions
+and methods, or are used to store certain information in several attributes of
+objects throughout the API.
 
-For instance to train a classifier, all you need is a 2D array ``X`` for the
-input variables and a 1D array ``y`` for the target variables. The array ``X``
-holds the features as columns and samples as rows . The array ``y`` contains
-integer values to encode the class membership of each sample in ``X``.
+They should not be used as an input; therefore you almost never need to create
+a ``Bunch`` object, unless you are extending the scikit-learn's API.
 
 How can I load my own datasets into a format usable by scikit-learn?
 --------------------------------------------------------------------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -74,9 +74,9 @@ See :ref:`model_persistence`.
 How can I create a bunch object?
 ------------------------------------------------
 
-:class:`~utils.Bunch` objects are sometimes used as an output in certain
-functions and methods, and also sometimes used to store certain information in
-several attributes of objects throughout the API.
+Bunch objects are sometimes used as an output for functions and methods. They
+extend dictionaries by enabling values to be accessed by key,
+`bunch["value_key"]`, or by an attribute, `bunch.value_key`.
 
 They should not be used as an input; therefore you almost never need to create
 a ``Bunch`` object, unless you are extending the scikit-learn's API.

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1546,6 +1546,7 @@ Plotting
    utils.arrayfuncs.min_pos
    utils.as_float_array
    utils.assert_all_finite
+   utils.Bunch
    utils.check_X_y
    utils.check_array
    utils.check_scalar

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -61,8 +61,8 @@ class Bunch(dict):
     """Container object exposing keys as attributes
 
     ``Bunch`` is a dictionary-like object that exposes its keys as attributes.
-    It is either used as an output or to store certain information in
-    attributes of certain objects. Please note that this object should not be
+    It is sometimes used as an output and sometimes to store certain
+    information in attributes of certain objects. This object should not be
     used as an input parameter.
 
     >>> b = Bunch(a=1, b=2)

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -58,9 +58,12 @@ _IS_32BIT = 8 * struct.calcsize("P") == 32
 
 
 class Bunch(dict):
-    """Container object for datasets
+    """Container object exposing keys as attributes
 
-    Dictionary-like object that exposes its keys as attributes.
+    ``Bunch`` is a dictionary-like object that exposes its keys as attributes.
+    It is either used as an output or to store certain information in
+    attributes of certain objects. Please note that this object should not be
+    used as an input parameter.
 
     >>> b = Bunch(a=1, b=2)
     >>> b['b']

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -60,10 +60,10 @@ _IS_32BIT = 8 * struct.calcsize("P") == 32
 class Bunch(dict):
     """Container object exposing keys as attributes
 
-    ``Bunch`` is a dictionary-like object that exposes its keys as attributes.
-    It is sometimes used as an output and sometimes to store certain
-    information in attributes of certain objects. This object should not be
-    used as an input parameter.
+    Bunch objects are sometimes used as an output for functions and methods.
+    They extend dictionaries by enabling values to be accessed by key,
+    `bunch["value_key"]`, or by an attribute, `bunch.value_key`.
+
 
     >>> b = Bunch(a=1, b=2)
     >>> b['b']


### PR DESCRIPTION
Adding the `Bunch` object to the public API in the docs, and changing the FAQ to mention it shouldn't be used as input.

ping @thomasjpfan , does this look ok?

Fixes #16390