### PR TITLE
[MRG] DOC Cleaning parameter docstrings in module compose

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -51,20 +51,20 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     Parameters
     ----------
     transformers : list of tuples
-        List of (name, transformer, column(s)) tuples specifying the
+        List of (name, transformer, columns) tuples specifying the
         transformer objects to be applied to subsets of the data.
 
-        name : string
+        name : str
             Like in Pipeline and FeatureUnion, this allows the transformer and
             its parameters to be set using ``set_params`` and searched in grid
             search.
-        transformer : estimator or {'passthrough', 'drop'}
+        transformer : {'drop', 'passthrough'} or estimator
             Estimator must support :term:`fit` and :term:`transform`.
             Special-cased strings 'drop' and 'passthrough' are accepted as
             well, to indicate to drop the columns or to pass them through
             untransformed, respectively.
-        column(s) : string or int, array-like of string or int, slice, \
-boolean mask array or callable
+        columns : str, array-like of str, int, array-like of int, \
+            array-like of bool, slice or callable \
             Indexes the data on its second axis. Integers are interpreted as
             positional columns, while strings can reference DataFrame columns
             by name.  A scalar string or int should be used where
@@ -74,7 +74,7 @@ boolean mask array or callable
             above. To select multiple columns by name or dtype, you can use
             :obj:`make_column_transformer`.
 
-    remainder : {'drop', 'passthrough'} or estimator, default 'drop'
+    remainder : {'drop', 'passthrough'} or estimator, default='drop'
         By default, only the specified columns in `transformers` are
         transformed and combined in the output, and the non-specified
         columns are dropped. (default of ``'drop'``).
@@ -88,25 +88,25 @@ boolean mask array or callable
         Note that using this feature requires that the DataFrame columns
         input at :term:`fit` and :term:`transform` have identical order.
 
-    sparse_threshold : float, default = 0.3
+    sparse_threshold : float, default=0.3
         If the output of the different transformers contains sparse matrices,
         these will be stacked as a sparse matrix if the overall density is
         lower than this value. Use ``sparse_threshold=0`` to always return
         dense.  When the transformed output consists of all dense data, the
         stacked result will be dense, and this keyword will be ignored.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int, default=None
         Number of jobs to run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    transformer_weights : dict, optional
+    transformer_weights : dict, default=None
         Multiplicative weights for features per transformer. The output of the
         transformer is multiplied by these weights. Keys are transformer names,
         values the weights.
 
-    verbose : boolean, optional(default=False)
+    verbose : bool, default=False
         If True, the time elapsed while fitting each transformer will be
         printed as it is completed.
 
@@ -124,12 +124,12 @@ boolean mask array or callable
         ``len(transformers_)==len(transformers)+1``, otherwise
         ``len(transformers_)==len(transformers)``.
 
-    named_transformers_ : Bunch object, a dictionary with attribute access
+    named_transformers_ : Bunch
         Read-only attribute to access any transformer by given name.
         Keys are transformer names and values are the fitted transformer
         objects.
 
-    sparse_output_ : boolean
+    sparse_output_ : bool
         Boolean flag indicating whether the output of ``transform`` is a
         sparse matrix or a dense numpy array, which depends on the output
         of the individual transformers and the `sparse_threshold` keyword.
@@ -206,13 +206,13 @@ boolean mask array or callable
 
         Parameters
         ----------
-        deep : boolean, optional
+        deep : bool, default=True
             If True, will return the parameters for this estimator and
             contained subobjects that are estimators.
 
         Returns
         -------
