### PR TITLE
MNT Reduces github API calls greatly in autolabeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,8 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.4.4
+    - uses: thomasjpfan/labeler@v2.4.5
+      if: github.repository == 'scikit-learn/scikit-learn'
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         max-labels: "3"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.4.3
+    - uses: thomasjpfan/labeler@v2.4.4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         max-labels: "3"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.4.5
+    - uses: thomasjpfan/labeler@v2.4.6
       if: github.repository == 'scikit-learn/scikit-learn'
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Before the autolabler would use API calls to look at the change files for every PR and check if there are more labels to add. This used up way too many API calls.

This update makes it so that if a PR was previously labeled at all, the autolabeler will leave it alone.