### PR TITLE
[MRG] Improve error message for None values in OneHotEncoder and OrdinalEncoder

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -366,10 +366,6 @@ Changelog
   normalizing the vectors. :pr:`16632` by
   :user:`Maura Pintor <Maupin1991>` and :user:`Battista Biggio <bbiggio>`.
 
-- |Fix| :func:`preprocessing._label._encode` now `OneHotEncoder` and
-  `OrdinalEncoder` raise a `ValueError` when input contains `None` values.
-  :pr:`16713` by :user:`Facundo Ferrin <fferrin>`.
-
 :mod:`sklearn.svm`
 ..................
 

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -366,6 +366,10 @@ Changelog
   normalizing the vectors. :pr:`16632` by
   :user:`Maura Pintor <Maupin1991>` and :user:`Battista Biggio <bbiggio>`.
 
+- |Fix| :func:`preprocessing._label._encode` now `OneHotEncoder` and
+`OrdinalEncoder` raise a `ValueError` when input contains `None` values.
+:pr:`16713` by :user:`Facundo Ferrin <fferrin>`.
+
 :mod:`sklearn.svm`
 ..................
 

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -367,8 +367,8 @@ Changelog
   :user:`Maura Pintor <Maupin1991>` and :user:`Battista Biggio <bbiggio>`.
 
 - |Fix| :func:`preprocessing._label._encode` now `OneHotEncoder` and
-`OrdinalEncoder` raise a `ValueError` when input contains `None` values.
-:pr:`16713` by :user:`Facundo Ferrin <fferrin>`.
+  `OrdinalEncoder` raise a `ValueError` when input contains `None` values.
+  :pr:`16713` by :user:`Facundo Ferrin <fferrin>`.
 
 :mod:`sklearn.svm`
 ..................

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -111,8 +111,9 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
         try:
             res = _encode_python(values, uniques, encode)
         except TypeError:
-            raise TypeError("Encoders require their input to be strings or "
-                            "numbers.")
+            raise TypeError("argument must be a string or number")
+            # raise TypeError("Encoders require their input to be strings or "
+            #                 "numbers.")
         return res
     else:
         return _encode_numpy(values, uniques, encode,

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -113,8 +113,6 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
         except TypeError:
             raise TypeError("Encoders require their input to be strings or "
                             "numbers.")
-        except ValueError:
-            raise
         return res
     else:
         return _encode_numpy(values, uniques, encode,

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -115,7 +115,8 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
         try:
             res = _encode_python(values, uniques, encode)
         except TypeError:
-            raise TypeError("Encoders require their input to be strings or numbers. Got {}")
+            raise TypeError("Encoders require their input to be strings or "
+                            "numbers. Got {}")
         except ValueError:
             raise
         return res

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -111,8 +111,10 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
         try:
             res = _encode_python(values, uniques, encode)
         except TypeError:
-            raise TypeError("Encoders require their input to be strings or "
-                            "numbers.")
+            types = sorted(t.__qualname__
+                           for t in set(type(v) for v in values))
+            raise TypeError("Encoders require their input to be uniformly "
+                            f"strings or numbers. Got {types}")
         return res
     else:
         return _encode_numpy(values, uniques, encode,

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -56,6 +56,10 @@ def _encode_numpy(values, uniques=None, encode=False, check_unknown=True):
 
 def _encode_python(values, uniques=None, encode=False):
     # only used in _encode below, see docstring there for details
+    if None in values:
+        raise ValueError("This encoder does not accept None typed values. "
+                         "Missing values should be imputed first, for "
+                         "instance using sklearn.preprocessing.SimpleImputer.")
     if uniques is None:
         uniques = sorted(set(values))
         uniques = np.array(uniques, dtype=values.dtype)
@@ -112,6 +116,8 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
             res = _encode_python(values, uniques, encode)
         except TypeError:
             raise TypeError("argument must be a string or number")
+        except ValueError as e:
+            raise e
         return res
     else:
         return _encode_numpy(values, uniques, encode,

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -115,9 +115,9 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
         try:
             res = _encode_python(values, uniques, encode)
         except TypeError:
-            raise TypeError("argument must be a string or number")
-        except ValueError as e:
-            raise e
+            raise TypeError("Encoders require their input to be strings or numbers. Got {}")
+        except ValueError:
+            raise
         return res
     else:
         return _encode_numpy(values, uniques, encode,

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -56,10 +56,6 @@ def _encode_numpy(values, uniques=None, encode=False, check_unknown=True):
 
 def _encode_python(values, uniques=None, encode=False):
     # only used in _encode below, see docstring there for details
-    if None in values:
-        raise ValueError("This encoder does not accept None typed values. "
-                         "Missing values should be imputed first, for "
-                         "instance using sklearn.preprocessing.SimpleImputer.")
     if uniques is None:
         uniques = sorted(set(values))
         uniques = np.array(uniques, dtype=values.dtype)
@@ -116,7 +112,7 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
             res = _encode_python(values, uniques, encode)
         except TypeError:
             raise TypeError("Encoders require their input to be strings or "
-                            "numbers. Got {}")
+                            "numbers.")
         except ValueError:
             raise
         return res

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -111,9 +111,8 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
         try:
             res = _encode_python(values, uniques, encode)
         except TypeError:
-            raise TypeError("argument must be a string or number")
-            # raise TypeError("Encoders require their input to be strings or "
-            #                 "numbers.")
+            raise TypeError("Encoders require their input to be strings or "
+                            "numbers.")
         return res
     else:
         return _encode_numpy(values, uniques, encode,

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -692,7 +692,7 @@ def test_encoders_has_categorical_tags(Encoder):
 
 @pytest.mark.parametrize('Encoder', [OneHotEncoder, OrdinalEncoder])
 def test_encoders_does_not_support_none_values(Encoder):
-    values = [["a", None]]
-    with pytest.raises(ValueError, match="This encoder does not accept "
-                                         "None typed values"):
+    values = [["a"], [None]]
+    with pytest.raises(TypeError, match="Encoders require their input to be "
+                                         "strings or numbers."):
         Encoder().fit(values)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -694,5 +694,5 @@ def test_encoders_has_categorical_tags(Encoder):
 def test_encoders_does_not_support_none_values(Encoder):
     values = [["a"], [None]]
     with pytest.raises(TypeError, match="Encoders require their input to be "
-                                        "strings or numbers."):
+                                        "uniformly strings or numbers."):
         Encoder().fit(values)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -694,5 +694,5 @@ def test_encoders_has_categorical_tags(Encoder):
 def test_encoders_does_not_support_none_values(Encoder):
     values = [["a"], [None]]
     with pytest.raises(TypeError, match="Encoders require their input to be "
-                                         "strings or numbers."):
+                                        "strings or numbers."):
         Encoder().fit(values)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -688,3 +688,11 @@ def test_categories(density, drop):
 @pytest.mark.parametrize('Encoder', [OneHotEncoder, OrdinalEncoder])
 def test_encoders_has_categorical_tags(Encoder):
     assert 'categorical' in Encoder()._get_tags()['X_types']
+
+
+@pytest.mark.parametrize('Encoder', [OneHotEncoder, OrdinalEncoder])
+def test_encoders_does_not_support_none_values(Encoder):
+    values = [["a", None]]
+    with pytest.raises(ValueError, match="This encoder does not accept "
+                                         "None typed values"):
+        Encoder().fit(values)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #16702, #16703 


#### What does this implement/fix? Explain your changes.
`None` input values were not checked when using `OneHotEncoder` and `OrdinalEncoder`. In this PR, a `ValueError`error is raised in those cases.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
