### PR TITLE
[MRG]Fix ZeroDivisionError in bagging with early_stopping

### DIFF
--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -75,8 +75,8 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
 
     if getattr(ensemble.base_estimator, 'early_stopping', False)\
        and support_sample_weight:
-        raise ValueError("The bagging class doesn't support the base estimator"
-                         "with both of early_stopping and sample_weight")
+        raise ValueError("The bagging estimator doesn't support "
+                         "the base estimator with early_stopping")
 
     # Build estimators
     estimators = []

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -73,6 +73,10 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
     if not support_sample_weight and sample_weight is not None:
         raise ValueError("The base estimator doesn't support sample weight")
 
+    if getattr(ensemble.base_estimator, 'early_stopping', False) and support_sample_weight:
+        raise ValueError("The bagging class doesn't support the base estimator "
+                         "with both of early_stopping and sample_weight")
+
     # Build estimators
     estimators = []
     estimators_features = []

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -73,8 +73,9 @@ def _parallel_build_estimators(n_estimators, ensemble, X, y, sample_weight,
     if not support_sample_weight and sample_weight is not None:
         raise ValueError("The base estimator doesn't support sample weight")
 
-    if getattr(ensemble.base_estimator, 'early_stopping', False) and support_sample_weight:
-        raise ValueError("The bagging class doesn't support the base estimator "
+    if getattr(ensemble.base_estimator, 'early_stopping', False)\
+       and support_sample_weight:
+        raise ValueError("The bagging class doesn't support the base estimator"
                          "with both of early_stopping and sample_weight")
 
     # Build estimators

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -916,6 +916,6 @@ def test_bagging_with_early_stopping():
     X, y = iris.data, iris.target
     bagging = BaggingRegressor(Perceptron(early_stopping=True))
     assert_raise_message(ValueError,
-                         "The bagging class doesn't support "
-                         "the base estimator",
+                         "The bagging estimator doesn't support "
+                         "the base estimator with early_stopping",
                          bagging.fit, X, y)

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -907,3 +907,15 @@ def test_bagging_get_estimators_indices():
 
     assert_array_equal(clf.estimators_[0]._sample_indices,
                        clf.estimators_samples_[0])
+
+
+def test_bagging_with_early_stopping():
+    # Verify that a exception can be raised by a base estimator
+    # with early_stopping
+    # See: https://github.com/scikit-learn/scikit-learn/pull/17435
+    X, y = iris.data, iris.target
+    bagging = BaggingRegressor(Perceptron(early_stopping=True))
+    assert_raise_message(ValueError,
+                         "The bagging class doesn't support "
+                         "the base estimator",
+                         bagging.fit, X, y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #17229. @RJTK, thank you for your report!

#### What does this implement/fix
* Add validation to raise error  for a base estimator with both of ```early_stopping``` and ```sample_weight``` to prevent ZeroDivisionError

#### Why ZeroDivisionError happen?
*  When ```early_stopping``` and ```sample_weight``` are valid, score of validation dataset is calculated (e.g., r2 score in SGD). But all sample_weight of validation dataset are sometimes zero (depending on random sample selection in bagging process). All zero sample_weight raise ZeroDivisionError in calculation weighted average of score (in sklearn.metrics._regression).
* To enable ```early_stopping```, we need more modification.

Any advice or discussion are welcome:)