### PR TITLE
Fixed issue with KernelPCA.inverse_transform mean

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -141,6 +141,7 @@ Changelog
 - |Fix| :class:`decomposition.KernelPCA` method ``inverse_transform`` now
   applies the correct inverse transform to the transformed data. :pr:`16655`
   by :user:`Lewis Ball <lrjball>`.
+
 :mod:`sklearn.ensemble`
 .......................
 

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -138,6 +138,9 @@ Changelog
   :func:`decomposition.non_negative_factorization` now preserves float32 dtype.
   :pr:`16280` by :user:`Jeremie du Boisberranger <jeremiedbb>`.
 
+- |Fix| :class:`decomposition.KernelPCA` method ``inverse_transform`` now
+  applies the correct inverse transform to the transformed data. :pr:`16655`
+  by :user:`Lewis Ball <lrjball>`.
 :mod:`sklearn.ensemble`
 .......................
 

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -358,5 +358,6 @@ class KernelPCA(TransformerMixin, BaseEstimator):
                                  "the inverse transform is not available.")
 
         K = self._get_kernel(X, self.X_transformed_fit_)
-
-        return np.dot(K, self.dual_coef_) + np.mean(self.dual_coef_, axis=0)
+        n_samples = self.X_transformed_fit_.shape[0]
+        K.flat[::n_samples + 1] += self.alpha
+        return np.dot(K, self.dual_coef_)

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -359,4 +359,4 @@ class KernelPCA(TransformerMixin, BaseEstimator):
 
         K = self._get_kernel(X, self.X_transformed_fit_)
 
-        return np.dot(K, self.dual_coef_)
+        return np.dot(K, self.dual_coef_) + np.mean(self.dual_coef_, axis=0)

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -294,4 +294,4 @@ def test_kernel_pca_inverse_transform(kernel):
     kp = KernelPCA(n_components=2, kernel=kernel, fit_inverse_transform=True)
     X_trans = kp.fit_transform(X)
     X_inv = kp.inverse_transform(X_trans)
-    assert np.isclose(X, X_inv).all()
+    assert_allclose(X, X_inv)

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -7,6 +7,7 @@ from sklearn.utils._testing import (assert_array_almost_equal,
 
 from sklearn.decomposition import PCA, KernelPCA
 from sklearn.datasets import make_circles
+from sklearn.datasets import make_blobs
 from sklearn.linear_model import Perceptron
 from sklearn.pipeline import Pipeline
 from sklearn.model_selection import GridSearchCV
@@ -282,3 +283,14 @@ def test_kernel_conditioning():
     # check that the small non-zero eigenvalue was correctly set to zero
     assert kpca.lambdas_.min() == 0
     assert np.all(kpca.lambdas_ == _check_psd_eigenvalues(kpca.lambdas_))
+
+
+@pytest.mark.parametrize("kernel", ["linear", "poly", "rbf", "sigmoid", "cosine"])
+def test_kernel_pca_inverse_transform_mean(kernel):
+    X, *_ = make_blobs(n_samples=100, n_features=4, centers=[[1, 1, 1, 1]],
+                       random_state=0)
+
+    kp = KernelPCA(n_components=2, kernel=kernel, fit_inverse_transform=True)
+    X_trans = kp.fit_transform(X)
+    X_inv = kp.inverse_transform(X_trans)
+    assert np.isclose(X.mean(axis=0), X_inv.mean(axis=0)).all()

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -285,7 +285,8 @@ def test_kernel_conditioning():
     assert np.all(kpca.lambdas_ == _check_psd_eigenvalues(kpca.lambdas_))
 
 
-@pytest.mark.parametrize("kernel", ["linear", "poly", "rbf", "sigmoid", "cosine"])
+@pytest.mark.parametrize("kernel",
+                         ["linear", "poly", "rbf", "sigmoid", "cosine"])
 def test_kernel_pca_inverse_transform_mean(kernel):
     X, *_ = make_blobs(n_samples=100, n_features=4, centers=[[1, 1, 1, 1]],
                        random_state=0)

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -287,11 +287,11 @@ def test_kernel_conditioning():
 
 @pytest.mark.parametrize("kernel",
                          ["linear", "poly", "rbf", "sigmoid", "cosine"])
-def test_kernel_pca_inverse_transform_mean(kernel):
+def test_kernel_pca_inverse_transform(kernel):
     X, *_ = make_blobs(n_samples=100, n_features=4, centers=[[1, 1, 1, 1]],
                        random_state=0)
 
     kp = KernelPCA(n_components=2, kernel=kernel, fit_inverse_transform=True)
     X_trans = kp.fit_transform(X)
     X_inv = kp.inverse_transform(X_trans)
-    assert np.isclose(X.mean(axis=0), X_inv.mean(axis=0)).all()
+    assert np.isclose(X, X_inv).all()


### PR DESCRIPTION
Currently `KernelPCA.inverse_transform` returns a data set with zero mean, even if the original data did not have zero mean.

I believe that this PR fixes that issue, so that the mean of the inverse-transformed data set is the same as the mean of the original data set. 

I've also added a test for this update.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #16654 