### PR TITLE
ENH Adds support for pandas dataframe with only sparse arrays

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -409,7 +409,7 @@ Changelog
   :pr:`16021` by :user:`Rushabh Vasani <rushabh-v>`.
 
 - |Enhancement| :func:`utils.validation.check_array` now constructs a sparse
-  matrix from a pandas DataFrame with containing only `SparseArray`s.
+  matrix from a pandas DataFrame that contains only `SparseArray`s.
   :pr:`16728` by `Thomas Fan`_.
 
 :mod:`sklearn.cluster`

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -408,6 +408,10 @@ Changelog
   pandas sparse DataFrame.
   :pr:`16021` by :user:`Rushabh Vasani <rushabh-v>`.
 
+- |Enhancement| :func:`utils.validation.check_array` now constructs a sparse
+  matrix from a pandas DataFrame with containing only `SparseArray`s.
+  :pr:`16728` by `Thomas Fan`_.
+
 :mod:`sklearn.cluster`
 ......................
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -208,19 +208,32 @@ def test_linear_regression_sparse_multiple_outcome(random_state=0):
 
 
 def test_linear_regression_pd_sparse_dataframe_warning():
+    # Warning is raised only when some of the columns is sparse
     pd = pytest.importorskip('pandas')
     # restrict the pd versions < '0.24.0' as they have a bug in is_sparse func
     if LooseVersion(pd.__version__) < '0.24.0':
         pytest.skip("pandas 0.24+ required.")
+
     df = pd.DataFrame()
     for col in range(4):
         arr = np.random.randn(10)
         arr[:8] = 0
-        df[str(col)] = pd.arrays.SparseArray(arr, fill_value=0)
+        if col != 0:
+            arr = pd.arrays.SparseArray(arr, fill_value=0)
+        df[str(col)] = arr
+
     msg = "pandas.DataFrame with sparse columns found."
     with pytest.warns(UserWarning, match=msg):
         reg = LinearRegression()
         reg.fit(df.iloc[:, 0:2], df.iloc[:, 3])
+
+    # does not warn when the whole dataframe is sparse
+    df['0'] = pd.arrays.SparseArray(df['0'], fill_value=0)
+    assert hasattr(df, "sparse")
+
+    with pytest.warns(None) as record:
+        reg.fit(df.iloc[:, 0:2], df.iloc[:, 3])
+    assert not record
 
 
 def test_preprocess_data():

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -218,8 +218,8 @@ def test_linear_regression_pd_sparse_dataframe_warning():
     for col in range(1, 4):
         arr = np.random.randn(10)
         arr[:8] = 0
+        # all columns but the first column is sparse
         if col != 0:
-            # the first column is not sparse
             arr = pd.arrays.SparseArray(arr, fill_value=0)
         df[str(col)] = arr
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -208,17 +208,18 @@ def test_linear_regression_sparse_multiple_outcome(random_state=0):
 
 
 def test_linear_regression_pd_sparse_dataframe_warning():
-    # Warning is raised only when some of the columns is sparse
     pd = pytest.importorskip('pandas')
     # restrict the pd versions < '0.24.0' as they have a bug in is_sparse func
     if LooseVersion(pd.__version__) < '0.24.0':
         pytest.skip("pandas 0.24+ required.")
 
-    df = pd.DataFrame()
-    for col in range(4):
+    # Warning is raised only when some of the columns is sparse
+    df = pd.DataFrame({'0': np.random.randn(10)})
+    for col in range(1, 4):
         arr = np.random.randn(10)
         arr[:8] = 0
         if col != 0:
+            # the first column is not sparse
             arr = pd.arrays.SparseArray(arr, fill_value=0)
         df[str(col)] = arr
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1155,25 +1155,20 @@ def test_check_fit_params(indices):
     )
 
 
-def test_check_sparse_pandas_default():
+@pytest.mark.parametrize('sp_format', [True, 'csr', 'csc', 'coo', 'bsr'])
+def test_check_sparse_pandas_sp_format(sp_format):
+    # check_array converts pandas dataframe with only sparse arrays into
+    # sparse matrix
     pd = pytest.importorskip("pandas")
     sp_mat = _sparse_random_matrix(10, 3)
 
     sdf = pd.DataFrame.sparse.from_spmatrix(sp_mat)
-    result = check_array(sdf, accept_sparse=True)
-
-    # by default pandas converts to coo
-    assert sp.issparse(result)
-    assert result.format == 'coo'
-    assert_allclose_dense_sparse(sp_mat, result)
-
-
-@pytest.mark.parametrize('sp_format', ['csr', 'csc', 'coo', 'bsr'])
-def test_check_sparse_pandas_sp_formts(sp_format):
-    pd = pytest.importorskip("pandas")
-    sp_mat = _sparse_random_matrix(10, 3)
-    sdf = pd.DataFrame.sparse.from_spmatrix(sp_mat)
-
     result = check_array(sdf, accept_sparse=sp_format)
+
+    if sp_format is True:
+        # by default pandas converts to coo when accept_sparse is True
+        sp_format = 'coo'
+
+    assert sp.issparse(result)
     assert result.format == sp_format
     assert_allclose_dense_sparse(sp_mat, result)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1153,3 +1153,20 @@ def test_check_fit_params(indices):
         result['sparse-col'],
         _safe_indexing(fit_params['sparse-col'], indices_)
     )
