### PR TITLE
MNT Completes position arg deprecation

### DIFF
--- a/examples/linear_model/plot_lasso_coordinate_descent_path.py
+++ b/examples/linear_model/plot_lasso_coordinate_descent_path.py
@@ -31,11 +31,11 @@ X /= X.std(axis=0)  # Standardize data (easier to set the l1_ratio parameter)
 eps = 5e-3  # the smaller it is the longer is the path
 
 print("Computing regularization path using the lasso...")
-alphas_lasso, coefs_lasso, _ = lasso_path(X, y, eps, fit_intercept=False)
+alphas_lasso, coefs_lasso, _ = lasso_path(X, y, eps=eps, fit_intercept=False)
 
 print("Computing regularization path using the positive lasso...")
 alphas_positive_lasso, coefs_positive_lasso, _ = lasso_path(
-    X, y, eps, positive=True, fit_intercept=False)
+    X, y, eps=eps, positive=True, fit_intercept=False)
 print("Computing regularization path using the elastic net...")
 alphas_enet, coefs_enet, _ = enet_path(
     X, y, eps=eps, l1_ratio=0.8, fit_intercept=False)

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -2,6 +2,7 @@
 """
 import os
 from contextlib import contextmanager as contextmanager
+from .utils.validation import _deprecate_positional_args
 
 _global_config = {
     'assume_finite': bool(os.environ.get('SKLEARN_ASSUME_FINITE', False)),
@@ -27,7 +28,8 @@ def get_config():
     return _global_config.copy()
 
 
-def set_config(assume_finite=None, working_memory=None,
+@_deprecate_positional_args
+def set_config(*, assume_finite=None, working_memory=None,
                print_changed_only=None, display=None):
     """Set global scikit-learn configuration
 

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -2,7 +2,6 @@
 """
 import os
 from contextlib import contextmanager as contextmanager
-from .utils.validation import _deprecate_positional_args
 
 _global_config = {
     'assume_finite': bool(os.environ.get('SKLEARN_ASSUME_FINITE', False)),
@@ -28,8 +27,7 @@ def get_config():
     return _global_config.copy()
 
 
-@_deprecate_positional_args
-def set_config(*, assume_finite=None, working_memory=None,
+def set_config(assume_finite=None, working_memory=None,
                print_changed_only=None, display=None):
     """Set global scikit-learn configuration
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -506,7 +506,8 @@ class _SigmoidCalibration(RegressorMixin, BaseEstimator):
         return expit(-(self.a_ * T + self.b_))
 
 
