### PR TITLE
FIX: normalizer l_inf should take maximum of absolute values

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -339,6 +339,11 @@ Changelog
   computing statistics when calling `partial_fit` on sparse inputs.
   :pr:`16466` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |Fix| Fix a bux in :class:`preprocessing.Normalizer` which was not taking the
+  absolute value of the maximum values before normalizing the vectors.
+  :pr:`16632` by :user:`Maura Pintor <Maupin1991>`
+  and :user:`Battista Biggio <freezebat>`.
+
 :mod:`sklearn.svm`
 ..................
 

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -342,7 +342,7 @@ Changelog
 - |Fix| Fix a bug in :class:`preprocessing.Normalizer` which was not taking the
   absolute value of the maximum values before normalizing the vectors.
   :pr:`16632` by :user:`Maura Pintor <Maupin1991>`
-  and :user:`Battista Biggio <freezebat>`.
+  and :user:`Battista Biggio <bbiggio>`.
 
 :mod:`sklearn.svm`
 ..................

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -339,10 +339,10 @@ Changelog
   computing statistics when calling `partial_fit` on sparse inputs.
   :pr:`16466` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |Fix| Fix a bug in :class:`preprocessing.Normalizer` which was not taking the
-  absolute value of the maximum values before normalizing the vectors.
-  :pr:`16632` by :user:`Maura Pintor <Maupin1991>`
-  and :user:`Battista Biggio <bbiggio>`.
+- |Fix| Fix a bug in :class:`preprocessing.Normalizer` with norm='max',
+  which was not taking the absolute value of the maximum values before
+  normalizing the vectors. :pr:`16632` by
+  :user:`Maura Pintor <Maupin1991>` and :user:`Battista Biggio <bbiggio>`.
 
 :mod:`sklearn.svm`
 ..................

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -339,7 +339,7 @@ Changelog
   computing statistics when calling `partial_fit` on sparse inputs.
   :pr:`16466` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |Fix| Fix a bux in :class:`preprocessing.Normalizer` which was not taking the
+- |Fix| Fix a bug in :class:`preprocessing.Normalizer` which was not taking the
   absolute value of the maximum values before normalizing the vectors.
   :pr:`16632` by :user:`Maura Pintor <Maupin1991>`
   and :user:`Battista Biggio <freezebat>`.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1728,7 +1728,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         elif norm == 'l2':
             norms = row_norms(X)
         elif norm == 'max':
