### PR TITLE
MNT Put back and properly deprecate MaskedArray

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -17,6 +17,9 @@ import scipy.sparse as sp
 import scipy
 import scipy.stats
 from scipy.sparse.linalg import lsqr as sparse_lsqr  # noqa
+from numpy.ma import MaskedArray as _MaskedArray  # TODO: remove in 0.25
+
+from .deprecation import deprecated
 
 
 def _parse_version(version_string):
@@ -154,3 +157,11 @@ class loguniform(scipy.stats.reciprocal):
     >>> rvs.max()  # doctest: +SKIP
     9.97403052786026
     """
+
+
+@deprecated(
+    'MaskedArray is deprecated in version 0.23 and will be removed in version '
+    '0.25. Use numpy.ma.MaskedArray instead.'
+)
+class MaskedArray(_MaskedArray):
+    pass  # TODO: remove in 0.25

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -14,6 +14,7 @@ from sklearn.utils._testing import assert_array_equal
 from sklearn.utils.fixes import _joblib_parallel_args
 from sklearn.utils.fixes import _object_dtype_isnan
 from sklearn.utils.fixes import loguniform
+from sklearn.utils.fixes import MaskedArray
 
 
 @pytest.mark.parametrize('joblib_version', ('0.11', '0.12.0'))
@@ -83,3 +84,8 @@ def test_loguniform(low, high, base):
         loguniform(base ** low, base ** high).rvs(random_state=0)
         == loguniform(base ** low, base ** high).rvs(random_state=0)
     )
+
+
+def test_masked_array_deprecated():
+    with pytest.warns(FutureWarning, match='is deprecated'):
+        MaskedArray()

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -86,6 +86,6 @@ def test_loguniform(low, high, base):
     )
 
 
-def test_masked_array_deprecated():
+def test_masked_array_deprecated():  # TODO: remove in 0.25
     with pytest.warns(FutureWarning, match='is deprecated'):
         MaskedArray()


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/17198

MaskedArray was deleted in https://github.com/scikit-learn/scikit-learn/pull/16725 without deprecation. It breaks scikit-optimize.

Sad, but I guess we need to put it back and deprecate...

CC @rth @thomasjpfan  @adrinjalali

Should be in the bugfix release