### PR TITLE
MNT minor optimization for subsampling in GBDT

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/binning.py
@@ -49,7 +49,7 @@ def _find_binning_thresholds(data, max_bins, subsample, random_state):
     """
     rng = check_random_state(random_state)
     if subsample is not None and data.shape[0] > subsample:
-        subset = rng.choice(np.arange(data.shape[0]), subsample, replace=False)
+        subset = rng.choice(data.shape[0], subsample, replace=False)
         data = data.take(subset, axis=0)
 
     binning_thresholds = []


### PR DESCRIPTION
Minor optimization that does not allocate an array when subsampling