### PR TITLE
DOC invite underrepresented groups to contribute

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -22,10 +22,10 @@ See :ref:`new_contributors` to get started.
     We are a community based on openness and friendly, didactic,
     discussions.
 
-    We aspire to treat everybody equally, and value their contributions.
-    We are particularly seeking people from underrepresented backgrounds
-    in Open Source Software and this project to participate and contribute
-    their expertise and experience.
+    We aspire to treat everybody equally, and value their contributions.  We
+    are particularly seeking people from underrepresented backgrounds in Open
+    Source Software and scikit-learn in particular to participate and
+    contribute their expertise and experience.
 
     Decisions are made based on technical merit and consensus.
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -23,6 +23,9 @@ See :ref:`new_contributors` to get started.
     discussions.
 
     We aspire to treat everybody equally, and value their contributions.
+    We are particularly seeking people from underrepresented backgrounds
+    in Open Source Software and this project to participate and contribute
+    their expertise and experience.
 
     Decisions are made based on technical merit and consensus.
 


### PR DESCRIPTION
This is a bit of a follow-up on #16262 and inspired by a talk by @nmsanchez at the Chan Zuckerberg kickoff meeting.

I think we all know that there's a diversity problem in OSS in general an sklearn in particular. I think anything we can do, we should do.

Inviting a more diverse contributor base explicitly might also give an additional anchoring point for discussing how we communicate and treat each other.