### PR TITLE
DOC Improve claim prediction example

### DIFF
--- a/examples/.flake8
+++ b/examples/.flake8
@@ -2,4 +2,4 @@
 
 [flake8]
 # Same ignore as project-wide plus E402 (imports not at top of file)
-ignore=E121,E123,E126,E24,E226,E704,W503,W504,E402
+ignore=E121,E123,E126,E24,E226,E704,W503,W504,E402,F401

--- a/examples/.flake8
+++ b/examples/.flake8
@@ -2,4 +2,4 @@
 
 [flake8]
 # Same ignore as project-wide plus E402 (imports not at top of file)
-ignore=E121,E123,E126,E24,E226,E704,W503,W504,E402,F401
+ignore=E121,E123,E126,E24,E226,E704,W503,W504,E402

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -10,13 +10,13 @@ learned with least squared error.
 
 A few definitions:
 
-- a **policy** is a contract between an insurance company and an individual:
+- A **policy** is a contract between an insurance company and an individual:
   the **policyholder**, that is, the vehicle driver in this case.
 
-- a **claim** is the request made by a policyholder to the insurer to
+- A **claim** is the request made by a policyholder to the insurer to
   compensate for a loss covered by the insurance.
 
-- the **exposure** is the duration of the insurance coverage of a given policy,
+- The **exposure** is the duration of the insurance coverage of a given policy,
   in years.
 
 - the claim **frequency** is the number of claims divided by the exposure,
@@ -233,7 +233,7 @@ score_estimator(poisson, df_test)
 # Regression Trees. Tree-based models do not require the categorical data to be
 # one-hot encoded: instead, we can encode each category label with an arbitrary
 # integer using :class:`preprocessing.OrdinalEncoder`. With this encoding, the
-# the trees will treat the categorical features as ordered features, which
+# trees will treat the categorical features as ordered features, which
 # might not be always a desired behavior. However this effect is limited for
 # deep enough trees which are able to recover the categorical nature of the
 # features. The main advantage of the :class:`preprocessing.OrdinalEncoder`
@@ -408,7 +408,7 @@ for axi, model in zip(ax.ravel(), [dummy, ridge, poisson, gbrt]):
 plt.tight_layout()
 
 ###############################################################################
-# The dummy regression model predicts on constant frequency. This model is not
+# The dummy regression model predicts a constant frequency. This model is not
 # attribute the same tied rank to all samples but is none-the-less well
 # calibrated.
 #
@@ -525,7 +525,7 @@ ax.legend(loc="upper left")
 #   model to be badly calibrated. In particular it tends to under estimate the
 #   risk and can even predict invalid negative frequencies...
 #
-# - Using the Poisson loss can correct this problem and lead to a
+# - Using the Poisson loss with a log-link can correct these problems and lead to a
 #   well-calibrated linear model.
 #
 # - Despite the improvement in calibration, the ranking power of both linear
@@ -538,7 +538,7 @@ ax.legend(loc="upper left")
 #
 # - The Poisson deviance computed as an evaluation metric reflects both the
 #   calibration and the ranking power of the model but makes a linear
-#   assumption on the ideal relationship between the expected value of an the
+#   assumption on the ideal relationship between the expected value and the
 #   variance of the response variable.
 #
 # - Traditional regression metrics such as Mean Squared Error and Mean Absolute

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -521,9 +521,10 @@ ax.legend(loc="upper left")
 #   value vs the mean predicted value on groups of test samples binned by
 #   predicted risk.
 #
-# - The least squares loss of the Ridge regression model seem to cause this
-#   model to be badly calibrated. In particular it tends to under estimate the
-#   risk and can even predict invalid negative frequencies...
+# - The least squares loss (along with the implicit use of the identity link
+#   function) of the Ridge regression model seems to cause this model to be
+#   badly calibrated. In particular it tends to under estimate the risk and can
+#   even predict invalid negative frequencies.
 #
 # - Using the Poisson loss with a log-link can correct these problems and lead
 #   to a well-calibrated linear model.
@@ -537,9 +538,10 @@ ax.legend(loc="upper left")
 #   squares loss).
 #
 # - The Poisson deviance computed as an evaluation metric reflects both the
-#   calibration and the ranking power of the model but makes a linear
+#   calibration and the ranking power of the model. It also makes a linear
 #   assumption on the ideal relationship between the expected value and the
