### PR TITLE
DOC Specify base_estimator=None in CalibratedClassifierCV

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -43,8 +43,8 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin,
     ----------
     base_estimator : BaseEstimator instance, default=None
         The classifier whose output need to be calibrated to provide more
-        accurate `predict_proba` outputs. If None, then
-        :class:`~sklearn.svm.LinearSVC` is calibrated.
+        accurate `predict_proba` outputs. The default classifier is
+        a :class:`~sklearn.svm.LinearSVC`.
 
     method : 'sigmoid' or 'isotonic'
         The method to use for calibration. Can be 'sigmoid' which

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -41,7 +41,7 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin,
 
     Parameters
     ----------
-    base_estimator : BaseEstimator instance, default=None
+    base_estimator : estimator instance, default=None
         The classifier whose output need to be calibrated to provide more
         accurate `predict_proba` outputs. The default classifier is
         a :class:`~sklearn.svm.LinearSVC`.

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -41,9 +41,10 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin,
 
     Parameters
     ----------
-    base_estimator : instance BaseEstimator
+    base_estimator : BaseEstimator instance, default=None
         The classifier whose output need to be calibrated to provide more
-        accurate `predict_proba` outputs.
+        accurate `predict_proba` outputs. If None, then
+        :class:`~sklearn.svm.LinearSVC` is calibrated.
 
     method : 'sigmoid' or 'isotonic'
         The method to use for calibration. Can be 'sigmoid' which


### PR DESCRIPTION
#### Reference Issues/PRs

Partially addresses #17295.

#### What does this implement/fix? Explain your changes.

This PR specifies the meaning of `base_estimator=None` in `sklearn.calibration.CalibratedClassifierCV`.