### PR TITLE
DOC Missing links for user guide and source code in KDTree

### DIFF
--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -244,6 +244,8 @@ CLASS_DOC = \
 
 {BinaryTree} for fast generalized N-point problems
 
+Read more in the :ref:`User Guide <unsupervised_neighbors>`.
+
 Parameters
 ----------
 X : array-like of shape (n_samples, n_features)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
"see user guide" and "show source" links are missing in KDTree docstring.

#### Any other comments?
Added "see user guide" link in `sklearn/neighbors/_binary_tree.pxi`.

The work for "show source" link is in progress.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
