### PR TITLE
[MRG+1] Make partial_fit ignore n_iter in MiniBatchDictionaryLearning 

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -44,6 +44,14 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.decomposition`
+............................
+
+- |Fix| Fixed a bug in
+  :func:`decomposition.MiniBatchDictionaryLearning.partial_fit` which should
+  update the dictionary by iterating only once over a mini-batch.
+  :pr:`17433` by :user:`Chiara Marmo <cmarmo>`
+
 :mod:`sklearn.ensemble`
 .......................
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -808,6 +808,7 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
 
     # If n_iter is zero, we need to return zero.
     ii = iter_offset - 1
+
     for ii, batch in zip(range(iter_offset, iter_offset + n_iter), batches):
         this_X = X_train[batch]
         dt = (time.time() - t0)

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -808,7 +808,6 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
 
     # If n_iter is zero, we need to return zero.
     ii = iter_offset - 1
-
     for ii, batch in zip(range(iter_offset, iter_offset + n_iter), batches):
         this_X = X_train[batch]
         dt = (time.time() - t0)
@@ -1490,7 +1489,7 @@ class MiniBatchDictionaryLearning(SparseCodingMixin, BaseEstimator):
             iter_offset = getattr(self, 'iter_offset_', 0)
         U, (A, B) = dict_learning_online(
             X, self.n_components, alpha=self.alpha,
-            n_iter=self.n_iter, method=self.fit_algorithm,
+            n_iter=1, method=self.fit_algorithm,
             method_max_iter=self.transform_max_iter,
             n_jobs=self.n_jobs, dict_init=dict_init,
             batch_size=len(X), shuffle=False,

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1504,5 +1504,5 @@ class MiniBatchDictionaryLearning(SparseCodingMixin, BaseEstimator):
         # Keep track of the state of the algorithm to be able to do
         # some online fitting (partial_fit)
         self.inner_stats_ = (A, B)
-        self.iter_offset_ = iter_offset + self.n_iter
+        self.iter_offset_ = iter_offset + 1
         return self

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -391,6 +391,23 @@ def test_dict_learning_online_partial_fit():
                               decimal=2)
 
 
+def test_dict_learning_iter_offset():
+    n_components = 12
+    rng = np.random.RandomState(0)
+    V = rng.randn(n_components, n_features)
+    dict1 = MiniBatchDictionaryLearning(n_components, n_iter=10,
+                                        dict_init=V, random_state=0,
+                                        shuffle=False)
+    dict2 = MiniBatchDictionaryLearning(n_components, n_iter=10,
+                                        dict_init=V, random_state=0,
+                                        shuffle=False)
+    dictV_fit = dict1.fit(X)
+    for sample in X:
+        dictV_pfit = dict2.partial_fit(sample[np.newaxis, :])
+
+    assert dictV_fit.iter_offset_ == dictV_pfit.iter_offset_
+
+
 def test_sparse_encode_shapes():
     n_components = 12
     rng = np.random.RandomState(0)

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -401,11 +401,11 @@ def test_dict_learning_iter_offset():
     dict2 = MiniBatchDictionaryLearning(n_components, n_iter=10,
                                         dict_init=V, random_state=0,
                                         shuffle=False)
-    dictV_fit = dict1.fit(X)
+    dict1.fit(X)
     for sample in X:
-        dictV_pfit = dict2.partial_fit(sample[np.newaxis, :])
+        dict2.partial_fit(sample[np.newaxis, :])
 
-    assert dictV_fit.iter_offset_ == dictV_pfit.iter_offset_
+    assert dict1.iter_offset_ == dict2.iter_offset_
 
 
 def test_sparse_encode_shapes():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #6779

#### What does this implement/fix? Explain your changes.
Makes `partial_fit` ignore `n_iter` in MiniBatchDictionaryLearning hardcoding  `n_iter=1` in `dict_learning_online` call.