### PR TITLE
MNT Uses azure pipelines for scipy-dev

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,9 @@ jobs:
         CHECK_WARNINGS: 'true'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'
+        # Tests that require large downloads over the networks are skipped in CI.
+        # Here we make sure, that they are still run on a regular basis.
+        SKLEARN_SKIP_NETWORK_TESTS: '0'
 
 # Will run all the time regardless of linting outcome.
 - template: build_tools/azure/posix.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,12 @@
 # Adapted from https://github.com/pandas-dev/pandas/blob/master/azure-pipelines.yml
+schedules:
+- cron: "30 2 * * *"
+  displayName: Run nightly build
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - job: linting
   displayName: Linting
@@ -21,7 +29,29 @@ jobs:
           ./build_tools/circle/linting.sh
         fi
       displayName: Run linting
+    - bash: |
+        if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[scipy-dev\] ]] || \
+           [[ $BUILD_REASON == "Schedule" ]]; then
+          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]true"
+        else
+          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]false"
+        fi
+      name: gitCommitMessage
+      displayName: Determine to run scipy-dev
 
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: Linux_Nightly
+    vmImage: ubuntu-18.04
+    dependsOn: [linting]
+    condition: eq(dependencies['linting']['outputs']['gitCommitMessage.runScipyDev'], 'true')
+    matrix:
+      pylatest_pip_scipy_dev:
+        DISTRIB: 'conda-pip-scipy-dev'
+        PYTHON_VERSION: '*'
+        CHECK_WARNINGS: 'true'
+        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+        TEST_DOCSTRINGS: 'true'
 
 # Will run all the time regardless of linting outcome.
 - template: build_tools/azure/posix.yml

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -100,6 +100,17 @@ elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     python -m pip install pandas matplotlib pyamg scikit-image
     # do not install dependencies for lightgbm since it requires scikit-learn
     python -m pip install lightgbm --no-deps
+elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
+    make_conda "python=$PYTHON_VERSION"
+    python -m pip install -U pip
+    python -m pip install pytest==$PYTEST_VERSION pytest-cov pytest-xdist
+    echo "Installing numpy and scipy master wheels"
+    dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
+    pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy pandas cython
+    echo "Installing joblib master"
+    pip install https://github.com/joblib/joblib/archive/master.zip
+    echo "Installing pillow master"
+    pip install https://github.com/python-pillow/Pillow/archive/master.zip
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/build_tools/azure/posix-32.yml
+++ b/build_tools/azure/posix-32.yml
@@ -3,10 +3,12 @@ parameters:
   vmImage: ''
   matrix: []
   dependsOn: []
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
 jobs:
 - job: ${{ parameters.name }}
   dependsOn: ${{ parameters.dependsOn }}
+  condition: ${{ parameters.condition }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -3,10 +3,12 @@ parameters:
   vmImage: ''
   matrix: []
   dependsOn: []
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
 jobs:
 - job: ${{ parameters.name }}
   dependsOn: ${{ parameters.dependsOn }}
+  condition: ${{ parameters.condition }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -4,10 +4,12 @@ parameters:
   vmImage: ''
   matrix: []
   dependsOn: []
+  condition: ne(variables['Build.Reason'], 'Schedule')
 
 jobs:
 - job: ${{ parameters.name }}
   dependsOn: ${{ parameters.dependsOn }}
+  condition: ${{ parameters.condition }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:


### PR DESCRIPTION
Uses azure pipelines for scipy-dev (instead of travisci)

This PR enables scipy-dev to run at 230am and also uses the `[scipy-dev]` tag to run on PRs.

CC @ogrisel 