### PR TITLE
MNT Cleaner cython cdef loss function in SGD

### DIFF
--- a/sklearn/linear_model/_sag_fast.pyx.tp
+++ b/sklearn/linear_model/_sag_fast.pyx.tp
@@ -152,7 +152,7 @@ cdef class MultinomialLogLoss{{name}}:
         loss = (logsumexp_prediction - prediction[int(y)]) * sample_weight
         return loss
 
-    cdef void _dloss(self, {{c_type}}* prediction, {{c_type}} y, int n_classes,
+    cdef void dloss(self, {{c_type}}* prediction, {{c_type}} y, int n_classes,
                      {{c_type}} sample_weight, {{c_type}}* gradient_ptr) nogil:
         r"""Multinomial Logistic regression gradient of the loss.
 
@@ -419,10 +419,10 @@ def sag{{name}}(SequentialDataset{{name}} dataset,
 
                 # compute the gradient for this sample, given the prediction
                 if multinomial:
-                    multiloss._dloss(prediction, y, n_classes, sample_weight,
+                    multiloss.dloss(prediction, y, n_classes, sample_weight,
                                      gradient)
                 else:
-                    gradient[0] = loss._dloss(prediction[0], y) * sample_weight
+                    gradient[0] = loss.dloss(prediction[0], y) * sample_weight
 
                 # L2 regularization by simply rescaling the weights
                 wscale *= wscale_update
@@ -783,7 +783,7 @@ def _multinomial_grad_loss_all_samples(
                            intercept, prediction, n_classes)
 
             # compute the gradient for this sample, given the prediction
-            multiloss._dloss(prediction, y, n_classes, sample_weight, gradient)
+            multiloss.dloss(prediction, y, n_classes, sample_weight, gradient)
 
             # compute the loss for this sample, given the prediction
             sum_loss += multiloss._loss(prediction, y, n_classes, sample_weight)

--- a/sklearn/linear_model/_sgd_fast.pxd
+++ b/sklearn/linear_model/_sgd_fast.pxd
@@ -3,24 +3,24 @@
 
 cdef class LossFunction:
     cdef double loss(self, double p, double y) nogil
-    cdef double _dloss(self, double p, double y) nogil
+    cdef double dloss(self, double p, double y) nogil
 
 
 cdef class Regression(LossFunction):
     cdef double loss(self, double p, double y) nogil
-    cdef double _dloss(self, double p, double y) nogil
+    cdef double dloss(self, double p, double y) nogil
 
 
 cdef class Classification(LossFunction):
     cdef double loss(self, double p, double y) nogil
-    cdef double _dloss(self, double p, double y) nogil
+    cdef double dloss(self, double p, double y) nogil
 
 
 cdef class Log(Classification):
     cdef double loss(self, double p, double y) nogil
-    cdef double _dloss(self, double p, double y) nogil
+    cdef double dloss(self, double p, double y) nogil
 
 
 cdef class SquaredLoss(Regression):
     cdef double loss(self, double p, double y) nogil
-    cdef double _dloss(self, double p, double y) nogil
+    cdef double dloss(self, double p, double y) nogil

--- a/sklearn/linear_model/_sgd_fast.pyx
+++ b/sklearn/linear_model/_sgd_fast.pyx
@@ -67,7 +67,10 @@ cdef class LossFunction:
         return 0.
 
     def py_dloss(self, double p, double y):
-        """Python version of derivative for testing."""
+        """Python version of `dloss` for testing.
+
+        Pytest needs a python function and can't use cdef functions.
+        """
         return self.dloss(p, y)
 
     cdef double dloss(self, double p, double y) nogil:
@@ -85,8 +88,6 @@ cdef class LossFunction:
         double
             The derivative of the loss function with regards to `p`.
         """
-        # Implementation of dloss; separate function because cpdef and nogil
-        # can't be combined.
         return 0.
 
 

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1438,7 +1438,7 @@ def _test_gradient_common(loss_function, cases):
     # Test gradient of different loss functions
     # cases is a list of (p, y, expected)
     for p, y, expected in cases:
-        assert_almost_equal(loss_function.dloss(p, y), expected)
+        assert_almost_equal(loss_function.py_dloss(p, y), expected)
 
 
 def test_gradient_hinge():
@@ -1488,8 +1488,8 @@ def test_gradient_log():
         (17.9, -1.0, 1.0), (-17.9, 1.0, -1.0),
     ]
     _test_gradient_common(loss, cases)
-    assert_almost_equal(loss.dloss(18.1, 1.0), np.exp(-18.1) * -1.0, 16)
-    assert_almost_equal(loss.dloss(-18.1, -1.0), np.exp(-18.1) * 1.0, 16)
+    assert_almost_equal(loss.py_dloss(18.1, 1.0), np.exp(-18.1) * -1.0, 16)
+    assert_almost_equal(loss.py_dloss(-18.1, -1.0), np.exp(-18.1) * 1.0, 16)
 
 
 def test_gradient_squared_loss():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR simpliefies the derivative loss functions for SGD. It makes the distinction bewtween `cdef dloss() nogil:` for productive use and `def py_dloss():` for calls in the test suite only.

