### PR TITLE
MNT Enables subset_invariance tests to run with SparsePCA

### DIFF
--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -205,14 +205,6 @@ class SparsePCA(TransformerMixin, BaseEstimator):
 
         return U
 
-    def _more_tags(self):
-        return {
-            '_xfail_checks': {
-                "check_methods_subset_invariance":
-                "fails for the transform method"
-            }
-        }
-
 
 class MiniBatchSparsePCA(SparsePCA):
     """Mini-batch Sparse Principal Components Analysis


### PR DESCRIPTION
With https://github.com/scikit-learn/scikit-learn/pull/11585, these the `*SparsePCA` now passes `check_methods_subset_invariance`.