### PR TITLE
DOC replace Boston in gradient_boosting.py

### DIFF
--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -119,7 +119,7 @@ scores = pd.concat(
     keys=['Original', 'SimpleImputer', 'IterativeImputer'], axis=1
 )
 
-# plot boston results
+# plot california housing results
 fig, ax = plt.subplots(figsize=(13, 6))
 means = -scores.mean()
 errors = scores.std()

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -855,11 +855,11 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     >>> # To use this experimental feature, we need to explicitly ask for it:
     >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
     >>> from sklearn.ensemble import HistGradientBoostingRegressor
-    >>> from sklearn.datasets import load_boston
-    >>> X, y = load_boston(return_X_y=True)
+    >>> from sklearn.datasets import load_diabetes
+    >>> X, y = load_diabetes(return_X_y=True)
     >>> est = HistGradientBoostingRegressor().fit(X, y)
     >>> est.score(X, y)
-    0.98...
+    0.92...
     """
 
     _VALID_LOSSES = ('least_squares', 'least_absolute_deviation')


### PR DESCRIPTION
Towards #16155

Replace Boston dataset with Diabetes dataset in `sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py`

Also fixes typo in `plot_iterative_imputer_variants_comparison.py`.