### PR TITLE
ENH: add categorical imputation to IterativeImputer

### DIFF
--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -413,14 +413,14 @@ class IterativeImputer(_BaseImputer):
             )
             # Reverse transformation, we do not want to encode labels
             if y_train.ndim == 1:
-                y_train = y_train.reshape(-1, 1) # inverse_transform requires 2D inputs
+                y_train = y_train.reshape(-1, 1)  # inverse_transform req. 2D
             y_train = self._transformers[feat_idx].inverse_transform(
                 y_train
             )
             if y_train.shape[1] == 1:
                 # Convert back to a 1D array, which many estimators require
                 y_train = y_train.reshape(-1, )
-            # Make y_train float dtype to avoid issues with label type detection
+            # Make y_train float dtype to avoid issues with label type
             try:
                 y_train = y_train.astype(float)
             except ValueError:
@@ -476,9 +476,9 @@ class IterativeImputer(_BaseImputer):
             np.where(missing_row_mask)[0],
             np.atleast_1d(self._col_mapping(feat_idx))
         )
-        # Re-apply transformation to predictions since now they will be features
+        # Re-apply transformation to predictions making them features
         if imputed_values.ndim == 1:
-            imputed_values = imputed_values.reshape(-1, 1)  # transform expects 2D
+            imputed_values = imputed_values.reshape(-1, 1)  # transform req. 2D
         imputed_values = self._transformers[feat_idx].transform(imputed_values)
         # Reshape imputed_values, X_filled[ix] will always be at least 2D
         X_filled[ix] = imputed_values.reshape(imputed_values.shape[0], -1)

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -455,8 +455,14 @@ class IterativeImputer(_BaseImputer):
                 imputed_values = np.clip(imputed_values, min_val, max_val,)
 
         # Update the feature
-        X_filled[missing_row_mask, self._col_mapping(feat_idx)] = \
-            imputed_values
+        # Create a valid index from the boolean row
+        # masks and integer column numbers
+        ix = np.ix_(
+            np.where(missing_row_mask)[0],
+            np.atleast_1d(self._col_mapping(feat_idx))
+        )
+        # Reshape imputed_values, X_filled[ix] will always be at least 2D
+        X_filled[ix] = imputed_values.reshape(imputed_values.shape[0], -1)
         return X_filled, estimator
 
     def _col_mapping(self, cols):
@@ -767,7 +773,7 @@ class IterativeImputer(_BaseImputer):
         )
         if fit_mode:
             self._split_cols = split_cols
-            self._transformers = tfs
+            self._transformers = np.asarray(tfs)
         Xtf = np.concatenate(transformed, axis=1)
         if Xtf.ndim == 2 and Xt.ndim == 1 and Xtf.shape[1] == 1:
             return np.squeeze(Xtf, axis=1)

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -411,6 +411,21 @@ class IterativeImputer(_BaseImputer):
                 X_filled[:, self._col_mapping(feat_idx)],
                 ~missing_row_mask
             )
+            # Reverse transformation, we do not want to encode labels
+            if y_train.ndim == 1:
+                y_train = y_train.reshape(-1, 1) # inverse_transform requires 2D inputs
+            y_train = self._transformers[feat_idx].inverse_transform(
+                y_train
+            )
+            if y_train.shape[1] == 1:
+                # Convert back to a 1D array, which many estimators require
+                y_train = y_train.reshape(-1, )
+            # Make y_train float dtype to avoid issues with label type detection
+            try:
+                y_train = y_train.astype(float)
+            except ValueError:
+                # y_train contains non-numeric values
+                pass
             estimator.fit(X_train, y_train)
 
         # if no missing values, don't predict
@@ -461,7 +476,12 @@ class IterativeImputer(_BaseImputer):
             np.where(missing_row_mask)[0],
             np.atleast_1d(self._col_mapping(feat_idx))
         )
+        # Re-apply transformation to predictions since now they will be features
+        if imputed_values.ndim == 1:
+            imputed_values = imputed_values.reshape(-1, 1)  # transform expects 2D
+        imputed_values = self._transformers[feat_idx].transform(imputed_values)
         # Reshape imputed_values, X_filled[ix] will always be at least 2D
+        # Cast dtypes to preserve dtype of X_filled
         X_filled[ix] = imputed_values.reshape(imputed_values.shape[0], -1)
         return X_filled, estimator
 

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -481,7 +481,6 @@ class IterativeImputer(_BaseImputer):
             imputed_values = imputed_values.reshape(-1, 1)  # transform expects 2D
         imputed_values = self._transformers[feat_idx].transform(imputed_values)
         # Reshape imputed_values, X_filled[ix] will always be at least 2D
