### PR TITLE
[MRG] Removes duplicate this in the release history

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -4,7 +4,7 @@
 Release History
 ===============
 
-Release notes for all scikit-learn releases are linked in this this page.
+Release notes for all scikit-learn releases are linked in this page.
 
 **Tip:** `Subscribe to scikit-learn releases <https://libraries.io/pypi/scikit-learn>`__
 on libraries.io to be notified when new versions are released.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Removes duplicate "this" in the [Release History](https://scikit-learn.org/dev/whats_new.html).
