### PR TITLE
DOC Fixes link in column transformer docstring

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -72,7 +72,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             otherwise a 2d array will be passed to the transformer.
             A callable is passed the input data `X` and can return any of the
             above. To select multiple columns by name or dtype, you can use
-            :obj:`make_column_transformer`.
+            :obj:`make_column_selector`.
 
     remainder : {'drop', 'passthrough'} or estimator, default='drop'
         By default, only the specified columns in `transformers` are
@@ -688,7 +688,8 @@ def make_column_transformer(*transformers, **kwargs):
             ``transformer`` expects X to be a 1d array-like (vector),
             otherwise a 2d array will be passed to the transformer.
             A callable is passed the input data `X` and can return any of the
-            above.
+            above. To select multiple columns by name or dtype, you can use
+            :obj:`make_column_selector`.
 
     remainder : {'drop', 'passthrough'} or estimator, default='drop'
         By default, only the specified columns in `transformers` are


### PR DESCRIPTION
The link correctly points to `make_column_selector`.