### PR TITLE
DOC: Clarify that LeaveOneGroupOut can be a particular case of GroupKFold

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -617,6 +617,9 @@ model is flexible enough to learn from highly person specific features it
 could fail to generalize to new subjects. :class:`GroupKFold` makes it possible
 to detect this kind of overfitting situations.
 
+:class:`GroupKFold` reduces to :class:`LeaveOneGroupOut` in the case that `K`
+or `n_splits` is equal to the number of groups.
+
 Imagine you have three subjects, each with an associated number from 1 to 3::
 
   >>> from sklearn.model_selection import GroupKFold


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #16853 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Clarifies that `LeaveOneGroupOut` can be a particular case of `GroupKFold`

#### Any other comments?
Is there any more investigation/clarification needed on `LeaveOneGroupOut` since it seems to indicate 3rd party provided groups?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
