### PR TITLE
Bug 16706

### DIFF
--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -501,7 +501,7 @@ def _fit_coordinate_descent(X, W, H, tol=1e-4, max_iter=200, l1_reg_W=0,
 
     rng = check_random_state(random_state)
 
-    for n_iter in range(max_iter):
+    for n_iter in range(max_iter + 1):
         violation = 0.
 
         # Update W

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -543,3 +543,17 @@ def test_nmf_custom_init_dtype_error():
 
     with pytest.raises(TypeError, match="should have the same dtype as X"):
         non_negative_factorization(X, H=H, update_H=False)
+
+
+def test_nmf_raise_warnings_when_max_iter_is_reached_using_both_solvers():
+    """Test raise warning when `max_iter` is raised using `¢d` and `mu`.
+
+    Bug #16706
+    """
+    # Matrix used in `test_nmf_fit_nn_output`
+    A = np.c_[5. - np.arange(1, 6),
+              5. + np.arange(1, 6)]
+    for solver in ('cd', 'mu'):
+        model = NMF(n_components=2, solver=solver, random_state=0, max_iter=1)
+        with pytest.warns(ConvergenceWarning):
+            _ = model.fit_transform(A)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #16706 


#### What does this implement/fix? Explain your changes.
There was an error in the implementation of the function `non_negative_factorization` since no warning was raised when `max_iter` was reached. In this PR, this is corrected and also a new test is added to verify that the warning is raised in those situations.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
