### PR TITLE
Correct formula in TfidfTransformer docstring

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1333,7 +1333,7 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
     If ``smooth_idf=True`` (the default), the constant "1" is added to the
     numerator and denominator of the idf as if an extra document was seen
     containing every term in the collection exactly once, which prevents
-    zero divisions: idf(d, t) = log [ (1 + n) / (1 + df(d, t)) ] + 1.
+    zero divisions: idf(t) = log [ (1 + n) / (1 + df(t)) ] + 1.
 
     Furthermore, the formulas used to compute tf and idf depend
     on parameter settings that correspond to the SMART notation used in IR


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR corrects the formula for the Inverse Document Frequency (IDF) in the docstring of the TfIdfTransformer class. 

The IDF depends only on the term **t**, not the document **d**, therefore it is correct to write `idf(t)` rather than `idf(d, t)`. 

This is correctly done in line 1331 (`idf(t) = log [ n / (df(t) + 1) ])`). In line 1336, this is not the case, there it is currently written `idf(d, t) = log [ (1 + n) / (1 + df(d, t)) ] + 1`. This PR corrects the formula in line 1336.