### PR TITLE
MRG/GOV add adrin to TC in governance doc

### DIFF
--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -71,10 +71,11 @@ subject to a two-third majority of all cast votes as well as a simple majority
 approval of all the current TC members. TC members who do not actively engage
 with the TC duties are expected to resign.
 
-The initial Technical Committee of scikit-learn consists of :user:`Alexandre Gramfort <agramfort>`,
-:user:`Olivier Grisel <ogrisel>`, :user:`Andreas Müller <amueller>`, :user:`Joel Nothman <jnothman>`,
-:user:`Hanmin Qin <qinhanmin2014>`, :user:`Gaël Varoquaux <GaelVaroquaux>`, and
-:user:`Roman Yurchak <rth>`.
+The initial Technical Committee of scikit-learn consists of :user:`Alexandre
+Gramfort <agramfort>`, :user:`Olivier Grisel <ogrisel>`, :user:`Adrin Jalali
+<adrinjalali>_`, :user:`Andreas Müller <amueller>`, :user:`Joel Nothman
+<jnothman>`, :user:`Hanmin Qin <qinhanmin2014>`, :user:`Gaël Varoquaux
+<GaelVaroquaux>`, and :user:`Roman Yurchak <rth>`.
 
 Decision Making Process
 =======================

--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -71,7 +71,7 @@ subject to a two-third majority of all cast votes as well as a simple majority
 approval of all the current TC members. TC members who do not actively engage
 with the TC duties are expected to resign.
 
-The initial Technical Committee of scikit-learn consists of :user:`Alexandre
+The Technical Committee of scikit-learn consists of :user:`Alexandre
 Gramfort <agramfort>`, :user:`Olivier Grisel <ogrisel>`, :user:`Adrin Jalali
 <adrinjalali>`, :user:`Andreas Müller <amueller>`, :user:`Joel Nothman
 <jnothman>`, :user:`Hanmin Qin <qinhanmin2014>`, :user:`Gaël Varoquaux

--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -73,7 +73,7 @@ with the TC duties are expected to resign.
 
 The initial Technical Committee of scikit-learn consists of :user:`Alexandre
 Gramfort <agramfort>`, :user:`Olivier Grisel <ogrisel>`, :user:`Adrin Jalali
-<adrinjalali>_`, :user:`Andreas Müller <amueller>`, :user:`Joel Nothman
+<adrinjalali>`, :user:`Andreas Müller <amueller>`, :user:`Joel Nothman
 <jnothman>`, :user:`Hanmin Qin <qinhanmin2014>`, :user:`Gaël Varoquaux
 <GaelVaroquaux>`, and :user:`Roman Yurchak <rth>`.
 


### PR DESCRIPTION
This adds @adrinjalali  to the list of tc members in the governance doc. That's the only place, right?