### PR TITLE
DOC use Ames housing for transformed_target example

### DIFF
--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -145,18 +145,18 @@ y_trans = quantile_transform(y.to_frame(),
 # the target distribution before applying a
 # :class:`~sklearn.linear_model.RidgeCV` model.
 
-f, (ax0, ax1) = plt.subplots(1, 2)
+f, (ax0, ax1) = plt.subplots(1, 2, figsize=(6.5, 5))
 
 ax0.hist(y, bins=100, **density_param)
 ax0.set_ylabel('Probability')
 ax0.set_xlabel('Target')
-ax0.text(s='Target distribution', x=1.2e5, y=1e-5, fontsize=12)
+ax0.text(s='Target distribution', x=1.2e5, y=9.8e-6, fontsize=12)
 ax0.ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
 
 ax1.hist(y_trans, bins=100, **density_param)
 ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
-ax1.text(s='Transformed target distribution', x=-6.8, y=0.4888, fontsize=12)
+ax1.text(s='Transformed target distribution', x=-6.8, y=0.479, fontsize=12)
 
 f.suptitle("Ames housing data: selling price", y=0.022)
 f.tight_layout(rect=[0., 0., 0.95, 0.95])

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -167,12 +167,11 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 ###############################################################################
 # The effect of the transformer is weaker than on the synthetic data. However,
 # the transformation results in an increase in :math:`R^2` and large decrease
-# of the
-# MAE. The residual plot (predicted target - true target vs predicted target)
-# without target transformation takes on a curved, 'reverse smile' shape due to
-# residual values that vary depending on the value of predicted target.
-# With target transformation, the shape is more linear indicating better model
-# fit.
+# of the MAE. The residual plot (predicted target - true target vs predicted
+# target) without target transformation takes on a curved, 'reverse smile'
+# shape due to residual values that vary depending on the value of predicted
+# target. With target transformation, the shape is more linear indicating
+# better model fit.
 
 f, (ax0, ax1) = plt.subplots(2, 2, sharey='row', figsize=(6.5, 8))
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -40,6 +40,7 @@ else:
 ###############################################################################
 # A synthetic random regression dataset is generated. The targets ``y`` are
 # modified by:
+#
 #   1. translating all targets such that all entries are
 #      non-negative (by adding the absolute value of the lowest ``y``) and
 #   2. applying an exponential function to obtain non-linear
@@ -50,7 +51,7 @@ else:
 # regression model and using it for prediction.
 
 X, y = make_regression(n_samples=10000, noise=100, random_state=0)
-y = np.exp((y + abs(y.min())) / 200)
+y = np.expm1((y + abs(y.min())) / 200)
 y_trans = np.log1p(y)
 
 ###############################################################################
@@ -145,7 +146,7 @@ y_trans = quantile_transform(y.to_frame(),
 # the target distribution before applying a
 # :class:`~sklearn.linear_model.RidgeCV` model.
 
-f, (ax0, ax1) = plt.subplots(1, 2, figsize=(6.5, 5))
+f, (ax0, ax1) = plt.subplots(1, 2)
 
 ax0.hist(y, bins=100, **density_param)
 ax0.set_ylabel('Probability')
@@ -158,13 +159,12 @@ ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
 ax1.text(s='Transformed target distribution', x=-6.8, y=0.479, fontsize=12)
 
-f.suptitle("Ames housing data: selling price", y=0.022)
-f.tight_layout(rect=[0., 0., 0.95, 0.9])
+f.suptitle("Ames housing data: selling price", y=0.035)
+f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 
 ###############################################################################
-#
 # The effect of the transformer is weaker than on the synthetic data. However,
 # the transformation results in an increase in R^2 and large decrease of the
 # MAE. The residual plot (predicted target - true target vs predicted target)

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -145,21 +145,21 @@ y_trans = quantile_transform(y.to_frame(),
 # the target distribution before applying a
 # :class:`~sklearn.linear_model.RidgeCV` model.
 
-f, (ax0, ax1) = plt.subplots(1, 2, sharey='row')
+f, (ax0, ax1) = plt.subplots(1, 2)
 
 ax0.hist(y, bins=100, **density_param)
 ax0.set_ylabel('Probability')
 ax0.set_xlabel('Target')
-ax0.set_title('Target distribution')
-ax0.ticklabel_format(axis="x", style="sci", scilimits=(0, 0))
+ax0.text(s='Target distribution', x=1.2e5, y=1e-5, fontsize=12)
+ax0.ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
 
 ax1.hist(y_trans, bins=100, **density_param)
 ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
-ax1.set_title('Transformed target distribution')
+ax1.text(s='Transformed target distribution', x=-7, y=0.4888, fontsize=12)
 
-f.suptitle("Ames housing data: selling price", y=0.035)
-f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
+f.suptitle("Ames housing data: selling price", y=0.022)
+f.tight_layout()
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -159,7 +159,7 @@ ax1.set_xlabel('Target')
 ax1.text(s='Transformed target distribution', x=-6.8, y=0.4888, fontsize=12)
 
 f.suptitle("Ames housing data: selling price", y=0.022)
-f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
+f.tight_layout(rect=[0., 0., 0.95, 0.95])
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -134,7 +134,7 @@ ames = fetch_openml(name="house_prices", as_frame=True)
 X = ames.data.select_dtypes(np.number)
 # Remove columns with NaN or Inf values
 X = X.drop(columns=['LotFrontage', 'GarageYrBlt', 'MasVnrArea'])
-y = ames.target.to_numpy()
+y = ames.target
 y_trans = quantile_transform(y.to_frame(),
                              n_quantiles=900,
                              output_distribution='normal',
@@ -164,6 +164,7 @@ f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 
 ###############################################################################
+#
 # The effect of the transformer is weaker than on the synthetic data. However,
 # the transformation results in an increase in R^2 and large decrease of the
 # MAE. The residual plot (predicted target - true target vs predicted target)

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -134,7 +134,7 @@ ames = fetch_openml(name="house_prices", as_frame=True)
 X = ames.data.select_dtypes(np.number)
 # Remove columns with NaN or Inf values
 X = X.drop(columns=['LotFrontage', 'GarageYrBlt', 'MasVnrArea'])
-y = ames.target
+y = ames.target.to_numpy()
 y_trans = quantile_transform(y.to_frame(),
                              n_quantiles=900,
                              output_distribution='normal',

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -6,28 +6,20 @@
 Effect of transforming the targets in regression model
 ======================================================
 
-In this example, we give an overview of the
-:class:`sklearn.compose.TransformedTargetRegressor`. Two examples
-illustrate the benefit of transforming the targets before learning a linear
+In this example, we give an overview of
+:class:`~sklearn.compose.TransformedTargetRegressor`. We use two examples
+to illustrate the benefit of transforming the targets before learning a linear
 regression model. The first example uses synthetic data while the second
-example is based on the Boston housing data set.
-
+example is based on the Ames housing data set.
 """
 
 # Author: Guillaume Lemaitre <guillaume.lemaitre@inria.fr>
 # License: BSD 3 clause
 
-
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 from distutils.version import LooseVersion
-
-print(__doc__)
-
-###############################################################################
-# Synthetic example
-###############################################################################
 
 from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
@@ -35,6 +27,9 @@ from sklearn.linear_model import RidgeCV
 from sklearn.compose import TransformedTargetRegressor
 from sklearn.metrics import median_absolute_error, r2_score
 
+###############################################################################
+# Synthetic example
+##############################################################################
 
 # `normed` is being deprecated in favor of `density` in histograms
 if LooseVersion(matplotlib.__version__) >= '2.1':
@@ -43,10 +38,12 @@ else:
     density_param = {'normed': True}
 
 ###############################################################################
-# A synthetic random regression problem is generated. The targets ``y`` are
-# modified by: (i) translating all targets such that all entries are
-# non-negative and (ii) applying an exponential function to obtain non-linear
-# targets which cannot be fitted using a simple linear model.
+# A synthetic random regression dataset is generated. The targets ``y`` are
+# modified by:
+#   1. translating all targets such that all entries are
+#      non-negative (by adding the absolute value of the lowest ``y``) and
+#   2. applying an exponential function to obtain non-linear
+#      targets which cannot be fitted using a simple linear model.
 #
 # Therefore, a logarithmic (`np.log1p`) and an exponential function
 # (`np.expm1`) will be used to transform the targets before training a linear
@@ -57,7 +54,7 @@ y = np.exp((y + abs(y.min())) / 200)
 y_trans = np.log1p(y)
 
 ###############################################################################
-# The following illustrate the probability density functions of the target
+# Below we plot the probability density functions of the target
 # before and after applying the logarithmic functions.
 
 f, (ax0, ax1) = plt.subplots(1, 2)
@@ -73,7 +70,7 @@ ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
 ax1.set_title('Transformed target distribution')
 
-f.suptitle("Synthetic data", y=0.035)
+f.suptitle("Synthetic data", y=0.06, x=0.53)
 f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
@@ -86,11 +83,11 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 # reported by the median absolute error (MAE).
 
 f, (ax0, ax1) = plt.subplots(1, 2, sharey=True)
-
+# Use linear model
 regr = RidgeCV()
 regr.fit(X_train, y_train)
 y_pred = regr.predict(X_test)
-
+# Plot results
 ax0.scatter(y_test, y_pred)
 ax0.plot([0, 2000], [0, 2000], '--k')
 ax0.set_ylabel('Target predicted')
@@ -100,7 +97,7 @@ ax0.text(100, 1750, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
 ax0.set_xlim([0, 2000])
 ax0.set_ylim([0, 2000])
-
+# Transform targets and use same linear model
 regr_trans = TransformedTargetRegressor(regressor=RidgeCV(),
                                         func=np.log1p,
                                         inverse_func=np.expm1)
@@ -127,15 +124,15 @@ f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 ###############################################################################
 # In a similar manner, the Ames housing data set is used to show the impact
 # of transforming the targets before learning a model. In this example, the
-# targets to be predicted is the selling price of each house.
+# target to be predicted is the selling price of each house.
 
 from sklearn.datasets import fetch_openml
 from sklearn.preprocessing import QuantileTransformer, quantile_transform
 
 ames = fetch_openml(name="house_prices", as_frame=True)
-# keep only numeric columns
+# Keep only numeric columns
 X = ames.data.select_dtypes(np.number)
-# remove columns with NaN or Inf values
+# Remove columns with NaN or Inf values
 X = X.drop(columns=['LotFrontage', 'GarageYrBlt', 'MasVnrArea'])
 y = ames.target
 y_trans = quantile_transform(y.to_frame(),
@@ -144,16 +141,17 @@ y_trans = quantile_transform(y.to_frame(),
                              copy=True).squeeze()
 
 ###############################################################################
-# A :class:`sklearn.preprocessing.QuantileTransformer` is used such that the
-# targets follows a normal distribution before applying a
-# :class:`sklearn.linear_model.RidgeCV` model.
+# A :class:`~sklearn.preprocessing.QuantileTransformer` is used to normalize
+# the target distribution before applying a
+# :class:`~sklearn.linear_model.RidgeCV` model.
 
-f, (ax0, ax1) = plt.subplots(1, 2)
+f, (ax0, ax1) = plt.subplots(1, 2, sharey='row')
 
 ax0.hist(y, bins=100, **density_param)
 ax0.set_ylabel('Probability')
 ax0.set_xlabel('Target')
 ax0.set_title('Target distribution')
+ax0.ticklabel_format(axis="x", style="sci", scilimits=(0, 0))
 
 ax1.hist(y_trans, bins=100, **density_param)
 ax1.set_ylabel('Probability')

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -156,10 +156,10 @@ ax0.ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
 ax1.hist(y_trans, bins=100, **density_param)
 ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
-ax1.text(s='Transformed target distribution', x=-7, y=0.4888, fontsize=12)
+ax1.text(s='Transformed target distribution', x=-6.8, y=0.4888, fontsize=12)
 
 f.suptitle("Ames housing data: selling price", y=0.022)
-f.tight_layout()
+f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -159,7 +159,7 @@ ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
 ax1.text(s='Transformed target distribution', x=-6.8, y=0.479, fontsize=12)
 
-f.suptitle("Ames housing data: selling price", y=0.035)
+f.suptitle("Ames housing data: selling price", y=0.04)
 f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -77,7 +77,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
 
 ###############################################################################
 # At first, a linear model will be applied on the original targets. Due to the
-# non-linearity, the model trained will not be precise during the
+# non-linearity, the model trained will not be precise during
 # prediction. Subsequently, a logarithmic function is used to linearize the
 # targets, allowing better prediction even with a similar linear model as
 # reported by the median absolute error (MAE).
@@ -165,14 +165,14 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 
 ###############################################################################
 # The effect of the transformer is weaker than on the synthetic data. However,
-# the transform induces an increase in R^2 and large decrease of the MAE. The
-# residual plot (predicted target - true target vs predicted target) without
-# target transformation takes on a curved, 'reverse smile' shape due to
-# residual values that tend to vary depending on the value of predicted target.
+# the transformation results in an increase in R^2 and large decrease of the
+# MAE. The residual plot (predicted target - true target vs predicted target)
+# without target transformation takes on a curved, 'reverse smile' shape due to
+# residual values that vary depending on the value of predicted target.
 # With target transformation, the shape is more linear indicating better model
 # fit.
 
-f, (ax0, ax1) = plt.subplots(2, 2, sharey='row')
+f, (ax0, ax1) = plt.subplots(2, 2, sharey='row', figsize=(6.5, 8))
 
 regr = RidgeCV()
 regr.fit(X_train, y_train)
@@ -220,6 +220,5 @@ ax1[1].set_xlabel('Predicted target')
 ax1[1].ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
 
 f.suptitle("Ames housing data: selling price", y=0.035)
-f.tight_layout(rect=[0.05, 0.05, 1, 1.7])
 
 plt.show()

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -166,7 +166,8 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 
 ###############################################################################
 # The effect of the transformer is weaker than on the synthetic data. However,
-# the transformation results in an increase in R^2 and large decrease of the
+# the transformation results in an increase in :math:`R^2` and large decrease
+# of the
 # MAE. The residual plot (predicted target - true target vs predicted target)
 # without target transformation takes on a curved, 'reverse smile' shape due to
 # residual values that vary depending on the value of predicted target.

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -159,7 +159,7 @@ ax1.set_xlabel('Target')
 ax1.text(s='Transformed target distribution', x=-6.8, y=0.479, fontsize=12)
 
 f.suptitle("Ames housing data: selling price", y=0.022)
-f.tight_layout(rect=[0., 0., 0.95, 0.95])
+f.tight_layout(rect=[0., 0., 0.95, 0.9])
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -176,14 +176,14 @@ regr.fit(X_train, y_train)
 y_pred = regr.predict(X_test)
 
 ax0.scatter(y_test, y_pred, s=8)
-ax0.plot([0, 8e5], [0, 8e5], '--k')
+ax0.plot([0, 7e5], [0, 7e5], '--k')
 ax0.set_ylabel('Target predicted')
 ax0.set_xlabel('True Target')
 ax0.set_title('Ridge regression \n without target transformation', pad=18)
-ax0.text(4e4, 74e4, r'$R^2$=%.2f, MAE=%.2f' % (
+ax0.text(4e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
-ax0.set_xlim([0, 8e5])
-ax0.set_ylim([0, 8e5])
+ax0.set_xlim([0, 7e5])
+ax0.set_ylim([0, 7e5])
 ax0.ticklabel_format(axis="both", style="sci", scilimits=(0,0))
 
 regr_trans = TransformedTargetRegressor(
@@ -194,14 +194,14 @@ regr_trans.fit(X_train, y_train)
 y_pred = regr_trans.predict(X_test)
 
 ax1.scatter(y_test, y_pred, s=8)
-ax1.plot([0, 8e5], [0, 8e5], '--k')
+ax1.plot([0, 7e5], [0, 7e5], '--k')
 ax1.set_ylabel('Target predicted')
 ax1.set_xlabel('True Target')
 ax1.set_title('Ridge regression \n with target transformation', pad=18)
-ax1.text(4e4, 74e4, r'$R^2$=%.2f, MAE=%.2f' % (
+ax1.text(4e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
-ax1.set_xlim([0, 8e5])
-ax1.set_ylim([0, 8e5])
+ax1.set_xlim([0, 7e5])
+ax1.set_ylim([0, 7e5])
 ax1.ticklabel_format(axis="x", style="sci", scilimits=(0,0))
 
 f.suptitle("Ames housing data: selling price", y=0.035)

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -180,7 +180,7 @@ ax0.plot([0, 7e5], [0, 7e5], '--k')
 ax0.set_ylabel('Target predicted')
 ax0.set_xlabel('True Target')
 ax0.set_title('Ridge regression \n without target transformation', pad=18)
-ax0.text(4e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
+ax0.text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
 ax0.set_xlim([0, 7e5])
 ax0.set_ylim([0, 7e5])
@@ -198,7 +198,7 @@ ax1.plot([0, 7e5], [0, 7e5], '--k')
 ax1.set_ylabel('Target predicted')
 ax1.set_xlabel('True Target')
 ax1.set_title('Ridge regression \n with target transformation', pad=18)
-ax1.text(4e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
+ax1.text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
 ax1.set_xlim([0, 7e5])
 ax1.set_ylim([0, 7e5])

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -184,7 +184,8 @@ ax0[0].scatter(y_pred, y_test, s=8)
 ax0[0].plot([0, 7e5], [0, 7e5], '--k')
 ax0[0].set_ylabel('True target')
 ax0[0].set_xlabel('Predicted target')
-ax0[0].set_title('Ridge regression \n without target transformation', pad=18)
+ax0[0].text(s='Ridge regression \n without target transformation', x=-5e4,
+            y=8e5, fontsize=12, multialignment='center')
 ax0[0].text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
 ax0[0].set_xlim([0, 7e5])
@@ -207,7 +208,8 @@ ax0[1].scatter(y_pred, y_test, s=8)
 ax0[1].plot([0, 7e5], [0, 7e5], '--k')
 ax0[1].set_ylabel('True target')
 ax0[1].set_xlabel('Predicted target')
-ax0[1].set_title('Ridge regression \n with target transformation', pad=18)
+ax0[1].text(s='Ridge regression \n with target transformation', x=-5e4,
+            y=8e5, fontsize=12, multialignment='center')
 ax0[1].text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
 ax0[1].set_xlim([0, 7e5])

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -165,7 +165,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 
 ###############################################################################
 # The effect of the transformer is weaker than on the synthetic data. However,
-# the transform induces an increase in R\ :sup:`2` and decrease of the MAE.
+# the transform induces an increase in R^2 and decrease of the MAE.
 
 f, (ax0, ax1) = plt.subplots(1, 2, sharey=True)
 

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -132,11 +132,11 @@ f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 from sklearn.datasets import fetch_openml
 from sklearn.preprocessing import QuantileTransformer, quantile_transform
 
-ames = datasets.fetch_openml(name="house_prices", as_frame=True)
+ames = fetch_openml(name="house_prices", as_frame=True)
 # keep only numeric columns
 X = ames.data.select_dtypes(np.number)
 # remove columns with NaN or Inf values
-X = X.drop(columns=['LotFrontage','GarageYrBlt', 'MasVnrArea'])
+X = X.drop(columns=['LotFrontage', 'GarageYrBlt', 'MasVnrArea'])
 y = ames.target
 y_trans = quantile_transform(y.to_frame(),
                              n_quantiles=900,
@@ -184,7 +184,7 @@ ax0.text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
 ax0.set_xlim([0, 7e5])
 ax0.set_ylim([0, 7e5])
-ax0.ticklabel_format(axis="both", style="sci", scilimits=(0,0))
+ax0.ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
 
 regr_trans = TransformedTargetRegressor(
     regressor=RidgeCV(),
@@ -202,7 +202,7 @@ ax1.text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
 ax1.set_xlim([0, 7e5])
 ax1.set_ylim([0, 7e5])
-ax1.ticklabel_format(axis="x", style="sci", scilimits=(0,0))
+ax1.ticklabel_format(axis="x", style="sci", scilimits=(0, 0))
 
 f.suptitle("Ames housing data: selling price", y=0.035)
 f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -125,20 +125,19 @@ f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 ###############################################################################
 
 ###############################################################################
-# In a similar manner, the boston housing data set is used to show the impact
+# In a similar manner, the wine recognition data set is used to show the impact
 # of transforming the targets before learning a model. In this example, the
-# targets to be predicted corresponds to the weighted distances to the five
-# Boston employment centers.
+# targets to be predicted corresponds to the Malic acid content of each sample.
 
-from sklearn.datasets import load_boston
+from sklearn.datasets import load_wine
 from sklearn.preprocessing import QuantileTransformer, quantile_transform
 
-dataset = load_boston()
-target = np.array(dataset.feature_names) == "DIS"
+dataset = load_wine()
+target = np.array(dataset.feature_names) == "malic_acid"
 X = dataset.data[:, np.logical_not(target)]
 y = dataset.data[:, target].squeeze()
 y_trans = quantile_transform(dataset.data[:, target],
-                             n_quantiles=300,
+                             n_quantiles=50,
                              output_distribution='normal',
                              copy=True).squeeze()
 
@@ -159,14 +158,14 @@ ax1.set_ylabel('Probability')
 ax1.set_xlabel('Target')
 ax1.set_title('Transformed target distribution')
 
-f.suptitle("Boston housing data: distance to employment centers", y=0.035)
+f.suptitle("Wine recognition data: malic_acid", y=0.035)
 f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 
 ###############################################################################
 # The effect of the transformer is weaker than on the synthetic data. However,
-# the transform induces a decrease of the MAE.
+# the transform induces an increase in R\ :sup:`2` and decrease of the MAE.
 
 f, (ax0, ax1) = plt.subplots(1, 2, sharey=True)
 
@@ -175,33 +174,33 @@ regr.fit(X_train, y_train)
 y_pred = regr.predict(X_test)
 
 ax0.scatter(y_test, y_pred)
-ax0.plot([0, 10], [0, 10], '--k')
+ax0.plot([0, 5], [0, 5], '--k')
 ax0.set_ylabel('Target predicted')
 ax0.set_xlabel('True Target')
 ax0.set_title('Ridge regression \n without target transformation')
-ax0.text(1, 9, r'$R^2$=%.2f, MAE=%.2f' % (
+ax0.text(1, 4.5, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
-ax0.set_xlim([0, 10])
-ax0.set_ylim([0, 10])
+ax0.set_xlim([0, 5])
+ax0.set_ylim([0, 5])
 
 regr_trans = TransformedTargetRegressor(
     regressor=RidgeCV(),
-    transformer=QuantileTransformer(n_quantiles=300,
+    transformer=QuantileTransformer(n_quantiles=50,
                                     output_distribution='normal'))
 regr_trans.fit(X_train, y_train)
 y_pred = regr_trans.predict(X_test)
 
 ax1.scatter(y_test, y_pred)
-ax1.plot([0, 10], [0, 10], '--k')
+ax1.plot([0, 5], [0, 5], '--k')
 ax1.set_ylabel('Target predicted')
 ax1.set_xlabel('True Target')
 ax1.set_title('Ridge regression \n with target transformation')
-ax1.text(1, 9, r'$R^2$=%.2f, MAE=%.2f' % (
+ax1.text(1, 4.5, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
-ax1.set_xlim([0, 10])
-ax1.set_ylim([0, 10])
+ax1.set_xlim([0, 5])
+ax1.set_ylim([0, 5])
 
-f.suptitle("Boston housing data: distance to employment centers", y=0.035)
+f.suptitle("Wine recognition data: malic_acid", y=0.035)
 f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
 
 plt.show()

--- a/examples/compose/plot_transformed_target.py
+++ b/examples/compose/plot_transformed_target.py
@@ -167,24 +167,34 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 
 ###############################################################################
 # The effect of the transformer is weaker than on the synthetic data. However,
-# the transform induces an increase in R^2 and large decrease of the MAE.
+# the transform induces an increase in R^2 and large decrease of the MAE. The
+# residual plot (predicted target - true target vs predicted target) without
+# target transformation takes on a curved, 'reverse smile' shape due to
+# residual values that tend to vary depending on the value of predicted target.
+# With target transformation, the shape is more linear indicating better model
+# fit.
 
-f, (ax0, ax1) = plt.subplots(1, 2, sharey=True)
+f, (ax0, ax1) = plt.subplots(2, 2, sharey='row')
 
 regr = RidgeCV()
 regr.fit(X_train, y_train)
 y_pred = regr.predict(X_test)
 
-ax0.scatter(y_test, y_pred, s=8)
-ax0.plot([0, 7e5], [0, 7e5], '--k')
-ax0.set_ylabel('Target predicted')
-ax0.set_xlabel('True Target')
-ax0.set_title('Ridge regression \n without target transformation', pad=18)
-ax0.text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
+ax0[0].scatter(y_pred, y_test, s=8)
+ax0[0].plot([0, 7e5], [0, 7e5], '--k')
+ax0[0].set_ylabel('True target')
+ax0[0].set_xlabel('Predicted target')
+ax0[0].set_title('Ridge regression \n without target transformation', pad=18)
+ax0[0].text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
-ax0.set_xlim([0, 7e5])
-ax0.set_ylim([0, 7e5])
-ax0.ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
+ax0[0].set_xlim([0, 7e5])
+ax0[0].set_ylim([0, 7e5])
+ax0[0].ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
+
+ax1[0].scatter(y_pred, (y_pred - y_test), s=8)
+ax1[0].set_ylabel('Residual')
+ax1[0].set_xlabel('Predicted target')
+ax1[0].ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
 
 regr_trans = TransformedTargetRegressor(
     regressor=RidgeCV(),
@@ -193,18 +203,23 @@ regr_trans = TransformedTargetRegressor(
 regr_trans.fit(X_train, y_train)
 y_pred = regr_trans.predict(X_test)
 
-ax1.scatter(y_test, y_pred, s=8)
-ax1.plot([0, 7e5], [0, 7e5], '--k')
-ax1.set_ylabel('Target predicted')
-ax1.set_xlabel('True Target')
-ax1.set_title('Ridge regression \n with target transformation', pad=18)
-ax1.text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
+ax0[1].scatter(y_pred, y_test, s=8)
+ax0[1].plot([0, 7e5], [0, 7e5], '--k')
+ax0[1].set_ylabel('True target')
+ax0[1].set_xlabel('Predicted target')
+ax0[1].set_title('Ridge regression \n with target transformation', pad=18)
+ax0[1].text(3e4, 64e4, r'$R^2$=%.2f, MAE=%.2f' % (
     r2_score(y_test, y_pred), median_absolute_error(y_test, y_pred)))
-ax1.set_xlim([0, 7e5])
-ax1.set_ylim([0, 7e5])
-ax1.ticklabel_format(axis="x", style="sci", scilimits=(0, 0))
+ax0[1].set_xlim([0, 7e5])
+ax0[1].set_ylim([0, 7e5])
+ax0[1].ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
+
+ax1[1].scatter(y_pred, (y_pred - y_test), s=8)
+ax1[1].set_ylabel('Residual')
+ax1[1].set_xlabel('Predicted target')
+ax1[1].ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
 
 f.suptitle("Ames housing data: selling price", y=0.035)
-f.tight_layout(rect=[0.05, 0.05, 0.95, 0.95])
+f.tight_layout(rect=[0.05, 0.05, 1, 1.7])
 
 plt.show()


### PR DESCRIPTION
Towards #16155

Use Ames housing data for `plot_transformed_target.py`.

Old plots:
![image](https://user-images.githubusercontent.com/23182829/77236306-9457e280-6bbd-11ea-867a-ba15c04f5761.png)
![image](https://user-images.githubusercontent.com/23182829/77236312-9cb01d80-6bbd-11ea-9034-8f17a235d2dc.png)

New plots:
![image](https://user-images.githubusercontent.com/23182829/77236415-86569180-6bbe-11ea-8923-f6575892eeef.png)

Hopefully `n_quantiles` I used is reasonable. Ames data has 1460 samples.