-def calibration_curve(y_true, y_prob, normalize=False, n_bins=5,
+@_deprecate_positional_args
+def calibration_curve(y_true, y_prob, *, normalize=False, n_bins=5,
                       strategy='uniform'):
     """Compute true and predicted probabilities for a calibration curve.
 

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -30,6 +30,7 @@ def _equal_similarities_and_preferences(S, preference):
     return all_equal_preferences() and all_equal_similarities()
 
 
+@_deprecate_positional_args
 def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
                          damping=0.5, copy=True, verbose=False,
                          return_n_iter=False, random_state='warn'):

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -31,8 +31,8 @@ def _equal_similarities_and_preferences(S, preference):
 
 
 @_deprecate_positional_args
-def affinity_propagation(S, preference=None, convergence_iter=15, max_iter=200,
-                         damping=0.5, copy=True, verbose=False,
+def affinity_propagation(S, *, preference=None, convergence_iter=15,
+                         max_iter=200, damping=0.5, copy=True, verbose=False,
                          return_n_iter=False, random_state='warn'):
     """Perform Affinity Propagation Clustering of data
 
@@ -412,7 +412,8 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
 
         self.cluster_centers_indices_, self.labels_, self.n_iter_ = \
             affinity_propagation(
-                self.affinity_matrix_, self.preference, max_iter=self.max_iter,
+                self.affinity_matrix_, preference=self.preference,
+                max_iter=self.max_iter,
                 convergence_iter=self.convergence_iter, damping=self.damping,
                 copy=self.copy, verbose=self.verbose, return_n_iter=True,
                 random_state=self.random_state)

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -877,7 +877,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         distance_threshold = self.distance_threshold
 
         return_distance = distance_threshold is not None
-        out = memory.cache(tree_builder)(X, connectivity,
+        out = memory.cache(tree_builder)(X, connectivity=connectivity,
                                          n_clusters=n_clusters,
                                          return_distance=return_distance,
                                          **kwargs)

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -136,7 +136,7 @@ def _single_linkage_tree(connectivity, n_samples, n_nodes, n_clusters,
 # Hierarchical tree building functions
 
 @_deprecate_positional_args
-def ward_tree(X, connectivity=None, n_clusters=None, return_distance=False):
+def ward_tree(X, *, connectivity=None, n_clusters=None, return_distance=False):
     """Ward clustering based on a Feature matrix.
 
     Recursively merges the pair of clusters that minimally increases

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -135,6 +135,7 @@ def _single_linkage_tree(connectivity, n_samples, n_nodes, n_clusters,
 ###############################################################################
 # Hierarchical tree building functions
 
+@_deprecate_positional_args
 def ward_tree(X, connectivity=None, n_clusters=None, return_distance=False):
     """Ward clustering based on a Feature matrix.
 

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -20,9 +20,10 @@ from ..neighbors import NearestNeighbors
 from ._dbscan_inner import dbscan_inner
 
 
-def dbscan(X, eps=0.5, min_samples=5, metric='minkowski', metric_params=None,
-           algorithm='auto', leaf_size=30, p=2, sample_weight=None,
-           n_jobs=None):
+@_deprecate_positional_args
+def dbscan(X, *, eps=0.5, min_samples=5, metric='minkowski',
+           metric_params=None, algorithm='auto', leaf_size=30, p=2,
+           sample_weight=None, n_jobs=None):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
     Read more in the :ref:`User Guide <dbscan>`.

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -21,7 +21,7 @@ from ._dbscan_inner import dbscan_inner
 
 
 @_deprecate_positional_args
-def dbscan(X, *, eps=0.5, min_samples=5, metric='minkowski',
+def dbscan(X, eps=0.5, *, min_samples=5, metric='minkowski',
            metric_params=None, algorithm='auto', leaf_size=30, p=2,
            sample_weight=None, n_jobs=None):
     """Perform DBSCAN clustering from vector array or distance matrix.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -182,7 +182,8 @@ def _check_normalize_sample_weight(sample_weight, X):
     return sample_weight
 
 
-def k_means(X, n_clusters, sample_weight=None, init='k-means++',
+@_deprecate_positional_args
+def k_means(X, n_clusters, *, sample_weight=None, init='k-means++',
             precompute_distances='deprecated', n_init=10, max_iter=300,
             verbose=False, tol=1e-4, random_state=None, copy_x=True,
             n_jobs='deprecated', algorithm="auto", return_n_iter=False):

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -26,7 +26,8 @@ from ..neighbors import NearestNeighbors
 from ..metrics.pairwise import pairwise_distances_argmin
 
 
-def estimate_bandwidth(X, quantile=0.3, n_samples=None, random_state=0,
+@_deprecate_positional_args
+def estimate_bandwidth(X, *, quantile=0.3, n_samples=None, random_state=0,
                        n_jobs=None):
     """Estimate the bandwidth to use with the mean-shift algorithm.
 
@@ -106,7 +107,8 @@ def _mean_shift_single_seed(my_mean, X, nbrs, max_iter):
     return tuple(my_mean), len(points_within), completed_iterations
 
 
-def mean_shift(X, bandwidth=None, seeds=None, bin_seeding=False,
+@_deprecate_positional_args
+def mean_shift(X, *, bandwidth=None, seeds=None, bin_seeding=False,
                min_bin_freq=1, cluster_all=True, max_iter=300,
                n_jobs=None):
     """Perform mean shift clustering of data using a flat kernel.

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -261,13 +261,13 @@ class OPTICS(ClusterMixin, BaseEstimator):
         # Extract clusters from the calculated orders and reachability
         if self.cluster_method == 'xi':
             labels_, clusters_ = cluster_optics_xi(
-                self.reachability_,
-                self.predecessor_,
-                self.ordering_,
-                self.min_samples,
-                self.min_cluster_size,
-                self.xi,
-                self.predecessor_correction)
+                reachability=self.reachability_,
+                predecessor=self.predecessor_,
+                ordering=self.ordering_,
+                min_samples=self.min_samples,
+                min_cluster_size=self.min_cluster_size,
+                xi=self.xi,
+                predecessor_correction=self.predecessor_correction)
             self.cluster_hierarchy_ = clusters_
         elif self.cluster_method == 'dbscan':
             if self.eps is None:
@@ -279,10 +279,10 @@ class OPTICS(ClusterMixin, BaseEstimator):
                 raise ValueError('Specify an epsilon smaller than %s. Got %s.'
                                  % (self.max_eps, eps))
 
-            labels_ = cluster_optics_dbscan(self.reachability_,
-                                            self.core_distances_,
-                                            self.ordering_,
-                                            eps)
+            labels_ = cluster_optics_dbscan(
+                reachability=self.reachability_,
+                core_distances=self.core_distances_,
+                ordering=self.ordering_, eps=eps)
 
         self.labels_ = labels_
         return self
@@ -339,7 +339,8 @@ def _compute_core_distances_(X, neighbors, min_samples, working_memory):
     return core_distances
 
 
-def compute_optics_graph(X, min_samples, max_eps, metric, p, metric_params,
+@_deprecate_positional_args
+def compute_optics_graph(X, *, min_samples, max_eps, metric, p, metric_params,
                          algorithm, leaf_size, n_jobs):
     """Computes the OPTICS reachability graph.
 
@@ -538,7 +539,8 @@ def _set_reach_dist(core_distances_, reachability_, predecessor_,
     predecessor_[unproc[improved]] = point_index
 
 
-def cluster_optics_dbscan(reachability, core_distances, ordering, eps):
+@_deprecate_positional_args
+def cluster_optics_dbscan(*, reachability, core_distances, ordering, eps):
     """Performs DBSCAN extraction for an arbitrary epsilon.
 
     Extracting the clusters runs in linear time. Note that this results in
@@ -577,7 +579,7 @@ def cluster_optics_dbscan(reachability, core_distances, ordering, eps):
     return labels
 
 
-def cluster_optics_xi(reachability, predecessor, ordering, min_samples,
+def cluster_optics_xi(*, reachability, predecessor, ordering, min_samples,
                       min_cluster_size=None, xi=0.05,
                       predecessor_correction=True):
     """Automatically extract clusters according to the Xi-steep method.

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -18,7 +18,8 @@ from ..manifold import spectral_embedding
 from ._kmeans import k_means
 
 
-def discretize(vectors, copy=True, max_svd_restarts=30, n_iter_max=20,
+@_deprecate_positional_args
+def discretize(vectors, *, copy=True, max_svd_restarts=30, n_iter_max=20,
                random_state=None):
     """Search for a partition matrix (clustering) which is closest to the
     eigenvector embedding.
@@ -156,7 +157,8 @@ def discretize(vectors, copy=True, max_svd_restarts=30, n_iter_max=20,
     return labels
 
 
-def spectral_clustering(affinity, n_clusters=8, n_components=None,
+@_deprecate_positional_args
+def spectral_clustering(affinity, *, n_clusters=8, n_components=None,
                         eigen_solver=None, random_state=None, n_init=10,
                         eigen_tol=0.0, assign_labels='kmeans'):
     """Apply clustering to a projection of the normalized Laplacian.

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -74,16 +74,16 @@ def test_structured_linkage_tree():
     connectivity = grid_to_graph(*mask.shape)
     for tree_builder in _TREE_BUILDERS.values():
         children, n_components, n_leaves, parent = \
-            tree_builder(X.T, connectivity)
+            tree_builder(X.T, connectivity=connectivity)
         n_nodes = 2 * X.shape[1] - 1
         assert len(children) + n_leaves == n_nodes
         # Check that ward_tree raises a ValueError with a connectivity matrix
         # of the wrong shape
         with pytest.raises(ValueError):
-            tree_builder(X.T, np.ones((4, 4)))
+            tree_builder(X.T, connectivity=np.ones((4, 4)))
         # Check that fitting with no samples raises an error
         with pytest.raises(ValueError):
-            tree_builder(X.T[:0], connectivity)
+            tree_builder(X.T[:0], connectivity=connectivity)
 
 
 def test_unstructured_linkage_tree():
@@ -116,7 +116,8 @@ def test_height_linkage_tree():
     X = rng.randn(50, 100)
     connectivity = grid_to_graph(*mask.shape)
     for linkage_func in _TREE_BUILDERS.values():
-        children, n_nodes, n_leaves, parent = linkage_func(X.T, connectivity)
+        children, n_nodes, n_leaves, parent = linkage_func(
+            X.T, connectivity=connectivity)
         n_nodes = 2 * X.shape[1] - 1
         assert len(children) + n_leaves == n_nodes
 
@@ -298,7 +299,8 @@ def test_sparse_scikit_vs_scipy():
             out = hierarchy.linkage(X, method=linkage)
 
             children_ = out[:, :2].astype(np.int, copy=False)
-            children, _, n_leaves, _ = _TREE_BUILDERS[linkage](X, connectivity)
+            children, _, n_leaves, _ = _TREE_BUILDERS[linkage](
+                X, connectivity=connectivity)
 
             # Sort the order of child nodes per row for consistency
             children.sort(axis=1)

--- a/sklearn/cluster/tests/test_mean_shift.py
+++ b/sklearn/cluster/tests/test_mean_shift.py
@@ -71,7 +71,7 @@ def test_estimate_bandwidth_with_sparse_matrix():
     # Test estimate_bandwidth with sparse matrix
     X = sparse.lil_matrix((1000, 1000))
     msg = "A sparse matrix was passed, but dense data is required."
-    assert_raise_message(TypeError, msg, estimate_bandwidth, X, 200)
+    assert_raise_message(TypeError, msg, estimate_bandwidth, X)
 
 
 def test_parallel():

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -187,7 +187,7 @@ def test_discretize(n_samples):
         y_true_noisy = (y_indicator.toarray()
                         + 0.1 * random_state.randn(n_samples,
                                                    n_class + 1))
-        y_pred = discretize(y_true_noisy, random_state)
+        y_pred = discretize(y_true_noisy, random_state=random_state)
         assert adjusted_rand_score(y_true, y_pred) > 0.8
 
 

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -48,7 +48,8 @@ def log_likelihood(emp_cov, precision):
     return log_likelihood_
 
 
-def empirical_covariance(X, assume_centered=False):
+@_deprecate_positional_args
+def empirical_covariance(X, *, assume_centered=False):
     """Computes the Maximum likelihood covariance estimator
 
 

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -75,8 +75,8 @@ def alpha_max(emp_cov):
 
 
 # The g-lasso algorithm
-
-def graphical_lasso(emp_cov, alpha, cov_init=None, mode='cd', tol=1e-4,
+@_deprecate_positional_args
+def graphical_lasso(emp_cov, *, alpha, cov_init=None, mode='cd', tol=1e-4,
                     enet_tol=1e-4, max_iter=100, verbose=False,
                     return_costs=False, eps=np.finfo(np.float64).eps,
                     return_n_iter=False):

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -76,7 +76,7 @@ def alpha_max(emp_cov):
 
 # The g-lasso algorithm
 @_deprecate_positional_args
-def graphical_lasso(emp_cov, *, alpha, cov_init=None, mode='cd', tol=1e-4,
+def graphical_lasso(emp_cov, alpha, *, cov_init=None, mode='cd', tol=1e-4,
                     enet_tol=1e-4, max_iter=100, verbose=False,
                     return_costs=False, eps=np.finfo(np.float64).eps,
                     return_n_iter=False):

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -253,7 +253,8 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
     return shrinkage
 
 
-def ledoit_wolf(X, assume_centered=False, block_size=1000):
+@_deprecate_positional_args
+def ledoit_wolf(X, *, assume_centered=False, block_size=1000):
     """Estimates the shrunk Ledoit-Wolf covariance matrix.
 
     Read more in the :ref:`User Guide <shrunk_covariance>`.
@@ -430,8 +431,8 @@ class LedoitWolf(EmpiricalCovariance):
 
 
 # OAS estimator
-
-def oas(X, assume_centered=False):
+@_deprecate_positional_args
+def oas(X, *, assume_centered=False):
     """Estimate covariance with the Oracle Approximating Shrinkage algorithm.
 
     Parameters

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -185,7 +185,8 @@ def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
 
 
 # XXX : could be moved to the linear_model module
-def sparse_encode(X, dictionary, gram=None, cov=None, algorithm='lasso_lars',
+@_deprecate_positional_args
+def sparse_encode(X, dictionary, *, gram=None, cov=None, algorithm='lasso_lars',
                   n_nonzero_coefs=None, alpha=None, copy_cov=True, init=None,
                   max_iter=1000, n_jobs=None, check_input=True, verbose=0,
                   positive=False):
@@ -421,7 +422,8 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
     return dictionary
 
 
-def dict_learning(X, n_components, alpha, max_iter=100, tol=1e-8,
+@_deprecate_positional_args
+def dict_learning(X, n_components, *, alpha, max_iter=100, tol=1e-8,
                   method='lars', n_jobs=None, dict_init=None, code_init=None,
                   callback=None, verbose=False, random_state=None,
                   return_n_iter=False, positive_dict=False,
@@ -615,7 +617,8 @@ def dict_learning(X, n_components, alpha, max_iter=100, tol=1e-8,
         return code, dictionary, errors
 
 
-def dict_learning_online(X, n_components=2, alpha=1, n_iter=100,
+@_deprecate_positional_args
+def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
                          return_code=True, dict_init=None, callback=None,
                          batch_size=3, verbose=False, shuffle=True,
                          n_jobs=None, method='lars', iter_offset=0,
@@ -1230,7 +1233,7 @@ class DictionaryLearning(SparseCodingMixin, BaseEstimator):
             n_components = self.n_components
 
         V, U, E, self.n_iter_ = dict_learning(
-            X, n_components, self.alpha,
+            X, n_components, alpha=self.alpha,
             tol=self.tol, max_iter=self.max_iter,
             method=self.fit_algorithm,
             method_max_iter=self.transform_max_iter,
@@ -1434,7 +1437,7 @@ class MiniBatchDictionaryLearning(SparseCodingMixin, BaseEstimator):
         X = self._validate_data(X)
 
         U, (A, B), self.n_iter_ = dict_learning_online(
-            X, self.n_components, self.alpha,
+            X, self.n_components, alpha=self.alpha,
             n_iter=self.n_iter, return_code=False,
             method=self.fit_algorithm,
             method_max_iter=self.transform_max_iter,
@@ -1486,7 +1489,7 @@ class MiniBatchDictionaryLearning(SparseCodingMixin, BaseEstimator):
         if iter_offset is None:
             iter_offset = getattr(self, 'iter_offset_', 0)
         U, (A, B) = dict_learning_online(
-            X, self.n_components, self.alpha,
+            X, self.n_components, alpha=self.alpha,
             n_iter=self.n_iter, method=self.fit_algorithm,
             method_max_iter=self.transform_max_iter,
             n_jobs=self.n_jobs, dict_init=dict_init,

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -186,10 +186,10 @@ def _sparse_encode(X, dictionary, gram, cov=None, algorithm='lasso_lars',
 
 # XXX : could be moved to the linear_model module
 @_deprecate_positional_args
-def sparse_encode(X, dictionary, *, gram=None, cov=None, algorithm='lasso_lars',
-                  n_nonzero_coefs=None, alpha=None, copy_cov=True, init=None,
-                  max_iter=1000, n_jobs=None, check_input=True, verbose=0,
-                  positive=False):
+def sparse_encode(X, dictionary, *, gram=None, cov=None,
+                  algorithm='lasso_lars', n_nonzero_coefs=None, alpha=None,
+                  copy_cov=True, init=None, max_iter=1000, n_jobs=None,
+                  check_input=True, verbose=0, positive=False):
     """Sparse coding
 
     Each row of the result is the solution to a sparse coding problem.

--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -147,7 +147,8 @@ def _cube(x, fun_args):
     return x ** 3, (3 * x ** 2).mean(axis=-1)
 
 
-def fastica(X, n_components=None, algorithm="parallel", whiten=True,
+@_deprecate_positional_args
+def fastica(X, n_components=None, *, algorithm="parallel", whiten=True,
             fun="logcosh", fun_args=None, max_iter=200, tol=1e-04, w_init=None,
             random_state=None, return_X_mean=False, compute_sources=True,
             return_n_iter=False):

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -841,7 +841,8 @@ def _fit_multiplicative_update(X, W, H, beta_loss='frobenius',
     return W, H, n_iter
 
 
-def non_negative_factorization(X, W=None, H=None, n_components=None,
+@_deprecate_positional_args
+def non_negative_factorization(X, W=None, H=None, n_components=None, *,
                                init=None, update_H=True, solver='cd',
                                beta_loss='frobenius', tol=1e-4,
                                max_iter=200, alpha=0., l1_ratio=0.,

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -187,7 +187,8 @@ class SparsePCA(TransformerMixin, BaseEstimator):
             n_components = self.n_components
         code_init = self.V_init.T if self.V_init is not None else None
         dict_init = self.U_init.T if self.U_init is not None else None
-        Vt, _, E, self.n_iter_ = dict_learning(X.T, n_components, self.alpha,
+        Vt, _, E, self.n_iter_ = dict_learning(X.T, n_components,
+                                               alpha=self.alpha,
                                                tol=self.tol,
                                                max_iter=self.max_iter,
                                                method=self.method,

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -107,7 +107,7 @@ def test_dict_learning_lars_positive_parameter():
     alpha = 1
     err_msg = "Positive constraint not supported for 'lars' coding method."
     with pytest.raises(ValueError, match=err_msg):
-        dict_learning(X, n_components, alpha, positive_code=True)
+        dict_learning(X, n_components, alpha=alpha, positive_code=True)
 
 
 @pytest.mark.parametrize("transform_algorithm", [
@@ -247,7 +247,7 @@ def test_dict_learning_online_lars_positive_parameter():
     alpha = 1
     err_msg = "Positive constraint not supported for 'lars' coding method."
     with pytest.raises(ValueError, match=err_msg):
-        dict_learning_online(X, alpha, positive_code=True)
+        dict_learning_online(X, alpha=alpha, positive_code=True)
 
 
 @pytest.mark.parametrize("transform_algorithm", [

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -234,19 +234,19 @@ def test_non_negative_factorization_checking():
     nnmf = non_negative_factorization
     msg = ("Number of components must be a positive integer; "
            "got (n_components=1.5)")
-    assert_raise_message(ValueError, msg, nnmf, A, A, A, 1.5, 'random')
+    assert_raise_message(ValueError, msg, nnmf, A, A, A, 1.5, init='random')
     msg = ("Number of components must be a positive integer; "
            "got (n_components='2')")
-    assert_raise_message(ValueError, msg, nnmf, A, A, A, '2', 'random')
+    assert_raise_message(ValueError, msg, nnmf, A, A, A, '2', init='random')
     msg = "Negative values in data passed to NMF (input H)"
-    assert_raise_message(ValueError, msg, nnmf, A, A, -A, 2, 'custom')
+    assert_raise_message(ValueError, msg, nnmf, A, A, -A, 2, init='custom')
     msg = "Negative values in data passed to NMF (input W)"
-    assert_raise_message(ValueError, msg, nnmf, A, -A, A, 2, 'custom')
+    assert_raise_message(ValueError, msg, nnmf, A, -A, A, 2, init='custom')
     msg = "Array passed to NMF (input H) is full of zeros"
-    assert_raise_message(ValueError, msg, nnmf, A, A, 0 * A, 2, 'custom')
+    assert_raise_message(ValueError, msg, nnmf, A, A, 0 * A, 2, init='custom')
     msg = "Invalid regularization parameter: got 'spam' instead of one of"
-    assert_raise_message(ValueError, msg, nnmf, A, A, 0 * A, 2, 'custom', True,
-                         'cd', 2., 1e-4, 200, 0., 0., 'spam')
+    assert_raise_message(ValueError, msg, nnmf, A, A, 0 * A, 2, init='custom',
+                         regularization='spam')
 
 
 def _beta_divergence_dense(X, W, H, beta):

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -130,7 +130,8 @@ def _to_graph(n_x, n_y, n_z, mask=None, img=None,
     return return_as(graph)
 
 
-def img_to_graph(img, mask=None, return_as=sparse.coo_matrix, dtype=None):
+@_deprecate_positional_args
+def img_to_graph(img, *, mask=None, return_as=sparse.coo_matrix, dtype=None):
     """Graph of the pixel-to-pixel gradient connections
 
     Edges are weighted with the gradient values.
@@ -166,7 +167,8 @@ def img_to_graph(img, mask=None, return_as=sparse.coo_matrix, dtype=None):
     return _to_graph(n_x, n_y, n_z, mask, img, return_as, dtype)
 
 
-def grid_to_graph(n_x, n_y, n_z=1, mask=None, return_as=sparse.coo_matrix,
+@_deprecate_positional_args
+def grid_to_graph(n_x, n_y, n_z=1, *, mask=None, return_as=sparse.coo_matrix,
                   dtype=np.int):
     """Graph of the pixel-to-pixel connections
 
@@ -344,7 +346,9 @@ def extract_patches(arr, patch_shape=8, extraction_step=1):
                             extraction_step=extraction_step)
 
 
-def extract_patches_2d(image, patch_size, max_patches=None, random_state=None):
+@_deprecate_positional_args
+def extract_patches_2d(image, patch_size, *, max_patches=None,
+                       random_state=None):
     """Reshape a 2D image into a collection of patches
 
     The resulting patches are allocated in a dedicated array.

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -583,7 +583,8 @@ class PatchExtractor(BaseEstimator):
         patches = np.empty(patches_shape)
         for ii, image in enumerate(X):
             patches[ii * n_patches:(ii + 1) * n_patches] = extract_patches_2d(
-                image, patch_size, self.max_patches, self.random_state)
+                image, patch_size, max_patches=self.max_patches,
+                random_state=self.random_state)
         return patches
 
     def _more_tags(self):

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -68,7 +68,7 @@ def test_connect_regions():
     face = face[::4, ::4]
     for thr in (50, 150):
         mask = face > thr
-        graph = img_to_graph(face, mask)
+        graph = img_to_graph(face, mask=mask)
         assert ndimage.label(mask)[1] == connected_components(graph)[0]
 
 

--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -11,6 +11,7 @@ from ..preprocessing import scale
 from ..utils import check_random_state
 from ..utils.fixes import _astype_copy_false
 from ..utils.validation import check_array, check_X_y
+from ..utils.validation import _deprecate_positional_args
 from ..utils.multiclass import check_classification_targets
 
 
@@ -290,7 +291,8 @@ def _estimate_mi(X, y, discrete_features='auto', discrete_target=False,
     return np.array(mi)
 
 
-def mutual_info_regression(X, y, discrete_features='auto', n_neighbors=3,
+@_deprecate_positional_args
+def mutual_info_regression(X, y, *, discrete_features='auto', n_neighbors=3,
                            copy=True, random_state=None):
     """Estimate mutual information for a continuous target variable.
 
@@ -367,7 +369,8 @@ def mutual_info_regression(X, y, discrete_features='auto', n_neighbors=3,
                         copy, random_state)
 
 
-def mutual_info_classif(X, y, discrete_features='auto', n_neighbors=3,
+@_deprecate_positional_args
+def mutual_info_classif(X, y, *, discrete_features='auto', n_neighbors=3,
                         copy=True, random_state=None):
     """Estimate mutual information for a discrete target variable.
 

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -229,7 +229,8 @@ def chi2(X, y):
     return _chisquare(observed, expected)
 
 
-def f_regression(X, y, center=True):
+@_deprecate_positional_args
+def f_regression(X, y, *, center=True):
     """Univariate linear regression tests.
 
     Linear model for testing the individual effect of each of many regressors.

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -76,7 +76,8 @@ def check_increasing(x, y):
     return increasing_bool
 
 
-def isotonic_regression(y, sample_weight=None, y_min=None, y_max=None,
+@_deprecate_positional_args
+def isotonic_regression(y, *, sample_weight=None, y_min=None, y_max=None,
                         increasing=True):
     """Solve the isotonic regression model.
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -254,8 +254,8 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
             X, y, sample_weight)
 
         X = unique_X
-        y = isotonic_regression(unique_y, unique_sample_weight,
-                                self.y_min, self.y_max,
+        y = isotonic_regression(unique_y, sample_weight=unique_sample_weight,
+                                y_min=self.y_min, y_max=self.y_max,
                                 increasing=self.increasing_)
 
         # Handle the left and right bounds on X

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -168,7 +168,8 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
                        num=n_alphas)[::-1]
 
 
-def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
+@_deprecate_positional_args
+def lasso_path(X, y, *, eps=1e-3, n_alphas=100, alphas=None,
                precompute='auto', Xy=None, copy_X=True, coef_init=None,
                verbose=False, return_n_iter=False, positive=False, **params):
     """Compute Lasso path with coordinate descent
@@ -313,7 +314,8 @@ def lasso_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
                      positive=positive, return_n_iter=return_n_iter, **params)
 
 
-def enet_path(X, y, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
+@_deprecate_positional_args
+def enet_path(X, y, *, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
               precompute='auto', Xy=None, copy_X=True, coef_init=None,
               verbose=False, return_n_iter=False, positive=False,
               check_input=True, **params):

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -662,7 +662,8 @@ def _logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
     # the class_weights are assigned after masking the labels with a OvR.
     le = LabelEncoder()
     if isinstance(class_weight, dict) or multi_class == 'multinomial':
-        class_weight_ = compute_class_weight(class_weight, classes, y)
+        class_weight_ = compute_class_weight(class_weight,
+                                             classes=classes, y=y)
         sample_weight *= class_weight_[le.fit_transform(y)]
 
     # For doing a ovr, we need to mask the labels first. for the
@@ -676,8 +677,9 @@ def _logistic_regression_path(X, y, pos_class=None, Cs=10, fit_intercept=True,
         # for compute_class_weight
 
         if class_weight == "balanced":
-            class_weight_ = compute_class_weight(class_weight, mask_classes,
-                                                 y_bin)
+            class_weight_ = compute_class_weight(class_weight,
+                                                 classes=mask_classes,
+                                                 y=y_bin)
             sample_weight *= class_weight_[le.fit_transform(y_bin)]
 
     else:
@@ -1867,9 +1869,8 @@ class LogisticRegressionCV(LogisticRegression, BaseEstimator,
 
         # compute the class weights for the entire dataset y
         if class_weight == "balanced":
-            class_weight = compute_class_weight(class_weight,
-                                                np.arange(len(self.classes_)),
-                                                y)
+            class_weight = compute_class_weight(
+                class_weight, classes=np.arange(len(self.classes_)), y=y)
             class_weight = dict(enumerate(class_weight))
 
         path_func = delayed(_log_reg_scoring_path)

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -497,8 +497,8 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
         n_classes = self.classes_.shape[0]
 
         # Allocate datastructures from input arguments
-        self._expanded_class_weight = compute_class_weight(self.class_weight,
-                                                           self.classes_, y)
+        self._expanded_class_weight = compute_class_weight(
+            self.class_weight, classes=self.classes_, y=y)
         sample_weight = _check_sample_weight(sample_weight, X)
 
         if getattr(self, "coef_", None) is None or coef_init is not None:
@@ -681,7 +681,8 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
         if self.class_weight in ['balanced']:
             raise ValueError("class_weight '{0}' is not supported for "
                              "partial_fit. In order to use 'balanced' weights,"
-                             " use compute_class_weight('{0}', classes, y). "
+                             " use compute_class_weight('{0}', "
+                             "classes=classes, y=y). "
                              "In place of y you can us a large enough sample "
                              "of the full training set target to properly "
                              "estimate the class frequency distributions. "

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -883,7 +883,7 @@ def test_logistic_regression_sample_weights():
 def _compute_class_weight_dictionary(y):
     # helper for returning a dictionary instead of an array
     classes = np.unique(y)
-    class_weight = compute_class_weight("balanced", classes, y)
+    class_weight = compute_class_weight("balanced", classes=classes, y=y)
     class_weight_dict = dict(zip(classes, class_weight))
     return class_weight_dict
 

--- a/sklearn/linear_model/tests/test_sag.py
+++ b/sklearn/linear_model/tests/test_sag.py
@@ -644,7 +644,8 @@ def test_binary_classifier_class_weight():
     clf2.fit(sp.csr_matrix(X), y)
 
     le = LabelEncoder()
-    class_weight_ = compute_class_weight(class_weight, np.unique(y), y)
+    class_weight_ = compute_class_weight(class_weight, classes=np.unique(y),
+                                         y=y)
     sample_weight = class_weight_[le.fit_transform(y)]
     spweights, spintercept = sag_sparse(X, y, step_size, alpha, n_iter=n_iter,
                                         dloss=log_dloss,
@@ -690,7 +691,8 @@ def test_multiclass_classifier_class_weight():
     clf2.fit(sp.csr_matrix(X), y)
 
     le = LabelEncoder()
-    class_weight_ = compute_class_weight(class_weight, np.unique(y), y)
+    class_weight_ = compute_class_weight(class_weight, classes=np.unique(y),
+                                         y=y)
     sample_weight = class_weight_[le.fit_transform(y)]
 
     coef1 = []

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -573,7 +573,7 @@ def test_partial_fit_weight_class_balanced(klass):
     # partial_fit with class_weight='balanced' not supported"""
     regex = (r"class_weight 'balanced' is not supported for "
              r"partial_fit\. In order to use 'balanced' weights, "
-             r"use compute_class_weight\('balanced', classes, y\). "
+             r"use compute_class_weight\('balanced', classes=classes, y=y\). "
              r"In place of y you can us a large enough sample "
              r"of the full training set target to properly "
              r"estimate the class frequency distributions\. "

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -977,8 +977,7 @@ def paired_distances(X, Y, *, metric="euclidean", **kwds):
 
 
 # Kernels
-@_deprecate_positional_args
-def linear_kernel(X, Y=None, *, dense_output=True):
+def linear_kernel(X, Y=None, dense_output=True):
     """
     Compute the linear kernel between X and Y.
 
@@ -1004,8 +1003,7 @@ def linear_kernel(X, Y=None, *, dense_output=True):
     return safe_sparse_dot(X, Y.T, dense_output=dense_output)
 
 
-@_deprecate_positional_args
-def polynomial_kernel(X, Y=None, *, degree=3, gamma=None, coef0=1):
+def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
     """
     Compute the polynomial kernel between X and Y::
 
@@ -1041,8 +1039,7 @@ def polynomial_kernel(X, Y=None, *, degree=3, gamma=None, coef0=1):
     return K
 
 
-@_deprecate_positional_args
-def sigmoid_kernel(X, Y=None, *, gamma=None, coef0=1):
+def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
     """
     Compute the sigmoid kernel between X and Y::
 
@@ -1076,8 +1073,7 @@ def sigmoid_kernel(X, Y=None, *, gamma=None, coef0=1):
     return K
 
 
-@_deprecate_positional_args
-def rbf_kernel(X, Y=None, *, gamma=None):
+def rbf_kernel(X, Y=None, gamma=None):
     """
     Compute the rbf (gaussian) kernel between X and Y::
 
@@ -1110,8 +1106,7 @@ def rbf_kernel(X, Y=None, *, gamma=None):
     return K
 
 
-@_deprecate_positional_args
-def laplacian_kernel(X, Y=None, *, gamma=None):
+def laplacian_kernel(X, Y=None, gamma=None):
     """Compute the laplacian kernel between X and Y.
 
     The laplacian kernel is defined as::
@@ -1145,8 +1140,7 @@ def laplacian_kernel(X, Y=None, *, gamma=None):
     return K
 
 
-@_deprecate_positional_args
-def cosine_similarity(X, Y=None, *, dense_output=True):
+def cosine_similarity(X, Y=None, dense_output=True):
     """Compute cosine similarity between samples in X and Y.
 
     Cosine similarity, or the cosine kernel, computes similarity as the
@@ -1256,8 +1250,7 @@ def additive_chi2_kernel(X, Y=None):
     return result
 
 
-@_deprecate_positional_args
-def chi2_kernel(X, Y=None, *, gamma=1.):
+def chi2_kernel(X, Y=None, gamma=1.):
     """Computes the exponential chi-squared kernel X and Y.
 
     The chi-squared kernel is computed between each pair of rows in X and Y.  X

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -977,7 +977,8 @@ def paired_distances(X, Y, *, metric="euclidean", **kwds):
 
 
 # Kernels
-def linear_kernel(X, Y=None, dense_output=True):
+@_deprecate_positional_args
+def linear_kernel(X, Y=None, *, dense_output=True):
     """
     Compute the linear kernel between X and Y.
 
@@ -1003,7 +1004,8 @@ def linear_kernel(X, Y=None, dense_output=True):
     return safe_sparse_dot(X, Y.T, dense_output=dense_output)
 
 
-def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
+@_deprecate_positional_args
+def polynomial_kernel(X, Y=None, *, degree=3, gamma=None, coef0=1):
     """
     Compute the polynomial kernel between X and Y::
 
@@ -1039,7 +1041,8 @@ def polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1):
     return K
 
 
-def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
+@_deprecate_positional_args
+def sigmoid_kernel(X, Y=None, *, gamma=None, coef0=1):
     """
     Compute the sigmoid kernel between X and Y::
 
@@ -1073,7 +1076,8 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
     return K
 
 
-def rbf_kernel(X, Y=None, gamma=None):
+@_deprecate_positional_args
+def rbf_kernel(X, Y=None, *, gamma=None):
     """
     Compute the rbf (gaussian) kernel between X and Y::
 
@@ -1106,7 +1110,8 @@ def rbf_kernel(X, Y=None, gamma=None):
     return K
 
 
-def laplacian_kernel(X, Y=None, gamma=None):
+@_deprecate_positional_args
+def laplacian_kernel(X, Y=None, *, gamma=None):
     """Compute the laplacian kernel between X and Y.
 
     The laplacian kernel is defined as::
@@ -1140,7 +1145,8 @@ def laplacian_kernel(X, Y=None, gamma=None):
     return K
 
 
-def cosine_similarity(X, Y=None, dense_output=True):
+@_deprecate_positional_args
+def cosine_similarity(X, Y=None, *, dense_output=True):
     """Compute cosine similarity between samples in X and Y.
 
     Cosine similarity, or the cosine kernel, computes similarity as the
@@ -1250,7 +1256,8 @@ def additive_chi2_kernel(X, Y=None):
     return result
 
 
-def chi2_kernel(X, Y=None, gamma=1.):
+@_deprecate_positional_args
+def chi2_kernel(X, Y=None, *, gamma=1.):
     """Computes the exponential chi-squared kernel X and Y.
 
     The chi-squared kernel is computed between each pair of rows in X and Y.  X

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -49,7 +49,8 @@ __all__ = ["SparseRandomProjection",
            "johnson_lindenstrauss_min_dim"]
 
 
-def johnson_lindenstrauss_min_dim(n_samples, eps=0.1):
+@_deprecate_positional_args
+def johnson_lindenstrauss_min_dim(n_samples, *, eps=0.1):
     """Find a 'safe' number of components to randomly project to
 
     The distortion introduced by a random projection `p` only changes the

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -543,7 +543,8 @@ class BaseSVC(ClassifierMixin, BaseLibSVM, metaclass=ABCMeta):
         y_ = column_or_1d(y, warn=True)
         check_classification_targets(y)
         cls, y = np.unique(y_, return_inverse=True)
-        self.class_weight_ = compute_class_weight(self.class_weight, cls, y_)
+        self.class_weight_ = compute_class_weight(self.class_weight,
+                                                  classes=cls, y=y_)
         if len(cls) < 2:
             raise ValueError(
                 "The number of classes has to be greater than one; got %d"
@@ -926,7 +927,8 @@ def _fit_liblinear(X, y, C, fit_intercept, intercept_scaling, class_weight,
                              " in the data, but the data contains only one"
                              " class: %r" % classes_[0])
 
-        class_weight_ = compute_class_weight(class_weight, classes_, y)
+        class_weight_ = compute_class_weight(class_weight, classes=classes_,
+                                             y=y)
     else:
         class_weight_ = np.empty(0, dtype=np.float64)
         y_ind = y

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -599,7 +599,8 @@ def test_auto_weight():
     unbalanced = np.delete(np.arange(y.size), np.where(y > 2)[0][::2])
 
     classes = np.unique(y[unbalanced])
-    class_weights = compute_class_weight('balanced', classes, y[unbalanced])
+    class_weights = compute_class_weight('balanced', classes=classes,
+                                         y=y[unbalanced])
     assert np.argmax(class_weights) == 2
 
     for clf in (svm.SVC(kernel='linear'), svm.LinearSVC(random_state=0),

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -273,7 +273,8 @@ def _determine_key_type(key, accept_slice=True):
 # TODO: remove in 0.24
 @deprecated("safe_indexing is deprecated in version "
             "0.22 and will be removed in version 0.24.")
-def safe_indexing(X, indices, axis=0):
+@_deprecate_positional_args
+def safe_indexing(X, indices, *, axis=0):
     """Return rows, items or columns of X using indices.
 
     .. deprecated:: 0.22

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -273,7 +273,6 @@ def _determine_key_type(key, accept_slice=True):
 # TODO: remove in 0.24
 @deprecated("safe_indexing is deprecated in version "
             "0.22 and will be removed in version 0.24.")
-@_deprecate_positional_args
 def safe_indexing(X, indices, *, axis=0):
     """Return rows, items or columns of X using indices.
 

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -7,7 +7,8 @@ import numpy as np
 from .validation import _deprecate_positional_args
 
 
-def compute_class_weight(class_weight, classes, y):
+@_deprecate_positional_args
+def compute_class_weight(class_weight, *, classes, y):
     """Estimate class weights for unbalanced datasets.
 
     Parameters
@@ -153,8 +154,8 @@ def compute_sample_weight(class_weight, y, *, indices=None):
             classes_subsample = np.unique(y_subsample)
 
             weight_k = np.take(compute_class_weight(class_weight_k,
-                                                    classes_subsample,
-                                                    y_subsample),
+                                                    classes=classes_subsample,
+                                                    y=y_subsample),
                                np.searchsorted(classes_subsample,
                                                classes_full),
                                mode='clip')
@@ -162,8 +163,8 @@ def compute_sample_weight(class_weight, y, *, indices=None):
             classes_missing = set(classes_full) - set(classes_subsample)
         else:
             weight_k = compute_class_weight(class_weight_k,
-                                            classes_full,
-                                            y_full)
+                                            classes=classes_full,
+                                            y=y_full)
 
         weight_k = weight_k[np.searchsorted(classes_full, y_full)]
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -20,6 +20,7 @@ from . import check_random_state
 from ._logistic_sigmoid import _log_logistic_sigmoid
 from .sparsefuncs_fast import csr_row_norms
 from .validation import check_array
+from .validation import _deprecate_positional_args
 from .deprecation import deprecated
 
 
@@ -115,7 +116,8 @@ def density(w, **kwargs):
     return d
 
 
-def safe_sparse_dot(a, b, dense_output=False):
+@_deprecate_positional_args
+def safe_sparse_dot(a, b, *, dense_output=False):
     """Dot product that handle the sparse matrix case correctly
 
     Parameters
@@ -156,7 +158,8 @@ def safe_sparse_dot(a, b, dense_output=False):
     return ret
 
 
-def randomized_range_finder(A, size, n_iter,
+@_deprecate_positional_args
+def randomized_range_finder(A, *, size, n_iter,
                             power_iteration_normalizer='auto',
                             random_state=None):
     """Computes an orthonormal matrix whose range approximates the range of A.
@@ -240,7 +243,8 @@ def randomized_range_finder(A, size, n_iter,
     return Q
 
 
-def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
+@_deprecate_positional_args
+def randomized_svd(M, n_components, *, n_oversamples=10, n_iter='auto',
                    power_iteration_normalizer='auto', transpose='auto',
                    flip_sign=True, random_state=0):
     """Computes a truncated randomized SVD
@@ -342,8 +346,10 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
         # this implementation is a bit faster with smaller shape[1]
         M = M.T
 
-    Q = randomized_range_finder(M, n_random, n_iter,
-                                power_iteration_normalizer, random_state)
+    Q = randomized_range_finder(
+        M, size=n_random, n_iter=n_iter,
+        power_iteration_normalizer=power_iteration_normalizer,
+        random_state=random_state)
 
     # project M to the (k + p) dimensional space using the basis vectors
     B = safe_sparse_dot(Q.T, M)
@@ -369,7 +375,8 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter='auto',
         return U[:, :n_components], s[:n_components], Vt[:n_components, :]
 
 
-def weighted_mode(a, w, axis=0):
+@_deprecate_positional_args
+def weighted_mode(a, w, *, axis=0):
     """Returns an array of the weighted modal (most common) value in a
 
     If there is more than one such value, only the first is returned.

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -20,6 +20,7 @@ from . import check_random_state
 from ._logistic_sigmoid import _log_logistic_sigmoid
 from .sparsefuncs_fast import csr_row_norms
 from .validation import check_array
+from .validation import _deprecate_positional_args
 from .deprecation import deprecated
 
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -20,7 +20,6 @@ from . import check_random_state
 from ._logistic_sigmoid import _log_logistic_sigmoid
 from .sparsefuncs_fast import csr_row_norms
 from .validation import check_array
-from .validation import _deprecate_positional_args
 from .deprecation import deprecated
 
 

--- a/sklearn/utils/graph.py
+++ b/sklearn/utils/graph.py
@@ -13,13 +13,14 @@ sparse matrices.
 from scipy import sparse
 
 from .graph_shortest_path import graph_shortest_path  # noqa
+from .validation import _deprecate_positional_args
 
 
 ###############################################################################
 # Path and connected component analysis.
 # Code adapted from networkx
-
-def single_source_shortest_path_length(graph, source, cutoff=None):
+@_deprecate_positional_args
+def single_source_shortest_path_length(graph, source, *, cutoff=None):
     """Return the shortest path length from source to all reachable nodes.
 
     Returns a dictionary of shortest path lengths keyed by target.

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -5,6 +5,7 @@
 # License: BSD 3 clause
 import scipy.sparse as sp
 import numpy as np
+from .validation import _deprecate_positional_args
 
 from .sparsefuncs_fast import (
     csr_mean_variance_axis0 as _csr_mean_var_axis0,
@@ -98,7 +99,8 @@ def mean_variance_axis(X, axis):
         _raise_typeerror(X)
 
 
-def incr_mean_variance_axis(X, axis, last_mean, last_var, last_n):
+@_deprecate_positional_args
+def incr_mean_variance_axis(X, *, axis, last_mean, last_var, last_n):
     """Compute incremental mean and variance along an axix on a CSR or
     CSC matrix.
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -15,7 +15,7 @@ def test_compute_class_weight():
     y = np.asarray([2, 2, 2, 3, 3, 4])
     classes = np.unique(y)
 
-    cw = compute_class_weight("balanced", classes, y)
+    cw = compute_class_weight("balanced", classes=classes, y=y)
     # total effect of samples is preserved
     class_counts = np.bincount(y)[2:]
     assert_almost_equal(np.dot(cw, class_counts), y.shape[0])
@@ -27,25 +27,25 @@ def test_compute_class_weight_not_present():
     classes = np.arange(4)
     y = np.asarray([0, 0, 0, 1, 1, 2])
     with pytest.raises(ValueError):
-        compute_class_weight("balanced", classes, y)
+        compute_class_weight("balanced", classes=classes, y=y)
     # Fix exception in error message formatting when missing label is a string
     # https://github.com/scikit-learn/scikit-learn/issues/8312
     with pytest.raises(ValueError,
                        match="Class label label_not_present not present"):
-        compute_class_weight({"label_not_present": 1.}, classes, y)
+        compute_class_weight({"label_not_present": 1.}, classes=classes, y=y)
     # Raise error when y has items not in classes
     classes = np.arange(2)
     with pytest.raises(ValueError):
-        compute_class_weight("balanced", classes, y)
+        compute_class_weight("balanced", classes=classes, y=y)
     with pytest.raises(ValueError):
-        compute_class_weight({0: 1., 1: 2.}, classes, y)
+        compute_class_weight({0: 1., 1: 2.}, classes=classes, y=y)
 
 
 def test_compute_class_weight_dict():
     classes = np.arange(3)
     class_weights = {0: 1.0, 1: 2.0, 2: 3.0}
     y = np.asarray([0, 0, 1, 2])
-    cw = compute_class_weight(class_weights, classes, y)
+    cw = compute_class_weight(class_weights, classes=classes, y=y)
 
     # When the user specifies class weights, compute_class_weights should just
     # return them.
@@ -56,12 +56,12 @@ def test_compute_class_weight_dict():
     msg = 'Class label 4 not present.'
     class_weights = {0: 1.0, 1: 2.0, 2: 3.0, 4: 1.5}
     with pytest.raises(ValueError, match=msg):
-        compute_class_weight(class_weights, classes, y)
+        compute_class_weight(class_weights, classes=classes, y=y)
 
     msg = 'Class label -1 not present.'
     class_weights = {-1: 5.0, 0: 1.0, 1: 2.0, 2: 3.0}
     with pytest.raises(ValueError, match=msg):
-        compute_class_weight(class_weights, classes, y)
+        compute_class_weight(class_weights, classes=classes, y=y)
 
 
 def test_compute_class_weight_invariance():
@@ -98,14 +98,14 @@ def test_compute_class_weight_balanced_negative():
     classes = np.array([-2, -1, 0])
     y = np.asarray([-1, -1, 0, 0, -2, -2])
 
-    cw = compute_class_weight("balanced", classes, y)
+    cw = compute_class_weight("balanced", classes=classes, y=y)
     assert len(cw) == len(classes)
     assert_array_almost_equal(cw, np.array([1., 1., 1.]))
 
     # Test with unbalanced class labels.
     y = np.asarray([-1, 0, 0, -2, -2, -2])
 
-    cw = compute_class_weight("balanced", classes, y)
+    cw = compute_class_weight("balanced", classes=classes, y=y)
     assert len(cw) == len(classes)
     class_counts = np.bincount(y + 2)
     assert_almost_equal(np.dot(cw, class_counts), y.shape[0])
@@ -117,7 +117,7 @@ def test_compute_class_weight_balanced_unordered():
     classes = np.array([1, 0, 3])
     y = np.asarray([1, 0, 0, 3, 3, 3])
 
-    cw = compute_class_weight("balanced", classes, y)
+    cw = compute_class_weight("balanced", classes=classes, y=y)
     class_counts = np.bincount(y)[classes]
     assert_almost_equal(np.dot(cw, class_counts), y.shape[0])
     assert_array_almost_equal(cw, [2., 1., 2. / 3])
@@ -131,16 +131,16 @@ def test_compute_class_weight_default():
     classes_len = len(classes)
 
     # Test for non specified weights
-    cw = compute_class_weight(None, classes, y)
+    cw = compute_class_weight(None, classes=classes, y=y)
     assert len(cw) == classes_len
     assert_array_almost_equal(cw, np.ones(3))
 
     # Tests for partly specified weights
-    cw = compute_class_weight({2: 1.5}, classes, y)
+    cw = compute_class_weight({2: 1.5}, classes=classes, y=y)
     assert len(cw) == classes_len
     assert_array_almost_equal(cw, [1.5, 1., 1.])
 
-    cw = compute_class_weight({2: 1.5, 4: 0.5}, classes, y)
+    cw = compute_class_weight({2: 1.5, 4: 0.5}, classes=classes, y=y)
     assert len(cw) == classes_len
     assert_array_almost_equal(cw, [1.5, 1., 0.5])
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -210,7 +210,8 @@ class BadBalancedWeightsClassifier(BaseBadClassifier):
 
         label_encoder = LabelEncoder().fit(y)
         classes = label_encoder.classes_
-        class_weight = compute_class_weight(self.class_weight, classes, y)
+        class_weight = compute_class_weight(self.class_weight, classes=classes,
+                                            y=y)
 
         # Intentionally modify the balanced class_weight
         # to simulate a bug and raise an exception

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -59,7 +59,7 @@ def test_uniform_weights():
 
     for axis in (None, 0, 1):
         mode, score = stats.mode(x, axis)
-        mode2, score2 = weighted_mode(x, weights, axis)
+        mode2, score2 = weighted_mode(x, weights, axis=axis)
 
         assert_array_equal(mode, mode2)
         assert_array_equal(score, score2)

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -105,14 +105,17 @@ def test_incr_mean_variance_axis():
         X_csr = sp.csr_matrix(X_lil)
 
         with pytest.raises(TypeError):
-            incr_mean_variance_axis(axis, last_mean, last_var, last_n)
+            incr_mean_variance_axis(X=axis, axis=last_mean, last_mean=last_var,
+                                    last_var=last_n)
         with pytest.raises(TypeError):
-            incr_mean_variance_axis(X_lil, axis, last_mean, last_var, last_n)
+            incr_mean_variance_axis(X_lil, axis=axis, last_mean=last_mean,
+                                    last_var=last_var, last_n=last_n)
 
         # Test _incr_mean_and_var with a 1 row input
         X_means, X_vars = mean_variance_axis(X_csr, axis)
         X_means_incr, X_vars_incr, n_incr = \
-            incr_mean_variance_axis(X_csr, axis, last_mean, last_var, last_n)
+            incr_mean_variance_axis(X_csr, axis=axis, last_mean=last_mean,
+                                    last_var=last_var, last_n=last_n)
         assert_array_almost_equal(X_means, X_means_incr)
         assert_array_almost_equal(X_vars, X_vars_incr)
         # X.shape[axis] picks # samples
@@ -142,8 +145,10 @@ def test_incr_mean_variance_axis():
                 last_var = last_var.astype(output_dtype)
                 X_means, X_vars = mean_variance_axis(X_sparse, axis)
                 X_means_incr, X_vars_incr, n_incr = \
-                    incr_mean_variance_axis(X_sparse, axis, last_mean,
-                                            last_var, last_n)
+                    incr_mean_variance_axis(X_sparse, axis=axis,
+                                            last_mean=last_mean,
+                                            last_var=last_var,
+                                            last_n=last_n)
                 assert X_means_incr.dtype == output_dtype
                 assert X_vars_incr.dtype == output_dtype
                 assert_array_almost_equal(X_means, X_means_incr)
@@ -171,10 +176,11 @@ def test_incr_mean_variance_axis_equivalence_mean_variance(X1, X2):
     last_mean, last_var = np.zeros(X1.shape[1]), np.zeros(X1.shape[1])
     last_n = np.zeros(X1.shape[1], dtype=np.int64)
     updated_mean, updated_var, updated_n = incr_mean_variance_axis(
-        X1, axis, last_mean, last_var, last_n
+        X1, axis=axis, last_mean=last_mean, last_var=last_var, last_n=last_n
     )
     updated_mean, updated_var, updated_n = incr_mean_variance_axis(
-        X2, axis, updated_mean, updated_var, updated_n
+        X2, axis=axis, last_mean=updated_mean, last_var=updated_var,
+        last_n=updated_n
     )
     X = sp.vstack([X1, X2])
     assert_allclose(updated_mean, np.nanmean(X.A, axis=axis))
@@ -190,11 +196,11 @@ def test_incr_mean_variance_no_new_n():
     last_mean, last_var = np.zeros(X1.shape[1]), np.zeros(X1.shape[1])
     last_n = np.zeros(X1.shape[1], dtype=np.int64)
     last_mean, last_var, last_n = incr_mean_variance_axis(
-        X1, axis, last_mean, last_var, last_n
+        X1, axis=axis, last_mean=last_mean, last_var=last_var, last_n=last_n
     )
     # update statistic with a column which should ignored
     updated_mean, updated_var, updated_n = incr_mean_variance_axis(
-        X2, axis, last_mean, last_var, last_n
+        X2, axis=axis, last_mean=last_mean, last_var=last_var, last_n=last_n
     )
     assert_allclose(updated_mean, last_mean)
     assert_allclose(updated_var, last_var)
@@ -227,11 +233,11 @@ def test_incr_mean_variance_axis_ignore_nan(axis, sparse_constructor):
 
     # take a copy of the old statistics since they are modified in place.
     X_means, X_vars, X_sample_count = incr_mean_variance_axis(
-        X, axis, old_means.copy(), old_variances.copy(),
-        old_sample_count.copy())
+        X, axis=axis, last_mean=old_means.copy(),
+        last_var=old_variances.copy(), last_n=old_sample_count.copy())
     X_nan_means, X_nan_vars, X_nan_sample_count = incr_mean_variance_axis(
-        X_nan, axis, old_means.copy(), old_variances.copy(),
-        old_sample_count.copy())
+        X_nan, axis=axis, last_mean=old_means.copy(),
+        last_var=old_variances.copy(), last_n=old_sample_count.copy())
 
     assert_allclose(X_nan_means, X_means)
     assert_allclose(X_nan_vars, X_vars)


### PR DESCRIPTION
After this PR here are the public functions that have 2 or more arguments that do not have a `*` for keyword only arguments. In this case, "public function" means it is listed in `classes.rst`.

These functions are **not** updated with this PR:

```py
[<function sklearn._config.set_config(assume_finite=None, working_memory=None, print_changed_only=None, display=None)>,
 <function sklearn.compose._column_transformer.make_column_transformer(*transformers, **kwargs)>,
 <function sklearn.covariance._shrunk_covariance.shrunk_covariance(emp_cov, shrinkage=0.1)>,
 <function sklearn.feature_extraction.image.reconstruct_from_patches_2d(patches, image_size)>,
 <function sklearn.feature_extraction.image.extract_patches(arr, patch_shape=8, extraction_step=1)>,
 <function sklearn.feature_selection._univariate_selection.f_classif(X, y)>,
 <function sklearn.feature_selection._univariate_selection.chi2(X, y)>,
 <function sklearn.isotonic.check_increasing(x, y)>,
 <function sklearn.metrics._ranking.auc(x, y)>,
 <function sklearn.metrics._regression.max_error(y_true, y_pred)>,
 <function sklearn.metrics.cluster._supervised.adjusted_rand_score(labels_true, labels_pred)>,
 <function sklearn.metrics.cluster._supervised.homogeneity_score(labels_true, labels_pred)>,
 <function sklearn.metrics.cluster._supervised.completeness_score(labels_true, labels_pred)>,
 <function sklearn.metrics.cluster._unsupervised.calinski_harabasz_score(X, labels)>,
 <function sklearn.metrics.cluster._unsupervised.davies_bouldin_score(X, labels)>,
 <function sklearn.metrics.pairwise.laplacian_kernel(X, Y=None, gamma=None)>,
 <function sklearn.metrics.pairwise.chi2_kernel(X, Y=None, gamma=1.0)>,
 <function sklearn.metrics.pairwise.linear_kernel(X, Y=None, dense_output=True)>,
 <function sklearn.metrics.pairwise.polynomial_kernel(X, Y=None, degree=3, gamma=None, coef0=1)>,
 <function sklearn.metrics.pairwise.haversine_distances(X, Y=None)>,
 <function sklearn.metrics.pairwise.additive_chi2_kernel(X, Y=None)>,
 <function sklearn.metrics.pairwise.paired_cosine_distances(X, Y)>,
 <function sklearn.metrics.pairwise.cosine_similarity(X, Y=None, dense_output=True)>,
 <function sklearn.metrics.pairwise.rbf_kernel(X, Y=None, gamma=None)>,
 <function sklearn.metrics.pairwise.paired_euclidean_distances(X, Y)>,
 <function sklearn.metrics.pairwise.sigmoid_kernel(X, Y=None, gamma=None, coef0=1)>,
 <function sklearn.metrics.pairwise.paired_manhattan_distances(X, Y)>,
 <function sklearn.metrics.pairwise.cosine_distances(X, Y=None)>,
 <function sklearn.model_selection._search.fit_grid_point(X, y, estimator, parameters, train, test, scorer, verbose, error_score=nan, **fit_params)>,
 <function sklearn.neural_network._base.log_loss(y_true, y_prob)>,
 <function sklearn.pipeline.make_pipeline(*steps, **kwargs)>,
 <function sklearn.pipeline.make_union(*transformers, **kwargs)>,
 <function sklearn.preprocessing._data.add_dummy_feature(X, value=1.0)>,
 <function sklearn.utils.safe_mask(X, mask)>,
 <function sklearn.utils.resample(*arrays, **options)>,
 <function sklearn.utils.shuffle(*arrays, **options)>,
 <function sklearn.utils.safe_indexing(X, indices, axis=0)>,
 <function sklearn.utils.class_weight.compute_class_weight(class_weight, classes, y)>,
 <function sklearn.utils.extmath.safe_sparse_dot(a, b, dense_output=False)>,
 <function sklearn.utils.extmath.density(w, **kwargs)>,
 <function sklearn.utils.extmath.randomized_svd(M, n_components, n_oversamples=10, n_iter='auto', power_iteration_normalizer='auto', transpose='auto', flip_sign=True, random_state=0)>,
 <function sklearn.utils.extmath.randomized_range_finder(A, size, n_iter, power_iteration_normalizer='auto', random_state=None)>,
 <function sklearn.utils.extmath.weighted_mode(a, w, axis=0)>,
 <function sklearn.utils.graph.single_source_shortest_path_length(graph, source, cutoff=None)>,
 <function sklearn.utils.sparsefuncs.inplace_csr_column_scale(X, scale)>,
 <function sklearn.utils.sparsefuncs.inplace_swap_column(X, m, n)>,
 <function sklearn.utils.sparsefuncs.inplace_swap_row(X, m, n)>,
 <function sklearn.utils.sparsefuncs.incr_mean_variance_axis(X, axis, last_mean, last_var, last_n)>,
 <function sklearn.utils.sparsefuncs.mean_variance_axis(X, axis)>,
 <function sklearn.utils.sparsefuncs.inplace_row_scale(X, scale)>,
 <function sklearn.utils.sparsefuncs.inplace_column_scale(X, scale)>,
 <function sklearn.utils.validation.has_fit_parameter(estimator, parameter)>]
```

The `utils` and `pairwise` ones are the biggest bunch that do not have `*`.

Are there any other functions we want to add `*` to?