### PR TITLE
DOC Fix link to user guide

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1384,7 +1384,7 @@ def validation_curve(estimator, X, y, param_name, param_range, groups=None,
     will also compute training scores and is merely a utility for plotting the
     results.
 
-    Read more in the :ref:`User Guide <learning_curve>`.
+    Read more in the :ref:`User Guide <validation_curve>`.
 
     Parameters
     ----------


### PR DESCRIPTION
The doc for validation_curve linked to the info for learning_curve rather than validation_curve in the User Guide. This PR corrects the link.