### PR TITLE
18 and 26 Connectivity for grid_to_graph

### DIFF
--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -56,18 +56,13 @@ def _make_edges_3d(n_x, n_y, n_z=1, connectivity=6):
     edges = [edges_deep, edges_right, edges_down]
 
     #Add the other connections
-    if connectivity == 26:
+    if connectivity >= 18:
         edges_right_deep = np.vstack((vertices[:, :-1, :-1].ravel(),
                                 vertices[:, 1:, 1:].ravel()))
         edges_down_right = np.vstack((vertices[:-1, :-1, :].ravel(),
                                 vertices[1:, 1:, :].ravel()))
         edges_down_deep = np.vstack((vertices[:-1, :, :-1].ravel(),
                                 vertices[1:, :, 1:].ravel()))
-
-                        
-        edges_down_right_deep = np.vstack((vertices[:-1, :-1, :-1].ravel(),
-                                vertices[1:, 1:, 1:].ravel()))      
-
         edges_down_left = np.vstack((vertices[:-1, 1:, :].ravel(),
                                 vertices[1:, :-1, :].ravel()))
         edges_down_shallow = np.vstack((vertices[:-1, :, 1:].ravel(),
@@ -75,6 +70,12 @@ def _make_edges_3d(n_x, n_y, n_z=1, connectivity=6):
         edges_deep_left = np.vstack((vertices[:, 1:, :-1].ravel(),
                                 vertices[:, :-1, 1:].ravel()))
 
+        edges.extend([edges_right_deep, edges_down_right, edges_down_deep,
+                    edges_down_left, edges_down_shallow, edges_deep_left])
+
+    if connectivity == 26:
+        edges_down_right_deep = np.vstack((vertices[:-1, :-1, :-1].ravel(),
+                                vertices[1:, 1:, 1:].ravel())) 
         edges_down_left_deep = np.vstack((vertices[:-1, 1:, :-1].ravel(),
                                 vertices[1:, :-1, 1:].ravel()))
         edges_down_right_shallow = np.vstack((vertices[:-1, :-1, 1:].ravel(),
@@ -82,9 +83,7 @@ def _make_edges_3d(n_x, n_y, n_z=1, connectivity=6):
         edges_down_left_shallow = np.vstack((vertices[:-1, 1:, 1:].ravel(),
                                 vertices[1:, :-1, :-1].ravel()))
 
-        edges.extend([edges_right_deep, edges_down_right, edges_down_deep,
-                    edges_down_right_deep, edges_down_left,
-                    edges_down_shallow, edges_deep_left, edges_down_left_deep,
+        edges.extend([edges_down_right_deep, edges_down_left_deep,
                     edges_down_right_shallow, edges_down_left_shallow])
 
     edges = np.hstack(edges)

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -39,10 +39,12 @@ def _make_edges_3d(n_x, n_y, n_z=1, connectivity=6):
         The size of the grid in the y direction.
     n_z : integer, default=1
         The size of the grid in the z direction, defaults to 1
-    connectivity : int, default=6
-        Defines what are considered neighbors in voxel space. Current
-        options are 6 or 26 (common connectivities for 3d images).
+    connectivity : int in [6,18,26], default=6
+        Defines what are considered neighbors in voxel space.
     """
+    if connectivity not in [6, 18, 26]:
+        raise ValueError("Invalid value for connectivity: %r" % connectivity)
+
     vertices = np.arange(n_x * n_y * n_z).reshape((n_x, n_y, n_z))
 
     edges = []
@@ -55,36 +57,36 @@ def _make_edges_3d(n_x, n_y, n_z=1, connectivity=6):
 
     edges = [edges_deep, edges_right, edges_down]
 
-    #Add the other connections
+    # Add the other connections
     if connectivity >= 18:
         edges_right_deep = np.vstack((vertices[:, :-1, :-1].ravel(),
-                                vertices[:, 1:, 1:].ravel()))
+                                      vertices[:, 1:, 1:].ravel()))
         edges_down_right = np.vstack((vertices[:-1, :-1, :].ravel(),
-                                vertices[1:, 1:, :].ravel()))
+                                      vertices[1:, 1:, :].ravel()))
         edges_down_deep = np.vstack((vertices[:-1, :, :-1].ravel(),
-                                vertices[1:, :, 1:].ravel()))
+                                     vertices[1:, :, 1:].ravel()))
         edges_down_left = np.vstack((vertices[:-1, 1:, :].ravel(),
-                                vertices[1:, :-1, :].ravel()))
+                                     vertices[1:, :-1, :].ravel()))
         edges_down_shallow = np.vstack((vertices[:-1, :, 1:].ravel(),
-                                vertices[1:, :, :-1].ravel()))
+                                        vertices[1:, :, :-1].ravel()))
         edges_deep_left = np.vstack((vertices[:, 1:, :-1].ravel(),
-                                vertices[:, :-1, 1:].ravel()))
+                                     vertices[:, :-1, 1:].ravel()))
 
         edges.extend([edges_right_deep, edges_down_right, edges_down_deep,
-                    edges_down_left, edges_down_shallow, edges_deep_left])
+                      edges_down_left, edges_down_shallow, edges_deep_left])
 
     if connectivity == 26:
         edges_down_right_deep = np.vstack((vertices[:-1, :-1, :-1].ravel(),
-                                vertices[1:, 1:, 1:].ravel())) 
+                                           vertices[1:, 1:, 1:].ravel()))
         edges_down_left_deep = np.vstack((vertices[:-1, 1:, :-1].ravel(),
-                                vertices[1:, :-1, 1:].ravel()))
+                                          vertices[1:, :-1, 1:].ravel()))
         edges_down_right_shallow = np.vstack((vertices[:-1, :-1, 1:].ravel(),
-                                vertices[1:, 1:, :-1].ravel())) 
+                                              vertices[1:, 1:, :-1].ravel()))
         edges_down_left_shallow = np.vstack((vertices[:-1, 1:, 1:].ravel(),
-                                vertices[1:, :-1, :-1].ravel()))
+                                             vertices[1:, :-1, :-1].ravel()))
 
         edges.extend([edges_down_right_deep, edges_down_left_deep,
-                    edges_down_right_shallow, edges_down_left_shallow])
+                      edges_down_right_shallow, edges_down_left_shallow])
 
     edges = np.hstack(edges)
     return edges
@@ -227,9 +229,8 @@ def grid_to_graph(n_x, n_y, n_z=1, mask=None, return_as=sparse.coo_matrix,
         The class to use to build the returned adjacency matrix.
     dtype : dtype, default=int
         The data of the returned sparse matrix. By default it is int
-    connectivity : int, default=6
-        Defines what are considered neighbors in voxel space. Current
-        options are 6 or 26 (common connectivities for 3d images).
+    connectivity : int in [6, 18, 26], default=6
+        Defines what are considered neighbors in voxel space.
 
     Notes
     -----

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -46,7 +46,38 @@ def _make_edges_3d(n_x, n_y, n_z=1):
     edges_right = np.vstack((vertices[:, :-1].ravel(),
                              vertices[:, 1:].ravel()))
     edges_down = np.vstack((vertices[:-1].ravel(), vertices[1:].ravel()))
-    edges = np.hstack((edges_deep, edges_right, edges_down))
+
+    
+    edges_right_deep = np.vstack((vertices[:, :-1, :-1].ravel(),
+                            vertices[:, 1:, 1:].ravel()))
+    edges_down_right = np.vstack((vertices[:-1, :-1, :].ravel(),
+                            vertices[1:, 1:, :].ravel()))
+    edges_down_deep = np.vstack((vertices[:-1, :, :-1].ravel(),
+                            vertices[1:, :, 1:].ravel()))
+
+                      
+    edges_down_right_deep = np.vstack((vertices[:-1, :-1, :-1].ravel(),
+                            vertices[1:, 1:, 1:].ravel()))      
+
+    edges_right_shallow = np.vstack((vertices[:, :-1, 1:].ravel(),
+                            vertices[:, 1:, :-1].ravel()))
+    edges_down_left = np.vstack((vertices[:-1, 1:, :].ravel(),
+                            vertices[1:, :-1, :].ravel()))
+    edges_down_shallow = np.vstack((vertices[:-1, :, 1:].ravel(),
+                            vertices[1:, :, :-1].ravel()))
+    edges_deep_left = np.vstack((vertices[:, 1:, :-1].ravel(),
+                            vertices[:, :-1, 1:].ravel()))
+
+    edges_down_left_deep = np.vstack((vertices[:-1, 1:, :-1].ravel(),
+                            vertices[1:, :-1, 1:].ravel()))
+    edges_down_right_shallow = np.vstack((vertices[:-1, :-1, 1:].ravel(),
+                            vertices[1:, 1:, :-1].ravel()))   
+
+    edges = np.hstack((edges_deep, edges_right, edges_down,
+                    edges_right_deep, edges_down_right, edges_down_deep,
+                    edges_down_right_deep, edges_right_shallow, edges_down_left,
+                    edges_down_shallow, edges_deep_left, edges_down_left_deep,
+                    edges_down_right_shallow))
     return edges
 
 

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -59,8 +59,6 @@ def _make_edges_3d(n_x, n_y, n_z=1):
     edges_down_right_deep = np.vstack((vertices[:-1, :-1, :-1].ravel(),
                             vertices[1:, 1:, 1:].ravel()))      
 
-    edges_right_shallow = np.vstack((vertices[:, :-1, 1:].ravel(),
-                            vertices[:, 1:, :-1].ravel()))
     edges_down_left = np.vstack((vertices[:-1, 1:, :].ravel(),
                             vertices[1:, :-1, :].ravel()))
     edges_down_shallow = np.vstack((vertices[:-1, :, 1:].ravel(),
@@ -71,13 +69,15 @@ def _make_edges_3d(n_x, n_y, n_z=1):
     edges_down_left_deep = np.vstack((vertices[:-1, 1:, :-1].ravel(),
                             vertices[1:, :-1, 1:].ravel()))
     edges_down_right_shallow = np.vstack((vertices[:-1, :-1, 1:].ravel(),
-                            vertices[1:, 1:, :-1].ravel()))   
+                            vertices[1:, 1:, :-1].ravel())) 
+    edges_down_left_shallow = np.vstack((vertices[:-1, 1:, 1:].ravel(),
+                            vertices[1:, :-1, :-1].ravel()))  
 
     edges = np.hstack((edges_deep, edges_right, edges_down,
                     edges_right_deep, edges_down_right, edges_down_deep,
-                    edges_down_right_deep, edges_right_shallow, edges_down_left,
+                    edges_down_right_deep, edges_down_left,
                     edges_down_shallow, edges_deep_left, edges_down_left_deep,
-                    edges_down_right_shallow))
+                    edges_down_right_shallow, edges_down_left_shallow))
     return edges
 
 

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -55,6 +55,22 @@ def test_grid_to_graph():
                       dtype=np.float64)
     assert A.dtype == np.float64
 
+def test_grid_to_graph_18():
+    #Check that 2x2x2 block has edges everywhere except across corners
+    size = 2
+    A = grid_to_graph(n_x=2, n_y=2, n_z=2, connectivity=18).todense()
+    B = np.array([[1,1,1,1,1,1,1,0],
+                [1,1,1,1,1,1,0,1],
+                [1,1,1,1,1,0,1,1],
+                [1,1,1,1,0,1,1,1],
+                [1,1,1,0,1,1,1,1],
+                [1,1,0,1,1,1,1,1],
+                [1,0,1,1,1,1,1,1],
+                [0,1,1,1,1,1,1,1]])
+    print(A)
+    print(B)
+    assert np.array_equal(A,B)
+
 def test_grid_to_graph_26():
     #Check that 2x2x2 block has edges everywhere
     size = 2

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -67,8 +67,6 @@ def test_grid_to_graph_18():
                 [1,1,0,1,1,1,1,1],
                 [1,0,1,1,1,1,1,1],
                 [0,1,1,1,1,1,1,1]])
-    print(A)
-    print(B)
     assert np.array_equal(A,B)
 
 def test_grid_to_graph_26():

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -55,6 +55,18 @@ def test_grid_to_graph():
                       dtype=np.float64)
     assert A.dtype == np.float64
 
+def test_grid_to_graph_26():
+    #Check that 2x2x2 block has edges everywhere
+    size = 2
+    A = grid_to_graph(n_x=2, n_y=2, n_z=2, connectivity=26).todense()
+    B = np.ones([size**3,size**3])
+    assert np.array_equal(A,B)
+
+    #Check (some of) the connectivity of the top corner of a 3x3x3 block
+    A = grid_to_graph(n_x=3, n_y=3, n_z=3, connectivity=26).todense()[0,14:]
+    B = np.zeros([1,14])
+    assert np.array_equal(A,B)
+
 
 @ignore_warnings(category=DeprecationWarning)  # scipy deprecation inside face
 def test_connect_regions():

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -60,11 +60,15 @@ def test_grid_to_graph_26():
     size = 2
     A = grid_to_graph(n_x=2, n_y=2, n_z=2, connectivity=26).todense()
     B = np.ones([size**3,size**3])
+    print(A)
+    print(B)
     assert np.array_equal(A,B)
 
     #Check (some of) the connectivity of the top corner of a 3x3x3 block
     A = grid_to_graph(n_x=3, n_y=3, n_z=3, connectivity=26).todense()[0,14:]
-    B = np.zeros([1,14])
+    B = np.zeros([1,13])
+    print(A)
+    print(B)
     assert np.array_equal(A,B)
 
 

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -55,35 +55,36 @@ def test_grid_to_graph():
                       dtype=np.float64)
     assert A.dtype == np.float64
 
+    with pytest.raises(ValueError):
+        A = grid_to_graph(n_x=size, n_y=size, n_z=size, connectivity=7)
+
+
 def test_grid_to_graph_18():
-    #Check that 2x2x2 block has edges everywhere except across corners
+    # Check that 2x2x2 block has edges everywhere except across corners
     size = 2
-    A = grid_to_graph(n_x=2, n_y=2, n_z=2, connectivity=18).todense()
-    B = np.array([[1,1,1,1,1,1,1,0],
-                [1,1,1,1,1,1,0,1],
-                [1,1,1,1,1,0,1,1],
-                [1,1,1,1,0,1,1,1],
-                [1,1,1,0,1,1,1,1],
-                [1,1,0,1,1,1,1,1],
-                [1,0,1,1,1,1,1,1],
-                [0,1,1,1,1,1,1,1]])
-    assert np.array_equal(A,B)
+    A = grid_to_graph(n_x=size, n_y=size, n_z=size, connectivity=18).todense()
+    B = np.array([[1, 1, 1, 1, 1, 1, 1, 0],
+                  [1, 1, 1, 1, 1, 1, 0, 1],
+                  [1, 1, 1, 1, 1, 0, 1, 1],
+                  [1, 1, 1, 1, 0, 1, 1, 1],
+                  [1, 1, 1, 0, 1, 1, 1, 1],
+                  [1, 1, 0, 1, 1, 1, 1, 1],
+                  [1, 0, 1, 1, 1, 1, 1, 1],
+                  [0, 1, 1, 1, 1, 1, 1, 1]])
+    assert np.array_equal(A, B)
+
 
 def test_grid_to_graph_26():
-    #Check that 2x2x2 block has edges everywhere
+    # Check that 2x2x2 block has edges everywhere
     size = 2
     A = grid_to_graph(n_x=2, n_y=2, n_z=2, connectivity=26).todense()
-    B = np.ones([size**3,size**3])
-    print(A)
-    print(B)
-    assert np.array_equal(A,B)
+    B = np.ones([size**3, size**3])
+    assert np.array_equal(A, B)
 
-    #Check (some of) the connectivity of the top corner of a 3x3x3 block
-    A = grid_to_graph(n_x=3, n_y=3, n_z=3, connectivity=26).todense()[0,14:]
-    B = np.zeros([1,13])
-    print(A)
-    print(B)
-    assert np.array_equal(A,B)
+    # Check (some of) the connectivity of the top corner of a 3x3x3 block
+    A = grid_to_graph(n_x=3, n_y=3, n_z=3, connectivity=26).todense()[0, 14:]
+    B = np.zeros([1, 13])
+    assert np.array_equal(A, B)
 
 
 @ignore_warnings(category=DeprecationWarning)  # scipy deprecation inside face
@@ -157,6 +158,7 @@ def _make_images(face=None):
     images[1] = face + 1
     images[2] = face + 2
     return images
+
 
 downsampled_face = _downsampled_face()
 orange_face = _orange_face(downsampled_face)


### PR DESCRIPTION

#### Reference Issues/PRs



#### What does this implement/fix? Explain your changes.

The current grid_to_graph function only defines voxel neighbors with the 6-connectivity definition. I would like to add 18 and 26 connectivity. (https://en.wikipedia.org/wiki/Pixel_connectivity#26-connected)

#### Any other comments?

I would like feedback on my test coverage. Thanks!
