### PR TITLE
DOC Remove unmaintained related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -112,9 +112,6 @@ and tasks.
 
 **Deep neural networks etc.**
 
-- `sklearn_theano <https://sklearn-theano.github.io/>`_ scikit-learn compatible
-  estimators, transformers, and datasets which use Theano internally
-
 - `nolearn <https://github.com/dnouri/nolearn>`_ A number of wrappers and
   abstractions around existing neural network libraries
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -23,16 +23,11 @@ enhance the functionality of scikit-learn's estimators.
 
 - `sklearn_pandas <https://github.com/paulgb/sklearn-pandas/>`_ bridge for
   scikit-learn pipelines and pandas data frame with dedicated transformers.
-  
+
 - `sklearn_xarray <https://github.com/phausamann/sklearn-xarray/>`_ provides
   compatibility of scikit-learn estimators with xarray data structures.
 
 **Auto-ML**
-
-- `auto_ml <https://github.com/ClimbsRocks/auto_ml/>`_
-  Automated machine learning for production and analytics, built on scikit-learn
-  and related projects. Trains a pipeline wth all the standard machine learning 
-  steps. Tuned for prediction speed and ease of transfer to production environments. 
 
 - `auto-sklearn <https://github.com/automl/auto-sklearn/>`_
   An automated machine learning toolkit and a drop-in replacement for a
@@ -66,11 +61,6 @@ enhance the functionality of scikit-learn's estimators.
   wrapper around scikit-learn that makes it easy to run machine learning
   experiments with multiple learners and large feature sets.
 
-- `Xcessiv <https://github.com/reiinakano/xcessiv>`_ is a notebook-like
-  application for quick, scalable, and automated hyperparameter tuning
-  and stacked ensembling. Provides a framework for keeping track of 
-  model-hyperparameter combinations.
-
 **Model inspection and visualisation**
 
 - `eli5 <https://github.com/TeamHG-Memex/eli5/>`_ A library for
@@ -79,9 +69,6 @@ enhance the functionality of scikit-learn's estimators.
 
 - `mlxtend <https://github.com/rasbt/mlxtend>`_ Includes model visualization
   utilities.
-
-- `scikit-plot <https://github.com/reiinakano/scikit-plot>`_ A visualization library
-  for quick and easy generation of common plots in data analysis and machine learning.
 
 - `yellowbrick <https://github.com/DistrictDataLabs/yellowbrick>`_ A suite of
   custom matplotlib visualizers for scikit-learn estimators to support visual feature
@@ -102,11 +89,6 @@ enhance the functionality of scikit-learn's estimators.
 - `sklearn-porter <https://github.com/nok/sklearn-porter>`_
   Transpile trained scikit-learn models to C, Java, Javascript and others.
 
-- `sklearn-compiledtrees <https://github.com/ajtulloch/sklearn-compiledtrees/>`_
-  Generate a C++ implementation of the predict function for decision trees (and
-  ensembles) trained by sklearn. Useful for latency-sensitive production
-  environments.
-
 
 Other estimators and tasks
 --------------------------
@@ -119,9 +101,6 @@ and tasks.
 **Structured learning**
 
 - `sktime <https://github.com/alan-turing-institute/sktime>`_ A scikit-learn compatible toolbox for machine learning with time series including time series classification/regression and (supervised/panel) forecasting.
-
-- `Seqlearn <https://github.com/larsmans/seqlearn>`_  Sequence classification
-  using HMMs or structured perceptron.
 
 - `HMMLearn <https://github.com/hmmlearn/hmmlearn>`_ Implementation of hidden
   markov models that was previously part of scikit-learn.
@@ -139,9 +118,6 @@ and tasks.
 
 **Deep neural networks etc.**
 
-- `pylearn2 <http://deeplearning.net/software/pylearn2/>`_ A deep learning and
-  neural network library build on theano with scikit-learn like interface.
-
 - `sklearn_theano <https://sklearn-theano.github.io/>`_ scikit-learn compatible
   estimators, transformers, and datasets which use Theano internally
 
@@ -153,17 +129,14 @@ and tasks.
 
 - `lasagne <https://github.com/Lasagne/Lasagne>`_ A lightweight library to
   build and train neural networks in Theano.
-  
-- `skorch <https://github.com/dnouri/skorch>`_ A scikit-learn compatible 
+
+- `skorch <https://github.com/dnouri/skorch>`_ A scikit-learn compatible
   neural network library that wraps PyTorch.
 
 **Broad scope**
 
 - `mlxtend <https://github.com/rasbt/mlxtend>`_ Includes a number of additional
   estimators as well as model visualization utilities.
-
-- `sparkit-learn <https://github.com/lensacom/sparkit-learn>`_ Scikit-learn
-  API and functionality for PySpark's distributed modelling.
 
 **Other regression and classification**
 
@@ -187,18 +160,15 @@ and tasks.
 - `gplearn <https://github.com/trevorstephens/gplearn>`_ Genetic Programming
   for symbolic regression tasks.
 
