### PR TITLE
[MRG] DOC EfficiencyWarning: Added example to doc

### DIFF
--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -121,7 +121,7 @@ class EfficiencyWarning(UserWarning):
     >>> samples = [[0., 0., 0.], [0., .5, 0.], [1., 1., .5]]
     >>> neigh = NearestNeighbors(n_neighbors=1, metric='precomputed')
     >>> neigh.fit(samples)
-    NearestNeighbors(n_neighbors=1)
+    NearestNeighbors(metric='precomputed', n_neighbors=1)
     >>> X = csr_matrix([[0., 2., 0.], [1., 0., 1.], [3., 0., 1.]])
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -120,7 +120,7 @@ class EfficiencyWarning(UserWarning):
     >>> samples = [[1., 1., .5], [0., 0., 0.], [0., .5, 0.]]
     >>> neigh = NearestNeighbors(n_neighbors=1)
     >>> neigh.fit(samples)
-    NearestNeighbors(...)
+    NearestNeighbors(n_neighbors=1)
     >>> X = [[1., 0., 1.], [0., 1., 0.]]
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -122,10 +122,11 @@ class EfficiencyWarning(UserWarning):
     >>> neigh.fit(samples)
     NearestNeighbors(n_neighbors=1)
     >>> X = [[1., 0., 1.], [0., 1., 0.]]
+    >>> neigh.effective_metric_ = 'precomputed'
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:
     ...         neigh.kneighbors(X, return_distance=False)
