### PR TITLE
Add sparse support for 'y' to multioutput regression

### DIFF
--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -613,6 +613,7 @@ def test_regressor_chain_w_fit_params():
         assert est.sample_weight_ is weight
 
 
+# check if MultiOutputRegressor accepts sparse 'y' input PR#16800
 def test_multioutput_use_sparse_y():
     X = sp.csr_matrix((13, 5))
     y = sp.csr_matrix((13, 2))

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -611,3 +611,11 @@ def test_regressor_chain_w_fit_params():
 
     for est in model.estimators_:
         assert est.sample_weight_ is weight
+
+
+def test_multioutput_use_sparse_y():
+    X = sp.csr_matrix((13, 5))
+    y = sp.csr_matrix((13, 2))
+
+    m_reg = MultiOutputRegressor(SGDRegressor())
+    m_reg.fit(X, y)

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -619,4 +619,5 @@ def test_multioutput_use_sparse_y():
     y = sp.csr_matrix((13, 2))
 
     m_reg = MultiOutputRegressor(SGDRegressor())
-    m_reg.fit(X, y)
+    with pytest.warns(UserWarning):
+        m_reg.fit(X, y)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1175,6 +1175,7 @@ def test_check_sparse_pandas_sp_format(sp_format):
     assert_allclose_dense_sparse(sp_mat, result)
 
 
+# check if column_or_1d accepts sparse input PR#16800
 def test_sparse_matrix_to_numpy():
     y = sp.csr_matrix((13, 1))
     column_or_1d(y)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -43,6 +43,7 @@ from sklearn.utils.validation import (
     _deprecate_positional_args,
     _check_sample_weight,
     _allclose_dense_sparse,
+    column_or_1d,
     FLOAT_DTYPES)
 from sklearn.utils.validation import _check_fit_params
 
@@ -1172,3 +1173,8 @@ def test_check_sparse_pandas_sp_format(sp_format):
     assert sp.issparse(result)
     assert result.format == sp_format
     assert_allclose_dense_sparse(sp_mat, result)
+
+
+def test_sparse_matrix_to_numpy():
+    y = sp.csr_matrix((13, 1))
+    column_or_1d(y)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1176,6 +1176,15 @@ def test_check_sparse_pandas_sp_format(sp_format):
 
 
 # check if column_or_1d accepts sparse input PR#16800
+@pytest.mark.filterwarnings("ignore", category=UserWarning)
 def test_sparse_matrix_to_numpy():
     y = sp.csr_matrix((13, 1))
-    column_or_1d(y)
+    expected = np.ravel(y.toarray())
+    result = column_or_1d(y)
+    assert_array_equal(expected, result)
+
+
+def test_if_sparse_matrix_to_numpy_warns():
+    y = sp.csr_matrix((13, 1))
+    with pytest.warns(UserWarning):
+        column_or_1d(y, warn=True)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1176,11 +1176,10 @@ def test_check_sparse_pandas_sp_format(sp_format):
 
 
 # check if column_or_1d accepts sparse input PR#16800
-@pytest.mark.filterwarnings("ignore", category=UserWarning)
 def test_sparse_matrix_to_numpy():
     y = sp.csr_matrix((13, 1))
     expected = np.ravel(y.toarray())
-    result = column_or_1d(y)
+    result = column_or_1d(y, warn=False)
     assert_array_equal(expected, result)
 
 
@@ -1188,3 +1187,8 @@ def test_if_sparse_matrix_to_numpy_warns():
     y = sp.csr_matrix((13, 1))
     with pytest.warns(UserWarning):
         column_or_1d(y, warn=True)
+
+def test_sparse_matrix_to_numpy_wrong_shape():
+    y = sp.csr_matrix((13, 2))
+    with pytest.raises(ValueError):
+        column_or_1d(y, warn=False)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1188,6 +1188,7 @@ def test_if_sparse_matrix_to_numpy_warns():
     with pytest.warns(UserWarning):
         column_or_1d(y, warn=True)
 
+
 def test_sparse_matrix_to_numpy_wrong_shape():
     y = sp.csr_matrix((13, 2))
     with pytest.raises(ValueError):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -760,7 +760,10 @@ def column_or_1d(y, warn=False):
     y : array
 
     """
-    y = np.asarray(y)
+    if type(y) == sp.csr_matrix:
+        y = y.toarray()
+    else:
+        y = np.asarray(y)
     shape = np.shape(y)
     if len(shape) == 1:
         return np.ravel(y)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -750,7 +750,7 @@ def column_or_1d(y, warn=False):
 
     Parameters
     ----------
-    y : array-like
+    y : {array-like, sparse matrix}
 
     warn : boolean, default False
        To control display of warnings.
@@ -760,10 +760,19 @@ def column_or_1d(y, warn=False):
     y : array
 
     """
-    if type(y) == sp.csr_matrix:
-        y = y.toarray()
-    else:
-        y = np.asarray(y)
+    if sp.issparse(y):
+        shape = y.shape
+        if len(shape) == 1 or (len(shape) == 2 and shape[1] == 1):
+            if warn:
+                warnings.warn("A sparse y matrix will be converted to "
+                              "dense array.", UserWarning)
+            return np.ravel(y.toarray())
+
+        raise ValueError(
+            "Sparse y should be of shape (n_samples, 1), or (n_samples,) "
+            "but got matrix of shape {} instead.".format(shape))
+
+    y = np.asarray(y)
     shape = np.shape(y)
     if len(shape) == 1:
         return np.ravel(y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #16686 

#### What does this implement/fix? Explain your changes.
Now it's possible to use 'y' of type "sparse.csr_matrix" as input to MultiOutputRegressor.