### PR TITLE
DOC Fix formating in docstrings _regression.py

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -349,8 +349,8 @@ def median_absolute_error(y_true, y_pred, *, multioutput='uniform_average'):
     y_pred : array-like of shape = (n_samples) or (n_samples, n_outputs)
         Estimated target values.
 
-    multioutput : {'raw_values', 'uniform_average'} or array-like of shape
-        (n_outputs,)
+    multioutput : {'raw_values', 'uniform_average'} or array-like of shape \
+                (n_outputs,)
         Defines aggregating of multiple output values. Array-like value defines
         weights used to average errors.
 

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -137,8 +137,8 @@ def mean_absolute_error(y_true, y_pred, *,
     sample_weight : array-like of shape (n_samples,), optional
         Sample weights.
 
-    multioutput : string in ['raw_values', 'uniform_average']
-        or array-like of shape (n_outputs)
+    multioutput : string in ['raw_values', 'uniform_average'] \
+                or array-like of shape (n_outputs)
         Defines aggregating of multiple output values.
         Array-like value defines weights used to average errors.
 

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -209,8 +209,8 @@ def mean_squared_error(y_true, y_pred, *,
     sample_weight : array-like of shape (n_samples,), optional
         Sample weights.
 
-    multioutput : string in ['raw_values', 'uniform_average']
-        or array-like of shape (n_outputs)
+    multioutput : string in ['raw_values', 'uniform_average'] \
+                or array-like of shape (n_outputs)
         Defines aggregating of multiple output values.
         Array-like value defines weights used to average errors.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fix formatting in docstring of `median_absolute_error`, `mean_squared_error` and `mean_absolute_error`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