-        params : mapping of string to any
+        params : dict
             Parameter names mapped to their values.
         """
         return self._get_params('_transformers', deep=deep)
@@ -467,11 +467,11 @@ boolean mask array or callable
 
         Parameters
         ----------
-        X : array-like or DataFrame of shape [n_samples, n_features]
+        X : {array-like, dataframe} of shape (n_samples, n_features)
             Input data, of which specified subsets are used to fit the
             transformers.
 
-        y : array-like, shape (n_samples, ...), optional
+        y : array-like of shape (n_samples,), default=None
             Targets for supervised learning.
 
         Returns
@@ -490,16 +490,17 @@ boolean mask array or callable
 
         Parameters
         ----------
-        X : array-like or DataFrame of shape [n_samples, n_features]
+        X : {array-like, dataframe} of shape (n_samples, n_features)
             Input data, of which specified subsets are used to fit the
             transformers.
 
-        y : array-like, shape (n_samples, ...), optional
+        y : array-like of shape (n_samples,), default=None
             Targets for supervised learning.
 
         Returns
         -------
-        X_t : array-like or sparse matrix, shape (n_samples, sum_n_components)
+        X_t : {array-like, sparse matrix} of \
+            shape (n_samples, sum_n_components)
             hstack of results of transformers. sum_n_components is the
             sum of n_components (output dimension) over transformers. If
             any result is a sparse matrix, everything will be converted to
@@ -545,12 +546,13 @@ boolean mask array or callable
 
         Parameters
         ----------
-        X : array-like or DataFrame of shape [n_samples, n_features]
+        X : {array-like, dataframe} of shape (n_samples, n_features)
             The data to be transformed by subset.
 
         Returns
         -------
-        X_t : array-like or sparse matrix, shape (n_samples, sum_n_components)
+        X_t : {array-like, sparse matrix} of \
+            shape (n_samples, sum_n_components)
             hstack of results of transformers. sum_n_components is the
             sum of n_components (output dimension) over transformers. If
             any result is a sparse matrix, everything will be converted to
@@ -603,7 +605,7 @@ boolean mask array or callable
 
         Parameters
         ----------
-        Xs : List of numpy arrays, sparse arrays, or DataFrames
+        Xs : List of {array-like, sparse matrix, dataframe}
         """
         if self.sparse_output_:
             try:
@@ -670,16 +672,16 @@ def make_column_transformer(*transformers, **kwargs):
     Parameters
     ----------
     *transformers : tuples
-        Tuples of the form (transformer, column(s)) specifying the
+        Tuples of the form (transformer, columns) specifying the
         transformer objects to be applied to subsets of the data.
 
-        transformer : estimator or {'passthrough', 'drop'}
+        transformer : {'drop', 'passthrough'} or estimator
             Estimator must support :term:`fit` and :term:`transform`.
             Special-cased strings 'drop' and 'passthrough' are accepted as
             well, to indicate to drop the columns or to pass them through
             untransformed, respectively.
-        column(s) : string or int, array-like of string or int, slice, \
-boolean mask array or callable
+        columns : str,  array-like of str, int, array-like of int, slice, \
+            array-like of bool or callable
             Indexes the data on its second axis. Integers are interpreted as
             positional columns, while strings can reference DataFrame columns
             by name. A scalar string or int should be used where
@@ -688,7 +690,7 @@ boolean mask array or callable
             A callable is passed the input data `X` and can return any of the
             above.
 
-    remainder : {'drop', 'passthrough'} or estimator, default 'drop'
+    remainder : {'drop', 'passthrough'} or estimator, default='drop'
         By default, only the specified columns in `transformers` are
         transformed and combined in the output, and the non-specified
         columns are dropped. (default of ``'drop'``).
@@ -700,7 +702,7 @@ boolean mask array or callable
         non-specified columns will use the ``remainder`` estimator. The
         estimator must support :term:`fit` and :term:`transform`.
 
-    sparse_threshold : float, default = 0.3
+    sparse_threshold : float, default=0.3
         If the transformed output consists of a mix of sparse and dense data,
         it will be stacked as a sparse matrix if the density is lower than this
         value. Use ``sparse_threshold=0`` to always return dense.
@@ -708,13 +710,13 @@ boolean mask array or callable
         the stacked result will be sparse or dense, respectively, and this
         keyword will be ignored.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int, default=None
         Number of jobs to run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    verbose : boolean, optional(default=False)
+    verbose : bool, default=False
         If True, the time elapsed while fitting each transformer will be
         printed as it is completed.
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -605,7 +605,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
         Parameters
         ----------
