### PR TITLE
Suggest to use SimpleImputer for str categorical data with None values

### DIFF
--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -116,7 +116,8 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
             error_msg = ("Encoders require their input to be uniformly "
                          f"strings or numbers. Got: {type_names}.")
             if unique_types == {str, type(None)}:
-                # Be extra helpful to the user for this specific yet common case:
+                # Be extra helpful to the user for this specific yet common
+                # case:
                 error_msg += (
                     '\nPreprocess the features with sklearn.impute.'
                     'SimpleImputer(strategy="constant", missing_values=None, '

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -116,7 +116,7 @@ def _encode(values, uniques=None, encode=False, check_unknown=True):
             error_msg = ("Encoders require their input to be uniformly "
                          f"strings or numbers. Got: {type_names}.")
             if unique_types == {str, type(None)}:
-                # Be extra helpful to the use for this common case:
+                # Be extra helpful to the user for this specific yet common case:
                 error_msg += (
                     '\nPreprocess the features with sklearn.impute.'
                     'SimpleImputer(strategy="constant", missing_values=None, '

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -692,7 +692,19 @@ def test_encoders_has_categorical_tags(Encoder):
 
 @pytest.mark.parametrize('Encoder', [OneHotEncoder, OrdinalEncoder])
 def test_encoders_does_not_support_none_values(Encoder):
+    values = [["a"], [1]]
+    expected_msg = (
+        r"Encoders require their input to be uniformly strings or numbers\. "
+        r"Got: \['int', 'str'\]\."
+    )
+    with pytest.raises(TypeError, match=expected_msg):
+        Encoder().fit(values)
+
+    # Special case with extra missing value imputation suggestion:
     values = [["a"], [None]]
-    with pytest.raises(TypeError, match="Encoders require their input to be "
-                                        "uniformly strings or numbers."):
+    expected_msg = (
+        r'SimpleImputer\(strategy="constant", missing_values=None, '
+        r'fill_value="missing"\)'
+    )
+    with pytest.raises(TypeError, match=expected_msg):
         Encoder().fit(values)


### PR DESCRIPTION
This is a follow up to #16713 to better tackle #16702 and #16703.

I found the this specific case when loading the Ames housing dataset from `fetch_openml`:

```python
X, y = fetch_openml("house_prices", as_frame=True, return_X_y=True)
```

Note that #11996 also discusses how to natively handle missing values in categorical encoders which could be an alternative to this PR, assuming we support both None and np.nan as missing value markers in object-dtyped columns.
