### PR TITLE
MNT Restores behavior of conditioning on linting for most instances

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,15 @@ jobs:
     - bash: conda create --name flake8_env --yes flake8
       displayName: Install flake8
     - bash: |
+        if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[scipy-dev\] ]] || \
+           [[ $BUILD_REASON == "Schedule" ]]; then
+          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]true"
+        else
+          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]false"
+        fi
+      name: gitCommitMessage
+      displayName: Determine to run scipy-dev
+    - bash: |
         if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[lint\ skip\] ]]; then
           # skip linting
           echo "Skipping linting"
@@ -29,15 +38,6 @@ jobs:
           ./build_tools/circle/linting.sh
         fi
       displayName: Run linting
-    - bash: |
-        if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[scipy-dev\] ]] || \
-           [[ $BUILD_REASON == "Schedule" ]]; then
-          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]true"
-        else
-          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]false"
-        fi
-      name: gitCommitMessage
-      displayName: Determine to run scipy-dev
 
 - template: build_tools/azure/posix.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,15 +20,6 @@ jobs:
     - bash: conda create --name flake8_env --yes flake8
       displayName: Install flake8
     - bash: |
-        if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[scipy-dev\] ]] || \
-           [[ $BUILD_REASON == "Schedule" ]]; then
-          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]true"
-        else
-          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]false"
-        fi
-      name: gitCommitMessage
-      displayName: Determine to run scipy-dev
-    - bash: |
         if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[lint\ skip\] ]]; then
           # skip linting
           echo "Skipping linting"
@@ -38,6 +29,15 @@ jobs:
           ./build_tools/circle/linting.sh
         fi
       displayName: Run linting
+    - bash: |
+        if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[scipy-dev\] ]] || \
+           [[ $BUILD_REASON == "Schedule" ]]; then
+          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]true"
+        else
+          echo "##vso[task.setvariable variable=runScipyDev;isOutput=true]false"
+        fi
+      name: gitCommitMessage
+      displayName: Determine to run scipy-dev
 
 - template: build_tools/azure/posix.yml
   parameters:
@@ -80,6 +80,7 @@ jobs:
     name: Linux
     vmImage: ubuntu-18.04
     dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
     matrix:
       # Linux environment to test that scikit-learn can be built against
       # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
@@ -90,91 +91,91 @@ jobs:
         JOBLIB_VERSION: '0.11'
         THREADPOOLCTL_VERSION: '2.0.0'
       # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
-      py36_conda_openblas:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '3.6'
-        BLAS: 'openblas'
-        NUMPY_VERSION: '1.13.3'
-        SCIPY_VERSION: '0.19.1'
-        PANDAS_VERSION: '*'
-        CYTHON_VERSION: '*'
-        # temporary pin pytest due to unknown failure with pytest 5.3
-        PYTEST_VERSION: '5.2'
-        PILLOW_VERSION: '4.2.1'
-        MATPLOTLIB_VERSION: '2.1.1'
-        SCIKIT_IMAGE_VERSION: '*'
-        # latest version of joblib available in conda for Python 3.6
-        JOBLIB_VERSION: '0.13.2'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-      # Linux environment to test the latest available dependencies and MKL.
-      # It runs tests requiring lightgbm, pandas and PyAMG.
-      pylatest_pip_openblas_pandas:
-        DISTRIB: 'conda-pip-latest'
-        PYTHON_VERSION: '3.8'
-        PYTEST_VERSION: '4.6.2'
-        COVERAGE: 'true'
-        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        TEST_DOCSTRINGS: 'true'
-        CHECK_WARNINGS: 'true'
+#       py36_conda_openblas:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '3.6'
+#         BLAS: 'openblas'
+#         NUMPY_VERSION: '1.13.3'
+#         SCIPY_VERSION: '0.19.1'
+#         PANDAS_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         # temporary pin pytest due to unknown failure with pytest 5.3
+#         PYTEST_VERSION: '5.2'
+#         PILLOW_VERSION: '4.2.1'
+#         MATPLOTLIB_VERSION: '2.1.1'
+#         SCIKIT_IMAGE_VERSION: '*'
+#         # latest version of joblib available in conda for Python 3.6
+#         JOBLIB_VERSION: '0.13.2'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#       # Linux environment to test the latest available dependencies and MKL.
+#       # It runs tests requiring lightgbm, pandas and PyAMG.
+#       pylatest_pip_openblas_pandas:
+#         DISTRIB: 'conda-pip-latest'
+#         PYTHON_VERSION: '3.8'
+#         PYTEST_VERSION: '4.6.2'
+#         COVERAGE: 'true'
+#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+#         TEST_DOCSTRINGS: 'true'
+#         CHECK_WARNINGS: 'true'
 
