### PR TITLE
Python wrapper and tests for sklearn/svm/newrand/

### DIFF
--- a/sklearn/svm/_newrand.pyx
+++ b/sklearn/svm/_newrand.pyx
@@ -4,11 +4,11 @@ Wrapper for newrand.h
 """
 
 cdef extern from "newrand.h":
-	void set_seed(unsigned)
-	int bounded_rand_int(int)
+	void set_seed(unsigned int)
+	unsigned int bounded_rand_int(unsigned int)
 
-def set_seed_wrap(unsigned custom_seed):
+def set_seed_wrap(unsigned int custom_seed):
 	set_seed(custom_seed)
 
-def bounded_rand_int_wrap(int orig_range):
-	return bounded_rand_int(orig_range)
+def bounded_rand_int_wrap(unsigned int range_):
+	return bounded_rand_int(range_)

--- a/sklearn/svm/_newrand.pyx
+++ b/sklearn/svm/_newrand.pyx
@@ -1,4 +1,3 @@
-# language: c++
 """
 Wrapper for newrand.h
 

--- a/sklearn/svm/_newrand.pyx
+++ b/sklearn/svm/_newrand.pyx
@@ -1,10 +1,11 @@
+# language: c++
 """
 Wrapper for newrand.h
 
 """
 
-cdef extern from "newrand-cache.h":
-	void set_seed(int)
+cdef extern from "newrand.h":
+	void set_seed(unsigned)
 	int bounded_rand_int(int)
 
 def set_seed_wrap(unsigned custom_seed):

--- a/sklearn/svm/_newrand.pyx
+++ b/sklearn/svm/_newrand.pyx
@@ -1,0 +1,14 @@
+"""
+Wrapper for newrand.h
+
+"""
+
+cdef extern from "newrand-cache.h":
+	void set_seed(int)
+	int bounded_rand_int(int)
+
+def set_seed_wrap(unsigned custom_seed):
+	set_seed(custom_seed)
+
+def bounded_rand_int_wrap(int orig_range):
+	return bounded_rand_int(orig_range)

--- a/sklearn/svm/setup.py
+++ b/sklearn/svm/setup.py
@@ -41,6 +41,17 @@ def configuration(parent_package='', top_path=None):
                          depends=libsvm_depends,
                          )
 
+    config.add_extension('_newrand',
+                         sources=['_newrand.pyx'],
+                         include_dirs=[numpy.get_include(),
+                                       join('src', 'libsvm'),
+                                       join('src', 'newrand')],
+                         libraries=['libsvm-skl'],
+                         depends=[join('src', 'newrand', 'newrand.h'),
+                                  join('src', 'newrand', 'newrand-cache.cpp'),
+                                  join('src', 'newrand', 'newrand-cache.h')],
+                         )
+
     # liblinear module
     libraries = []
     if os.name == 'posix':

--- a/sklearn/svm/setup.py
+++ b/sklearn/svm/setup.py
@@ -47,9 +47,8 @@ def configuration(parent_package='', top_path=None):
                                        join('src', 'libsvm'),
                                        join('src', 'newrand')],
                          libraries=['libsvm-skl'],
-                         depends=[join('src', 'newrand', 'newrand.h'),
-                                  join('src', 'newrand', 'newrand-cache.cpp'),
-                                  join('src', 'newrand', 'newrand-cache.h')],
+                         depends=[join('src', 'newrand', 'newrand.h')],
+                         language='c++',
                          )
 
     # liblinear module

--- a/sklearn/svm/setup.py
+++ b/sklearn/svm/setup.py
@@ -10,6 +10,15 @@ def configuration(parent_package='', top_path=None):
 
     config.add_subpackage('tests')
 
+    # newrand wrappers
+    config.add_extension('_newrand',
+                         sources=['_newrand.pyx'],
+                         include_dirs=[numpy.get_include(),
+                                       join('src', 'newrand')],
+                         depends=[join('src', 'newrand', 'newrand.h')],
+                         language='c++',
+                         )
+
     # Section LibSVM
 
     # we compile both libsvm and libsvm_sparse
