### PR TITLE
DOC Improves readability of kernel functions in SVM docs

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -456,13 +456,13 @@ The *kernel function* can be any of the following:
 
   * linear: :math:`\langle x, x'\rangle`.
 
-  * polynomial: :math:`(\gamma \langle x, x'\rangle + r)^d`.
+  * polynomial: :math:`(\gamma \langle x, x'\rangle + r)^d`, where
     :math:`d` is specified by keyword ``degree``, :math:`r` by ``coef0``.
 
-  * rbf: :math:`\exp(-\gamma \|x-x'\|^2)`. :math:`\gamma` is
+  * rbf: :math:`\exp(-\gamma \|x-x'\|^2)`, where :math:`\gamma` is
     specified by keyword ``gamma``, must be greater than 0.
 
-  * sigmoid (:math:`\tanh(\gamma \langle x,x'\rangle + r)`),
+  * sigmoid :math:`\tanh(\gamma \langle x,x'\rangle + r)`,
     where :math:`r` is specified by ``coef0``.
 
 Different kernels are specified by keyword kernel at initialization::


### PR DESCRIPTION
When reading docs on kernel functions in SVMs, on master, it looks like there is another product:

<img width="625" alt="Screen Shot 2020-02-12 at 11 44 53 AM" src="https://user-images.githubusercontent.com/5402633/74469236-420efd80-4e6a-11ea-8e4e-455221fa5c41.png">

This PR updates this by adding some words to visually separate the formula.

<img width="680" alt="Screen Shot 2020-02-13 at 2 14 00 PM" src="https://user-images.githubusercontent.com/5402633/74469659-1c362880-4e6b-11ea-9ce2-6c8f47ec2169.png">



