### PR TITLE
[MRG] Add test for multinomial identifiability constraint in logistic regression

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1825,3 +1825,43 @@ def test_scores_attribute_layout_elasticnet():
 
             avg_score_lr = cross_val_score(lr, X, y, cv=cv).mean()
             assert avg_scores_lrcv[i, j] == pytest.approx(avg_score_lr)
+
+
+@pytest.mark.parametrize("fit_intercept", [False, True])
+def test_multinomial_identifiability_on_iris(fit_intercept):
+    """Test that the multinomial classification is identifiable.
+
+    A multinomial with c classes can be modeled with
+    probability_k = exp(X@coef_k) / sum(X@coef_l, l=1..c) for k=1..c.
+    This is not identifiable, unless one chooses a further constraint.
+    According to [1], the maximum of the L2 penalized likelihood automatically
+    satisfies the symmetric constraint:
+    sum(coef_k, k=1..c) = 0
+
+    Further details can be found in the appendix of [2].
+
+    Reference
+    ---------
+    .. [1] Zhu, Ji and Trevor J. Hastie. "Classification of gene microarrays by
+    penalized logistic regression". Biostatistics 5 3 (2004): 427-43.
+    https://doi.org/10.1093/biostatistics%2Fkxg046
+
+    .. [2] Powers, Scott, Trevor J. Hastie and Robert Tibshirani. "Nuclear
+    penalized multinomial regression with an application to predicting at bat
+    outcomes in baseball." Statistical modelling 18 5-6 (2017): 388-410 .
+    https://arxiv.org/pdf/1706.10272.pdf
+    """
+    # Test logistic regression with the iris dataset
+    n_samples, n_features = iris.data.shape
+    target = iris.target_names[iris.target]
+
+    clf = LogisticRegression(C=len(iris.data), solver='lbfgs', max_iter=300,
+                             multi_class='multinomial',
+                             fit_intercept=fit_intercept
+                             )
+    clf.fit(iris.data, target)
+
+    # axis=0 is sum over classes
+    assert_array_almost_equal(clf.coef_.sum(axis=0), np.zeros(n_features))
+    if fit_intercept:
+        assert_array_almost_equal(clf.intercept_.sum(axis=0), 0)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1862,6 +1862,6 @@ def test_multinomial_identifiability_on_iris(fit_intercept):
     clf.fit(iris.data, target)
 
     # axis=0 is sum over classes
-    assert_allclose(clf.coef_.sum(axis=0), np.zeros(n_features), atol=1e-11)
+    assert_allclose(clf.coef_.sum(axis=0), 0, atol=1e-11)
     if fit_intercept:
         clf.intercept_.sum(axis=0) == pytest.approx(0, abs=1e-15)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1862,6 +1862,6 @@ def test_multinomial_identifiability_on_iris(fit_intercept):
     clf.fit(iris.data, target)
 
     # axis=0 is sum over classes
-    assert_allclose(clf.coef_.sum(axis=0), 0, atol=1e-11)
+    assert_allclose(clf.coef_.sum(axis=0), 0, atol=1e-10)
     if fit_intercept:
         clf.intercept_.sum(axis=0) == pytest.approx(0, abs=1e-15)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1832,7 +1832,7 @@ def test_multinomial_identifiability_on_iris(fit_intercept):
     """Test that the multinomial classification is identifiable.
 
     A multinomial with c classes can be modeled with
-    probability_k = exp(X@coef_k) / sum(X@coef_l, l=1..c) for k=1..c.
+    probability_k = exp(X@coef_k) / sum(exp(X@coef_l), l=1..c) for k=1..c.
     This is not identifiable, unless one chooses a further constraint.
     According to [1], the maximum of the L2 penalized likelihood automatically
     satisfies the symmetric constraint:
@@ -1862,6 +1862,6 @@ def test_multinomial_identifiability_on_iris(fit_intercept):
     clf.fit(iris.data, target)
 
     # axis=0 is sum over classes
-    assert_array_almost_equal(clf.coef_.sum(axis=0), np.zeros(n_features))
+    assert_allclose(clf.coef_.sum(axis=0), np.zeros(n_features), atol=1e-11)
     if fit_intercept:
-        assert_array_almost_equal(clf.intercept_.sum(axis=0), 0)
+        clf.intercept_.sum(axis=0) == pytest.approx(0, abs=1e-15)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import numpy as np
+from numpy.testing import assert_allclose, assert_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 import scipy.sparse as sp
 from scipy import linalg, optimize, sparse
 
@@ -16,10 +18,6 @@ from sklearn.model_selection import train_test_split
 from sklearn.model_selection import cross_val_score
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 from sklearn.utils import compute_class_weight, _IS_32BIT
-from sklearn.utils._testing import assert_almost_equal
-from sklearn.utils._testing import assert_allclose
-from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_warns


### PR DESCRIPTION
#### Reference Issues/PRs
Issue #6722 is somehow related.

#### What does this implement/fix? Explain your changes.
This PR adds a test for the symmetric identifiability constraint, see [1] and appendix of [2] (and [3] for more context).

A multinomial GLM with `c` classes can be modeled with `probability_k = exp(X@coef_k) / sum(X@coef_l, l=1..c)` for `k=1..c`. This is not identifiable, unless one chooses a further constraint. According to [1], the maximum of the L2 penalized likelihood automatically satisfies the symmetric constraint: `sum(coef_k, k=1..c) = 0`

#### Open questions?
- Is this something, the user guide should mention? It took me quite some time to figure this out reading code and literature.

#### References
[1] Zhu, Ji and Trevor J. Hastie. "Classification of gene microarrays by penalized logistic regression". Biostatistics 5 3 (2004): 427-43.
https://doi.org/10.1093/biostatistics%2Fkxg046
[2] Powers, Scott, Trevor J. Hastie and Robert Tibshirani. "Nuclear penalized multinomial regression with an application to predicting at bat outcomes in baseball." Statistical modelling 18 5-6 (2017): 388-410 .
https://arxiv.org/pdf/1706.10272.pdf
[3] Zahid, Faisal Maqbool and Gerhard Tutz. “Ridge estimation for multinomial logit models with symmetric side constraints.” Computational Statistics 28 (2013): 1017-1034.
http://epub.ub.uni-muenchen.de/11001/1/tr067.pdf

