### PR TITLE
TST More stable test_uniform_grid

### DIFF
--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -772,11 +772,11 @@ def test_uniform_grid(method):
     we re-run t-SNE from the final point when the convergence is not good
     enough.
     """
-    seeds = [0, 1, 2]
+    seeds = range(3)
     n_iter = 500
     for seed in seeds:
         tsne = TSNE(n_components=2, init='random', random_state=seed,
-                    perplexity=20, n_iter=n_iter, method=method)
+                    perplexity=50, n_iter=n_iter, method=method)
         Y = tsne.fit_transform(X_2d_grid)
 
         try_name = "{}_{}".format(method, seed)


### PR DESCRIPTION
This is a tentative fix for #15821 (`test_uniform_grid` fails on ppc64le and aarch64).

By increasing the number of random seeds used in the test I could trigger similar failures on amd64. I then increased the perplexity to make the test easier. On amd64 this ensures that the test passes for all seeds in `range(100)` (IIRC).

Hopefully this will also make the tests pass on ppc64le and aarch64 although I have not tested because that would require setting up a local VM or new CI configuration.