### PR TITLE
[MRG] FIX index overflow error in sparse matrix polynomial expansion

### DIFF
--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -8,7 +8,9 @@ from scipy.sparse import csr_matrix
 from numpy cimport ndarray
 cimport numpy as np
 
-ctypedef np.int32_t INDEX_T
+ctypedef fused INDEX_T:
+    np.int32_t
+    np.int64_t
 
 ctypedef fused DATA_T:
     np.float32_t
@@ -119,7 +121,7 @@ def _csr_polynomial_expansion(ndarray[DATA_T, ndim=1] data,
 
     cdef INDEX_T expanded_index = 0, row_starts, row_ends, i, j, k, \
                  i_ptr, j_ptr, k_ptr, num_cols_in_row,  \
-                 expanded_column
+                 expanded_column, col
 
     with nogil:
         expanded_indptr[0] = indptr[0]

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1560,8 +1560,12 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
                 to_stack.append(np.ones(shape=(n_samples, 1), dtype=X.dtype))
             to_stack.append(X)
             for deg in range(2, self.degree+1):
-                Xp_next = _csr_polynomial_expansion(X.data, X.indices,
-                                                    X.indptr, X.shape[1],
+                # use np.int64 for index datatype to prevent overflow
+                # in case X has a large dimension
+                Xp_next = _csr_polynomial_expansion(X.data,
+                                                    X.indices.astype(np.int64),
+                                                    X.indptr.astype(np.int64),
+                                                    np.int64(X.shape[1]),
                                                     self.interaction_only,
                                                     deg)
                 if Xp_next is None:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #16803

#### What does this implement/fix? Explain your changes.
Change index type from `np.int32_` to a fused type and explicitly cast indices to `np.int64` before passed into the polynomial expansion function.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
