### PR TITLE
[MRG] Fix path to what's new in the navigation bar

### DIFF
--- a/doc/themes/scikit-learn-modern/nav.html
+++ b/doc/themes/scikit-learn-modern/nav.html
@@ -9,7 +9,7 @@
 {%- set drop_down_navigation = [
   ('Getting Started', pathto('getting_started')),
   ('Tutorial', pathto('tutorial/index')),
-  ("What's new", 'whats_new/v' + version + '.html'),
+  ("What's new", pathto('whats_new/v' + version)),
   ('Glossary', pathto('glossary')),
   ('Development', pathto('developers/index')),
   ('FAQ', pathto('faq')),


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Fixes the path to what's new in the navigation bar. Currently, the `pathto` Jinja function is not used to refer to the corresponding built document. Thus, Jinja assumes that this document is within the same folder of the current HTML page, which is true only in the root folder.

To reproduce this issue:

1. Go to [API Reference](https://scikit-learn.org/stable/modules/classes.html)
2. Click on the *What's new* item in the *More* drop-down list.

This should fix this issue. @thomasjpfan What do you think?