### PR TITLE
Fix TruncatedSVD.fit(X).transform(X) is not the same as .fit_transform(X)

### DIFF
--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -182,8 +182,12 @@ class TruncatedSVD(TransformerMixin, BaseEstimator):
 
         self.components_ = VT
 
+        if self.algorithm == "randomized" or self.tol > 0:
+            X_transformed = self.transform(X)
+        else:
+            X_transformed = U * Sigma
+
         # Calculate explained variance & explained variance ratio
-        X_transformed = U * Sigma
         self.explained_variance_ = exp_var = np.var(X_transformed, axis=0)
         if sp.issparse(X):
             _, full_var = mean_variance_axis(X, axis=0)

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -198,14 +198,18 @@ def test_fit_transform(X_sparse):
     # when: 1, algorithm="randomized", 2, algorithm="arpack" with tol > 0,
     # fit_transform(X) should equal to fit(X).transform(X)
 
-    svd1 = TruncatedSVD(n_components=5, n_iter=7, random_state=42, algorithm='randomized')
-    svd2 = TruncatedSVD(n_components=5, n_iter=7, random_state=42, algorithm='randomized')
+    svd1 = TruncatedSVD(n_components=5, n_iter=7, random_state=42,
+                        algorithm='randomized')
+    svd2 = TruncatedSVD(n_components=5, n_iter=7, random_state=42,
+                        algorithm='randomized')
     x1 = svd1.fit_transform(X_sparse)
     x2 = svd2.fit(X_sparse).transform(X_sparse)
     assert_almost_equal(x1, x2)
 
-    svd3 = TruncatedSVD(n_components=5, n_iter=7, random_state=42, algorithm='arpack', tol=1e-6)
-    svd4 = TruncatedSVD(n_components=5, n_iter=7, random_state=42, algorithm='arpack', tol=1e-6)
+    svd3 = TruncatedSVD(n_components=5, n_iter=7, random_state=42,
+                        algorithm='arpack', tol=1e-6)
+    svd4 = TruncatedSVD(n_components=5, n_iter=7, random_state=42,
+                        algorithm='arpack', tol=1e-6)
     x3 = svd3.fit_transform(X_sparse)
     x4 = svd4.fit(X_sparse).transform(X_sparse)
     assert_almost_equal(x3, x4)

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -7,6 +7,7 @@ import pytest
 
 from sklearn.decomposition import TruncatedSVD, PCA
 from sklearn.utils import check_random_state
+from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_less, assert_allclose
 
 SVD_SOLVERS = ['arpack', 'randomized']
@@ -191,3 +192,20 @@ def test_truncated_svd_eq_pca(X_sparse):
     assert_allclose(Xt_svd, Xt_pca, rtol=1e-9)
     assert_allclose(pca.mean_, 0, atol=1e-9)
     assert_allclose(svd.components_, pca.components_)
+
+
+def test_fit_transform(X_sparse):
+    # when: 1, algorithm="randomized", 2, algorithm="arpack" with tol > 0,
+    # fit_transform(X) should equal to fit(X).transform(X)
+
+    svd1 = TruncatedSVD(n_components=5, n_iter=7, random_state=42, algorithm='randomized')
+    svd2 = TruncatedSVD(n_components=5, n_iter=7, random_state=42, algorithm='randomized')
+    x1 = svd1.fit_transform(X_sparse)
+    x2 = svd2.fit(X_sparse).transform(X_sparse)
+    assert_almost_equal(x1, x2)
+
+    svd3 = TruncatedSVD(n_components=5, n_iter=7, random_state=42, algorithm='arpack', tol=1e-6)
+    svd4 = TruncatedSVD(n_components=5, n_iter=7, random_state=42, algorithm='arpack', tol=1e-6)
+    x3 = svd3.fit_transform(X_sparse)
+    x4 = svd4.fit(X_sparse).transform(X_sparse)
+    assert_almost_equal(x3, x4)


### PR DESCRIPTION
#### Reference Issues/PRs
Fix https://github.com/scikit-learn/scikit-learn/issues/15144


#### What does this implement/fix? Explain your changes.
`fit_transform` do the projection whenever algorithm="randomized" or when algorithm="arpack" with tol > 0

#### Any other comments?
