### PR TITLE
correct spelling mistake from "not effect" to "no effect"

### DIFF
--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -94,7 +94,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
         processors. See :term:`Glossary <n_jobs>` for more details.
 
     behaviour : str, default='deprecated'
-        This parameter has not effect, is deprecated, and will be removed.
+        This parameter has no effect, is deprecated, and will be removed.
 
         .. versionadded:: 0.20
            ``behaviour`` is added in 0.20 for back-compatibility purpose.


### PR DESCRIPTION
Fixes #16852