### PR TITLE
Update nightly build URL and release staging config

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,4 +1,4 @@
---find-links https://sklearn-nightly.scdn8.secure.raxcdn.com scikit-learn
+--extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
 --pre
 matplotlib
 scikit-image

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -26,7 +26,7 @@ Installing a nightly build is the quickest way to:
 
 ::
 
-  pip install --pre -f https://sklearn-nightly.scdn8.secure.raxcdn.com scikit-learn
+  pip install --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
 
 
 .. _install_bleeding_edge:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,9 @@ filterwarnings =
 
 [wheelhouse_uploader]
 artifact_indexes=
-    # Wheels built by travis (only for specific tags):
+    # Wheels built by Azure Pipelines (only for specific tags):
     # https://github.com/MacPython/scikit-learn-wheels
-    http://wheels.scipy.org
+    https://pypi.anaconda.org/scikit-learn-wheels-staging/simple/scikit-learn/
 
 [flake8]
 # Default flake8 3.5 ignored flags


### PR DESCRIPTION
This should fix: #16412 and fix #16414.

This should be backported to the 0.22.X branch as soon as merged to update the /stable website.