### PR TITLE
[DOC] Issue #14312 - Ensure All Attributes are Documented: OAS: location_ added 

### DIFF
--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -82,11 +82,11 @@ class ShrunkCovariance(EmpiricalCovariance):
 
     Attributes
     ----------
-    location_ : ndarray of shape (n_features,)
-        Estimated location, i.e. the estimated mean.
-
     covariance_ : ndarray of shape (n_features, n_features)
         Estimated covariance matrix
+
+    location_ : ndarray of shape (n_features,)
+        Estimated location, i.e. the estimated mean.
 
     precision_ : ndarray of shape (n_features, n_features)
         Estimated pseudo inverse matrix.
@@ -344,11 +344,11 @@ class LedoitWolf(EmpiricalCovariance):
 
     Attributes
     ----------
-    location_ : ndarray of shape (n_features,)
-        Estimated location, i.e. the estimated mean.
-
     covariance_ : ndarray of shape (n_features, n_features)
         Estimated covariance matrix.
+
+    location_ : ndarray of shape (n_features,)
+        Estimated location, i.e. the estimated mean.
 
     precision_ : ndarray of shape (n_features, n_features)
         Estimated pseudo inverse matrix.
@@ -525,6 +525,9 @@ class OAS(EmpiricalCovariance):
     ----------
     covariance_ : ndarray of shape (n_features, n_features)
         Estimated covariance matrix.
+
+    location_ : ndarray of shape (n_features,)
+        Estimated location, i.e. the estimated mean.
 
     precision_ : ndarray of shape (n_features, n_features)
         Estimated pseudo inverse matrix.

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -82,11 +82,11 @@ class ShrunkCovariance(EmpiricalCovariance):
 
     Attributes
     ----------
-    location_ : ndarray of shape (n_features,)
-        Estimated location, i.e. the estimated mean.
-
     covariance_ : ndarray of shape (n_features, n_features)
         Estimated covariance matrix
+
+    location_ : ndarray of shape (n_features,)
+        Estimated location, i.e. the estimated mean.
 
     precision_ : ndarray of shape (n_features, n_features)
         Estimated pseudo inverse matrix.
@@ -344,11 +344,11 @@ class LedoitWolf(EmpiricalCovariance):
 
     Attributes
     ----------
+    covariance_ : ndarray of shape (n_features, n_features)
+    Estimated covariance matrix.
+
     location_ : ndarray of shape (n_features,)
         Estimated location, i.e. the estimated mean.
-
-    covariance_ : ndarray of shape (n_features, n_features)
-        Estimated covariance matrix.
 
     precision_ : ndarray of shape (n_features, n_features)
         Estimated pseudo inverse matrix.
@@ -525,6 +525,9 @@ class OAS(EmpiricalCovariance):
     ----------
     covariance_ : ndarray of shape (n_features, n_features)
         Estimated covariance matrix.
+
+    location_ : ndarray of shape (n_features,)
+        Estimated location, i.e. the estimated mean.
 
     precision_ : ndarray of shape (n_features, n_features)
         Estimated pseudo inverse matrix.

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -239,7 +239,7 @@ def test_fit_docstring_attributes(name, Estimator):
                'MiniBatchKMeans', 'MLPClassifier', 'MLPRegressor',
                'MultiTaskElasticNet', 'MultiTaskElasticNetCV',
                'MultiTaskLasso', 'MultiTaskLassoCV', 'NearestNeighbors',
-               'NuSVR', 'OAS', 'OneClassSVM', 'OrthogonalMatchingPursuit',
+               'NuSVR', 'OneClassSVM', 'OrthogonalMatchingPursuit',
                'PLSCanonical', 'PLSRegression', 'PLSSVD',
                'PassiveAggressiveClassifier', 'Perceptron', 'RBFSampler',
                'RadiusNeighborsClassifier', 'RadiusNeighborsRegressor',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Issue #14312
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This adds documentation for an attribute of the OAS function and reorders attributes of ShrunkCovariance and LedoitWolf in alphabetical order. 

- OAS: location_ attribute added (covariance_,location_,precision_)
- ShrunkCovariance: attributes now in alphabetical order (covariance_,location_,precision_)
- LedoitWolf: attributes now in alphabetical order (covariance_,location_,precision_,shrinkage_)

#### Any other comments?

ShrunkCovariance: --> shrinkage seems to be a false positive, as it is not an attribute but a parameter for ShrunkCovariance. Hence, shrinkage wasn't added to attributes. 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
