### PR TITLE
[MRG] Preserving memory and verbose when slicing a pipeline

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -365,8 +365,8 @@ Changelog
 ............................
 
 - |Fix| A slice of a pipeline now inherits the parameters of the
-  original pipeline (`memory` and `verbose`).  :pr: `16868` by `Paweł
-  Biernat`_.
+  original pipeline (`memory` and `verbose`).  :pr: `16868` by :user:`Paweł
+  Biernat <pwl>`.
 
 :mod:`sklearn.preprocessing`
 ............................

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -361,6 +361,13 @@ Changelog
   :class:`neural_network.MLPClassifier` by clipping the probabilities.
   :pr:`16117` by `Thomas Fan`_.
 
+:mod:`sklearn.pipeline`
+............................
+
+- |Fix| A slice of a pipeline now inherits the parameters of the
+  original pipeline (`memory` and `verbose`).  :pr: `16868` by `Paweł
+  Biernat`_.
+
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -200,8 +200,10 @@ class Pipeline(_BaseComposition):
         """
         if isinstance(ind, slice):
             if ind.step not in (1, None):
-                raise ValueError('Pipeline slicing only supports a step of 1')
-            return self.__class__(self.steps[ind])
+                raise ValueError("Pipeline slicing only supports a step of 1")
+            return self.__class__(
+                self.steps[ind], memory=self.memory, verbose=self.verbose
+            )
         try:
             name, est = self.steps[ind]
         except TypeError:

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -564,6 +564,8 @@ def test_pipeline_slice():
     assert isinstance(pipe2, Pipeline)
     assert pipe2.steps == pipe.steps[:-1]
     assert 2 == len(pipe2.named_steps)
+    assert pipe2.memory == pipe.memory
+    assert pipe2.verbose == pipe.verbose
     assert_raises(ValueError, lambda: pipe[::-1])
 
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -557,9 +557,11 @@ def test_pipeline_fit_transform():
 
 
 def test_pipeline_slice():
-    pipe = Pipeline([('transf1', Transf()),
-                     ('transf2', Transf()),
-                     ('clf', FitParamT())])
+    pipe = Pipeline(
+        [("transf1", Transf()), ("transf2", Transf()), ("clf", FitParamT())],
+        memory="123",
+        verbose=True,
+    )
     pipe2 = pipe[:-1]
     assert isinstance(pipe2, Pipeline)
     assert pipe2.steps == pipe.steps[:-1]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #16863

#### What does this implement/fix? Explain your changes.
Passes over `memory` and `verbose` attributes to the constructor when slicing a pipeline.

#### Any other comments?
Tests are passing.