-            norms = np.max(X, axis=1).abs()
+            norms = np.abs(np.max(X, axis=1))
         norms = _handle_zeros_in_scale(norms, copy=False)
         X /= norms[:, np.newaxis]
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -719,8 +719,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
             sparse_constructor = (sparse.csr_matrix
                                   if X.format == 'csr' else sparse.csc_matrix)
             counts_nan = sparse_constructor(
-                        (np.isnan(X.data), X.indices, X.indptr),
-                        shape=X.shape).sum(axis=0).A.ravel()
+                (np.isnan(X.data), X.indices, X.indptr),
+                shape=X.shape).sum(axis=0).A.ravel()
 
             if not hasattr(self, 'n_samples_seen_'):
                 self.n_samples_seen_ = (
@@ -1438,6 +1438,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
     See :ref:`examples/linear_model/plot_polynomial_interpolation.py
     <sphx_glr_auto_examples_linear_model_plot_polynomial_interpolation.py>`
     """
+
     def __init__(self, degree=2, interaction_only=False, include_bias=True,
                  order='C'):
         self.degree = degree
@@ -1559,7 +1560,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
             if self.include_bias:
                 to_stack.append(np.ones(shape=(n_samples, 1), dtype=X.dtype))
             to_stack.append(X)
-            for deg in range(2, self.degree+1):
+            for deg in range(2, self.degree + 1):
                 Xp_next = _csr_polynomial_expansion(X.data, X.indices,
                                                     X.indptr, X.shape[1],
                                                     self.interaction_only,
@@ -2310,7 +2311,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
                 self.quantiles_.append([0] * len(references))
             else:
                 self.quantiles_.append(
-                        np.nanpercentile(column_data, references))
+                    np.nanpercentile(column_data, references))
         self.quantiles_ = np.transpose(self.quantiles_)
         # due to floating-point precision error in `np.nanpercentile`,
         # make sure the quantiles are monotonically increasing
@@ -2414,9 +2415,9 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
             # used (the upper when we do ascending, and the
             # lower for descending). We take the mean of these two
             X_col[isfinite_mask] = .5 * (
-                np.interp(X_col_finite, quantiles, self.references_)
-                - np.interp(-X_col_finite, -quantiles[::-1],
-                            -self.references_[::-1]))
+                    np.interp(X_col_finite, quantiles, self.references_)
+                    - np.interp(-X_col_finite, -quantiles[::-1],
+                                -self.references_[::-1]))
         else:
             X_col[isfinite_mask] = np.interp(X_col_finite,
                                              self.references_, quantiles)
@@ -2468,7 +2469,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         if self.output_distribution not in ('normal', 'uniform'):
             raise ValueError("'output_distribution' has to be either 'normal'"
                              " or 'uniform'. Got '{}' instead.".format(
-                                 self.output_distribution))
+                self.output_distribution))
 
         return X
 
@@ -2766,6 +2767,7 @@ class PowerTransformer(TransformerMixin, BaseEstimator):
     .. [2] G.E.P. Box and D.R. Cox, "An Analysis of Transformations", Journal
            of the Royal Statistical Society B, 26, 211-252 (1964).
     """
+
     def __init__(self, method='yeo-johnson', standardize=True, copy=True):
         self.method = method
         self.standardize = standardize

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1718,7 +1718,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         elif norm == 'l2':
             inplace_csr_row_normalize_l2(X)
         elif norm == 'max':
-            _, norms = min_max_axis(X, 1)
+            _, norms = np.abs(min_max_axis(X, 1))
             norms_elementwise = norms.repeat(np.diff(X.indptr))
             mask = norms_elementwise != 0
             X.data[mask] /= norms_elementwise[mask]

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1718,7 +1718,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         elif norm == 'l2':
             inplace_csr_row_normalize_l2(X)
         elif norm == 'max':
-            mins, maxes = min_max_axis(np.abs(X), 1)
+            mins, maxes = min_max_axis(X, 1)
             norms = np.maximum(abs(mins), maxes)
             norms_elementwise = norms.repeat(np.diff(X.indptr))
             mask = norms_elementwise != 0
@@ -1729,7 +1729,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         elif norm == 'l2':
             norms = row_norms(X)
         elif norm == 'max':
-            norms = np.max(np.abs(X), axis=1)
+            norms = np.max(abs(X), axis=1)
         norms = _handle_zeros_in_scale(norms, copy=False)
         X /= norms[:, np.newaxis]
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1718,7 +1718,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         elif norm == 'l2':
             inplace_csr_row_normalize_l2(X)
         elif norm == 'max':
-            _, norms = np.abs(min_max_axis(X, 1))
+            _, norms = min_max_axis(np.abs(X), 1)
             norms_elementwise = norms.repeat(np.diff(X.indptr))
             mask = norms_elementwise != 0
             X.data[mask] /= norms_elementwise[mask]
@@ -1728,7 +1728,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         elif norm == 'l2':
             norms = row_norms(X)
         elif norm == 'max':
-            norms = np.abs(np.max(X, axis=1))
+            norms = np.max(np.abs(X), axis=1)
         norms = _handle_zeros_in_scale(norms, copy=False)
         X /= norms[:, np.newaxis]
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1747,7 +1747,7 @@ class Normalizer(TransformerMixin, BaseEstimator):
 
     Each sample (i.e. each row of the data matrix) with at least one
     non zero component is rescaled independently of other samples so
-    that its norm (l1 or l2) equals one.
+    that its norm (l1, l2 or inf) equals one.
 
     This transformer is able to work both with dense numpy arrays and
     scipy.sparse matrix (use CSR format if you want to avoid the burden of
@@ -1764,7 +1764,9 @@ class Normalizer(TransformerMixin, BaseEstimator):
     Parameters
     ----------
     norm : 'l1', 'l2', or 'max', optional ('l2' by default)
-        The norm to use to normalize each non zero sample.
+        The norm to use to normalize each non zero sample. If norm='max'
+        is used, values will be rescaled by the maximum of the absolute
+        value.
 
     copy : boolean, optional, default True
         set to False to perform inplace row normalization and avoid a

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -719,8 +719,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
             sparse_constructor = (sparse.csr_matrix
                                   if X.format == 'csr' else sparse.csc_matrix)
             counts_nan = sparse_constructor(
-                (np.isnan(X.data), X.indices, X.indptr),
-                shape=X.shape).sum(axis=0).A.ravel()
+                        (np.isnan(X.data), X.indices, X.indptr),
+                        shape=X.shape).sum(axis=0).A.ravel()
 
             if not hasattr(self, 'n_samples_seen_'):
                 self.n_samples_seen_ = (
@@ -1438,7 +1438,6 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
     See :ref:`examples/linear_model/plot_polynomial_interpolation.py
     <sphx_glr_auto_examples_linear_model_plot_polynomial_interpolation.py>`
     """
-
     def __init__(self, degree=2, interaction_only=False, include_bias=True,
                  order='C'):
         self.degree = degree
@@ -1560,7 +1559,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
             if self.include_bias:
                 to_stack.append(np.ones(shape=(n_samples, 1), dtype=X.dtype))
             to_stack.append(X)
-            for deg in range(2, self.degree + 1):
+            for deg in range(2, self.degree+1):
                 Xp_next = _csr_polynomial_expansion(X.data, X.indices,
                                                     X.indptr, X.shape[1],
                                                     self.interaction_only,
@@ -2311,7 +2310,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
                 self.quantiles_.append([0] * len(references))
             else:
                 self.quantiles_.append(
-                    np.nanpercentile(column_data, references))
+                        np.nanpercentile(column_data, references))
         self.quantiles_ = np.transpose(self.quantiles_)
         # due to floating-point precision error in `np.nanpercentile`,
         # make sure the quantiles are monotonically increasing
@@ -2415,9 +2414,9 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
             # used (the upper when we do ascending, and the
             # lower for descending). We take the mean of these two
             X_col[isfinite_mask] = .5 * (
-                    np.interp(X_col_finite, quantiles, self.references_)
-                    - np.interp(-X_col_finite, -quantiles[::-1],
-                                -self.references_[::-1]))
+                np.interp(X_col_finite, quantiles, self.references_)
+                - np.interp(-X_col_finite, -quantiles[::-1],
+                            -self.references_[::-1]))
         else:
             X_col[isfinite_mask] = np.interp(X_col_finite,
                                              self.references_, quantiles)
@@ -2469,7 +2468,7 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         if self.output_distribution not in ('normal', 'uniform'):
             raise ValueError("'output_distribution' has to be either 'normal'"
                              " or 'uniform'. Got '{}' instead.".format(
-                self.output_distribution))
+                                 self.output_distribution))
 
         return X
 
@@ -2767,7 +2766,6 @@ class PowerTransformer(TransformerMixin, BaseEstimator):
     .. [2] G.E.P. Box and D.R. Cox, "An Analysis of Transformations", Journal
            of the Royal Statistical Society B, 26, 211-252 (1964).
     """
-
     def __init__(self, method='yeo-johnson', standardize=True, copy=True):
         self.method = method
         self.standardize = standardize

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1728,7 +1728,7 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         elif norm == 'l2':
             norms = row_norms(X)
         elif norm == 'max':
-            norms = np.max(X, axis=1)
+            norms = np.max(X, axis=1).abs()
         norms = _handle_zeros_in_scale(norms, copy=False)
         X /= norms[:, np.newaxis]
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1718,7 +1718,8 @@ def normalize(X, norm='l2', axis=1, copy=True, return_norm=False):
         elif norm == 'l2':
             inplace_csr_row_normalize_l2(X)
         elif norm == 'max':
-            _, norms = min_max_axis(np.abs(X), 1)
+            mins, maxes = min_max_axis(np.abs(X), 1)
+            norms = np.maximum(abs(mins), maxes)
             norms_elementwise = norms.repeat(np.diff(X.indptr))
             mask = norms_elementwise != 0
             X.data[mask] /= norms_elementwise[mask]

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1766,7 +1766,7 @@ class Normalizer(TransformerMixin, BaseEstimator):
     norm : 'l1', 'l2', or 'max', optional ('l2' by default)
         The norm to use to normalize each non zero sample. If norm='max'
         is used, values will be rescaled by the maximum of the absolute
-        value.
+        values.
 
     copy : boolean, optional, default True
         set to False to perform inplace row normalization and avoid a

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1972,10 +1972,13 @@ def test_normalizer_max_sign():
     X_dense = rng.randn(4, 5)
     # set the row number 3 to zero
     X_dense[3, :] = 0.0
+    # check for mixed data where the value with
+    # largest magnitude is negative
+    X_dense[2, abs(X_dense[2, :]).argmax()] *= -1
     X_all_neg = -np.abs(X_dense)
     X_all_neg_sparse = sparse.csr_matrix(X_all_neg)
 
-    for X in (X_all_neg, X_all_neg_sparse):
+    for X in (X_dense, X_all_neg, X_all_neg_sparse):
         normalizer = Normalizer(norm='max')
         X_norm = normalizer.transform(X)
         assert X_norm is not X

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -89,7 +89,7 @@ def assert_correct_incr(i, batch_start, batch_stop, n, chunk_size,
         assert (i + 1) * chunk_size == n_samples_seen
     else:
         assert (i * chunk_size + (batch_stop - batch_start) ==
-                n_samples_seen)
+                     n_samples_seen)
 
 
 def test_polynomial_features():
@@ -626,6 +626,7 @@ def test_partial_fit_sparse_input():
 
     null_transform = StandardScaler(with_mean=False, with_std=False, copy=True)
     for X in [X_csr, X_csc]:
+
         X_null = null_transform.partial_fit(X).transform(X)
         assert_array_equal(X_null.data, X.data)
         X_orig = null_transform.inverse_transform(X_null)
@@ -639,6 +640,7 @@ def test_standard_scaler_trasform_with_partial_fit():
 
     scaler_incr = StandardScaler()
     for i, batch in enumerate(gen_batches(X.shape[0], 1)):
+
         X_sofar = X[:(i + 1), :]
         chunks_copy = X_sofar.copy()
         scaled_batch = StandardScaler().fit_transform(X_sofar)
@@ -1051,7 +1053,7 @@ def test_scale_input_finiteness_validation():
     # Check if non finite inputs raise ValueError
     X = [[np.inf, 5, 6, 7, 8]]
     with pytest.raises(ValueError, match="Input contains infinity "
-                                         "or a value too large"):
+                       "or a value too large"):
         scale(X)
 
 
@@ -1284,8 +1286,8 @@ def test_quantile_transform_sparse_ignore_zeros():
 
     # dense case -> warning raise
     assert_warns_message(UserWarning, "'ignore_implicit_zeros' takes effect"
-                                      " only with sparse matrix. This parameter has no"
-                                      " effect.", transformer.fit, X)
+                         " only with sparse matrix. This parameter has no"
+                         " effect.", transformer.fit, X)
 
     X_expected = np.array([[0, 0],
                            [0, 0],
@@ -1494,15 +1496,15 @@ def test_quantile_transform_bounds():
     transformer = QuantileTransformer()
     transformer.fit(X)
     assert (transformer.transform([[-10]]) ==
-            transformer.transform([[np.min(X)]]))
+                 transformer.transform([[np.min(X)]]))
     assert (transformer.transform([[10]]) ==
-            transformer.transform([[np.max(X)]]))
+                 transformer.transform([[np.max(X)]]))
     assert (transformer.inverse_transform([[-10]]) ==
-            transformer.inverse_transform(
-                [[np.min(transformer.references_)]]))
+                 transformer.inverse_transform(
+                     [[np.min(transformer.references_)]]))
     assert (transformer.inverse_transform([[10]]) ==
-            transformer.inverse_transform(
-                [[np.max(transformer.references_)]]))
+                 transformer.inverse_transform(
+                     [[np.max(transformer.references_)]]))
 
 
 def test_quantile_transform_and_inverse():
