### PR TITLE
BLD Sets minimal supported numpy version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,11 @@ requires = [
     "setuptools",
     "wheel",
     "Cython>=0.28.5",
-    "numpy>=1.13.3",
+    "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
+    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
     "scipy>=0.19.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,14 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=0.28.5",
-    "numpy>=1.13.3",
-    "scipy>=0.19.1",
+    "Cython>=0.29.13", 
+    "scipy>=1.2.2",
+    "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
+    "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
+    "numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=0.29.13", 
-    "scipy>=1.2.2",
-    "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
-    "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
-    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
-    "numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
+    "Cython>=0.28.5",
+    "numpy>=1.13.3",
+    "scipy>=0.19.1",
 ]

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -658,6 +658,9 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
+    dual_gaps_ : float or ndarray of shape (n_targets,)
+        Given param alpha, the dual gaps at the end of the optimization for each column of target y.
+
     Examples
     --------
     >>> from sklearn.linear_model import ElasticNet
@@ -1607,6 +1610,9 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
     alphas_ : ndarray of shape (n_alphas,) or (n_l1_ratio, n_alphas)
         The grid of alphas used for fitting, for each l1_ratio.
 
+    dual_gap_ : float
+        The dual gaps at the end of the optimization for the optimal alpha.
+
     n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
@@ -1774,6 +1780,15 @@ class MultiTaskElasticNet(Lasso):
     n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
+
+    dual_gap_ : float
+        The dual gaps at the end of the optimization
+
+    sparse_coef_ : sparse matrix of shape (n_tasks, n_features)
+        ``sparse_coef_`` is a readonly property derived from ``coef_``
+
+    eps_: float, default=1e-4
+        same as tol
 
     Examples
     --------
@@ -1958,6 +1973,15 @@ class MultiTaskLasso(MultiTaskElasticNet):
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
+    dual_gap_ : ndarray of shape (n_alphas,)
+        The dual gaps at the end of the optimization for each alpha
+
+    sparse_coef_ : sparse matrix of shape (n_tasks, n_features)
+        ``sparse_coef_`` is a readonly property derived from ``coef_``
+
+    eps_: float, default=1e-4
+        same as tol
+
     Examples
     --------
     >>> from sklearn import linear_model
@@ -2134,6 +2158,9 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
 
+    dual_gap_ : float
+        The dual gap at the end of the optimization for the optimal alpha
+
     Examples
     --------
     >>> from sklearn import linear_model
@@ -2303,6 +2330,9 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
     n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
+
+    dual_gap_ : float
+        The dual gap at the end of the optimization for the optimal alpha.
 
     Examples
     --------

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -658,9 +658,6 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
-    dual_gaps_ : float or ndarray of shape (n_targets,)
-        Given param alpha, the dual gaps at the end of the optimization for each column of target y.
-
     Examples
     --------
     >>> from sklearn.linear_model import ElasticNet
@@ -1610,9 +1607,6 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
     alphas_ : ndarray of shape (n_alphas,) or (n_l1_ratio, n_alphas)
         The grid of alphas used for fitting, for each l1_ratio.
 
-    dual_gap_ : float
-        The dual gaps at the end of the optimization for the optimal alpha.
-
     n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
@@ -1780,15 +1774,6 @@ class MultiTaskElasticNet(Lasso):
     n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
-
-    dual_gap_ : float
-        The dual gaps at the end of the optimization
-
-    sparse_coef_ : sparse matrix of shape (n_tasks, n_features)
-        ``sparse_coef_`` is a readonly property derived from ``coef_``
-
-    eps_: float, default=1e-4
-        same as tol
 
     Examples
     --------
@@ -1973,15 +1958,6 @@ class MultiTaskLasso(MultiTaskElasticNet):
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance.
 
-    dual_gap_ : ndarray of shape (n_alphas,)
-        The dual gaps at the end of the optimization for each alpha
-
-    sparse_coef_ : sparse matrix of shape (n_tasks, n_features)
-        ``sparse_coef_`` is a readonly property derived from ``coef_``
-
-    eps_: float, default=1e-4
-        same as tol
-
     Examples
     --------
     >>> from sklearn import linear_model
@@ -2158,9 +2134,6 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
 
-    dual_gap_ : float
-        The dual gap at the end of the optimization for the optimal alpha
-
     Examples
     --------
     >>> from sklearn import linear_model
@@ -2330,9 +2303,6 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
     n_iter_ : int
         number of iterations run by the coordinate descent solver to reach
         the specified tolerance for the optimal alpha.
-
-    dual_gap_ : float
-        The dual gap at the end of the optimization for the optimal alpha.
 
     Examples
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #16788


#### What does this implement/fix? Explain your changes.
SciPy>=1.2.2 are built with OpenBLAS
SciPy 1.2 requires oldest-supported-numpy (https://pypi.org/project/oldest-supported-numpy/)
numpy>=1.16.0 starts supporting AIX machine 

#### Any other comments?
For now changes in pyproject.toml files only, other changes in relevant files will be required. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
