### PR TITLE
[MRG] Rename _parallel_fit_estimator to _fit_single_estimator

### DIFF
--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -20,8 +20,8 @@ from ..utils import check_random_state
 from ..utils.metaestimators import _BaseComposition
 
 
-def _parallel_fit_estimator(estimator, X, y, sample_weight=None,
-                            message_clsname=None, message=None):
+def _fit_single_estimator(estimator, X, y, sample_weight=None,
+                          message_clsname=None, message=None):
     """Private function used to fit an estimator within a job."""
     if sample_weight is not None:
         try:

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -14,7 +14,7 @@ from ..base import clone
 from ..base import ClassifierMixin, RegressorMixin, TransformerMixin
 from ..base import is_classifier, is_regressor
 
-from ._base import _parallel_fit_estimator
+from ._base import _fit_single_estimator
 from ._base import _BaseHeterogeneousEnsemble
 
 from ..linear_model import LogisticRegression
@@ -137,7 +137,7 @@ class _BaseStacking(TransformerMixin, _BaseHeterogeneousEnsemble,
         # base estimators will be used in transform, predict, and
         # predict_proba. They are exposed publicly.
         self.estimators_ = Parallel(n_jobs=self.n_jobs)(
-            delayed(_parallel_fit_estimator)(clone(est), X, y, sample_weight)
+            delayed(_fit_single_estimator)(clone(est), X, y, sample_weight)
             for est in all_estimators if est != 'drop'
         )
 

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -23,7 +23,7 @@ from ..base import ClassifierMixin
 from ..base import RegressorMixin
 from ..base import TransformerMixin
 from ..base import clone
-from ._base import _parallel_fit_estimator
+from ._base import _fit_single_estimator
 from ._base import _BaseHeterogeneousEnsemble
 from ..preprocessing import LabelEncoder
 from ..utils import Bunch
@@ -68,7 +68,7 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
                              % (len(self.weights), len(self.estimators)))
 
         self.estimators_ = Parallel(n_jobs=self.n_jobs)(
-                delayed(_parallel_fit_estimator)(
+                delayed(_fit_single_estimator)(
                         clone(clf), X, y,
                         sample_weight=sample_weight,
                         message_clsname='Voting',

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -316,7 +316,7 @@ def test_sample_weight():
     with pytest.raises(TypeError, match=msg):
         eclf3.fit(X, y, sample_weight)
 
-    # check that _parallel_fit_estimator will raise the right error
+    # check that _fit_single_estimator will raise the right error
     # it should raise the original error if this is not linked to sample_weight
     class ClassifierErrorFit(ClassifierMixin, BaseEstimator):
         def fit(self, X, y, sample_weight):


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #16595 


#### What does this implement/fix? Explain your changes.
Renames a non-public API method from `_parallel_fit_estimator` to `_fit_single_estimator` to better reflect the serial/single-threaded operation actually performed by the method. No parallel calls are made in the method. The parallel part will come when we pass this method to the `Parallel` class, as we do [here](https://github.com/scikit-learn/scikit-learn/blob/5009d113474b163d409822a5cac036b448a9dc3d/sklearn/ensemble/_stacking.py#L140) and [here](https://github.com/scikit-learn/scikit-learn/blob/5009d113474b163d409822a5cac036b448a9dc3d/sklearn/ensemble/_voting.py#L71).

In PR #16539, it was suggested that we rename this method to `_fit_single_estimator` to clarify the usage intent. See this comment specifically: https://github.com/scikit-learn/scikit-learn/pull/16539/files#r385937964

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