@@ -1516,7 +1518,7 @@ def test_quantile_transform_and_inverse():
 
 
 def test_quantile_transform_nan():
-    X = np.array([[np.nan, 0, 0, 1],
+    X = np.array([[np.nan, 0,  0, 1],
                   [np.nan, np.nan, 0, 0.5],
                   [np.nan, 1, 1, 0]])
 
@@ -1700,17 +1702,17 @@ def test_maxabs_scaler_zero_variance_features():
 
 def test_maxabs_scaler_large_negative_value():
     # Check MaxAbsScaler on toy data with a large negative value
-    X = [[0., 1., +0.5, -1.0],
-         [0., 1., -0.3, -0.5],
-         [0., 1., -100.0, 0.0],
-         [0., 0., +0.0, -2.0]]
+    X = [[0., 1.,   +0.5, -1.0],
+         [0., 1.,   -0.3, -0.5],
+         [0., 1., -100.0,  0.0],
+         [0., 0.,   +0.0, -2.0]]
 
     scaler = MaxAbsScaler()
     X_trans = scaler.fit_transform(X)
-    X_expected = [[0., 1., 0.005, -0.5],
-                  [0., 1., -0.003, -0.25],
-                  [0., 1., -1.0, 0.0],
-                  [0., 0., 0.0, -1.0]]
+    X_expected = [[0., 1.,  0.005,    -0.5],
+                  [0., 1., -0.003,    -0.25],
+                  [0., 1., -1.0,       0.0],
+                  [0., 0.,  0.0,      -1.0]]
     assert_array_almost_equal(X_trans, X_expected)
 
 
@@ -1787,9 +1789,9 @@ def test_maxabs_scaler_partial_fit():
                                   scaler_incr_csc.max_abs_)
         assert scaler_batch.n_samples_seen_ == scaler_incr.n_samples_seen_
         assert (scaler_batch.n_samples_seen_ ==
-                scaler_incr_csr.n_samples_seen_)
+                     scaler_incr_csr.n_samples_seen_)
         assert (scaler_batch.n_samples_seen_ ==
-                scaler_incr_csc.n_samples_seen_)
+                     scaler_incr_csc.n_samples_seen_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csc.scale_)
@@ -1998,7 +2000,7 @@ def test_normalize():
                 if norm == 'l1':
                     row_sums = np.abs(X_norm).sum(axis=1)
                 else:
