### PR TITLE
DOC promote shallow copy in the docs

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -43,13 +43,8 @@ feature, code or documentation improvement).
    `scikit-learn repository <https://github.com/scikit-learn/scikit-learn>`_ on
    Github.::
 
-        git clone git://github.com/scikit-learn/scikit-learn.git
+        git clone git://github.com/scikit-learn/scikit-learn.git  # add --depth 1 if your connection is slow
         cd scikit-learn
-
-   If you have issues downloading the complete history, you can instead clone a
-   shallow copy::
-
-        git clone --depth 1 git://github.com/scikit-learn/scikit-learn.git
 
    If you plan on submitting a pull-request, you should clone from your fork
    instead.

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -46,6 +46,11 @@ feature, code or documentation improvement).
         git clone git://github.com/scikit-learn/scikit-learn.git
         cd scikit-learn
 
+   If you have issues downloading the complete history, you can instead clone a
+   shallow copy::
+
+        git clone --depth 1 git://github.com/scikit-learn/scikit-learn.git
+
    If you plan on submitting a pull-request, you should clone from your fork
    instead.
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -210,13 +210,8 @@ how to set up your git repository:
 3. Clone your fork of the scikit-learn repo from your GitHub account to your
    local disk::
 
-       $ git clone git@github.com:YourLogin/scikit-learn.git
+       $ git clone git@github.com:YourLogin/scikit-learn.git  # add --depth 1 if your connection is slow
        $ cd scikit-learn
-
-   If you have issues downloading the complete history, you can instead clone a
-   shallow copy::
-
-       $ git clone --depth 1 git@github.com:YourLogin/scikit-learn.git
 
 4. Install the development dependencies::
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -213,6 +213,11 @@ how to set up your git repository:
        $ git clone git@github.com:YourLogin/scikit-learn.git
        $ cd scikit-learn
 
+   If you have issues downloading the complete history, you can instead clone a
+   shallow copy::
+
+       $ git clone --depth 1 git@github.com:YourLogin/scikit-learn.git
+
 4. Install the development dependencies::
 
        $ pip install cython pytest pytest-cov flake8


### PR DESCRIPTION
Fixes #16008

Seems like we rather promote a shallow copy instead of touching our git history. This PR puts that in the contributing guides.