### PR TITLE
STY Adjust line height of code blocks

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -90,7 +90,7 @@ div.highlight {
 
 div.highlight pre {
   margin-bottom: 0;
-  line-height: 1rem;
+  line-height: 1.2rem;
 }
 
 div.highlight a {

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -90,7 +90,7 @@ div.highlight {
 
 div.highlight pre {
   margin-bottom: 0;
-  line-height: 1.1rem;
+  line-height: 1.2rem;
 }
 
 div.highlight a {

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -90,7 +90,7 @@ div.highlight {
 
 div.highlight pre {
   margin-bottom: 0;
-  line-height: 1.15rem;
+  line-height: 1.1rem;
 }
 
 div.highlight a {

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -90,7 +90,7 @@ div.highlight {
 
 div.highlight pre {
   margin-bottom: 0;
-  line-height: 1.2rem;
+  line-height: 1.15rem;
 }
 
 div.highlight a {


### PR DESCRIPTION
While reviewing https://github.com/scikit-learn/scikit-learn/pull/17062 the line height of the code blocks seemed a little small. This PR makes it slightly bigger:

### this PR
<img width="434" alt="Screen Shot 2020-04-30 at 2 54 48 PM" src="https://user-images.githubusercontent.com/5402633/80748211-91bca700-8af2-11ea-9278-3ad9ff7094b8.png">

### master

<img width="428" alt="Screen Shot 2020-04-30 at 2 51 10 PM" src="https://user-images.githubusercontent.com/5402633/80747880-16f38c00-8af2-11ea-97d8-fdda95fbfade.png">
