### PR TITLE
ENH Uses binned values from training to find missing values

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -184,8 +184,6 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
             X_train, y_train, sample_weight_train = X, y, sample_weight
             X_val = y_val = sample_weight_val = None
 
-        has_missing_values = np.isnan(X_train).any(axis=0).astype(np.uint8)
-
         # Bin the data
         # For ease of use of the API, the user-facing GBDT classes accept the
         # parameter max_bins, which doesn't take into account the bin for
@@ -203,6 +201,10 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         else:
             X_binned_val = None
 
+        # Uses binned data to check for missing values
+        has_missing_values = (
+            X_binned_train == self.bin_mapper_.missing_values_bin_idx_).any(
+                axis=0).astype(np.uint8)
         if self.verbose:
             print("Fitting gradient boosted rounds:")
 

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -205,6 +205,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         has_missing_values = (
             X_binned_train == self.bin_mapper_.missing_values_bin_idx_).any(
                 axis=0).astype(np.uint8)
+
         if self.verbose:
             print("Fitting gradient boosted rounds:")
 


### PR DESCRIPTION
From my understanding: If the training data, `X_binned_train`, has no missing values, we would not need to do the right to left sweep when splitting. Secondly, this seems leaks data from the validation set, `X_binned_val`, into training.

@NicolasHug What do you think?