-- template: build_tools/azure/posix-32.yml
-  parameters:
-    name: Linux32
-    vmImage: ubuntu-18.04
-    dependsOn: [linting]
-    matrix:
-      py36_ubuntu_atlas_32bit:
-        DISTRIB: 'ubuntu-32'
-        PYTHON_VERSION: '3.6'
-        JOBLIB_VERSION: '0.13'
-        THREADPOOLCTL_VERSION: '2.0.0'
+# - template: build_tools/azure/posix-32.yml
+#   parameters:
+#     name: Linux32
+#     vmImage: ubuntu-18.04
+#     dependsOn: [linting]
+#     matrix:
+#       py36_ubuntu_atlas_32bit:
+#         DISTRIB: 'ubuntu-32'
+#         PYTHON_VERSION: '3.6'
+#         JOBLIB_VERSION: '0.13'
+#         THREADPOOLCTL_VERSION: '2.0.0'
 
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: macOS
-    vmImage: macOS-10.14
-    dependsOn: [linting]
-    matrix:
-      pylatest_conda_mkl:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-      pylatest_conda_mkl_no_openmp:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-        SKLEARN_TEST_NO_OPENMP: 'true'
-        SKLEARN_SKIP_OPENMP_TEST: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: macOS
+#     vmImage: macOS-10.14
+#     dependsOn: [linting]
+#     matrix:
+#       pylatest_conda_mkl:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#       pylatest_conda_mkl_no_openmp:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#         SKLEARN_TEST_NO_OPENMP: 'true'
+#         SKLEARN_SKIP_OPENMP_TEST: 'true'
 
-- template: build_tools/azure/windows.yml
-  parameters:
-    name: Windows
-    vmImage: vs2017-win2016
-    dependsOn: [linting]
-    matrix:
-      py37_conda_mkl:
-        PYTHON_VERSION: '3.7'
-        CHECK_WARNINGS: 'true'
-        PYTHON_ARCH: '64'
-        PYTEST_VERSION: '*'
-        COVERAGE: 'true'
-      py36_pip_openblas_32bit:
-        PYTHON_VERSION: '3.6'
-        PYTHON_ARCH: '32'
+# - template: build_tools/azure/windows.yml
+#   parameters:
+#     name: Windows
+#     vmImage: vs2017-win2016
+#     dependsOn: [linting]
+#     matrix:
+#       py37_conda_mkl:
+#         PYTHON_VERSION: '3.7'
+#         CHECK_WARNINGS: 'true'
+#         PYTHON_ARCH: '64'
+#         PYTEST_VERSION: '*'
+#         COVERAGE: 'true'
+#       py36_pip_openblas_32bit:
+#         PYTHON_VERSION: '3.6'
+#         PYTHON_ARCH: '32'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,91 +91,94 @@ jobs:
         JOBLIB_VERSION: '0.11'
         THREADPOOLCTL_VERSION: '2.0.0'
       # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
-#       py36_conda_openblas:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '3.6'
-#         BLAS: 'openblas'
-#         NUMPY_VERSION: '1.13.3'
-#         SCIPY_VERSION: '0.19.1'
-#         PANDAS_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         # temporary pin pytest due to unknown failure with pytest 5.3
-#         PYTEST_VERSION: '5.2'
-#         PILLOW_VERSION: '4.2.1'
-#         MATPLOTLIB_VERSION: '2.1.1'
-#         SCIKIT_IMAGE_VERSION: '*'
-#         # latest version of joblib available in conda for Python 3.6
-#         JOBLIB_VERSION: '0.13.2'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#       # Linux environment to test the latest available dependencies and MKL.
-#       # It runs tests requiring lightgbm, pandas and PyAMG.
-#       pylatest_pip_openblas_pandas:
-#         DISTRIB: 'conda-pip-latest'
-#         PYTHON_VERSION: '3.8'
-#         PYTEST_VERSION: '4.6.2'
-#         COVERAGE: 'true'
-#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-#         TEST_DOCSTRINGS: 'true'
-#         CHECK_WARNINGS: 'true'
+      py36_conda_openblas:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '3.6'
+        BLAS: 'openblas'
+        NUMPY_VERSION: '1.13.3'
+        SCIPY_VERSION: '0.19.1'
+        PANDAS_VERSION: '*'
+        CYTHON_VERSION: '*'
+        # temporary pin pytest due to unknown failure with pytest 5.3
+        PYTEST_VERSION: '5.2'
+        PILLOW_VERSION: '4.2.1'
+        MATPLOTLIB_VERSION: '2.1.1'
+        SCIKIT_IMAGE_VERSION: '*'
+        # latest version of joblib available in conda for Python 3.6
+        JOBLIB_VERSION: '0.13.2'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+      # Linux environment to test the latest available dependencies and MKL.
+      # It runs tests requiring lightgbm, pandas and PyAMG.
+      pylatest_pip_openblas_pandas:
+        DISTRIB: 'conda-pip-latest'
+        PYTHON_VERSION: '3.8'
+        PYTEST_VERSION: '4.6.2'
+        COVERAGE: 'true'
+        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+        TEST_DOCSTRINGS: 'true'
+        CHECK_WARNINGS: 'true'
 
