### PR TITLE
FIX don't modify sample weight inplace in KMeans

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -2,6 +2,23 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_0_23_1:
+
+Version 0.23.1
+==============
+
+**TBD**
+
+Changelog
+---------
+
+:mod:`sklearn.cluster`
+......................
+
+- |Fix| Fixed a bug in :class:`cluster.KMeans` where the sample weights
+  provided by the user was modified in place. :pr:`17204` by
+  :user:`Jeremie du Boisberranger <jeremiedbb>`.
+
 .. _changes_0_23:
 
 Version 0.23.0

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -177,7 +177,7 @@ def _check_normalize_sample_weight(sample_weight, X):
         # an array of 1 (i.e. samples_weight is None) is already normalized
         n_samples = len(sample_weight)
         scale = n_samples / sample_weight.sum()
-        sample_weight *= scale
+        sample_weight = sample_weight * scale
     return sample_weight
 
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1167,3 +1167,13 @@ def test_inertia(dtype):
     assert_allclose(inertia_dense, inertia_sparse, rtol=1e-6)
     assert_allclose(inertia_dense, expected, rtol=1e-6)
     assert_allclose(inertia_sparse, expected, rtol=1e-6)
+
+
+def test_sample_weight_unchanged():
+    # Check that sample_weight is not modified in place by KMeans (#)
+    X = np.array([[1], [2], [4]])
+    sample_weight = np.array([0.5, 0.2, 0.3])
+    KMeans(n_clusters=2, random_state=0).fit(X, sample_weight=sample_weight)
+
+    # internally, sample_weight is rescale to sum up to n_samples = 3
+    assert_array_equal(sample_weight, np.array([0.5, 0.2, 0.3]))

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1170,7 +1170,7 @@ def test_inertia(dtype):
 
 
 def test_sample_weight_unchanged():
-    # Check that sample_weight is not modified in place by KMeans (#)
+    # Check that sample_weight is not modified in place by KMeans (#17204)
     X = np.array([[1], [2], [4]])
     sample_weight = np.array([0.5, 0.2, 0.3])
     KMeans(n_clusters=2, random_state=0).fit(X, sample_weight=sample_weight)


### PR DESCRIPTION
Fixes #17203

KMeans scales sample weight to sum up to n_samples. It has been done inplace when we generalized the use of check_sample_weight.

@rth