-                    X_norm_squared = X_norm ** 2
+                    X_norm_squared = X_norm**2
                     row_sums = X_norm_squared.sum(axis=1)
 
                 assert_array_almost_equal(row_sums, ones)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1952,18 +1952,6 @@ def test_normalizer_max():
                 assert_almost_equal(row_maxs[i], 1.0)
             assert_almost_equal(row_maxs[3], 0.0)
 
-    # test all negative data
-    X_all_neg = -np.abs(X_dense)
-    X_all_neg_sparse = sparse.csr_matrix(X_all_neg)
-
-    for X in (X_all_neg, X_all_neg_sparse):
-        normalizer = Normalizer(norm='max')
-        X_norm = normalizer.transform(X)
-        assert X_norm is not X
-        X_norm = toarray(X_norm)
-        assert_array_equal(
-            np.sign(X_norm).ravel(), np.sign(toarray(X)).ravel())
-
     # check input for which copy=False won't prevent a copy
     for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):
         X = init(X_dense)
@@ -1976,6 +1964,24 @@ def test_normalizer_max():
         for i in range(3):
             assert_almost_equal(row_maxs[i], 1.0)
         assert_almost_equal(la.norm(X_norm[3]), 0.0)
+
+
+def test_normalizer_max_sign():
+    # check that we normalize by a positive number even for negative data
+    rng = np.random.RandomState(0)
+    X_dense = rng.randn(4, 5)
+    # set the row number 3 to zero
+    X_dense[3, :] = 0.0
+    X_all_neg = -np.abs(X_dense)
+    X_all_neg_sparse = sparse.csr_matrix(X_all_neg)
+
+    for X in (X_all_neg, X_all_neg_sparse):
+        normalizer = Normalizer(norm='max')
+        X_norm = normalizer.transform(X)
+        assert X_norm is not X
+        X_norm = toarray(X_norm)
+        assert_array_equal(
+            np.sign(X_norm), np.sign(toarray(X)))
 
 
 def test_normalize():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -89,7 +89,7 @@ def assert_correct_incr(i, batch_start, batch_stop, n, chunk_size,
         assert (i + 1) * chunk_size == n_samples_seen
     else:
         assert (i * chunk_size + (batch_stop - batch_start) ==
-                     n_samples_seen)
+                n_samples_seen)
 
 
 def test_polynomial_features():
