### PR TITLE
[DOC] consistent symbol subscripts

### DIFF
--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -36,9 +36,9 @@ output.
    **Figure 1 : One hidden layer MLP.**
 
 The leftmost layer, known as the input layer, consists of a set of neurons
-:math:`\{x_i | x_1, x_2, ..., x_m\}` representing the input features. Each
+:math:`\{x_i | x_1, x_2, ..., x_n\}` representing the input features. Each
 neuron in the hidden layer transforms the values from the previous layer with
-a weighted linear summation :math:`w_1x_1 + w_2x_2 + ... + w_mx_m`, followed
+a weighted linear summation :math:`w_1x_1 + w_2x_2 + ... + w_nx_n`, followed
 by a non-linear activation function :math:`g(\cdot):R \rightarrow R` - like
 the hyperbolic tan function. The output layer receives the values from the
 last hidden layer and transforms them into output values.


### PR DESCRIPTION
Making consistent subscripts between _text_ and _figure_.

However, the first paragraph still confusing, for the **output dimension** `o`.
Should we change it to something like this?

```
Given a set of features :math:`X = {x_1, x_2, ..., x_m}` and a target :math:`y = {y_1, y_2, ..., y_o}`,
```