-#   variance of the response variable.
+#   variance of the response variable. For the sake of conciseness we did not
+#   check whether this assumption holds.
 #
 # - Traditional regression metrics such as Mean Squared Error and Mean Absolute
 #   Error are hard to meaningfully interpret on count values with many zeros.

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -455,9 +455,10 @@ plt.tight_layout()
 # absolute value of the prediction. In this case, the model evaluation would
 # cast the problem as a ranking problem rather than a regression problem.
 #
-# To compare the 3 models from this perspective, one can plot the fraction of
-# the number of claims vs the fraction of exposure for test samples ordered by
-# the model predictions, from safest to riskiest according to each model.
+# To compare the 3 models from this perspective, one can plot the cumulative
+# proportion of claims vs the cumulative proportion of exposure for the test
+# samples order by the model predictions, from safest to riskiest according to
+# each model.
 #
 # This plot is called a Lorenz curve and can be summarized by the Gini index:
 
@@ -502,9 +503,9 @@ ax.plot(cum_exposure, cum_claims, linestyle="-.", color="gray", label=label)
 ax.plot([0, 1], [0, 1], linestyle="--", color="black",
         label="Random baseline")
 ax.set(
-    title="Cumulated number of claims by model",
-    xlabel='Fraction of exposure (from safest to riskiest)',
-    ylabel='Fraction of number of claims'
+    title="Lorenz curves by model",
+    xlabel='Cumulative proportion of exposure (from safest to riskiest)',
+    ylabel='Cumulative proportion of claims'
 )
 ax.legend(loc="upper left")
 

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -39,7 +39,6 @@ print(__doc__)
 #          Roman Yurchak <rth.yurchak@gmail.com>
 #          Olivier Grisel <olivier.grisel@ensta.org>
 # License: BSD 3 clause
-import warnings
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -168,10 +167,10 @@ def score_estimator(estimator, df_test):
     # the Poisson deviance
     mask = y_pred > 0
     if (~mask).any():
