### PR TITLE
[WIP] FIX KBinsDiscretizer: allow nans #9341

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -162,8 +162,9 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         contains_nan = []
         for jj in range(n_features):
             column = X[:, jj]
-            contains_nan.append(np.isnan(column).any()) # check whether there are NaN
-            column = column[~np.isnan(column)] # remove NaNs for the fit
+            contains_nan.append(
+                np.isnan(column).any())  # check whether there are NaN
+            column = column[~np.isnan(column)]  # remove NaNs for the fit
             col_min, col_max = column.min(), column.max()
 
             if col_min == col_max:
@@ -210,8 +211,9 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         if 'onehot' in self.encode:
             self._encoder = OneHotEncoder(
-                categories=[np.arange(-1, self.n_bins_[jj]) if contains_nan[jj] else
-                            np.arange(0, self.n_bins_[jj]) 
+                categories=[np.arange(-1, self.n_bins_[jj])
+                            if contains_nan[jj] else
+                            np.arange(0, self.n_bins_[jj])
                             for jj in range(n_features)],
                 sparse=self.encode == 'onehot')
             # Fit the OneHotEncoder with toy datasets
@@ -270,7 +272,8 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         """
         check_is_fitted(self)
 
-        Xt = check_array(X, copy=True, dtype=FLOAT_DTYPES, force_all_finite=False)
+        Xt = check_array(
+            X, copy=True, dtype=FLOAT_DTYPES, force_all_finite=False)
         n_features = self.n_bins_.shape[0]
         if Xt.shape[1] != n_features:
             raise ValueError("Incorrect number of features. Expecting {}, "
@@ -331,5 +334,4 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             column = bin_centers[np.int_(column)]
             column[Xinv[:, jj] == -1] = np.NaN
             Xinv[:, jj] = column
-            
         return Xinv

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -159,8 +159,10 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         n_bins = self._validate_n_bins(n_features)
 
         bin_edges = np.zeros(n_features, dtype=object)
+        contains_nan = []
         for jj in range(n_features):
             column = X[:, jj]
+            contains_nan.append(np.isnan(column).any()) # check whether there are NaN
             column = column[~np.isnan(column)] # remove NaNs for the fit
             col_min, col_max = column.min(), column.max()
 
@@ -208,7 +210,9 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         if 'onehot' in self.encode:
             self._encoder = OneHotEncoder(
-                categories=[np.arange(-1, i) for i in self.n_bins_],
+                categories=[np.arange(-1, self.n_bins_[jj]) if contains_nan[jj] else
+                            np.arange(0, self.n_bins_[jj]) 
+                            for jj in range(n_features)],
                 sparse=self.encode == 'onehot')
             # Fit the OneHotEncoder with toy datasets
             # so that it's ready for use after the KBinsDiscretizer is fitted

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -335,3 +335,6 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             column[Xinv[:, jj] == -1] = np.NaN
             Xinv[:, jj] = column
         return Xinv
+
+    def _more_tags(self):
+        return {'allow_nan': True}

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -284,7 +284,7 @@ def test_percentile_numeric_stability():
 
 
 @pytest.mark.parametrize('strategy', ['uniform', 'kmeans', 'quantile'])
-@pytest.mark.parametrize('encode', ['ordinal', 'onehot'])
+@pytest.mark.parametrize('encode', ['ordinal', 'onehot', 'onehot-dense'])
 def test_nan_handling(strategy, encode):
     X = np.array([[1, 3],
                   [2, -1],
@@ -294,16 +294,18 @@ def test_nan_handling(strategy, encode):
     kbd = KBinsDiscretizer(n_bins=3, strategy=strategy, encode=encode)
     Xt = kbd.fit_transform(X)
     Xinv = kbd.inverse_transform(Xt)
-    if encode == 'onehot':
+    if encode in ('onehot', 'onehot-dense'):
         # one additional column for feature 1
         # because of NaN but no additional column
         # for feature 2 since it has no NaNs
         assert Xt.shape[1] == 7
-        assert Xt[2, 0] == 1
+        # expected column 0 after onehot-encoding NaN
+        expected_col0 = np.zeros(Xt[:, 0].shape)
+        expected_col0[2] = 1
+        assert all(Xt[:, 0] == expected_col0)
     elif encode == 'ordinal':
         flat_Xt = Xt.ravel()
         mask = np.ones(flat_Xt.shape, dtype=bool)
         mask[4] = False  # NaN position
-        assert ~(flat_Xt[mask] == -1).any()
-        assert (flat_Xt[~mask] == -1).any()
+        assert all(mask == (flat_Xt != -1))
     assert np.isnan(Xinv[2, 0])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This fixes #9341

#### What does this implement/fix? Explain your changes.
This fix extends the functionality of the KBinsDiscretizer to allow for NaNs in the dataset. The NaN will be assigned to an additional category -1 and this category will be propagated into the onehot-encoding if specified.

#### Any other comments?
The new feature in KBinsDiscretizer did not pass the test
```
pytest sklearn/tests/test_common.py -k KBinsDiscretizer
```
getting the following assertion error:
```
AssertionError: ("Estimator doesn't check for NaN and inf in fit.", KBinsDiscretizer())
```
Since it does not need to check for NaN anymore I'm just wondering if this test is needed. In the case it is not needed anymore, then the pull request is complete :-)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
