### PR TITLE
[MRG] DOC UndefinedMetricWarning: example doc added

### DIFF
--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -171,6 +171,23 @@ class SkipTestWarning(UserWarning):
 class UndefinedMetricWarning(UserWarning):
     """Warning used when the metric is invalid
 
+    Examples
+    --------
+    >>> from sklearn.metrics import r2_score
+    >>> from sklearn.exceptions import UndefinedMetricWarning
+    >>> import warnings
+    >>> warnings.simplefilter('always', UndefinedMetricWarning)
+    >>> y_true = [3]
+    >>> y_pred = [3]
+    >>> with warnings.catch_warnings(record=True) as w:
+    ...     try:
+    ...         r2_score(y_true, y_pred)
+    ...     except ValueError:
+    ...         pass
+    ...     print(repr(w[-1].message))
+    nan
+    UndefinedMetricWarning('R^2 score is not well-defined with less than two samples.')
+
     .. versionchanged:: 0.18
        Moved from sklearn.base.
     """

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -185,7 +185,7 @@ class UndefinedMetricWarning(UserWarning):
     ...     except ValueError:
     ...         pass
     ...     print(repr(w[-1].message))
-    UndefinedMetricWarning('R^2 score is not well-defined with less than two 
+    UndefinedMetricWarning('R^2 score is not well-defined with less than two
     samples.')
 
     .. versionchanged:: 0.18

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -177,7 +177,7 @@ class UndefinedMetricWarning(UserWarning):
     >>> from sklearn.exceptions import UndefinedMetricWarning
     >>> import warnings
     >>> warnings.simplefilter('always', UndefinedMetricWarning)
-    >>> y_true = [3]
+    >>> y_true, y_pred = [3], [3]
     >>> y_pred = [3]
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -185,7 +185,6 @@ class UndefinedMetricWarning(UserWarning):
     ...     except ValueError:
     ...         pass
     ...     print(repr(w[-1].message))
-    nan
     UndefinedMetricWarning('R^2 score is not well-defined with less than two samples.')
 
     .. versionchanged:: 0.18

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -185,6 +185,7 @@ class UndefinedMetricWarning(UserWarning):
     ...     except ValueError:
     ...         pass
     ...     print(repr(w[-1].message))
+    nan
     UndefinedMetricWarning('R^2 score is not well-defined with less than two
     samples.')
 

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -185,7 +185,8 @@ class UndefinedMetricWarning(UserWarning):
     ...     except ValueError:
     ...         pass
     ...     print(repr(w[-1].message))
-    UndefinedMetricWarning('R^2 score is not well-defined with less than two samples.')
+    UndefinedMetricWarning('R^2 score is not well-defined with less than two 
+    samples.')
 
     .. versionchanged:: 0.18
        Moved from sklearn.base.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes part of #3846 by adding example to exceptions.UndefinedMetricWarning which is one of the remaining TODOs. 

#### What does this implement/fix? Explain your changes.
I added an example to UndefinedMetricWarning which uses the R^2 score which raises a warning when used on less than 2 samples.

#### Any other comments?
This is my first PR and any comments are welcome :).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
