### PR TITLE
[MRG] Fix undefined behavior in _tree.pyx and  _quad_tree.pyx

### DIFF
--- a/sklearn/neighbors/_quad_tree.pyx
+++ b/sklearn/neighbors/_quad_tree.pyx
@@ -29,32 +29,8 @@ cdef extern from "numpy/arrayobject.h":
                                 np.npy_intp* strides,
                                 void* data, int flags, object obj)
 
-# Dummy variable to avoid computing member offsets using a null pointer.
 cdef Cell dummy;
-
-# Repeat struct definition for numpy
-CELL_DTYPE = np.dtype({
-    'names': ['parent', 'children', 'cell_id', 'point_index', 'is_leaf',
-              'max_width', 'depth', 'cumulative_size', 'center', 'barycenter',
-              'min_bounds', 'max_bounds'],
-    'formats': [np.intp, (np.intp, 8), np.intp, np.intp, np.int32, np.float32,
-                np.intp, np.intp, (np.float32, 3), (np.float32, 3),
-                (np.float32, 3), (np.float32, 3)],
-    'offsets': [
-        (<Py_ssize_t>&(dummy.parent) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.children) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.cell_id) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.point_index) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.is_leaf) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.squared_max_width) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.depth) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.cumulative_size) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.center) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.barycenter) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.min_bounds) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.max_bounds) - <Py_ssize_t>&(dummy)),
-    ]
-})
+CELL_DTYPE = np.asarray(<Cell[:1]>(&dummy)).dtype
 
 assert CELL_DTYPE.itemsize == sizeof(Cell)
 

--- a/sklearn/neighbors/_quad_tree.pyx
+++ b/sklearn/neighbors/_quad_tree.pyx
@@ -29,7 +29,7 @@ cdef extern from "numpy/arrayobject.h":
                                 np.npy_intp* strides,
                                 void* data, int flags, object obj)
 
-# Build the corresponding numpy dtyle for Cell.
+# Build the corresponding numpy dtype for Cell.
 # This works by casting `dummy` to an array of Cell of length 1, which numpy
 # can construct a `dtype`-object for. See https://stackoverflow.com/q/62448946
 # for a more detailed explanation.

--- a/sklearn/neighbors/_quad_tree.pyx
+++ b/sklearn/neighbors/_quad_tree.pyx
@@ -29,6 +29,10 @@ cdef extern from "numpy/arrayobject.h":
                                 np.npy_intp* strides,
                                 void* data, int flags, object obj)
 
+# Build the corresponding numpy dtyle for Cell.
+# This works by casting `dummy` to an array of Cell of length 1, which numpy
+# can construct a `dtype`-object for. See https://stackoverflow.com/q/62448946
+# for a more detailed explanation.
 cdef Cell dummy;
 CELL_DTYPE = np.asarray(<Cell[:1]>(&dummy)).dtype
 

--- a/sklearn/neighbors/_quad_tree.pyx
+++ b/sklearn/neighbors/_quad_tree.pyx
@@ -29,6 +29,8 @@ cdef extern from "numpy/arrayobject.h":
                                 np.npy_intp* strides,
                                 void* data, int flags, object obj)
 
+# Dummy variable to avoid computing member offsets using a null pointer.
+cdef Cell dummy;
 
 # Repeat struct definition for numpy
 CELL_DTYPE = np.dtype({
@@ -39,18 +41,18 @@ CELL_DTYPE = np.dtype({
                 np.intp, np.intp, (np.float32, 3), (np.float32, 3),
                 (np.float32, 3), (np.float32, 3)],
     'offsets': [
-        <Py_ssize_t> &(<Cell*> NULL).parent,
-        <Py_ssize_t> &(<Cell*> NULL).children,
-        <Py_ssize_t> &(<Cell*> NULL).cell_id,
-        <Py_ssize_t> &(<Cell*> NULL).point_index,
-        <Py_ssize_t> &(<Cell*> NULL).is_leaf,
-        <Py_ssize_t> &(<Cell*> NULL).squared_max_width,
-        <Py_ssize_t> &(<Cell*> NULL).depth,
-        <Py_ssize_t> &(<Cell*> NULL).cumulative_size,
-        <Py_ssize_t> &(<Cell*> NULL).center,
-        <Py_ssize_t> &(<Cell*> NULL).barycenter,
-        <Py_ssize_t> &(<Cell*> NULL).min_bounds,
-        <Py_ssize_t> &(<Cell*> NULL).max_bounds,
+        (<Py_ssize_t>&(dummy.parent) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.children) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.cell_id) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.point_index) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.is_leaf) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.squared_max_width) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.depth) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.cumulative_size) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.center) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.barycenter) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.min_bounds) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.max_bounds) - <Py_ssize_t>&(dummy)),
     ]
 })
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -67,6 +67,10 @@ cdef SIZE_t _TREE_LEAF = TREE_LEAF
 cdef SIZE_t _TREE_UNDEFINED = TREE_UNDEFINED
 cdef SIZE_t INITIAL_STACK_SIZE = 10
 
