### PR TITLE
DOC: use semilogx for a more readable xaxis in LassoCV plots

### DIFF
--- a/examples/linear_model/plot_lasso_model_selection.py
+++ b/examples/linear_model/plot_lasso_model_selection.py
@@ -80,14 +80,12 @@ alpha_aic_ = model_aic.alpha_
 
 
 def plot_ic_criterion(model, name, color):
-    alpha_ = model.alpha_ + EPSILON
-    alphas_ = model.alphas_ + EPSILON
     criterion_ = model.criterion_
-    plt.plot(-np.log10(alphas_), criterion_, '--', color=color,
-             linewidth=3, label='%s criterion' % name)
-    plt.axvline(-np.log10(alpha_), color=color, linewidth=3,
+    plt.semilogx(model.alphas_ + EPSILON, criterion_, '--', color=color,
+                 linewidth=3, label='%s criterion' % name)
+    plt.axvline(model.alpha_ + EPSILON, color=color, linewidth=3,
                 label='alpha: %s estimate' % name)
-    plt.xlabel('-log(alpha)')
+    plt.xlabel(r'$\alpha$')
     plt.ylabel('criterion')
 
 
@@ -108,19 +106,17 @@ model = LassoCV(cv=20).fit(X, y)
 t_lasso_cv = time.time() - t1
 
 # Display results
-m_log_alphas = -np.log10(model.alphas_ + EPSILON)
-
 plt.figure()
 ymin, ymax = 2300, 3800
-plt.plot(m_log_alphas, model.mse_path_, ':')
-plt.plot(m_log_alphas, model.mse_path_.mean(axis=-1), 'k',
+plt.semilogx(model.alphas_ + EPSILON, model.mse_path_, ':')
+plt.plot(model.alphas_ + EPSILON, model.mse_path_.mean(axis=-1), 'k',
          label='Average across the folds', linewidth=2)
-plt.axvline(-np.log10(model.alpha_ + EPSILON), linestyle='--', color='k',
+plt.axvline(model.alpha_ + EPSILON, linestyle='--', color='k',
             label='alpha: CV estimate')
 
 plt.legend()
 
-plt.xlabel('-log(alpha)')
+plt.xlabel(r'$\alpha$')
 plt.ylabel('Mean square error')
 plt.title('Mean square error on each fold: coordinate descent '
           '(train time: %.2fs)' % t_lasso_cv)
@@ -137,17 +133,15 @@ model = LassoLarsCV(cv=20).fit(X, y)
 t_lasso_lars_cv = time.time() - t1
 
 # Display results
-m_log_alphas = -np.log10(model.cv_alphas_ + EPSILON)
-
 plt.figure()
-plt.plot(m_log_alphas, model.mse_path_, ':')
-plt.plot(m_log_alphas, model.mse_path_.mean(axis=-1), 'k',
-         label='Average across the folds', linewidth=2)
-plt.axvline(-np.log10(model.alpha_), linestyle='--', color='k',
+plt.semilogx(model.cv_alphas_ + EPSILON, model.mse_path_, ':')
+plt.semilogx(model.cv_alphas_ + EPSILON, model.mse_path_.mean(axis=-1), 'k',
+             label='Average across the folds', linewidth=2)
+plt.axvline(model.alpha_, linestyle='--', color='k',
             label='alpha CV')
 plt.legend()
 
-plt.xlabel('-log(alpha)')
+plt.xlabel(r'$\alpha$')
 plt.ylabel('Mean square error')
 plt.title('Mean square error on each fold: Lars (train time: %.2fs)'
           % t_lasso_lars_cv)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I found the xaxis difficult to read in [this example](https://scikit-learn.org/stable/auto_examples/linear_model/plot_lasso_model_selection.html#sphx-glr-auto-examples-linear-model-plot-lasso-model-selection-py)
so I used plt.semilogx instead. I also wrote alpha in greek alphabet.

It changes the x orientation of the plot, but usually going right means increasing value so I am not sure this is an issue. @agramfort 

Old:
![image](https://user-images.githubusercontent.com/8993218/79985105-68749900-84aa-11ea-900f-ce71ecd13611.png)


New:
![image](https://user-images.githubusercontent.com/8993218/79985130-70ccd400-84aa-11ea-89fc-dacdb804c995.png)


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
