### PR TITLE
[MRG] DOC Cleaning parameter spec in docstrings for module gaussian_process

### DIFF
--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -338,7 +338,8 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         log_likelihood : float
             Log-marginal likelihood of theta for training data.
 
-        log_likelihood_gradient : ndarray of shape = (n_kernel_params,), optional
+        log_likelihood_gradient : ndarray of shape = (n_kernel_params,), \
+            optional
             Gradient of the log-marginal likelihood with respect to the kernel
             hyperparameters at position theta.
             Only returned when eval_gradient is True.
@@ -760,7 +761,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         log_likelihood : float
             Log-marginal likelihood of theta for training data.
 
-        log_likelihood_gradient : ndarray of shape = (n_kernel_params,), optional
+        log_likelihood_gradient : ndarray of shape (n_kernel_params,), optional
             Gradient of the log-marginal likelihood with respect to the kernel
             hyperparameters at position theta.
             Only returned when eval_gradient is True.

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -49,7 +49,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
     Parameters
     ----------
-    kernel : Kernel, default=None
+    kernel : kernel instance, default=None
         The kernel specifying the covariance function of the GP. If None is
         passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
         the kernel's hyperparameters are optimized during fitting.
@@ -124,7 +124,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
     classes_ : array-like of shape (n_classes,)
         Unique class labels.
 
-    kernel_ : Kernel
+    kernel_ : kernl instance
         The kernel used for prediction. The structure of the kernel is the
         same as the one passed as parameter but with optimized hyperparameters
 
@@ -332,10 +332,10 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
             Log-marginal likelihood of theta for training data.
 
         log_likelihood_gradient : ndarray of shape (n_kernel_params,), \
-            optional
+                optional
             Gradient of the log-marginal likelihood with respect to the kernel
             hyperparameters at position theta.
-            Only returned when eval_gradient is True.
+            Only returned when `eval_gradient` is True.
         """
         if theta is None:
             if eval_gradient:
@@ -469,7 +469,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     Parameters
     ----------
-    kernel : Kernel, default=None
+    kernel : kernel instance, default=None
         The kernel specifying the covariance function of the GP. If None is
         passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
         the kernel's hyperparameters are optimized during fitting.
@@ -551,7 +551,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     Attributes
     ----------
-    kernel_ : Kernel
+    kernel_ : kernel instance
         The kernel used for prediction. In case of binary classification,
         the structure of the kernel is the same as the one passed as parameter
         but with optimized hyperparameters. In case of multi-class
@@ -751,7 +751,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         log_likelihood_gradient : ndarray of shape (n_kernel_params,), optional
             Gradient of the log-marginal likelihood with respect to the kernel
             hyperparameters at position theta.
-            Only returned when eval_gradient is True.
+            Only returned when `eval_gradient` is True.
         """
         check_is_fitted(self)
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -116,8 +116,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
     ----------
     X_train_ : array-like of shape (n_samples, n_features) or list of object
         Feature vectors or other representations of training data (also
-        required for prediction). Could either be array-like with shape =
-        (n_samples, n_features) or a list of objects.
+        required for prediction).
 
     y_train_ : array-like of shape (n_samples,)
         Target values in training data (also required for prediction)
@@ -163,8 +162,6 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         ----------
         X : array-like of shape (n_samples, n_features) or list of object
             Feature vectors or other representations of training data.
-            Could either be array-like with shape = (n_samples, n_features)
-            or a list of objects.
 
         y : array-like of shape (n_samples,)
             Target values, must be binary
@@ -253,8 +250,6 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         ----------
         X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
-            Could either be array-like with shape = (n_samples, n_features)
-            or a list of objects.
 
         Returns
         -------
@@ -278,8 +273,6 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         ----------
         X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
-            Could either be array-like with shape = (n_samples, n_features)
-            or a list of objects.
 
         Returns
         -------
@@ -338,7 +331,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         log_likelihood : float
             Log-marginal likelihood of theta for training data.
 
-        log_likelihood_gradient : ndarray of shape = (n_kernel_params,), \
+        log_likelihood_gradient : ndarray of shape (n_kernel_params,), \
             optional
             Gradient of the log-marginal likelihood with respect to the kernel
             hyperparameters at position theta.
@@ -612,8 +605,6 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         ----------
         X : array-like of shape (n_samples, n_features) or list of object
             Feature vectors or other representations of training data.
-            Could either be array-like with shape = (n_samples, n_features)
-            or a list of objects.
 
         y : array-like of shape (n_samples,)
             Target values, must be binary
@@ -673,8 +664,6 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         ----------
         X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
-            Could either be array-like with shape = (n_samples, n_features)
-            or a list of objects.
 
         Returns
         -------
@@ -697,8 +686,6 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         ----------
         X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
-            Could either be array-like with shape = (n_samples, n_features)
-            or a list of objects.
 
         Returns
         -------

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -49,12 +49,12 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
     Parameters
     ----------
-    kernel : kernel object
+    kernel : Kernel, default=None
         The kernel specifying the covariance function of the GP. If None is
         passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
         the kernel's hyperparameters are optimized during fitting.
 
-    optimizer : string or callable, optional (default: "fmin_l_bfgs_b")
+    optimizer : 'fmin_l_bfgs_b' or callable, default='fmin_l_bfgs_b'
         Can either be one of the internally supported optimizers for optimizing
         the kernel's parameters, specified by a string, or an externally
         defined optimizer passed as a callable. If a callable is passed, it
@@ -79,7 +79,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
             'fmin_l_bfgs_b'
 
-    n_restarts_optimizer: int, optional (default: 0)
+    n_restarts_optimizer : int, default=0
         The number of restarts of the optimizer for finding the kernel's
         parameters which maximize the log-marginal likelihood. The first run
         of the optimizer is performed from the kernel's initial parameters,
@@ -88,12 +88,12 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         must be finite. Note that n_restarts_optimizer=0 implies that one
         run is performed.
 
-    max_iter_predict: int, optional (default: 100)
+    max_iter_predict : int, default=100
         The maximum number of iterations in Newton's method for approximating
         the posterior during predict. Smaller values will reduce computation
         time at the cost of worse results.
 
-    warm_start : bool, optional (default: False)
+    warm_start : bool, default=False
         If warm-starts are enabled, the solution of the last Newton iteration
         on the Laplace approximation of the posterior mode is used as
         initialization for the next call of _posterior_mode(). This can speed
@@ -101,20 +101,20 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         problems as in hyperparameter optimization. See :term:`the Glossary
         <warm_start>`.
 
-    copy_X_train : bool, optional (default: True)
+    copy_X_train : bool, default=True
         If True, a persistent copy of the training data is stored in the
         object. Otherwise, just a reference to the training data is stored,
         which might cause predictions to change if the data is modified
         externally.
 
