### PR TITLE
DOC fix MAE formula for tree splitting criterion

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -515,7 +515,7 @@ Mean Absolute Error:
 
 .. math::
 
-    median(y)_m = median\{y_i for i in N_m\}
+    median(y)_m = \underset{\mathrm{median}}{i \in N_m}(y_i)
 
     H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - median(y)_m|
 

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -515,7 +515,7 @@ Mean Absolute Error:
 
 .. math::
 
-    median(y)_m = \underset{\mathrm{median}}{i \in N_m}(y_i)
+    median(y)_m = \underset{i \in N_m}{\mathrm{median}}(y_i)
 
     H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - median(y)_m|
 

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -136,14 +136,14 @@ Once trained, you can plot the tree with the plot_tree function::
 
 We can also export the tree in `Graphviz
 <https://www.graphviz.org/>`_ format using the :func:`export_graphviz`
-exporter. If you use the `conda <https://conda.io>`_ package manager, the graphviz binaries  
+exporter. If you use the `conda <https://conda.io>`_ package manager, the graphviz binaries
 
-and the python package can be installed with 
+and the python package can be installed with
 
     conda install python-graphviz
-   
+
 Alternatively binaries for graphviz can be downloaded from the graphviz project homepage,
-and the Python wrapper installed from pypi with `pip install graphviz`. 
+and the Python wrapper installed from pypi with `pip install graphviz`.
 
 Below is an example graphviz export of the above tree trained on the entire
 iris dataset; the results are saved in an output file `iris.pdf`::
@@ -414,7 +414,7 @@ it differs in that it supports numerical target variables (regression) and
 does not compute rule sets. CART constructs binary trees using the feature
 and threshold that yield the largest information gain at each node.
 
-scikit-learn uses an optimised version of the CART algorithm; however, scikit-learn 
+scikit-learn uses an optimised version of the CART algorithm; however, scikit-learn
 implementation does not support categorical variables for now.
 
 .. _ID3: https://en.wikipedia.org/wiki/ID3_algorithm
@@ -500,8 +500,8 @@ If the target is a continuous value, then for node :math:`m`,
 representing a region :math:`R_m` with :math:`N_m` observations, common
 criteria to minimise as for determining locations for future
 splits are Mean Squared Error, which minimizes the L2 error
-using mean values at terminal nodes, and Mean Absolute Error, which 
-minimizes the L1 error using median values at terminal nodes. 
+using mean values at terminal nodes, and Mean Absolute Error, which
+minimizes the L1 error using median values at terminal nodes.
 
 Mean Squared Error:
 
@@ -515,9 +515,9 @@ Mean Absolute Error:
 
 .. math::
 
-    \bar{y}_m = \frac{1}{N_m} \sum_{i \in N_m} y_i
+    median(y)_m = median\{y_i for i in N_m\}
 
-    H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - \bar{y}_m|
+    H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - median(y)_m|
 
 where :math:`X_m` is the training data in node :math:`m`
 
@@ -560,7 +560,7 @@ be pruned. This process stops when the pruned tree's minimal
 .. topic:: Examples:
 
     * :ref:`sphx_glr_auto_examples_tree_plot_cost_complexity_pruning.py`
-  
+
 .. topic:: References:
 
     .. [BRE] L. Breiman, J. Friedman, R. Olshen, and C. Stone. Classification


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
I think the formula for the tree splitting criterion Mean Absolute Error should involve the empirical median instead of the empirical mean.

#### Any other comments?
While the empirical mean is usually written as `\bar{y}`, I'm not aware of a common symbol for the empirical median. Open for suggestions.