### PR TITLE
[ENH] Added warning for RidgeCV

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1619,12 +1619,13 @@ class _BaseRidgeCV(LinearModel):
         min_alpha = min(self.alphas)
         max_alpha = max(self.alphas)
         if self.alpha_ in [min_alpha, max_alpha]:
-            warnings.warn(f"The optimal value for the regularization "
-                          "parameter 'alpha' was {self.alpha_}\n which "
-                          "lies at a boundary of the explored range "
-                          "(between {min_alpha} and {max_alpha}).\n Consider "
-                          "setting the 'alphas' parameter to explore a "
-                          "wider range. ")
+            warnings.warn('The optimal value for the regularization '
+                          'parameter ''alpha'' was %g which '
+                          'lies at a boundary of the explored range '
+                          '(between %g and %g). Consider setting '
+                          'the ''alphas'' parameter to explore a '
+                          'wider range.'
+                          % (self.alpha_, min_alpha, max_alpha))
 
         self.coef_ = estimator.coef_
         self.intercept_ = estimator.intercept_

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1617,6 +1617,8 @@ class _BaseRidgeCV(LinearModel):
             self.alpha_ = gs.best_estimator_.alpha
             self.best_score_ = gs.best_score_
 
+        min_alpha = min(self.alphas)
+        max_alpha = max(self.alphas)
         if self.alpha_ in [min_alpha, max_alpha]:
             warnings.warn("The optimal value for the regularization parameter "
                           "'alpha' was {}\n which lies at a boundary of the "

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1624,9 +1624,7 @@ class _BaseRidgeCV(LinearModel):
                           "lies at a boundary of the explored range "
                           "(between {min_alpha} and {max_alpha}).\n Consider "
                           "setting the 'alphas' parameter to explore a "
-                          "wider range.\n To ignore warnings try running "
-                          "\nimport warnings "
-                          "\nwarnings.filterwarnings('ignore')")
+                          "wider range. ")
 
         self.coef_ = estimator.coef_
         self.intercept_ = estimator.intercept_

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1548,8 +1548,8 @@ class _RidgeGCV(LinearModel):
 class _BaseRidgeCV(LinearModel):
     def __init__(self, alphas=(0.1, 1.0, 10.0),
                  fit_intercept=True, normalize=False, scoring=None,
-                 cv=None, gcv_mode=None, store_cv_values=False, 
-                 boundary_warning = False):
+                 cv=None, gcv_mode=None, store_cv_values=False,
+                 boundary_warning=False):
         self.alphas = np.asarray(alphas)
         self.fit_intercept = fit_intercept
         self.normalize = normalize
@@ -1615,14 +1615,14 @@ class _BaseRidgeCV(LinearModel):
             gs.fit(X, y, sample_weight=sample_weight)
             estimator = gs.best_estimator_
             self.alpha_ = gs.best_estimator_.alpha
-            if (self.alpha_ in [min(self.alphas), max(self.alphas)])*\
+            if (self.alpha_ in [min(self.alphas), max(self.alphas)]) * \
                                                  self.boundary_warning :
-                warnings.warn("The optimal value for " 
+                warnings.warn("The optimal value for "
                 "the regularization parameter 'alpha' was {} "
                 "which lies at a boundary of the explored range "
-                "(between {} and {}). Consider setting the 'alphas' " 
+                "(between {} and {}). Consider setting the 'alphas' "
                 " parameter to explore a wider range. "
-                .format(self.alpha_,min(self.alphas),max(self.alphas)))
+                .format(self.alpha_, min(self.alphas), max(self.alphas)))
 
             self.best_score_ = gs.best_score_
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1618,11 +1618,11 @@ class _BaseRidgeCV(LinearModel):
             if (self.alpha_ in [min(self.alphas), max(self.alphas)]) * \
                                                  self.boundary_warning:
                 warnings.warn("The optimal value for "
-                "the regularization parameter 'alpha' was {} "
-                "which lies at a boundary of the explored range "
-                "(between {} and {}). Consider setting the 'alphas' "
-                "parameter to explore a wider range. "
-                .format(self.alpha_, min(self.alphas), max(self.alphas)))
+                    "the regularization parameter 'alpha' was {} "
+                    "which lies at a boundary of the explored range "
+                    "(between {} and {}). Consider setting the 'alphas' "
+                    "parameter to explore a wider range. "
+                    .format(self.alpha_, min(self.alphas), max(self.alphas)))
 
             self.best_score_ = gs.best_score_
 
