### PR TITLE
[MRG] TST Adapt rtol to precision in a sparsefuncs test

### DIFF
--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -551,10 +551,12 @@ def test_inplace_normalize():
 def test_csr_row_norms(dtype):
     # checks that csr_row_norms returns the same output as
     # scipy.sparse.linalg.norm, and that the dype is the same as X.dtype.
-    X = sp.random(100, 10, format='csr', dtype=dtype)
+    X = sp.random(100, 10, format='csr', dtype=dtype, random_state=0)
 
     scipy_norms = sp.linalg.norm(X, axis=1)**2
     norms = csr_row_norms(X)
 
     assert norms.dtype == dtype
-    assert_allclose(norms, scipy_norms)
+
+    rtol = 1e-6 if dtype == np.float32 else 1e-7
+    assert_allclose(norms, scipy_norms, rtol=rtol)


### PR DESCRIPTION
`test_csr_row_norms` did not have a fixed random_state so failure is hard to catch. It appeared in #16499, see https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=13730&view=logs&jobId=91634bb0-5686-577d-d1fa-65c16f031456

The issue is that the default rtol (1e-7) of `assert_allclose` is not adapted to float32 because in that case machine precision is ~1.2e-7.