-    ...     except IndexError('list index out of range'):
+    ...     except IndexError:
     ...         pass
     ...     print(repr(w[-1].message))
     EfficiencyWarning('The input centres are not sorted, which is probably a

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -130,6 +130,7 @@ class EfficiencyWarning(UserWarning):
     ...     except ValueError:
     ...         pass
     ...     print(repr(w[-1].message))
+    array(...)
     EfficiencyWarning('Precomputed sparse input was not sorted by data.')
 
     .. versionadded:: 0.18

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -114,6 +114,7 @@ class EfficiencyWarning(UserWarning):
     Examples
     --------
     >>> from sklearn.neighbors import NearestNeighbors
+    >>> from sklearn.exceptions import EfficiencyWarning
     >>> import warnings
     >>> warnings.simplefilter('always', EfficiencyWarning)
     >>> samples = [[1., 1., .5], [0., 0., 0.], [0., .5, 0.]]
@@ -123,8 +124,9 @@ class EfficiencyWarning(UserWarning):
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:
     ...         neigh.kneighbors(X)
-    ...     except EfficiencyWarning as e:
-    ...         print(repr(e))
+    ...     except EfficiencyWarning:
+    ...         pass
+    ...     print(repr(w[-1].message))
     EfficiencyWarning('The input centres are not sorted, which is probably a
     result of a precomputed sparse input which was not sorted by data..')
 

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -119,11 +119,10 @@ class EfficiencyWarning(UserWarning):
     >>> import warnings
     >>> warnings.simplefilter('always', EfficiencyWarning)
     >>> samples = [[0., 0., 0.], [0., .5, 0.], [1., 1., .5]]
-    >>> neigh = NearestNeighbors(n_neighbors=1)
+    >>> neigh = NearestNeighbors(n_neighbors=1, metric='precomputed')
     >>> neigh.fit(samples)
     NearestNeighbors(n_neighbors=1)
     >>> X = csr_matrix([[0., 2., 0.], [1., 0., 1.], [3., 0., 1.]])
-    >>> neigh.effective_metric_ = 'precomputed'
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:
     ...         neigh.kneighbors(X, return_distance=False)

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -115,22 +115,22 @@ class EfficiencyWarning(UserWarning):
     --------
     >>> from sklearn.neighbors import NearestNeighbors
     >>> from sklearn.exceptions import EfficiencyWarning
+    >>> from scipy.sparse import csr_matrix
     >>> import warnings
     >>> warnings.simplefilter('always', EfficiencyWarning)
-    >>> samples = [[1., 1., .5], [0., 0., 0.], [0., .5, 0.]]
+    >>> samples = [[0., 0., 0.], [0., .5, 0.], [1., 1., .5]]
     >>> neigh = NearestNeighbors(n_neighbors=1)
     >>> neigh.fit(samples)
     NearestNeighbors(n_neighbors=1)
-    >>> X = [[1., 0., 1.], [0., 1., 0.]]
+    >>> X = csr_matrix([[0., 2., 0.], [1., 0., 1.], [3., 0., 1.]])
     >>> neigh.effective_metric_ = 'precomputed'
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:
     ...         neigh.kneighbors(X, return_distance=False)
-    ...     except IndexError:
+    ...     except ValueError:
     ...         pass
     ...     print(repr(w[-1].message))
-    EfficiencyWarning('The input centres are not sorted, which is probably a
-    result of a precomputed sparse input which was not sorted by data.')
+    EfficiencyWarning('Precomputed sparse input was not sorted by data.')
 
     .. versionadded:: 0.18
     """

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -111,6 +111,23 @@ class EfficiencyWarning(UserWarning):
     to some reason which may be included as a part of the warning message.
     This may be subclassed into a more specific Warning class.
 
+    Examples
+    --------
+    >>> from sklearn.neighbors import NearestNeighbors
+    >>> import warnings
+    >>> warnings.simplefilter('always', EfficiencyWarning)
+    >>> samples = [[1., 1., .5], [0., 0., 0.], [0., .5, 0.]]
+    >>> neigh = NearestNeighbors(n_neighbors=1)
+    >>> neigh.fit(samples)
+    >>> X = [[1., 0., 1.], [0., 1., 0.]]
+    >>> with warnings.catch_warnings(record=True) as w:
+    ...     try:
+    ...         neigh.kneighbors(X)
+    ...     except EfficiencyWarning as e:
+    ...         print(repr(e))
+    EfficiencyWarning('The input centres are not sorted, which is probably a
+    result of a precomputed sparse input which was not sorted by data..')
+
     .. versionadded:: 0.18
     """
 

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -124,12 +124,12 @@ class EfficiencyWarning(UserWarning):
     >>> X = [[1., 0., 1.], [0., 1., 0.]]
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:
-    ...         neigh.kneighbors(X)
-    ...     except EfficiencyWarning:
+    ...         neigh.kneighbors(X, return_distance=False)
+    ...     except ValueError:
     ...         pass
     ...     print(repr(w[-1].message))
     EfficiencyWarning('The input centres are not sorted, which is probably a
-    result of a precomputed sparse input which was not sorted by data..')
+    result of a precomputed sparse input which was not sorted by data.')
 
     .. versionadded:: 0.18
     """

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -120,6 +120,7 @@ class EfficiencyWarning(UserWarning):
     >>> samples = [[1., 1., .5], [0., 0., 0.], [0., .5, 0.]]
     >>> neigh = NearestNeighbors(n_neighbors=1)
     >>> neigh.fit(samples)
+    NearestNeighbors(...)
     >>> X = [[1., 0., 1.], [0., 1., 0.]]
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -125,7 +125,7 @@ class EfficiencyWarning(UserWarning):
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:
     ...         neigh.kneighbors(X, return_distance=False)
-    ...     except ValueError:
+    ...     except IndexError:
     ...         pass
     ...     print(repr(w[-1].message))
     EfficiencyWarning('The input centres are not sorted, which is probably a

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -125,7 +125,7 @@ class EfficiencyWarning(UserWarning):
     >>> with warnings.catch_warnings(record=True) as w:
     ...     try:
     ...         neigh.kneighbors(X, return_distance=False)
-    ...     except IndexError:
+    ...     except IndexError('list index out of range'):
     ...         pass
     ...     print(repr(w[-1].message))
     EfficiencyWarning('The input centres are not sorted, which is probably a


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes a todo in #3846, the `EfficiencyWarning` needed an example documentation. I followed the style of `FitFailedWarning` and took inspiration for an example of `sklearn.neighbors._base.KNeighborsMixin`.

#### What does this implement/fix? Explain your changes.
Improves the documentation by adding an example to `EfficiencyWarning`.

#### Any other comments?
This is my first pull-request for any open-source library, any feedback is welcome.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
