### PR TITLE
[WIP] Add warning for Cross-Validation classes 'fit' method

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1620,10 +1620,11 @@ class _BaseRidgeCV(LinearModel):
         max_alpha = max(self.alphas)
         if self.alpha_ in [min_alpha, max_alpha]:
             warnings.warn("The optimal value for the regularization parameter "
-                            "'alpha' was %g which lies at a boundary of the "
-                            "explored range (between %g and %g). Consider "
-                            "setting the 'alphas' parameter to explore a wider "
-                            "range." % (self.alpha_, min_alpha, max_alpha))
+                          "'alpha' was %g which lies at a boundary of the "
+                          "explored range (between %g and %g). Consider "
+                          "setting the 'alphas' parameter to explore a "
+                          "wider range." % (self.alpha_, min_alpha,
+                                            max_alpha))
 
         self.coef_ = estimator.coef_
         self.intercept_ = estimator.intercept_

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1616,6 +1616,15 @@ class _BaseRidgeCV(LinearModel):
             self.alpha_ = gs.best_estimator_.alpha
             self.best_score_ = gs.best_score_
 
+        min_alpha = min(self.alphas)
+        max_alpha = max(self.alphas)
+        if self.alpha_ in [min_alpha, max_alpha]:
+            warnings.warn("The optimal value for the regularization parameter "
+                            "'alpha' was %g which lies at a boundary of the "
+                            "explored range (between %g and %g). Consider "
+                            "setting the 'alphas' parameter to explore a wider "
+                            "range." % (self.alpha_, min_alpha, max_alpha))
+
         self.coef_ = estimator.coef_
         self.intercept_ = estimator.intercept_
         self.n_features_in_ = estimator.n_features_in_

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1324,3 +1324,9 @@ def test_ridge_sag_with_X_fortran():
     X = X[::2, :]
     y = y[::2]
     Ridge(solver='sag').fit(X, y)
+
+
+def test_ridge_alpha_boundary_warning():
+    clf = RidgeCV(alphas=[1e-1, 1])
+    assert_warns(UserWarning, clf.fit, X_diabetes, y_diabetes)
+

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1329,4 +1329,3 @@ def test_ridge_sag_with_X_fortran():
 def test_ridge_alpha_boundary_warning():
     clf = RidgeCV(alphas=[1e-1, 1])
     assert_warns(UserWarning, clf.fit, X_diabetes, y_diabetes)
-


### PR DESCRIPTION
Fixes #16398

#### What does this implement/fix? Explain your changes.
Added the warning when found optimal 'alpha' parameter in RidgeCV lies at the boundary of the given range. I also added the test, that checks if warning occurs, when it should, although I'm not entirely sure if this test is necessary.

#### Any other comments?
As proposed in the linked Issue, I would like to add this warning in the rest of "Cross-Validation" classes. The rest that I found are:

- [ ] GraphicalLassoCV
- [ ] RidgeClassifierCV
- [ ] LogisticRegressionCV
- [ ] LinearModelCV (base class of LassoCV, ElasticNetCV, MultiTaskLassoCV, MultiTaskElasticNetCV)
- [ ] GridSearchCV
- [ ] RandomisedSearchCV

If you think it'll be beneficial, I'll finish these classes too.
