### PR TITLE
BUG avoid nan variance with sparse input in StandardScaler

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -258,10 +258,8 @@ Changelog
   each feature with two categories. :pr:`#16245`
   by :user:`Rushabh Vasani <rushabh-v>`.
 
-- |Fix| Fix a bug in :class:`preprocessing.StandardScaler` reporting a variance
-  equal to `np.nan` with sparse matrices as input. It was only the case when
-  the number of samples during a `partial_fit` call would be greater than the
-  total number of samples seen in the previous call.
+- |Fix| Fix a bug in :class:`preprocessing.StandardScaler` which was computing
+  falsely statistics when calling `partial_fit` on sparse inputs.
   :pr:`16466` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.svm`

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -258,10 +258,9 @@ Changelog
   each feature with two categories. :pr:`#16245`
   by :user:`Rushabh Vasani <rushabh-v>`.
 
-- |Fix| Fix an undesirable integer division leading to potential division by
-  zero and a variance equal to `np.nan` in
-  :class:`preprocessing.StandardScaler`.
-  :pr:``
+- |Fix| Fix a bug in :class:`preprocessing.StandardScaler` reporting a variance
+  equal to `np.nan` with sparse matrices as input.
+  :pr:`16466` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.svm`
 ..................

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -259,7 +259,9 @@ Changelog
   by :user:`Rushabh Vasani <rushabh-v>`.
 
 - |Fix| Fix a bug in :class:`preprocessing.StandardScaler` reporting a variance
-  equal to `np.nan` with sparse matrices as input.
+  equal to `np.nan` with sparse matrices as input. It was only the case when
+  the number of samples during a `partial_fit` call would be greater than the
+  total number of samples seen in the previous call.
   :pr:`16466` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.svm`

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -258,8 +258,8 @@ Changelog
   each feature with two categories. :pr:`#16245`
   by :user:`Rushabh Vasani <rushabh-v>`.
 
-- |Fix| Fix a bug in :class:`preprocessing.StandardScaler` which was computing
-  falsely statistics when calling `partial_fit` on sparse inputs.
+- |Fix| Fix a bug in :class:`preprocessing.StandardScaler` which was incorrectly
+  computing statistics when calling `partial_fit` on sparse inputs.
   :pr:`16466` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.svm`

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -258,6 +258,11 @@ Changelog
   each feature with two categories. :pr:`#16245`
   by :user:`Rushabh Vasani <rushabh-v>`.
 
+- |Fix| Fix an undesirable integer division leading to potential division by
+  zero and a variance equal to `np.nan` in
+  :class:`preprocessing.StandardScaler`.
+  :pr:``
+
 :mod:`sklearn.svm`
 ..................
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2473,15 +2473,15 @@ def test_power_transformer_copy_False(method, standardize):
     assert X_trans is X_inv_trans
 
 
-def test_standard_scaler_sparse_finite_variance():
+@pytest.mark.parametrize(
+    "X_2",
+    [sparse.random(10, 1, density=0.8, random_state=0),
+     sparse.csr_matrix(np.full((10, 1), fill_value=np.nan))]
+)
+def test_standard_scaler_sparse_partial_fit_finite_variance(X_2):
     # non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/16448
-    # Check that we don't have implicit integer casting leading to division by
-    # zero and therefore to NaN. It only happened when the sum of the samples
-    # seen is smaller than the number of samples in `X` when calling
-    # partial_fit()
     X_1 = sparse.random(5, 1, density=0.8)
-    X_2 = sparse.random(10, 1, density=0.8)
     scaler = StandardScaler(with_mean=False)
     scaler.fit(X_1).partial_fit(X_2)
     assert np.isfinite(scaler.var_[0])

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2471,3 +2471,41 @@ def test_power_transformer_copy_False(method, standardize):
 
     X_inv_trans = pt.inverse_transform(X_trans)
     assert X_trans is X_inv_trans