-# - template: build_tools/azure/posix-32.yml
-#   parameters:
-#     name: Linux32
-#     vmImage: ubuntu-18.04
-#     dependsOn: [linting]
-#     matrix:
-#       py36_ubuntu_atlas_32bit:
-#         DISTRIB: 'ubuntu-32'
-#         PYTHON_VERSION: '3.6'
-#         JOBLIB_VERSION: '0.13'
-#         THREADPOOLCTL_VERSION: '2.0.0'
+- template: build_tools/azure/posix-32.yml
+  parameters:
+    name: Linux32
+    vmImage: ubuntu-18.04
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      py36_ubuntu_atlas_32bit:
+        DISTRIB: 'ubuntu-32'
+        PYTHON_VERSION: '3.6'
+        JOBLIB_VERSION: '0.13'
+        THREADPOOLCTL_VERSION: '2.0.0'
 
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: macOS
-#     vmImage: macOS-10.14
-#     dependsOn: [linting]
-#     matrix:
-#       pylatest_conda_mkl:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#       pylatest_conda_mkl_no_openmp:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#         SKLEARN_TEST_NO_OPENMP: 'true'
-#         SKLEARN_SKIP_OPENMP_TEST: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: macOS
+    vmImage: macOS-10.14
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      pylatest_conda_mkl:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+      pylatest_conda_mkl_no_openmp:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+        SKLEARN_TEST_NO_OPENMP: 'true'
+        SKLEARN_SKIP_OPENMP_TEST: 'true'
 
-# - template: build_tools/azure/windows.yml
-#   parameters:
-#     name: Windows
-#     vmImage: vs2017-win2016
-#     dependsOn: [linting]
-#     matrix:
-#       py37_conda_mkl:
-#         PYTHON_VERSION: '3.7'
-#         CHECK_WARNINGS: 'true'
-#         PYTHON_ARCH: '64'
-#         PYTEST_VERSION: '*'
-#         COVERAGE: 'true'
-#       py36_pip_openblas_32bit:
-#         PYTHON_VERSION: '3.6'
-#         PYTHON_ARCH: '32'
+- template: build_tools/azure/windows.yml
+  parameters:
+    name: Windows
+    vmImage: vs2017-win2016
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      py37_conda_mkl:
+        PYTHON_VERSION: '3.7'
+        CHECK_WARNINGS: 'true'
+        PYTHON_ARCH: '64'
+        PYTEST_VERSION: '*'
+        COVERAGE: 'true'
+      py36_pip_openblas_32bit:
+        PYTHON_VERSION: '3.6'
+        PYTHON_ARCH: '32'

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -3,7 +3,7 @@ parameters:
   vmImage: ''
   matrix: []
   dependsOn: []
-  condition: ne(variables['Build.Reason'], 'Schedule')
+  condition: ''
 
 jobs:
 - job: ${{ parameters.name }}

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -9,7 +9,6 @@ from functools import partial
 
 import pytest
 import joblib
-from sklearn.datasets import make_biclusters
 
 import numpy as np
 from sklearn.datasets import get_data_home

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -9,6 +9,7 @@ from functools import partial
 
 import pytest
 import joblib
+from sklearn.datasets import make_biclusters
 
 import numpy as np
 from sklearn.datasets import get_data_home


### PR DESCRIPTION
When condition was added to enable `scipy-dev` on azure pipeliens in https://github.com/scikit-learn/scikit-learn/pull/16603, it disabled the feature where linting is required for most instances. 

This PR adds an extra `succeeded('linting')` to the condition to reenable this behavior.