### PR TITLE
TST Skips derivative check on 32bit platforms

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -9,6 +9,7 @@ import pytest
 from sklearn.ensemble._hist_gradient_boosting.loss import _LOSSES
 from sklearn.ensemble._hist_gradient_boosting.common import Y_DTYPE
 from sklearn.ensemble._hist_gradient_boosting.common import G_H_DTYPE
+from sklearn.utils._testing import skip_if_32bit
 
 
 def get_derivatives_helper(loss):
@@ -58,8 +59,7 @@ def get_derivatives_helper(loss):
 ])
 @pytest.mark.skipif(sp_version == (1, 2, 0),
                     reason='bug in scipy 1.2.0, see scipy issue #9608')
-@pytest.mark.skipif(Y_DTYPE != np.float64,
-                    reason='Newton internally uses float64 != Y_DTYPE')
+@skip_if_32bit
 def test_derivatives(loss, x0, y_true):
     # Check that gradients are zero when the loss is minimized on 1D array
     # using Halley's method with the first and second order derivatives
@@ -85,8 +85,7 @@ def test_derivatives(loss, x0, y_true):
     assert np.allclose(loss.pointwise_loss(y_true, optimum), 0)
 
     gradient = get_gradients(y_true, optimum)
-    atol = 1e-6 if gradient.dtype == np.float32 else 1e-7
-    assert np.allclose(gradient, 0, atol=atol)
+    assert np.allclose(gradient, 0, atol=1e-7)
 
 
 @pytest.mark.parametrize('loss, n_classes, prediction_dim', [

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -83,9 +83,7 @@ def test_derivatives(loss, x0, y_true):
                      maxiter=70, tol=2e-8)
     assert np.allclose(loss.inverse_link_function(optimum), y_true)
     assert np.allclose(loss.pointwise_loss(y_true, optimum), 0)
-
-    gradient = get_gradients(y_true, optimum)
-    assert np.allclose(gradient, 0, atol=1e-7)
+    assert np.allclose(get_gradients(y_true, optimum), 0, atol=1e-7)
 
 
 @pytest.mark.parametrize('loss, n_classes, prediction_dim', [

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -83,7 +83,10 @@ def test_derivatives(loss, x0, y_true):
                      maxiter=70, tol=2e-8)
     assert np.allclose(loss.inverse_link_function(optimum), y_true)
     assert np.allclose(loss.pointwise_loss(y_true, optimum), 0)
-    assert np.allclose(get_gradients(y_true, optimum), 0, atol=1e-7)
+
+    gradient = get_gradients(y_true, optimum)
+    atol = 1e-6 if gradient.dtype == np.float32 else 1e-7
+    assert np.allclose(gradient, 0, atol=atol)
 
 
 @pytest.mark.parametrize('loss, n_classes, prediction_dim', [


### PR DESCRIPTION
Fixes build failure in [scikit-learn-wheels CI](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=15971&view=logs&j=bb1c2637-64c6-57bd-9ea6-93823b2df951&t=9c62e7ff-391e-517d-ede1-af63bc6a25da) when running on 32bit linux.