### PR TITLE
DOC Specify the meaning of y=None in fit_transform

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -667,9 +667,10 @@ class TransformerMixin:
         ----------
         X : {array-like, sparse matrix, dataframe} of shape \
                 (n_samples, n_features)
+            The input samples.
 
         y : ndarray of shape (n_samples,), default=None
-            Target values.
+            Target values (None for unsupervised transformations).
 
         **fit_params : dict
             Additional fit parameters.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -667,7 +667,7 @@ class TransformerMixin:
         ----------
         X : {array-like, sparse matrix, dataframe} of shape \
                 (n_samples, n_features)
-            The input samples.
+            Input samples.
 
         y : ndarray of shape (n_samples,), default=None
             Target values (None for unsupervised transformations).


### PR DESCRIPTION
#### Reference Issues/PRs

Partially addresses #17295.

#### What does this implement/fix? Explain your changes.

Specifies that `y=None` in `sklearn.base.TransformerMixin.fit_transform` is for unsupervised transformations.