### PR TITLE
TST Replace boston in ensemble test_bagging

### DIFF
--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -493,6 +493,7 @@ def test_parallel_regression():
                                                         random_state=rng)
 
     ensemble = BaggingRegressor(DecisionTreeRegressor(),
+                                n_jobs=3,
                                 random_state=0).fit(X_train, y_train)
 
     ensemble.set_params(n_jobs=1)
@@ -502,7 +503,7 @@ def test_parallel_regression():
     assert_array_almost_equal(y1, y2)
 
     ensemble = BaggingRegressor(DecisionTreeRegressor(),
-                                n_jobs=3,
+                                n_jobs=1,
                                 random_state=0).fit(X_train, y_train)
 
     y3 = ensemble.predict(X_test)

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -29,7 +29,7 @@ from sklearn.random_projection import SparseRandomProjection
 from sklearn.pipeline import make_pipeline
 from sklearn.feature_selection import SelectKBest
 from sklearn.model_selection import train_test_split
-from sklearn.datasets import load_boston, load_iris, make_hastie_10_2
+from sklearn.datasets import load_diabetes, load_iris, make_hastie_10_2
 from sklearn.utils import check_random_state
 from sklearn.preprocessing import FunctionTransformer
 
@@ -44,12 +44,12 @@ perm = rng.permutation(iris.target.size)
 iris.data = iris.data[perm]
 iris.target = iris.target[perm]
 
-# also load the boston dataset
+# also load the diabetes dataset
 # and randomly permute it
-boston = load_boston()
-perm = rng.permutation(boston.target.size)
-boston.data = boston.data[perm]
-boston.target = boston.target[perm]
+diabetes = load_diabetes()
+perm = rng.permutation(diabetes.target.size)
+diabetes.data = diabetes.data[perm]
+diabetes.target = diabetes.target[perm]
 
 
 # TODO: Remove in 0.24 when DummyClassifier's `strategy` default updates
@@ -140,8 +140,8 @@ def test_sparse_classification():
 def test_regression():
     # Check regression for various parameter settings.
     rng = check_random_state(0)
-    X_train, X_test, y_train, y_test = train_test_split(boston.data[:50],
-                                                        boston.target[:50],
+    X_train, X_test, y_train, y_test = train_test_split(diabetes.data[:50],
+                                                        diabetes.target[:50],
                                                         random_state=rng)
     grid = ParameterGrid({"max_samples": [0.5, 1.0],
                           "max_features": [0.5, 1.0],
@@ -162,8 +162,8 @@ def test_regression():
 def test_sparse_regression():
     # Check regression for various parameter settings on sparse input.
     rng = check_random_state(0)
-    X_train, X_test, y_train, y_test = train_test_split(boston.data[:50],
-                                                        boston.target[:50],
+    X_train, X_test, y_train, y_test = train_test_split(diabetes.data[:50],
+                                                        diabetes.target[:50],
                                                         random_state=rng)
 
     class CustomSVR(SVR):
@@ -229,8 +229,8 @@ class DummySizeEstimator(BaseEstimator):
 def test_bootstrap_samples():
     # Test that bootstrapping samples generate non-perfect base estimators.
     rng = check_random_state(0)
-    X_train, X_test, y_train, y_test = train_test_split(boston.data,
-                                                        boston.target,
+    X_train, X_test, y_train, y_test = train_test_split(diabetes.data,
+                                                        diabetes.target,
                                                         random_state=rng)
 
     base_estimator = DecisionTreeRegressor().fit(X_train, y_train)
@@ -268,8 +268,8 @@ def test_bootstrap_samples():
 def test_bootstrap_features():
     # Test that bootstrapping features may generate duplicate features.
     rng = check_random_state(0)
-    X_train, X_test, y_train, y_test = train_test_split(boston.data,
-                                                        boston.target,
+    X_train, X_test, y_train, y_test = train_test_split(diabetes.data,
+                                                        diabetes.target,
                                                         random_state=rng)
 
     ensemble = BaggingRegressor(base_estimator=DecisionTreeRegressor(),
@@ -278,7 +278,7 @@ def test_bootstrap_features():
                                 random_state=rng).fit(X_train, y_train)
 
     for features in ensemble.estimators_features_:
-        assert boston.data.shape[1] == np.unique(features).shape[0]
+        assert diabetes.data.shape[1] == np.unique(features).shape[0]
 
     ensemble = BaggingRegressor(base_estimator=DecisionTreeRegressor(),
                                 max_features=1.0,
@@ -286,7 +286,7 @@ def test_bootstrap_features():
                                 random_state=rng).fit(X_train, y_train)
 
     for features in ensemble.estimators_features_:
-        assert boston.data.shape[1] > np.unique(features).shape[0]
+        assert diabetes.data.shape[1] > np.unique(features).shape[0]
 
 
 def test_probability():
@@ -355,8 +355,8 @@ def test_oob_score_regression():
     # Check that oob prediction is a good estimation of the generalization
     # error.
     rng = check_random_state(0)
-    X_train, X_test, y_train, y_test = train_test_split(boston.data,
-                                                        boston.target,
+    X_train, X_test, y_train, y_test = train_test_split(diabetes.data,
+                                                        diabetes.target,
                                                         random_state=rng)
 
     clf = BaggingRegressor(base_estimator=DecisionTreeRegressor(),
@@ -383,8 +383,8 @@ def test_oob_score_regression():
 def test_single_estimator():
     # Check singleton ensembles.
     rng = check_random_state(0)
-    X_train, X_test, y_train, y_test = train_test_split(boston.data,
-                                                        boston.target,
+    X_train, X_test, y_train, y_test = train_test_split(diabetes.data,
+                                                        diabetes.target,
                                                         random_state=rng)
 
     clf1 = BaggingRegressor(base_estimator=KNeighborsRegressor(),
@@ -488,12 +488,11 @@ def test_parallel_regression():
     # Check parallel regression.
     rng = check_random_state(0)
 
-    X_train, X_test, y_train, y_test = train_test_split(boston.data,
-                                                        boston.target,
+    X_train, X_test, y_train, y_test = train_test_split(diabetes.data,
+                                                        diabetes.target,
                                                         random_state=rng)
 
     ensemble = BaggingRegressor(DecisionTreeRegressor(),
-                                n_jobs=3,
                                 random_state=0).fit(X_train, y_train)
 
     ensemble.set_params(n_jobs=1)
@@ -503,7 +502,7 @@ def test_parallel_regression():
     assert_array_almost_equal(y1, y2)
 
     ensemble = BaggingRegressor(DecisionTreeRegressor(),
-                                n_jobs=1,
+                                n_jobs=3,
                                 random_state=0).fit(X_train, y_train)
 
     y3 = ensemble.predict(X_test)
@@ -553,8 +552,8 @@ def test_base_estimator():
     assert isinstance(ensemble.base_estimator_, Perceptron)
 
     # Regression
-    X_train, X_test, y_train, y_test = train_test_split(boston.data,
-                                                        boston.target,
+    X_train, X_test, y_train, y_test = train_test_split(diabetes.data,
+                                                        diabetes.target,
                                                         random_state=rng)
 
     ensemble = BaggingRegressor(None,


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #16155


#### What does this implement/fix? Explain your changes.
Replace boston dataset with diabetes dataset in `sklearn/ensemble/tests/test_bagging.py`.

Also amended `test_parallel_regression`. I might be mistaken but is the purpose of `test_parallel_regression` to ensure that the results with `n_jobs` equal to 1, 2 and 3 are all equal? `y1` and `y3` are both `n_jobs=1`. Also `n_jobs` is set and then overwritten before being used.

#### Any other comments?

