### PR TITLE
[MRG] EXA align lorenz curves between the two examples with GLMs

### DIFF
--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -393,11 +393,11 @@ plt.tight_layout()
 #
 # To compare the 3 models within this perspective, one can plot the fraction of
 # the number of claims vs the fraction of exposure for test samples ordered by
-# the model predictions, from riskiest to safest according to each model:
+# the model predictions, from safest to riskiest  according to each model:
 
 
 def _cumulated_claims(y_true, y_pred, exposure):
-    idx_sort = np.argsort(y_pred)[::-1]  # from riskiest to safest
+    idx_sort = np.argsort(y_pred)  # from safest to riskiest
     sorted_exposure = exposure[idx_sort]
     sorted_frequencies = y_true[idx_sort]
     cumulated_exposure = np.cumsum(sorted_exposure)
@@ -434,7 +434,7 @@ ax.plot([0, 1], [0, 1], linestyle="--", color="black",
         label="Random baseline")
 ax.set(
     title="Cumulated number of claims by model",
-    xlabel='Fraction of exposure (from riskiest to safest)',
+    xlabel='Fraction of exposure (from safest to riskiest)',
     ylabel='Fraction of number of claims'
 )
 ax.legend(loc="lower right")

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -437,7 +437,7 @@ ax.set(
     xlabel='Fraction of exposure (from safest to riskiest)',
     ylabel='Fraction of number of claims'
 )
-ax.legend(loc="lower right")
+ax.legend(loc="upper left")
 
 ##############################################################################
 # This plot reveals that the random forest model is slightly better at ranking


### PR DESCRIPTION
#### Reference Issues/PRs
#14300 added 2 examples, one for Poisson, one for Tweedie regression. In the last plot of each example, a lorenz curve shown. But one orders the x-axis opposite to the other example.

#### What does this implement/fix? Explain your changes.
This PR aligns the x-axis of the last plot, always from _safest to riskiest policies_.