### PR TITLE
[MRG] MNT Fixes for PCA with n_components='mle'

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -133,10 +133,12 @@ Changelog
 - |Fix| :class:`decomposition.PCA` with a float `n_components` parameter, will
    exclusively choose the components that explain the variance greater than
    `n_components`. :pr:`15669` by :user:`Krishna Chaitanya <krishnachaitanya9>`
-- |Fix| :func:`decomposition._pca._assess_dimension` now correctly handles small
-   eigenvalues. :pr: `4441` by :user:`Lisa Schwetlick <lschwetlick>`, and
-   :user:`Gelavizh Ahmadi <gelavizh1>` and
-   :user:`Marija Vlajic Wheeler <marijavlajic>`.
+
+- |Fix| :class:`decomposition.PCA` with `n_components='mle'` now correctly
+  handles small eigenvalues, and does not infer 0 as the correct number of
+  components. :pr: `4441` by :user:`Lisa Schwetlick <lschwetlick>`, and
+  :user:`Gelavizh Ahmadi <gelavizh1>` and :user:`Marija Vlajic Wheeler
+  <marijavlajic>` and :pr:`todo` by `Nicolas Hug`_.
 
 - |Enhancement| :class:`decomposition.NMF` and
   :func:`decomposition.non_negative_factorization` now preserves float32 dtype.

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -138,7 +138,7 @@ Changelog
   handles small eigenvalues, and does not infer 0 as the correct number of
   components. :pr: `4441` by :user:`Lisa Schwetlick <lschwetlick>`, and
   :user:`Gelavizh Ahmadi <gelavizh1>` and :user:`Marija Vlajic Wheeler
-  <marijavlajic>` and :pr:`todo` by `Nicolas Hug`_.
+  <marijavlajic>` and :pr:`16841` by `Nicolas Hug`_.
 
 - |Enhancement| :class:`decomposition.NMF` and
   :func:`decomposition.non_negative_factorization` now preserves float32 dtype.

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -28,22 +28,22 @@ from ..utils.validation import check_is_fitted
 from ..utils.validation import _deprecate_positional_args
 
 
-def _assess_dimension(spectrum, rank, n_samples, n_features):
-    """Compute the likelihood of a rank ``rank`` dataset.
+def _assess_dimension(spectrum, rank, n_samples):
+    """Compute the log-likelihood of a rank ``rank`` dataset.
 
     The dataset is assumed to be embedded in gaussian noise of shape(n,
     dimf) having spectrum ``spectrum``.
 
     Parameters
     ----------
-    spectrum : array of shape (n)
+    spectrum : array of shape (n_features)
         Data spectrum.
     rank : int
-        Tested rank value.
+        Tested rank value. It should be strictly lower than n_features,
+        otherwise the method isn't specified (division by zero in equation
+        (31) from the paper).
     n_samples : int
         Number of samples.
-    n_features : int
-        Number of features.
 
     Returns
     -------
@@ -55,45 +55,36 @@ def _assess_dimension(spectrum, rank, n_samples, n_features):
     This implements the method of `Thomas P. Minka:
     Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604`
     """
-    if rank > len(spectrum):
-        raise ValueError("The tested rank cannot exceed the rank of the"
-                         " dataset")
 
-    spectrum_threshold = np.finfo(type(spectrum[0])).eps
+    n_features = spectrum.shape[0]
+    if not 1 <= rank < n_features:
+        raise ValueError("the tested rank should be in [1, n_features - 1]")
+
+    if spectrum[rank - 1] < 1e-15:
+        # When the tested rank is associated with a small eigenvalue, there's
+        # no point in testing. Also, it can lead to numerical issues below
+        # when computing pa, in particular in log((spectrum[i] - spectrum[j])
+        # because this will take the log of something very small.
+        return -np.inf
 
     pu = -rank * log(2.)
-    for i in range(rank):
-        pu += (gammaln((n_features - i) / 2.) -
-               log(np.pi) * (n_features - i) / 2.)
+    for i in range(1, rank + 1):
+        pu += (gammaln((n_features - i + 1) / 2.) -
+               log(np.pi) * (n_features - i + 1) / 2.)
 
     pl = np.sum(np.log(spectrum[:rank]))
     pl = -pl * n_samples / 2.
 
-    if rank == n_features:
-        # TODO: this line is never executed because _infer_dimension's
-        # for loop is off by one
-        pv = 0
-        v = 1
-    else:
-        v = np.sum(spectrum[rank:]) / (n_features - rank)
-        if spectrum_threshold > v:
-            return -np.inf
-        pv = -np.log(v) * n_samples * (n_features - rank) / 2.
+    v = np.sum(spectrum[rank:]) / (n_features - rank)
+    pv = -np.log(v) * n_samples * (n_features - rank) / 2.
 
     m = n_features * rank - rank * (rank + 1.) / 2.
-    pp = log(2. * np.pi) * (m + rank + 1.) / 2.
+    pp = log(2. * np.pi) * (m + rank) / 2.
 
     pa = 0.
     spectrum_ = spectrum.copy()
     spectrum_[rank:n_features] = v
     for i in range(rank):
-        if spectrum_[i] < spectrum_threshold:
-            # TODO: this line is never executed
-            # (off by one in _infer_dimension)
-            # this break only happens when rank == n_features and
-            # spectrum_[i] < spectrum_threshold, otherwise the early return
-            # above catches this case.
-            break
         for j in range(i + 1, len(spectrum)):
             pa += log((spectrum[i] - spectrum[j]) *
                       (1. / spectrum_[j] - 1. / spectrum_[i])) + log(n_samples)
@@ -103,15 +94,12 @@ def _assess_dimension(spectrum, rank, n_samples, n_features):
     return ll
 
 
-def _infer_dimension(spectrum, n_samples, n_features):
-    """Infers the dimension of a dataset of shape (n_samples, n_features)
-
-    The dataset is described by its spectrum `spectrum`.
-    """
-    n_spectrum = len(spectrum)
-    ll = np.empty(n_spectrum)
-    for rank in range(n_spectrum):
-        ll[rank] = _assess_dimension(spectrum, rank, n_samples, n_features)
+def _infer_dimension(spectrum, n_samples):
+    """Infers the dimension of a dataset with a given spectrum."""
+    ll = np.empty_like(spectrum)
+    ll[0] = -np.inf  # we don't want to return n_components = 0
+    for rank in range(1, spectrum.shape[0]):
+        ll[rank] = _assess_dimension(spectrum, rank, n_samples)
     return ll.argmax()
 
 
@@ -472,7 +460,7 @@ class PCA(_BasePCA):
         # Postprocess the number of components required
         if n_components == 'mle':
             n_components = \
-                _infer_dimension(explained_variance_, n_samples, n_features)
+                _infer_dimension(explained_variance_, n_samples)
         elif 0 < n_components < 1.0:
             # number of components for which the cumulated explained
             # variance percentage is superior to the desired threshold

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -95,7 +95,10 @@ def _assess_dimension(spectrum, rank, n_samples):
 
 
 def _infer_dimension(spectrum, n_samples):
-    """Infers the dimension of a dataset with a given spectrum."""
+    """Infers the dimension of a dataset with a given spectrum.
+
+    The returned value will be in [1, n_features - 1].
+    """
     ll = np.empty_like(spectrum)
     ll[0] = -np.inf  # we don't want to return n_components = 0
     for rank in range(1, spectrum.shape[0]):

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -60,11 +60,14 @@ def _assess_dimension(spectrum, rank, n_samples):
     if not 1 <= rank < n_features:
         raise ValueError("the tested rank should be in [1, n_features - 1]")
 
-    if spectrum[rank - 1] < 1e-15:
+    eps = 1e-15
+
+    if spectrum[rank - 1] < eps:
         # When the tested rank is associated with a small eigenvalue, there's
-        # no point in testing. Also, it can lead to numerical issues below
-        # when computing pa, in particular in log((spectrum[i] - spectrum[j])
-        # because this will take the log of something very small.
+        # no point in computing the log-likelihood: it's going to be very
+        # small and won't be the max anyway. Also, it can lead to numerical
+        # issues below when computing pa, in particular in log((spectrum[i] -
+        # spectrum[j]) because this will take the log of something very small.
         return -np.inf
 
     pu = -rank * log(2.)
@@ -75,7 +78,7 @@ def _assess_dimension(spectrum, rank, n_samples):
     pl = np.sum(np.log(spectrum[:rank]))
     pl = -pl * n_samples / 2.
 
-    v = np.sum(spectrum[rank:]) / (n_features - rank)
+    v = max(eps, np.sum(spectrum[rank:]) / (n_features - rank))
     pv = -np.log(v) * n_samples * (n_features - rank) / 2.
 
     m = n_features * rank - rank * (rank + 1.) / 2.

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -626,3 +626,15 @@ def test_mle_simple_case():
     pca_skl = PCA('mle', svd_solver='full')
     pca_skl.fit(X)
     assert pca_skl.n_components_ == n_dim - 1
+
+
+def test_assess_dimesion_rank_one():
+    # Make sure assess_dimension works properly on a matrix of rank 1
+    n_samples, n_features = 9, 6
+    X = np.ones((n_samples, n_features))  # rank 1 matrix
+    _, s, _ = np.linalg.svd(X, full_matrices=True)
+    assert sum(s[1:]) == 0  # except for rank 1, all eigenvalues are 0
+
+    assert np.isfinite(_assess_dimension(s, rank=1, n_samples=n_samples))
+    for rank in range(2, n_features):
+        assert _assess_dimension(s, rank, n_samples) == -np.inf

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -576,7 +576,7 @@ def test_assess_dimension_bad_rank():
     n_samples = 10
     for rank in (0, 5):
         with pytest.raises(ValueError,
-                        match=r"should be in \[1, n_features - 1\]"):
+                           match=r"should be in \[1, n_features - 1\]"):
             _assess_dimension(spectrum, rank, n_samples)
 
 


### PR DESCRIPTION
Fixes  #16730
Closes https://github.com/scikit-learn/scikit-learn/issues/16546

- `infer_dimension()` now returns a value in `[1, n_features - 1]`. rank = 0 isn't possible anymore (it's a bug fix, as this would transform into an empty array).
- `rank` as passed to `_assess_dimension()` is actually the rank, not an index as previously. This fixes the infamous off-by-one error.  Note also that the method isn't defined if we pass it rank == n_features (division by zero)
- a few fixes in the formula

