### PR TITLE
TST Sets random state in test_csr_row_norms

### DIFF
--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -549,9 +549,10 @@ def test_inplace_normalize():
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_csr_row_norms(dtype):
+    rng = np.random.RandomState(42)
     # checks that csr_row_norms returns the same output as
     # scipy.sparse.linalg.norm, and that the dype is the same as X.dtype.
-    X = sp.random(100, 10, format='csr', dtype=dtype)
+    X = sp.random(100, 10, format='csr', dtype=dtype, random_state=rng)
 
     scipy_norms = sp.linalg.norm(X, axis=1)**2
     norms = csr_row_norms(X)

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -549,10 +549,9 @@ def test_inplace_normalize():
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_csr_row_norms(dtype):
-    rng = np.random.RandomState(42)
     # checks that csr_row_norms returns the same output as
     # scipy.sparse.linalg.norm, and that the dype is the same as X.dtype.
-    X = sp.random(100, 10, format='csr', dtype=dtype, random_state=rng)
+    X = sp.random(100, 10, format='csr', dtype=dtype, random_state=42)
 
     scipy_norms = sp.linalg.norm(X, axis=1)**2
     norms = csr_row_norms(X)

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -556,5 +556,6 @@ def test_csr_row_norms(dtype):
     scipy_norms = sp.linalg.norm(X, axis=1)**2
     norms = csr_row_norms(X)
 
+    assert norms.dtype == dtype
     rtol = 1e-6 if dtype == np.float32 else 1e-7
     assert_allclose(norms, scipy_norms, rtol=rtol)

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -557,5 +557,5 @@ def test_csr_row_norms(dtype):
     scipy_norms = sp.linalg.norm(X, axis=1)**2
     norms = csr_row_norms(X)
 
-    assert norms.dtype == dtype
-    assert_allclose(norms, scipy_norms)
+    rtol = 1e-6 if dtype == np.float32 else 1e-7
+    assert_allclose(norms, scipy_norms, rtol=rtol)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/16506


#### What does this implement/fix? Explain your changes.
Makes test deterministic by setting random state in `test_csr_row_norms`.

The alternative is to lower the tolerance for `float32`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
