### PR TITLE
TST Replace Boston dataset in test_tree

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -261,7 +261,7 @@ def test_iris():
 
 
 def test_diabetes():
-    # Check consistency on dataset diabetes house prices.
+    # Check consistency on diabetes dataset.
 
     for (name, Tree), criterion in product(REG_TREES.items(), REG_CRITERIONS):
         reg = Tree(criterion=criterion, random_state=0)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -265,18 +265,21 @@ def test_diabetes():
 
     for (name, Tree), criterion in product(REG_TREES.items(), REG_CRITERIONS):
         reg = Tree(criterion=criterion, random_state=0)
+        # fitting a fully grown tree should completely overfit the data
+        # and lead to an MSE of 0 (or near of 0)
         reg.fit(diabetes.data, diabetes.target)
         score = mean_squared_error(diabetes.target, reg.predict(diabetes.data))
-        assert score < 1, (
+        assert score == pytest.approx(0), (
             "Failed with {0}, criterion = {1} and score = {2}"
             "".format(name, criterion, score))
 
-        # using fewer features reduces the learning ability of this tree,
-        # but reduces training time.
-        reg = Tree(criterion=criterion, max_features=6, random_state=0)
+        # using fewer features and limiting tree depth reduces the learning
+        # ability of this tree, but reduces training time.
+        reg = Tree(criterion=criterion, max_features=6, max_depth=18,
+                   random_state=0)
         reg.fit(diabetes.data, diabetes.target)
         score = mean_squared_error(diabetes.target, reg.predict(diabetes.data))
-        assert score < 2, (
+        assert score < 11, (
             "Failed with {0}, criterion = {1} and score = {2}"
             "".format(name, criterion, score))
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -25,6 +25,7 @@ from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import create_memmap_backed_data
 from sklearn.utils._testing import ignore_warnings
+from sklearn.utils._testing import skip_if_32bit
 
 from sklearn.utils.validation import check_random_state
 
@@ -273,6 +274,7 @@ def test_diabetes_overfit(name, Tree, criterion):
     )
 
 
+@skip_if_32bit
 @pytest.mark.parametrize("name, Tree", REG_TREES.items())
 @pytest.mark.parametrize(
     "criterion, max_depth",

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -275,11 +275,11 @@ def test_diabetes():
 
         # using fewer features and limiting tree depth reduces the learning
         # ability of this tree, but reduces training time.
-        reg = Tree(criterion=criterion, max_features=6, max_depth=18,
+        reg = Tree(criterion=criterion, max_features=6, max_depth=20,
                    random_state=0)
         reg.fit(diabetes.data, diabetes.target)
         score = mean_squared_error(diabetes.target, reg.predict(diabetes.data))
-        assert score < 22, (
+        assert score < 10, (
             "Failed with {0}, criterion = {1} and score = {2}"
             "".format(name, criterion, score))
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -108,12 +108,12 @@ perm = rng.permutation(iris.target.size)
 iris.data = iris.data[perm]
 iris.target = iris.target[perm]
 
-# also load the boston dataset
+# also load the diabetes dataset
 # and randomly permute it
-boston = datasets.load_boston()
-perm = rng.permutation(boston.target.size)
-boston.data = boston.data[perm]
-boston.target = boston.target[perm]
+diabetes = datasets.load_diabetes()
+perm = rng.permutation(diabetes.target.size)
+diabetes.data = diabetes.data[perm]
+diabetes.target = diabetes.target[perm]
 
 digits = datasets.load_digits()
 perm = rng.permutation(digits.target.size)
@@ -134,7 +134,7 @@ X_sparse_mix = _sparse_random_matrix(20, 10, density=0.25,
 
 DATASETS = {
     "iris": {"X": iris.data, "y": iris.target},
-    "boston": {"X": boston.data, "y": boston.target},
+    "diabetes": {"X": diabetes.data, "y": diabetes.target},
     "digits": {"X": digits.data, "y": digits.target},
     "toy": {"X": X, "y": y},
     "clf_small": {"X": X_small, "y": y_small},
@@ -260,13 +260,13 @@ def test_iris():
             "".format(name, criterion, score))
 
 
-def test_boston():
-    # Check consistency on dataset boston house prices.
+def test_diabetes():
+    # Check consistency on dataset diabetes house prices.
 
     for (name, Tree), criterion in product(REG_TREES.items(), REG_CRITERIONS):
         reg = Tree(criterion=criterion, random_state=0)
-        reg.fit(boston.data, boston.target)
-        score = mean_squared_error(boston.target, reg.predict(boston.data))
+        reg.fit(diabetes.data, diabetes.target)
+        score = mean_squared_error(diabetes.target, reg.predict(diabetes.data))
         assert score < 1, (
             "Failed with {0}, criterion = {1} and score = {2}"
             "".format(name, criterion, score))
@@ -274,8 +274,8 @@ def test_boston():
         # using fewer features reduces the learning ability of this tree,
         # but reduces training time.
         reg = Tree(criterion=criterion, max_features=6, random_state=0)
-        reg.fit(boston.data, boston.target)
-        score = mean_squared_error(boston.target, reg.predict(boston.data))
+        reg.fit(diabetes.data, diabetes.target)
+        score = mean_squared_error(diabetes.target, reg.predict(diabetes.data))
         assert score < 2, (
             "Failed with {0}, criterion = {1} and score = {2}"
             "".format(name, criterion, score))
@@ -420,8 +420,8 @@ def test_max_features():
     # Check max_features.
     for name, TreeRegressor in REG_TREES.items():
         reg = TreeRegressor(max_features="auto")
-        reg.fit(boston.data, boston.target)
-        assert reg.max_features_ == boston.data.shape[1]
+        reg.fit(diabetes.data, diabetes.target)
+        assert reg.max_features_ == diabetes.data.shape[1]
 
     for name, TreeClassifier in CLF_TREES.items():
         clf = TreeClassifier(max_features="auto")
@@ -902,7 +902,7 @@ def test_min_impurity_decrease():
         if "Classifier" in name:
             X, y = iris.data, iris.target
         else:
-            X, y = boston.data, boston.target
+            X, y = diabetes.data, diabetes.target
 
         est = TreeEstimator(random_state=0)
         est.fit(X, y)
@@ -1327,7 +1327,7 @@ def check_sparse_input(tree, dataset, max_depth=None):
     y = DATASETS[dataset]["y"]
 
     # Gain testing time
-    if dataset in ["digits", "boston"]:
+    if dataset in ["digits", "diabetes"]:
         n_samples = X.shape[0] // 5
         X = X[:n_samples]
         X_sparse = X_sparse[:n_samples]
@@ -1375,7 +1375,7 @@ def test_sparse_input(tree_type, dataset):
 
 @pytest.mark.parametrize("tree_type",
                          sorted(set(SPARSE_TREES).intersection(REG_TREES)))
-@pytest.mark.parametrize("dataset", ["boston", "reg_small"])
+@pytest.mark.parametrize("dataset", ["diabetes", "reg_small"])
 def test_sparse_input_reg_trees(tree_type, dataset):
     # Due to numerical instability of MSE and too strict test, we limit the
     # maximal depth
@@ -1817,7 +1817,7 @@ def test_empty_leaf_infinite_threshold():
 
 @pytest.mark.parametrize("criterion", CLF_CRITERIONS)
 @pytest.mark.parametrize(
-    "dataset", sorted(set(DATASETS.keys()) - {"reg_small", "boston"}))
+    "dataset", sorted(set(DATASETS.keys()) - {"reg_small", "diabetes"}))
 @pytest.mark.parametrize(
     "tree_cls", [DecisionTreeClassifier, ExtraTreeClassifier])
 def test_prune_tree_classifier_are_subtrees(criterion, dataset, tree_cls):

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -279,7 +279,7 @@ def test_diabetes():
                    random_state=0)
         reg.fit(diabetes.data, diabetes.target)
         score = mean_squared_error(diabetes.target, reg.predict(diabetes.data))
-        assert score < 11, (
+        assert score < 22, (
             "Failed with {0}, criterion = {1} and score = {2}"
             "".format(name, criterion, score))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Towards #16155

#### What does this implement/fix? Explain your changes.
Replace Boston dataset with diabetes dataset in `sklearn/tree/trests/test_tree.py`

#### Any other comments?
I noticed that in `test_boston` (now `test_diabetes`) the score was always 0 for all estimators and criterions - for both boston and diabetes datasets. I confirmed that `reg.predict(diabetes.data)`  gives exactly `diabetes.target` - possibly due to the `reg` being fitted on the same dataset. I don't think this is what was intended? Happy to amend, here or in another PR, if this is not right.
