### PR TITLE
MAINT Clean root of sklearn repo

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,5 +1,0 @@
-pylint:
-  disable:
-    - unpacking-non-sequence
-ignore-paths:
-    - sklearn/externals

--- a/site.cfg
+++ b/site.cfg
@@ -1,6 +1,0 @@
-
-# Uncomment to link against the MKL library on windows
-# [mkl]
-# include_dirs=C:\Program Files\Intel\MKL\10.2.5.035\include
-# library_dirs=C:\Program Files\Intel\MKL\10.2.5.035\ia32\lib
-# mkl_libs=mkl_core, mkl_intel_c, mkl_intel_s, libguide, libguide40, mkl_blacs_dll, mkl_intel_sequential


### PR DESCRIPTION
- removed `.landscape.yml` : relic from the past

- cleaned the site.cfg : since we access blas through scipy, linking against mkl doesn't apply anymore.