### PR TITLE
DOC Clarify how initial conditions are chosen for NMF.

### DIFF
--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -913,6 +913,9 @@ def non_negative_factorization(X, W=None, H=None, n_components=None, *,
 
         - 'custom': use custom matrices W and H
 
+        Ignored if update_H is False, in which case the initial value of W
+        is set automatically.
+
         .. versionchanged:: 0.23
             The default value of `init` changed from 'random' to None in 0.23.
 

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -911,10 +911,8 @@ def non_negative_factorization(X, W=None, H=None, n_components=None, *,
             (generally faster, less accurate alternative to NNDSVDa
             for when sparsity is not desired)
 
-        - 'custom': use custom matrices W and H
-
-        Ignored if update_H is False, in which case the initial value of W
-        is set automatically.
+        - 'custom': use custom matrices W and H if `update_H=True`. If
+          `update_H=False`, then only custom matrix H is used.
 
         .. versionchanged:: 0.23
             The default value of `init` changed from 'random' to None in 0.23.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

None yet.  I can submit an issue if that's important.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

For `sklearn.decomposition.non_negative_factorization`, when update_H is False, any given initial value of W is silently ignored, as are all of the initialization procedures.

See: [sklearn/decomposition/_nmf.py#L1032-L1053](https://github.com/scikit-learn/scikit-learn/blob/fd237278e/sklearn/decomposition/_nmf.py#L1032-L1053)

This commit fixes that by clarifying this in the non_negative_factorization function docstring.

#### Any other comments?

Nope.  Simple problem, simple fix.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