-    random_state : int, RandomState instance, default=None
+    random_state : int or RandomState, default=None
         Determines random number generation used to initialize the centers.
         Pass an int for reproducible results across multiple function calls.
         See :term: `Glossary <random_state>`.
 
     Attributes
     ----------
-    X_train_ : sequence of length n_samples
+    X_train_ : array-like of shape (n_samples, n_features) or list of object
         Feature vectors or other representations of training data (also
         required for prediction). Could either be array-like with shape =
         (n_samples, n_features) or a list of objects.
@@ -125,7 +125,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
     classes_ : array-like of shape (n_classes,)
         Unique class labels.
 
-    kernel_ : kernel object
+    kernel_ : Kernel
         The kernel used for prediction. The structure of the kernel is the
         same as the one passed as parameter but with optimized hyperparameters
 
@@ -161,7 +161,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples, n_features) or list of object
             Feature vectors or other representations of training data.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.
@@ -251,7 +251,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.
@@ -276,7 +276,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.
@@ -319,12 +319,12 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
         Parameters
         ----------
-        theta : array-like of shape (n_kernel_params,) or None
+        theta : array-like of shape (n_kernel_params,), default=None
             Kernel hyperparameters for which the log-marginal likelihood is
             evaluated. If None, the precomputed log_marginal_likelihood
             of ``self.kernel_.theta`` is returned.
 
-        eval_gradient : bool, default: False
+        eval_gradient : bool, default=False
             If True, the gradient of the log-marginal likelihood with respect
             to the kernel hyperparameters at position theta is returned
             additionally. If True, theta must not be None.
@@ -338,7 +338,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         log_likelihood : float
             Log-marginal likelihood of theta for training data.
 
-        log_likelihood_gradient : array, shape = (n_kernel_params,), optional
+        log_likelihood_gradient : ndarray of shape = (n_kernel_params,), optional
             Gradient of the log-marginal likelihood with respect to the kernel
             hyperparameters at position theta.
             Only returned when eval_gradient is True.
@@ -475,12 +475,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     Parameters
     ----------
-    kernel : kernel object
+    kernel : Kernel, default=None
         The kernel specifying the covariance function of the GP. If None is
         passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
         the kernel's hyperparameters are optimized during fitting.
 
-    optimizer : string or callable, optional (default: "fmin_l_bfgs_b")
+    optimizer : 'fmin_l_bfgs_b' or callable, default='fmin_l_bfgs_b'
         Can either be one of the internally supported optimizers for optimizing
         the kernel's parameters, specified by a string, or an externally
         defined optimizer passed as a callable. If a callable is passed, it
@@ -505,7 +505,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
             'fmin_l_bfgs_b'
 
-    n_restarts_optimizer : int, optional (default: 0)
+    n_restarts_optimizer : int, default=0
         The number of restarts of the optimizer for finding the kernel's
         parameters which maximize the log-marginal likelihood. The first run
         of the optimizer is performed from the kernel's initial parameters,
@@ -514,12 +514,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         must be finite. Note that n_restarts_optimizer=0 implies that one
         run is performed.
 
-    max_iter_predict : int, optional (default: 100)
+    max_iter_predict : int, default=100
         The maximum number of iterations in Newton's method for approximating
         the posterior during predict. Smaller values will reduce computation
         time at the cost of worse results.
 
-    warm_start : bool, optional (default: False)
+    warm_start : bool, default=False
         If warm-starts are enabled, the solution of the last Newton iteration
         on the Laplace approximation of the posterior mode is used as
         initialization for the next call of _posterior_mode(). This can speed
@@ -527,29 +527,29 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         problems as in hyperparameter optimization. See :term:`the Glossary
         <warm_start>`.
 
-    copy_X_train : bool, optional (default: True)
+    copy_X_train : bool, default=True
         If True, a persistent copy of the training data is stored in the
         object. Otherwise, just a reference to the training data is stored,
         which might cause predictions to change if the data is modified
         externally.
 
-    random_state : int, RandomState instance, default=None
+    random_state : int or RandomState, default=None
         Determines random number generation used to initialize the centers.
         Pass an int for reproducible results across multiple function calls.
         See :term: `Glossary <random_state>`.
 
-    multi_class : string, default : "one_vs_rest"
+    multi_class : {'one_vs_rest', 'one_vs_one'}, default='one_vs_rest'
         Specifies how multi-class classification problems are handled.
-        Supported are "one_vs_rest" and "one_vs_one". In "one_vs_rest",
+        Supported are 'one_vs_rest' and 'one_vs_one'. In 'one_vs_rest',
         one binary Gaussian process classifier is fitted for each class, which
-        is trained to separate this class from the rest. In "one_vs_one", one
+        is trained to separate this class from the rest. In 'one_vs_one', one
         binary Gaussian process classifier is fitted for each pair of classes,
         which is trained to separate these two classes. The predictions of
         these binary predictors are combined into multi-class predictions.
-        Note that "one_vs_one" does not support predicting probability
+        Note that 'one_vs_one' does not support predicting probability
         estimates.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int, default=None
         The number of jobs to use for the computation.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -557,7 +557,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     Attributes
     ----------
-    kernel_ : kernel object
+    kernel_ : Kernel
         The kernel used for prediction. In case of binary classification,
         the structure of the kernel is the same as the one passed as parameter
         but with optimized hyperparameters. In case of multi-class
@@ -609,7 +609,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples, n_features) or list of object
             Feature vectors or other representations of training data.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.
@@ -670,7 +670,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.
@@ -694,7 +694,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.
@@ -737,7 +737,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        theta : array-like of shape (n_kernel_params,) or None
+        theta : array-like of shape (n_kernel_params,), default=None
             Kernel hyperparameters for which the log-marginal likelihood is
             evaluated. In the case of multi-class classification, theta may
             be the  hyperparameters of the compound kernel or of an individual
@@ -745,7 +745,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
             same theta values. If None, the precomputed log_marginal_likelihood
             of ``self.kernel_.theta`` is returned.
 
-        eval_gradient : bool, default: False
+        eval_gradient : bool, default=False
             If True, the gradient of the log-marginal likelihood with respect
             to the kernel hyperparameters at position theta is returned
             additionally. Note that gradient computation is not supported
@@ -760,7 +760,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         log_likelihood : float
             Log-marginal likelihood of theta for training data.
 
-        log_likelihood_gradient : array, shape = (n_kernel_params,), optional
+        log_likelihood_gradient : ndarray of shape = (n_kernel_params,), optional
             Gradient of the log-marginal likelihood with respect to the kernel
             hyperparameters at position theta.
             Only returned when eval_gradient is True.

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -42,12 +42,12 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
     Parameters
     ----------