@@ -626,7 +626,6 @@ def test_partial_fit_sparse_input():
 
     null_transform = StandardScaler(with_mean=False, with_std=False, copy=True)
     for X in [X_csr, X_csc]:
-
         X_null = null_transform.partial_fit(X).transform(X)
         assert_array_equal(X_null.data, X.data)
         X_orig = null_transform.inverse_transform(X_null)
@@ -640,7 +639,6 @@ def test_standard_scaler_trasform_with_partial_fit():
 
     scaler_incr = StandardScaler()
     for i, batch in enumerate(gen_batches(X.shape[0], 1)):
-
         X_sofar = X[:(i + 1), :]
         chunks_copy = X_sofar.copy()
         scaled_batch = StandardScaler().fit_transform(X_sofar)
@@ -1053,7 +1051,7 @@ def test_scale_input_finiteness_validation():
     # Check if non finite inputs raise ValueError
     X = [[np.inf, 5, 6, 7, 8]]
     with pytest.raises(ValueError, match="Input contains infinity "
-                       "or a value too large"):
+                                         "or a value too large"):
         scale(X)
 
 
@@ -1286,8 +1284,8 @@ def test_quantile_transform_sparse_ignore_zeros():
 
     # dense case -> warning raise
     assert_warns_message(UserWarning, "'ignore_implicit_zeros' takes effect"
-                         " only with sparse matrix. This parameter has no"
-                         " effect.", transformer.fit, X)
+                                      " only with sparse matrix. This parameter has no"
+                                      " effect.", transformer.fit, X)
 
     X_expected = np.array([[0, 0],
                            [0, 0],
@@ -1496,15 +1494,15 @@ def test_quantile_transform_bounds():
     transformer = QuantileTransformer()
     transformer.fit(X)
     assert (transformer.transform([[-10]]) ==
-                 transformer.transform([[np.min(X)]]))
+            transformer.transform([[np.min(X)]]))
     assert (transformer.transform([[10]]) ==
-                 transformer.transform([[np.max(X)]]))
+            transformer.transform([[np.max(X)]]))
     assert (transformer.inverse_transform([[-10]]) ==
-                 transformer.inverse_transform(
-                     [[np.min(transformer.references_)]]))
+            transformer.inverse_transform(
+                [[np.min(transformer.references_)]]))
     assert (transformer.inverse_transform([[10]]) ==
-                 transformer.inverse_transform(
-                     [[np.max(transformer.references_)]]))
+            transformer.inverse_transform(
+                [[np.max(transformer.references_)]]))
 
 
 def test_quantile_transform_and_inverse():
