### PR TITLE
[MRG] MNT Ignore xfail_checks in check_estimator

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -525,8 +525,8 @@ _skip_test (default=False)
 _xfail_checks (default=False)
     dictionary ``{check_name: reason}`` of common checks that will be marked
     as `XFAIL` for pytest, when using
-    :func:`~sklearn.utils.estimator_checks.parametrize_with_checks`. This tag
-    currently has no effect on
+    :func:`~sklearn.utils.estimator_checks.parametrize_with_checks`. These
+    checks will be simply ignored and not run by
     :func:`~sklearn.utils.estimator_checks.check_estimator`.
     Don't use this unless there is a *very good* reason for your estimator
     not to pass the check.

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -350,6 +350,13 @@ def _mark_xfail_checks(estimator, check, pytest):
                             marks=pytest.mark.xfail(reason=reason))
 
 
+def _is_xfail(estimator, check):
+    # Whether the check is part of the _xfail_checks tag of the estimator
+    xfail_checks = estimator._get_tags()['_xfail_checks'] or {}
+    check_name = _set_check_estimator_ids(check)
+    return check_name in xfail_checks
+
+
 def parametrize_with_checks(estimators):
     """Pytest specific decorator for parametrizing estimator checks.
 
@@ -456,7 +463,8 @@ def check_estimator(Estimator, generate_only=False):
     name = type(estimator).__name__
 
     checks_generator = ((estimator, partial(check, name))
-                        for check in _yield_all_checks(name, estimator))
+                        for check in _yield_all_checks(name, estimator)
+                        if not _is_xfail(estimator, check))
 
     if generate_only:
         return checks_generator

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -6,7 +6,6 @@ import pickle
 import re
 from copy import deepcopy
 from functools import partial
-from itertools import chain
 from inspect import signature
 
 import numpy as np
@@ -399,9 +398,11 @@ def parametrize_with_checks(estimators):
                "Please pass an instance instead.")
         raise TypeError(msg)
 
-    checks_generator = chain.from_iterable(
-        check_estimator(estimator, generate_only=True)
-        for estimator in estimators)
+    names = (type(estimator).__name__ for estimator in estimators)
+
+    checks_generator = ((estimator, partial(check, name))
+                        for name, estimator in zip(names, estimators)
+                        for check in _yield_all_checks(name, estimator))
 
     checks_with_marks = (
         _mark_xfail_checks(estimator, check, pytest)

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -32,7 +32,7 @@ from sklearn.mixture import GaussianMixture
 from sklearn.cluster import MiniBatchKMeans
 from sklearn.decomposition import NMF
 from sklearn.linear_model import MultiTaskElasticNet, LogisticRegression
-from sklearn.svm import SVC
+from sklearn.svm import SVC, NuSVC
 from sklearn.neighbors import KNeighborsRegressor
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils.validation import check_array
@@ -609,3 +609,9 @@ if __name__ == '__main__':
     # This module is run as a script to check that we have no dependency on
     # pytest for estimator checks.
     run_tests_without_pytest()
+
+
+def test_xfail_ignored_in_check_estimator():
+    # Make sure checks marked as xfail are just ignored and not run by
+    # check_estimator().
+    check_estimator(NuSVC())


### PR DESCRIPTION
Fixes #16958

Alternative to and Closes https://github.com/scikit-learn/scikit-learn/pull/16963

Alternative to and Closes #17222


CC @thomasjpfan @rth. 

I would prefer this approach, considering how much simpler it is. I agree with what @rth said: for a more advanced control, developers should be using `parametrize_with_checks` and pytest.