### PR TITLE
BUG ensure that estimator_name is properly stored in the ROC display

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -247,7 +247,7 @@ Changelog
 - |Fix| Fixed a bug in :func:`metrics.plot_roc_curve` where the parameter
   the name of the estimator was passed in the :class:`metrics.RocCurveDisplay`
   instead of the parameter `name`. It results in a different plot when calling
-  :method:`metrics.RocCurveDisplay.plot` for the subsequent times.
+  :meth:`metrics.RocCurveDisplay.plot` for the subsequent times.
   :pr:`16500` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.model_selection`

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -244,6 +244,12 @@ Changelog
 - |Fix| Fixed a bug in :func:`metrics.mutual_info_score` where negative
   scores could be returned. :pr:`16362` by `Thomas Fan`_.
 
+- |Fix| Fixed a bug in :func:`metrics.plot_roc_curve` where the parameter
+  the name of the estimator was passed in the :class:`metrics.RocCurveDisplay`
+  instead of the parameter `name`. It results in a different plot when calling
+  :method:`metrics.RocCurveDisplay.plot` for the subsequent times.
+  :pr:`16500` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -244,7 +244,7 @@ Changelog
 - |Fix| Fixed a bug in :func:`metrics.mutual_info_score` where negative
   scores could be returned. :pr:`16362` by `Thomas Fan`_.
 
-- |Fix| Fixed a bug in :func:`metrics.plot_roc_curve` where the parameter
+- |Fix| Fixed a bug in :func:`metrics.plot_roc_curve` where
   the name of the estimator was passed in the :class:`metrics.RocCurveDisplay`
   instead of the parameter `name`. It results in a different plot when calling
   :meth:`metrics.RocCurveDisplay.plot` for the subsequent times.

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -165,8 +165,9 @@ def plot_roc_curve(estimator, X, y, sample_weight=None,
     """
     check_matplotlib_support('plot_roc_curve')
 
-    classification_error = ("{} should be a binary classifer".format(
-        estimator.__class__.__name__))
+    classification_error = (
+        f"{estimator.__class__.__name__} should be a binary classifer"
+    )
     if not is_classifier(estimator):
         raise ValueError(classification_error)
 
@@ -185,5 +186,7 @@ def plot_roc_curve(estimator, X, y, sample_weight=None,
                             sample_weight=sample_weight,
                             drop_intermediate=drop_intermediate)
     roc_auc = auc(fpr, tpr)
-    viz = RocCurveDisplay(fpr, tpr, roc_auc, estimator.__class__.__name__)
+    viz = RocCurveDisplay(
+        fpr=fpr, tpr=tpr, roc_auc=roc_auc, estimator_name=name
+    )
     return viz.plot(ax=ax, name=name, **kwargs)

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -186,6 +186,7 @@ def plot_roc_curve(estimator, X, y, sample_weight=None,
                             sample_weight=sample_weight,
                             drop_intermediate=drop_intermediate)
     roc_auc = auc(fpr, tpr)
+    name = estimator.__class__.__name__ if name is None else name
     viz = RocCurveDisplay(
         fpr=fpr, tpr=tpr, roc_auc=roc_auc, estimator_name=name
     )

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -166,7 +166,7 @@ def plot_roc_curve(estimator, X, y, sample_weight=None,
     check_matplotlib_support('plot_roc_curve')
 
     classification_error = (
-        f"{estimator.__class__.__name__} should be a binary classifer"
+        "{} should be a binary classifier".format(estimator.__class__.__name__)
     )
     if not is_classifier(estimator):
         raise ValueError(classification_error)

--- a/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
+++ b/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
@@ -131,6 +131,7 @@ def test_roc_curve_not_fitted_errors(pyplot, data_binary, clf):
         plot_roc_curve(clf, X, y)
     clf.fit(X, y)
     disp = plot_roc_curve(clf, X, y)
+    assert clf.__class__.__name__ in disp.line_.get_label()
     assert disp.estimator_name == clf.__class__.__name__
 
 

--- a/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
+++ b/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
@@ -135,18 +135,12 @@ def test_roc_curve_not_fitted_errors(pyplot, data_binary, clf):
     assert disp.estimator_name == clf.__class__.__name__
 
 
-@pytest.mark.parametrize(
-    "clf", [LogisticRegression(),
-            make_pipeline(StandardScaler(), LogisticRegression()),
-            make_pipeline(make_column_transformer((StandardScaler(), [0, 1])),
-                          LogisticRegression())])
-def test_plot_roc_curve_estimator_name_multiple_calls(pyplot, data_binary,
-                                                      clf):
+def test_plot_roc_curve_estimator_name_multiple_calls(pyplot, data_binary):
     # non-regression test checking that the `name` used when calling
     # `plot_roc_curve` is used as well when calling `disp.plot()`
     X, y = data_binary
     clf_name = "my hand-crafted name"
-    clf.fit(X, y)
+    clf = LogisticRegression().fit(X, y)
     disp = plot_roc_curve(clf, X, y, name=clf_name)
     assert disp.estimator_name == clf_name
     pyplot.close("all")

--- a/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
+++ b/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
@@ -132,3 +132,25 @@ def test_roc_curve_not_fitted_errors(pyplot, data_binary, clf):
     clf.fit(X, y)
     disp = plot_roc_curve(clf, X, y)
     assert disp.estimator_name == clf.__class__.__name__
+
+
+@pytest.mark.parametrize(
+    "clf", [LogisticRegression(),
+            make_pipeline(StandardScaler(), LogisticRegression()),
+            make_pipeline(make_column_transformer((StandardScaler(), [0, 1])),
+                          LogisticRegression())])
+def test_roc_curve_estimator_name_multiple_calls(pyplot, data_binary, clf):
+    # non-regression test checking that the `name` used when calling
+    # `plot_roc_curve` is used as well when calling `disp.plot()`
+    X, y = data_binary
+    clf_name = "my hand-crafted name"
+    clf.fit(X, y)
+    disp = plot_roc_curve(clf, X, y, name=clf_name)
+    assert disp.estimator_name == clf_name
+    pyplot.close("all")
+    disp.plot()
+    assert clf_name in disp.line_.get_label()
+    pyplot.close("all")
+    clf_name = "another_name"
+    disp.plot(name=clf_name)
+    assert clf_name in disp.line_.get_label()

--- a/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
+++ b/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
@@ -140,7 +140,8 @@ def test_roc_curve_not_fitted_errors(pyplot, data_binary, clf):
             make_pipeline(StandardScaler(), LogisticRegression()),
             make_pipeline(make_column_transformer((StandardScaler(), [0, 1])),
                           LogisticRegression())])
-def test_roc_curve_estimator_name_multiple_calls(pyplot, data_binary, clf):
+def test_plot_roc_curve_estimator_name_multiple_calls(pyplot, data_binary,
+                                                      clf):
     # non-regression test checking that the `name` used when calling
     # `plot_roc_curve` is used as well when calling `disp.plot()`
     X, y = data_binary

--- a/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
+++ b/sklearn/metrics/_plot/tests/test_plot_roc_curve.py
@@ -36,7 +36,7 @@ def test_plot_roc_curve_error_non_binary(pyplot, data):
     clf = DecisionTreeClassifier()
     clf.fit(X, y)
 
-    msg = "DecisionTreeClassifier should be a binary classifer"
+    msg = "DecisionTreeClassifier should be a binary classifier"
     with pytest.raises(ValueError, match=msg):
         plot_roc_curve(clf, X, y)
 


### PR DESCRIPTION
We were storing `estimator.__class__.__name__` instead of `name` which wrongly label the curve when calling `disp.plot()` for the second time.