### PR TITLE
Update the URL of valgrind-python.supp in the doc

### DIFF
--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -249,7 +249,7 @@ code. Follow these steps:
 
 .. _valgrind: http://valgrind.org
 .. _`README.valgrind`: https://svn.python.org/projects/python/trunk/Misc/README.valgrind
-.. _`valgrind-python.supp`: https://svn.python.org/projects/python/trunk/Misc/valgrind-python.supp
+.. _`valgrind-python.supp`: https://github.com/python/cpython/blob/master/Misc/valgrind-python.supp
 
 
 The result will be a list of all the memory-related errors, which reference

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -248,7 +248,7 @@ code. Follow these steps:
        $> valgrind -v --suppressions=valgrind-python.supp python my_test_script.py
 
 .. _valgrind: http://valgrind.org
-.. _`README.valgrind`: https://svn.python.org/projects/python/trunk/Misc/README.valgrind
+.. _`README.valgrind`: https://github.com/python/cpython/blob/master/Misc/README.valgrind
 .. _`valgrind-python.supp`: https://github.com/python/cpython/blob/master/Misc/valgrind-python.supp
 
 


### PR DESCRIPTION
Quick doc fix to avoid pointing to the old subversion repo of CPython.