### PR TITLE
Delegate choice of final model to sub class in LinearModelCV 

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1153,7 +1153,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
         self.selection = selection
 
     @abstractmethod
-    def _get_model(self):
+    def _get_estimator(self):
         """Model to be fitted after the best alpha has been determined."""
 
     @abstractmethod
@@ -1201,7 +1201,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
                                                             check_y_params))
             if sparse.isspmatrix(X):
                 if (hasattr(reference_to_old_X, "data") and
-                   not np.may_share_memory(reference_to_old_X.data, X.data)):
+                        not np.may_share_memory(reference_to_old_X.data, X.data)):
                     # X is a sparse matrix and has been copied
                     copy_X = False
             elif not np.may_share_memory(reference_to_old_X, X):
@@ -1237,7 +1237,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
                 raise ValueError("For mono-task outputs, use "
                                  "%sCV" % self.__class__.__name__[9:])
 
-        model = self._get_model()
+        model = self._get_estimator()
 
         if self.selection not in ["random", "cyclic"]:
             raise ValueError("selection should be either random or cyclic.")
@@ -1504,7 +1504,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
             cv=cv, verbose=verbose, n_jobs=n_jobs, positive=positive,
             random_state=random_state, selection=selection)
 
-    def _get_model(self):
+    def _get_estimator(self):
         return Lasso()
 
     def _is_multitask(self):
@@ -1718,7 +1718,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         self.random_state = random_state
         self.selection = selection
 
-    def _get_model(self):
+    def _get_estimator(self):
         return ElasticNet()
 
     def _is_multitask(self):
@@ -2231,7 +2231,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         self.random_state = random_state
         self.selection = selection
 
-    def _get_model(self):
+    def _get_estimator(self):
         return MultiTaskElasticNet()
 
     def _is_multitask(self):
@@ -2401,7 +2401,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
             cv=cv, verbose=verbose, n_jobs=n_jobs, random_state=random_state,
             selection=selection)
 
-    def _get_model(self):
+    def _get_estimator(self):
         return MultiTaskLasso()
 
     def _is_multitask(self):

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1155,12 +1155,10 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
     @abstractmethod
     def _get_model(self):
         """Model to be fitted after the best alpha has been determined."""
-        return
 
     @abstractmethod
     def _is_multitask(self):
         """Bool indicating if the class is meant for mutidimensional target."""
-        return
 
     def fit(self, X, y):
         """Fit linear model with coordinate descent

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1158,7 +1158,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
 
     @abstractmethod
     def _is_multitask(self):
-        """Bool indicating if the class is meant for mutidimensional target."""
+        """Bool indicating if class is meant for multidimensional target."""
 
     def fit(self, X, y):
         """Fit linear model with coordinate descent
@@ -1201,7 +1201,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
                                                             check_y_params))
             if sparse.isspmatrix(X):
                 if (hasattr(reference_to_old_X, "data") and
-                        not np.may_share_memory(reference_to_old_X.data, X.data)):
+                   not np.may_share_memory(reference_to_old_X.data, X.data)):
                     # X is a sparse matrix and has been copied
                     copy_X = False
             elif not np.may_share_memory(reference_to_old_X, X):

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1203,7 +1203,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
                                                             check_y_params))
             if sparse.isspmatrix(X):
                 if (hasattr(reference_to_old_X, "data") and
-                        not np.may_share_memory(reference_to_old_X.data, X.data)):
+                   not np.may_share_memory(reference_to_old_X.data, X.data)):
                     # X is a sparse matrix and has been copied
                     copy_X = False
             elif not np.may_share_memory(reference_to_old_X, X):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The current design of the base class `LinearModelCV` uses conditions based on `l1_ratio` to instantiate, in a hardcoded fashion, the model to be fitted after the best alpha has been determined by CV (eg `Lasso` for `LassoCV`, `MultitaskElasticNet` for `MultitaskElasticNetCV`)

This is not a common design and it makes it difficult to subclass `LinearModelCV` when implementing `AnotherEstimatorCV`

With the proposed PR, the model to instantiate is implemented by the sub class, in `_get_model(self)`

I also implemented `_is_multitask(self)` to address a similar issue

@agramfort

@NicolasHug do you have an opinion on this ?


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
