### PR TITLE
DOC add detail about flip_y parameter in make_classification

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -100,7 +100,9 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         ``weights`` exceeds 1.
 
     flip_y : float, optional (default=0.01)
-        The fraction of samples whose class is assigned randomly. Larger
+        The fraction of samples whose class is assigned randomly. If you
+        prefer the output dataset to have all the class labels you specified
+        at n_classes, you should set flip_y to 0. Larger
         values introduce noise in the labels and make the classification
         task harder.
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -100,10 +100,10 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         ``weights`` exceeds 1.
 
     flip_y : float, optional (default=0.01)
-        The fraction of samples whose class is assigned randomly. Note that the
-        default setting flip_y > 0 might lead to less than n_classes in y in some cases.
-        Larger values introduce noise in the labels and make the classification
-        task harder.
+        The fraction of samples whose class is assigned randomly. Larger
+        values introduce noise in the labels and make the classification
+        task harder. Note that the default setting flip_y > 0 might lead
+        to less than n_classes in y in some cases.
 
     class_sep : float, optional (default=1.0)
         The factor multiplying the hypercube size.  Larger values spread

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -100,10 +100,9 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         ``weights`` exceeds 1.
 
     flip_y : float, optional (default=0.01)
-        The fraction of samples whose class is assigned randomly. If you
-        prefer the output dataset to have all the class labels you specified
-        at n_classes, you should set flip_y to 0. Larger
-        values introduce noise in the labels and make the classification
+        The fraction of samples whose class is assigned randomly. Note that the
+        default setting flip_y > 0 might lead to less than n_classes in y in some cases.
+        Larger values introduce noise in the labels and make the classification
         task harder.
 
     class_sep : float, optional (default=1.0)


### PR DESCRIPTION


#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #Issue #16789 

#### What does this implement/fix? Explain your changes.
There has been confusion on datasets.make_classification 's output dataset having less class labels than speficified in n_classes. This is due to the default flip_y parameter being nonzero, effectively adding noise to label distribution by default. This fix is to add explicit note in documentation, and ask people to set flip_y to zero if you prefer output dataset to have exact number of labels as specified in n_classes. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
