### PR TITLE
CI Check for unused imports when linting

### DIFF
--- a/build_tools/circle/linting.sh
+++ b/build_tools/circle/linting.sh
@@ -142,7 +142,7 @@ else
     check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" \
         --config ./examples/.flake8
     # check code for unused imports
-    flake8 --exclude=sklearn/externals/ --select=F401 sklearn/ examples/ setup.py
+    flake8 --exclude=sklearn/externals/ --select=F401 sklearn/ examples/
 fi
 echo -e "No problem detected by flake8\n"
 

--- a/build_tools/circle/linting.sh
+++ b/build_tools/circle/linting.sh
@@ -141,8 +141,8 @@ else
     check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
     check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" \
         --config ./examples/.flake8
-    # check code base for unused imports
-    flake8 --select=F401 sklearn/ examples/ setup.py
+    # check code for unused imports
+    flake8 --exclude=sklearn/externals/ --select=F401 sklearn/ examples/ setup.py
 fi
 echo -e "No problem detected by flake8\n"
 

--- a/build_tools/circle/linting.sh
+++ b/build_tools/circle/linting.sh
@@ -141,6 +141,8 @@ else
     check_files "$(echo "$MODIFIED_FILES" | grep -v ^examples)"
     check_files "$(echo "$MODIFIED_FILES" | grep ^examples)" \
         --config ./examples/.flake8
+    # check code base for unused imports
+    flake8 --select=F401 sklearn/ examples/ setup.py
 fi
 echo -e "No problem detected by flake8\n"
 

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -13,7 +13,6 @@ machine-learning as a versatile tool for science and engineering.
 See http://scikit-learn.org for complete documentation.
 """
 import sys
-import re
 import logging
 import os
 

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -9,7 +9,6 @@ from sklearn.model_selection import ParameterGrid
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import SkipTest
 
 from sklearn.base import BaseEstimator, BiclusterMixin
 

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 from numpy.testing import assert_approx_equal
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -8,7 +8,6 @@ from pickle import dumps
 from functools import partial
 
 import pytest
-import joblib
 
 import numpy as np
 from sklearn.datasets import get_data_home

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -13,7 +13,6 @@ import pytest
 
 from sklearn import datasets
 from sklearn.base import clone
-from sklearn.base import BaseEstimator
 from sklearn.datasets import (make_classification, fetch_california_housing,
                               make_regression)
 from sklearn.ensemble import GradientBoostingClassifier

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 from scipy import optimize, sparse
-import pytest
 
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal

--- a/sklearn/linear_model/tests/test_perceptron.py
+++ b/sklearn/linear_model/tests/test_perceptron.py
@@ -1,6 +1,5 @@
 import numpy as np
 import scipy.sparse as sp
-import pytest
 
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_raises

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 from scipy import sparse
 

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -5,7 +5,6 @@ from scipy.sparse import csr_matrix
 
 from sklearn import datasets
 from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_warns_message
 from sklearn.metrics.cluster import silhouette_score
 from sklearn.metrics.cluster import silhouette_samples
 from sklearn.metrics import pairwise_distances

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -20,7 +20,7 @@ import pytest
 from sklearn.utils import all_estimators
 from sklearn.utils._testing import ignore_warnings
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.utils.estimator_checks import check_estimator, _safe_tags
+from sklearn.utils.estimator_checks import check_estimator
 
 import sklearn
 from sklearn.base import BiclusterMixin

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -4,10 +4,8 @@ import pytest
 
 from scipy import linalg
 
-from sklearn.exceptions import ChangedBehaviorWarning
 from sklearn.utils import check_random_state
-from sklearn.utils._testing import (assert_array_equal, assert_no_warnings,
-                                   assert_warns_message)
+from sklearn.utils._testing import assert_array_equal, assert_no_warnings
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_almost_equal

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -1,5 +1,3 @@
-import pytest
-
 import numpy as np
 import scipy.sparse as sp
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -25,7 +25,6 @@ from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import create_memmap_backed_data
 from sklearn.utils._testing import ignore_warnings
-from sklearn.utils._testing import TempMemmap
 
 from sklearn.utils.validation import check_random_state
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -51,6 +51,7 @@ __all__ = ["murmurhash3_32", "as_float_array",
            "check_symmetric", "indices_to_mask", "deprecated",
            "parallel_backend", "register_parallel_backend",
            "resample", "shuffle", "check_matplotlib_support", "all_estimators",
+           "DataConversionWarning"
            ]
 
 IS_PYPY = platform.python_implementation() == 'PyPy'

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -35,7 +35,7 @@ from sklearn.linear_model import MultiTaskElasticNet, LogisticRegression
 from sklearn.svm import SVC
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.tree import DecisionTreeClassifier
-from sklearn.utils.validation import check_X_y, check_array
+from sklearn.utils.validation import check_array
 from sklearn.utils import all_estimators
 
 


### PR DESCRIPTION
Adds a [check for unused imports](https://flake8.pycqa.org/en/3.1.1/user/error-codes.html#error-violation-codes) with flake8 to the linter CI job. This should helps catching them when refactoring.

Otherwise we have to do this manually every year or so (e.g. https://github.com/scikit-learn/scikit-learn/pull/14021 https://github.com/scikit-learn/scikit-learn/pull/16665 )