### PR TITLE
MNT Add threadpoolctl in show_versions

### DIFF
--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -51,6 +51,7 @@ def _get_deps_info():
         "pandas",
         "matplotlib",
         "joblib",
+        "threadpoolctl"
     ]
 
     def get_version(module):
@@ -87,7 +88,7 @@ def show_versions():
 
     print('\nPython dependencies:')
     for k, stat in deps_info.items():
-        print("{k:>10}: {stat}".format(k=k, stat=stat))
+        print("{k:>13}: {stat}".format(k=k, stat=stat))
 
-    print("\n{k:>10}: {stat}".format(k="Built with OpenMP",
-                                     stat=_openmp_parallelism_enabled()))
+    print("\n{k}: {stat}".format(k="Built with OpenMP",
+                                 stat=_openmp_parallelism_enabled()))


### PR DESCRIPTION
threadpoolctl is a dependency added in 0.23. It should be displayed by `show_versions`