### PR TITLE
ENH Moves to next line when _deprecate_positional_args is hit

### DIFF
--- a/doc/sphinxext/github_link.py
+++ b/doc/sphinxext/github_link.py
@@ -63,7 +63,7 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
                          start=os.path.dirname(__import__(package).__file__))
     try:
         lines, lineno = inspect.getsourcelines(obj)
-        # TODO: Remove in v0.24
+        # TODO: Remove in v0.25
         if lines[0] == "@_deprecate_positional_args\n":
             lineno += 1
     except Exception:

--- a/doc/sphinxext/github_link.py
+++ b/doc/sphinxext/github_link.py
@@ -62,7 +62,10 @@ def _linkcode_resolve(domain, info, package, url_fmt, revision):
     fn = os.path.relpath(fn,
                          start=os.path.dirname(__import__(package).__file__))
     try:
-        lineno = inspect.getsourcelines(obj)[1]
+        lines, lineno = inspect.getsourcelines(obj)
+        # TODO: Remove in v0.24
+        if lines[0] == "@_deprecate_positional_args\n":
+            lineno += 1
     except Exception:
         lineno = ''
     return url_fmt.format(revision=revision, package=package,


### PR DESCRIPTION
Follow up to https://github.com/scikit-learn/scikit-learn/pull/17247

This PR shifts the lineno up one when decorated with `_deprecate_positional_args`. This will only effect functions because there is no whitespace before `@_deprecate_positional_args` when decorating functions.

CC: @alfaro96