-        # Cast dtypes to preserve dtype of X_filled
         X_filled[ix] = imputed_values.reshape(imputed_values.shape[0], -1)
         return X_filled, estimator
 

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -775,8 +775,6 @@ class IterativeImputer(_BaseImputer):
             self._split_cols = split_cols
             self._transformers = np.asarray(tfs)
         Xtf = np.concatenate(transformed, axis=1)
-        if Xtf.ndim == 2 and Xt.ndim == 1 and Xtf.shape[1] == 1:
-            return np.squeeze(Xtf, axis=1)
         return Xtf
 
     @staticmethod
@@ -810,9 +808,6 @@ class IterativeImputer(_BaseImputer):
             )
         )
         Xt = np.concatenate(transformed, axis=1)
-        if Xt.ndim == 2 and Xt.shape[1] == 1:
-            # Always squeeze singleton dimension
-            return np.squeeze(Xt, axis=1)
         return Xt
 
     def fit_transform(self, X, y=None):

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -119,6 +119,7 @@ class IterativeImputer(_BaseImputer):
         Minimum possible imputed value. Broadcast to shape (n_features,) if
         scalar. If array-like, expects shape (n_features,), one min value for
         each feature. The default is `-np.inf`.
+
     max_value : float or array-like of shape (n_features,), default=np.inf
         Maximum possible imputed value. Broadcast to shape (n_features,) if
         scalar. If array-like, expects shape (n_features,), one max value for
@@ -394,10 +395,8 @@ class IterativeImputer(_BaseImputer):
             ``X_filled[missing_row_mask, feat_idx]``.
         """
         if estimator is None and fit_mode is False:
-            raise ValueError(
-                "If fit_mode is False, then an already-fitted "
-                "estimator should be passed in."
-            )
+            raise ValueError("If fit_mode is False, then an already-fitted "
+                             "estimator should be passed in.")
 
         if estimator is None:
             estimator = clone(self._estimators[feat_idx])
@@ -421,9 +420,8 @@ class IterativeImputer(_BaseImputer):
             return X_filled, estimator
 
         # get posterior samples if there is at least one missing value
-        X_test = _safe_indexing(
-            X_filled[:, neighbor_feat_idx], missing_row_mask
-        )
+        X_test = _safe_indexing(X_filled[:, neighbor_feat_idx],
+                                missing_row_mask)
         if self.sample_posterior:
             mus, sigmas = estimator.predict(X_test, return_std=True)
             imputed_values = np.zeros(mus.shape, dtype=X_filled.dtype)
@@ -508,15 +506,19 @@ class IterativeImputer(_BaseImputer):
 
     def _get_ordered_idx(self, mask_missing_values):
         """Decide in what order we will update the features.
+
         As a homage to the MICE R package, we will have 4 main options of
         how to order the updates, and use a random order if anything else
         is specified.
+
         Also, this function skips features which have no missing values.
+
         Parameters
         ----------
         mask_missing_values : array-like, shape (n_samples, n_features)
             Input data's missing indicator matrix, where "n_samples" is the
             number of samples and "n_features" is the number of features.
+
         Returns
         -------
         ordered_idx : ndarray, shape (n_features,)
@@ -551,13 +553,16 @@ class IterativeImputer(_BaseImputer):
 
     def _get_abs_corr_mat(self, X_filled, tolerance=1e-6):
         """Get absolute correlation matrix between features.
+
         Parameters
         ----------
         X_filled : ndarray, shape (n_samples, n_features)
             Input data with the most recent imputations.
+
         tolerance : float, default=1e-6
             ``abs_corr_mat`` can have nans, which will be replaced
             with ``tolerance``.
+
         Returns
         -------
         abs_corr_mat : ndarray, shape (n_features, n_features)
@@ -898,10 +903,8 @@ class IterativeImputer(_BaseImputer):
 
         n_samples, n_features = Xt.shape
         if self.verbose > 0:
-            print(
-                "[IterativeImputer] Completing matrix with shape %s"
-                % (X.shape,)
-            )
+            print("[IterativeImputer] Completing matrix with shape %s"
+                  % (X.shape,))
         start_t = time()
         if not self.sample_posterior:
             Xt_previous = Xt.copy()
@@ -911,7 +914,7 @@ class IterativeImputer(_BaseImputer):
                 )
         self.imputation_sequence_ = []
         for self.n_iter_ in range(1, self.max_iter + 1):
-            if self.imputation_order == "random":
+            if self.imputation_order == 'random':
                 ordered_idx = self._get_ordered_idx(mask_missing_values)
 
             for feat_idx in ordered_idx:
@@ -937,13 +940,18 @@ class IterativeImputer(_BaseImputer):
                         Xt - Xt_previous, ord=np.inf, axis=None
                     )
                     if self.verbose > 0:
-                        print('[IterativeImputer] '
-                          'Change: {}, scaled tolerance: {} '.format(
-                              inf_norm, normalized_tol))
+                        print(
+                            '[IterativeImputer] '
+                            'Change: {}, scaled tolerance: {} '.format(
+                                inf_norm, normalized_tol
+                            )
+                        )
                     if inf_norm < normalized_tol:
                         if self.verbose > 0:
-                            print('[IterativeImputer] Early stopping criterion '
-                              'reached.')
+                            print(
+                                '[IterativeImputer] Early stopping '
+                                'criterion reached.'
+                            )
                         break
                 Xt_previous = Xt.copy()
         else:
@@ -955,12 +963,15 @@ class IterativeImputer(_BaseImputer):
 
     def transform(self, X):
         """Imputes all missing values in X.
