### PR TITLE
MNT Replaced kwargs by named args for train_test_split

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2073,6 +2073,7 @@ def check_cv(cv=5, y=None, *, classifier=False):
 
 
 def train_test_split(*arrays,
+                     *,
                      test_size=None,
                      train_size=None,
                      random_state=None,

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2072,7 +2072,12 @@ def check_cv(cv=5, y=None, *, classifier=False):
     return cv  # New style cv objects are passed without any modification
 
 
-def train_test_split(*arrays, **options):
+def train_test_split(*arrays,
+                     test_size=None,
+                     train_size=None,
+                     random_state=None,
+                     shuffle=True,
+                     stratify=None):
     """Split arrays or matrices into random train and test subsets
 
     Quick utility that wraps input validation and

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2073,7 +2073,6 @@ def check_cv(cv=5, y=None, *, classifier=False):
 
 
 def train_test_split(*arrays,
-                     *,
                      test_size=None,
                      train_size=None,
                      random_state=None,

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2166,14 +2166,6 @@ def train_test_split(*arrays,
     n_arrays = len(arrays)
     if n_arrays == 0:
         raise ValueError("At least one array required as input")
-    test_size = options.pop('test_size', None)
-    train_size = options.pop('train_size', None)
-    random_state = options.pop('random_state', None)
-    stratify = options.pop('stratify', None)
-    shuffle = options.pop('shuffle', True)
-
-    if options:
-        raise TypeError("Invalid parameters passed: %s" % str(options))
 
     arrays = indexable(*arrays)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
By using **options in the argument list, named arguments where not immediately shown when pressing shift+tab in jupyter. I replaced it by using named arguments and their default values described in the docstring.
