### PR TITLE
[MRG] check_is_fitted() should handle getter/setter attributes

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -940,7 +940,13 @@ def check_is_fitted(estimator, attributes=None, msg=None, all_or_any=all):
             attributes = [attributes]
         attrs = all_or_any([hasattr(estimator, attr) for attr in attributes])
     else:
-        attrs = [v for v in vars(estimator)
+        properties = vars(estimator)
+        # properties to check here could be implemented as getter/setter or
+        # use the @property so vars() will return empty. dir() will return
+        # the correct results.
+        if not properties:
+            properties = dir(estimator)
+        attrs = [v for v in properties
                  if v.endswith("_") and not v.startswith("__")]
 
     if not attrs:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/issues/16878


#### What does this implement/fix? Explain your changes.
I used LightGBM to train a regression model, but it failed to create partial dependence graph due to the implementation of LightGBM uses `@property` tag for estimator. This PR is to address the issue by also checking the `dir(estimator)` when `vars(estimator)` returns empty.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