+# Build the corresponding numpy dtyle for Node.
+# This works by casting `dummy` to an array of Node of length 1, which numpy
+# can construct a `dtype`-object for. See https://stackoverflow.com/q/62448946
+# for a more detailed explanation.
 cdef Node dummy;
 NODE_DTYPE = np.asarray(<Node[:1]>(&dummy)).dtype
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -67,7 +67,7 @@ cdef SIZE_t _TREE_LEAF = TREE_LEAF
 cdef SIZE_t _TREE_UNDEFINED = TREE_UNDEFINED
 cdef SIZE_t INITIAL_STACK_SIZE = 10
 
-# Build the corresponding numpy dtyle for Node.
+# Build the corresponding numpy dtype for Node.
 # This works by casting `dummy` to an array of Node of length 1, which numpy
 # can construct a `dtype`-object for. See https://stackoverflow.com/q/62448946
 # for a more detailed explanation.

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -67,6 +67,9 @@ cdef SIZE_t _TREE_LEAF = TREE_LEAF
 cdef SIZE_t _TREE_UNDEFINED = TREE_UNDEFINED
 cdef SIZE_t INITIAL_STACK_SIZE = 10
 
+# Dummy variable to avoid computing member offsets using a null pointer.
+cdef Node dummy;
+
 # Repeat struct definition for numpy
 NODE_DTYPE = np.dtype({
     'names': ['left_child', 'right_child', 'feature', 'threshold', 'impurity',
@@ -74,13 +77,13 @@ NODE_DTYPE = np.dtype({
     'formats': [np.intp, np.intp, np.intp, np.float64, np.float64, np.intp,
                 np.float64],
     'offsets': [
-        <Py_ssize_t> &(<Node*> NULL).left_child,
-        <Py_ssize_t> &(<Node*> NULL).right_child,
-        <Py_ssize_t> &(<Node*> NULL).feature,
-        <Py_ssize_t> &(<Node*> NULL).threshold,
-        <Py_ssize_t> &(<Node*> NULL).impurity,
-        <Py_ssize_t> &(<Node*> NULL).n_node_samples,
-        <Py_ssize_t> &(<Node*> NULL).weighted_n_node_samples
+        (<Py_ssize_t>&(dummy.left_child) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.right_child) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.feature) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.threshold) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.impurity) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.n_node_samples) - <Py_ssize_t>&(dummy)),
+        (<Py_ssize_t>&(dummy.weighted_n_node_samples) - <Py_ssize_t>&(dummy))
     ]
 })
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -67,25 +67,8 @@ cdef SIZE_t _TREE_LEAF = TREE_LEAF
 cdef SIZE_t _TREE_UNDEFINED = TREE_UNDEFINED
 cdef SIZE_t INITIAL_STACK_SIZE = 10
 
-# Dummy variable to avoid computing member offsets using a null pointer.
 cdef Node dummy;
-
-# Repeat struct definition for numpy
-NODE_DTYPE = np.dtype({
-    'names': ['left_child', 'right_child', 'feature', 'threshold', 'impurity',
-              'n_node_samples', 'weighted_n_node_samples'],
-    'formats': [np.intp, np.intp, np.intp, np.float64, np.float64, np.intp,
-                np.float64],
-    'offsets': [
-        (<Py_ssize_t>&(dummy.left_child) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.right_child) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.feature) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.threshold) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.impurity) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.n_node_samples) - <Py_ssize_t>&(dummy)),
-        (<Py_ssize_t>&(dummy.weighted_n_node_samples) - <Py_ssize_t>&(dummy))
-    ]
-})
+NODE_DTYPE = np.asarray(<Node[:1]>(&dummy)).dtype
 
 # =============================================================================
 # TreeBuilder


### PR DESCRIPTION
Accessing a member through a null pointer is undefined behavior, even if
no actual memory access is performed (like in this case, where it was
used only for offset computation). See the following link for an
explanation:
https://software.intel.com/content/www/us/en/develop/blogs/null-pointer-dereferencing-causes-undefined-behavior.html

The current approach will also fail when building with tools like ubsan
(undefined behavior sanitizer).

The standard way to compute offsets of struct members is the offsetof
macro but it seems it's not supported by Cython so I've used the
approach described here:

https://mail.python.org/pipermail/cython-devel/2013-April/003505.html
