### PR TITLE
MNT Removes voting classifer mention in base.py

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1,8 +1,4 @@
-"""
-Base classes for all estimators.
-
-Used for VotingClassifier
-"""
+"""Base classes for all estimators."""
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
 # License: BSD 3 clause


### PR DESCRIPTION
Just saw this in the [API docs](https://scikit-learn.org/dev/modules/classes.html#module-sklearn.base)

Do not think the mention of voting classifier belongs here.