### PR TITLE
Removed unnecessary if-statements, variables

### DIFF
--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -26,26 +26,21 @@ def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
     cdef vector[np.npy_intp] stack
 
     for i in range(labels.shape[0]):
-        if labels[i] != -1 or not is_core[i]:
-            continue
+        if labels[i] == -1 and not is_core[i]:
 
-        # Depth-first search starting from i, ending at the non-core points.
-        # This is very similar to the classic algorithm for computing connected
-        # components, the difference being that we label non-core points as
-        # part of a cluster (component), but don't expand their neighborhoods.
-        while True:
-            if labels[i] == -1:
+            # Depth-first search starting from i, ending at the non-core points.
+            # This is very similar to the classic algorithm for computing connected
+            # components, the difference being that we label non-core points as
+            # part of a cluster (component), but don't expand their neighborhoods.
+            while True:
                 labels[i] = label_num
-                if is_core[i]:
-                    neighb = neighborhoods[i]
-                    for i in range(neighb.shape[0]):
-                        v = neighb[i]
-                        if labels[v] == -1:
-                            push(stack, v)
+                for j in range(neighborhoods[i].shape[0]):
+                    if labels[neighborhoods[i][j]] == -1:
+                        push(stack, neighborhoods[i][j])
 
-            if stack.size() == 0:
-                break
-            i = stack.back()
-            stack.pop_back()
+                if stack.size() == 0:
+                    break
+                i = stack.back()
+                stack.pop_back()
 
-        label_num += 1
+            label_num += 1


### PR DESCRIPTION
This can save some memory usage and execution time, especially for very large datasets.

I replaced and continue statement by enclosing the rest of the loop within an if-statement. This also adds the advantage that the program does not have to repeat the if labels[i] != -1 and if not is_core[i] comparisons.

I've also edited the code so some unnecessary variables are not initialized, which saves a bit of memory.