### PR TITLE
[MRG] Use sample weight probability for tree predictions

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -469,6 +469,7 @@ def _accumulate_prediction(predict, X, out, lock, out_sample_weight=None):
     else:
         prediction = predict(X, check_input=False)
     with lock:
+        print(out, len(out))
         if len(out) == 1:
             if out_sample_weight:
                 out[0] += proba * normalizer[:, np.newaxis]
@@ -476,13 +477,8 @@ def _accumulate_prediction(predict, X, out, lock, out_sample_weight=None):
             else:
                 out[0] += prediction
         else:
-            if out_sample_weight:
-                for i in range(len(out)):
-                    out[i] += proba[i] * normalizer[i][:, np.newaxis]
-                    out_sample_weight[i] += normalizer[i]
-            else:
-                for i in range(len(out)):
-                    out[i] += prediction[i]
+            for i in range(len(out)):
+                out[i] += prediction[i]
 
 
 class ForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -469,7 +469,6 @@ def _accumulate_prediction(predict, X, out, lock, out_sample_weight=None):
     else:
         prediction = predict(X, check_input=False)
     with lock:
-        print(out, len(out))
         if len(out) == 1:
             if out_sample_weight:
                 out[0] += proba * normalizer[:, np.newaxis]

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -117,11 +117,13 @@ def check_classification_toy(name):
     clf = ForestClassifier(n_estimators=10, random_state=1)
     clf.fit(X, y)
     assert_array_equal(clf.predict(T), true_result)
+    assert_array_equal(clf.predict(T, use_sample_weight=True), true_result)
     assert 10 == len(clf)
 
     clf = ForestClassifier(n_estimators=10, max_features=1, random_state=1)
     clf.fit(X, y)
     assert_array_equal(clf.predict(T), true_result)
+    assert_array_equal(clf.predict(T, use_sample_weight=True), true_result)
     assert 10 == len(clf)
 
     # also test apply
@@ -209,6 +211,9 @@ def check_probability(name):
         clf.fit(iris.data, iris.target)
         assert_array_almost_equal(np.sum(clf.predict_proba(iris.data), axis=1),
                                   np.ones(iris.data.shape[0]))
+        assert_array_almost_equal(np.sum(clf.predict_proba(iris.data,
+                                  use_sample_weight=True),
+                                  axis=1), np.ones(iris.data.shape[0]))
         assert_array_almost_equal(clf.predict_proba(iris.data),
                                   np.exp(clf.predict_log_proba(iris.data)))
 
@@ -467,9 +472,15 @@ def check_parallel(name, X, y):
 
     forest.set_params(n_jobs=1)
     y1 = forest.predict(X)
+    if name in FOREST_CLASSIFIERS:
+        y1_sample_weights = forest.predict(X, use_sample_weight=True)
     forest.set_params(n_jobs=2)
     y2 = forest.predict(X)
+    if name in FOREST_CLASSIFIERS:
+        y2_sample_weights = forest.predict(X, use_sample_weight=True)
     assert_array_almost_equal(y1, y2, 3)
+    if name in FOREST_CLASSIFIERS:
+        assert_array_almost_equal(y1_sample_weights, y2_sample_weights, 3)
 
 
 @pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
@@ -533,6 +544,10 @@ def check_multioutput(name):
             assert log_proba[0].shape == (4, 2)
             assert log_proba[1].shape == (4, 4)
 
+            msg = "Not supported for multi-output classification."
+            with pytest.raises(ValueError, match=msg):
+                est.predict_proba(X_test, use_sample_weight=True)
+
 
 @pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
 def test_multioutput(name):
@@ -567,6 +582,10 @@ def test_multioutput_string(name):
         assert len(log_proba) == 2
         assert log_proba[0].shape == (4, 2)
         assert log_proba[1].shape == (4, 4)
+
+        msg = "Not supported for multi-output classification."
+        with pytest.raises(ValueError, match=msg):
+            est.predict_proba(X_test, use_sample_weight=True)
 
 
 def check_classes_shape(name):
@@ -845,6 +864,7 @@ def check_min_weight_fraction_leaf(name):
             total_weight * est.min_weight_fraction_leaf), (
                 "Failed with {0} min_weight_fraction_leaf={1}".format(
                     name, est.min_weight_fraction_leaf))
+
 
 @pytest.mark.parametrize('name', FOREST_ESTIMATORS)
 def test_min_weight_fraction_leaf(name):

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -300,6 +300,29 @@ def test_probability():
                             err_msg="Failed with {0}".format(name))
 
 
+def test_probability_using_sample_weights():
+    # Predict probabilities with sample weights with toy example
+
+    for name, Tree in CLF_TREES.items():
+        clf = Tree(random_state=0)
+        clf.fit(X, y)
+        sample_weight_element0 = np.array([[1., 0.], [0., 1.], [0., 1.]])
+        sample_weight_element1_dt = np.array([3., 3., 3.])
+        sample_weight_element1_et = np.array([2., 3., 3.])
+        assert_array_equal(clf.predict_proba(T, use_sample_weight=True)[0],
+                           sample_weight_element0,
+                           "Failed with {0}".format(name))
+
+        if name == 'DecisionTreeClassifier':
+            assert_array_equal(clf.predict_proba(T, use_sample_weight=True)[1],
+                               sample_weight_element1_dt,
+                               "Failed with {0}".format(name))
+        else:
+            assert_array_equal(clf.predict_proba(T, use_sample_weight=True)[1],
+                               sample_weight_element1_et,
+                               "Failed with {0}".format(name))
+
+
 def test_arrayrepr():
     # Check the array representation.
     # Check resize


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
I want to fix #15934 so that my test commits doesn't show up anymore.

#### What does this implement/fix? Explain your changes.
Forest ensembles take the mean of class weights from each tree, which may sometimes be problematic. For example, in a trained forest at prediction time, the input sample falls into a leaf with 5 samples from the training set in the first tree while it falls into a leaf with 5000 samples from the training set in the second tree. With the current implementations, this difference in sample size from the training examples are not taken into consideration when making predictions. The method predict_proba_with_sample_weight will allow all forest ensembles to predict class probabilities with each tree's vote weighted by how many times it's seen similar data points in the training set (number of samples in the leaf the input sample falls into). Users can also call the predict function in classification problems with sample_weight set to True, this will call the function predict_proba_with_sample_weight in place of predict_proba.

#### Any other comments?
See also #15934

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
