### PR TITLE
TST Checks can now skip test based on estimator tag _xfail_test

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -93,13 +93,6 @@ def test_estimators(estimator, check, request):
                                    ConvergenceWarning,
                                    UserWarning, FutureWarning)):
         _set_checking_parameters(estimator)
-
-        xfail_checks = _safe_tags(estimator, '_xfail_test')
-        check_name = _set_check_estimator_ids(check)
-        if xfail_checks:
-            if check_name in xfail_checks:
-                msg = xfail_checks[check_name]
-                request.applymarker(pytest.mark.xfail(reason=msg))
         check(estimator)
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -363,14 +363,14 @@ def _mark_xfail_checks(estimator, check, pytest):
     if not xfail_checks:
         return estimator, check
 
-    try:
-        check_name = _set_check_estimator_ids(check)
-        msg = xfail_checks[check_name]
-        return pytest.param(
-            estimator, check, marks=pytest.mark.xfail(reason=msg))
+    check_name = _set_check_estimator_ids(check)
+    msg = xfail_checks.get(check_name, None)
 
-    except KeyError:
+    if msg is None:
         return estimator, check
+
+    return pytest.param(
+        estimator, check, marks=pytest.mark.xfail(reason=msg))
 
 
 def parametrize_with_checks(estimators):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -364,16 +364,15 @@ def _check_tags_to_skip(check):
     def wrapper(name, estimator_orig):
         xfail_checks = _safe_tags(estimator_orig, '_xfail_test')
         check_name = _set_check_estimator_ids(check).split("(", maxsplit=1)[0]
-        if xfail_checks:
-            try:
-                msg = xfail_checks[check_name]
-            except KeyError:
-                return check(name, estimator_orig)
+        if xfail_checks and check_name in xfail_checks:
+            msg = xfail_checks[check_name]
             try:
                 import pytest
                 pytest.xfail(msg)
             except ImportError:
                 raise SkipTest(msg)
+        else:
+            return check(name, estimator_orig)
 
     return wrapper
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -6,7 +6,6 @@ import pickle
 import re
 from copy import deepcopy
 from functools import partial
-from functools import wraps
 from itertools import chain
 from inspect import signature
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -620,23 +620,6 @@ def test_all_estimators_all_public():
         assert not est.__class__.__name__.startswith("_")
 
 
-def test_check_to_skip():
-    class CheckEstimator(BaseEstimator):
-
-        def _more_tags(self):
-            return {
-                '_xfail_test': {'check_things': 'This check is bad'}
-            }
-
-    def check_things(name, estimator_orig):
-        pass
-
-    wrapped_check = _check_tags_to_skip(check_things)
-
-    assert_raises_regex(SkipTest, 'This check is bad', wrapped_check,
-                        'checkestimator', CheckEstimator())
-
-
 if __name__ == '__main__':
     # This module is run as a script to check that we have no dependency on
     # pytest for estimator checks.

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -633,8 +633,8 @@ def test_check_to_skip():
 
     wrapped_check = _check_tags_to_skip(check_things)
 
-    assert_raises(SkipTest, 'This check is bad', wrapped_check,
-                  'checkestimator', CheckEstimator)
+    assert_raises_regex(SkipTest, 'This check is bad', wrapped_check,
+                        'checkestimator', CheckEstimator())
 
 
 if __name__ == '__main__':

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -23,7 +23,6 @@ from sklearn.utils.estimator_checks import check_fit_score_takes_y
 from sklearn.utils.estimator_checks import check_no_attributes_set_in_init
 from sklearn.utils.estimator_checks import check_classifier_data_not_an_array
 from sklearn.utils.estimator_checks import check_regressor_data_not_an_array
-from sklearn.utils.estimator_checks import _check_tags_to_skip
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.estimator_checks import check_outlier_corruption
 from sklearn.utils.fixes import _parse_version

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -23,6 +23,7 @@ from sklearn.utils.estimator_checks import check_fit_score_takes_y
 from sklearn.utils.estimator_checks import check_no_attributes_set_in_init
 from sklearn.utils.estimator_checks import check_classifier_data_not_an_array
 from sklearn.utils.estimator_checks import check_regressor_data_not_an_array
+from sklearn.utils.estimator_checks import _check_tags_to_skip
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.estimator_checks import check_outlier_corruption
 from sklearn.utils.fixes import _parse_version
@@ -617,6 +618,23 @@ def test_all_estimators_all_public():
     estimators = all_estimators()
     for est in estimators:
         assert not est.__class__.__name__.startswith("_")
+
+
+def test_check_to_skip():
+    class CheckEstimator(BaseEstimator):
+
+        def _more_tags(self):
+            return {
+                '_xfail_test': {'check_things': 'This check is bad'}
+            }
+
+    def check_things(name, estimator_orig):
+        pass
+
+    wrapped_check = _check_tags_to_skip(check_things)
+
+    assert_raises(SkipTest, 'This check is bad', wrapped_check,
+                  'checkestimator', CheckEstimator)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Continues https://github.com/scikit-learn/scikit-learn/pull/16502

#### What does this implement/fix? Explain your changes.
The checks can now skip tests based on the `_xfail_test`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
