### PR TITLE
DOC Rename clf to regr in SVR examples

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -320,10 +320,10 @@ floating point values instead of integer values::
     >>> from sklearn import svm
     >>> X = [[0, 0], [2, 2]]
     >>> y = [0.5, 2.5]
-    >>> clf = svm.SVR()
-    >>> clf.fit(X, y)
+    >>> regr = svm.SVR()
+    >>> regr.fit(X, y)
     SVR()
-    >>> clf.predict([[1, 1]])
+    >>> regr.predict([[1, 1]])
     array([1.5])
 
 

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -939,8 +939,8 @@ class SVR(RegressorMixin, BaseLibSVM):
     >>> rng = np.random.RandomState(0)
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
-    >>> clf = SVR(C=1.0, epsilon=0.2)
-    >>> clf.fit(X, y)
+    >>> regr = SVR(C=1.0, epsilon=0.2)
+    >>> regr.fit(X, y)
     SVR(epsilon=0.2)
 
     See also
@@ -1079,8 +1079,8 @@ class NuSVR(RegressorMixin, BaseLibSVM):
     >>> np.random.seed(0)
     >>> y = np.random.randn(n_samples)
     >>> X = np.random.randn(n_samples, n_features)
-    >>> clf = NuSVR(C=1.0, nu=0.1)
-    >>> clf.fit(X, y)
+    >>> regr = NuSVR(C=1.0, nu=0.1)
+    >>> regr.fit(X, y)
     NuSVR(nu=0.1)
 
     See also


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None


#### What does this implement/fix? Explain your changes.
I guess the variable names for SVR object in some documents should be `regr`(indicates a regressor), not `clf`(indicates a classifier) because SVR is a class for regression, not for classification.

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
