### PR TITLE
[MRG] _get_estimators_indices() in BaseBagging class does not generate indices properly

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -23,7 +23,8 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-- :class:`ensemble.BaggingClassifier`, :class:`ensemble.BaggingRegressor` and :class:`ensemble.IsolationForest`. |Fix|
+- :class:`ensemble.BaggingClassifier`, :class:`ensemble.BaggingRegressor`,
+  and :class:`ensemble.IsolationForest`. |Fix|
 
 Details are listed in the changelog below.
 
@@ -138,9 +139,9 @@ Changelog
 
 - |Fix| Fixed a bug in :class:`ensemble.BaggingClassifier`,
   :class:`ensemble.BaggingRegressor` and :class:`ensemble.IsolationForest`
-  where the property `estimators_samples_` did not generate the proper indices
+  where the attribute `estimators_samples_` did not generate the proper indices
   used during `fit`.
-  :pr: `16437` by :user:`Jin-Hwan CHO <chofchof>`.
+  :pr:`16437` by :user:`Jin-Hwan CHO <chofchof>`.
 
 :mod:`sklearn.feature_extraction`
 .................................

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -23,7 +23,7 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-- list models here
+- :class:`ensemble.BaggingClassifier`, :class:`ensemble.BaggingRegressor` and :class:`ensemble.IsolationForest`. |Fix|
 
 Details are listed in the changelog below.
 
@@ -136,11 +136,11 @@ Changelog
   samples in the training set. :pr:`14516` by :user:`Johann Faouzi
   <johannfaouzi>`.
 
-- |Fix| Fixed a bug in :class:`ensemble._bagging.BaseBagging` method
-  ``_get_estimators_indices`` that does not generate indices properly. Both
-  this method and :func:`_parallel_build_estimators` are changed to use a seed
-  instead of a `RandomState` object. :pr: `16437` by :user:`Jin-Hwan CHO
-  <chofchof>`.
+- |Fix| Fixed a bug in :class:`ensemble.BaggingClassifier`,
+  :class:`ensemble.BaggingRegressor` and :class:`ensemble.IsolationForest`
+  where the property `estimators_samples_` did not generate the proper indices
+  used during `fit`.
+  :pr: `16437` by :user:`Jin-Hwan CHO <chofchof>`.
 
 :mod:`sklearn.feature_extraction`
 .................................

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -136,6 +136,12 @@ Changelog
   samples in the training set. :pr:`14516` by :user:`Johann Faouzi
   <johannfaouzi>`.
 
+- |Fix| Fixed a bug in :class:`ensemble._bagging.BaseBagging` method
+  ``_get_estimators_indices`` that does not generate indices properly. Both
+  this method and :func:`_parallel_build_estimators` are changed to use a seed
+  instead of a `RandomState` object. :pr: `16437` by :user:`Jin-Hwan CHO
+  <chofchof>`.
+
 :mod:`sklearn.feature_extraction`
 .................................
 

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -48,7 +48,7 @@ def _generate_bagging_indices(seed, bootstrap_features,
                               max_features, max_samples):
     """Randomly draw feature and sample indices."""
     # Get valid random state
