### PR TITLE
[MRG] DOC Fix SVs computation in example

### DIFF
--- a/examples/svm/plot_linearsvc_support_vectors.py
+++ b/examples/svm/plot_linearsvc_support_vectors.py
@@ -24,7 +24,10 @@ for i, C in enumerate([1, 100]):
     decision_function = clf.decision_function(X)
     # we can also calculate the decision function manually
     # decision_function = np.dot(X, clf.coef_[0]) + clf.intercept_[0]
-    support_vector_indices = np.where((2 * y - 1) * decision_function <= 1)[0]
+    # The support vectors are the samples that lie within the margin
+    # boundaries, whose size is conventionally constrained to 1
+    support_vector_indices = np.where(
+        np.abs(decision_function) <= 1 + 1e-15)[0]
     support_vectors = X[support_vector_indices]
 
     plt.subplot(1, 2, i + 1)


### PR DESCRIPTION
The SVs are the samples that lie within the margin boundary in general. In master the code is only correct because the samples are properly classified but it's incorrect in general.

Also, I added a small EPS to the condition: otherwise no red sample would be consider a SV in the second plot, which is impossible: there has to be at least one SV in each class

follow up to https://github.com/scikit-learn/scikit-learn/issues/17397