### PR TITLE
ENH Poisson loss for HistGradientBoostingRegressor

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -952,8 +952,9 @@ controls the number of iterations of the boosting process::
   >>> clf.score(X_test, y_test)
   0.8965
 
-Available losses for regression are 'least_squares' and
-'least_absolute_deviation', which is less sensitive to outliers. For
+Available losses for regression are 'least_squares',
+'least_absolute_deviation', which is less sensitive to outliers, and
+'poisson', which is well suited to model counts and frequencies. For
 classification, 'binary_crossentropy' is used for binary classification and
 'categorical_crossentropy' is used for multiclass classification. By default
 the loss is 'auto' and will select the appropriate loss depending on

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -193,6 +193,11 @@ Changelog
   to obtain the input to the meta estimator.
   :pr:`16539` by :user:`Bill DeRose <wderose>`.
 
+- |Feature| Added additional option `loss="poisson"` to
+  :class:`ensemble.HistGradientBoostingRegressor`, which adds Poisson deviance
+  with log-link as splitting criterion.
+  :pr:`16692` by :user:`Christian Lorentzen <lorentzenchr>`
+
 :mod:`sklearn.feature_extraction`
 .................................
 
@@ -287,7 +292,7 @@ Changelog
 - |API| Changed the formatting of values in
   :meth:`metrics.ConfusionMatrixDisplay.plot` and
   :func:`metrics.plot_confusion_matrix` to pick the shorter format (either '2g'
-  or 'd'). :pr:`16159` by :user:`Rick Mackenbach <Rick-Mackenbach>` and 
+  or 'd'). :pr:`16159` by :user:`Rick Mackenbach <Rick-Mackenbach>` and
   `Thomas Fan`_.
 
 - |Enhancement| :func:`metrics.pairwise.pairwise_distances_chunked` now allows

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -195,7 +195,7 @@ Changelog
 
 - |Feature| Added additional option `loss="poisson"` to
   :class:`ensemble.HistGradientBoostingRegressor`, which adds Poisson deviance
-  with log-link as splitting criterion.
+  with log-link useful for modeling count data.
   :pr:`16692` by :user:`Christian Lorentzen <lorentzenchr>`
 
 :mod:`sklearn.feature_extraction`

--- a/sklearn/ensemble/_hist_gradient_boosting/_loss.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_loss.pyx
@@ -10,7 +10,7 @@ from cython.parallel import prange
 import numpy as np
 cimport numpy as np
 
-from libc.math cimport exp
+from libc.math cimport exp, log
 
 from .common cimport Y_DTYPE_C
 from .common cimport G_H_DTYPE_C