-    kernel : kernel object
+    kernel : Kernel, default=None
         The kernel specifying the covariance function of the GP. If None is
         passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
         the kernel's hyperparameters are optimized during fitting.
 
-    alpha : float or array-like, optional (default: 1e-10)
+    alpha : float or array-like of shape (n_samples), default=1e-10
         Value added to the diagonal of the kernel matrix during fitting.
         Larger values correspond to increased noise level in the observations.
         This can also prevent a potential numerical issue during fitting, by
@@ -58,7 +58,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
         Allowing to specify the noise level directly as a parameter is mainly
         for convenience and for consistency with Ridge.
 
-    optimizer : string or callable, optional (default: "fmin_l_bfgs_b")
+    optimizer : "fmin_l_bfgs_b" or callable, default="fmin_l_bfgs_b"
         Can either be one of the internally supported optimizers for optimizing
         the kernel's parameters, specified by a string, or an externally
         defined optimizer passed as a callable. If a callable is passed, it
@@ -83,7 +83,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
             'fmin_l_bfgs_b'
 
-    n_restarts_optimizer : int, optional (default: 0)
+    n_restarts_optimizer : int, default=0
         The number of restarts of the optimizer for finding the kernel's
         parameters which maximize the log-marginal likelihood. The first run
         of the optimizer is performed from the kernel's initial parameters,
@@ -92,7 +92,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
         must be finite. Note that n_restarts_optimizer == 0 implies that one
         run is performed.
 
-    normalize_y : boolean, optional (default: False)
+    normalize_y : bool, default=False
         Whether the target values y are normalized, i.e., the mean of the
         observed target values become zero. This parameter should be set to
         True if the target values' mean is expected to differ considerable from
@@ -100,20 +100,20 @@ class GaussianProcessRegressor(MultiOutputMixin,
         prior based on the data, which contradicts the likelihood principle;
         normalization is thus disabled per default.
 
-    copy_X_train : bool, optional (default: True)
+    copy_X_train : bool, default=True
         If True, a persistent copy of the training data is stored in the
         object. Otherwise, just a reference to the training data is stored,
         which might cause predictions to change if the data is modified
         externally.
 
-    random_state : int, RandomState instance, default=None
+    random_state : int or RandomState, default=None
         Determines random number generation used to initialize the centers.
         Pass an int for reproducible results across multiple function calls.
         See :term: `Glossary <random_state>`.
 
     Attributes
     ----------
-    X_train_ : sequence of length n_samples
+    X_train_ : array-like of shape (n_samples, n_features) or list of object
         Feature vectors or other representations of training data (also
         required for prediction). Could either be array-like with shape =
         (n_samples, n_features) or a list of objects.
@@ -121,7 +121,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
     y_train_ : array-like of shape (n_samples,) or (n_samples, n_targets)
         Target values in training data (also required for prediction)
 
-    kernel_ : kernel object
+    kernel_ : Kernel
         The kernel used for prediction. The structure of the kernel is the
         same as the one passed as parameter but with optimized hyperparameters
 
@@ -165,7 +165,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples, n_features) or a list of object
             Feature vectors or other representations of training data.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.
@@ -281,29 +281,29 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.
 
-        return_std : bool, default: False
+        return_std : bool, default=False
             If True, the standard-deviation of the predictive distribution at
             the query points is returned along with the mean.
 
-        return_cov : bool, default: False
+        return_cov : bool, default=False
             If True, the covariance of the joint predictive distribution at
             the query points is returned along with the mean
 
         Returns
         -------
-        y_mean : array, shape = (n_samples, [n_output_dims])
+        y_mean : ndarray of shape (n_samples, [n_output_dims])
             Mean of predictive distribution a query points
 
-        y_std : array, shape = (n_samples,), optional
+        y_std : ndarray of shape (n_samples,), optional
             Standard deviation of predictive distribution at query points.
             Only returned when return_std is True.
 
-        y_cov : array, shape = (n_samples, n_samples), optional
+        y_cov : ndarray of shape (n_samples, n_samples), optional
             Covariance of joint predictive distribution a query points.
             Only returned when return_cov is True.
         """
@@ -370,15 +370,15 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.
 
-        n_samples : int, default: 1
+        n_samples : int, default=1
             The number of samples drawn from the Gaussian process
 
-        random_state : int, RandomState instance, default=0
+        random_state : int, RandomState, default=0
             Determines random number generation to randomly draw samples.
             Pass an int for reproducible results across multiple function
             calls.
@@ -386,7 +386,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Returns
         -------
-        y_samples : array, shape = (n_samples_X, [n_output_dims], n_samples)
+        y_samples : ndarray of shape (n_samples_X, [n_output_dims], n_samples)
             Values of n_samples samples drawn from Gaussian process and
             evaluated at query points.
         """
@@ -409,12 +409,12 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        theta : array-like of shape (n_kernel_params,) or None
+        theta : array-like of shape (n_kernel_params,) default=None
             Kernel hyperparameters for which the log-marginal likelihood is
             evaluated. If None, the precomputed log_marginal_likelihood
             of ``self.kernel_.theta`` is returned.
 
-        eval_gradient : bool, default: False
+        eval_gradient : bool, default=False
             If True, the gradient of the log-marginal likelihood with respect
             to the kernel hyperparameters at position theta is returned
             additionally. If True, theta must not be None.
@@ -428,7 +428,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
         log_likelihood : float
             Log-marginal likelihood of theta for training data.
 
-        log_likelihood_gradient : array, shape = (n_kernel_params,), optional
+        log_likelihood_gradient : ndarray of shape (n_kernel_params,), optional
             Gradient of the log-marginal likelihood with respect to the kernel
             hyperparameters at position theta.
             Only returned when eval_gradient is True.

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -115,8 +115,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
     ----------
     X_train_ : array-like of shape (n_samples, n_features) or list of object
         Feature vectors or other representations of training data (also
-        required for prediction). Could either be array-like with shape =
-        (n_samples, n_features) or a list of objects.
+        required for prediction).
 
     y_train_ : array-like of shape (n_samples,) or (n_samples, n_targets)
         Target values in training data (also required for prediction)
