### PR TITLE
ENH: Uses int for encoding y in histogram gradient boosting

### DIFF
--- a/benchmarks/bench_hist_gradient_boosting.py
+++ b/benchmarks/bench_hist_gradient_boosting.py
@@ -79,7 +79,7 @@ def one_run(n_samples):
                     max_iter=n_trees,
                     max_bins=max_bins,
                     max_leaf_nodes=n_leaf_nodes,
-                    n_iter_no_change=None,
+                    early_stopping=False,
                     random_state=0,
                     verbose=0)
     loss = args.loss

--- a/benchmarks/bench_hist_gradient_boosting.py
+++ b/benchmarks/bench_hist_gradient_boosting.py
@@ -79,7 +79,7 @@ def one_run(n_samples):
                     max_iter=n_trees,
                     max_bins=max_bins,
                     max_leaf_nodes=n_leaf_nodes,
-                    early_stopping=False,
+                    n_iter_no_change=None,
                     random_state=0,
                     verbose=0)
     loss = args.loss

--- a/sklearn/ensemble/_hist_gradient_boosting/_loss.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_loss.pyx
@@ -14,6 +14,7 @@ from libc.math cimport exp
 
 from .common cimport Y_DTYPE_C
 from .common cimport G_H_DTYPE_C
+from .common cimport Y_CLF_DTYPE_C
 
 
 def _update_gradients_least_squares(
@@ -48,7 +49,7 @@ def _update_gradients_least_absolute_deviation(
 def _update_gradients_hessians_binary_crossentropy(
         G_H_DTYPE_C [::1] gradients,  # OUT
         G_H_DTYPE_C [::1] hessians,  # OUT
-        const Y_DTYPE_C [::1] y_true,  # IN
+        const Y_CLF_DTYPE_C [::1] y_true,  # IN
         const Y_DTYPE_C [::1] raw_predictions):  # IN
     cdef:
         int n_samples
@@ -65,7 +66,7 @@ def _update_gradients_hessians_binary_crossentropy(
 def _update_gradients_hessians_categorical_crossentropy(
         G_H_DTYPE_C [:, ::1] gradients,  # OUT
         G_H_DTYPE_C [:, ::1] hessians,  # OUT
-        const Y_DTYPE_C [::1] y_true,  # IN
+        const Y_CLF_DTYPE_C [::1] y_true,  # IN
         const Y_DTYPE_C [:, ::1] raw_predictions):  # IN
     cdef:
         int prediction_dim = raw_predictions.shape[0]

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pxd
@@ -6,6 +6,7 @@ cimport numpy as np
 ctypedef np.npy_float64 X_DTYPE_C
 ctypedef np.npy_uint8 X_BINNED_DTYPE_C
 ctypedef np.npy_float64 Y_DTYPE_C
+ctypedef np.npy_int32 Y_CLF_DTYPE_C
 ctypedef np.npy_float32 G_H_DTYPE_C
 
 cdef packed struct hist_struct:

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pyx
@@ -4,6 +4,7 @@ import numpy as np
 # dtype for leaf values, gains, and sums of gradients / hessians. The gradients
 # and hessians arrays are stored as floats to avoid using too much memory.
 Y_DTYPE = np.float64
+Y_CLF_DTYPE = np.int32
 X_DTYPE = np.float64
 X_BINNED_DTYPE = np.uint8  # hence max_bins == 256
 # dtype for gradients and hessians arrays

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -15,7 +15,7 @@ from ...metrics import check_scoring
 from ...model_selection import train_test_split
 from ...preprocessing import LabelEncoder
 from ._gradient_boosting import _update_raw_predictions
-from .common import Y_DTYPE, X_DTYPE, X_BINNED_DTYPE
+from .common import Y_DTYPE, X_DTYPE, X_BINNED_DTYPE, Y_CLF_DTYPE
 
 from .binning import _BinMapper
 from .grower import TreeGrower
@@ -1055,7 +1055,7 @@ class HistGradientBoostingClassifier(BaseHistGradientBoosting,
         # only 1 tree for binary classification. For multiclass classification,
         # we build 1 tree per class.
         self.n_trees_per_iteration_ = 1 if n_classes <= 2 else n_classes
-        encoded_y = encoded_y.astype(Y_DTYPE, copy=False)
+        encoded_y = encoded_y.astype(Y_CLF_DTYPE, copy=False)
         return encoded_y
 
     def _get_loss(self):

--- a/sklearn/ensemble/_hist_gradient_boosting/loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/loss.py
@@ -240,7 +240,7 @@ class BinaryCrossEntropy(BaseLoss):
                 " classification with n_classes=%d, use"
                 " loss='categorical_crossentropy' instead" % prediction_dim)
         proba_positive_class = np.mean(y_train)
-        eps = np.finfo(y_train.dtype).eps
+        eps = np.finfo(proba_positive_class.dtype).eps
         proba_positive_class = np.clip(proba_positive_class, eps, 1 - eps)
         # log(x / 1 - x) is the anti function of sigmoid, or the link function
         # of the Binomial model.
@@ -288,7 +288,7 @@ class CategoricalCrossEntropy(BaseLoss):
 
     def get_baseline_prediction(self, y_train, prediction_dim):
         init_value = np.zeros(shape=(prediction_dim, 1), dtype=Y_DTYPE)
-        eps = np.finfo(y_train.dtype).eps
+        eps = np.finfo(init_value.dtype).eps
         for k in range(prediction_dim):
             proba_kth_class = np.mean(y_train == k)
             proba_kth_class = np.clip(proba_kth_class, eps, 1 - eps)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -63,8 +63,7 @@ def test_derivatives(loss, x0, y_true):
     # using Halley's method with the first and second order derivatives
     # computed by the Loss instance.
 
-    if loss.endswith('crossentropy'):
-        y_dtype = Y_CLF_DTYPE
+    y_dtype = Y_CLF_DTYPE if loss.endswith('crossentropy') else Y_DTYPE
 
     loss = _LOSSES[loss]()
     y_true = np.array([y_true], dtype=y_dtype)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -8,6 +8,7 @@ import pytest
 
 from sklearn.ensemble._hist_gradient_boosting.loss import _LOSSES
 from sklearn.ensemble._hist_gradient_boosting.common import Y_DTYPE
+from sklearn.ensemble._hist_gradient_boosting.common import Y_CLF_DTYPE
 from sklearn.ensemble._hist_gradient_boosting.common import G_H_DTYPE
 
 
@@ -62,8 +63,11 @@ def test_derivatives(loss, x0, y_true):
     # using Halley's method with the first and second order derivatives
     # computed by the Loss instance.
 
+    if loss.endswith('crossentropy'):
+        y_dtype = Y_CLF_DTYPE
+
     loss = _LOSSES[loss]()
-    y_true = np.array([y_true], dtype=Y_DTYPE)
+    y_true = np.array([y_true], dtype=y_dtype)
     x0 = np.array([x0], dtype=Y_DTYPE).reshape(1, 1)
     get_gradients, get_hessians = get_derivatives_helper(loss)
 
@@ -101,7 +105,7 @@ def test_numerical_gradients(loss, n_classes, prediction_dim, seed=0):
     if loss in ('least_squares', 'least_absolute_deviation'):
         y_true = rng.normal(size=n_samples).astype(Y_DTYPE)
     else:
-        y_true = rng.randint(0, n_classes, size=n_samples).astype(Y_DTYPE)
+        y_true = rng.randint(0, n_classes, size=n_samples).astype(Y_CLF_DTYPE)
     raw_predictions = rng.normal(
         size=(prediction_dim, n_samples)
     ).astype(Y_DTYPE)


### PR DESCRIPTION
When calculating cross entropy, we are comparing ints with floats.

https://github.com/scikit-learn/scikit-learn/blob/3e92edbab8b1d210523e775d2050039055dda1d7/sklearn/ensemble/_hist_gradient_boosting/_loss.pyx#L88

https://github.com/scikit-learn/scikit-learn/blob/3e92edbab8b1d210523e775d2050039055dda1d7/sklearn/ensemble/_hist_gradient_boosting/loss.py#L283

https://github.com/scikit-learn/scikit-learn/blob/3e92edbab8b1d210523e775d2050039055dda1d7/sklearn/ensemble/_hist_gradient_boosting/loss.py#L293

This PR encodes the target as floats for classification.

CC: @NicolasHug 