### PR TITLE
MISC: fix rst syntax

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -436,7 +436,7 @@ Changelog
   type and details.
   :pr:`15622` by :user:`Gregory Morse <GregoryMorse>`.
 
-- |Fix| :func: `cross_val_predict` supports `method="predict_proba"`
+- |Fix| :func:`cross_val_predict` supports `method="predict_proba"`
   when `y=None`.
   :pr:`15918` by :user:`Luca Kubin <lkubin>`.
 

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -436,9 +436,9 @@ Changelog
   type and details.
   :pr:`15622` by :user:`Gregory Morse <GregoryMorse>`.
 
-- |Fix| :func:`cross_val_predict` supports `method="predict_proba"`
-  when `y=None`.
-  :pr:`15918` by :user:`Luca Kubin <lkubin>`.
+- |Fix| :func:`model_selection.cross_val_predict` supports
+  `method="predict_proba"` when `y=None`.:pr:`15918` by
+  :user:`Luca Kubin <lkubin>`.
 
 - |Fix| :func:`model_selection.fit_grid_point` is deprecated in 0.23 and will
   be removed in 0.25. :pr:`16401` by


### PR DESCRIPTION
Fix a small rst syntax bug in the 0.23 whats_new