### PR TITLE
TST Replace Boston dataset in test_plot_partial_dependence

### DIFF
--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -4,7 +4,7 @@ from scipy.stats.mstats import mquantiles
 import pytest
 from numpy.testing import assert_allclose
 
-from sklearn.datasets import load_boston
+from sklearn.datasets import load_diabetes
 from sklearn.datasets import load_iris
 from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import GradientBoostingRegressor
@@ -22,23 +22,27 @@ pytestmark = pytest.mark.filterwarnings(
 
 
 @pytest.fixture(scope="module")
-def boston():
-    return load_boston()
+def diabetes():
+    diabetes = load_diabetes()
+    # Match type of `feature_names` of prev used `load_boston`
+    diabetes.feature_names = np.asarray(diabetes.feature_names)
+    return diabetes
 
 
 @pytest.fixture(scope="module")
-def clf_boston(boston):
+def clf_diabetes(diabetes):
     clf = GradientBoostingRegressor(n_estimators=10, random_state=1)
-    clf.fit(boston.data, boston.target)
+    clf.fit(diabetes.data, diabetes.target)
     return clf
 
 
 @pytest.mark.parametrize("grid_resolution", [10, 20])
-def test_plot_partial_dependence(grid_resolution, pyplot, clf_boston, boston):
+def test_plot_partial_dependence(grid_resolution, pyplot, clf_diabetes, diabetes):
     # Test partial dependence plot function.
-    feature_names = boston.feature_names
-    disp = plot_partial_dependence(clf_boston, boston.data,
-                                   [0, 1, (0, 1)],
+    # Use columns 0 & 2 as 1 is not quantitative (sex)
+    feature_names = diabetes.feature_names
+    disp = plot_partial_dependence(clf_diabetes, diabetes.data,
+                                   [0, 2, (0, 2)],
                                    grid_resolution=grid_resolution,
                                    feature_names=feature_names,
                                    contour_kw={"cmap": "jet"})
@@ -65,21 +69,21 @@ def test_plot_partial_dependence(grid_resolution, pyplot, clf_boston, boston):
     assert disp.deciles_hlines_[0, 1] is None
     assert disp.deciles_hlines_[0, 2] is not None
 
-    assert disp.features == [(0, ), (1, ), (0, 1)]
+    assert disp.features == [(0, ), (2, ), (0, 2)]
     assert np.all(disp.feature_names == feature_names)
     assert len(disp.deciles) == 2
-    for i in [0, 1]:
+    for i in [0, 2]:
         assert_allclose(disp.deciles[i],
-                        mquantiles(boston.data[:, i],
+                        mquantiles(diabetes.data[:, i],
                                    prob=np.arange(0.1, 1.0, 0.1)))
 
-    single_feature_positions = [(0, 0), (0, 1)]
+    single_feature_positions = [(0, (0, 0)), (2, (0, 1))]
     expected_ylabels = ["Partial dependence", ""]
 
-    for i, pos in enumerate(single_feature_positions):
+    for i, (feat_col, pos) in enumerate(single_feature_positions):
         ax = disp.axes_[pos]
         assert ax.get_ylabel() == expected_ylabels[i]
-        assert ax.get_xlabel() == boston.feature_names[i]
+        assert ax.get_xlabel() == diabetes.feature_names[feat_col]
         assert_allclose(ax.get_ylim(), disp.pdp_lim[1])
 
         line = disp.lines_[pos]
@@ -98,8 +102,8 @@ def test_plot_partial_dependence(grid_resolution, pyplot, clf_boston, boston):
     expected_levels = np.linspace(*disp.pdp_lim[2], num=8)
     assert_allclose(coutour.levels, expected_levels)
     assert coutour.get_cmap().name == "jet"
-    assert ax.get_xlabel() == boston.feature_names[0]
-    assert ax.get_ylabel() == boston.feature_names[1]
+    assert ax.get_xlabel() == diabetes.feature_names[0]
+    assert ax.get_ylabel() == diabetes.feature_names[2]
 
 
 @pytest.mark.parametrize(
@@ -110,26 +114,26 @@ def test_plot_partial_dependence(grid_resolution, pyplot, clf_boston, boston):
      ('dataframe', 'series'), ('list', 'series'), ('array', 'series'),
      ('dataframe', 'index'), ('list', 'index'), ('array', 'index')]
 )
-def test_plot_partial_dependence_str_features(pyplot, clf_boston, boston,
+def test_plot_partial_dependence_str_features(pyplot, clf_diabetes, diabetes,
                                               input_type, feature_names_type):
     if input_type == 'dataframe':
         pd = pytest.importorskip("pandas")
-        X = pd.DataFrame(boston.data, columns=boston.feature_names)
+        X = pd.DataFrame(diabetes.data, columns=diabetes.feature_names)
     elif input_type == 'list':
-        X = boston.data.tolist()
+        X = diabetes.data.tolist()
     else:
-        X = boston.data
+        X = diabetes.data
 
     if feature_names_type is None:
         feature_names = None
     else:
-        feature_names = _convert_container(boston.feature_names,
+        feature_names = _convert_container(diabetes.feature_names,
                                            feature_names_type)
 
     grid_resolution = 25
     # check with str features and array feature names and single column
-    disp = plot_partial_dependence(clf_boston, X,
-                                   [('CRIM', 'ZN'), 'ZN'],
+    disp = plot_partial_dependence(clf_diabetes, X,
+                                   [('age', 'bmi'), 'bmi'],
                                    grid_resolution=grid_resolution,
                                    feature_names=feature_names,
                                    n_cols=1, line_kw={"alpha": 0.8})
@@ -153,7 +157,7 @@ def test_plot_partial_dependence_str_features(pyplot, clf_boston, boston,
 
     # line
     ax = disp.axes_[1, 0]
-    assert ax.get_xlabel() == "ZN"
+    assert ax.get_xlabel() == "bmi"
     assert ax.get_ylabel() == "Partial dependence"
 
     line = disp.lines_[1, 0]
@@ -170,16 +174,16 @@ def test_plot_partial_dependence_str_features(pyplot, clf_boston, boston,
     coutour = disp.contours_[0, 0]
     expect_levels = np.linspace(*disp.pdp_lim[2], num=8)
     assert_allclose(coutour.levels, expect_levels)
-    assert ax.get_xlabel() == "CRIM"
-    assert ax.get_ylabel() == "ZN"
+    assert ax.get_xlabel() == "age"
+    assert ax.get_ylabel() == "bmi"
 
 
-def test_plot_partial_dependence_custom_axes(pyplot, clf_boston, boston):
+def test_plot_partial_dependence_custom_axes(pyplot, clf_diabetes, diabetes):
     grid_resolution = 25
     fig, (ax1, ax2) = pyplot.subplots(1, 2)
-    feature_names = boston.feature_names.tolist()
-    disp = plot_partial_dependence(clf_boston, boston.data,
-                                   ['CRIM', ('CRIM', 'ZN')],
+    feature_names = diabetes.feature_names.tolist()
+    disp = plot_partial_dependence(clf_diabetes, diabetes.data,
+                                   ['age', ('age', 'bmi')],
                                    grid_resolution=grid_resolution,
                                    feature_names=feature_names, ax=[ax1, ax2])
     assert fig is disp.figure_
@@ -189,7 +193,7 @@ def test_plot_partial_dependence_custom_axes(pyplot, clf_boston, boston):
     assert disp.axes_[1] is ax2
 
     ax = disp.axes_[0]
-    assert ax.get_xlabel() == "CRIM"
+    assert ax.get_xlabel() == "age"
     assert ax.get_ylabel() == "Partial dependence"
 
     line = disp.lines_[0]
@@ -205,16 +209,16 @@ def test_plot_partial_dependence_custom_axes(pyplot, clf_boston, boston):
     coutour = disp.contours_[1]
     expect_levels = np.linspace(*disp.pdp_lim[2], num=8)
     assert_allclose(coutour.levels, expect_levels)
-    assert ax.get_xlabel() == "CRIM"
-    assert ax.get_ylabel() == "ZN"
+    assert ax.get_xlabel() == "age"
+    assert ax.get_ylabel() == "bmi"
 
 
-def test_plot_partial_dependence_passing_numpy_axes(pyplot, clf_boston,
-                                                    boston):
+def test_plot_partial_dependence_passing_numpy_axes(pyplot, clf_diabetes,
+                                                    diabetes):
     grid_resolution = 25
-    feature_names = boston.feature_names.tolist()
-    disp1 = plot_partial_dependence(clf_boston, boston.data,
-                                    ['CRIM', 'ZN'],
+    feature_names = diabetes.feature_names.tolist()
+    disp1 = plot_partial_dependence(clf_diabetes, diabetes.data,
+                                    ['age', 'bmi'],
                                     grid_resolution=grid_resolution,
                                     feature_names=feature_names)
     assert disp1.axes_.shape == (1, 2)
@@ -224,10 +228,10 @@ def test_plot_partial_dependence_passing_numpy_axes(pyplot, clf_boston,
     assert len(disp1.axes_[0, 1].get_lines()) == 1
 
     lr = LinearRegression()
-    lr.fit(boston.data, boston.target)
+    lr.fit(diabetes.data, diabetes.target)
 
-    disp2 = plot_partial_dependence(lr, boston.data,
-                                    ['CRIM', 'ZN'],
+    disp2 = plot_partial_dependence(lr, diabetes.data,
+                                    ['age', 'bmi'],
                                     grid_resolution=grid_resolution,
                                     feature_names=feature_names,
                                     ax=disp1.axes_)
@@ -238,25 +242,25 @@ def test_plot_partial_dependence_passing_numpy_axes(pyplot, clf_boston,
 
 
 @pytest.mark.parametrize("nrows, ncols", [(2, 2), (3, 1)])
-def test_plot_partial_dependence_incorrent_num_axes(pyplot, clf_boston,
-                                                    boston, nrows, ncols):
+def test_plot_partial_dependence_incorrent_num_axes(pyplot, clf_diabetes,
+                                                    diabetes, nrows, ncols):
     grid_resolution = 5
     fig, axes = pyplot.subplots(nrows, ncols)
     axes_formats = [list(axes.ravel()), tuple(axes.ravel()), axes]
 
     msg = "Expected ax to have 2 axes, got {}".format(nrows * ncols)
 
-    disp = plot_partial_dependence(clf_boston, boston.data,
-                                   ['CRIM', 'ZN'],
+    disp = plot_partial_dependence(clf_diabetes, diabetes.data,
+                                   ['age', 'bmi'],
                                    grid_resolution=grid_resolution,
-                                   feature_names=boston.feature_names)
+                                   feature_names=diabetes.feature_names)
 
     for ax_format in axes_formats:
         with pytest.raises(ValueError, match=msg):
-            plot_partial_dependence(clf_boston, boston.data,
-                                    ['CRIM', 'ZN'],
+            plot_partial_dependence(clf_diabetes, diabetes.data,
+                                    ['age', 'bmi'],
                                     grid_resolution=grid_resolution,
-                                    feature_names=boston.feature_names,
+                                    feature_names=diabetes.feature_names,
                                     ax=ax_format)
 
         # with axes object
@@ -264,7 +268,8 @@ def test_plot_partial_dependence_incorrent_num_axes(pyplot, clf_boston,
             disp.plot(ax=ax_format)
 
 
-def test_plot_partial_dependence_with_same_axes(pyplot, clf_boston, boston):
+def test_plot_partial_dependence_with_same_axes(pyplot, clf_diabetes,
+                                                diabetes):
     # The first call to plot_partial_dependence will create two new axes to
     # place in the space of the passed in axes, which results in a total of
     # three axes in the figure.
@@ -278,32 +283,32 @@ def test_plot_partial_dependence_with_same_axes(pyplot, clf_boston, boston):
 
     grid_resolution = 25
     fig, ax = pyplot.subplots()
-    plot_partial_dependence(clf_boston, boston.data, ['CRIM', 'ZN'],
+    plot_partial_dependence(clf_diabetes, diabetes.data, ['age', 'bmi'],
                             grid_resolution=grid_resolution,
-                            feature_names=boston.feature_names, ax=ax)
+                            feature_names=diabetes.feature_names, ax=ax)
 
     msg = ("The ax was already used in another plot function, please set "
            "ax=display.axes_ instead")
 
     with pytest.raises(ValueError, match=msg):
-        plot_partial_dependence(clf_boston, boston.data,
-                                ['CRIM', 'ZN'],
+        plot_partial_dependence(clf_diabetes, diabetes.data,
+                                ['age', 'bmi'],
                                 grid_resolution=grid_resolution,
-                                feature_names=boston.feature_names, ax=ax)
+                                feature_names=diabetes.feature_names, ax=ax)
 
 
-def test_plot_partial_dependence_feature_name_reuse(pyplot, clf_boston,
-                                                    boston):
+def test_plot_partial_dependence_feature_name_reuse(pyplot, clf_diabetes,
+                                                    diabetes):
     # second call to plot does not change the feature names from the first
     # call
 
-    feature_names = boston.feature_names
-    disp = plot_partial_dependence(clf_boston, boston.data,
+    feature_names = diabetes.feature_names
+    disp = plot_partial_dependence(clf_diabetes, diabetes.data,
                                    [0, 1],
                                    grid_resolution=10,
                                    feature_names=feature_names)
 
-    plot_partial_dependence(clf_boston, boston.data, [0, 1],
+    plot_partial_dependence(clf_diabetes, diabetes.data, [0, 1],
                             grid_resolution=10, ax=disp.axes_)
 
     for i, ax in enumerate(disp.axes_.ravel()):
@@ -389,14 +394,14 @@ def test_plot_partial_dependence_multioutput(pyplot, target):
         assert ax.get_xlabel() == "{}".format(i)
 
 
-def test_plot_partial_dependence_dataframe(pyplot, clf_boston, boston):
+def test_plot_partial_dependence_dataframe(pyplot, clf_diabetes, diabetes):
     pd = pytest.importorskip('pandas')
-    df = pd.DataFrame(boston.data, columns=boston.feature_names)
+    df = pd.DataFrame(diabetes.data, columns=diabetes.feature_names)
 
     grid_resolution = 25
 
     plot_partial_dependence(
-        clf_boston, df, ['TAX', 'AGE'], grid_resolution=grid_resolution,
+        clf_diabetes, df, ['bp', 's1'], grid_resolution=grid_resolution,
         feature_names=df.columns.tolist()
     )
 

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -37,7 +37,8 @@ def clf_diabetes(diabetes):
 
 
 @pytest.mark.parametrize("grid_resolution", [10, 20])
-def test_plot_partial_dependence(grid_resolution, pyplot, clf_diabetes, diabetes):
+def test_plot_partial_dependence(grid_resolution, pyplot, clf_diabetes,
+                                 diabetes):
     # Test partial dependence plot function.
     # Use columns 0 & 2 as 1 is not quantitative (sex)
     feature_names = diabetes.feature_names

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -23,10 +23,7 @@ pytestmark = pytest.mark.filterwarnings(
 
 @pytest.fixture(scope="module")
 def diabetes():
-    diabetes = load_diabetes()
-    # Match type of `feature_names` of prev used `load_boston`
-    diabetes.feature_names = np.asarray(diabetes.feature_names)
-    return diabetes
+    return load_diabetes()
 
 
 @pytest.fixture(scope="module")
@@ -182,11 +179,11 @@ def test_plot_partial_dependence_str_features(pyplot, clf_diabetes, diabetes,
 def test_plot_partial_dependence_custom_axes(pyplot, clf_diabetes, diabetes):
     grid_resolution = 25
     fig, (ax1, ax2) = pyplot.subplots(1, 2)
-    feature_names = diabetes.feature_names.tolist()
     disp = plot_partial_dependence(clf_diabetes, diabetes.data,
                                    ['age', ('age', 'bmi')],
                                    grid_resolution=grid_resolution,
-                                   feature_names=feature_names, ax=[ax1, ax2])
+                                   feature_names=diabetes.feature_names,
+                                   ax=[ax1, ax2])
     assert fig is disp.figure_
     assert disp.bounding_ax_ is None
     assert disp.axes_.shape == (2, )
@@ -217,7 +214,7 @@ def test_plot_partial_dependence_custom_axes(pyplot, clf_diabetes, diabetes):
 def test_plot_partial_dependence_passing_numpy_axes(pyplot, clf_diabetes,
                                                     diabetes):
     grid_resolution = 25
-    feature_names = diabetes.feature_names.tolist()
+    feature_names = diabetes.feature_names
     disp1 = plot_partial_dependence(clf_diabetes, diabetes.data,
                                     ['age', 'bmi'],
                                     grid_resolution=grid_resolution,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Towards #16155 

#### What does this implement/fix? Explain your changes.
Replaces Boston dataset with diabetes dataset in `test_plot_partial_dependence.py`.

#### Any other comments?
Col 1 of diabetes is not quantitative (sex), thus used columns 0 & 2 instead of 0 & 1.
`feature_names` of Boston is of type `numpy.ndarray` while for diabetes it is a `list`. Amended diabetes `feature_names` to type numpy array (in this test) instead of changing the original tests.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