@@ -27,7 +27,7 @@ def _update_gradients_least_squares(
 
     n_samples = raw_predictions.shape[0]
     for i in prange(n_samples, schedule='static', nogil=True):
-        # Note: a more correct exp is 2 * (raw_predictions - y_true)
+        # Note: a more correct expression is 2 * (raw_predictions - y_true)
         # but since we use 1 for the constant hessian value (and not 2) this
         # is strictly equivalent for the leaves values.
         gradients[i] = raw_predictions[i] - y_true[i]
@@ -151,6 +151,35 @@ def _update_gradients_hessians_categorical_crossentropy(
                 p_i_k = p[i, k]
                 gradients[k, i] = (p_i_k - (y_true[i] == k)) * sw
                 hessians[k, i] = (p_i_k * (1. - p_i_k)) * sw
+
+
+def _update_gradients_hessians_poisson_loss(
+        G_H_DTYPE_C [::1] gradients,  # OUT
+        G_H_DTYPE_C [::1] hessians,  # OUT
+        const Y_DTYPE_C [::1] y_true,  # IN
+        const Y_DTYPE_C [::1] raw_predictions,  # IN
+        const Y_DTYPE_C [::1] sample_weight):  # IN
+
+    cdef:
+        int n_samples
+        int i
+        Y_DTYPE_C y_pred
+
+    n_samples = raw_predictions.shape[0]
+    if sample_weight is None:
+        for i in prange(n_samples, schedule='static', nogil=True):
+            # Note: We use only half of the deviance loss. Therefore, there is
+            # no factor of 2.
+            y_pred = exp(raw_predictions[i])
+            gradients[i] = (y_pred - y_true[i])
+            hessians[i] = y_pred
+    else:
+        for i in prange(n_samples, schedule='static', nogil=True):
+            # Note: We use only half of the deviance loss. Therefore, there is
+            # no factor of 2.
+            y_pred = exp(raw_predictions[i])
+            gradients[i] = (y_pred - y_true[i]) * sample_weight[i]
+            hessians[i] = y_pred * sample_weight[i]
 
 
 cdef inline void _compute_softmax(Y_DTYPE_C [:, ::1] p, const int i) nogil:

--- a/sklearn/ensemble/_hist_gradient_boosting/_loss.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_loss.pyx
@@ -153,7 +153,7 @@ def _update_gradients_hessians_categorical_crossentropy(
                 hessians[k, i] = (p_i_k * (1. - p_i_k)) * sw
 
 
-def _update_gradients_hessians_poisson_loss(
+def _update_gradients_hessians_poisson(
         G_H_DTYPE_C [::1] gradients,  # OUT
         G_H_DTYPE_C [::1] hessians,  # OUT
         const Y_DTYPE_C [::1] y_true,  # IN

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -903,6 +903,11 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         # Just convert y to the expected dtype
         self.n_trees_per_iteration_ = 1
         y = y.astype(Y_DTYPE, copy=False)
+        if self.loss == 'poisson':
+            # Ensure y >= 0 and sum(y) > 0
+            if not (np.all(y >= 0) and np.sum(y) > 0):
+                raise ValueError("loss='poisson' requires non-negative y and "
+                                 "sum(y) > 0.")
         return y
 
     def _get_loss(self, sample_weight):

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -757,12 +757,12 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
     Parameters
     ----------
-    loss : {'least_squares', 'least_absolute_deviation', 'poisson_loss'}, \
+    loss : {'least_squares', 'least_absolute_deviation', 'poisson'}, \
             optional (default='least_squares')
         The loss function to use in the boosting process. Note that the
         "least squares" loss actually implements an "half least squares loss",
-        "poisson loss" implements "half poisson deviance"
-        to simplify the computation of the gradient.
+        "poisson" implements "half poisson deviance" to simplify the
+        computation of the gradient.
     learning_rate : float, optional (default=0.1)
         The learning rate, also known as *shrinkage*. This is used as a
         multiplicative factor for the leaves values. Use ``1`` for no
@@ -864,7 +864,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     """
 
     _VALID_LOSSES = ('least_squares', 'least_absolute_deviation',
-                     'poisson_loss')
+                     'poisson')
 
     def __init__(self, loss='least_squares', learning_rate=0.1,
                  max_iter=100, max_leaf_nodes=31, max_depth=None,

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -760,9 +760,10 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     loss : {'least_squares', 'least_absolute_deviation', 'poisson'}, \
             optional (default='least_squares')
         The loss function to use in the boosting process. Note that the
-        "least squares" loss actually implements an "half least squares loss",
-        "poisson" implements "half poisson deviance" to simplify the
-        computation of the gradient.
+        "least squares" and "poisson" losses actually implement
+        "half least squares loss" and "half poisson deviance" to simplify the
+        computation of the gradient. Furthermore, "poisson" loss internally
+        uses a log-link and requires ``y >= 0``
     learning_rate : float, optional (default=0.1)
         The learning rate, also known as *shrinkage*. This is used as a
         multiplicative factor for the leaves values. Use ``1`` for no

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -911,6 +911,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         y : ndarray, shape (n_samples,)
             The predicted values.
         """
+        check_is_fitted(self)
         # Return inverse link of raw predictions after converting
         # shape (n_samples, 1) to (n_samples,)
         return self.loss_.inverse_link_function(self._raw_predict(X).ravel())

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -757,10 +757,11 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
     Parameters
     ----------
-    loss : {'least_squares', 'least_absolute_deviation'}, \
+    loss : {'least_squares', 'least_absolute_deviation', 'poisson_loss'}, \
             optional (default='least_squares')
         The loss function to use in the boosting process. Note that the
-        "least squares" loss actually implements an "half least squares loss"
+        "least squares" loss actually implements an "half least squares loss",
+        "poisson loss" implements "half poisson deviance"
         to simplify the computation of the gradient.
     learning_rate : float, optional (default=0.1)
         The learning rate, also known as *shrinkage*. This is used as a
@@ -862,7 +863,8 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     0.98...
     """
 
-    _VALID_LOSSES = ('least_squares', 'least_absolute_deviation')
+    _VALID_LOSSES = ('least_squares', 'least_absolute_deviation',
+                     'poisson_loss')
 
     def __init__(self, loss='least_squares', learning_rate=0.1,
                  max_iter=100, max_leaf_nodes=31, max_depth=None,
@@ -893,9 +895,9 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         y : ndarray, shape (n_samples,)
             The predicted values.
         """
-        # Return raw predictions after converting shape
-        # (n_samples, 1) to (n_samples,)
-        return self._raw_predict(X).ravel()
+        # Return inverse link of raw predictions after converting
+        # shape (n_samples, 1) to (n_samples,)
+        return self.loss_.inverse_link_function(self._raw_predict(X).ravel())
 
     def _encode_y(self, y):
         # Just convert y to the expected dtype

--- a/sklearn/ensemble/_hist_gradient_boosting/loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/loss.py
@@ -313,13 +313,6 @@ class Poisson(BaseLoss):
                                            y_true, raw_predictions,
                                            sample_weight)
 
-    def predict_target(self, raw_predictions):
-        # shape (1, n_samples) --> (n_samples,). reshape(-1) is more likely to
-        # return a view.
-        raw_predictions = raw_predictions.reshape(-1)
-        target = np.exp(raw_predictions, dtype=Y_DTYPE)
-        return target
-
 
 class BinaryCrossEntropy(BaseLoss):
     """Binary cross-entropy loss, for binary classification.

--- a/sklearn/ensemble/_hist_gradient_boosting/loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/loss.py
@@ -286,9 +286,6 @@ class Poisson(BaseLoss):
     """
 
     def __init__(self, sample_weight):
-        # If sample weights are provided, the hessians and gradients
-        # are multiplied by sample_weight, which means the hessians are
-        # equal to sample weights.
         super().__init__(hessians_are_constant=False)
 
     inverse_link_function = staticmethod(np.exp)

--- a/sklearn/ensemble/_hist_gradient_boosting/loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/loss.py
@@ -317,8 +317,7 @@ class Poisson(BaseLoss):
         # shape (1, n_samples) --> (n_samples,). reshape(-1) is more likely to
         # return a view.
         raw_predictions = raw_predictions.reshape(-1)
-        target = np.empty_like(raw_predictions, dtype=Y_DTYPE)
-        target = np.exp(raw_predictions)
+        target = np.exp(raw_predictions, dtype=Y_DTYPE)
         return target
 
 

--- a/sklearn/ensemble/_hist_gradient_boosting/loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/loss.py
@@ -23,7 +23,7 @@ from ._loss import _update_gradients_least_absolute_deviation
 from ._loss import _update_gradients_hessians_least_absolute_deviation
 from ._loss import _update_gradients_hessians_binary_crossentropy
 from ._loss import _update_gradients_hessians_categorical_crossentropy
-from ._loss import _update_gradients_hessians_poisson_loss
+from ._loss import _update_gradients_hessians_poisson
 from ...utils.stats import _weighted_percentile
 
 
@@ -376,7 +376,7 @@ class CategoricalCrossEntropy(BaseLoss):
         return proba.T
 
 
-class PoissonLoss(BaseLoss):
+class Poisson(BaseLoss):
     """Poisson deviance loss with log-link, for regression.
 
     For a given sample x_i, Poisson deviance loss is defined as::
@@ -419,9 +419,9 @@ class PoissonLoss(BaseLoss):
         raw_predictions = raw_predictions.reshape(-1)
         gradients = gradients.reshape(-1)
         hessians = hessians.reshape(-1)
-        _update_gradients_hessians_poisson_loss(gradients, hessians,
-                                                y_true, raw_predictions,
-                                                sample_weight)
+        _update_gradients_hessians_poisson(gradients, hessians,
+                                           y_true, raw_predictions,
+                                           sample_weight)
 
     def predict_target(self, raw_predictions):
         # shape (1, n_samples) --> (n_samples,). reshape(-1) is more likely to
@@ -437,5 +437,5 @@ _LOSSES = {
     'least_absolute_deviation': LeastAbsoluteDeviation,
     'binary_crossentropy': BinaryCrossEntropy,
     'categorical_crossentropy': CategoricalCrossEntropy,
-    'poisson_loss': PoissonLoss,
+    'poisson': Poisson,
 }

--- a/sklearn/ensemble/_hist_gradient_boosting/loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/loss.py
@@ -28,6 +28,7 @@ from ...utils.stats import _weighted_percentile
 
 class BaseLoss(ABC):
     """Base class for a loss."""
+
     def __init__(self, hessians_are_constant):
         self.hessians_are_constant = hessians_are_constant
 
@@ -157,6 +158,7 @@ class LeastSquares(BaseLoss):
     the computation of the gradients and get a unit hessian (and be consistent
     with what is done in LightGBM).
     """
+
     def __init__(self, sample_weight):
         # If sample weights are provided, the hessians and gradients
         # are multiplied by sample_weight, which means the hessians are
@@ -199,6 +201,7 @@ class LeastAbsoluteDeviation(BaseLoss):
 
         loss(x_i) = |y_true_i - raw_pred_i|
     """
+
     def __init__(self, sample_weight):
         # If sample weights are provided, the hessians and gradients
         # are multiplied by sample_weight, which means the hessians are

--- a/sklearn/ensemble/_hist_gradient_boosting/loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/loss.py
@@ -392,7 +392,7 @@ class PoissonLoss(BaseLoss):
         # If sample weights are provided, the hessians and gradients
         # are multiplied by sample_weight, which means the hessians are
         # equal to sample weights.
-        super().__init__(hessians_are_constant=sample_weight is None)
+        super().__init__(hessians_are_constant=False)
 
     inverse_link_function = staticmethod(np.exp)
 

--- a/sklearn/ensemble/_hist_gradient_boosting/loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/loss.py
@@ -9,7 +9,7 @@ classification.
 from abc import ABC, abstractmethod
 
 import numpy as np
-from scipy.special import expit
+from scipy.special import expit, xlogy
 try:  # logsumexp was moved from mist to special in 0.19
     from scipy.special import logsumexp
 except ImportError:
@@ -23,6 +23,7 @@ from ._loss import _update_gradients_least_absolute_deviation
 from ._loss import _update_gradients_hessians_least_absolute_deviation
 from ._loss import _update_gradients_hessians_binary_crossentropy
 from ._loss import _update_gradients_hessians_categorical_crossentropy
+from ._loss import _update_gradients_hessians_poisson_loss
 from ...utils.stats import _weighted_percentile
 
 
@@ -375,9 +376,66 @@ class CategoricalCrossEntropy(BaseLoss):
         return proba.T
 
 
+class PoissonLoss(BaseLoss):
+    """Poisson deviance loss with log-link, for regression.
+
+    For a given sample x_i, Poisson deviance loss is defined as::
+
+        loss(x_i) = y_true_i * log(y_true_i/exp(raw_pred_i))
+                    - y_true_i + exp(raw_pred_i))
+
+    This actually computes half the Poisson deviance to simplify
+    the computation of the gradients.
+    """
+
+    def __init__(self, sample_weight):
+        # If sample weights are provided, the hessians and gradients
+        # are multiplied by sample_weight, which means the hessians are
+        # equal to sample weights.
+        super().__init__(hessians_are_constant=sample_weight is None)
+
+    inverse_link_function = staticmethod(np.exp)
+
+    def pointwise_loss(self, y_true, raw_predictions):
+        # shape (1, n_samples) --> (n_samples,). reshape(-1) is more likely to
+        # return a view.
+        raw_predictions = raw_predictions.reshape(-1)
+        # TODO: For speed, we could remove the constant xlogy(y_true, y_true)
+        # Advantage of this form: minimum of zero at raw_predictions = y_true.
+        loss = (xlogy(y_true, y_true) - y_true * (raw_predictions + 1)
+                + np.exp(raw_predictions))
+        return loss
+
+    def get_baseline_prediction(self, y_train, sample_weight, prediction_dim):
+        y_pred = np.average(y_train, weights=sample_weight)
+        eps = np.finfo(y_train.dtype).eps
+        y_pred = np.clip(y_pred, eps, None)
+        return np.log(y_pred)
+
+    def update_gradients_and_hessians(self, gradients, hessians, y_true,
+                                      raw_predictions, sample_weight):
+        # shape (1, n_samples) --> (n_samples,). reshape(-1) is more likely to
+        # return a view.
+        raw_predictions = raw_predictions.reshape(-1)
+        gradients = gradients.reshape(-1)
+        hessians = hessians.reshape(-1)
+        _update_gradients_hessians_poisson_loss(gradients, hessians,
+                                                y_true, raw_predictions,
+                                                sample_weight)
+
+    def predict_target(self, raw_predictions):
+        # shape (1, n_samples) --> (n_samples,). reshape(-1) is more likely to
+        # return a view.
+        raw_predictions = raw_predictions.reshape(-1)
+        target = np.empty_like(raw_predictions, dtype=Y_DTYPE)
+        target = np.exp(raw_predictions)
+        return target
+
+
 _LOSSES = {
     'least_squares': LeastSquares,
     'least_absolute_deviation': LeastAbsoluteDeviation,
     'binary_crossentropy': BinaryCrossEntropy,
-    'categorical_crossentropy': CategoricalCrossEntropy
+    'categorical_crossentropy': CategoricalCrossEntropy,
+    'poisson_loss': PoissonLoss,
 }

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -217,21 +217,21 @@ def test_poisson():
     y = rng.poisson(lam=np.exp(X @ coef))
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=n_test,
                                                         random_state=rng)
-    gbdt1 = HistGradientBoostingRegressor(loss='poisson', random_state=rng)
-    gbdt2 = HistGradientBoostingRegressor(loss='least_squares',
-                                          random_state=rng)
-    gbdt1.fit(X_train, y_train)
-    gbdt2.fit(X_train, y_train)
+    gbdt_pois = HistGradientBoostingRegressor(loss='poisson', random_state=rng)
+    gbdt_ls = HistGradientBoostingRegressor(loss='least_squares',
+                                            random_state=rng)
+    gbdt_pois.fit(X_train, y_train)
+    gbdt_ls.fit(X_train, y_train)
     dummy = DummyRegressor(strategy="mean").fit(X_train, y_train)
 
     for X, y in [(X_train, y_train), (X_test, y_test)]:
-        metric1 = mean_poisson_deviance(y, gbdt1.predict(X))
+        metric_pois = mean_poisson_deviance(y, gbdt_pois.predict(X))
         # least_squares might produce non-positive predictions => clip
-        metric2 = mean_poisson_deviance(y, np.clip(gbdt2.predict(X), 1e-15,
-                                                   None))
-        metric3 = mean_poisson_deviance(y, dummy.predict(X))
-        assert metric1 < metric2
-        assert metric1 < metric3
+        metric_ls = mean_poisson_deviance(y, np.clip(gbdt_ls.predict(X), 1e-15,
+                                                     None))
+        metric_dummy = mean_poisson_deviance(y, dummy.predict(X))
+        assert metric_pois < metric_ls
+        assert metric_pois < metric_dummy
 
 
 def test_binning_train_validation_are_separated():

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -192,14 +192,14 @@ def test_least_absolute_deviation():
     assert gbdt.score(X, y) > .9
 
 
-def test_poisson_loss():
+def test_poisson():
     # For Poisson distributed target, Poisson loss should give better results
     # than least squares measured in Poisson deviance as score.
     rng = np.random.RandomState(42)
     X, y, coef = make_regression(n_samples=500, coef=True, random_state=rng)
     coef /= np.max(np.abs(coef))
     y = rng.poisson(lam=np.exp(X @ coef))
-    gbdt1 = HistGradientBoostingRegressor(loss='poisson_loss',
+    gbdt1 = HistGradientBoostingRegressor(loss='poisson',
                                           scoring='neg_mean_poisson_deviance',
                                           random_state=0)
     gbdt2 = HistGradientBoostingRegressor(loss='least_squares',

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -192,6 +192,24 @@ def test_least_absolute_deviation():
     assert gbdt.score(X, y) > .9
 
 
+def test_poisson_loss():
+    # For Poisson distributed target, Poisson loss should give better results
+    # than least squares measured in Poisson deviance as score.
+    rng = np.random.RandomState(42)
+    X, y, coef = make_regression(n_samples=500, coef=True, random_state=rng)
+    coef /= np.max(np.abs(coef))
+    y = rng.poisson(lam=np.exp(X @ coef))
+    gbdt1 = HistGradientBoostingRegressor(loss='poisson_loss',
+                                          scoring='neg_mean_poisson_deviance',
+                                          random_state=0)
+    gbdt2 = HistGradientBoostingRegressor(loss='least_squares',
+                                          scoring='neg_mean_poisson_deviance',
+                                          random_state=0)
+    gbdt1.fit(X, y)
+    gbdt2.fit(X, y)
+    assert gbdt1.score(X, y) > gbdt2.score(X, y)
+
+
 def test_binning_train_validation_are_separated():
     # Make sure training and validation data are binned separately.
     # See issue 13926

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -195,6 +195,19 @@ def test_least_absolute_deviation():
     assert gbdt.score(X, y) > .9
 
 
+@pytest.mark.parametrize(
+    'y',
+    [([1., -2., 0.]),
+     ([0., 0., 0.]),
+     ])
+def test_poisson_y_positive(y):
+    # Test that ValueError is raised if either one y_i < 0 or sum(y_i) <= 0.
+    err_msg = r"loss='poisson' requires non-negative y and sum\(y\) > 0."
+    gbdt = HistGradientBoostingRegressor(loss='poisson', random_state=0)
+    with pytest.raises(ValueError, match=err_msg):
+        gbdt.fit(np.zeros(shape=(len(y), 1)), y)
+
+
 def test_poisson():
     # For Poisson distributed target, Poisson loss should give better results
     # than least squares measured in Poisson deviance as metric.

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -180,7 +180,7 @@ def test_baseline_poisson():
     # log(0)
     assert y_train.sum() > 0
     baseline_prediction = loss.get_baseline_prediction(y_train, None, 1)
-    assert baseline_prediction.shape == tuple()  # scalar
+    assert np.isscalar(baseline_prediction)
     assert baseline_prediction.dtype == y_train.dtype
     assert_all_finite(baseline_prediction)
     # Make sure baseline prediction produces the log of the mean of all targets

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -183,9 +183,8 @@ def test_baseline_poisson():
     assert baseline_prediction.shape == tuple()  # scalar
     assert baseline_prediction.dtype == y_train.dtype
     assert_all_finite(baseline_prediction)
-    # Make sure baseline prediction produces the mean of all targets
-    y_baseline = loss.inverse_link_function(baseline_prediction)
-    assert_almost_equal(np.mean(y_baseline), y_train.mean())
+    # Make sure baseline prediction produces the log of the mean of all targets
+    assert_almost_equal(np.log(y_train.mean()), baseline_prediction)
 
     # Test baseline for y_true = 0
     y_train.fill(0.)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -52,9 +52,9 @@ def get_derivatives_helper(loss):
     # ('binary_crossentropy', 0.3, 0),
     ('binary_crossentropy', -12, 1),
     ('binary_crossentropy', 30, 1),
-    ('poisson_loss', 12., 1.),
-    ('poisson_loss', 0., 2.),
-    ('poisson_loss', -22., 10.),
+    ('poisson', 12., 1.),
+    ('poisson', 0., 2.),
+    ('poisson', -22., 10.),
 ])
 @pytest.mark.skipif(sp_version == (1, 2, 0),
                     reason='bug in scipy 1.2.0, see scipy issue #9608')
@@ -91,7 +91,7 @@ def test_derivatives(loss, x0, y_true):
     ('least_absolute_deviation', 0, 1),
     ('binary_crossentropy', 2, 1),
     ('categorical_crossentropy', 3, 3),
-    ('poisson_loss', 0, 1),
+    ('poisson', 0, 1),
 ])
 @pytest.mark.skipif(Y_DTYPE != np.float64,
                     reason='Need 64 bits float precision for numerical checks')
@@ -105,7 +105,7 @@ def test_numerical_gradients(loss, n_classes, prediction_dim, seed=0):
     n_samples = 100
     if loss in ('least_squares', 'least_absolute_deviation'):
         y_true = rng.normal(size=n_samples).astype(Y_DTYPE)
-    elif loss in ('poisson_loss'):
+    elif loss in ('poisson'):
         y_true = rng.poisson(size=n_samples).astype(Y_DTYPE)
     else:
         y_true = rng.randint(0, n_classes, size=n_samples).astype(Y_DTYPE)
@@ -218,10 +218,10 @@ def test_baseline_categorical_crossentropy():
         assert np.allclose(baseline_prediction[k, :], np.log(p))
 
 
-def test_baseline_poisson_loss():
+def test_baseline_poisson():
     rng = np.random.RandomState(0)
 
-    loss = _LOSSES['poisson_loss'](sample_weight=None)
+    loss = _LOSSES['poisson'](sample_weight=None)
     y_train = rng.poisson(size=100).astype(np.float64)
     # Make sure at least one sample point is larger than zero
     y_train[0] = 1.
@@ -244,7 +244,7 @@ def test_baseline_poisson_loss():
     ('least_absolute_deviation', 'regression'),
     ('binary_crossentropy', 'classification'),
     ('categorical_crossentropy', 'classification'),
-    ('poisson_loss', 'poisson_regression'),
+    ('poisson', 'poisson_regression'),
     ])
 @pytest.mark.parametrize('sample_weight', ['ones', 'random'])
 def test_sample_weight_multiplies_gradients(loss, problem, sample_weight):

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -176,8 +176,9 @@ def test_baseline_poisson():
 
     loss = _LOSSES['poisson'](sample_weight=None)
     y_train = rng.poisson(size=100).astype(np.float64)
-    # Make sure at least one sample point is larger than zero
-    y_train[0] = 1.
+    # Sanity check, make sure at least one sample is non-zero so we don't take
+    # log(0)
+    assert y_train.sum() > 0
     baseline_prediction = loss.get_baseline_prediction(y_train, None, 1)
     assert baseline_prediction.shape == tuple()  # scalar
     assert baseline_prediction.dtype == y_train.dtype


### PR DESCRIPTION
#### Reference Issues/PRs
This PR partly addresses #16668 and #5975.

#### What does this implement/fix? Explain your changes.
This PR implements the Poisson loss for `HistGradientBoostingRegressor`, i.e. splitting based on improvement in Poisson deviance.