### PR TITLE
CI Use "Bug: triage" label for user reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us reproduce and correct the bug
 title: ''
-labels: Bug
+labels: 'Bug: triage'
 assignees: ''
 
 ---


### PR DESCRIPTION
With the introduction of issues templates, new reports of defects have a "Bug" label, while in a number of cases it's not a bug but rather a user question, an intended behaviour etc. This makes the "Bug" label not very reliable or useful.

I propose to use instead the "Bug: triage" label for new bug reports, which can then be changed to "Bug" once it's confirmed. There may be a way to automate that.