### PR TITLE
DOC Remove 3.5 from Python badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@
 .. |CircleCI| image:: https://circleci.com/gh/scikit-learn/scikit-learn/tree/master.svg?style=shield&circle-token=:circle-token
 .. _CircleCI: https://circleci.com/gh/scikit-learn/scikit-learn
 
-.. |PythonVersion| image:: https://img.shields.io/pypi/pyversions/scikit-learn.svg
-.. _PythonVersion: https://img.shields.io/pypi/pyversions/scikit-learn.svg
+.. |PythonVersion| image:: https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue
+.. _PythonVersion: https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue
 
 .. |PyPi| image:: https://badge.fury.io/py/scikit-learn.svg
 .. _PyPi: https://badge.fury.io/py/scikit-learn


### PR DESCRIPTION
Fixes #16575 

Removes version `3.5` from the Python badge in the README file as defined by the issue.