-- `multiisotonic <https://github.com/alexfields/multiisotonic>`_ Isotonic
-  regression on multidimensional features.
-
-- `scikit-multilearn <https://scikit.ml>`_ Multi-label classification with 
+- `scikit-multilearn <https://scikit.ml>`_ Multi-label classification with
   focus on label space manipulation.
 
-- `seglearn <https://github.com/dmbee/seglearn>`_ Time series and sequence 
+- `seglearn <https://github.com/dmbee/seglearn>`_ Time series and sequence
   learning using sliding window segmentation.
 
 **Decomposition and clustering**
 
-- `lda <https://github.com/ariddell/lda/>`_: Fast implementation of latent
+- `lda <https://github.com/lda-project/lda/>`_: Fast implementation of latent
   Dirichlet allocation in Cython which uses `Gibbs sampling
   <https://en.wikipedia.org/wiki/Gibbs_sampling>`_ to sample from the true
   posterior distribution. (scikit-learn's
@@ -206,9 +176,6 @@ and tasks.
   `variational inference
   <https://en.wikipedia.org/wiki/Variational_Bayesian_methods>`_ to sample from
   a tractable approximation of a topic model's posterior distribution.)
-
-- `Sparse Filtering <https://github.com/jmetzen/sparse-filtering>`_
-  Unsupervised feature learning based on sparse-filtering
 
 - `kmodes <https://github.com/nicodv/kmodes>`_ k-modes clustering algorithm for
   categorical data, and several of its variations.
@@ -237,9 +204,6 @@ Other packages useful for data analysis and machine learning.
 - `Pandas <https://pandas.pydata.org/>`_ Tools for working with heterogeneous and
   columnar data, relational queries, time series and basic statistics.
 
-- `theano <http://deeplearning.net/software/theano/>`_ A CPU/GPU array
-  processing framework geared towards deep learning research.
-
 - `statsmodels <https://www.statsmodels.org>`_ Estimating and analysing
   statistical models. More focused on statistical tests and less on prediction
   than scikit-learn.
@@ -253,16 +217,8 @@ Other packages useful for data analysis and machine learning.
 - `Seaborn <https://stanford.edu/~mwaskom/software/seaborn/>`_ Visualization library based on
   matplotlib. It provides a high-level interface for drawing attractive statistical graphics.
 
-- `Deep Learning <http://deeplearning.net/software_links/>`_ A curated list of deep learning
-  software libraries.
-
 Recommendation Engine packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
- - `GraphLab
-   <https://turi.com/products/create/docs/graphlab.toolkits.recommender.html>`_
-   Implementation of classical recommendation techniques (in C++, with
-   Python bindings).
 
 - `implicit <https://github.com/benfred/implicit>`_, Library for implicit
   feedback datasets.
@@ -297,11 +253,3 @@ Domain specific packages
 
 - `MSMBuilder <http://msmbuilder.org/>`_  Machine learning for protein
   conformational dynamics time series.
-
-- `scikit-surprise <https://surpriselib.com/>`_ A scikit for building and
-  evaluating recommender systems.
-
-Snippets and tidbits
----------------------
-
-The `wiki <https://github.com/scikit-learn/scikit-learn/wiki/Third-party-projects-and-code-snippets>`_ has more!

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -50,12 +50,6 @@ enhance the functionality of scikit-learn's estimators.
 - `REP <https://github.com/yandex/REP>`_ Environment for conducting data-driven
   research in a consistent and reproducible way
 
-- `ML Frontend <https://github.com/jeff1evesque/machine-learning>`_ provides
-  dataset management and SVM fitting/prediction through
-  `web-based <https://github.com/jeff1evesque/machine-learning#web-interface>`_
-  and `programmatic <https://github.com/jeff1evesque/machine-learning#programmatic-interface>`_
-  interfaces.
-
 - `Scikit-Learn Laboratory
   <https://skll.readthedocs.io/en/latest/index.html>`_  A command-line
   wrapper around scikit-learn that makes it easy to run machine learning
@@ -160,8 +154,8 @@ and tasks.
 - `gplearn <https://github.com/trevorstephens/gplearn>`_ Genetic Programming
   for symbolic regression tasks.
 
-- `scikit-multilearn <https://scikit.ml>`_ Multi-label classification with
-  focus on label space manipulation.
+- `scikit-multilearn <https://github.com/scikit-multilearn/scikit-multilearn>`_
+  Multi-label classification with focus on label space manipulation.
 
 - `seglearn <https://github.com/dmbee/seglearn>`_ Time series and sequence
   learning using sliding window segmentation.


### PR DESCRIPTION
Removes unmaintained related projects, using the following criteria,
 - at least one commit in the last 2 years (which is less strict than 1 release in the last 2 years)
 - supports at least Python 3.7
 - does not explicitly say that the project is unmaintained.
 - after clicking on the link (and if necessary searching for 2min) it was clear to me how to install and use the project.

excluded from removed projects are `scikit-learn-contrib` projects (e.g. https://github.com/scikit-learn-contrib/py-earth we should probably make sure that at least the CI passes with latest dependencies)