### PR TITLE
[MRG] DOC add example to tree.ExtraTreeClassifier

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1472,6 +1472,12 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
     reduce memory consumption, the complexity and size of the trees should be
     controlled by setting those parameter values.
 
+    References
+    ----------
+
+    .. [1] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized trees",
+           Machine Learning, 63(1), 3-42, 2006.
+
     Examples
     --------
     >>> from sklearn.datasets import load_iris
@@ -1486,12 +1492,6 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
     ...    X_train, y_train)
     >>> cls.score(X_test, y_test)
     0.8947...
-
-    References
-    ----------
-
-    .. [1] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized trees",
-           Machine Learning, 63(1), 3-42, 2006.
     """
     def __init__(self,
                  criterion="gini",

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1474,14 +1474,18 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
 
     Examples
     --------
+    >>> from sklearn.datasets import load_iris
+    >>> from sklearn.model_selection import train_test_split
+    >>> from sklearn.ensemble import BaggingClassifier
     >>> from sklearn.tree import ExtraTreeClassifier
-    >>> from sklearn.datasets import make_classification
-    >>> X, y = make_classification(n_samples=1000, n_features=4,
-    ...                            n_informative=2, n_redundant=0,
-    ...                            random_state=0, shuffle=False)
-    >>> clf = ExtraTreeClassifier(random_state=0).fit(X, y)
-    >>> clf.predict([[0, 0, 0, 0]])
-    array([1])
+    >>> X, y = load_iris(return_X_y=True)
+    >>> X_train, X_test, y_train, y_test = train_test_split(
+    ...    X, y, random_state=0)
+    >>> extra_tree = ExtraTreeClassifier(random_state=0)
+    >>> cls = BaggingClassifier(extra_tree, random_state=0).fit(
+    ...    X_train, y_train)
+    >>> cls.score(X_test, y_test)
+    0.8947...
 
     References
     ----------

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1472,6 +1472,17 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
     reduce memory consumption, the complexity and size of the trees should be
     controlled by setting those parameter values.
 
+    Examples
+    --------
+    >>> from sklearn.tree import ExtraTreeClassifier
+    >>> from sklearn.datasets import make_classification
+    >>> X, y = make_classification(n_samples=1000, n_features=4,
+    ...                            n_informative=2, n_redundant=0,
+    ...                            random_state=0, shuffle=False)
+    >>> clf = ExtraTreeClassifier(random_state=0).fit(X, y)
+    >>> clf.predict([[0, 0, 0, 0]])
+    array([1])
+
     References
     ----------
 


### PR DESCRIPTION
Fixes #3846. Fixes #15190 

This PR adds an example to tree.ExtraTreeClassifier, within ensemble method.