@@ -1518,7 +1516,7 @@ def test_quantile_transform_and_inverse():
 
 
 def test_quantile_transform_nan():
-    X = np.array([[np.nan, 0,  0, 1],
+    X = np.array([[np.nan, 0, 0, 1],
                   [np.nan, np.nan, 0, 0.5],
                   [np.nan, 1, 1, 0]])
 
@@ -1702,17 +1700,17 @@ def test_maxabs_scaler_zero_variance_features():
 
 def test_maxabs_scaler_large_negative_value():
     # Check MaxAbsScaler on toy data with a large negative value
-    X = [[0., 1.,   +0.5, -1.0],
-         [0., 1.,   -0.3, -0.5],
-         [0., 1., -100.0,  0.0],
-         [0., 0.,   +0.0, -2.0]]
+    X = [[0., 1., +0.5, -1.0],
+         [0., 1., -0.3, -0.5],
+         [0., 1., -100.0, 0.0],
+         [0., 0., +0.0, -2.0]]
 
     scaler = MaxAbsScaler()
     X_trans = scaler.fit_transform(X)
-    X_expected = [[0., 1.,  0.005,    -0.5],
-                  [0., 1., -0.003,    -0.25],
-                  [0., 1., -1.0,       0.0],
-                  [0., 0.,  0.0,      -1.0]]
+    X_expected = [[0., 1., 0.005, -0.5],
+                  [0., 1., -0.003, -0.25],
+                  [0., 1., -1.0, 0.0],
+                  [0., 0., 0.0, -1.0]]
     assert_array_almost_equal(X_trans, X_expected)
 
 
@@ -1789,9 +1787,9 @@ def test_maxabs_scaler_partial_fit():
                                   scaler_incr_csc.max_abs_)
         assert scaler_batch.n_samples_seen_ == scaler_incr.n_samples_seen_
         assert (scaler_batch.n_samples_seen_ ==
-                     scaler_incr_csr.n_samples_seen_)
+                scaler_incr_csr.n_samples_seen_)
         assert (scaler_batch.n_samples_seen_ ==
-                     scaler_incr_csc.n_samples_seen_)
+                scaler_incr_csc.n_samples_seen_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csc.scale_)
@@ -2000,7 +1998,7 @@ def test_normalize():
                 if norm == 'l1':
                     row_sums = np.abs(X_norm).sum(axis=1)
                 else:
