### PR TITLE
[WIP] Add inverse_transform method for Y to _PLS base object

### DIFF
--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -445,7 +445,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
 
         return x_scores
 
-    def inverse_transform(self, X):
+    def inverse_transform(self, X=None, Y=None):
         """Transform data back to its original space.
 
         Parameters
@@ -454,23 +454,47 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
             New data, where n_samples is the number of samples
             and n_components is the number of pls components.
 
+        Y : array-like of shape (n_samples, n_targets)
+            Target vectors, where n_samples is the number of samples and
+            n_targets is the number of response variables.
+
         Returns
         -------
         x_reconstructed : array-like of shape (n_samples, n_features)
+        y_reconstructed : array-like of shape (n_samples, n_targets)
 
         Notes
         -----
         This transformation will only be exact if n_components=n_features
         """
         check_is_fitted(self)
-        X = check_array(X, dtype=FLOAT_DTYPES)
-        # From pls space to original space
-        X_reconstructed = np.matmul(X, self.x_loadings_.T)
 
-        # Denormalize
-        X_reconstructed *= self.x_std_
-        X_reconstructed += self.x_mean_
-        return X_reconstructed
+        if X is not None:
+            X = check_array(X, dtype=FLOAT_DTYPES)
+            # From pls space to original space
+            X_reconstructed = np.matmul(X, self.x_loadings_.T)
+
+            # Denormalize
+            X_reconstructed *= self.x_std_
+            X_reconstructed += self.x_mean_
+
+        if Y is not None:
+            Y = check_array(Y, dtype=FLOAT_DTYPES)
+            # From pls space to original space
+            Y_reconstructed = np.matmul(Y, self.y_loadings_.T)
+
+            # Denormalize
+            Y_reconstructed *= self.y_std_
+            Y_reconstructed += self.y_mean_
+
+        if X is not None and Y is not None:
+            return X_reconstructed, Y_reconstructed
+
+        if X is not None and Y is None:
+            return X_reconstructed
+
+        if Y is not None and X is None:
+            return Y_reconstructed
 
     def predict(self, X, copy=True):
         """Apply the dimension reduction learned on the train data.


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.

This PR is the continuation of scikit-learn#15289.

I simply implemented the method to inverse transform the response variables Y back to the original space. Indeed, the current method only allows to inverse transform the X data array.
Within this new implementation, the user has now the choice to either inverse transform X, Y or both of them.

I adapted the example code from scikit-learn#15289 :

```
from sklearn.cross_decomposition import PLSRegression

X = [[0., 0., 1.], [1.,0.,0.], [2.,2.,2.], [2.,5.,4.]]
Y = [[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]]

pls2 = PLSRegression(n_components=2)
x, y = pls2.fit_transform(X, Y)

# back transform to the original space:
X_reconstructed = pls2.inverse_transform(X=x)
Y_reconstructed = pls2.inverse_transform(Y=y)
# or:
X_reconstructed, Y_reconstructed = pls2.inverse_transform(X=x, Y=y)
```

#### Any other comments?

I missed this feature for my work so I added it here.

Cheers,

Robin

