### PR TITLE
[MRG] Add threadpoolctl requirement to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ scikit-learn requires:
 - NumPy (>= 1.13.3)
 - SciPy (>= 0.19.1)
 - joblib (>= 0.11)
+- threadpoolctl (>= 2.0.0)
 
 **Scikit-learn 0.20 was the last version to support Python 2.7 and Python 3.4.**
 scikit-learn 0.23 and later require Python 3.6 or newer.

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -89,7 +89,8 @@ runtime:
 - Python (>= 3.6),
 - NumPy (>= 1.13.3),
 - SciPy (>= 0.19),
-- Joblib (>= 0.11).
+- Joblib (>= 0.11),
+- threadpoolctl (>= 2.0.0).
 
 Those dependencies are **automatically installed by pip** if they were missing
 when building scikit-learn from source.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR documents that threadpoolctl is a dependency (requirement) to install scikit-learn.