-                    X_norm_squared = X_norm**2
+                    X_norm_squared = X_norm ** 2
                     row_sums = X_norm_squared.sum(axis=1)
 
                 assert_array_almost_equal(row_sums, ones)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1906,8 +1906,7 @@ def test_normalizer_l2():
     # check input for which copy=False won't prevent a copy
     for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):
         X = init(X_dense)
-        X_norm = normalizer = \
-            Normalizer(norm='l2', copy=False).transform(X)
+        X_norm = normalizer = Normalizer(norm='l2', copy=False).transform(X)
 
         assert X_norm is not X
         assert isinstance(X_norm, sparse.csr_matrix)
@@ -1964,7 +1963,8 @@ def test_normalizer_max():
         # check input for which copy=False won't prevent a copy
         for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):
             X = init(X_dense)
-            X_norm = normalizer = Normalizer(norm='l2', copy=False).transform(X)
+            X_norm = normalizer = \
+                Normalizer(norm='l2', copy=False).transform(X)
 
             assert X_norm is not X
             assert isinstance(X_norm, sparse.csr_matrix)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1961,7 +1961,8 @@ def test_normalizer_max():
         X_norm = normalizer.transform(X)
         assert X_norm is not X
         X_norm = toarray(X_norm)
-        assert_array_equal(np.sign(X_norm).ravel(), np.sign(toarray(X)).ravel())
+        assert_array_equal(
+            np.sign(X_norm).ravel(), np.sign(toarray(X)).ravel())
 
     # check input for which copy=False won't prevent a copy
     for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1957,7 +1957,8 @@ def test_normalizer_max():
                 assert_almost_equal(row_maxs[3], 0.0)
 
             # assert the sign does not change after normalization
-            assert_array_almost_equal(X_norm1.ravel(), toarray(X).ravel())
+            assert_array_almost_equal(
+                np.sign(X_norm1.ravel()), np.sign(toarray(X).ravel()))
 
     # check input for which copy=False won't prevent a copy
     for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1952,6 +1952,15 @@ def test_normalizer_max():
                 assert_almost_equal(row_maxs[i], 1.0)
             assert_almost_equal(row_maxs[3], 0.0)
 
