### PR TITLE
Improve IsolationForest average depth evaluation

### DIFF
--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -501,9 +501,7 @@ def _average_path_length(n_samples_leaf):
 
     average_path_length[mask_1] = 0.
     average_path_length[mask_2] = 1.
-    average_path_length[not_mask] = (
-        2.0 * (np.log(n_samples_leaf[not_mask] - 1.0) + np.euler_gamma)
-        - 2.0 * (n_samples_leaf[not_mask] - 1.0) / n_samples_leaf[not_mask]
-    )
+    average_path_length[not_mask] = 2.0 * (np.log(n_samples_leaf[not_mask])
+                                           + np.euler_gamma - 1.0)
 
     return average_path_length.reshape(n_samples_leaf_shape)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -235,19 +235,22 @@ def test_iforest_subsampled_features():
 
 
 def test_iforest_average_path_length():
+    def harmonic_humber(n):
+        return np.sum(1.0/np.arange(1, n+1))
     # It tests non-regression for #8549 which used the wrong formula
     # for average path length, strictly for the integer case
     # Updated to check average path length when input is <= 2 (issue #11839)
-    result_one = 2.0 * (np.log(4.0) + np.euler_gamma) - 2.0 * 4.0 / 5.0
-    result_two = 2.0 * (np.log(998.0) + np.euler_gamma) - 2.0 * 998.0 / 999.0
+    result_one = 2.0 * harmonic_humber(4.0) - 2.0 * 4.0 / 5.0
+    result_two = 2.0 * harmonic_humber(998.0) - 2.0 * 998.0 / 999.0
     assert_allclose(_average_path_length([0]), [0.0])
     assert_allclose(_average_path_length([1]), [0.0])
     assert_allclose(_average_path_length([2]), [1.0])
-    assert_allclose(_average_path_length([5]), [result_one])
-    assert_allclose(_average_path_length([999]), [result_two])
+    assert_allclose(_average_path_length([5]), [result_one], rtol=0.1)
+    assert_allclose(_average_path_length([999]), [result_two], rtol=1e-4)
     assert_allclose(
         _average_path_length(np.array([1, 2, 5, 999])),
         [0.0, 1.0, result_one, result_two],
+        rtol=0.1
     )
     # _average_path_length is increasing
     avg_path_length = _average_path_length(np.arange(5))

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -325,37 +325,3 @@ def test_iforest_deprecation():
     warn_msg = "'behaviour' is deprecated in 0.22 and will be removed in 0.24"
     with pytest.warns(FutureWarning, match=warn_msg):
         iforest.fit(iris.data)
-
-
-def test_iforest_with_uniform_data():
-    """Test whether iforest predicts inliers when using uniform data"""
-
-    # 2-d array of all 1s
-    X = np.ones((100, 10))
-    iforest = IsolationForest()
-    iforest.fit(X)
-
-    rng = np.random.RandomState(0)
-
-    assert all(iforest.predict(X) == 1)
-    assert all(iforest.predict(rng.randn(100, 10)) == 1)
-    assert all(iforest.predict(X + 1) == 1)
-    assert all(iforest.predict(X - 1) == 1)
-
-    # 2-d array where columns contain the same value across rows
-    X = np.repeat(rng.randn(1, 10), 100, 0)
-    iforest = IsolationForest()
-    iforest.fit(X)
-
-    assert all(iforest.predict(X) == 1)
-    assert all(iforest.predict(rng.randn(100, 10)) == 1)
-    assert all(iforest.predict(np.ones((100, 10))) == 1)
-
-    # Single row
-    X = rng.randn(1, 10)
-    iforest = IsolationForest()
-    iforest.fit(X)
-
-    assert all(iforest.predict(X) == 1)
-    assert all(iforest.predict(rng.randn(100, 10)) == 1)
-    assert all(iforest.predict(np.ones((100, 10))) == 1)


### PR DESCRIPTION
The equation in the original paper is undersimplified:

    c(n) = 2 H(n-1) - 2 (n-1) / n,

where H(k) ~ (ln(k) + gamma)

The definition of the harmonic number is:

    H(n) = sum_{j=1}^{n} (1 / j)

then it follows that:

    H(n) = H(n-1) + 1 / n

and then:

    c(n) = 2 H(n-1) - 2 (n-1) / n = 2 ( H(n-1) - 1 + 1 / n ) =
         = 2 (H(n) - 1)

Here we use simplier equation to save calculations.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