-        warnings.warn("Estimator yields non-positive predictions for {} "
-                      "samples out of {}. These predictions will be clipped "
-                      " while computing the Poisson deviance"
-                      .format((~mask).sum(), mask.shape[0]))
+        n_clipped, n_samples = (~mask).sum(), mask.shape[0]
+        print(f"WARNING: Estimator yields non-positive predictions for "
+              f"{n_clipped} samples out of {n_samples}. These predictions "
+              f"will be clipped while computing the Poisson deviance.")
 
     print("mean Poisson deviance: %.3f" %
           mean_poisson_deviance(df_test["Frequency"], y_pred.clip(min=1e-6),

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -310,10 +310,10 @@ plt.tight_layout()
 # The experimental data presents a long tail distribution for ``y``. In all
 # models, we predict the expected frequency of a random variable, so we will
 # have necessarily fewer extreme values than for the observed realizations of
-# that random variable. Additionally, the normal conditional distribution used
-# in ``Ridge`` and ``HistGradientBoostingRegressor`` has a constant variance,
-# while for the Poisson distribution used in ``PoissonRegressor``, the variance
-# is proportional to the predicted expected value.
+# that random variable. Additionally, the normal distribution used in ``Ridge``
+# and ``HistGradientBoostingRegressor`` has a constant variance, while for the
+# Poisson distribution used in ``PoissonRegressor``, the variance is
+# proportional to the predicted expected value.
 #
 # Thus, among the considered estimators, ``PoissonRegressor`` is a-priori
 # better suited for modeling the long tail distribution of the non-negative
@@ -321,7 +321,7 @@ plt.tight_layout()
 #
 # The ``HistGradientBoostingRegressor`` estimator has more flexibility and is
 # able to predict higher expected values while still assuming a normal
-# conditional distribution with constant variance for the response variable.
+# distribution with constant variance for the response variable.
 #
 # Evaluation of the calibration of predictions
 # --------------------------------------------
@@ -389,6 +389,8 @@ for axi, model in zip(ax.ravel(), [dummy, ridge, poisson, gbrt]):
     q, y_true_seg, y_pred_seg = _mean_frequency_by_risk_group(
         y_true, y_pred, sample_weight=exposure, n_bins=10)
 
+    # Name of the model after the class of the estimator used in the last step
+    # of the pipeline.
     model_name = model.steps[-1][1].__class__.__name__
     print(f"Predicted number of claims by {model_name}: "
           f"{np.sum(y_pred * exposure):.1f}")
@@ -407,7 +409,8 @@ plt.tight_layout()
 
 ###############################################################################
 # The dummy regression model predicts on constant frequency. This model is not
-# discriminative at all but is none-the-less well calibrated.
+# attribute the same tied rank to all samples but is none-the-less well
+# calibrated.
 #
 # The ``Ridge`` regression model can predict very low expected frequencies that
 # do not match the data. It can therefore severly under-estimate the risk for
@@ -422,13 +425,13 @@ plt.tight_layout()
 # claims in the test set while the other three models can approximately recover
 # the total number of claims of the test portfolio.
 #
-# Evaluation of the discriminative power
-# --------------------------------------
+# Evaluation of the ranking power
+# -------------------------------
 #
 # For some business applications, we are interested in the ability of the model
-# to discriminate the riskiest from the safest policyholders, irrespective of
-# the absolute value of the prediction. In this case, the model evaluation
-# would cast the problem as a ranking problem rather than a regression problem.
+# to rank the riskiest from the safest policyholders, irrespective of the
+# absolute value of the prediction. In this case, the model evaluation would
+# cast the problem as a ranking problem rather than a regression problem.
 #
 # To compare the 3 models from this perspective, one can plot the fraction of
 # the number of claims vs the fraction of exposure for test samples ordered by
@@ -485,8 +488,8 @@ ax.set(
 ax.legend(loc="upper left")
 
 ##############################################################################
-# As expected, the dummy regressor is unable to discriminate and therefore
-# performs the worst on this plot.
+# As expected, the dummy regressor is unable to correctly rank the samples and
+# therefore performs the worst on this plot.
 #
 # The tree-based model is significantly better at ranking policyholders by risk
 # while the two linear models perform similarly.
@@ -507,11 +510,12 @@ ax.legend(loc="upper left")
 # Main takeaways
 # --------------
 #
-# - A ideal model is both well-calibrated and discriminative.
+# - The performance of the models can be evaluted by their ability to yield
+#   well-calibrated predictions and a good ranking.
 #
 # - The Gini index reflects the ability of a model to rank predictions
 #   irrespective of their absolute values, and therefore only assess their
-#   discriminative power.
+#   ranking power.
 #
 # - The calibration of the model can be assessed by plotting the mean observed
 #   value vs the mean predicted value on groups of test samples binned by
@@ -524,16 +528,16 @@ ax.legend(loc="upper left")
 # - Using the Poisson loss can correct this problem and lead to a
 #   well-calibrated linear model.
 #
-# - Despite the improvement in calibration, the discriminative power of both
-#   linear models are comparable and well below the discriminative power of the
-#   Gradient Boosting Regression Trees.
+# - Despite the improvement in calibration, the ranking power of both linear
+#   models are comparable and well below the ranking power of the Gradient
+#   Boosting Regression Trees.
 #
 # - The non-linear Gradient Boosting Regression Trees model does not seem to
 #   suffer from significant mis-calibration issues (despite the use of a least
 #   squares loss).
 #
 # - The Poisson deviance computed as an evaluation metric reflects both the
-#   calibration and the discriminative power of the model but makes a linear
+#   calibration and the ranking power of the model but makes a linear
 #   assumption on the ideal relationship between the expected value of an the
 #   variance of the response variable.
 #

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -489,7 +489,8 @@ ax.legend(loc="upper left")
 # performs the worst on this plot.
 #
 # The tree-based model is significantly better at ranking policyholders by risk
-# while the two linear models perform similarly.
+# while the two linear models perform similarly. The linear models assume no
+# interactions between the input variables which likely causes under-fitting.
 #
 # All three models are significantly better than chance but also very far from
 # making perfect predictions.

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -64,8 +64,9 @@ df
 # events occurring with a constant rate in a given time interval (``Exposure``,
 # in units of years).
 #
-# Here we want to model the frequency ``y = ClaimNb / Exposure`` via a (scaled)
-# conditional Poisson distribution, and use ``Exposure`` as ``sample_weight``.
+# Here we want to model the frequency ``y = ClaimNb / Exposure`` conditionally
+# on ``X`` via a (scaled) Poisson distribution, and use ``Exposure`` as
+# ``sample_weight``.
 
 df["Frequency"] = df["ClaimNb"] / df["Exposure"]
 

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -240,7 +240,7 @@ score_estimator(poisson, df_test)
 # over the :class:`preprocessing.OneHotEncoder` is that it will make training
 # faster.
 
-from sklearn.experimental import enable_hist_gradient_boosting
+from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.preprocessing import OrdinalEncoder
 

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -19,7 +19,7 @@ A few definitions:
 - the **exposure** is the duration of the insurance coverage of a given policy,
   in years.
 
-- the claim **frequency** is the number of claims divided by the **exposure**,
+- the claim **frequency** is the number of claims divided by the exposure,
   typically measured in number of claims per year.
 
 In this dataset, each sample corresponds to an insurance policy. Available

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -158,10 +158,10 @@ def score_estimator(estimator, df_test):
 
     print("MSE: %.3f" %
           mean_squared_error(df_test["Frequency"], y_pred,
-                             df_test["Exposure"]))
+                             sample_weight=df_test["Exposure"]))
     print("MAE: %.3f" %
           mean_absolute_error(df_test["Frequency"], y_pred,
-                              df_test["Exposure"]))
+                              sample_weight=df_test["Exposure"]))
 
     # ignore non-positive predictions, as they are invalid for
     # the Poisson deviance