-        Xs : List of {array-like, sparse matrix, dataframe}
+        Xs : list of {array-like, sparse matrix, dataframe}
         """
         if self.sparse_output_:
             try:

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -63,8 +63,8 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             Special-cased strings 'drop' and 'passthrough' are accepted as
             well, to indicate to drop the columns or to pass them through
             untransformed, respectively.
-        columns : str, array-like of str, int, array-like of int, \
-            array-like of bool, slice or callable \
+        columns :  str, array-like of str, int, array-like of int, \
+                array-like of bool, slice or callable
             Indexes the data on its second axis. Integers are interpreted as
             positional columns, while strings can reference DataFrame columns
             by name.  A scalar string or int should be used where
@@ -500,7 +500,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         Returns
         -------
         X_t : {array-like, sparse matrix} of \
-            shape (n_samples, sum_n_components)
+                shape (n_samples, sum_n_components)
             hstack of results of transformers. sum_n_components is the
             sum of n_components (output dimension) over transformers. If
             any result is a sparse matrix, everything will be converted to
@@ -552,7 +552,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         Returns
         -------
         X_t : {array-like, sparse matrix} of \
-            shape (n_samples, sum_n_components)
+                shape (n_samples, sum_n_components)
             hstack of results of transformers. sum_n_components is the
             sum of n_components (output dimension) over transformers. If
             any result is a sparse matrix, everything will be converted to
@@ -681,7 +681,7 @@ def make_column_transformer(*transformers, **kwargs):
             well, to indicate to drop the columns or to pass them through
             untransformed, respectively.
         columns : str,  array-like of str, int, array-like of int, slice, \
-            array-like of bool or callable
+                array-like of bool or callable
             Indexes the data on its second axis. Integers are interpreted as
             positional columns, while strings can reference DataFrame columns
             by name. A scalar string or int should be used where

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -471,7 +471,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             Input data, of which specified subsets are used to fit the
             transformers.
 
-        y : array-like of shape (n_samples,), default=None
+        y : array-like of shape (n_samples,...), default=None
             Targets for supervised learning.
 
         Returns

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -42,9 +42,10 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
 
     Parameters
     ----------
-    regressor : object, default=LinearRegression()
+    regressor : object, default=None
         Regressor object such as derived from ``RegressorMixin``. This
         regressor will automatically be cloned each time prior to fitting.
+        If regressor is ``None``, ``LinearRegression()`` is created and used.
 
     transformer : object, default=None
         Estimator object such as derived from ``TransformerMixin``. Cannot be
@@ -54,13 +55,13 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
         transformer will be cloned during fitting. Also, the transformer is
         restricting ``y`` to be a numpy array.
 
-    func : function, optional
+    func : function, default=None
         Function to apply to ``y`` before passing to ``fit``. Cannot be set at
         the same time as ``transformer``. The function needs to return a
         2-dimensional array. If ``func`` is ``None``, the function used will be
         the identity function.
 
-    inverse_func : function, optional
+    inverse_func : function, default=None
         Function to apply to the prediction of the regressor. Cannot be set at
         the same time as ``transformer`` as well. The function needs to return
         a 2-dimensional array. The inverse function is used to return
@@ -153,14 +154,14 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Training vector, where n_samples is the number of samples and
             n_features is the number of features.
 
-        y : array-like, shape (n_samples,)
+        y : array-like of shape (n_samples,)
             Target values.
 
-        **fit_params : dict of string -> object
+        **fit_params : dict
             Parameters passed to the ``fit`` method of the underlying
             regressor.
 
@@ -215,7 +216,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
 
         Returns
         -------
-        y_hat : array, shape = (n_samples,)
+        y_hat : ndarray of shape (n_samples,)
             Predicted values.
 
         """


### PR DESCRIPTION
#### Reference Issues/PRs
#15761 

#### What does this implement/fix? Explain your changes.

Cleans up parameter spec in compose, so it follows the convention outlined in the Contributing Guide.

Only changes in docstrings.