+
+def test_standard_scaler_sparse_finite_variance():
+    # non-regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/16448
+    # check that we don't have implicit integer casting leading to division by
+    # zero and therefore to NaN
+    arr0 = sparse.coo_matrix(
+        np.array([[-0.33333334],
+                  [ 0.33333334],
+                  [ 0.        ],
+                  [-0.6666667 ],
+                  [ 1.        ],
+                  [-0.33333334],
+                  [ 0.        ],
+                  [ 0.2       ],
+                  [-0.2       ]], dtype=np.float32)
+    )
+    arr1 = sparse.coo_matrix(
+        np.array([[-0.5272109 ],
+                  [ 0.1904762 ],
+                  [ 0.21428572],
+                  [ 0.12244898],
+                  [-0.08333334],
+                  [-0.16666667],
+                  [ 0.25      ],
+                  [ 0.        ],
+                  [-0.21428572],
+                  [-0.5714286 ],
+                  [ 1.0714285 ],
+                  [-0.2857143 ],
+                  [-0.07142857],
+                  [ 0.        ],
+                  [ 0.16666667],
+                  [-0.0952381 ]], dtype=np.float32)
+    )
+    scaler = StandardScaler(with_mean=False)
+    scaler.fit(arr0).partial_fit(arr1)
+    assert np.isfinite(scaler.var_[0])

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2472,40 +2472,16 @@ def test_power_transformer_copy_False(method, standardize):
     X_inv_trans = pt.inverse_transform(X_trans)
     assert X_trans is X_inv_trans
 
+
 def test_standard_scaler_sparse_finite_variance():
     # non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/16448
-    # check that we don't have implicit integer casting leading to division by
-    # zero and therefore to NaN
-    arr0 = sparse.coo_matrix(
-        np.array([[-0.33333334],
-                  [ 0.33333334],
-                  [ 0.        ],
-                  [-0.6666667 ],
-                  [ 1.        ],
-                  [-0.33333334],
-                  [ 0.        ],
-                  [ 0.2       ],
-                  [-0.2       ]], dtype=np.float32)
-    )
-    arr1 = sparse.coo_matrix(
-        np.array([[-0.5272109 ],
-                  [ 0.1904762 ],
-                  [ 0.21428572],
-                  [ 0.12244898],
-                  [-0.08333334],
-                  [-0.16666667],
-                  [ 0.25      ],
-                  [ 0.        ],
-                  [-0.21428572],
-                  [-0.5714286 ],
-                  [ 1.0714285 ],
-                  [-0.2857143 ],
-                  [-0.07142857],
-                  [ 0.        ],
-                  [ 0.16666667],
-                  [-0.0952381 ]], dtype=np.float32)
-    )
+    # Check that we don't have implicit integer casting leading to division by
+    # zero and therefore to NaN. It only happened when the sum of the samples
+    # seen is smaller than the number of samples in `X` when calling
+    # partial_fit()
+    X_1 = sparse.random(5, 1, density=0.8)
+    X_2 = sparse.random(10, 1, density=0.8)
     scaler = StandardScaler(with_mean=False)
