### PR TITLE
BUG fix behaviour in confusion_matrix with with empty array-like as input

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -196,7 +196,7 @@ Changelog
 ......................
 
 - |Fix| Fixed a bug in :func:`metrics.mean_squared_error` to not ignore
-  argument `squared` when argument `multioutput='raw_values'`. 
+  argument `squared` when argument `multioutput='raw_values'`.
   :pr:`16323` by :user:`Rushabh Vasani <rushabh-v>`
 
 - |Fix| Fixed a bug in :func:`metrics.mutual_info_score` where negative
@@ -204,7 +204,9 @@ Changelog
 
 - |Fix| Fixed a bug in :func:`metrics.confusion_matrix` that would raise
   an error when `y_true` and `y_pred` were length zero and `labels` was
-  not `None`. :pr:`16442` by `Kyle Parsons <parsons-kyle-89>`
+  not `None`. In addition, we raise an error when an empty list is given to
+  the `labels` parameter.
+  :pr:`16442` by `Kyle Parsons <parsons-kyle-89>`.
 
 :mod:`sklearn.model_selection`
 ..............................

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -202,6 +202,10 @@ Changelog
 - |Fix| Fixed a bug in :func:`metrics.mutual_info_score` where negative
   scores could be returned. :pr:`16362` by `Thomas Fan`_.
 
+- |Fix| Fixed a bug in :func:`metrics.confusion_matrix` that would raise
+  an error when `y_true` and `y_pred` were length zero and `labels` was
+  not `None`. :pr:`16442` by `Kyle Parsons <parsons-kyle-89>`
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -274,6 +274,9 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
 
     if labels is None:
         labels = unique_labels(y_true, y_pred)
+    elif len(y_true) == 0:
+        n_labels = len(labels)
+        return np.zeros((n_labels, n_labels), dtype=np.int)
     else:
         labels = np.asarray(labels)
         if np.all([l not in y_true for l in labels]):

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -279,9 +279,9 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
         n_labels = labels.size
         if n_labels == 0:
             raise ValueError("'labels' should contains at least one label.")
-        if y_true.size == 0:
+        elif y_true.size == 0:
             return np.zeros((n_labels, n_labels), dtype=np.int)
-        if np.all([l not in y_true for l in labels]):
+        elif np.all([l not in y_true for l in labels]):
             raise ValueError("At least one label specified must be in y_true")
 
     if sample_weight is None:

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -274,11 +274,13 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
 
     if labels is None:
         labels = unique_labels(y_true, y_pred)
-    elif y_true.size == 0:
-        n_labels = len(labels)
-        return np.zeros((n_labels, n_labels), dtype=np.int)
     else:
         labels = np.asarray(labels)
