### PR TITLE
DOC Improve CountVectorizer and TfidfVectorizer return type

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1165,7 +1165,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         return self
 
     def fit_transform(self, raw_documents, y=None):
-        """Learn the vocabulary dictionary and return term-document matrix.
+        """Learn the vocabulary dictionary and return document-term matrix.
 
         This is equivalent to fit followed by transform, but more efficiently
         implemented.
@@ -1816,7 +1816,7 @@ class TfidfVectorizer(CountVectorizer):
         return self
 
     def fit_transform(self, raw_documents, y=None):
-        """Learn vocabulary and idf, return term-document matrix.
+        """Learn vocabulary and idf, return document-term matrix.
 
         This is equivalent to fit followed by transform, but more efficiently
         implemented.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #16776 

#### What does this implement/fix? Explain your changes.
Correct the one-line description of the fit_transform method of CountVectorizer and TfidfVectorizer to be consistent with the *Returns* documentation of each methods.

Previously : "return term-document matrix"

Now: "return document-term matrix"

This is in line with the return type.