### PR TITLE
FIX LabelPropagation handling of sparce matrices #17085

### DIFF
--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -190,7 +190,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         """
         check_is_fitted(self)
 
-        X_2d = check_array(X, accept_sparse=['csc', 'csr', 'coo', 'dok',
+        X_2d = check_array(X, accept_sparse=['csc', 'csr', 'coo',
                                              'bsr', 'lil', 'dia'])
         weight_matrices = self._get_kernel(self.X_, X_2d)
         if self.kernel == 'knn':
@@ -225,7 +225,8 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         -------
         self : object
         """
-        X, y = self._validate_data(X, y)
+        X, y = self._validate_data(X, y, accept_sparse=['csc', 'csr', 'coo',
+                                                        'bsr', 'lil', 'dia'])
         self.X_ = X
         check_classification_targets(y)
 

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -131,7 +131,8 @@ def test_valid_alpha():
     for sparse_or_dense in SPARSE_OR_DENSE:
         for alpha in [-0.1, 0, 1, 1.1, None]:
             with pytest.raises(ValueError):
-                label_propagation.LabelSpreading(alpha=alpha).fit(sparse_or_dense(X), y)
+                label_propagation.LabelSpreading(alpha=alpha).fit(
+                    sparse_or_dense(X), y)
 
 
 def test_convergence_speed():


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #17085

#### What does this implement/fix? Explain your changes.

Label propagation and spreading allow to classify using sparse data according to documentation. Tests only covered the dense case. Newly added coverage for sparse matrices allows to reproduce the problem in #17085. The proposed fix in #17085 works for the extended tests.

#### Any other comments?

- Supporting scipy's dok_matrix produces the UserWarning "Can't check dok sparse matrix for nan or inf.". So this format seems to be unsuitable?
- `test_label_propagation_closed_form` fails for sparse matrices 
