### PR TITLE
[MRG] Make `drop_idx_` a masked array in OneHotEncoder

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -225,10 +225,10 @@ class OneHotEncoder(_BaseEncoder):
         of ``transform``). This includes the category specified in ``drop``
         (if any).
 
-    drop_idx_ : array of shape (n_features,)
+    drop_idx_ : masked array of shape (n_features,)
         ``drop_idx_[i]`` is the index in ``categories_[i]`` of the category to
         be dropped for each feature.
-        ``drop_idx_[i] = -1`` if no category is to be dropped from the feature
+        ``drop_idx_.mask[i] = 1`` if no category is to be dropped from the feature
         with index ``i``, e.g. when `drop='if_binary'` and the feature isn't
         binary
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -228,9 +228,9 @@ class OneHotEncoder(_BaseEncoder):
     drop_idx_ : masked array of shape (n_features,)
         ``drop_idx_[i]`` is the index in ``categories_[i]`` of the category to
         be dropped for each feature.
-        ``drop_idx_.mask[i] = 1`` if no category is to be dropped from the feature
-        with index ``i``, e.g. when `drop='if_binary'` and the feature isn't
-        binary
+        ``drop_idx_.mask[i] = 1`` if no category is to be dropped from the
+        feature with index ``i``, e.g. when `drop='if_binary'` and the feature
+        isn't binary
 
         ``drop_idx_ = None`` if all the transformed features will be retained.
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -517,20 +517,17 @@ class OneHotEncoder(_BaseEncoder):
         found_unknown = {}
 
         for i in range(n_features):
-            if self.drop is None:
-                cats = self.categories_[i]
-            else:
-                if not self.drop_idx_.mask[i]:
-                    cats = np.delete(self.categories_[i], self.drop_idx_[i])
+            cats = self.categories_[i]
+            if self.drop_idx_ is not None and not self.drop_idx_.mask[i]:
+                cats = np.delete(self.categories_[i], self.drop_idx_[i])
             n_categories = len(cats)
 
             # Only happens if there was a column with a unique
             # category. In this case we just fill the column with this
             # unique category value.
             if n_categories == 0:
-                if not self.drop_idx_.mask[i]:
-                    X_tr[:, i] = self.categories_[i][self.drop_idx_[i]]
-                    j += n_categories
+                X_tr[:, i] = self.categories_[i][self.drop_idx_[i]]
+                j += n_categories
                 continue
             sub = X[:, j:j + n_categories]
             # for sparse X argmax returns 2D matrix, ensure 1D array


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #16552.

#### What does this implement/fix? Explain your changes.
Make `drop_idx_` a [numpy masked array](https://docs.scipy.org/doc/numpy/reference/maskedarray.generic.html#what-is-a-masked-array) in order to manage column selection. 