### PR TITLE
query_filtered functionality for KDTree

### DIFF
--- a/sklearn/neighbors/_ball_tree.pyx
+++ b/sklearn/neighbors/_ball_tree.pyx
@@ -190,3 +190,11 @@ cdef inline DTYPE_t max_rdist_dual(BinaryTree tree1, ITYPE_t i_node1,
     else:
         return tree1.dist_metric._dist_to_rdist(max_dist_dual(tree1, i_node1,
                                                               tree2, i_node2))
+
+
+cdef DTYPE_t min_filter_rdist(BinaryTree tree,
+                              ITYPE_t i_node,
+                              DTYPE_t* rs,
+                              DTYPE_t* pt) nogil except -1:
+    """Compute the minimum reduced-distance between a point and a node"""
+    raise NotImplementedError("filtering not possible with BallTree")

--- a/sklearn/neighbors/_dist_metrics.pxd
+++ b/sklearn/neighbors/_dist_metrics.pxd
@@ -3,12 +3,16 @@
 #cython: wraparound=False
 #cython: cdivision=True
 
+import numpy as np
+
 cimport cython
 cimport numpy as np
 from libc.math cimport fabs, sqrt, exp, cos, pow
 
 from ._typedefs cimport DTYPE_t, ITYPE_t, DITYPE_t
 from ._typedefs import DTYPE, ITYPE
+
+cdef DTYPE_t INF = np.inf
 
 ######################################################################
 # Inline distance functions
@@ -32,6 +36,21 @@ cdef inline DTYPE_t euclidean_rdist(DTYPE_t* x1, DTYPE_t* x2,
     for j in range(size):
         tmp = x1[j] - x2[j]
         d += tmp * tmp
+    return d
+
+
+cdef inline DTYPE_t filtered_euclidean_rdist(DTYPE_t* x1, DTYPE_t* x2,
+                                             DTYPE_t* rs,
+                                             ITYPE_t size) nogil except -1:
+    cdef DTYPE_t tmp, d=0
+    cdef np.intp_t j
+    for j in range(size):
+        if rs[j] >= 0:
+            if fabs(x1[j] - x2[j]) > rs[j]:
+                return INF
+        else:
+            tmp = x1[j] - x2[j]
+            d += tmp * tmp
     return d
 
 

--- a/sklearn/neighbors/tests/test_kd_tree.py
+++ b/sklearn/neighbors/tests/test_kd_tree.py
@@ -1,6 +1,73 @@
+import numpy as np
+
+from sklearn.neighbors import KDTree
+
 DIMENSION = 3
 
-METRICS = {'euclidean': {},
-           'manhattan': {},
-           'chebyshev': {},
-           'minkowski': dict(p=3)}
+METRICS = {"euclidean": {}, "manhattan": {}, "chebyshev": {}, "minkowski": dict(p=3)}
+
+
+def test_kd_tree_filter_query():
+
+    X = np.array(
+        [
+            [0, 2, 1],
+            [2, 2, 3],
+            [10, 3, 1],
+            [4, 5, 6],
+            [0, 0, 0],
+            [-10, -3, 2],
+            [1, -5, 2],
+        ]
+    )
+    tree = KDTree(X, leaf_size=1)
+    queries = np.array([[1, 1, 1]])
+
+    dist, ind = tree.query_filtered(queries, [[1, -1, -1]], k=2)
+
+    assert ind[0][0] == 0
+    assert ind[0][1] == 4
+    assert dist[0][0] == 1
+
+    rand = np.random.RandomState(18)
+
+    n_features = 6
+    data_size = 2000
+    query_num = 20
+
+    X = rand.rand(data_size, n_features)
+
+    tree2 = KDTree(X, leaf_size=4)
+
+    queries = rand.rand(query_num, n_features)
+    filter_radiuses = rand.rand(query_num, n_features) - 0.5
+
+    bruteforce_ind = []
+    bruteforce_dist = []
+    for q, rads in zip(queries, filter_radiuses):
+        effective_rads = np.array([r if r >= 0 else np.inf for r in rads])
+        _dist_inds = rads < 0
+        min_rdist = np.inf
+        min_ind = 0
+        for i, x_i in enumerate(X):
+            if (np.abs(x_i - q) <= effective_rads).all():
+                _d = ((x_i[_dist_inds] - q[_dist_inds]) ** 2).sum()
+                if _d < min_rdist:
+                    min_rdist = _d
+                    min_ind = i
+        bruteforce_ind.append([min_ind])
+        bruteforce_dist.append([np.sqrt(min_rdist)])
+
+    bf_dist = np.array(bruteforce_dist)
+    bf_ind = np.array(bruteforce_ind)
+
+    dist, ind = tree2.query_filtered(queries, filter_radiuses, k=1)
+
+    for q, rad, i, bi, d, bd in zip(
+        queries, filter_radiuses, ind[:, 0], bf_ind[:, 0], dist[:, 0], bf_dist[:, 0]
+    ):
+        _dist_inds = rad < 0
+        _filt_inds = rad >= 0
+        if (rad < 0).any():
+            assert i == bi
+        assert d == bd

--- a/sklearn/neighbors/tests/test_kd_tree.py
+++ b/sklearn/neighbors/tests/test_kd_tree.py
@@ -4,7 +4,12 @@ from sklearn.neighbors import KDTree
 
 DIMENSION = 3
 
-METRICS = {"euclidean": {}, "manhattan": {}, "chebyshev": {}, "minkowski": dict(p=3)}
+METRICS = {
+    "euclidean": {},
+    "manhattan": {},
+    "chebyshev": {},
+    "minkowski": dict(p=3),
+}
 
 
 def test_kd_tree_filter_query():
@@ -64,10 +69,13 @@ def test_kd_tree_filter_query():
     dist, ind = tree2.query_filtered(queries, filter_radiuses, k=1)
 
     for q, rad, i, bi, d, bd in zip(
-        queries, filter_radiuses, ind[:, 0], bf_ind[:, 0], dist[:, 0], bf_dist[:, 0]
+        queries,
+        filter_radiuses,
+        ind[:, 0],
+        bf_ind[:, 0],
+        dist[:, 0],
+        bf_dist[:, 0],
     ):
-        _dist_inds = rad < 0
-        _filt_inds = rad >= 0
         if (rad < 0).any():
             assert i == bi
         assert d == bd


### PR DESCRIPTION
Hello!

I added some extra functionality to KDTree, which is mix between query and query radius.

I'm fine with abandoning it if you think it would just bloat the API, but if it is welcome, I'm happy to touch up the documentation and whatever else is necessary a bit.

However I've found that there is no great tool for doing this kind of filter+search combination efficiently, and it cannot be done with the current API.

It's probably easiest to understand how it works from the first part of the test:

```python
    X = np.array(
        [
            [0, 2, 1],
            [2, 2, 3],
            [10, 3, 1],
            [4, 5, 6],
            [0, 0, 0],
            [-10, -3, 2],
            [1, -5, 2],
        ]
    )
    tree = KDTree(X, leaf_size=1)
    queries = np.array([[1, 1, 1]])

    dist, ind = tree.query_filtered(queries, [[1, -1, -1]], k=2)

    assert ind[0][0] == 0
    assert ind[0][1] == 4
    assert dist[0][0] == 1
```

