### PR TITLE
[MRG] Encoders: make it optional to fit if categories are given (Issue #12616)

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -108,9 +108,9 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
             types = [type(cat) for cat in cats]
 
             if types[:-1] != types[1:]:
-                raise ValueError("All the categories from {} are expected to "
-                                 "be of the same type, but actually {}"
-                                 .format(cats, types))
+                raise ValueError("All the classes from category {} are "
+                                 "expected to be of the same type, but "
+                                 "actually {}".format(idx, types))
 
             if isinstance(cats[0], Integral):
                 dtype = np.int64

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -682,3 +682,39 @@ def test_encoders_no_need_to_fit_with_given_categories(Encoder):
     X = [['a', 2], ['b', 1]]
     categories = [['a', 'b'], [1, 2, 3]]
     Encoder(categories).fit(X)
+
+
+@pytest.mark.parametrize('Encoder', [OneHotEncoder, OrdinalEncoder])
+def test_encoders_one_empty_category(Encoder):
+    categories = [['a', 'b'], [1, 2, 3], []]
+    msg = "Category {} if of zero length, but it's not allowed".format(2)
+
+    with pytest.raises(ValueError, match=msg):
+        Encoder(categories)
+
+
+def test_floating_point_categories():
+    X = [['a', 2.], ['b', 3.]]
+    exp = np.array([[1, 0, 1, 0], [0, 1, 0, 1]])
+
+    encoder = OneHotEncoder()
+    assert_array_equal(encoder.fit_transform(X).toarray(), exp)
+
+
+def test_floating_point_given_categories():
+    categories = [['a', 'b'], [1., 2., 3.]]
+    X = [['a', 2.], ['b', 3.]]
+    exp = np.array([[1, 0, 0, 1, 0], [0, 1, 0, 0, 1]])
+
+    encoder = OneHotEncoder(categories)
+    assert_array_equal(encoder.fit_transform(X).toarray(), exp)
+
+
+@pytest.mark.parametrize('Encoder', [OneHotEncoder, OrdinalEncoder])
+def test_mixed_types_within_category(Encoder):
+    categories = [['a', 1, 2.]]
+    msg = ("All the classes from category {} are expected to be of the same "
+           "type".format(0))
+
+    with pytest.raises(ValueError, match=msg):
+        _ = Encoder(categories)


### PR DESCRIPTION
For both present encoders, OneHotEncoder and OrdinalEncoder make it optional to
fit the encoder if categories list was passed to the constructor.

I faced an issue, that even though I pass categories list to a class constructor, I still forced to fit an encoder for no reason. I looked though the Internet, and just found an issue #14310, but there's still no solution for this.

For now I did changes which fits (actually, fill in `self.categories_` array with contents checks.

As this code is common for both encoders, `OneHotEncoder` and `OrdinalEncoder`, I did changes in a base class, `_BaseEncoder`, which now has a constructor, and sets common for both encoders instance variables.

In case if `categories` argument, given to the constructor is not `'auto'`, it's expected to contain list of categories. The flow goes to actual filling the `categories_` instance variable with those, given to constructor. This makes encoders' check `check_is_fitted()` not to fail, and `transform()` works with no errors.

Also I found an issue: in case if categories were of mixed types (i.e., strings and numbers, `[['a', 'b'], [2, 1, 3]]`, both categories are supposed to be of an `object` type, and user was not forced to pass the numeric category ordered.

I added/modified tests to check what I added, and modified those, which fails new checks (passing 1-d list of categories).

Current (master) implementation allows passing 1-d categories array, but fails on `fit()` attempt.

Could you please review and comment my implementation?