### PR TITLE
MNT Add pre-comit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
     -   id: flake8
         types: [file, python]
-        # only check for unused impors for now, as long as
+        # only check for unused imports for now, as long as
         # the code is not fully PEP8 compatible
         args: [--select=F401]
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.8
+    hooks:
+    -   id: flake8
+        types: [file, python]
+        # only check for unused impors for now, as long as
+        # the code is not fully PEP8 compatible
+        args: [--select=F401]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.730
+    hooks:
+     -  id: mypy
+        args:
+          - --ignore-missing-imports
+          - --follow-imports
+          - skip
+        files: sklearn/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,4 @@ repos:
      -  id: mypy
         args:
           - --ignore-missing-imports
-          - --follow-imports
-          - skip
         files: sklearn/

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -248,8 +248,8 @@ modifying code and submitting a PR:
    and start making changes. Always use a feature branch. It's good
    practice to never work on the ``master`` branch!
 
-9. (**Optional**) Install `pre-commit <https://pre-commit.com/#install>`_ to run code style
-   checks before each commit::
+9. (**Optional**) Install `pre-commit <https://pre-commit.com/#install>`_ to
+   run code style checks before each commit::
 
         $ pip install pre-commit
         $ pre-commit install

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -248,7 +248,7 @@ modifying code and submitting a PR:
    and start making changes. Always use a feature branch. It's good
    practice to never work on the ``master`` branch!
 
-9. Install `pre-commit <https://pre-commit.com/#install>`_ to run code style
+9. (**Optional**) Install `pre-commit <https://pre-commit.com/#install>`_ to run code style
    checks before each commit::
 
         $ pip install pre-commit

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -255,14 +255,14 @@ modifying code and submitting a PR:
         $ pre-commit install
 
 10. Develop the feature on your feature branch on your computer, using Git to
-   do the version control. When you're done editing, add changed files using
-   ``git add`` and then ``git commit``::
+    do the version control. When you're done editing, add changed files using
+    ``git add`` and then ``git commit``::
+ 
+        $ git add modified_files
+        $ git commit
 
-       $ git add modified_files
-       $ git commit
-
-   to record your changes in Git, then push the changes to your GitHub
-   account with::
+    to record your changes in Git, then push the changes to your GitHub
+    account with::
 
        $ git push -u origin my_feature
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -254,6 +254,9 @@ modifying code and submitting a PR:
         $ pip install pre-commit
         $ pre-commit install
 
+   pre-commit checks can be disabled for a particular commit with
+   `git commit -n`.
+
 10. Develop the feature on your feature branch on your computer, using Git to
     do the version control. When you're done editing, add changed files using
     ``git add`` and then ``git commit``::

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -248,7 +248,13 @@ modifying code and submitting a PR:
    and start making changes. Always use a feature branch. It's good
    practice to never work on the ``master`` branch!
 
-9. Develop the feature on your feature branch on your computer, using Git to
+9. Install `pre-commit <https://pre-commit.com/#install>`_ to run code style
+   checks before each commit::
+
+        $ pip install pre-commit
+        $ pre-commit install
+
+10. Develop the feature on your feature branch on your computer, using Git to
    do the version control. When you're done editing, add changed files using
    ``git add`` and then ``git commit``::
 
@@ -260,7 +266,7 @@ modifying code and submitting a PR:
 
        $ git push -u origin my_feature
 
-10. Follow `these
+11. Follow `these
     <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_
     instructions to create a pull request from your fork. This will send an
     email to the committers. You may want to consider sending an email to the


### PR DESCRIPTION
This adds a [pre-commit](https://pre-commit.com/) setup to run a number of code style checks locally before each commit.

This is fully op-in, and only affect contributors who install pre-commit locally. Most of the below checks are already run in CI, so this allows to fail earlier. Among other things this would help not overwhelming CI during sprints.

It runs only on modified files and currently,
 - checks that yaml files have have valid syntax (e.g. CI config would fail with an error otherwise)
 - strip trailing whitespaces. Some editors already do this automatically. This can produce unrelated changes in edited files, but as long as everybody does it it should not result in merge conflicts. Trailing white-spaces are already marked in red in github diff, and currently sometimes reviewers ask to remove them manually. It's also a "W291 trailing whitespace" flake error.
 - fix the end of files (by making sure there is newline there, I think)
 - run flake8 (only for unused imports F401 for now, since we are generally not fully flake8 compatible) https://github.com/scikit-learn/scikit-learn/issues/11336#issuecomment-613724473
 - run mypy on changed files

When one does `pre-commit install` this install all of the above into a virtualenv, so in the long run it can simplify our contributing guide by not asking to install them manually. It also pins versions of these tools to avoid a situation where locally linters pass but fail in CI.

So far this doesn't add `pre-comit` in CI, and pre-commit remains fully optional for contributors. Personally I would would like to be able to use it though, and it makes sense to share the config.

For instance pandas has an extensive setup https://github.com/pandas-dev/pandas/blob/master/.pre-commit-config.yaml

cc @thomasjpfan @NicolasHug @adrinjalali 