### PR TITLE
DOC Fix parametrize_with_checks link

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -247,8 +247,9 @@ several internals of scikit-learn that you should be aware of in addition to
 the scikit-learn API outlined above. You can check whether your estimator
 adheres to the scikit-learn interface and standards by running
 :func:`~sklearn.utils.estimator_checks.check_estimator` on an instance. The
-:func:`~sklearn.utils.parametrize_with_checks` pytest decorator can also be
-used (see its docstring for details and possible interactions with `pytest`)::
+:func:`~sklearn.utils.estimator_checks.parametrize_with_checks` pytest
+decorator can also be used (see its docstring for details and possible
+interactions with `pytest`)::
 
   >>> from sklearn.utils.estimator_checks import check_estimator
   >>> from sklearn.svm import LinearSVC


### PR DESCRIPTION
The link to `parametrize_with_checks` under "Rolling your own estimator" is currently not working
https://scikit-learn.org/dev/developers/develop.html#rolling-your-own-estimator