### PR TITLE
WIP DOC remove boston from the docs

### DIFF
--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -73,7 +73,6 @@ They can be loaded using the following functions:
    :toctree: ../modules/generated/
    :template: function.rst
 
-   load_boston
    load_iris
    load_diabetes
    load_digits
@@ -84,8 +83,6 @@ They can be loaded using the following functions:
 These datasets are useful to quickly illustrate the behavior of the
 various algorithms implemented in scikit-learn. They are however often too
 small to be representative of real world machine learning tasks.
-
-.. include:: ../../sklearn/datasets/descr/boston_house_prices.rst
 
 .. include:: ../../sklearn/datasets/descr/iris.rst
 


### PR DESCRIPTION
towards: #16155
Removing all the references to the boston dataset from the docs

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
