### PR TITLE
DOC Libsvm liblinear rand fix - minor doc and header fixes

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -407,14 +407,14 @@ Changelog
   generators used to randomly select coordinates in the coordinate descent
   algorithms. Platform-dependent C ``rand()`` was used, which is only able to
   generate numbers up to ``32767`` on windows platform (see this `blog
-  post <https://codeforces.com/blog/entry/61587>`) and also has poor
+  post <https://codeforces.com/blog/entry/61587>`_) and also has poor
   randomization power as suggested by `this presentation
-  <https://channel9.msdn.com/Events/GoingNative/2013/rand-Considered-Harmful>`.
+  <https://channel9.msdn.com/Events/GoingNative/2013/rand-Considered-Harmful>`_.
   It was replaced with C++11 ``mt19937``, a Mersenne Twister that correctly
   generates 31bits/63bits random numbers on all platforms. In addition, the
   crude "modulo" postprocessor used to get a random number in a bounded
   interval was replaced by the tweaked Lemire method as suggested by `this blog
-  post <http://www.pcg-random.org/posts/bounded-rands.html>`.
+  post <http://www.pcg-random.org/posts/bounded-rands.html>`_.
   Any model using the :func:`svm.libsvm` or the :func:`svm.liblinear` solver,
   including :class:`svm.LinearSVC`, :class:`svm.LinearSVR`,
   :class:`svm.NuSVC`, :class:`svm.NuSVR`, :class:`svm.OneClassSVM`,

--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -26,7 +26,7 @@
    Modified 2020:
    - Improved random number generator by using a mersenne twister + tweaked
      lemire postprocessor. This fixed a convergence issue on windows targets.
-     Sylvain Marie
+     Sylvain Marie, Schneider Electric
      See <https://github.com/scikit-learn/scikit-learn/pull/13511#issuecomment-481729756>
 
  */

--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -52,7 +52,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
    - Improved random number generator by using a mersenne twister + tweaked
      lemire postprocessor. This fixed a convergence issue on windows targets.
-     Sylvain Marie,
+     Sylvain Marie, Schneider Electric
      see <https://github.com/scikit-learn/scikit-learn/pull/13511#issuecomment-481729756>
 
  */

--- a/sklearn/svm/src/newrand/newrand.h
+++ b/sklearn/svm/src/newrand/newrand.h
@@ -3,7 +3,7 @@
    - New random number generator using a mersenne twister + tweaked lemire
      postprocessor. This fixed a convergence issue on windows targets for
      libsvm and liblinear.
-     Sylvain Marie
+     Sylvain Marie, Schneider Electric
      See <https://github.com/scikit-learn/scikit-learn/pull/13511#issuecomment-481729756>
 
  */


### PR DESCRIPTION
Hi, following #13511

 - I found out that the generated doc links were incorrect: https://scikit-learn.org/dev/whats_new/v0.23.html#sklearn-svm

 - Also I take this opportunity to add my company's name next to my name in the file headers

Sorry for not realizing this upfront.
