### PR TITLE
New Feature: return_all_estimators option in GridSearch and RandomizedSearch

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -778,8 +778,11 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                 refit_end_time = time.time()
                 self.refit_time_ += refit_end_time - refit_start_time
                 estimators.append(estimator)
-            self.best_estimator_ = estimators[self.best_index_] if self.return_all_estimators else estimators[0]
-            
+            if return_all_estimators:
+                self.best_estimator_ = estimators[self.best_index_]
+            else:
+                self.best_estimator_ = estimators[0]
+
         # Store the only scorer not as a dict for single metric evaluation
         self.scorer_ = scorers if self.multimetric_ else scorers['score']
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -761,7 +761,6 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             self.refit_time_ = 0.0
             if self.return_all_estimators:
                 params_grid = results["params"]
-                self.all_estimators_ = estimators
             else:
                 params_grid = [results["params"][self.best_index_]]
             for params in params_grid:
@@ -779,6 +778,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                 estimators.append(estimator)
             if self.return_all_estimators:
                 self.best_estimator_ = estimators[self.best_index_]
+                self.all_estimators_ = estimators
             else:
                 self.best_estimator_ = estimators[0]
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -683,11 +683,12 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         parallel = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                             pre_dispatch=self.pre_dispatch)
+        return_all_estimators = self.return_all_estimators
 
         fit_and_score_kwargs = dict(scorer=scorers,
                                     fit_params=fit_params,
                                     return_train_score=self.return_train_score,
-                                    return_estimator=self.return_all_estimators,
+                                    return_estimator=return_all_estimators,
                                     return_n_test_samples=True,
                                     return_times=True,
                                     return_parameters=False,
@@ -792,8 +793,8 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             (train_score_dicts, test_score_dicts, test_sample_counts, fit_time,
              score_time, estimators) = zip(*out)
         elif self.return_all_estimators:
-            (test_score_dicts, test_sample_counts, fit_time, 
-            score_time, estimators) = zip(*out)
+            (test_score_dicts, test_sample_counts, fit_time,
+             score_time, estimators) = zip(*out)
         else:
             (test_score_dicts, test_sample_counts, fit_time,
              score_time) = zip(*out)
@@ -1189,7 +1190,7 @@ class GridSearchCV(BaseSearchCV):
     def __init__(self, estimator, param_grid, *, scoring=None,
                  n_jobs=None, iid='deprecated', refit=True, cv=None,
                  verbose=0, pre_dispatch='2*n_jobs',
-                 error_score=np.nan, return_train_score=False, 
+                 error_score=np.nan, return_train_score=False,
                  return_all_estimators=False):
         super().__init__(
             estimator=estimator, scoring=scoring,
@@ -1538,7 +1539,7 @@ class RandomizedSearchCV(BaseSearchCV):
             estimator=estimator, scoring=scoring,
             n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
             pre_dispatch=pre_dispatch, error_score=error_score,
-            return_train_score=return_train_score, 
+            return_train_score=return_train_score,
             return_all_estimators=return_all_estimators)
 
     def _run_search(self, evaluate_candidates):

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -683,7 +683,6 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         parallel = Parallel(n_jobs=self.n_jobs, verbose=self.verbose,
                             pre_dispatch=self.pre_dispatch)
-        return_all_estimators = self.return_all_estimators
 
         fit_and_score_kwargs = dict(scorer=scorers,
                                     fit_params=fit_params,
@@ -778,7 +777,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                 refit_end_time = time.time()
                 self.refit_time_ += refit_end_time - refit_start_time
                 estimators.append(estimator)
-            if return_all_estimators:
+            if self.return_all_estimators:
                 self.best_estimator_ = estimators[self.best_index_]
             else:
                 self.best_estimator_ = estimators[0]

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1965,6 +1965,10 @@ def test_grid_search_return_all_estimators():
     # Check the length of estimators
     assert(len(estimators) == 3)
 
+    # Check that the best estimator is the same as in the list of all_estimators_
+    # based on the best_index_
+    assert(estimators[grid_search.best_index_] == grid_search.best_estimator_)
+
     # Apply the same check with a single param.
     param_grid = {'C': [1]}
     grid_search = GridSearchCV(SVC(), param_grid=param_grid,

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1953,3 +1953,20 @@ def test_scalar_fit_param_compat(SearchCV, param_search):
         'scalar_param': 42,
     }
     model.fit(X_train, y_train, **fit_params)
+
+def test_grid_search_return_all_estimators():
+    X, y = make_blobs(n_samples=50, random_state=42)
+    param_grid = {'C': [1, 1.001, 0.001]}
+    grid_search = GridSearchCV(SVC(), param_grid=param_grid,
+                               return_all_estimators=True).fit(X, y)
+    estimators = grid_search.all_estimators_
+    
+    # Check the length of estimators
+    assert(len(estimators) == 3)
+
+    # Apply the same check with a single param.
+    param_grid = {'C': [1]}
+    grid_search = GridSearchCV(SVC(), param_grid=param_grid,
+                               return_all_estimators=True).fit(X, y)
+    estimators = grid_search.all_estimators_
+    assert(len(estimators) == 1)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1960,7 +1960,7 @@ def test_grid_search_return_all_estimators():
     grid_search = GridSearchCV(SVC(), param_grid=param_grid,
                                return_all_estimators=True).fit(X, y)
     estimators = grid_search.all_estimators_
-    
+
     # Check the length of estimators
     assert(len(estimators) == 3)
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1965,8 +1965,8 @@ def test_grid_search_return_all_estimators():
     # Check the length of estimators
     assert(len(estimators) == 3)
 
-    # Check that the best estimator is the same as in the list of all_estimators_
-    # based on the best_index_
+    # Check that the best estimator is the same as in the list
+    # of all_estimators_ based on the best_index_
     assert(estimators[grid_search.best_index_] == grid_search.best_estimator_)
 
     # Apply the same check with a single param.

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1954,6 +1954,7 @@ def test_scalar_fit_param_compat(SearchCV, param_search):
     }
     model.fit(X_train, y_train, **fit_params)
 
+
 def test_grid_search_return_all_estimators():
     X, y = make_blobs(n_samples=50, random_state=42)
     param_grid = {'C': [1, 1.001, 0.001]}


### PR DESCRIPTION
#### New feature: return_all_estimators option in GridSearch and RandomizedSearch
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Implements new feature as requested in #16765. 

#### What does this implement/fix? Explain your changes.
New option is included to the search functions in order to refit all the estimators and return them.
Here's a list of the changes:
- Any `BaseSearchCV` object now includes an init parameter `return_all_estimators` (set to False by default).
- If flag is set to True then all the refitted estimators are stored in a list under the variable `<BaseSearchCV object>.all_estimators_`
- The estimators are refitted and stored only if `refit=True`
- The `refit_time` will include the time needed to fit the rest of the models if `return_all_estimators=True`

#### Any other comments?
Please review the changes and if you agree with the overall solution and then I'll move forward with updating the documentation.