+        n_labels = labels.size
+        if n_labels == 0:
+            raise ValueError("'labels' should contains at least one label.")
+        if y_true.size == 0:
+            return np.zeros((n_labels, n_labels), dtype=np.int)
         if np.all([l not in y_true for l in labels]):
             raise ValueError("At least one label specified must be in y_true")
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -274,7 +274,7 @@ def confusion_matrix(y_true, y_pred, labels=None, sample_weight=None,
 
     if labels is None:
         labels = unique_labels(y_true, y_pred)
-    elif len(y_true) == 0:
+    elif y_true.size == 0:
         n_labels = len(labels)
         return np.zeros((n_labels, n_labels), dtype=np.int)
     else:

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -225,7 +225,14 @@ def test_confusion_matrix_contrast(pyplot):
     assert_allclose(disp.text_[1, 0].get_color(), max_color)
     assert_allclose(disp.text_[1, 1].get_color(), min_color)
 
+    # Non-regression test for #16442
+    cm = np.array([[0, 0], [0, 0]])
+    disp = ConfusionMatrixDisplay(cm, display_labels=[0, 1])
 
+    disp.plot(cmap=pyplot.cm.Blues)
+    min_color = pyplot.cm.Blues(0)
+    for text in disp.text_.ravel():
+        assert_allclose(text.get_color(), min_color)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -225,15 +225,6 @@ def test_confusion_matrix_contrast(pyplot):
     assert_allclose(disp.text_[1, 0].get_color(), max_color)
     assert_allclose(disp.text_[1, 1].get_color(), min_color)
 
-    # Non-regression test for #16442
-    cm = np.array([[0, 0], [0, 0]])
-    disp = ConfusionMatrixDisplay(cm, display_labels=[0, 1])
-
-    disp.plot(cmap=pyplot.cm.Blues)
-    min_color = pyplot.cm.Blues(0)
-    for text in disp.text_.ravel():
-        assert_allclose(text.get_color(), min_color)
-
 
 @pytest.mark.parametrize(
     "clf", [LogisticRegression(),

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -908,10 +908,17 @@ def test_confusion_matrix_multiclass_subset_labels():
     assert_array_equal(cm, [[18, 0],
                             [0, 0]])
 
-    # check for exception when none of the specified labels are in y_true
-    with pytest.raises(ValueError):
-        confusion_matrix(y_true, y_pred,
-                         labels=[extra_label, extra_label + 1])
+
+@pytest.mark.parametrize(
+    "labels, err_msg",
+    [([], "'labels' should contains at least one label."),
+     ([3, 4], "At least one label specified must be in y_true")],
+    ids=["empty list", "unknown labels"]
+)
+def test_confusion_matrix_error(labels, err_msg):
+    y_true, y_pred, _ = make_prediction(binary=False)
+    with pytest.raises(ValueError, match=err_msg):
+        confusion_matrix(y_true, y_pred, labels=labels)
 
 
 @pytest.mark.parametrize(
@@ -921,7 +928,7 @@ def test_confusion_matrix_multiclass_subset_labels():
 def test_confusion_matrix_on_zero_length_input(labels):
     expected_n_classes = len(labels) if labels else 0
     expected = np.zeros((expected_n_classes, expected_n_classes), dtype=np.int)
-    cm = confusion_matrix([], [], labels)
+    cm = confusion_matrix([], [], labels=labels)
     assert_array_equal(cm, expected)
 
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -919,9 +919,8 @@ def test_confusion_matrix_multiclass_subset_labels():
     ids=['None', 'binary', 'multiclass']
 )
 def test_confusion_matrix_on_zero_length_input(labels):
-    labels = [] if not labels else labels
-    n_classes = len(labels)
-    expected = np.zeros((n_classes, n_classes), dtype=np.int)
+    expected_n_classes = len(labels) if labels else 0
+    expected = np.zeros((expected_n_classes, expected_n_classes), dtype=np.int)
     cm = confusion_matrix([], [], labels)
     assert_array_equal(cm, expected)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -914,6 +914,18 @@ def test_confusion_matrix_multiclass_subset_labels():
                          labels=[extra_label, extra_label + 1])
 
 
+@pytest.mark.parametrize(
+    'labels', (None, [0, 1], [0, 1, 2]),
+    ids=['labels None', 'binary classification', 'three way classification']
+)
+def test_confusion_matrix_on_zero_length_input(labels):
+    labels = [] if not labels else labels
+    n_classes = len(labels)
+    expected = np.zeros((n_classes, n_classes))
+    cm = confusion_matrix([], [], labels)
+    assert_array_equal(cm, expected)
+
+
 def test_confusion_matrix_dtype():
     y = [0, 1, 1]
     weight = np.ones(len(y))

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -921,7 +921,7 @@ def test_confusion_matrix_multiclass_subset_labels():
 def test_confusion_matrix_on_zero_length_input(labels):
     labels = [] if not labels else labels
     n_classes = len(labels)
-    expected = np.zeros((n_classes, n_classes))
+    expected = np.zeros((n_classes, n_classes), dtype=np.int)
     cm = confusion_matrix([], [], labels)
     assert_array_equal(cm, expected)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -916,7 +916,7 @@ def test_confusion_matrix_multiclass_subset_labels():
 
 @pytest.mark.parametrize(
     'labels', (None, [0, 1], [0, 1, 2]),
-    ids=['labels None', 'binary classification', 'three way classification']
+    ids=['None', 'binary', 'multiclass']
 )
 def test_confusion_matrix_on_zero_length_input(labels):
     labels = [] if not labels else labels


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Fixes #16432 

#### What does this implement/fix? Explain your changes.

Currently on master `confusion_matrix` raises a `ValueError` when `y_true` and `y_pred` are empty and `labels` is not `None`.  

```python
from sklearn.metrics import confusion_matrix

confusion_matrix([], [])
# returns a 0x0 numpy array of dtype int64

confusion_matrix([], [], labels=[True, False])
# raises ValueError
```
With the change in this PR, the second case will return an nxn numpy array of zeros.  This is correct with respect to the definition of confusion matrix given in the documentation.

#### Any other comments?

This change should be especially useful to users using `confusion_matrix` in automated reporting.  Automated reports will sometimes (correctly) be run on datasets of size 0.  In this case allowing `confusion_matrix` to correctly return an nxn matrix of zeros rather than raising will eliminate the need for the user to write a special case.

