### PR TITLE
MNT properly activate the env in the linting CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,27 +18,30 @@ jobs:
     - bash: sudo chown -R $USER $CONDA
       displayName: Take ownership of conda installation
     - bash: |
+        set -ex
         conda create --name flake8_env --yes python=3.8
-        conda activate flake8_env
+        source activate flake8_env
         pip install flake8 mypy==0.770
       displayName: Install flake8
     - bash: |
+        set -ex
         if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[lint\ skip\] ]]; then
           # skip linting
           echo "Skipping linting"
           exit 0
         else
-          conda activate flake8_env
+          source activate flake8_env
           ./build_tools/circle/linting.sh
         fi
       displayName: Run linting
     - bash: |
+        set -ex
         if [[ $BUILD_SOURCEVERSIONMESSAGE =~ \[lint\ skip\] ]]; then
           # skip linting
           echo "Skipping linting"
           exit 0
         else
-          conda activate flake8_env
+          source activate flake8_env
           mypy sklearn/ --ignore-missing-imports
         fi
       displayName: Run mypy

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -21,7 +21,8 @@ from ..utils.validation import check_memory, _deprecate_positional_args
 from ..neighbors import DistanceMetric
 from ..neighbors._dist_metrics import METRIC_MAPPING
 
-from . import _hierarchical_fast as _hierarchical
+# mypy error: Module 'sklearn.cluster' has no attribute '_hierarchical_fast'
+from . import _hierarchical_fast as _hierarchical  # type: ignore
 from ._feature_agglomeration import AgglomerationTransform
 from ..utils._fast_dict import IntFloatDict
 from ..utils.fixes import _astype_copy_false

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -22,7 +22,8 @@ from ..utils.validation import check_non_negative
 from ..utils.validation import _deprecate_positional_args
 from ..decomposition import PCA
 from ..metrics.pairwise import pairwise_distances
-from . import _utils
+# mypy error: Module 'sklearn.manifold' has no attribute '_utils'
+from . import _utils  # type: ignore
 # mypy error: Module 'sklearn.manifold' has no attribute '_barnes_hut_tsne'
 from . import _barnes_hut_tsne  # type: ignore
 

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -657,9 +657,9 @@ def test_print_elapsed_time(message, expected, capsys, monkeypatch):
 
 @pytest.mark.parametrize("value, result", [(float("nan"), True),
                                            (np.nan, True),
-                                           (np.float(float("nan")), True),
-                                           (np.float32(float("nan")), True),
-                                           (np.float64(float("nan")), True),
+                                           (np.float(np.nan), True),
+                                           (np.float32(np.nan), True),
+                                           (np.float64(np.nan), True),
                                            (0, False),
                                            (0., False),
                                            (None, False),

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -657,9 +657,9 @@ def test_print_elapsed_time(message, expected, capsys, monkeypatch):
 
 @pytest.mark.parametrize("value, result", [(float("nan"), True),
                                            (np.nan, True),
-                                           (np.float("nan"), True),
-                                           (np.float32("nan"), True),
-                                           (np.float64("nan"), True),
+                                           (np.float(float("nan")), True),
+                                           (np.float32(float("nan")), True),
+                                           (np.float64(float("nan")), True),
                                            (0, False),
                                            (0., False),
                                            (None, False),

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -18,7 +18,8 @@ import scipy.sparse as sp
 from distutils.version import LooseVersion
 from inspect import signature, isclass, Parameter
 
-from numpy.core.numeric import ComplexWarning
+# mypy error: Module 'numpy.core.numeric' has no attribute 'ComplexWarning'
+from numpy.core.numeric import ComplexWarning  # type: ignore
 import joblib
 
 from contextlib import suppress


### PR DESCRIPTION
Fixes linting CI job on azure.

~~Currently it always returns a green status because the env fails to activate and the error is silenly ignored.~~

The error on master is,
```
CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.
To initialize your shell, run

    $ conda init <SHELL_NAME>

Currently supported shells are:
  - bash
  - fish
  - tcsh
  - xonsh
  - zsh
  - powershell

See 'conda init --help' for more information and options.

IMPORTANT: You may need to close and restart your shell after running 'conda init'.
```

Originally fix added in https://github.com/scikit-learn/scikit-learn/pull/17053 see discussion there for more details.
