### PR TITLE
MNT fix test for binary crossentropy in hist-GBDT

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -72,6 +72,8 @@ def test_derivatives(loss, x0, y_true):
     x0 = np.array([x0], dtype=Y_DTYPE).reshape(1, 1)
     get_gradients, get_hessians = get_derivatives_helper(loss)
 
+    # Note: Methods of loss classes often call rehappe(-1). Therefore we work
+    # with arrays with one single element instead of scalars.
     def func(x):
         if isinstance(loss, _LOSSES['binary_crossentropy']):
             # Subtract a constant term such that the binary cross entropy

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -76,8 +76,8 @@ def test_derivatives(loss, x0, y_true):
         if isinstance(loss, _LOSSES['binary_crossentropy']):
             # Subtract a constant term such that the binary cross entropy
             # has its minimum at zero. This only works if 0 < y_true < 1.
-            return (loss.pointwise_loss(y_true, x)
-                    - loss.pointwise_loss(y_true, logit(y_true))).item(0)
+            actual_min = loss.pointwise_loss(y_true, logit(y_true))
+            return (loss.pointwise_loss(y_true, x) - actual_min).item(0)
         else:
             return loss.pointwise_loss(y_true, x).item(0)
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -50,7 +50,7 @@ def get_derivatives_helper(loss):
     ('least_squares', -2., 42),
     ('least_squares', 117., 1.05),
     ('least_squares', 0., 0.),
-    # The argmin of binary_crossentropy for y_true=[-1, 1] is [-inf, inf] due
+    # The argmin of binary_crossentropy for y_true=[0, 1] is [-inf, +inf] due
     # to logit, cf. "complete separation". Therefore we use 0 < y_true < 1.
     ('binary_crossentropy', 0.3, 0.1),
     ('binary_crossentropy', -12, 0.2),
@@ -73,7 +73,7 @@ def test_derivatives(loss, x0, y_true):
     get_gradients, get_hessians = get_derivatives_helper(loss)
 
     def func(x):
-        if type(loss) == _LOSSES['binary_crossentropy']:
+        if isinstance(loss, _LOSSES['binary_crossentropy']):
             # Subtract a constant term such that the binary cross entropy
             # has its minimum at zero. This only works if 0 < y_true < 1.
             return loss.pointwise_loss(y_true, x) \

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -87,11 +87,10 @@ def test_derivatives(loss, x0, y_true):
     def fprime2(x):
         return get_hessians(y_true, x)
 
-    optimum = newton(func, x0=x0, fprime=fprime, fprime2=fprime2,
-                     maxiter=70, tol=2e-8)
-    assert np.allclose(loss.inverse_link_function(optimum), y_true)
-    assert np.allclose(func(optimum), 0)
-    assert np.allclose(get_gradients(y_true, optimum), 0)
+    optimum = newton(func, x0=x0, fprime=fprime, fprime2=fprime2)
+    assert_allclose(loss.inverse_link_function(optimum)[0], y_true)
+    assert_allclose(func(optimum)[0], 0, atol=1e-17)
+    assert_allclose(get_gradients(y_true, optimum)[0], 0, atol=1e-8)
 
 
 @pytest.mark.parametrize('loss, n_classes, prediction_dim', [

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -87,10 +87,11 @@ def test_derivatives(loss, x0, y_true):
     def fprime2(x):
         return get_hessians(y_true, x)
 
-    optimum = newton(func, x0=x0, fprime=fprime, fprime2=fprime2)
+    optimum = newton(func, x0=x0, fprime=fprime, fprime2=fprime2,
+                     maxiter=70, tol=2e-8)
     assert_allclose(loss.inverse_link_function(optimum)[0], y_true)
-    assert_allclose(func(optimum)[0], 0, atol=1e-17)
-    assert_allclose(get_gradients(y_true, optimum)[0], 0, atol=1e-8)
+    assert_allclose(func(optimum)[0], 0, atol=1e-14)
+    assert_allclose(get_gradients(y_true, optimum)[0], 0, atol=1e-7)
 
 
 @pytest.mark.parametrize('loss, n_classes, prediction_dim', [

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -78,7 +78,7 @@ def test_derivatives(loss, x0, y_true):
     def func(x: np.ndarray) -> np.ndarray:
         if isinstance(loss, _LOSSES['binary_crossentropy']):
             # Subtract a constant term such that the binary cross entropy
-            # has its minimum at zero. This only works if 0 < y_true < 1.
+            # has its minimum at zero, which is needed for the newton method.
             actual_min = loss.pointwise_loss(y_true, logit(y_true))
             return loss.pointwise_loss(y_true, x) - actual_min
         else:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This fixes a test for the binary cross entropy loss function in the module for `HistGradientBoostingClassifier`.

#### Any other comments?
See added comments in commits.

