### PR TITLE
ENH Include verbose message when sample_weight is provided.

### DIFF
--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -25,7 +25,8 @@ def _parallel_fit_estimator(estimator, X, y, sample_weight=None,
     """Private function used to fit an estimator within a job."""
     if sample_weight is not None:
         try:
-            estimator.fit(X, y, sample_weight=sample_weight)
+            with _print_elapsed_time(message_clsname, message):
+                estimator.fit(X, y, sample_weight=sample_weight)
         except TypeError as exc:
             if "unexpected keyword argument 'sample_weight'" in str(exc):
                 raise TypeError(


### PR DESCRIPTION
#### Reference Issues/PRs
Address @jnothman [comment](https://github.com/scikit-learn/scikit-learn/pull/16069#discussion_r385109624) in #16069.

#### What does this implement/fix? Explain your changes.
Add verbose message in `_parallel_fit_estimator` for estimators supporting `sample_weights`.