+
         Note that this is stochastic, and that if random_state is not fixed,
         repeated calls, or permuted input, will yield different results.
+
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
             The input data to complete.
+
         Returns
         -------
         Xt : array-like, shape (n_samples, n_features)
@@ -1002,12 +1013,15 @@ class IterativeImputer(_BaseImputer):
 
     def fit(self, X, y=None):
         """Fits the imputer on X and return self.
+
         Parameters
         ----------
         X : array-like, shape (n_samples, n_features)
             Input data, where "n_samples" is the number of samples and
             "n_features" is the number of features.
+
         y : ignored
+
         Returns
         -------
         self : object

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -689,7 +689,7 @@ class IterativeImputer(_BaseImputer):
             limit = np.full(n_features, limit)
             # Set to None for classification tasks
             if np.any(self._is_cls_task):
-                limit[self._is_cls_task] = None
+                limit[self._is_cls_task] = np.nan
         else:
             # Ensure array
             limit = check_array(

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -685,7 +685,8 @@ class IterativeImputer(_BaseImputer):
             if np.any(error_col):
                 # User specified a numeric limit for a cls task
                 raise ValueError(
-                    f"Limit detected for categorical column {np.argmax(error_col)}."
+                    "Limit detected for categorical column " +
+                    f"{np.argmax(error_col)}."
                 )
         return limit
 
@@ -757,16 +758,14 @@ class IterativeImputer(_BaseImputer):
 
         if self.max_iter < 0:
             raise ValueError(
-                "'max_iter' should be a positive integer. Got {} instead.".format(
-                    self.max_iter
-                )
+                "'max_iter' should be a positive integer."
+                " Got {} instead.".format(self.max_iter)
             )
 
         if self.tol < 0:
             raise ValueError(
-                "'tol' should be a non-negative float. Got {} instead.".format(
-                    self.tol
-                )
+                "'tol' should be a non-negative float."
+                " Got {} instead.".format(self.tol)
             )
 
         # Basic validation

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -315,7 +315,10 @@ class IterativeImputer(_BaseImputer):
                     col_group.start or 0, col_group.stop, col_group.step or 1
                 )
             # Convert columns to numeric index from strings
-            col_group = [self._columns[col] for col in col_group]
+            try:
+                col_group = [self._columns[col] for col in col_group]
+            except:
+                pass
             # Iterate over column groups and process
             for col_num in col_group:
                 if self._estimators[col_num]:
@@ -823,18 +826,17 @@ class IterativeImputer(_BaseImputer):
             )
 
         # Save column name to index mapping
+        self._columns = {i: i for i in range(np.asarray(X).shape[1])}
         if hasattr(X, "columns"):
             # Pandas dataframe
-            self._columns = {col: i for i, col in enumerate(X.columns)}
+            for i, col in enumerate(X.columns):
+                self._columns[col] = i
 
         # Basic validation
         # Ensure X is an array
         X = self._validate_data(
             X, dtype=None, order="F", force_all_finite=False
         )
-        # Process mapping of transformers and estimators
-        if not hasattr(self, "_columns"):
-            self._columns = {i: i for i in range(X.shape[1])}
         self._validate_estimators(X)
         self._validate_transformers(X)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -627,6 +627,81 @@ def test_iterative_imputer_mixed_categorical(cls_columns, n_jobs, max_value):
     X_filled = imputer.fit_transform(X)
     assert not np.any(pd.isnull(X_filled))
 
+@pytest.mark.parametrize(
+    ["cls_columns", "tf_columns"],
+    [
+        [[1, 1], [1, 2]],
+        [[1, 2], [1, 1]],
+        [[1, 1], [1, 1]],
+    ],
+)
+def test_iterative_duplicate_columns(cls_columns, tf_columns):
+    age = [np.nan, 82.0, 28.0]
+    sex = ["male", "female", np.nan]
+    cabin = ["c1", np.nan, "e8"]
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame({"age": age, "sex": sex, "cabin": cabin})
+    imputer = IterativeImputer(
+        estimator=[(DummyClassifier(), cls_columns)],
+        transformers=[(OneHotEncoder(sparse=False), tf_columns)],
+        initial_strategy="most_frequent",
+    )
+    with pytest.raises(ValueError):
+        imputer.fit_transform(X)
+
+@pytest.mark.parametrize(
+    "initial_strategy",
+    [
+        "mean",
+        "median",
+    ]
+)
+def test_iterative_categorical_initial_strategy(initial_strategy):
+    age = [np.nan, 82.0, 28.0]
+    sex = ["male", "female", np.nan]
+    cabin = ["c1", np.nan, "e8"]
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame({"age": age, "sex": sex, "cabin": cabin})
+    imputer = IterativeImputer(
+        estimator=[(DummyClassifier(), [1, 2])],
+        transformers=[(OneHotEncoder(sparse=False), [1, 2])],
+        initial_strategy=initial_strategy,
+    )
+    with pytest.raises(ValueError):
+        imputer.fit_transform(X)
+
+
+def test_iterative_categorical_sample_posterior():
+    age = [np.nan, 82.0, 28.0]
+    sex = ["male", "female", np.nan]
+    cabin = ["c1", np.nan, "e8"]
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame({"age": age, "sex": sex, "cabin": cabin})
+    imputer = IterativeImputer(
+        estimator=[(DummyClassifier(), [1, 2])],
+        transformers=[(OneHotEncoder(sparse=False), [1, 2])],
+        initial_strategy="most_frequent",
+        sample_posterior=True
+    )
+    with pytest.raises(ValueError):
+        imputer.fit_transform(X)
+
+
+def test_iterative_categorical_tol():
+    age = [np.nan, 82.0, 28.0]
+    sex = ["male", "female", np.nan]
+    cabin = ["c1", np.nan, "e8"]
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame({"age": age, "sex": sex, "cabin": cabin})
+    imputer = IterativeImputer(
+        estimator=[(DummyClassifier(), [1, 2])],
+        transformers=[(OneHotEncoder(sparse=False), [1, 2])],
+        initial_strategy="most_frequent",
+        tol=1, # a non-default value
+    )
+    with pytest.warns(UserWarning, match="ignored"):
+        imputer.fit_transform(X)
+
 
 @pytest.mark.parametrize(
     "max_value",

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -627,6 +627,7 @@ def test_iterative_imputer_mixed_categorical(cls_columns, n_jobs, max_value):
     X_filled = imputer.fit_transform(X)
     assert not np.any(pd.isnull(X_filled))
 
+
 @pytest.mark.parametrize(
     ["cls_columns", "tf_columns"],
     [
@@ -648,6 +649,7 @@ def test_iterative_duplicate_columns(cls_columns, tf_columns):
     )
     with pytest.raises(ValueError):
         imputer.fit_transform(X)
+
 
 @pytest.mark.parametrize(
     "initial_strategy",
@@ -697,7 +699,7 @@ def test_iterative_categorical_tol():
         estimator=[(DummyClassifier(), [1, 2])],
         transformers=[(OneHotEncoder(sparse=False), [1, 2])],
         initial_strategy="most_frequent",
-        tol=1, # a non-default value
+        tol=1  # a non-default value
     )
     with pytest.warns(UserWarning, match="ignored"):
         imputer.fit_transform(X)
@@ -725,6 +727,7 @@ def test_iterative_imputer_invalid_limit_for_categorical(max_value):
     )
     with pytest.raises(ValueError):
         imputer.fit_transform(X)
+
 
 @pytest.mark.parametrize(
     "imputation_order",


### PR DESCRIPTION
#### Reference Issues/PRs
This would close #17087

#### What does this implement/fix? Explain your changes.
This implements user-selectable transformers and estimators for `IterativeImputer` on a per-column basis (similar interface as `ColumnTransformer`), primarily to allow mixed data type imputation.

#### Any other comments?
There are several optimizations needed and a lot more tests, but I am submitting to get some preliminary feedback on the general approach.