-    random_state = np.random.RandomState(seed)
+    random_state = check_random_state(seed)
 
     # Draw indices
     feature_indices = _generate_indices(random_state, bootstrap_features,
@@ -82,12 +82,12 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
             print("Building estimator %d of %d for this parallel run "
                   "(total %d)..." % (i + 1, n_estimators, total_n_estimators))
 
-        random_state = np.random.RandomState(seeds[i])
+        random_state = seeds[i]
         estimator = ensemble._make_estimator(append=False,
                                              random_state=random_state)
 
         # Draw random feature, sample indices
-        features, indices = _generate_bagging_indices(seeds[i],
+        features, indices = _generate_bagging_indices(random_state,
                                                       bootstrap_features,
                                                       bootstrap, n_features,
                                                       n_samples, max_features,

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -43,12 +43,12 @@ def _generate_indices(random_state, bootstrap, n_population, n_samples):
     return indices
 
 
-def _generate_bagging_indices(seed, bootstrap_features,
+def _generate_bagging_indices(random_state, bootstrap_features,
                               bootstrap_samples, n_features, n_samples,
                               max_features, max_samples):
     """Randomly draw feature and sample indices."""
     # Get valid random state
-    random_state = check_random_state(seed)
+    random_state = check_random_state(random_state)
 
     # Draw indices
     feature_indices = _generate_indices(random_state, bootstrap_features,

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -43,12 +43,12 @@ def _generate_indices(random_state, bootstrap, n_population, n_samples):
     return indices
 
 
-def _generate_bagging_indices(random_state, bootstrap_features,
+def _generate_bagging_indices(seed, bootstrap_features,
                               bootstrap_samples, n_features, n_samples,
                               max_features, max_samples):
     """Randomly draw feature and sample indices."""
     # Get valid random state
-    random_state = check_random_state(random_state)
+    random_state = np.random.RandomState(seed)
 
     # Draw indices
     feature_indices = _generate_indices(random_state, bootstrap_features,
@@ -87,7 +87,7 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
                                              random_state=random_state)
 
         # Draw random feature, sample indices
-        features, indices = _generate_bagging_indices(random_state,
+        features, indices = _generate_bagging_indices(seeds[i],
                                                       bootstrap_features,
                                                       bootstrap, n_features,
                                                       n_samples, max_features,
@@ -405,9 +405,8 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
         for seed in self._seeds:
             # Operations accessing random_state must be performed identically
             # to those in `_parallel_build_estimators()`
-            random_state = np.random.RandomState(seed)
             feature_indices, sample_indices = _generate_bagging_indices(
-                random_state, self.bootstrap_features, self.bootstrap,
+                seed, self.bootstrap_features, self.bootstrap,
                 self.n_features_, self._n_samples, self._max_features,
                 self._max_samples)
 

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -885,16 +885,18 @@ def test_bagging_get_estimators_indices():
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/16436
 
-    X = np.zeros((13, 1))
+    rng = np.random.RandomState(0)
+    X = np.zeros((13, 4))
     y = np.arange(13)
 
     class MyEstimator(DecisionTreeRegressor):
+        """An estimator which will y indices information at fit."""
         def fit(self, X, y):
-            self.sample_indices = y
+            self._sample_indices = y
 
     clf = BaggingRegressor(base_estimator=MyEstimator(),
                            n_estimators=1, random_state=0)
     clf.fit(X, y)
 
-    assert_array_equal(clf.estimators_[0].sample_indices,
+    assert_array_equal(clf.estimators_[0]._sample_indices,
                        clf.estimators_samples_[0])

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -890,7 +890,7 @@ def test_bagging_get_estimators_indices():
     y = np.arange(13)
 
     class MyEstimator(DecisionTreeRegressor):
-        """An estimator which will y indices information at fit."""
+        """An estimator which stores y indices information at fit."""
         def fit(self, X, y):
             self._sample_indices = y
 

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -879,6 +879,7 @@ def test_bagging_small_max_features():
                                 max_features=0.3, random_state=1)
     bagging.fit(X, y)
 
+
 def test_bagging_get_estimators_indices():
     # Check that Bagging estimator can generate sample indices properly
 
@@ -889,7 +890,9 @@ def test_bagging_get_estimators_indices():
         def fit(self, X, y):
             self.sample_indices = y
 
-    clf = BaggingRegressor(base_estimator=MyEstimator(), n_estimators=1, random_state=0)
+    clf = BaggingRegressor(base_estimator=MyEstimator(),
+                           n_estimators=1, random_state=0)
     clf.fit(X, y)
 
-    assert_array_equal(clf.estimators_[0].sample_indices, clf.estimators_samples_[0])
+    assert_array_equal(clf.estimators_[0].sample_indices,
+                       clf.estimators_samples_[0])

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -886,7 +886,7 @@ def test_bagging_get_estimators_indices():
     # https://github.com/scikit-learn/scikit-learn/issues/16436
 
     rng = np.random.RandomState(0)
-    X = np.zeros((13, 4))
+    X = rng.randn(13, 4)
     y = np.arange(13)
 
     class MyEstimator(DecisionTreeRegressor):

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -882,6 +882,8 @@ def test_bagging_small_max_features():
 
 def test_bagging_get_estimators_indices():
     # Check that Bagging estimator can generate sample indices properly
+    # Non-regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/16436
 
     X = np.zeros((13, 1))
     y = np.arange(13)

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -878,3 +878,18 @@ def test_bagging_small_max_features():
     bagging = BaggingClassifier(LogisticRegression(),
                                 max_features=0.3, random_state=1)
     bagging.fit(X, y)
+
+def test_bagging_get_estimators_indices():
+    # Check that Bagging estimator can generate sample indices properly
+
+    X = np.zeros((13, 1))
+    y = np.arange(13)
+
+    class MyEstimator(DecisionTreeRegressor):
+        def fit(self, X, y):
+            self.sample_indices = y
+
+    clf = BaggingRegressor(base_estimator=MyEstimator(), n_estimators=1, random_state=0)
+    clf.fit(X, y)
+
+    assert_array_equal(clf.estimators_[0].sample_indices, clf.estimators_samples_[0])

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1668,7 +1668,7 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
     >>> reg = BaggingRegressor(extra_tree, random_state=0).fit(
     ...     X_train, y_train)
     >>> reg.score(X_test, y_test)
-    0.7788...
+    0.7447...
     """
     def __init__(self,
                  criterion="mse",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #16436.

#### What does this implement/fix? Explain your changes.

It solves the bug reported by the issue #16436, `_get_estimators_indices()` in `BaseBagging` class does not generate indices properly.

As Joel Nothman suggested, the seed is passed directly into `_generate_bagging_indices()` instead of the numpy `RandomState` object generated by the seed.

#### Any other comments?

None.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