@@ -1746,7 +1746,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     RidgeClassifier : Ridge classifier
     RidgeClassifierCV : Ridge classifier with built-in cross validation
     """
-    
+
     
 class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     """Ridge classifier with built-in cross-validation.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1615,14 +1615,16 @@ class _BaseRidgeCV(LinearModel):
             gs.fit(X, y, sample_weight=sample_weight)
             estimator = gs.best_estimator_
             self.alpha_ = gs.best_estimator_.alpha
-            if (self.alpha_ in [min(self.alphas), max(self.alphas)]) * \
-                                                 self.boundary_warning:
-                warnings.warn("The optimal value for "
+            min_alpha = min(self.alphas)
+            max_alpha = max(self.alphas)
+            if (self.alpha_ in [min_alpha, max_alpha]) * self.boundary_warning:
+                warnings.warn(
+                    "The optimal value for "
                     "the regularization parameter 'alpha' was {} "
                     "which lies at a boundary of the explored range "
                     "(between {} and {}). Consider setting the 'alphas' "
                     "parameter to explore a wider range. "
-                    .format(self.alpha_, min(self.alphas), max(self.alphas)))
+                    .format(self.alpha_, min_alpha, max_alpha))
 
             self.best_score_ = gs.best_score_
 
@@ -1747,7 +1749,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     RidgeClassifierCV : Ridge classifier with built-in cross validation
     """
 
-    
+
 class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     """Ridge classifier with built-in cross-validation.
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1615,18 +1615,17 @@ class _BaseRidgeCV(LinearModel):
             gs.fit(X, y, sample_weight=sample_weight)
             estimator = gs.best_estimator_
             self.alpha_ = gs.best_estimator_.alpha
-            min_alpha = min(self.alphas)
-            max_alpha = max(self.alphas)
-            if (self.alpha_ in [min_alpha, max_alpha]) * self.boundary_warning:
-                warnings.warn(
-                    "The optimal value for "
-                    "the regularization parameter 'alpha' was {} "
-                    "which lies at a boundary of the explored range "
-                    "(between {} and {}). Consider setting the 'alphas' "
-                    "parameter to explore a wider range. "
-                    .format(self.alpha_, min_alpha, max_alpha))
-
             self.best_score_ = gs.best_score_
+
+        if self.alpha_ in [min_alpha, max_alpha]:
+            warnings.warn("The optimal value for the regularization parameter "
+                          "'alpha' was {}\n which lies at a boundary of the "
+                          "explored range (between {} and {}).\n Consider "
+                          "setting the 'alphas' parameter to explore a "
+                          "wider range.\n To ignore warnings try running "
+                          "\nimport warnings "
+                          "\nwarnings.filterwarnings('ignore')"
+                          .format(self.alpha_, min_alpha, max_alpha))
 
         self.coef_ = estimator.coef_
         self.intercept_ = estimator.intercept_

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1548,8 +1548,8 @@ class _RidgeGCV(LinearModel):
 class _BaseRidgeCV(LinearModel):
     def __init__(self, alphas=(0.1, 1.0, 10.0),
                  fit_intercept=True, normalize=False, scoring=None,
-                 cv=None, gcv_mode=None, store_cv_values=False,
-                 boundary_warning=False):
+                 cv=None, gcv_mode=None,
+                 store_cv_values=False):
         self.alphas = np.asarray(alphas)
         self.fit_intercept = fit_intercept
         self.normalize = normalize
@@ -1557,7 +1557,6 @@ class _BaseRidgeCV(LinearModel):
         self.cv = cv
         self.gcv_mode = gcv_mode
         self.store_cv_values = store_cv_values
-        self.boundary_warning = boundary_warning
 
     def fit(self, X, y, sample_weight=None):
         """Fit Ridge regression model with cv.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1616,12 +1616,12 @@ class _BaseRidgeCV(LinearModel):
             estimator = gs.best_estimator_
             self.alpha_ = gs.best_estimator_.alpha
             if (self.alpha_ in [min(self.alphas), max(self.alphas)]) * \
-                                                 self.boundary_warning :
+                                                 self.boundary_warning:
                 warnings.warn("The optimal value for "
                 "the regularization parameter 'alpha' was {} "
                 "which lies at a boundary of the explored range "
                 "(between {} and {}). Consider setting the 'alphas' "
-                " parameter to explore a wider range. "
+                "parameter to explore a wider range. "
                 .format(self.alpha_, min(self.alphas), max(self.alphas)))
 
             self.best_score_ = gs.best_score_

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1548,8 +1548,8 @@ class _RidgeGCV(LinearModel):
 class _BaseRidgeCV(LinearModel):
     def __init__(self, alphas=(0.1, 1.0, 10.0),
                  fit_intercept=True, normalize=False, scoring=None,
-                 cv=None, gcv_mode=None,
-                 store_cv_values=False):
+                 cv=None, gcv_mode=None, store_cv_values=False, 
+                 boundary_warning = False):
         self.alphas = np.asarray(alphas)
         self.fit_intercept = fit_intercept
         self.normalize = normalize
@@ -1557,6 +1557,7 @@ class _BaseRidgeCV(LinearModel):
         self.cv = cv
         self.gcv_mode = gcv_mode
         self.store_cv_values = store_cv_values
+        self.boundary_warning = boundary_warning
 
     def fit(self, X, y, sample_weight=None):
         """Fit Ridge regression model with cv.
