### PR TITLE
FIX Fixes mixed dataframes bool dtype in pandas

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -466,7 +466,7 @@ def check_array(array, accept_sparse=False, accept_large_sparse=True,
         # pandas boolean dtype __array__ interface coerces bools to objects
         for i, dtype_iter in enumerate(dtypes_orig):
             if dtype_iter.kind == 'b':
-                dtypes_orig[i] = np.object
+                dtypes_orig[i] = np.dtype(np.object)
 
         if all(isinstance(dtype, np.dtype) for dtype in dtypes_orig):
             dtype_orig = np.result_type(*dtypes_orig)


### PR DESCRIPTION
This makes `dtype_orig` give to the correct result, when used with `np.result_type`.

The logic worked before because `dtype_orig` ended to be `None` which would activate `dtype = dtype[0]` in:

https://github.com/scikit-learn/scikit-learn/blob/388999b59d0070fafdcd76cf599af6758b25d987/sklearn/utils/validation.py#L485-L488
