### PR TITLE
[WIP] Add information gain ratio criterion to tree classifiers

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -902,9 +902,10 @@ class RandomForestClassifier(ForestClassifier):
            The default value of ``n_estimators`` changed from 10 to 100
            in 0.22.
 
-    criterion : {"gini", "entropy"}, default="gini"
+    criterion : {"gini", "entropy", "gain_ratio"}, default="gini"
         The function to measure the quality of a split. Supported criteria are
-        "gini" for the Gini impurity and "entropy" for the information gain.
+        "gini" for the Gini impurity, "entropy" for the information gain and
+        "gain_ratio" for the information gain ratio.
         Note: this parameter is tree-specific.
 
     max_depth : int, default=None
@@ -1508,9 +1509,10 @@ class ExtraTreesClassifier(ForestClassifier):
            The default value of ``n_estimators`` changed from 10 to 100
            in 0.22.
 
-    criterion : {"gini", "entropy"}, default="gini"
+    criterion : {"gini", "entropy", "gain_ratio"}, default="gini"
         The function to measure the quality of a split. Supported criteria are
-        "gini" for the Gini impurity and "entropy" for the information gain.
+        "gini" for the Gini impurity, "entropy" for the information gain and
+        "gain_ratio" for the information gain ratio.
 
     max_depth : int, default=None
         The maximum depth of the tree. If None, then nodes are expanded until

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -259,7 +259,7 @@ def check_importances(name, criterion, dtype, tolerance):
 @pytest.mark.parametrize(
         'name, criterion',
         itertools.chain(product(FOREST_CLASSIFIERS,
-                                ["gini", "entropy"]),
+                                ["gini", "entropy", "gain_ratio"]),
                         product(FOREST_REGRESSORS,
                                 ["mse", "friedman_mse", "mae"])))
 def test_importances(dtype, name, criterion):

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -60,7 +60,9 @@ __all__ = ["DecisionTreeClassifier",
 DTYPE = _tree.DTYPE
 DOUBLE = _tree.DOUBLE
 
-CRITERIA_CLF = {"gini": _criterion.Gini, "entropy": _criterion.Entropy}
+CRITERIA_CLF = {"gini": _criterion.Gini, "entropy": _criterion.Entropy,
+                "gain_ratio": _criterion.GainRatio}
+
 CRITERIA_REG = {"mse": _criterion.MSE, "friedman_mse": _criterion.FriedmanMSE,
                 "mae": _criterion.MAE}
 
@@ -592,9 +594,10 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
 
     Parameters
     ----------
-    criterion : {"gini", "entropy"}, default="gini"
+    criterion : {"gini", "entropy", "gain_ratio"}, default="gini"
         The function to measure the quality of a split. Supported criteria are
-        "gini" for the Gini impurity and "entropy" for the information gain.
+        "gini" for the Gini impurity, "entropy" for the information gain and
+        "gain_ratio" for the information gain ratio.
 
     splitter : {"best", "random"}, default="best"
         The strategy used to choose the split at each node. Supported
@@ -1265,9 +1268,10 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
 
     Parameters
     ----------
-    criterion : {"gini", "entropy"}, default="gini"
+    criterion : {"gini", "entropy", "gain_ratio"}, default="gini"
         The function to measure the quality of a split. Supported criteria are
-        "gini" for the Gini impurity and "entropy" for the information gain.
+        "gini" for the Gini impurity, "entropy" for the information gain and
+        "gain_ratio" for the information gain ratio.
 
     splitter : {"random", "best"}, default="random"
         The strategy used to choose the split at each node. Supported

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -450,6 +450,25 @@ def test_plot_tree_gini(pyplot):
     assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"
 
 
+def test_plot_tree_gain_ratio(pyplot):
+    # mostly smoke tests
+    # Check correctness of export_graphviz for criterion = gini
+    clf = DecisionTreeClassifier(max_depth=3,
+                                 min_samples_split=2,
+                                 criterion="gain_ratio",
+                                 random_state=2)
+    clf.fit(X, y)
+
+    # Test export code
+    feature_names = ['first feat', 'sepal_width']
+    nodes = plot_tree(clf, feature_names=feature_names)
+    assert len(nodes) == 3
+    assert nodes[0].get_text() == ("first feat <= 0.0\ngini = 1.0\n"
+                                   "samples = 6\nvalue = [3, 3]")
+    assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [3, 0]"
+    assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"
+
+
 # FIXME: to be removed in 0.25
 def test_plot_tree_rotate_deprecation(pyplot):
     tree = DecisionTreeClassifier()

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -43,7 +43,7 @@ from sklearn import datasets
 
 from sklearn.utils import compute_sample_weight
 
-CLF_CRITERIONS = ("gini", "entropy")
+CLF_CRITERIONS = ("gini", "entropy", "gain_ratio")
 REG_CRITERIONS = ("mse", "mae", "friedman_mse")
 
 CLF_TREES = {


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #6821.

#### What does this implement/fix? Explain your changes.

This PR implements the information gain ratio criterion in decision tree classifiers according to the reference:

> J. R. Quinlan, "Induction of Decision Trees", Machine Learning, vol. 1, pp. 81-106, 1986.

which generally leads to considerably smaller decision trees, while obtaining similar scores to other criteria.