### PR TITLE
Implement Extended Isolation Forest

### DIFF
--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -81,6 +81,12 @@ class IsolationForest(OutlierMixin, BaseBagging):
             - If int, then draw `max_features` features.
             - If float, then draw `max_features * X.shape[1]` features.
 
+    extended : bool, default=False
+        If True, use the extended version of the isolation forest algorithm.
+        This make the isolation forest partitioning the space using random
+        oblique hyperplanes instead of choosing a single feature for each
+        split.
+
     bootstrap : bool, default=False
         If True, individual trees are fit on random subsets of the training
         data sampled with replacement. If False, sampling without replacement
@@ -184,6 +190,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
                  max_samples="auto",
                  contamination="auto",
                  max_features=1.,
+                 extended=False,
                  bootstrap=False,
                  n_jobs=None,
                  behaviour='deprecated',
@@ -193,7 +200,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
         super().__init__(
             base_estimator=ExtraTreeRegressor(
                 max_features=1,
-                splitter='random',
+                splitter='random_oblique' if extended else 'random',
                 random_state=random_state),
             # here above max_features has no links with self.max_features
             bootstrap=bootstrap,
@@ -206,6 +213,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
             random_state=random_state,
             verbose=verbose)
 
+        self.extended = extended
         self.behaviour = behaviour
         self.contamination = contamination
 

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -64,7 +64,8 @@ CRITERIA_REG = {"mse": _criterion.MSE, "friedman_mse": _criterion.FriedmanMSE,
                 "mae": _criterion.MAE}
 
 DENSE_SPLITTERS = {"best": _splitter.BestSplitter,
-                   "random": _splitter.RandomSplitter}
+                   "random": _splitter.RandomSplitter,
+                   "random_oblique": _splitter.RandomObliqueSplitter}
 
 SPARSE_SPLITTERS = {"best": _splitter.BestSparseSplitter,
                     "random": _splitter.RandomSparseSplitter}

--- a/sklearn/tree/_utils.pxd
+++ b/sklearn/tree/_utils.pxd
@@ -59,6 +59,7 @@ cdef SIZE_t rand_int(SIZE_t low, SIZE_t high,
 cdef double rand_uniform(double low, double high,
                          UINT32_t* random_state) nogil
 
+cdef double rand_normal(UINT32_t* random_state) nogil
 
 cdef double log(double x) nogil
 

--- a/sklearn/tree/_utils.pyx
+++ b/sklearn/tree/_utils.pyx
@@ -14,7 +14,7 @@
 from libc.stdlib cimport free
 from libc.stdlib cimport malloc
 from libc.stdlib cimport realloc
-from libc.math cimport log as ln
+from libc.math cimport log as ln, sqrt, cos, M_PI
 
 import numpy as np
 cimport numpy as np
@@ -73,6 +73,11 @@ cdef inline double rand_uniform(double low, double high,
     return ((high - low) * <double> our_rand_r(random_state) /
             <double> RAND_R_MAX) + low
 
+cdef inline double rand_normal(UINT32_t* random_state) nogil:
+    # Use the Box-Muller transform
+    cdef double u = rand_uniform(0.0, 1.0, random_state)
+    cdef double v = rand_uniform(0.0, 1.0, random_state)
+    return sqrt(-2 * ln(u)) * cos(2 * M_PI * v)
 
 cdef inline double log(double x) nogil:
     return ln(x) / ln(2.0)


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #16517 
(note that the feature proposal wasn't approved yet, but well, I need it for my job :) )

#### What does this implement/fix? Explain your changes.
It implements the Extended Isolation Forest Algorithm by:
- Adding an "extended" argument to the Isolation Forest class,
- Add a new "random_oblique" mode to the ExtraTreeRegressor class, which uses a new splitter,
- Add this new RandomObliqueSplitter to split instances with an oblique hyperplane.

#### Any other comments?

This is a WIP, several things still need to be implemented or require a discussion:
- The sparse version of the splitter is not implemented yet,
- What should be done with the `max_features` , `min_samples_leaf` and `min_weight_leaf` arguments needs to be discussed. With the oblique splitter, there is not really a way to select the best split out of several ones, unless we use `max_features` as the number of retries to find the best split ? The other two parameters could then be used to drop incorrect split then.
