### PR TITLE
TST Fixes test so that whole test isn't skipped if pandas not…

### DIFF
--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1040,7 +1040,7 @@ def test_column_transformer_no_estimators_set_params():
 
 
 def test_column_transformer_callable_specifier():
-    # assert that function gets the full array / dataframe
+    # assert that function gets the full array
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     X_res_first = np.array([[0, 1, 2]]).T
 
@@ -1055,7 +1055,13 @@ def test_column_transformer_callable_specifier():
     assert callable(ct.transformers[0][2])
     assert ct.transformers_[0][2] == [0]
 
+
+def test_column_transformer_callable_specifier_dataframe():
+    # assert that function gets the full dataframe
     pd = pytest.importorskip('pandas')
+    X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
+    X_res_first = np.array([[0, 1, 2]]).T
+
     X_df = pd.DataFrame(X_array, columns=['first', 'second'])
 
     def func(X):

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1021,7 +1021,7 @@ def test_column_transformer_no_estimators_set_params():
 
 
 def test_column_transformer_callable_specifier():
-    # assert that function gets the full array / dataframe
+    # assert that function gets the full array
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     X_res_first = np.array([[0, 1, 2]]).T
 
@@ -1036,7 +1036,13 @@ def test_column_transformer_callable_specifier():
     assert callable(ct.transformers[0][2])
     assert ct.transformers_[0][2] == [0]
 
+
+def test_column_transformer_callable_specifier_dataframe():
+    # assert that function gets the full dataframe
     pd = pytest.importorskip('pandas')
+    X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
+    X_res_first = np.array([[0, 1, 2]]).T
+
     X_df = pd.DataFrame(X_array, columns=['first', 'second'])
 
     def func(X):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This issue was raised by @thomasjpfan in #14048 and this PR fixes a different test which has the same problem.

#### What does this implement/fix? Explain your changes.

`pytest.importorskip` is being used halfway down the test function, so if the import fails the whole test will be skipped. This PR splits the array and dataframe tests into two function, so that the array one can still pass even in pandas is not installed.



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