@@ -167,8 +166,6 @@ class GaussianProcessRegressor(MultiOutputMixin,
         ----------
         X : array-like of shape (n_samples, n_features) or list of object
             Feature vectors or other representations of training data.
-            Could either be array-like with shape = (n_samples, n_features)
-            or a list of objects.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Target values
@@ -283,8 +280,6 @@ class GaussianProcessRegressor(MultiOutputMixin,
         ----------
         X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated.
-            Could either be array-like with shape = (n_samples, n_features)
-            or a list of objects.
 
         return_std : bool, default=False
             If True, the standard-deviation of the predictive distribution at
@@ -372,8 +367,6 @@ class GaussianProcessRegressor(MultiOutputMixin,
         ----------
         X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated.
-            Could either be array-like with shape = (n_samples, n_features)
-            or a list of objects.
 
         n_samples : int, default=1
             The number of samples drawn from the Gaussian process

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -42,7 +42,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
     Parameters
     ----------
-    kernel : Kernel, default=None
+    kernel : kernel instance, default=None
         The kernel specifying the covariance function of the GP. If None is
         passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
         the kernel's hyperparameters are optimized during fitting.
@@ -120,7 +120,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
     y_train_ : array-like of shape (n_samples,) or (n_samples, n_targets)
         Target values in training data (also required for prediction)
 
-    kernel_ : Kernel
+    kernel_ : kernel instance
         The kernel used for prediction. The structure of the kernel is the
         same as the one passed as parameter but with optimized hyperparameters
 
@@ -296,11 +296,11 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         y_std : ndarray of shape (n_samples,), optional
             Standard deviation of predictive distribution at query points.
-            Only returned when return_std is True.
+            Only returned when `return_std` is True.
 
         y_cov : ndarray of shape (n_samples, n_samples), optional
             Covariance of joint predictive distribution a query points.
-            Only returned when return_cov is True.
+            Only returned when `return_cov` is True.
         """
         if return_std and return_cov:
             raise RuntimeError(

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -165,7 +165,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features) or a list of object
+        X : array-like of shape (n_samples, n_features) or list of object
             Feature vectors or other representations of training data.
             Could either be array-like with shape = (n_samples, n_features)
             or a list of objects.

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -505,14 +505,11 @@ class CompoundKernel(Kernel):
         X : array-like of shape (n_samples_X, n_features) or list of object, \
             default=None
             Left argument of the returned kernel k(X, Y)
-            Could either be array-like with shape = (n_samples_X, n_features)
-            or a list of objects.
 
         Y : array-like of shape (n_samples_X, n_features) or list of object, \
             default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            is evaluated instead. Y could either be array-like with
-            shape = (n_samples_Y, n_features) or a list of objects.
+            is evaluated instead.
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
@@ -567,8 +564,7 @@ class CompoundKernel(Kernel):
         Parameters
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
-            Argument to the kernel. Could either be array-like with
-            shape = (n_samples_X, n_features) or a list of objects.
+            Argument to the kernel.
 
         Returns
         -------
@@ -712,14 +708,11 @@ class Sum(KernelOperator):
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
-            Could either be array-like with shape = (n_samples_X, n_features)
-            or a list of objects.
 
         Y : array-like of shape (n_samples_X, n_features) or list of object,\
             default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            is evaluated instead. Y could either be array-like with
-            shape = (n_samples_Y, n_features) or a list of objects.
+            is evaluated instead.
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
@@ -753,8 +746,7 @@ class Sum(KernelOperator):
         Parameters
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
-            Argument to the kernel. Could either be array-like with
-            shape = (n_samples_X, n_features) or a list of objects.
+            Argument to the kernel.
 
         Returns
         -------
@@ -792,14 +784,11 @@ class Product(KernelOperator):
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
-            Could either be array-like with shape = (n_samples_X, n_features)
-            or a list of objects.
 
         Y : array-like of shape = (n_samples_Y, n_features) or list of object,\
             default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            is evaluated instead. Y could either be array-like with
-            shape = (n_samples_Y, n_features) or a list of objects.
+            is evaluated instead.
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
@@ -834,8 +823,7 @@ class Product(KernelOperator):
         Parameters
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
-            Argument to the kernel. Could either be array-like with
-            shape = (n_samples_X, n_features) or a list of objects.
+            Argument to the kernel.
 
         Returns
         -------
@@ -950,14 +938,11 @@ class Exponentiation(Kernel):
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
-            Could either be array-like with shape = (n_samples_X, n_features)
-            or a list of objects.
 
         Y : array-like of shape (n_samples_Y, n_features) or list of object,\
             default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            is evaluated instead. Y could either be array-like with
-            shape = (n_samples_Y, n_features) or a list of objects.
+            is evaluated instead.
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
@@ -993,8 +978,7 @@ class Exponentiation(Kernel):
         Parameters
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
-            Argument to the kernel. Could either be array-like with
-            shape = (n_samples_X, n_features) or a list of objects.
+            Argument to the kernel.
 
         Returns
         -------
@@ -1054,14 +1038,11 @@ class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
-            Could either be array-like with shape = (n_samples_X, n_features)
-            or a list of objects.
 
         Y : array-like of shape (n_samples_X, n_features) or list of object, \
             default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            is evaluated instead. Y could either be array-like with
-            shape = (n_samples_Y, n_features) or a list of objects.
+            is evaluated instead.
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
@@ -1105,8 +1086,7 @@ class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
         Parameters
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
-            Argument to the kernel. Could either be array-like with
-            shape = (n_samples_X, n_features) or a list of objects.
+            Argument to the kernel.
 
         Returns
         -------
@@ -1157,14 +1137,11 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
-            Could either be array-like with shape = (n_samples_X, n_features)
-            or a list of objects.
 
         Y : array-like of shape (n_samples_X, n_features) or list of object,\
             default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
-            is evaluated instead. Y could either be array-like with
-            shape = (n_samples_Y, n_features) or a list of objects.
+            is evaluated instead.
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
@@ -1207,8 +1184,7 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
         Parameters
         ----------
         X : array-like of shape (n_samples_X, n_features) or list of object
-            Argument to the kernel. Could either be array-like with
-            shape = (n_samples_X, n_features) or a list of objects.
+            Argument to the kernel.
 
         Returns
         -------

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -389,12 +389,12 @@ class NormalizedKernelMixin:
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : ndarray of shape (n_samples_X, n_features)
             Left argument of the returned kernel k(X, Y)
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X,)
+        K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
         return np.ones(X.shape[0])
@@ -593,13 +593,13 @@ class KernelOperator(Kernel):
 
         Parameters
         ----------
-        deep : boolean, optional
+        deep : bool, default=True
             If True, will return the parameters for this estimator and
             contained subobjects that are estimators.
 
         Returns
         -------
-        params : mapping of string to any
+        params : dict
             Parameter names mapped to their values.
         """
         params = dict(k1=self.k1, k2=self.k2)
@@ -637,7 +637,7 @@ class KernelOperator(Kernel):
 
         Returns
         -------
-        theta : array, shape (n_dims,)
+        theta : ndarray of shape (n_dims,)
             The non-fixed, log-transformed hyperparameters of the kernel
         """
         return np.append(self.k1.theta, self.k2.theta)
@@ -648,7 +648,7 @@ class KernelOperator(Kernel):
 
         Parameters
         ----------
-        theta : array, shape (n_dims,)
+        theta : ndarray of shape (n_dims,)
             The non-fixed, log-transformed hyperparameters of the kernel
         """
         k1_dims = self.k1.n_dims
@@ -661,7 +661,7 @@ class KernelOperator(Kernel):
 
         Returns
         -------
-        bounds : array, shape (n_dims, 2)
+        bounds : ndarray of shape (n_dims, 2)
             The log-transformed bounds on the kernel's hyperparameters theta
         """
         if self.k1.bounds.size == 0:
@@ -697,10 +697,10 @@ class Sum(KernelOperator):
 
     Parameters
     ----------
-    k1 : Kernel object
+    k1 : Kernel
         The first base-kernel of the sum-kernel
 
-    k2 : Kernel object
+    k2 : Kernel
         The second base-kernel of the sum-kernel
 
     """
@@ -715,21 +715,23 @@ class Sum(KernelOperator):
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
 
-        Y : sequence of length n_samples_Y
+        Y : array-like of shape (n_samples_X, n_features) or list of object,\
+            default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             is evaluated instead. Y could either be array-like with
             shape = (n_samples_Y, n_features) or a list of objects.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
+            optional
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -756,7 +758,7 @@ class Sum(KernelOperator):
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X,)
+        K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
         return self.k1.diag(X) + self.k2.diag(X)
@@ -775,10 +777,10 @@ class Product(KernelOperator):
 
     Parameters
     ----------
-    k1 : Kernel object
+    k1 : Kernel
         The first base-kernel of the product-kernel
 
-    k2 : Kernel object
+    k2 : Kernel
         The second base-kernel of the product-kernel
 
     """
@@ -793,21 +795,23 @@ class Product(KernelOperator):
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
 
-        Y : sequence of length n_samples_Y
+        Y : array-like of shape = (n_samples_Y, n_features) or list of object,\
+            default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             is evaluated instead. Y could either be array-like with
             shape = (n_samples_Y, n_features) or a list of objects.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
+            optional
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -835,7 +839,7 @@ class Product(KernelOperator):
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X,)
+        K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
         return self.k1.diag(X) * self.k2.diag(X)
@@ -854,7 +858,7 @@ class Exponentiation(Kernel):
 
     Parameters
     ----------
-    kernel : Kernel object
+    kernel : Kernel
         The base kernel
 
     exponent : float
@@ -870,13 +874,13 @@ class Exponentiation(Kernel):
 
         Parameters
         ----------
-        deep : boolean, optional
+        deep : bool, default=True
             If True, will return the parameters for this estimator and
             contained subobjects that are estimators.
 
         Returns
         -------
-        params : mapping of string to any
+        params : dict
             Parameter names mapped to their values.
         """
         params = dict(kernel=self.kernel, exponent=self.exponent)
@@ -907,7 +911,7 @@ class Exponentiation(Kernel):
 
         Returns
         -------
-        theta : array, shape (n_dims,)
+        theta : ndarray of shape (n_dims,)
             The non-fixed, log-transformed hyperparameters of the kernel
         """
         return self.kernel.theta
@@ -918,7 +922,7 @@ class Exponentiation(Kernel):
 
         Parameters
         ----------
-        theta : array, shape (n_dims,)
+        theta : ndarray of shape (n_dims,)
             The non-fixed, log-transformed hyperparameters of the kernel
         """
         self.kernel.theta = theta
@@ -929,7 +933,7 @@ class Exponentiation(Kernel):
 
         Returns
         -------
-        bounds : array, shape (n_dims, 2)
+        bounds : ndarray of shape (n_dims, 2)
             The log-transformed bounds on the kernel's hyperparameters theta
         """
         return self.kernel.bounds
@@ -949,21 +953,23 @@ class Exponentiation(Kernel):
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
 
-        Y : sequence of length n_samples_Y
+        Y : array-like of shape (n_samples_Y, n_features) or list of object,\
+            default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             is evaluated instead. Y could either be array-like with
             shape = (n_samples_Y, n_features) or a list of objects.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
+            optional
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -992,7 +998,7 @@ class Exponentiation(Kernel):
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X,)
+        K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
         return self.kernel.diag(X) ** self.exponent
@@ -1129,10 +1135,10 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
 
     Parameters
     ----------
-    noise_level : float, default: 1.0
+    noise_level : float, default=1.0
         Parameter controlling the noise level (variance)
 
-    noise_level_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    noise_level_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on noise_level
     """
     def __init__(self, noise_level=1.0, noise_level_bounds=(1e-5, 1e5)):
@@ -1154,21 +1160,23 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
 
-        Y : sequence of length n_samples_Y
+        Y : array-like of shape (n_samples_X, n_features) or list of object,\
+            default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             is evaluated instead. Y could either be array-like with
             shape = (n_samples_Y, n_features) or a list of objects.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
+            optional
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -1204,7 +1212,7 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X,)
+        K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
         return np.full(_num_samples(X), self.noise_level,
@@ -1234,12 +1242,12 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
     Parameters
     ----------
-    length_scale : float or array with shape (n_features,), default: 1.0
+    length_scale : float or ndarray of shape (n_features,), default=1.0
         The length scale of the kernel. If a float, an isotropic kernel is
         used. If an array, an anisotropic kernel is used where each dimension
         of l defines the length-scale of the respective feature dimension.
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    length_scale_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on length_scale
 
     """
@@ -1265,23 +1273,24 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : ndarray of shape (n_samples_X, n_features)
             Left argument of the returned kernel k(X, Y)
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : ndarray of shape (n_samples_Y, n_features), default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             if evaluated instead.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
+            optional
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -1347,15 +1356,15 @@ class Matern(RBF):
 
     Parameters
     ----------
-    length_scale : float or array with shape (n_features,), default: 1.0
+    length_scale : float or ndarray of shape (n_features,), default=1.0
         The length scale of the kernel. If a float, an isotropic kernel is
         used. If an array, an anisotropic kernel is used where each dimension
         of l defines the length-scale of the respective feature dimension.
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    length_scale_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on length_scale
 
-    nu : float, default: 1.5
+    nu : float, default=1.5
         The parameter nu controlling the smoothness of the learned function.
         The smaller nu, the less smooth the approximated function is.
         For nu=inf, the kernel becomes equivalent to the RBF kernel and for
@@ -1378,23 +1387,24 @@ class Matern(RBF):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : ndarray of shape (n_samples_X, n_features)
             Left argument of the returned kernel k(X, Y)
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : ndarray of shape (n_samples_Y, n_features), default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             if evaluated instead.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
+            optional
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -1498,16 +1508,16 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
     Parameters
     ----------
-    length_scale : float > 0, default: 1.0
+    length_scale : float > 0, default=1.0
         The length scale of the kernel.
 
-    alpha : float > 0, default: 1.0
+    alpha : float > 0, default=1.0
         Scale mixture parameter
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    length_scale_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on length_scale
 
-    alpha_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    alpha_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on alpha
 
     """
@@ -1532,23 +1542,23 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : ndarray of shape (n_samples_X, n_features)
             Left argument of the returned kernel k(X, Y)
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : ndarray of shape (n_samples_Y, n_features), default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             if evaluated instead.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims)
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -1614,16 +1624,16 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
     Parameters
     ----------
-    length_scale : float > 0, default: 1.0
+    length_scale : float > 0, default=1.0
         The length scale of the kernel.
 
-    periodicity : float > 0, default: 1.0
+    periodicity : float > 0, default=1.0
         The periodicity of the kernel.
 
-    length_scale_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    length_scale_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on length_scale
 
-    periodicity_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    periodicity_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on periodicity
 
     """
@@ -1650,23 +1660,24 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : ndarray of shape (n_samples_X, n_features)
             Left argument of the returned kernel k(X, Y)
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : ndarray of shape (n_samples_Y, n_features), default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             if evaluated instead.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
+            optional
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -1850,13 +1861,15 @@ class PairwiseKernel(Kernel):
 
     Parameters
     ----------
-    gamma : float >= 0, default: 1.0
+    gamma : float >= 0, default=1.0
         Parameter gamma of the pairwise kernel specified by metric
 
-    gamma_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    gamma_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on gamma
 
-    metric : string, or callable, default: "linear"
+    metric : {"linear", "additive_chi2", "chi2", "poly", "polynomial",
+              "rbf", "laplacian", "sigmoid", "cosine"} or callable, \
+              default="linear"
         The metric to use when calculating kernel between instances in a
         feature array. If metric is a string, it must be one of the metrics
         in pairwise.PAIRWISE_KERNEL_FUNCTIONS.
@@ -1866,7 +1879,7 @@ class PairwiseKernel(Kernel):
         should take two arrays from X as input and return a value indicating
         the distance between them.
 
-    pairwise_kernels_kwargs : dict, default: None
+    pairwise_kernels_kwargs : dict, default=None
         All entries of this dict (if any) are passed as keyword arguments to
         the pairwise kernel function.
 
@@ -1888,23 +1901,23 @@ class PairwiseKernel(Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : ndarray of shape (n_samples_X, n_features)
             Left argument of the returned kernel k(X, Y)
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : ndarray of shape (n_samples_Y, n_features), default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             if evaluated instead.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims)
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -1939,12 +1952,12 @@ class PairwiseKernel(Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : ndarray of shape (n_samples_X, n_features)
             Left argument of the returned kernel k(X, Y)
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X,)
+        K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
         # We have to fall back to slow way of computing diagonal

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -785,7 +785,7 @@ class Product(KernelOperator):
         X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
 
-        Y : array-like of shape = (n_samples_Y, n_features) or list of object,\
+        Y : array-like of shape (n_samples_Y, n_features) or list of object,\
             default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             is evaluated instead.

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -54,12 +54,12 @@ class Hyperparameter(namedtuple('Hyperparameter',
 
     Attributes
     ----------
-    name : string
+    name : str
         The name of the hyperparameter. Note that a kernel using a
         hyperparameter with name "x" must have the attributes self.x and
         self.x_bounds
 
-    value_type : string
+    value_type : str
         The type of the hyperparameter. Currently, only "numeric"
         hyperparameters are supported.
 
@@ -75,7 +75,7 @@ class Hyperparameter(namedtuple('Hyperparameter',
         corresponds to a hyperparameter which is vector-valued,
         such as, e.g., anisotropic length-scales.
 
-    fixed : bool, default: None
+    fixed : bool, default=None
         Whether the value of this hyperparameter is fixed, i.e., cannot be
         changed during hyperparameter tuning. If None is passed, the "fixed" is
         derived based on the given bounds.
@@ -353,7 +353,7 @@ class Kernel(metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : sequence of length n_samples
+        X : array-like of shape (n_samples,)
             Left argument of the returned kernel k(X, Y)
 
         Returns
@@ -431,7 +431,7 @@ class CompoundKernel(Kernel):
 
     Parameters
     ----------
-    kernels : list of Kernel
+    kernels : list of Kernels
         The other kernels
     """
 
@@ -476,7 +476,7 @@ class CompoundKernel(Kernel):
 
         Parameters
         ----------
-        theta : array, shape (n_dims,)
+        theta : array of shape (n_dims,)
             The non-fixed, log-transformed hyperparameters of the kernel
         """
         k_dims = self.k1.n_dims
@@ -489,7 +489,7 @@ class CompoundKernel(Kernel):
 
         Returns
         -------
-        bounds : array, shape (n_dims, 2)
+        bounds : array of shape (n_dims, 2)
             The log-transformed bounds on the kernel's hyperparameters theta
         """
         return np.vstack([kernel.bounds for kernel in self.kernels])
@@ -521,9 +521,9 @@ class CompoundKernel(Kernel):
             Kernel k(X, Y)
 
         K_gradient : ndarray of shape \
-            (n_samples_X, n_samples_X, n_dims, n_kernels), optional
+                (n_samples_X, n_samples_X, n_dims, n_kernels), optional
             The gradient of the kernel k(X, X) with respect to the
-            hyperparameter of the kernel. Only returned when eval_gradient
+            hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
         if eval_gradient:
@@ -557,7 +557,7 @@ class CompoundKernel(Kernel):
     def diag(self, X):
         """Returns the diagonal of the kernel k(X, X).
 
-        The result of this method is identical to np.diag(self(X)); however,
+        The result of this method is identical to `np.diag(self(X))`; however,
         it can be evaluated more efficiently since only the diagonal is
         evaluated.
 
@@ -710,7 +710,7 @@ class Sum(KernelOperator):
             Left argument of the returned kernel k(X, Y)
 
         Y : array-like of shape (n_samples_X, n_features) or list of object,\
-            default=None
+                default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             is evaluated instead.
 
@@ -724,9 +724,9 @@ class Sum(KernelOperator):
             Kernel k(X, Y)
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
-            optional
+                optional
             The gradient of the kernel k(X, X) with respect to the
-            hyperparameter of the kernel. Only returned when eval_gradient
+            hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
         if eval_gradient:
@@ -739,7 +739,7 @@ class Sum(KernelOperator):
     def diag(self, X):
         """Returns the diagonal of the kernel k(X, X).
 
-        The result of this method is identical to np.diag(self(X)); however,
+        The result of this method is identical to `np.diag(self(X))`; however,
         it can be evaluated more efficiently since only the diagonal is
         evaluated.
 
@@ -800,9 +800,9 @@ class Product(KernelOperator):
             Kernel k(X, Y)
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
-            optional
+                optional
             The gradient of the kernel k(X, X) with respect to the
-            hyperparameter of the kernel. Only returned when eval_gradient
+            hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
         if eval_gradient:
@@ -954,9 +954,9 @@ class Exponentiation(Kernel):
             Kernel k(X, Y)
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
-            optional
+                optional
             The gradient of the kernel k(X, X) with respect to the
-            hyperparameter of the kernel. Only returned when eval_gradient
+            hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
         if eval_gradient:
@@ -1266,9 +1266,9 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             Kernel k(X, Y)
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
-            optional
+                optional
             The gradient of the kernel k(X, X) with respect to the
-            hyperparameter of the kernel. Only returned when eval_gradient
+            hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
         X = np.atleast_2d(X)
@@ -1380,9 +1380,9 @@ class Matern(RBF):
             Kernel k(X, Y)
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
-            optional
+                optional
             The gradient of the kernel k(X, X) with respect to the
-            hyperparameter of the kernel. Only returned when eval_gradient
+            hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
         X = np.atleast_2d(X)
@@ -1600,17 +1600,17 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
     Parameters
     ----------
-    length_scale : float > 0, default=1.0
-        The length scale of the kernel.
+    length_scale : float, default=1.0
+        The length scale of the kernel. It should be strictly positive.
 
-    periodicity : float > 0, default=1.0
-        The periodicity of the kernel.
+    periodicity : float, default=1.0
+        The periodicity of the kernel. It should be strictly positive.
 
     length_scale_bounds : pair of floats >= 0, default=(1e-5, 1e5)
-        The lower and upper bound on length_scale
+        The lower and upper bound on length scale.
 
     periodicity_bounds : pair of floats >= 0, default=(1e-5, 1e5)
-        The lower and upper bound on periodicity
+        The lower and upper bound on periodicity.
 
     """
     def __init__(self, length_scale=1.0, periodicity=1.0,
@@ -1653,9 +1653,9 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             Kernel k(X, Y)
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
-            optional
+                optional
             The gradient of the kernel k(X, X) with respect to the
-            hyperparameter of the kernel. Only returned when eval_gradient
+            hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
         X = np.atleast_2d(X)
@@ -1723,7 +1723,7 @@ class DotProduct(Kernel):
         the kernel is homogenous.
 
     sigma_0_bounds : pair of floats >= 0, default=(1e-5, 1e5)
-        The lower and upper bound on l
+        The lower and upper bound on l.
 
     """
 
@@ -1756,9 +1756,10 @@ class DotProduct(Kernel):
         K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
+                optional
             The gradient of the kernel k(X, X) with respect to the
-            hyperparameter of the kernel. Only returned when eval_gradient
+            hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
         X = np.atleast_2d(X)
@@ -1790,12 +1791,12 @@ class DotProduct(Kernel):
         Parameters
         ----------
         X : ndarray of shape (n_samples_X, n_features)
-            Left argument of the returned kernel k(X, Y)
+            Left argument of the returned kernel k(X, Y).
 
         Returns
         -------
         K_diag : ndarray of shape (n_samples_X,)
-            Diagonal of kernel k(X, X)
+            Diagonal of kernel k(X, X).
         """
         return np.einsum('ij,ij->i', X, X) + self.sigma_0 ** 2
 
@@ -1837,11 +1838,12 @@ class PairwiseKernel(Kernel):
 
     Parameters
     ----------
-    gamma : float >= 0, default=1.0
-        Parameter gamma of the pairwise kernel specified by metric
+    gamma : float, default=1.0
+        Parameter gamma of the pairwise kernel specified by metric. It should
+        be positive.
 
-    gamma_bounds : pair of floats >= 0, default=(1e-5, 1e5)
-        The lower and upper bound on gamma
+    gamma_bounds : pair of floats, default=(1e-5, 1e5)
+        The lower and upper bound on gamma. They should be positive.
 
     metric : {"linear", "additive_chi2", "chi2", "poly", "polynomial", \
               "rbf", "laplacian", "sigmoid", "cosine"} or callable, \
@@ -1893,9 +1895,10 @@ class PairwiseKernel(Kernel):
         K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
+                optional
             The gradient of the kernel k(X, X) with respect to the
-            hyperparameter of the kernel. Only returned when eval_gradient
+            hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
         pairwise_kernels_kwargs = self.pairwise_kernels_kwargs

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -128,13 +128,13 @@ class Kernel(metaclass=ABCMeta):
 
         Parameters
         ----------
-        deep : boolean, optional
+        deep : bool, default=True
             If True, will return the parameters for this estimator and
             contained subobjects that are estimators.
 
         Returns
         -------
-        params : mapping of string to any
+        params : dict
             Parameter names mapped to their values.
         """
         params = dict()
@@ -213,7 +213,7 @@ class Kernel(metaclass=ABCMeta):
 
         Parameters
         ----------
-        theta : array, shape (n_dims,)
+        theta : ndarray of shape (n_dims,)
             The hyperparameters
         """
         cloned = clone(self)
@@ -243,7 +243,7 @@ class Kernel(metaclass=ABCMeta):
 
         Returns
         -------
-        theta : array, shape (n_dims,)
+        theta : ndarray of shape (n_dims,)
             The non-fixed, log-transformed hyperparameters of the kernel
         """
         theta = []
@@ -262,7 +262,7 @@ class Kernel(metaclass=ABCMeta):
 
         Parameters
         ----------
-        theta : array, shape (n_dims,)
+        theta : ndarray of shape (n_dims,)
             The non-fixed, log-transformed hyperparameters of the kernel
         """
         params = self.get_params()
@@ -291,7 +291,7 @@ class Kernel(metaclass=ABCMeta):
 
         Returns
         -------
-        bounds : array, shape (n_dims, 2)
+        bounds : ndarray of shape (n_dims, 2)
             The log-transformed bounds on the kernel's hyperparameters theta
         """
         bounds = [hyperparameter.bounds
@@ -358,7 +358,7 @@ class Kernel(metaclass=ABCMeta):
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X,)
+        K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
 
@@ -431,7 +431,7 @@ class CompoundKernel(Kernel):
 
     Parameters
     ----------
-    kernels : list of Kernel objects
+    kernels : list of Kernel
         The other kernels
     """
 
@@ -443,13 +443,13 @@ class CompoundKernel(Kernel):
 
         Parameters
         ----------
-        deep : boolean, optional
+        deep : bool, default=True
             If True, will return the parameters for this estimator and
             contained subobjects that are estimators.
 
         Returns
         -------
-        params : mapping of string to any
+        params : dict
             Parameter names mapped to their values.
         """
         return dict(kernels=self.kernels)
@@ -465,7 +465,7 @@ class CompoundKernel(Kernel):
 
         Returns
         -------
-        theta : array, shape (n_dims,)
+        theta : ndarray of shape (n_dims,)
             The non-fixed, log-transformed hyperparameters of the kernel
         """
         return np.hstack([kernel.theta for kernel in self.kernels])
@@ -502,26 +502,29 @@ class CompoundKernel(Kernel):
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object, \
+            default=None
             Left argument of the returned kernel k(X, Y)
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
 
-        Y : sequence of length n_samples_Y
+        Y : array-like of shape (n_samples_X, n_features) or list of object, \
+            default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             is evaluated instead. Y could either be array-like with
             shape = (n_samples_Y, n_features) or a list of objects.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y, n_kernels)
+        K : ndarray of shape (n_samples_X, n_samples_Y, n_kernels)
             Kernel k(X, Y)
 
-        K_gradient : array, shape (n_samples_X, n_samples_X, n_dims, n_kernels)
+        K_gradient : ndarray of shape \
+            (n_samples_X, n_samples_X, n_dims, n_kernels), optional
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -563,13 +566,13 @@ class CompoundKernel(Kernel):
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Argument to the kernel. Could either be array-like with
             shape = (n_samples_X, n_features) or a list of objects.
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X, n_kernels)
+        K_diag : ndarray of shape (n_samples_X, n_kernels)
             Diagonal of kernel k(X, X)
         """
         return np.vstack([kernel.diag(X) for kernel in self.kernels]).T
@@ -707,7 +710,7 @@ class Sum(KernelOperator):
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
@@ -747,7 +750,7 @@ class Sum(KernelOperator):
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Argument to the kernel. Could either be array-like with
             shape = (n_samples_X, n_features) or a list of objects.
 
@@ -785,7 +788,7 @@ class Product(KernelOperator):
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
@@ -826,7 +829,7 @@ class Product(KernelOperator):
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Argument to the kernel. Could either be array-like with
             shape = (n_samples_X, n_features) or a list of objects.
 
@@ -941,7 +944,7 @@ class Exponentiation(Kernel):
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
@@ -983,7 +986,7 @@ class Exponentiation(Kernel):
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Argument to the kernel. Could either be array-like with
             shape = (n_samples_X, n_features) or a list of objects.
 
@@ -1021,11 +1024,11 @@ class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
 
     Parameters
     ----------
-    constant_value : float, default: 1.0
+    constant_value : float, default=1.0
         The constant value which defines the covariance:
         k(x_1, x_2) = constant_value
 
-    constant_value_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    constant_value_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on constant_value
 
     """
@@ -1043,26 +1046,28 @@ class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
 
-        Y : sequence of length n_samples_Y
+        Y : array-like of shape (n_samples_X, n_features) or list of object, \
+            default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             is evaluated instead. Y could either be array-like with
             shape = (n_samples_Y, n_features) or a list of objects.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
+            optional
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -1093,13 +1098,13 @@ class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Argument to the kernel. Could either be array-like with
             shape = (n_samples_X, n_features) or a list of objects.
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X,)
+        K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
         return np.full(_num_samples(X), self.constant_value,
@@ -1144,7 +1149,7 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Left argument of the returned kernel k(X, Y)
             Could either be array-like with shape = (n_samples_X, n_features)
             or a list of objects.
@@ -1193,7 +1198,7 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
 
         Parameters
         ----------
-        X : sequence of length n_samples_X
+        X : array-like of shape (n_samples_X, n_features) or list of object
             Argument to the kernel. Could either be array-like with
             shape = (n_samples_X, n_features) or a list of objects.
 
@@ -1726,11 +1731,11 @@ class DotProduct(Kernel):
 
     Parameters
     ----------
-    sigma_0 : float >= 0, default: 1.0
+    sigma_0 : float >= 0, default=1.0
         Parameter controlling the inhomogenity of the kernel. If sigma_0=0,
         the kernel is homogenous.
 
-    sigma_0_bounds : pair of floats >= 0, default: (1e-5, 1e5)
+    sigma_0_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on l
 
     """
@@ -1748,23 +1753,23 @@ class DotProduct(Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : ndarray of shape (n_samples_X, n_features)
             Left argument of the returned kernel k(X, Y)
 
-        Y : array, shape (n_samples_Y, n_features), (optional, default=None)
+        Y : ndarray of shape (n_samples_Y, n_features), default=None
             Right argument of the returned kernel k(X, Y). If None, k(X, X)
             if evaluated instead.
 
-        eval_gradient : bool (optional, default=False)
+        eval_gradient : bool, default=False
             Determines whether the gradient with respect to the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
         -------
-        K : array, shape (n_samples_X, n_samples_Y)
+        K : ndarray of shape (n_samples_X, n_samples_Y)
             Kernel k(X, Y)
 
-        K_gradient : array (opt.), shape (n_samples_X, n_samples_X, n_dims)
+        K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims)
             The gradient of the kernel k(X, X) with respect to the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
@@ -1797,12 +1802,12 @@ class DotProduct(Kernel):
 
         Parameters
         ----------
-        X : array, shape (n_samples_X, n_features)
+        X : ndarray of shape (n_samples_X, n_features)
             Left argument of the returned kernel k(X, Y)
 
         Returns
         -------
-        K_diag : array, shape (n_samples_X,)
+        K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X)
         """
         return np.einsum('ij,ij->i', X, X) + self.sigma_0 ** 2

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1843,7 +1843,7 @@ class PairwiseKernel(Kernel):
     gamma_bounds : pair of floats >= 0, default=(1e-5, 1e5)
         The lower and upper bound on gamma
 
-    metric : {"linear", "additive_chi2", "chi2", "poly", "polynomial",
+    metric : {"linear", "additive_chi2", "chi2", "poly", "polynomial", \
               "rbf", "laplacian", "sigmoid", "cosine"} or callable, \
               default="linear"
         The metric to use when calculating kernel between instances in a


### PR DESCRIPTION
#### Reference Issues/PRs
#15761


#### What does this implement/fix? Explain your changes.
Cleans up parameter spec in gaussian_process, so it follows the convention outlined in the Contributing Guide

Only changes in docstrings.

