### PR TITLE
BUG Ignores tags when estimator is a class in parametrize_with_checks

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -47,6 +47,12 @@ def test_all_estimator_no_base_class():
         assert not name.lower().startswith('base'), msg
 
 
+@parametrize_with_checks([LogisticRegression])
+def test_non_init_estimator_with_parameterize_with_checks(estimator, check):
+    # Non-regression test for #16707
+    check(estimator)
+
+
 @pytest.mark.parametrize(
         'name, Estimator',
         all_estimators()

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -56,7 +56,7 @@ def test_estimator_cls_parameterize_with_checks():
     list(param_checks.args[1])
 
 
-def test_mark_xfail_checks_with_consructable_estimator():
+def test_mark_xfail_checks_with_unconsructable_estimator():
     class MyEstimator:
         def __init__(self):
             raise ValueError("This is bad")

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -47,10 +47,10 @@ def test_all_estimator_no_base_class():
         assert not name.lower().startswith('base'), msg
 
 
-@parametrize_with_checks([LogisticRegression])
-def test_non_init_estimator_with_parameterize_with_checks(estimator, check):
-    # Non-regression test for #16707
-    check(estimator)
+def test_estimator_cls_parameterize_with_checks():
+    # Non-regression test for #16707 to ensure that parametrize_with_checks
+    # works with estimator classes
+    parametrize_with_checks([LogisticRegression])
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -31,6 +31,7 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.utils import IS_PYPY
 from sklearn.utils._testing import SkipTest
 from sklearn.utils.estimator_checks import (
+    _mark_xfail_checks,
     _construct_instance,
     _set_checking_parameters,
     _set_check_estimator_ids,
@@ -50,7 +51,19 @@ def test_all_estimator_no_base_class():
 def test_estimator_cls_parameterize_with_checks():
     # Non-regression test for #16707 to ensure that parametrize_with_checks
     # works with estimator classes
-    parametrize_with_checks([LogisticRegression])
+    param_checks = parametrize_with_checks([LogisticRegression])
+    # Using the generator does not raise
+    list(param_checks.args[1])
+
+
+def test_mark_xfail_checks_with_consructable_estimator():
+    class MyEstimator:
+        def __init__(self):
+            raise ValueError("This is bad")
+
+    estimator, check = _mark_xfail_checks(MyEstimator, 42, None)
+    assert estimator == MyEstimator
+    assert check == 42
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -361,10 +361,16 @@ def _generate_class_checks(Estimator):
 def _mark_xfail_checks(estimator, check, pytest):
     """Mark estimator check pairs with xfail"""
     if isinstance(estimator, type):
-        # Does not check _xfail_test when estimator is a class
-        return estimator, check
+        # try to construct estimator to get tags, if it is unable to then
+        # return the estimator class
+        try:
+            xfail_checks = _safe_tags(_construct_instance(estimator),
+                                      '_xfail_test')
+        except Exception:
+            return estimator, check
+    else:
+        xfail_checks = _safe_tags(estimator, '_xfail_test')
 
-    xfail_checks = _safe_tags(estimator, '_xfail_test')
     if not xfail_checks:
         return estimator, check
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -360,6 +360,9 @@ def _generate_class_checks(Estimator):
 
 def _mark_xfail_checks(estimator, check, pytest):
     """Mark estimator check pairs with xfail"""
+    if isinstance(estimator, type):
+        # Does not check _xfail_test when estimator is a class
+        return estimator, check
 
     xfail_checks = _safe_tags(estimator, '_xfail_test')
     if not xfail_checks:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #16707


#### What does this implement/fix? Explain your changes.
Ignores the tags when estimator is a class in `parametrize_with_checks`

CC @rth
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
