### PR TITLE
MNT Removes unused private attributes in IsotonicRegression

### DIFF
--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -252,12 +252,10 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         unique_X, unique_y, unique_sample_weight = _make_unique(
             X, y, sample_weight)
 
-        # Store _X_ and _y_ to maintain backward compat during the deprecation
-        # period of X_ and y_
-        self._X_ = X = unique_X
-        self._y_ = y = isotonic_regression(unique_y, unique_sample_weight,
-                                           self.y_min, self.y_max,
-                                           increasing=self.increasing_)
+        X = unique_X
+        y = isotonic_regression(unique_y, unique_sample_weight,
+                                self.y_min, self.y_max,
+                                increasing=self.increasing_)
 
         # Handle the left and right bounds on X
         self.X_min_, self.X_max_ = np.min(X), np.max(X)


### PR DESCRIPTION
These private attributes are unused since `X_` and `y_` are already removed.