### PR TITLE
EXA/FIX logsumexp import in plot_nca_illustration.py example

### DIFF
--- a/examples/neighbors/plot_nca_illustration.py
+++ b/examples/neighbors/plot_nca_illustration.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 from sklearn.datasets import make_classification
 from sklearn.neighbors import NeighborhoodComponentsAnalysis
 from matplotlib import cm
-from sklearn.utils.fixes import logsumexp
+from scipy.special import logsumexp
 
 print(__doc__)
 


### PR DESCRIPTION
Fix an import from fixes in examples that was removed in https://github.com/scikit-learn/scikit-learn/pull/16725 and currently results in CI failures on master.

Fill merge on green CI.