### PR TITLE
DOC Replace Canopy installers by Enthought Deployment Manager

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -221,12 +221,11 @@ command::
     $ sudo port install py36-scikit-learn
 
 
-Canopy and Anaconda for all supported platforms
------------------------------------------------
+Enthought Deployment Manager and Anaconda for all supported platforms
+---------------------------------------------------------------------
 
-`Canopy
-<https://www.enthought.com/products/canopy>`_ and `Anaconda
-<https://www.anaconda.com/download>`_ both ship a recent
+`Enthought Deployment Manager <https://assets.enthought.com/downloads/>`_
+and `Anaconda <https://www.anaconda.com/download>`_ both ship a recent
 version of scikit-learn, in addition to a large set of scientific python
 library for Windows, Mac OSX and Linux.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -221,11 +221,11 @@ command::
     $ sudo port install py36-scikit-learn
 
 
-Enthought Deployment Manager and Anaconda for all supported platforms
+Anaconda and Enthought Deployment Manager for all supported platforms
 ---------------------------------------------------------------------
 
-`Enthought Deployment Manager <https://assets.enthought.com/downloads/>`_
-and `Anaconda <https://www.anaconda.com/download>`_ both ship a recent
+`Anaconda <https://www.anaconda.com/download>`_ and
+`Enthought Deployment Manager <https://assets.enthought.com/downloads/>`_ both ship a recent
 version of scikit-learn, in addition to a large set of scientific python
 library for Windows, Mac OSX and Linux.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -225,9 +225,9 @@ Anaconda and Enthought Deployment Manager for all supported platforms
 ---------------------------------------------------------------------
 
 `Anaconda <https://www.anaconda.com/download>`_ and
-`Enthought Deployment Manager <https://assets.enthought.com/downloads/>`_ both ship a recent
-version of scikit-learn, in addition to a large set of scientific python
-library for Windows, Mac OSX and Linux.
+`Enthought Deployment Manager <https://assets.enthought.com/downloads/>`_
+both ship with scikit-learn in addition to a large set of scientific
+python library for Windows, Mac OSX and Linux.
 
 Anaconda offers scikit-learn as part of its free distribution.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #17311.

#### What does this implement/fix? Explain your changes.

This PR replaces the end-of-life Canopy installers by the new Enthought Deployment Manager in the installation instructions.

CC @cmarmo.