### PR TITLE
DOC avoid FutureWarnings for deprecations examples

### DIFF
--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -173,7 +173,8 @@ edge_model.fit(X)
 # #############################################################################
 # Cluster using affinity propagation
 
-_, labels = cluster.affinity_propagation(edge_model.covariance_)
+_, labels = cluster.affinity_propagation(edge_model.covariance_,
+                                         random_state=0)
 n_labels = labels.max()
 
 for i in range(n_labels + 1):

--- a/examples/calibration/plot_calibration.py
+++ b/examples/calibration/plot_calibration.py
@@ -65,23 +65,25 @@ prob_pos_clf = clf.predict_proba(X_test)[:, 1]
 
 # Gaussian Naive-Bayes with isotonic calibration
 clf_isotonic = CalibratedClassifierCV(clf, cv=2, method='isotonic')
-clf_isotonic.fit(X_train, y_train, sw_train)
+clf_isotonic.fit(X_train, y_train, sample_weight=sw_train)
 prob_pos_isotonic = clf_isotonic.predict_proba(X_test)[:, 1]
 
 # Gaussian Naive-Bayes with sigmoid calibration
 clf_sigmoid = CalibratedClassifierCV(clf, cv=2, method='sigmoid')
-clf_sigmoid.fit(X_train, y_train, sw_train)
+clf_sigmoid.fit(X_train, y_train, sample_weight=sw_train)
 prob_pos_sigmoid = clf_sigmoid.predict_proba(X_test)[:, 1]
 
 print("Brier scores: (the smaller the better)")
 
-clf_score = brier_score_loss(y_test, prob_pos_clf, sw_test)
+clf_score = brier_score_loss(y_test, prob_pos_clf, sample_weight=sw_test)
 print("No calibration: %1.3f" % clf_score)
 
-clf_isotonic_score = brier_score_loss(y_test, prob_pos_isotonic, sw_test)
+clf_isotonic_score = brier_score_loss(y_test, prob_pos_isotonic,
+                                      sample_weight=sw_test)
 print("With isotonic calibration: %1.3f" % clf_isotonic_score)
 
-clf_sigmoid_score = brier_score_loss(y_test, prob_pos_sigmoid, sw_test)
+clf_sigmoid_score = brier_score_loss(y_test, prob_pos_sigmoid,
+                                     sample_weight=sw_test)
 print("With sigmoid calibration: %1.3f" % clf_sigmoid_score)
 
 # #############################################################################

--- a/examples/cluster/plot_ward_structured_vs_unstructured.py
+++ b/examples/cluster/plot_ward_structured_vs_unstructured.py
@@ -37,7 +37,7 @@ from sklearn.datasets import make_swiss_roll
 # Generate data (swiss roll dataset)
 n_samples = 1500
 noise = 0.05
-X, _ = make_swiss_roll(n_samples, noise)
+X, _ = make_swiss_roll(n_samples, noise=noise)
 # Make it thinner
 X[:, 1] *= .5
 

--- a/examples/linear_model/plot_sparse_logistic_regression_20newsgroups.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_20newsgroups.py
@@ -42,7 +42,7 @@ solver = 'saga'
 # Turn down for faster run time
 n_samples = 10000
 
-X, y = fetch_20newsgroups_vectorized('all', return_X_y=True)
+X, y = fetch_20newsgroups_vectorized(subset='all', return_X_y=True)
 X = X[:n_samples]
 y = y[:n_samples]
 

--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -115,7 +115,7 @@ def plot_obs_pred(df, feature, weight, observed, predicted, y_label=None,
     df_["observed"] = df[observed] * df[weight]
     df_["predicted"] = predicted * df[weight]
     df_ = (
-        df_.groupby([feature])[weight, "observed", "predicted"]
+        df_.groupby([feature])[[weight, "observed", "predicted"]]
         .sum()
         .assign(observed=lambda x: x["observed"] / x[weight])
         .assign(predicted=lambda x: x["predicted"] / x[weight])

--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -173,9 +173,9 @@ def score_estimator(
             if metric is None:
                 if not hasattr(estimator, "score"):
                     continue
-                score = estimator.score(X, y, _weights)
+                score = estimator.score(X, y, sample_weight=_weights)
             else:
-                score = metric(y, y_pred, _weights)
+                score = metric(y, y_pred, sample_weight=_weights)
 
             res.append(
                 {"subset": subset_label, "metric": score_label, "score": score}

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -126,7 +126,8 @@ plot_embedding(X_lda,
 # Isomap projection of the digits dataset
 print("Computing Isomap projection")
 t0 = time()
-X_iso = manifold.Isomap(n_neighbors, n_components=2).fit_transform(X)
+X_iso = manifold.Isomap(n_neighbors=n_neighbors, n_components=2
+                        ).fit_transform(X)
 print("Done.")
 plot_embedding(X_iso,
                "Isomap projection of the digits (time %.2fs)" %
@@ -136,7 +137,7 @@ plot_embedding(X_iso,
 # ----------------------------------------------------------------------
 # Locally linear embedding of the digits dataset
 print("Computing LLE embedding")
-clf = manifold.LocallyLinearEmbedding(n_neighbors, n_components=2,
+clf = manifold.LocallyLinearEmbedding(n_neighbors=n_neighbors, n_components=2,
                                       method='standard')
 t0 = time()
 X_lle = clf.fit_transform(X)
@@ -149,7 +150,7 @@ plot_embedding(X_lle,
 # ----------------------------------------------------------------------
 # Modified Locally linear embedding of the digits dataset
 print("Computing modified LLE embedding")
-clf = manifold.LocallyLinearEmbedding(n_neighbors, n_components=2,
+clf = manifold.LocallyLinearEmbedding(n_neighbors=n_neighbors, n_components=2,
                                       method='modified')
 t0 = time()
 X_mlle = clf.fit_transform(X)
@@ -162,7 +163,7 @@ plot_embedding(X_mlle,
 # ----------------------------------------------------------------------
 # HLLE embedding of the digits dataset
 print("Computing Hessian LLE embedding")
-clf = manifold.LocallyLinearEmbedding(n_neighbors, n_components=2,
+clf = manifold.LocallyLinearEmbedding(n_neighbors=n_neighbors, n_components=2,
                                       method='hessian')
 t0 = time()
 X_hlle = clf.fit_transform(X)
@@ -175,7 +176,7 @@ plot_embedding(X_hlle,
 # ----------------------------------------------------------------------
 # LTSA embedding of the digits dataset
 print("Computing LTSA embedding")
-clf = manifold.LocallyLinearEmbedding(n_neighbors, n_components=2,
+clf = manifold.LocallyLinearEmbedding(n_neighbors=n_neighbors, n_components=2,
                                       method='ltsa')
 t0 = time()
 X_ltsa = clf.fit_transform(X)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR improves the examples by fixing FutureWarnings currently present in the examples:
- keyword only arguments
- new arguments in scikit-learn version 0.23
- deprecation in pandas 1.0.0 (https://github.com/pandas-dev/pandas/issues/23566)

Some warnings may still remain.

#### Any other comments?
If a version 0.23.1 is planned, this would be a nice to have.