### PR TITLE
TST Replace boston in histgradboost test_predictor

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sklearn.datasets import load_diabetes
+from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import r2_score
 import pytest
@@ -11,11 +11,10 @@ from sklearn.ensemble._hist_gradient_boosting.common import (
     G_H_DTYPE, PREDICTOR_RECORD_DTYPE, ALMOST_INF)
 
 
-@pytest.mark.parametrize('n_bins', [50, 100])
-def test_california_dataset(n_bins):
-    X, y = load_diabetes(return_X_y=True)
-    # X = X[:500, :]
-    # y = y[:500]
+@pytest.mark.parametrize('n_bins', [200, 256])
+def test_regression_dataset(n_bins):
+    X, y = make_regression(n_samples=500, n_features=10, n_informative=5,
+                           random_state=42)
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, random_state=42)
 
@@ -26,8 +25,8 @@ def test_california_dataset(n_bins):
     gradients = -y_train.astype(G_H_DTYPE)
     hessians = np.ones(1, dtype=G_H_DTYPE)
 
-    min_samples_leaf = 50
-    max_leaf_nodes = None
+    min_samples_leaf = 10
+    max_leaf_nodes = 30
     grower = TreeGrower(X_train_binned, gradients, hessians,
                         min_samples_leaf=min_samples_leaf,
                         max_leaf_nodes=max_leaf_nodes, n_bins=n_bins,
@@ -35,11 +34,9 @@ def test_california_dataset(n_bins):
     grower.grow()
 
     predictor = grower.make_predictor(bin_thresholds=mapper.bin_thresholds_)
-    print(r2_score(y_train, predictor.predict(X_train)))
-    print(r2_score(y_test, predictor.predict(X_test)))
 
-    # assert r2_score(y_train, predictor.predict(X_train)) > 0.3
-    # assert r2_score(y_test, predictor.predict(X_test)) > 0.3
+    assert r2_score(y_train, predictor.predict(X_train)) > 0.82
+    assert r2_score(y_test, predictor.predict(X_test)) > 0.67
 
 
 @pytest.mark.parametrize('threshold, expected_predictions', [

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sklearn.datasets import load_diabetes
+from sklearn.datasets import fetch_california_housing
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import r2_score
 import pytest
@@ -11,9 +11,11 @@ from sklearn.ensemble._hist_gradient_boosting.common import (
     G_H_DTYPE, PREDICTOR_RECORD_DTYPE, ALMOST_INF)
 
 
-@pytest.mark.parametrize('n_bins', [100, 150])
-def test_diabetes_dataset(n_bins):
-    X, y = load_diabetes(return_X_y=True)
+@pytest.mark.parametrize('n_bins', [200, 256])
+def test_california_dataset(n_bins):
+    X, y = fetch_california_housing(return_X_y=True)
+    X = X[:500, :]
+    y = y[:500]
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, random_state=42)
 
@@ -34,8 +36,8 @@ def test_diabetes_dataset(n_bins):
 
     predictor = grower.make_predictor(bin_thresholds=mapper.bin_thresholds_)
 
-    assert r2_score(y_train, predictor.predict(X_train)) > 0.69
-    assert r2_score(y_test, predictor.predict(X_test)) > 0.30
+    assert r2_score(y_train, predictor.predict(X_train)) > 0.81
+    assert r2_score(y_test, predictor.predict(X_test)) > 0.80
 
 
 @pytest.mark.parametrize('threshold, expected_predictions', [

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -11,7 +11,7 @@ from sklearn.ensemble._hist_gradient_boosting.common import (
     G_H_DTYPE, PREDICTOR_RECORD_DTYPE, ALMOST_INF)
 
 
-@pytest.mark.parametrize('n_bins', [100,150])
+@pytest.mark.parametrize('n_bins', [100, 150])
 def test_diabetes_dataset(n_bins):
     X, y = load_diabetes(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sklearn.datasets import fetch_california_housing
+from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import r2_score
 import pytest
@@ -11,11 +11,11 @@ from sklearn.ensemble._hist_gradient_boosting.common import (
     G_H_DTYPE, PREDICTOR_RECORD_DTYPE, ALMOST_INF)
 
 
-@pytest.mark.parametrize('n_bins', [200, 256])
+@pytest.mark.parametrize('n_bins', [50, 100])
 def test_california_dataset(n_bins):
-    X, y = fetch_california_housing(return_X_y=True)
-    X = X[:500, :]
-    y = y[:500]
+    X, y = load_diabetes(return_X_y=True)
+    # X = X[:500, :]
+    # y = y[:500]
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, random_state=42)
 
@@ -26,8 +26,8 @@ def test_california_dataset(n_bins):
     gradients = -y_train.astype(G_H_DTYPE)
     hessians = np.ones(1, dtype=G_H_DTYPE)
 
-    min_samples_leaf = 8
-    max_leaf_nodes = 31
+    min_samples_leaf = 50
+    max_leaf_nodes = None
     grower = TreeGrower(X_train_binned, gradients, hessians,
                         min_samples_leaf=min_samples_leaf,
                         max_leaf_nodes=max_leaf_nodes, n_bins=n_bins,
@@ -35,9 +35,11 @@ def test_california_dataset(n_bins):
     grower.grow()
 
     predictor = grower.make_predictor(bin_thresholds=mapper.bin_thresholds_)
+    print(r2_score(y_train, predictor.predict(X_train)))
+    print(r2_score(y_test, predictor.predict(X_test)))
 
-    assert r2_score(y_train, predictor.predict(X_train)) > 0.81
-    assert r2_score(y_test, predictor.predict(X_test)) > 0.80
+    # assert r2_score(y_train, predictor.predict(X_train)) > 0.3
+    # assert r2_score(y_test, predictor.predict(X_test)) > 0.3
 
 
 @pytest.mark.parametrize('threshold, expected_predictions', [

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sklearn.datasets import load_boston
+from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import r2_score
 import pytest
@@ -11,9 +11,9 @@ from sklearn.ensemble._hist_gradient_boosting.common import (
     G_H_DTYPE, PREDICTOR_RECORD_DTYPE, ALMOST_INF)
 
 
-@pytest.mark.parametrize('n_bins', [200, 256])
-def test_boston_dataset(n_bins):
-    X, y = load_boston(return_X_y=True)
+@pytest.mark.parametrize('n_bins', [100,150])
+def test_diabetes_dataset(n_bins):
+    X, y = load_diabetes(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, random_state=42)
 
@@ -34,8 +34,8 @@ def test_boston_dataset(n_bins):
 
     predictor = grower.make_predictor(bin_thresholds=mapper.bin_thresholds_)
 
-    assert r2_score(y_train, predictor.predict(X_train)) > 0.85
-    assert r2_score(y_test, predictor.predict(X_test)) > 0.70
+    assert r2_score(y_train, predictor.predict(X_train)) > 0.69
+    assert r2_score(y_test, predictor.predict(X_test)) > 0.30
 
 
 @pytest.mark.parametrize('threshold, expected_predictions', [


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #16155

#### What does this implement/fix? Explain your changes.
Replace boston dataset with ~diabetes~ California housing dataset in `sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py`

#### Any other comments?
~Unsure of the best `n_bins` values/what this is testing. I noticed that the boston features are more spread out and generally has a longer right tail cf the diabetes dataset. Also the R2 values with `n_bin` 200 and 256 with diabetes were the same.~

The R2 values with California housing are:
* train: (bins=200; 0.8233 (bins=256; 0.8340)
* test: (bins=200; 0.8112) (bins=256; 0.8094)