### PR TITLE
STY Makes ordered list and unordered list look the same.

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -722,11 +722,11 @@ dd {
   margin-top: 1rem;
 }
 
-ul.simple li p {
+ul.simple li p, ol.simple li p {
   margin-bottom: 0;
 }
 
-ul.simple {
+ul.simple, ol.simple {
   padding-left: 1.5rem;
 }
 


### PR DESCRIPTION
For example, on [the roadmap](https://scikit-learn.org/stable/roadmap.html)

This PR:

<img width="524" alt="Screen Shot 2020-06-02 at 7 25 23 PM" src="https://user-images.githubusercontent.com/5402633/83579284-d29b4780-a506-11ea-83c2-25bf8c4c9ee8.png">

Master:

<img width="514" alt="Screen Shot 2020-06-02 at 7 24 46 PM" src="https://user-images.githubusercontent.com/5402633/83579288-d62ece80-a506-11ea-8357-18aa0b87c297.png">


