### PR TITLE
DOC Note on commit co-authorship when merging PRs

### DIFF
--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -213,6 +213,24 @@ The following GitHub checklist might be helpful in a release PR::
       #15847)
     * [ ] announce on mailing list and on twitter
 
+Merging Pull Requests
+---------------------
+
+Individual commits are squashed when a Pull Request (PR) is merged on Github.
+Before merging,
+
+- the resulting commit title can be edited if necessary. Note
+  that this will rename the PR title by default.
+- the detailed description, containing the titles of all the commits, can
+  be edited or deleted.
+- for PRs with multiple code contributors care must be taken to keep
+  the `Co-authored-by: name <name@example.com>` tags in the detailed
+  description. This will mark the PR as having `multiple co-authors
+  <https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors>`_.
+  Whether code contributions are significanly enough to merit co-authorship is
+  left to the maintainer's appreciation, same as for the "what's new" entry.
+
+
 The scikit-learn.org web site
 -----------------------------
 

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -228,7 +228,7 @@ Before merging,
   description. This will mark the PR as having `multiple co-authors
   <https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors>`_.
   Whether code contributions are significanly enough to merit co-authorship is
-  left to the maintainer's appreciation, same as for the "what's new" entry.
+  left to the maintainer's discretion, same as for the "what's new" entry.
 
 
 The scikit-learn.org web site


### PR DESCRIPTION
A short note to raise awareness of @scikit-learn/core-devs that multiple co-authors can be attributed in git when merging PRs. The [`Co-authored-by`](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-github) tag pre-filled by Github needs to be kept in the detailed description for it to happen.

When to give co-authorship is left it maintainers appreciation, but I think there are at least the following cases where it could make sense to reflect co-authorship in git blame,
 - the what's new has multiple authors
 - stalled PR continued in another PR: first author should get co-authorship
 - stalled (and typically minor) PR fixed by a maintainer by pushing directly without creating a new PR. 

Note that Github already does this by default, unless ones removes the detailed commit description when merging PRs.
