### PR TITLE
FIX Fixes HistGradientBoosting when warm_start is on + early_stopping is on + no validation

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -304,6 +304,8 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
             raw_predictions = self._raw_predict(X_binned_train)
             if self.do_early_stopping_ and self._use_validation_data:
                 raw_predictions_val = self._raw_predict(X_binned_val)
+            else:
+                raw_predictions_val = None
 
             if self.do_early_stopping_ and self.scoring != 'loss':
                 # Compute the subsample set

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -396,6 +396,8 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                                     self.bin_mapper_.missing_values_bin_idx_
                                 )
                             )
+                    else:
+                        raw_predictions_val = None
 
                     should_early_stop = self._check_early_stopping_loss(
                         raw_predictions, y_train, sample_weight_train,

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -396,8 +396,6 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                                     self.bin_mapper_.missing_values_bin_idx_
                                 )
                             )
-                    else:
-                        raw_predictions_val = None
 
                     should_early_stop = self._check_early_stopping_loss(
                         raw_predictions, y_train, sample_weight_train,

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -645,3 +645,16 @@ def test_max_depth_max_leaf_nodes():
     tree = est._predictors[0][0]
     assert tree.get_max_depth() == 2
     assert tree.get_n_leaf_nodes() == 3  # would be 4 prior to bug fix
+
+
+def test_early_stopping_on_test_set_with_warm_start():
+    # Non regression test for #16661 where second fit fails with
+    # warm_start=True, early_stopping is on, and no validation set
+    X, y = make_classification(random_state=0)
+    gb = HistGradientBoostingClassifier(
+        max_iter=1, scoring='loss', warm_start=True, early_stopping=True,
+        n_iter_no_change=1, validation_fraction=None)
+
+    gb.fit(X, y)
+    # does not raise on second call
+    gb.fit(X, y)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -657,4 +657,5 @@ def test_early_stopping_on_test_set_with_warm_start():
 
     gb.fit(X, y)
     # does not raise on second call
+    gb.set_params(max_iter=2)
     gb.fit(X, y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #16661

#### What does this implement/fix? Explain your changes.
Defines `raw_predictions_val` + adds a test non regression test.

#### Any other comments?
Do we want to backport this fix? 

CC @NicolasHug 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