+
+
+def test_check_sparse_pandas():
+    pd = pytest.importorskip("pandas")
+    sp_mat = _sparse_random_matrix(1000, 5)
+
+    sdf = pd.DataFrame.sparse.from_spmatrix(sp_mat)
+    result = check_array(sdf, accept_sparse=True)
+
+    assert sp.issparse(result)
+    assert result.format == 'coo'
+    assert_allclose_dense_sparse(sp_mat, result)
+
+    for sp_format in ['csr', 'csc', 'coo', 'bsr']:
+        result = check_array(sdf, accept_sparse=sp_format)
+        assert result.format == sp_format
+        assert_allclose_dense_sparse(sp_mat, result)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1155,18 +1155,25 @@ def test_check_fit_params(indices):
     )
 
 
-def test_check_sparse_pandas():
+def test_check_sparse_pandas_default():
     pd = pytest.importorskip("pandas")
-    sp_mat = _sparse_random_matrix(1000, 5)
+    sp_mat = _sparse_random_matrix(10, 3)
 
     sdf = pd.DataFrame.sparse.from_spmatrix(sp_mat)
     result = check_array(sdf, accept_sparse=True)
 
+    # by default pandas converts to coo
     assert sp.issparse(result)
     assert result.format == 'coo'
     assert_allclose_dense_sparse(sp_mat, result)
 
-    for sp_format in ['csr', 'csc', 'coo', 'bsr']:
-        result = check_array(sdf, accept_sparse=sp_format)
-        assert result.format == sp_format
-        assert_allclose_dense_sparse(sp_mat, result)
+
+@pytest.mark.parametrize('sp_format', ['csr', 'csc', 'coo', 'bsr'])
+def test_check_sparse_pandas_sp_formts(sp_format):
+    pd = pytest.importorskip("pandas")
+    sp_mat = _sparse_random_matrix(10, 3)
+    sdf = pd.DataFrame.sparse.from_spmatrix(sp_mat)
+
+    result = check_array(sdf, accept_sparse=sp_format)
+    assert result.format == sp_format
+    assert_allclose_dense_sparse(sp_mat, result)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -452,7 +452,7 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     dtypes_orig = None
     if hasattr(array, "dtypes") and hasattr(array.dtypes, '__array__'):
         # throw warning if columns are sparse. If all columns are sparse, then
-        # array.sparse exist and sparsity will be perserved.
+        # array.sparse exists and sparsity will be perserved (later).
         with suppress(ImportError):
             from pandas.api.types import is_sparse
             if (not hasattr(array, 'sparse') and
@@ -500,8 +500,9 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
         estimator_name = "Estimator"
     context = " by %s" % estimator_name if estimator is not None else ""
 
-    # handles pandas sparse by checking for sparse attribute
+    # When all dataframe columns are sparse, convert to a sparse array
     if hasattr(array, 'sparse') and array.ndim > 1:
+        # DataFrame.sparse only supports `to_coo`
         array = array.sparse.to_coo()
 
     if sp.issparse(array):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -498,6 +498,10 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
         estimator_name = "Estimator"
     context = " by %s" % estimator_name if estimator is not None else ""
 
+    # handles pandas sparse by checking for sparse attribute
+    if hasattr(array, 'sparse'):
+        array = array.sparse.to_coo()
+
     if sp.issparse(array):
         _ensure_no_complex_data(array)
         array = _ensure_sparse_format(array, accept_sparse=accept_sparse,

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -451,10 +451,12 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     # DataFrame), and store them. If not, store None.
     dtypes_orig = None
     if hasattr(array, "dtypes") and hasattr(array.dtypes, '__array__'):
-        # throw warning if pandas dataframe is sparse
+        # throw warning if columns are sparse. If all columns are sparse, then
+        # array.sparse exist and sparsity will be perserved.
         with suppress(ImportError):
             from pandas.api.types import is_sparse
-            if array.dtypes.apply(is_sparse).any():
+            if (not hasattr(array, 'sparse') and
+                    array.dtypes.apply(is_sparse).any()):
                 warnings.warn(
                     "pandas.DataFrame with sparse columns found."
                     "It will be converted to a dense numpy array."

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -499,7 +499,8 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     context = " by %s" % estimator_name if estimator is not None else ""
 
     # handles pandas sparse by checking for sparse attribute
-    if hasattr(array, 'sparse'):
+    # handles pandas sparse by checking for sparse attribute
+    if hasattr(array, 'sparse') and array.ndim > 1:
         array = array.sparse.to_coo()
 
     if sp.issparse(array):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -499,7 +499,6 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
     context = " by %s" % estimator_name if estimator is not None else ""
 
     # handles pandas sparse by checking for sparse attribute
-    # handles pandas sparse by checking for sparse attribute
     if hasattr(array, 'sparse') and array.ndim > 1:
         array = array.sparse.to_coo()
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/12800


#### What does this implement/fix? Explain your changes.
Does not convert pandas dataframe into a dense array if ALL its columns are sparse arrays.

#### Any other comments?
Since we have pandas sparse support on our minds: CC @rth

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