@@ -174,7 +174,7 @@ def score_estimator(estimator, df_test):
 
     print("mean Poisson deviance: %.3f" %
           mean_poisson_deviance(df_test["Frequency"], y_pred.clip(min=1e-6),
-                                df_test["Exposure"]))
+                                sample_weight=df_test["Exposure"]))
 
 
 print("Constant mean frequency evaluation:")

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -5,8 +5,9 @@ Poisson regression and non-normal loss
 
 This example illustrates the use of log-linear Poisson regression on the
 `French Motor Third-Party Liability Claims dataset
-<https://www.openml.org/d/41214>`_ from [1]_ and compares it with models
-learned with least squared error.
+<https://www.openml.org/d/41214>`_ from [1]_ and compares it with a linear
+model fitted with the usual least squared error and a non-linear GBRT model
+fitted with the Poisson loss (and a log-link).
 
 A few definitions:
 
@@ -124,7 +125,8 @@ linear_model_preprocessor = ColumnTransformer(
 #
 # It is worth noting that more than 93% of policyholders have zero claims. If
 # we were to convert this problem into a binary classification task, it would
-# be significantly imbalanced, and even a simplistic model that would only predict mean can achieve an accuracy of 93%.
+# be significantly imbalanced, and even a simplistic model that would only
+# predict mean can achieve an accuracy of 93%.
 #
 # To evaluate the pertinence of the used metrics, we will consider as a
 # baseline a "dummy" estimator that constantly predicts the mean frequency of
@@ -186,8 +188,8 @@ score_estimator(dummy, df_test)
 #
 # We start by modeling the target variable with the (l2 penalized) least
 # squares linear regression model, more comonly known as Ridge regression. We
-# use a low penalization `alpha`, as we expect such a linear model to under-fit on such
-# a large dataset.
+# use a low penalization `alpha`, as we expect such a linear model to under-fit
+# on such a large dataset.
 
 from sklearn.linear_model import Ridge
 
@@ -212,8 +214,8 @@ score_estimator(ridge_glm, df_test)
 ##############################################################################
 # Next we fit the Poisson regressor on the target variable. We set the
 # regularization strength ``alpha`` to approximately 1e-6 over number of
-# samples (i.e. `1e-12`) in order to mimic the Ridge regressor whose L2 penalty term scales
-# differently with the number of samples.
+# samples (i.e. `1e-12`) in order to mimic the Ridge regressor whose L2 penalty
+# term scales differently with the number of samples.
 
 from sklearn.linear_model import PoissonRegressor
 
@@ -233,10 +235,10 @@ score_estimator(poisson_glm, df_test)
 # Finally, we will consider a non-linear model, namely Gradient Boosting
 # Regression Trees. Tree-based models do not require the categorical data to be
 # one-hot encoded: instead, we can encode each category label with an arbitrary
-# integer using :class:`~sklearn.preprocessing.OrdinalEncoder`. With this encoding, the
-# trees will treat the categorical features as ordered features, which might
-# not be always a desired behavior. However this effect is limited for deep
-# enough trees which are able to recover the categorical nature of the
+# integer using :class:`~sklearn.preprocessing.OrdinalEncoder`. With this
+# encoding, the trees will treat the categorical features as ordered features,
+# which might not be always a desired behavior. However this effect is limited
+# for deep enough trees which are able to recover the categorical nature of the
 # features. The main advantage of the :class:`preprocessing.OrdinalEncoder`
 # over the :class:`preprocessing.OneHotEncoder` is that it will make training
 # faster.
@@ -333,11 +335,11 @@ plt.tight_layout()
 #
 # Note that we could have used the least squares loss for the
 # ``HistGradientBoostingRegressor`` model. This would wrongly assume a normal
-# distribution the response variable as for the `Ridge` model, and possibly also
-# lead to slightly negative predictions. However the gradient boosted trees
-# would still perform relatively well and in particular better than
-# ``PoissonRegressor`` thanks to the flexibility of the trees combined with
-# the large number of training samples.
+# distribution the response variable as for the `Ridge` model, and possibly
+# also lead to slightly negative predictions. However the gradient boosted
+# trees would still perform relatively well and in particular better than
+# ``PoissonRegressor`` thanks to the flexibility of the trees combined with the
+# large number of training samples.
 #
 # Evaluation of the calibration of predictions
 # --------------------------------------------
@@ -548,10 +550,6 @@ ax.legend(loc="upper left")
 # - Despite the improvement in calibration, the ranking power of both linear
 #   models are comparable and well below the ranking power of the Gradient
 #   Boosting Regression Trees.
-#
-# - The non-linear Gradient Boosting Regression Trees model does not seem to
-#   suffer from significant mis-calibration issues (despite the use of a least
-#   squares loss).
 #
 # - The Poisson deviance computed as an evaluation metric reflects both the
 #   calibration and the ranking power of the model. It also makes a linear

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -19,7 +19,7 @@ A few definitions:
 - The **exposure** is the duration of the insurance coverage of a given policy,
   in years.
 
-- the claim **frequency** is the number of claims divided by the exposure,
+- The claim **frequency** is the number of claims divided by the exposure,
   typically measured in number of claims per year.
 
 In this dataset, each sample corresponds to an insurance policy. Available
@@ -124,7 +124,7 @@ linear_model_preprocessor = ColumnTransformer(
 #
 # It is worth noting that more than 93% of policyholders have zero claims. If
 # we were to convert this problem into a binary classification task, it would
-# be significantly imbalanced.
+# be significantly imbalanced, and even a simplistic model that would only predict mean can achieve an accuracy of 93%.
 #
 # To evaluate the pertinence of the used metrics, we will consider as a
 # baseline a "dummy" estimator that constantly predicts the mean frequency of
@@ -186,7 +186,7 @@ score_estimator(dummy, df_test)
 #
 # We start by modeling the target variable with the (l2 penalized) least
 # squares linear regression model, more comonly known as Ridge regression. We
-# use a low penalization as we expect such a linear model to under-fit on such
+# use a low penalization `alpha`, as we expect such a linear model to under-fit on such
 # a large dataset.
 
 from sklearn.linear_model import Ridge
@@ -212,7 +212,7 @@ score_estimator(ridge_glm, df_test)
 ##############################################################################
 # Next we fit the Poisson regressor on the target variable. We set the
 # regularization strength ``alpha`` to approximately 1e-6 over number of
-# samples in oder to mimic the Ridge regressor whose L2 penalty term scales
+# samples (i.e. `1e-12`) in order to mimic the Ridge regressor whose L2 penalty term scales
 # differently with the number of samples.
 
 from sklearn.linear_model import PoissonRegressor
@@ -233,7 +233,7 @@ score_estimator(poisson_glm, df_test)
 # Finally, we will consider a non-linear model, namely Gradient Boosting
 # Regression Trees. Tree-based models do not require the categorical data to be
 # one-hot encoded: instead, we can encode each category label with an arbitrary
-# integer using :class:`preprocessing.OrdinalEncoder`. With this encoding, the
+# integer using :class:`~sklearn.preprocessing.OrdinalEncoder`. With this encoding, the
 # trees will treat the categorical features as ordered features, which might
 # not be always a desired behavior. However this effect is limited for deep
 # enough trees which are able to recover the categorical nature of the
@@ -241,7 +241,7 @@ score_estimator(poisson_glm, df_test)
 # over the :class:`preprocessing.OneHotEncoder` is that it will make training
 # faster.
 #
-# Gradient Boosting also give the possibility to fit the trees with a Poisson
+# Gradient Boosting also gives the possibility to fit the trees with a Poisson
 # loss (with an implicit log-link function) instead of the default
 # least-squares loss. Here we only fit trees with the Poisson loss to keep this
 # example concise.
@@ -333,7 +333,7 @@ plt.tight_layout()
 #
 # Note that we could have used the least squares loss for the
 # ``HistGradientBoostingRegressor`` model. This would wrongly assume a normal
-# distribution the response variable as for the `Ridge` model and possibly also
+# distribution the response variable as for the `Ridge` model, and possibly also
 # lead to slightly negative predictions. However the gradient boosted trees
 # would still perform relatively well and in particular better than
 # ``PoissonRegressor`` thanks to the flexibility of the trees combined with
@@ -519,7 +519,7 @@ ax.legend(loc="upper left")
 #
 # The linear models assume no interactions between the input variables which
 # likely causes under-fitting. Inserting a polynomial feature extractor
-# (func:`sklearn.preprocessing.PolynomialFeatures`) indeed increases their
+# (:func:`~sklearn.preprocessing.PolynomialFeatures`) indeed increases their
 # discrimative power by 2 points of Gini index. In particular it improves the
 # ability of the models to identify the top 5% riskiest profiles.
 #

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -489,8 +489,7 @@ ax.legend(loc="upper left")
 # performs the worst on this plot.
 #
 # The tree-based model is significantly better at ranking policyholders by risk
-# while the two linear models perform similarly. The linear models assume no
-# interactions between the input variables which likely causes under-fitting.
+# while the two linear models perform similarly.
 #
 # All three models are significantly better than chance but also very far from
 # making perfect predictions.
@@ -498,6 +497,12 @@ ax.legend(loc="upper left")
 # This last point is expected due to the nature of the problem: the occurrence
 # of accidents is mostly dominated by circumstantial causes that are not
 # captured in the columns of the dataset or that are indeed random.
+#
+# The linear models assume no interactions between the input variables which
+# likely causes under-fitting. Inserting a polynomial feature extractor
+# (func:`sklearn.preprocessing.PolynomialFeatures`) indeed increases their
+# discrimative power by 2 points of Gini index. In particular it improves the
+# ability of the models to identify the top 5% riskiest profiles.
 #
 # Main takeaways
 # --------------

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -430,7 +430,7 @@ for axi, model in zip(ax.ravel(), [ridge_glm, poisson_glm, poisson_gbrt,
 plt.tight_layout()
 
 ###############################################################################
-# The dummy regression model predicts a constant frequency. This model is not
+# The dummy regression model predicts a constant frequency. This model does not
 # attribute the same tied rank to all samples but is none-the-less globally
 # well calibrated (to estimate the mean frequency of the entire population).
 #

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -49,8 +49,8 @@ import pandas as pd
 # The French Motor Third-Party Liability Claims dataset
 # -----------------------------------------------------
 #
-# Let's load the motor claim dataset. We ignore the severity data for this
-# study for the sake of simplicitly:
+# Let's load the motor claim dataset from OpenML:
+# https://www.openml.org/d/41214
 
 from sklearn.datasets import fetch_openml
 

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -525,8 +525,8 @@ ax.legend(loc="upper left")
 #   model to be badly calibrated. In particular it tends to under estimate the
 #   risk and can even predict invalid negative frequencies...
 #
-# - Using the Poisson loss with a log-link can correct these problems and lead to a
-#   well-calibrated linear model.
+# - Using the Poisson loss with a log-link can correct these problems and lead
+#   to a well-calibrated linear model.
 #
 # - Despite the improvement in calibration, the ranking power of both linear
 #   models are comparable and well below the ranking power of the Gradient

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -523,7 +523,7 @@ ax.legend(loc="upper left")
 #
 # - The least squares loss (along with the implicit use of the identity link
 #   function) of the Ridge regression model seems to cause this model to be
-#   badly calibrated. In particular it tends to under estimate the risk and can
+#   badly calibrated. In particular, it tends to underestimate the risk and can
 #   even predict invalid negative frequencies.
 #
 # - Using the Poisson loss with a log-link can correct these problems and lead


### PR DESCRIPTION
This rewrite is motivated by the following:

- use headers to split the content into sections;
- simplify the data-loading, display the data-frame content (an excerpt) and histograms for the target variable;
- use HistGradientBoostingRegressor (with the default least squares loss) now that it supports sample weights: it's better and much faster than RandomForestRegressors and it makes it possible to use the full dataset.
- break the top level import block to progressively introduce scikit-learn component when needed;
- contrast calibration and discriminative power of the models in the narrative;
- add a take-aways section at the end.