### PR TITLE
[WIP] Fix MultiOutputRegressor to support sparse y matrix

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -753,7 +753,7 @@ def column_or_1d(y, warn=False):
     y : array
 
     """
-    y = np.asarray(y)
+    y = np.asarray(y.toarray())
     shape = np.shape(y)
     if len(shape) == 1:
         return np.ravel(y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #16686 


#### What does this implement/fix? Explain your changes.
`y = np.asarray(y)` couldn't parse `csr_matrix` to an numpy array.
It is now able to do so by adding `toarray()` to `y`.
This gives us `y = np.asarray(y.toarray())`.