@@ -39,16 +48,6 @@ def configuration(parent_package='', top_path=None):
                                        join('src', 'newrand')],
                          libraries=['libsvm-skl'],
                          depends=libsvm_depends,
-                         )
-
-    config.add_extension('_newrand',
-                         sources=['_newrand.pyx'],
-                         include_dirs=[numpy.get_include(),
-                                       join('src', 'libsvm'),
-                                       join('src', 'newrand')],
-                         libraries=['libsvm-skl'],
-                         depends=[join('src', 'newrand', 'newrand.h')],
-                         language='c++',
                          )
 
     # liblinear module

--- a/sklearn/svm/src/newrand/newrand.h
+++ b/sklearn/svm/src/newrand/newrand.h
@@ -33,7 +33,7 @@ void set_seed(unsigned custom_seed) {
 }
 
 // - (3) New internal `bounded_rand_int` function, used instead of rand() everywhere.
-inline int bounded_rand_int(int orig_range) {
+int bounded_rand_int(int orig_range) {
     // "LibSVM / LibLinear Original way" - make a 31bit or 63bit positive
     // random number and use modulo to make it fit in the range
     // return abs( (int)mt_rand()) % orig_range;

--- a/sklearn/svm/src/newrand/newrand.h
+++ b/sklearn/svm/src/newrand/newrand.h
@@ -10,7 +10,7 @@
 #define _NEWRAND_H
 
 #ifdef __cplusplus
-#include <random>
+#include <random>  // needed for cython to generate a .cpp file from newrand.h
 extern "C" {
 #endif
 

--- a/sklearn/svm/src/newrand/newrand.h
+++ b/sklearn/svm/src/newrand/newrand.h
@@ -18,14 +18,7 @@ extern "C" {
 // used in LibSVM / LibLinear, to ensure the same behaviour on windows-linux,
 // with increased speed
 // - (1) Init a `mt_rand` object
-#if INT_MAX == 0x7FFFFFFF
 std::mt19937 mt_rand(std::mt19937::default_seed);
-#elif INT_MAX == 0x7FFFFFFFFFFFFFFF
-std::mt19937_64 mt_rand(std::mt19937::default_seed);
-#else
-info("Random number generator is not fixed for this system. Please report issue. INT_MAX=%d\n", INT_MAX);
-exit(1);
-#endif
 
 // - (2) public `set_seed()` function that should be used instead of `srand()` to set a new seed.
 void set_seed(unsigned custom_seed) {
@@ -33,15 +26,13 @@ void set_seed(unsigned custom_seed) {
 }
 
 // - (3) New internal `bounded_rand_int` function, used instead of rand() everywhere.
-inline int bounded_rand_int(int orig_range) {
-    // "LibSVM / LibLinear Original way" - make a 31bit or 63bit positive
+inline uint32_t bounded_rand_int(uint32_t range) {
+    // "LibSVM / LibLinear Original way" - make a 31bit positive
     // random number and use modulo to make it fit in the range
-    // return abs( (int)mt_rand()) % orig_range;
+    // return abs( (int)mt_rand()) % range;
 
     // "Better way": tweaked Lemire post-processor
     // from http://www.pcg-random.org/posts/bounded-rands.html
-    // TODO how could we make this casting safer, raising an error if lost information?
-    uint32_t range = uint32_t(orig_range);
     uint32_t x = mt_rand();
     uint64_t m = uint64_t(x) * uint64_t(range);
     uint32_t l = uint32_t(m);

--- a/sklearn/svm/src/newrand/newrand.h
+++ b/sklearn/svm/src/newrand/newrand.h
@@ -5,12 +5,12 @@
      libsvm and liblinear.
      Sylvain Marie, Schneider Electric
      See <https://github.com/scikit-learn/scikit-learn/pull/13511#issuecomment-481729756>
-
  */
 #ifndef _NEWRAND_H
 #define _NEWRAND_H
 
 #ifdef __cplusplus
+#include <random>
 extern "C" {
 #endif
 
@@ -33,7 +33,7 @@ void set_seed(unsigned custom_seed) {
 }
 
 // - (3) New internal `bounded_rand_int` function, used instead of rand() everywhere.
-int bounded_rand_int(int orig_range) {
+inline int bounded_rand_int(int orig_range) {
     // "LibSVM / LibLinear Original way" - make a 31bit or 63bit positive
     // random number and use modulo to make it fit in the range
     // return abs( (int)mt_rand()) % orig_range;

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -113,8 +113,8 @@ def test_bounded_rand_int(orig_range, n_pts):
     # Null hypothesis = samples come from an uniform distribution.
     # Under the null hypothesis, p-values should be uniformly distributed and not concentrated 
     # on low values (this may seem counter-intuitive but is backed by multiple refs)
-    # So we can do two checks: 
-    
+    # So we can do two checks:
+
     # (1) check uniformity of p-values 
     uniform_p_vals_dist = stats.uniform(loc=0, scale=1)
     res_pvals = stats.kstest(ks_pvals, uniform_p_vals_dist.cdf)
@@ -122,7 +122,7 @@ def test_bounded_rand_int(orig_range, n_pts):
         "Null hypothesis rejected: generated random numbers are not uniform."\
         " Details: the (meta) p-value of the test of uniform distribution of p-values"\
         " is {} which is not > 0.05".format(res_pvals.pvalue)
-    
+
     # (2) (safety belt) check that most p-values are above 0.05
     min_10pct_pval = np.percentile(ks_pvals, q=10)
     # lower 10th quantile pvalue <= 0.05 means that the test rejects the

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -6,8 +6,8 @@ import pytest
 
 from sklearn.svm._bounds import l1_min_c
 from sklearn.svm import LinearSVC
-from sklearn.svm._newrand import set_seed_wrap, bounded_rand_int_wrap
 from sklearn.linear_model import LogisticRegression
+from sklearn.svm._newrand import bounded_rand_int_wrap
 
 from sklearn.utils._testing import assert_raise_message
 
@@ -78,34 +78,38 @@ def test_unsupported_loss():
         l1_min_c(dense_X, Y1, loss='l1')
 
 
-def test_set_seed():
-    def _test(seed, val):
-        # TODO currently causes 99% coverage in test_bounds.py
-        if seed is not None:
-            set_seed_wrap(seed)
-        x = bounded_rand_int_wrap(100)
-        assert(x == val), 'Expected {} but got {} instead'.format(val, x)
+# TODO test deterministic results on differing systems
+# def test_set_seed():
+#     def _test(seed, val):
+#         # TODO currently causes 99% coverage in test_bounds.py
+#         if seed is not None:
+#             set_seed_wrap(seed)
+#         x = bounded_rand_int_wrap(100)
+#         assert(x == val), 'Expected {} but got {} instead'.format(val, x)
 
-    # TODO should be default seed for std::mt19937,
-    # but different results on jupyter lab
-    # _test(None, 81)
-    _test(5489, 81)  # default seed for std::mt19937
-    _test(0, 54)
-    _test(4294967295, 9)  # max unsigned int size
+#     # TODO should be default seed for std::mt19937,
+#     # but different results on jupyter lab
+#     # _test(None, 81)
+#     _test(5489, 81)  # default seed for std::mt19937
+#     _test(0, 54)
+#     _test(4294967295, 9)  # max unsigned int size
 
 
 def test_bounded_rand_int():
-    orig_range = 2147483647  # max int as input to bounded_rand_int
-    n_pts = 1000
-    n_iter = 100
-    ks_pvals = []
-    uniform_dist = stats.uniform(loc=0, scale=orig_range)
-    for _ in range(n_iter):
-        # Deterministic random sampling
-        sample = [bounded_rand_int_wrap(orig_range) for _ in range(n_pts)]
-        res = stats.kstest(sample, uniform_dist.cdf)
-        ks_pvals.append(res.pvalue)
-    avg_pval = np.mean(ks_pvals)
-    assert(avg_pval > 0.05),\
-        'p-value of {} not > 0.05, '\
-        'therefore distribution isn\'t uniform'.format(avg_pval)
+    def _test(orig_range):
+        n_pts = 1000
+        n_iter = 100
+        ks_pvals = []
+        uniform_dist = stats.uniform(loc=0, scale=orig_range)
+        # avg over multiple tests to make chance of outlier result negligible
+        for _ in range(n_iter):
+            # Deterministic random sampling
+            sample = [bounded_rand_int_wrap(orig_range) for _ in range(n_pts)]
+            res = stats.kstest(sample, uniform_dist.cdf)
+            ks_pvals.append(res.pvalue)
+        avg_pval = np.mean(ks_pvals)
+        assert(avg_pval > 0.05),\
+            'p-value of {} not > 0.05, '\
+            'therefore distribution isn\'t uniform'.format(avg_pval)
+    _test(2147483647)  # max int
+    _test(100)  # arbitrary less than max max int

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -111,11 +111,13 @@ def test_bounded_rand_int(orig_range, n_pts):
         res = stats.kstest(sample, uniform_dist.cdf)
         ks_pvals.append(res.pvalue)
     # Null hypothesis = samples come from an uniform distribution.
-    # Under the null hypothesis, p-values should be uniformly distributed and not concentrated 
-    # on low values (this may seem counter-intuitive but is backed by multiple refs)
+    # Under the null hypothesis,
+    #   p-values should be uniformly distributed and not concentrated
+    # on low values
+    #   (this may seem counter-intuitive but is backed by multiple refs)
     # So we can do two checks:
 
-    # (1) check uniformity of p-values 
+    # (1) check uniformity of p-values
     uniform_p_vals_dist = stats.uniform(loc=0, scale=1)
     res_pvals = stats.kstest(ks_pvals, uniform_p_vals_dist.cdf)
     assert res_pvals.pvalue > 0.05,\

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -128,7 +128,7 @@ def test_newrand_bounded_rand_int(range_, n_pts):
         " Details: the (meta) p-value of the test of uniform distribution"\
         " of p-values is {} which is not > 0.05".format(res_pvals.pvalue)
 
-    # (2) (safety belt) check that most p-values are above 0.05
+    # (2) (safety belt) check that 90% of p-values are above 0.05
     min_10pct_pval = np.percentile(ks_pvals, q=10)
     # lower 10th quantile pvalue <= 0.05 means that the test rejects the
     # null hypothesis that the sample came from the uniform distribution

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -133,8 +133,9 @@ def test_newrand_bounded_rand_int(range_, n_pts):
     # lower 10th quantile pvalue <= 0.05 means that the test rejects the
     # null hypothesis that the sample came from the uniform distribution
     assert min_10pct_pval > 0.05, (
-        "Null hypothesis rejected: generated random numbers are not uniform."
-        f" Details: lower 10th quantile p-value of {min_10pct_pval} not > 0.05.")
+        "Null hypothesis rejected: generated random numbers are not uniform. "
+        f"Details: lower 10th quantile p-value of {min_10pct_pval} not > 0.05."
+        )
 
 
 @pytest.mark.parametrize('range_',

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -86,9 +86,9 @@ def test_set_seed():
         x = bounded_rand_int_wrap(100)
         assert(x == val), 'Expected {} but got {} instead'.format(val, x)
 
-    # _test(None, 81)
     # TODO should be default seed for std::mt19937,
     # but different results on jupyter lab
+    # _test(None, 81)
     _test(5489, 81)  # default seed for std::mt19937
     _test(0, 54)
     _test(4294967295, 9)  # max unsigned int size

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -78,24 +78,19 @@ def test_unsupported_loss():
         l1_min_c(dense_X, Y1, loss='l1')
 
 
-# TODO test deterministic results on differing systems
-# def test_set_seed():
-#     def _test(seed, val):
-#         # TODO currently causes 99% coverage in test_bounds.py
-#         if seed is not None:
-#             set_seed_wrap(seed)
-#         x = bounded_rand_int_wrap(100)
-#         assert(x == val), 'Expected {} but got {} instead'.format(val, x)
-
-#     # TODO should be default seed for std::mt19937,
-#     # but different results on jupyter lab
-#     # _test(None, 81)
-#     _test(5489, 81)  # default seed for std::mt19937
-#     _test(0, 54)
-#     _test(4294967295, 9)  # max unsigned int size
-
-
+_MAX_UNSIGNED_INT = 4294967295
 _MAX_INT = 2147483647
+
+
+@pytest.mark.parametrize('seed, val',
+                         [(None, 81),
+                          (0, 54),
+                          (_MAX_UNSIGNED_INT, 9)])
+def test_set_seed(seed, val32, val64):
+    if seed is not None:
+        set_seed_wrap(seed)
+    x = bounded_rand_int_wrap(100)
+    assert(x == val), 'Expected {} but got {} instead'.format(val, x)
 
 
 @pytest.mark.parametrize('orig_range, n_pts',

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -96,6 +96,8 @@ def test_unsupported_loss():
 
 
 _MAX_INT = 2147483647
+
+
 @pytest.mark.parametrize('orig_range, n_pts',
                          [(_MAX_INT, 10000), (100, 10)])
 def test_bounded_rand_int(orig_range, n_pts):

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -102,7 +102,7 @@ def test_newrand_set_seed_overflow(seed):
 
 
 @pytest.mark.parametrize('range_, n_pts',
-                         [(_MAX_UNSIGNED_INT, 10000), (100, 10)])
+                         [(_MAX_UNSIGNED_INT, 10000), (100, 25)])
 def test_newrand_bounded_rand_int(range_, n_pts):
     """Test that `bounded_rand_int` follows a uniform distribution"""
     n_iter = 100

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -95,21 +95,22 @@ def test_unsupported_loss():
 #     _test(4294967295, 9)  # max unsigned int size
 
 
-def test_bounded_rand_int():
-    def _test(orig_range):
-        n_pts = 1000
-        n_iter = 100
-        ks_pvals = []
-        uniform_dist = stats.uniform(loc=0, scale=orig_range)
-        # avg over multiple tests to make chance of outlier result negligible
-        for _ in range(n_iter):
-            # Deterministic random sampling
-            sample = [bounded_rand_int_wrap(orig_range) for _ in range(n_pts)]
-            res = stats.kstest(sample, uniform_dist.cdf)
-            ks_pvals.append(res.pvalue)
-        avg_pval = np.mean(ks_pvals)
-        assert(avg_pval > 0.05),\
-            'p-value of {} not > 0.05, '\
-            'therefore distribution isn\'t uniform'.format(avg_pval)
-    _test(2147483647)  # max int
-    _test(100)  # arbitrary less than max max int
+_MAX_INT = 2147483647
+
+
+@pytest.mark.parametrize("orig_range", [_MAX_INT, 100])
+def test_bounded_rand_int(orig_range):
+    n_pts = 1000
+    n_iter = 100
+    ks_pvals = []
+    uniform_dist = stats.uniform(loc=0, scale=orig_range)
+    # avg over multiple tests to make chance of outlier result negligible
+    for _ in range(n_iter):
+        # Deterministic random sampling
+        sample = [bounded_rand_int_wrap(orig_range) for _ in range(n_pts)]
+        res = stats.kstest(sample, uniform_dist.cdf)
+        ks_pvals.append(res.pvalue)
+    avg_pval = np.mean(ks_pvals)
+    assert(avg_pval > 0.05),\
+        'p-value of {} not > 0.05, '\
+        'therefore distribution isn\'t uniform'.format(avg_pval)

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -122,8 +122,8 @@ def test_bounded_rand_int(orig_range, n_pts):
     res_pvals = stats.kstest(ks_pvals, uniform_p_vals_dist.cdf)
     assert res_pvals.pvalue > 0.05,\
         "Null hypothesis rejected: generated random numbers are not uniform."\
-        " Details: the (meta) p-value of the test of uniform distribution of p-values"\
-        " is {} which is not > 0.05".format(res_pvals.pvalue)
+        " Details: the (meta) p-value of the test of uniform distribution"\
+        " of p-values is {} which is not > 0.05".format(res_pvals.pvalue)
 
     # (2) (safety belt) check that most p-values are above 0.05
     min_10pct_pval = np.percentile(ks_pvals, q=10)

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -7,7 +7,7 @@ import pytest
 from sklearn.svm._bounds import l1_min_c
 from sklearn.svm import LinearSVC
 from sklearn.linear_model import LogisticRegression
-from sklearn.svm._newrand import bounded_rand_int_wrap
+from sklearn.svm._newrand import set_seed_wrap, bounded_rand_int_wrap
 
 from sklearn.utils._testing import assert_raise_message
 
@@ -86,7 +86,7 @@ _MAX_INT = 2147483647
                          [(None, 81),
                           (0, 54),
                           (_MAX_UNSIGNED_INT, 9)])
-def test_set_seed(seed, val32, val64):
+def test_set_seed(seed, val):
     if seed is not None:
         set_seed_wrap(seed)
     x = bounded_rand_int_wrap(100)

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -90,7 +90,7 @@ def test_newrand_set_seed(seed, val):
     if seed is not None:
         set_seed_wrap(seed)
     x = bounded_rand_int_wrap(100)
-    assert(x == val), 'Expected {} but got {} instead'.format(val, x)
+    assert x == val, f'Expected {val} but got {x} instead'
 
 
 @pytest.mark.parametrize('seed',

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -123,19 +123,18 @@ def test_newrand_bounded_rand_int(range_, n_pts):
     # (1) check uniformity of p-values
     uniform_p_vals_dist = stats.uniform(loc=0, scale=1)
     res_pvals = stats.kstest(ks_pvals, uniform_p_vals_dist.cdf)
-    assert res_pvals.pvalue > 0.05,\
-        "Null hypothesis rejected: generated random numbers are not uniform."\
-        " Details: the (meta) p-value of the test of uniform distribution"\
-        " of p-values is {} which is not > 0.05".format(res_pvals.pvalue)
+    assert res_pvals.pvalue > 0.05, (
+        "Null hypothesis rejected: generated random numbers are not uniform."
+        " Details: the (meta) p-value of the test of uniform distribution"
+        f" of p-values is {res_pvals.pvalue} which is not > 0.05")
 
     # (2) (safety belt) check that 90% of p-values are above 0.05
     min_10pct_pval = np.percentile(ks_pvals, q=10)
     # lower 10th quantile pvalue <= 0.05 means that the test rejects the
     # null hypothesis that the sample came from the uniform distribution
-    assert(min_10pct_pval > 0.05),\
-        "Null hypothesis rejected: generated random numbers are not uniform." \
-        " Details: lower 10th quantile p-value of {} not > 0.05."\
-        .format(min_10pct_pval)
+    assert min_10pct_pval > 0.05, (
+        "Null hypothesis rejected: generated random numbers are not uniform."
+        f" Details: lower 10th quantile p-value of {min_10pct_pval} not > 0.05.")
 
 
 @pytest.mark.parametrize('range_',

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -110,7 +110,7 @@ def test_bounded_rand_int(orig_range, n_pts):
         sample = [bounded_rand_int_wrap(orig_range) for _ in range(n_pts)]
         res = stats.kstest(sample, uniform_dist.cdf)
         ks_pvals.append(res.pvalue)
-    min_10pct_pval = np.quantile(ks_pvals, q=0.1)
+    min_10pct_pval = np.percentile(ks_pvals, q=10)
     # lower 10th quantile pvalue <= 0.05 means that the test rejects the
     # null hypothesis that the sample came from the uniform distribution
     assert(min_10pct_pval > 0.05),\


### PR DESCRIPTION
#### Reference Issues/PRs
Resolves #16862

#### What does this implement/fix? Explain your changes.
Created a python wrapper and tests for sklearn/svm/newrand/
Test that newrand creates an unbiased distribution of random numbers in the given range by comparing a deterministic sampling against scipy's scipy.stats.uniform using scipy.stats.kstest (kolmogorov-smirnov test) at a significance level of 0.05.