### PR TITLE
DOC use make_column_selector inside the mixed type example

### DIFF
--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -90,11 +90,11 @@ print("model score: %.3f" % clf.score(X_test, y_test))
 ###############################################################################
 # Use ``ColumnTransformer`` by selecting column by data types
 ###############################################################################
-# When dealing with cleaned dataset, the preprocessing can be automatic by
+# When dealing with a cleaned dataset, the preprocessing can be automatic by
 # using the data types of the column to decide whether to treat a column as a
-# numerical or categorical features.
+# numerical or categorical feature.
 # :func:`sklearn.compose.make_column_selector` gives this possibility.
-# First, let's only select a subset of columns to ease the simplify our
+# First, let's only select a subset of columns to simplify our
 # example.
 
 subset_feature = ['embarked', 'sex', 'pclass', 'age', 'fare']
@@ -107,14 +107,14 @@ X.info()
 
 ###############################################################################
 # We can observe that the `embarked` and `sex` columns were tagged as
-# `category` columns when lading the data with ``fetch_openml``. Therefore, we
+# `category` columns when loading the data with ``fetch_openml``. Therefore, we
 # can use this information to dispatch the categorical columns to the
 # ``categorical_transformer`` and the remaining columns to the
 # ``numerical_transformer``.
 
 ###############################################################################
-# .. note:: In practise, you will have to handle yourself the column data type.
-# If you want some columnw to be considered as `category`, you will have to
+# .. note:: In practice, you will have to handle yourself the column data type.
+# If you want some columns to be considered as `category`, you will have to
 # convert them into categorical columns. If you are using pandas, you can refer
 # to their documentation regarding `Categorical data
 # <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_.

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -48,13 +48,16 @@ X, y = fetch_openml("titanic", version=1, as_frame=True, return_X_y=True)
 # Use ``ColumnTransformer`` by selecting column by names
 ###############################################################################
 # We will train our classifier with the following features:
+#
 # Numeric Features:
-# - age: float.
-# - fare: float.
+# * ``age``: float;
+# * ``fare``: float.
+#
 # Categorical Features:
-# - embarked: categories encoded as strings {'C', 'S', 'Q'}.
-# - sex: categories encoded as strings {'female', 'male'}.
-# - pclass: ordinal integers {1, 2, 3}.
+# * ``embarked``: categories encoded as strings ``{'C', 'S', 'Q'}``;
+# * ``sex``: categories encoded as strings ``{'female', 'male'}``;
+# * ``pclass``: ordinal integers ``{1, 2, 3}``.
+#
 # We create the preprocessing pipelines for both numeric and categorical data.
 
 numeric_features = ['age', 'fare']

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -98,7 +98,7 @@ X = X[subset_feature]
 ###############################################################################
 # Then, we introspect the information regarding each column data type.
 
-print(X.info())
+X.info()
 
 ###############################################################################
 # We can observe that the "embarked" and "sex" columns were tagged as

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -110,11 +110,10 @@ print(X.info())
 # to some specific columns.
 
 from sklearn.compose import make_column_selector as selector
-from pandas.api.types import CategoricalDtype
 
 preprocessor = ColumnTransformer(transformers=[
-    ('num', numeric_transformer, selector(dtype_exclude=CategoricalDtype)),
-    ('cat', categorical_transformer, selector(dtype_include='category'))
+    ('num', numeric_transformer, selector(dtype_exclude="category")),
+    ('cat', categorical_transformer, selector(dtype_include="category"))
 ])
 
 # Reproduce the identical fit/score process

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -114,10 +114,10 @@ X.info()
 
 ###############################################################################
 # .. note:: In practice, you will have to handle yourself the column data type.
-# If you want some columns to be considered as `category`, you will have to
-# convert them into categorical columns. If you are using pandas, you can refer
-# to their documentation regarding `Categorical data
-# <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_.
+#    If you want some columns to be considered as `category`, you will have to
+#    convert them into categorical columns. If you are using pandas, you can
+#    refer to their documentation regarding `Categorical data
+#    <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_.
 
 from sklearn.compose import make_column_selector as selector
 

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -50,10 +50,12 @@ X, y = fetch_openml("titanic", version=1, as_frame=True, return_X_y=True)
 # We will train our classifier with the following features:
 #
 # Numeric Features:
+#
 # * ``age``: float;
 # * ``fare``: float.
 #
 # Categorical Features:
+#
 # * ``embarked``: categories encoded as strings ``{'C', 'S', 'Q'}``;
 # * ``sex``: categories encoded as strings ``{'female', 'male'}``;
 # * ``pclass``: ordinal integers ``{1, 2, 3}``.

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -101,13 +101,18 @@ X = X[subset_feature]
 X.info()
 
 ###############################################################################
-# We can observe that the "embarked" and "sex" columns were tagged as
-# "categorical" columns when calling ``fetch_openml``. Therefore, we can use
-# this information to dispatch the categorical columns to the
+# We can observe that the `embarked` and `sex` columns were tagged as
+# `category` columns when lading the data with ``fetch_openml``. Therefore, we
+# can use this information to dispatch the categorical columns to the
 # ``categorical_transformer`` and the remaining columns to the
 # ``numerical_transformer``.
-# Note that in practise, it is hope to you to affect the "categorical" dtype
-# to some specific columns.
+
+###############################################################################
+# .. note:: In practise, you will have to handle yourself the column data type.
+# If you want some columnw to be considered as `category`, you will have to
+# convert them into categorical columns. If you are using pandas, you can refer
+# to their documentation regarding `Categorical data
+# <https://pandas.pydata.org/pandas-docs/stable/user_guide/categorical.html>`_.
 
 from sklearn.compose import make_column_selector as selector
 

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -114,7 +114,7 @@ from pandas.api.types import CategoricalDtype
 
 preprocessor = ColumnTransformer(transformers=[
     ('num', numeric_transformer, selector(dtype_exclude=CategoricalDtype)),
-    ('cat', categorical_transformer, selector(dtype_include=CategoricalDtype))
+    ('cat', categorical_transformer, selector(dtype_include='category'))
 ])
 
 # Reproduce the identical fit/score process


### PR DESCRIPTION
I think that we should illustrate the usage of `make_column_selector` which might be hidden in the documentation since it is not used in any example. I propose to add a section in the "mixed types" example using the `titanic` dataset.