### PR TITLE
_xfail_tests -> _xfail_checks & revert changes to check_estimator

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -235,7 +235,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin,
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1211,7 +1211,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }
@@ -1876,7 +1876,7 @@ class MiniBatchKMeans(KMeans):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -478,7 +478,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -2086,7 +2086,7 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -505,7 +505,7 @@ class RANSACRegressor(MetaEstimatorMixin, RegressorMixin,
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1912,7 +1912,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1096,7 +1096,7 @@ class SGDClassifier(BaseSGDClassifier):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }
@@ -1586,7 +1586,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -277,7 +277,7 @@ class KernelDensity(BaseEstimator):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'sample_weight must have positive values',
             }

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -246,7 +246,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }
@@ -434,7 +434,7 @@ class LinearSVR(RegressorMixin, LinearModel):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }
@@ -668,7 +668,7 @@ class SVC(BaseSVC):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }
@@ -1055,7 +1055,7 @@ class SVR(RegressorMixin, BaseLibSVM):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }
@@ -1193,7 +1193,7 @@ class NuSVR(RegressorMixin, BaseLibSVM):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }
@@ -1416,7 +1416,7 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
 
     def _more_tags(self):
         return {
-            '_xfail_test': {
+            '_xfail_checks': {
                 'check_sample_weights_invariance(kind=zeros)':
                 'zero sample_weight is not equivalent to removing samples',
             }

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -434,17 +434,20 @@ def parametrize_with_checks(estimators):
 
 def check_estimator(Estimator, generate_only=False):
     """Check if estimator adheres to scikit-learn conventions.
+
     This estimator will run an extensive test-suite for input validation,
     shapes, etc, making sure that the estimator complies with `scikit-learn`
     conventions as detailed in :ref:`rolling_your_own_estimator`.
     Additional tests for classifiers, regressors, clustering or transformers
     will be run if the Estimator class inherits from the corresponding mixin
     from sklearn.base.
+
     This test can be applied to classes or instances.
     Classes currently have some additional tests that related to construction,
     while passing instances allows the testing of multiple options. However,
     support for classes is deprecated since version 0.23 and will be removed
     in version 0.24 (class checks will still be run on the instances).
+
     Setting `generate_only=True` returns a generator that yields (estimator,
     check) tuples where the check can be called independently from each
     other, i.e. `check(estimator)`. This allows all checks to be run
@@ -452,19 +455,23 @@ def check_estimator(Estimator, generate_only=False):
     scikit-learn provides a pytest specific decorator,
     :func:`~sklearn.utils.parametrize_with_checks`, making it easier to test
     multiple estimators.
+
     Parameters
     ----------
     estimator : estimator object
         Estimator to check. Estimator is a class object or instance.
+
         .. deprecated:: 0.23
            Passing a class is deprecated from version 0.23, and won't be
            supported in 0.24. Pass an instance instead.
+
     generate_only : bool, optional (default=False)
         When `False`, checks are evaluated when `check_estimator` is called.
         When `True`, `check_estimator` returns a generator that yields
         (estimator, check) tuples. The check is run by calling
         `check(estimator)`.
         .. versionadded:: 0.22
+
     Returns
     -------
     checks_generator : generator

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -452,6 +452,7 @@ def check_estimator(Estimator, generate_only=False):
     check) tuples where the check can be called independently from each
     other, i.e. `check(estimator)`. This allows all checks to be run
     independently and report the checks that are failing.
+
     scikit-learn provides a pytest specific decorator,
     :func:`~sklearn.utils.parametrize_with_checks`, making it easier to test
     multiple estimators.
@@ -470,6 +471,7 @@ def check_estimator(Estimator, generate_only=False):
         When `True`, `check_estimator` returns a generator that yields
         (estimator, check) tuples. The check is run by calling
         `check(estimator)`.
+
         .. versionadded:: 0.22
 
     Returns

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -434,46 +434,37 @@ def parametrize_with_checks(estimators):
 
 def check_estimator(Estimator, generate_only=False):
     """Check if estimator adheres to scikit-learn conventions.
-
     This estimator will run an extensive test-suite for input validation,
     shapes, etc, making sure that the estimator complies with `scikit-learn`
     conventions as detailed in :ref:`rolling_your_own_estimator`.
     Additional tests for classifiers, regressors, clustering or transformers
     will be run if the Estimator class inherits from the corresponding mixin
     from sklearn.base.
-
     This test can be applied to classes or instances.
     Classes currently have some additional tests that related to construction,
     while passing instances allows the testing of multiple options. However,
     support for classes is deprecated since version 0.23 and will be removed
     in version 0.24 (class checks will still be run on the instances).
-
     Setting `generate_only=True` returns a generator that yields (estimator,
     check) tuples where the check can be called independently from each
     other, i.e. `check(estimator)`. This allows all checks to be run
     independently and report the checks that are failing.
-
     scikit-learn provides a pytest specific decorator,
     :func:`~sklearn.utils.parametrize_with_checks`, making it easier to test
     multiple estimators.
-
     Parameters
     ----------
     estimator : estimator object
         Estimator to check. Estimator is a class object or instance.
-
         .. deprecated:: 0.23
            Passing a class is deprecated from version 0.23, and won't be
            supported in 0.24. Pass an instance instead.
-
     generate_only : bool, optional (default=False)
         When `False`, checks are evaluated when `check_estimator` is called.
         When `True`, `check_estimator` returns a generator that yields
         (estimator, check) tuples. The check is run by calling
         `check(estimator)`.
-
         .. versionadded:: 0.22
-
     Returns
     -------
     checks_generator : generator
@@ -489,7 +480,6 @@ def check_estimator(Estimator, generate_only=False):
         warnings.warn(msg, FutureWarning)
 
         checks_generator = _generate_class_checks(Estimator)
-        estimator = _construct_instance(Estimator)
     else:
         # got an instance
         estimator = Estimator
@@ -499,19 +489,12 @@ def check_estimator(Estimator, generate_only=False):
     if generate_only:
         return checks_generator
 
-    xfail_checks = _safe_tags(estimator, '_xfail_test')
-
     for estimator, check in checks_generator:
-        check_name = _set_check_estimator_ids(check)
-        if xfail_checks and check_name in xfail_checks:
-            # skip tests marked as a known failure and raise a warning
-            msg = xfail_checks[check_name]
-            warnings.warn(f'Skipping {check_name}: {msg}', SkipTestWarning)
-            continue
         try:
             check(estimator)
         except SkipTest as exception:
-            # raise warning for tests that are are skipped
+            # the only SkipTest thrown currently results from not
+            # being able to import pandas.
             warnings.warn(str(exception), SkipTestWarning)
 
 


### PR DESCRIPTION
Fixes CI and some outdated parts from https://github.com/scikit-learn/scikit-learn/pull/16507 merged by accident.

Reverts `check_estimator` to its previous version on master, since the xfail estimators tags were better addressed in earlier PRs. 