+    # test all negative data
+    X_all_neg = -np.abs(X_dense)
+    normalizer = Normalizer(norm='max')
+    X_norm = normalizer.transform(X_all_neg)
+    assert X_norm is not X_all_neg
+    X_norm = toarray(X_norm)
+    print(X_norm, X_all_neg)
+    assert_array_equal(np.sign(X_norm).ravel(), np.sign(toarray(X_all_neg)).ravel())
+
     # check input for which copy=False won't prevent a copy
     for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):
         X = init(X_dense)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1960,17 +1960,18 @@ def test_normalizer_max():
             assert_array_almost_equal(
                 np.sign(X_norm1.ravel()), np.sign(toarray(X).ravel()))
 
-    # check input for which copy=False won't prevent a copy
-    for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):
-        X = init(X_dense)
-        X_norm = normalizer = Normalizer(norm='l2', copy=False).transform(X)
+        # check input for which copy=False won't prevent a copy
+        for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):
+            X = init(X_dense)
+            X_norm = normalizer = Normalizer(norm='l2', copy=False).transform(X)
 
-        assert X_norm is not X
-        assert isinstance(X_norm, sparse.csr_matrix)
-        X_norm = toarray(X_norm)
-        for i in range(3):
-            assert_almost_equal(row_maxs[i], 1.0)
-        assert_almost_equal(la.norm(X_norm[3]), 0.0)
+            assert X_norm is not X
+            assert isinstance(X_norm, sparse.csr_matrix)
+            X_norm = toarray(X_norm)
+            if row_maxs.max() > 0:
+                for i in range(3):
+                    assert_almost_equal(row_maxs[i], 1.0)
+                assert_almost_equal(la.norm(X_norm[3]), 0.0)
 
 
 def test_normalize():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1947,7 +1947,7 @@ def test_normalizer_max():
         X_norm2 = toarray(X_norm2)
 
         for X_norm in (X_norm1, X_norm2):
-            row_maxs = X_norm.max(axis=1)
+            row_maxs = abs(X_norm).max(axis=1)
             for i in range(3):
                 assert_almost_equal(row_maxs[i], 1.0)
             assert_almost_equal(row_maxs[3], 0.0)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -16,7 +16,7 @@ import pytest
 
 from sklearn.utils import gen_batches
 
-from sklearn.utils._testing import assert_almost_equal, assert_equal
+from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_less

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1906,7 +1906,8 @@ def test_normalizer_l2():
     # check input for which copy=False won't prevent a copy
     for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):
         X = init(X_dense)
-        X_norm = normalizer = Normalizer(norm='l2', copy=False).transform(X)
+        X_norm = normalizer = \
+            Normalizer(norm='l2', copy=False).transform(X)
 
         assert X_norm is not X
         assert isinstance(X_norm, sparse.csr_matrix)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1954,12 +1954,14 @@ def test_normalizer_max():
 
     # test all negative data
     X_all_neg = -np.abs(X_dense)
-    normalizer = Normalizer(norm='max')
-    X_norm = normalizer.transform(X_all_neg)
-    assert X_norm is not X_all_neg
-    X_norm = toarray(X_norm)
-    print(X_norm, X_all_neg)
-    assert_array_equal(np.sign(X_norm).ravel(), np.sign(toarray(X_all_neg)).ravel())
+    X_all_neg_sparse = sparse.csr_matrix(X_all_neg)
+
+    for X in (X_all_neg, X_all_neg_sparse):
+        normalizer = Normalizer(norm='max')
+        X_norm = normalizer.transform(X)
+        assert X_norm is not X
+        X_norm = toarray(X_norm)
+        assert_array_equal(np.sign(X_norm).ravel(), np.sign(toarray(X)).ravel())
 
     # check input for which copy=False won't prevent a copy
     for init in (sparse.coo_matrix, sparse.csc_matrix, sparse.lil_matrix):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #16632 

#### What does this implement/fix? Explain your changes.

Takes the max of the absolute values as a norm before normalizing the vectors. 
See [here](https://en.wikipedia.org/wiki/Norm_(mathematics)) the norm definition.
