### PR TITLE
[MRG] DOC fix ref for ParameterSampler

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -189,7 +189,7 @@ class ParameterSampler:
     It is highly recommended to use continuous distributions for continuous
     parameters.
 
-    Read more in the :ref:`User Guide <search>`.
+    Read more in the :ref:`User Guide <grid_search>`.
 
     Parameters
     ----------


### PR DESCRIPTION
Just fixes a ref.

Though ironically neither ParameterSample or ParameterGrid are ever mentioned in the UG. Maybe we should remove the refs, or even make these things private. Or part of that developer API that we're aiming for.