@@ -1614,6 +1615,15 @@ class _BaseRidgeCV(LinearModel):
             gs.fit(X, y, sample_weight=sample_weight)
             estimator = gs.best_estimator_
             self.alpha_ = gs.best_estimator_.alpha
+            if (self.alpha_ in [min(self.alphas), max(self.alphas)])*\
+                                                 self.boundary_warning :
+                warnings.warn("The optimal value for " 
+                "the regularization parameter 'alpha' was {} "
+                "which lies at a boundary of the explored range "
+                "(between {} and {}). Consider setting the 'alphas' " 
+                " parameter to explore a wider range. "
+                .format(self.alpha_,min(self.alphas),max(self.alphas)))
+
             self.best_score_ = gs.best_score_
 
         self.coef_ = estimator.coef_
@@ -1736,8 +1746,8 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     RidgeClassifier : Ridge classifier
     RidgeClassifierCV : Ridge classifier with built-in cross validation
     """
-
-
+    
+    
 class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     """Ridge classifier with built-in cross-validation.
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1619,14 +1619,14 @@ class _BaseRidgeCV(LinearModel):
         min_alpha = min(self.alphas)
         max_alpha = max(self.alphas)
         if self.alpha_ in [min_alpha, max_alpha]:
-            warnings.warn("The optimal value for the regularization parameter "
-                          "'alpha' was {}\n which lies at a boundary of the "
-                          "explored range (between {} and {}).\n Consider "
+            warnings.warn(f"The optimal value for the regularization "
+                          "parameter 'alpha' was {self.alpha_}\n which "
+                          "lies at a boundary of the explored range "
+                          "(between {min_alpha} and {max_alpha}).\n Consider "
                           "setting the 'alphas' parameter to explore a "
                           "wider range.\n To ignore warnings try running "
                           "\nimport warnings "
-                          "\nwarnings.filterwarnings('ignore')"
-                          .format(self.alpha_, min_alpha, max_alpha))
+                          "\nwarnings.filterwarnings('ignore')")
 
         self.coef_ = estimator.coef_
         self.intercept_ = estimator.intercept_

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1324,3 +1324,9 @@ def test_ridge_sag_with_X_fortran():
     X = X[::2, :]
     y = y[::2]
     Ridge(solver='sag').fit(X, y)
+
+    
+def test_ridge_alpha_boundary_warning():
+    ridge = RidgeCV(alphas=[0.1, 1])
+    X, y = X_diabetes, y_diabetes
+    assert_warns(UserWarning, ridge.fit, X, y)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1325,7 +1325,7 @@ def test_ridge_sag_with_X_fortran():
     y = y[::2]
     Ridge(solver='sag').fit(X, y)
 
-    
+
 def test_ridge_alpha_boundary_warning():
     ridge = RidgeCV(alphas=[0.1, 1])
     X, y = X_diabetes, y_diabetes

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1329,4 +1329,12 @@ def test_ridge_sag_with_X_fortran():
 def test_ridge_alpha_boundary_warning():
     ridge = RidgeCV(alphas=[0.1, 1])
     X, y = X_diabetes, y_diabetes
-    assert_warns(UserWarning, ridge.fit, X, y)
+    msg = ('The optimal value for the regularization '
+           'parameter ''alpha'' was %g which '
+           'lies at a boundary of the explored range '
+           '(between %g and %g). Consider setting '
+           'the ''alphas'' parameter to explore a '
+           'wider range.'
+           % (0.1, 0.1, 1))
+    with pytest.warns(UserWarning, match=msg):
+        ridge.fit(X, y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #16398
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Added warning in RidgeCV when the optimal value found for the alpha is at the boundary of the given values.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
