### PR TITLE
STY Improve css block for scroll bars

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -83,12 +83,12 @@ span.highlighted {
 }
 
 div.highlight {
-  padding: 0.2rem 0.5rem;
   border: 1px solid #ddd;
   margin-bottom: 1rem;
 }
 
 div.highlight pre {
+  padding: 0.2rem 0.5rem;
   margin-bottom: 0;
   line-height: 1.2rem;
 }


### PR DESCRIPTION
Makes sure that the scroll bar is flush with the code block. (when the screen is narrow (for example on mobile)

## PR

in the [release highlights](https://105249-843222-gh.circle-artifacts.com/0/doc/auto_examples/release_highlights/plot_release_highlights_0_23_0.html#generalized-linear-models-and-poisson-loss-for-gradient-boosting)

![Screen Shot 2020-06-19 at 2 28 54 PM](https://user-images.githubusercontent.com/5402633/85169160-61af9b80-b239-11ea-8b36-b872c89558ee.png)

## Master

in the [release highlights](https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_0_23_0.html#generalized-linear-models-and-poisson-loss-for-gradient-boosting)

![Screen Shot 2020-06-19 at 2 28 43 PM](https://user-images.githubusercontent.com/5402633/85169168-65dbb900-b239-11ea-9588-5c2753f2405a.png)