-    scaler.fit(arr0).partial_fit(arr1)
+    scaler.fit(X_1).partial_fit(X_2)
     assert np.isfinite(scaler.var_[0])

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -334,23 +334,26 @@ def _incr_mean_variance_axis0(np.ndarray[floating, ndim=1] X_data,
 
     # Next passes
     for i in range(n_features):
-        updated_n[i] = last_n[i] + new_n[i]
-        last_over_new_n[i] = dtype(last_n[i]) / dtype(new_n[i])
-
-    # Unnormalized stats
-    for i in range(n_features):
-        last_mean[i] *= last_n[i]
-        last_var[i] *= last_n[i]
-        new_mean[i] *= new_n[i]
-        new_var[i] *= new_n[i]
-
-    # Update stats
-    for i in range(n_features):
-        updated_var[i] = (last_var[i] + new_var[i] +
-                          last_over_new_n[i] / updated_n[i] *
-                          (last_mean[i] / last_over_new_n[i] - new_mean[i])**2)
-        updated_mean[i] = (last_mean[i] + new_mean[i]) / updated_n[i]
-        updated_var[i] /= updated_n[i]
+        if new_n[i] > 0:
+            updated_n[i] = last_n[i] + new_n[i]
+            last_over_new_n[i] = dtype(last_n[i]) / dtype(new_n[i])
+            # Unnormalized stats
+            last_mean[i] *= last_n[i]
+            last_var[i] *= last_n[i]
+            new_mean[i] *= new_n[i]
+            new_var[i] *= new_n[i]
+            # Update stats
+            updated_var[i] = (
+                last_var[i] + new_var[i] +
+                last_over_new_n[i] / updated_n[i] *
+                (last_mean[i] / last_over_new_n[i] - new_mean[i])**2
+            )
+            updated_mean[i] = (last_mean[i] + new_mean[i]) / updated_n[i]
+            updated_var[i] /= updated_n[i]
+        else:
+            updated_var[i] = last_var[i]
+            updated_mean[i] = last_mean[i]
+            updated_n[i] = last_n[i]
 
     return updated_mean, updated_var, updated_n
 

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -335,7 +335,7 @@ def _incr_mean_variance_axis0(np.ndarray[floating, ndim=1] X_data,
     # Next passes
     for i in range(n_features):
         updated_n[i] = last_n[i] + new_n[i]
-        last_over_new_n[i] = last_n[i] / new_n[i]
+        last_over_new_n[i] = dtype(last_n[i]) / dtype(new_n[i])
 
     # Unnormalized stats
     for i in range(n_features):

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -150,28 +150,60 @@ def test_incr_mean_variance_axis():
                 assert_array_equal(X.shape[axis], n_incr)
 
 
-def test_incr_mean_variance_axis_var_nan():
+@pytest.mark.parametrize(
+    "X1, X2",
+    [
+        (sp.random(5, 2, density=0.8, random_state=0).tocsr(),
+         sp.random(13, 2, density=0.8, random_state=0).tocsr()),
+        (sp.random(5, 2, density=0.8, random_state=0).tocsr(),
+         sp.hstack([sp.csr_matrix(np.full((13, 1), fill_value=np.nan)),
+                    sp.random(13, 1, density=0.8, random_state=42)],
+                   format="csr"))
+    ]
+)
+def test_incr_mean_variance_axis_equivalence_mean_variance(X1, X2):
     # non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/16448
-    # check that we don't have implicit integer casting leading to division by
-    # zero and therefore variance which is NaN. It only happened when the sum
-    # of sample from t=0 to t=i-1 is smaller than the number of sample at time
-    # i
+    # check that computing the incremental mean and variance is equivalent to
+    # computing the mean and variance on the stacked dataset.
     axis = 0
-    # initialize the statistics
-    X = sp.random(5, 1, density=0.8).tocsr()
-    last_mean, last_var = np.zeros(X.shape[1]), np.zeros(X.shape[1])
-    last_n = np.zeros(X.shape[1], dtype=np.int64)
-    update_mean, update_var, update_n = incr_mean_variance_axis(
-        X, axis, last_mean, last_var, last_n
+    last_mean, last_var = np.zeros(X1.shape[1]), np.zeros(X1.shape[1])
+    last_n = np.zeros(X1.shape[1], dtype=np.int64)
+    updated_mean, updated_var, updated_n = incr_mean_variance_axis(
+        X1, axis, last_mean, last_var, last_n
     )
-    X = sp.random(10, 1, density=0.8).tocsr()
-    update_mean, update_var, update_n = incr_mean_variance_axis(
-        X, axis, update_mean, update_var, update_n
+    updated_mean, updated_var, updated_n = incr_mean_variance_axis(
+        X2, axis, updated_mean, updated_var, updated_n
     )
-    assert np.isfinite(update_mean[0])
-    assert np.isfinite(update_var[0])
-    assert update_n[0] == 15
+    X = sp.vstack([X1, X2])
+    assert_allclose(updated_mean, np.nanmean(X.A, axis=axis))
+    assert_allclose(updated_var, np.nanvar(X.A, axis=axis))
+    assert_allclose(updated_n, np.count_nonzero(~np.isnan(X.A), axis=0))
+
+
+@pytest.mark.parametrize(
+    "X2",
+    [sp.random(0, 1, density=0.8, random_state=0).tocsr(),
+     sp.csr_matrix(np.full((3, 1), fill_value=np.nan))],
+    ids=["empty", "full nan"]
+)
+def test_incr_mean_variance_no_new_n(X2):
+    # check the behaviour when we update the variance with an empty
+    # (or only NaN) column
+    axis = 0
+    X1 = sp.random(5, 1, density=0.8, random_state=0).tocsr()
+    last_mean, last_var = np.zeros(X1.shape[1]), np.zeros(X1.shape[1])
+    last_n = np.zeros(X1.shape[1], dtype=np.int64)
+    last_mean, last_var, last_n = incr_mean_variance_axis(
+        X1, axis, last_mean, last_var, last_n
+    )
+    # update statistic with a column which should ignored
+    updated_mean, updated_var, updated_n = incr_mean_variance_axis(
+        X2, axis, last_mean, last_var, last_n
+    )
+    assert_allclose(updated_mean, last_mean)
+    assert_allclose(updated_var, last_var)
+    assert_allclose(updated_n, last_n)
 
 
 @pytest.mark.parametrize("axis", [0, 1])

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -153,9 +153,9 @@ def test_incr_mean_variance_axis():
 @pytest.mark.parametrize(
     "X1, X2",
     [
-        (sp.random(5, 2, density=0.8, random_state=0).tocsr(),
-         sp.random(13, 2, density=0.8, random_state=0).tocsr()),
-        (sp.random(5, 2, density=0.8, random_state=0).tocsr(),
+        (sp.random(5, 2, density=0.8, format='csr', random_state=0),
+         sp.random(13, 2, density=0.8, format='csr', random_state=0)),
+        (sp.random(5, 2, density=0.8, format='csr', random_state=0),
          sp.hstack([sp.csr_matrix(np.full((13, 1), fill_value=np.nan)),
                     sp.random(13, 1, density=0.8, random_state=42)],
                    format="csr"))

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -161,7 +161,7 @@ def test_incr_mean_variance_axis_var_nan():
     # initialize the statistics
     X = sp.random(5, 1, density=0.8).tocsr()
     last_mean, last_var = np.zeros(X.shape[1]), np.zeros(X.shape[1])
-    last_n = np.zeros(X.shape[1], dtype=int)
+    last_n = np.zeros(X.shape[1], dtype=np.int64)
     update_mean, update_var, update_n = incr_mean_variance_axis(
         X, axis, last_mean, last_var, last_n
     )

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -181,17 +181,11 @@ def test_incr_mean_variance_axis_equivalence_mean_variance(X1, X2):
     assert_allclose(updated_n, np.count_nonzero(~np.isnan(X.A), axis=0))
 
 
-@pytest.mark.parametrize(
-    "X2",
-    [sp.random(0, 1, density=0.8, random_state=0).tocsr(),
-     sp.csr_matrix(np.full((3, 1), fill_value=np.nan))],
-    ids=["empty", "full nan"]
-)
-def test_incr_mean_variance_no_new_n(X2):
-    # check the behaviour when we update the variance with an empty
-    # (or only NaN) column
+def test_incr_mean_variance_no_new_n():
+    # check the behaviour when we update the variance with an empty matrix
     axis = 0
     X1 = sp.random(5, 1, density=0.8, random_state=0).tocsr()
+    X2 = sp.random(0, 1, density=0.8, random_state=0).tocsr()
     last_mean, last_var = np.zeros(X1.shape[1]), np.zeros(X1.shape[1])
     last_n = np.zeros(X1.shape[1], dtype=np.int64)
     last_mean, last_var, last_n = incr_mean_variance_axis(


### PR DESCRIPTION
closes #16448 

Some issues due to expectations regarding integer casting. The statistics where wrongly reported due to this C division casting.