### PR TITLE
Run common checks on estimators with non default parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ requires = [
     "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
     "scipy>=0.19.1",
 ]
+
+[tool.black]
+line-length = 79

--- a/sklearn/tests/test_common_non_default.py
+++ b/sklearn/tests/test_common_non_default.py
@@ -1,0 +1,240 @@
+import pprint
+import itertools
+from inspect import signature
+from typing import Optional, List, Dict, Any
+
+from sklearn.datasets import load_iris
+from sklearn.base import is_classifier, is_regressor
+from sklearn.tree._classes import BaseDecisionTree
+from sklearn.ensemble._forest import BaseForest
+from sklearn.ensemble._gb import BaseGradientBoosting
+from sklearn.utils import all_estimators
+from sklearn.utils.estimator_checks import (
+    _enforce_estimator_tags_y,
+    parametrize_with_checks,
+)
+
+
+categorical_params = [
+    "solver",
+    "algorithm",
+    "loss",
+    "strategy",
+    "selection",
+    "criterion",
+    "multi_class",
+    "kernel",
+]
+bool_params = [
+    "fit_prior",
+    "fit_intercept",
+    "positive",
+    "normalize",
+    "dual",
+    "average",
+    "shuffle",
+]
+
+
+class FakeParam(str):
+    """Fake string parameter
+
+    This object always returns False when compared to other values,
+    but remember values it was compared with. It is used to determine
+    valid values for a categorical parameter.
+
+    Examples
+    --------
+    >>> fp = FakeParam()
+    >>> isinstance(fp, str)
+    True
+    >>> fp
+    fake-param
+    >>> fp == 'a'
+    False
+    >>> fp.values
+    {'a'}
+    """
+
+    def __init__(self):
+        self.values = set()
+
+    def __repr__(self):
+        return "fake-param"
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        self.values.add(other)
+        return False
+
+    def __getattr__(self, key):
+        if key == "requires_vector_input":
+            # Workaround for GaussianProcessClassifier
+            return False
+        raise AttributeError
+
+
+def detect_valid_categorical_params(
+    Estimator, param: str = "solver"
+) -> Optional[List]:
+    """Detect valid parameters for an estimator
+
+
+    Returns
+    -------
+    set or None: a set of valid parameters of None if
+                 it they could not be determined (or the
+                 estimator has no such parameter name)
+
+    Example
+    -------
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> detect_valid_categorical_params(LogisticRegression, param="solver")
+    ['lbfgs', 'liblinear', 'newton-cg', 'sag', 'saga']
+    """
+    if not (is_regressor(Estimator) or is_classifier(Estimator)):
+        return None
+
+    est_signature = signature(Estimator)
+    if param not in est_signature.parameters:
+        return None
+
+    # Special cases
+    if param == "criterion" and issubclass(
+        Estimator, (BaseDecisionTree, BaseForest, BaseGradientBoosting)
+    ):
+        # hardcode this case as the FakeParam apporach then doesn't work with
+        # `param in valid_list` checks.
+        from sklearn.tree._classes import CRITERIA_CLF, CRITERIA_REG
+
+        if is_regressor(Estimator):
+            return list(CRITERIA_REG)
+        else:
+            return list(CRITERIA_CLF)
+    elif param == "loss":
+        # hardcode a few other cases that can't be auto-detected
+        from sklearn.linear_model import (
+            PassiveAggressiveClassifier,
+            PassiveAggressiveRegressor,
+            SGDClassifier,
+            SGDRegressor,
+        )
+
+        if issubclass(Estimator, PassiveAggressiveClassifier):
+            return ["hinge", "squared_hinge"]
+        elif issubclass(Estimator, SGDClassifier):
+            return [
+                "hinge",
+                "log",
+                "modified_huber",
+                "squared_hinge",
+                "perceptron",
+            ]
+        elif issubclass(Estimator, PassiveAggressiveRegressor):
+            return ["epsilon_insensitive", "squared_epsilon_insensitive"]
+        elif issubclass(Estimator, SGDRegressor):
+            return [
+                "squared_loss",
+                "huber",
+                "epsilon_insensitive",
+                "squared_epsilon_insensitive",
+            ]
+    elif param == "kernel":
+        from sklearn.gaussian_process import (
+            GaussianProcessClassifier,
+            GaussianProcessRegressor,
+        )
+
+        if issubclass(
+            Estimator, (GaussianProcessClassifier, GaussianProcessRegressor)
+        ):
+            # these kernels are not string but instances, skip
+            return None
+    fp = FakeParam()
+
+    X, y = load_iris(return_X_y=True)
+
+    # Auto-detect valid string parameters with FakeParam
+    try:
+        args = {param: fp}
+        est = Estimator(**args)
+        y = _enforce_estimator_tags_y(est, y)
+        est.fit(X, y)
+    except Exception:
+        if not fp.values:
+            raise
+    return list(sorted(fp.values))
+
+
+def detect_all_params(Estimator) -> Dict[str, List]:
+    """Detect all valid parameters for an estimator
+
+    Example
+    -------
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> detect_all_params(LogisticRegression)
+    {'solver': ['lbfgs', 'liblinear', 'newton-cg', 'sag', 'saga'],
+     'multi_class': ['auto', 'multinomial', 'ovr'],
+     'fit_intercept': [False, True],
+     'dual': [False, True]}
+    """
+    res = {}
+    for param_name in categorical_params:
+        values = detect_valid_categorical_params(Estimator, param=param_name)
+        if values is not None:
+            res[param_name] = values
+    for param_name in bool_params:
+        est_signature = signature(Estimator)
+        if param_name in est_signature.parameters:
+            res[param_name] = [False, True]
+    return res
+
+
+def _merge_dict_product(**kwargs) -> List[Dict]:
+    """Merge the cathesian product of dictionaries with lists
+
+    Example
+    -------
+    >>> _merge_dict_product(a=[1, 2], b=[True, False], c=['O'])
+    [{'a': 1, 'b': True, 'c': 'O'},
+     {'a': 1, 'b': False, 'c': 'O'},
+     {'a': 2, 'b': True, 'c': 'O'},
+     {'a': 2, 'b': False, 'c': 'O'}]
+    """
+    tmp = []
+    for key, val in kwargs.items():
+        tmp.append([{key: el} for el in val])
+
+    res = []
+    for val in itertools.product(*tmp):
+        row: Dict[str, Any] = {}
+        for el in val:
+            row.update(el)
+        res.append(row)
+
+    return res
+
+
+def _make_all_estimator_instances(verbose=False):
+    for name, Estimator in all_estimators(
+        type_filter=["classifier", "regressor"]
+    ):
+        valid_params = detect_all_params(Estimator)
+        if valid_params:
+            for params in _merge_dict_product(**valid_params):
+                yield Estimator(**params)
+            if verbose:
+                print(f"{name}")
+                pprint.pp(valid_params, sort_dicts=True)
+
+
+@parametrize_with_checks(list(_make_all_estimator_instances()))
+def test_common_non_default(estimator, check):
+    check(estimator)
+
+
+if __name__ == "__main__":
+    # Print the list of tested estimator
+    list(_make_all_estimator_instances(verbose=True))


### PR DESCRIPTION
This adds a mechanism for running common checks on estimators with non default parameters. It works as follows,
 1. try to auto-determine valid values for parameters of each estimator (e.g. solvers, losses etc) (https://github.com/scikit-learn/scikit-learn/issues/14063). Currently parameters taken into account are, 
    - categorical parameters:  `"solver",  "algorithm",  "loss",  "strategy", "selection", "criterion", "multi_class", "kernel"`
    - boolean parameter:  `"fit_prior", "fit_intercept", "positive" "normalize", "dual", "average", "shuffle"`.
  The determination for valid parameters for an estimator is bit of a hack but it works in most cases (with a few hard-coded special cases),
   ```py
   >>> from sklearn.tests.test_common_non_default import detect_all_params
   >>> from sklearn.linear_model import LogisticRegression
   >>> detect_all_params(LogisticRegression)
   {'solver': ['lbfgs', 'liblinear', 'newton-cg', 'sag', 'saga'],
    'multi_class': ['auto', 'multinomial', 'ovr'],
    'fit_intercept': [False, True],
    'dual': [False, True]}
   ```
The list of detected parameters can be obtained with
```
python sklearn/tests/test_common_non_default.py
```

<details>

```
ARDRegression
{'fit_intercept': [False, True], 'normalize': [False, True]}
AdaBoostClassifier
{'algorithm': ['SAMME', 'SAMME.R']}
AdaBoostRegressor
{'loss': ['exponential', 'linear', 'square']}
BayesianRidge
{'fit_intercept': [False, True], 'normalize': [False, True]}
BernoulliNB
{'fit_prior': [False, True]}
CategoricalNB
{'fit_prior': [False, True]}
ComplementNB
{'fit_prior': [False, True]}
DecisionTreeClassifier
{'criterion': ['gini', 'entropy']}
DecisionTreeRegressor
{'criterion': ['mse', 'friedman_mse', 'mae']}
DummyClassifier
{'strategy': ['constant', 'most_frequent', 'prior', 'stratified', 'uniform']}
DummyRegressor
{'strategy': ['constant', 'mean', 'median', 'quantile']}
ElasticNet
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'positive': [False, True],
 'selection': ['cyclic', 'random']}
ElasticNetCV
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'positive': [False, True],
 'selection': ['cyclic', 'random']}
ExtraTreeClassifier
{'criterion': ['gini', 'entropy']}
ExtraTreeRegressor
{'criterion': ['mse', 'friedman_mse', 'mae']}
ExtraTreesClassifier
{'criterion': ['gini', 'entropy']}
ExtraTreesRegressor
{'criterion': ['mse', 'friedman_mse', 'mae']}
GammaRegressor
{'fit_intercept': [False, True]}
GaussianProcessClassifier
{'multi_class': ['one_vs_one', 'one_vs_rest']}
GradientBoostingClassifier
{'criterion': ['gini', 'entropy'], 'loss': ['deviance', 'exponential']}
GradientBoostingRegressor
{'criterion': ['mse', 'friedman_mse', 'mae'],
 'loss': ['huber', 'lad', 'ls', 'quantile']}
HistGradientBoostingClassifier
{'loss': ['auto', 'binary_crossentropy', 'categorical_crossentropy']}
HistGradientBoostingRegressor
{'loss': ['least_absolute_deviation', 'least_squares', 'poisson']}
HuberRegressor
{'fit_intercept': [False, True]}
KNeighborsClassifier
{'algorithm': ['auto', 'ball_tree', 'brute', 'kd_tree']}
KNeighborsRegressor
{'algorithm': ['auto', 'ball_tree', 'brute', 'kd_tree']}
KernelRidge
{'kernel': ['precomputed']}
LabelPropagation
{'kernel': ['knn', 'rbf']}
LabelSpreading
{'kernel': ['knn', 'rbf']}
Lars
{'fit_intercept': [False, True], 'normalize': [False, True]}
LarsCV
{'fit_intercept': [False, True], 'normalize': [False, True]}
Lasso
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'positive': [False, True],
 'selection': ['cyclic', 'random']}
LassoCV
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'positive': [False, True],
 'selection': ['cyclic', 'random']}
LassoLars
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'positive': [False, True]}
LassoLarsCV
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'positive': [False, True]}
LassoLarsIC
{'criterion': ['aic', 'bic'],
 'fit_intercept': [False, True],
 'normalize': [False, True],
 'positive': [False, True]}
LinearDiscriminantAnalysis
{'solver': ['eigen', 'lsqr', 'svd']}
LinearRegression
{'fit_intercept': [False, True], 'normalize': [False, True]}
LinearSVC
{'dual': [False, True],
 'fit_intercept': [False, True],
 'loss': ['epsilon_insensitive', 'squared_epsilon_insensitive'],
 'multi_class': ['crammer_singer']}
LinearSVR
{'dual': [False, True],
 'fit_intercept': [False, True],
 'loss': ['epsilon_insensitive', 'squared_epsilon_insensitive']}
LogisticRegression
{'dual': [False, True],
 'fit_intercept': [False, True],
 'multi_class': ['auto', 'multinomial', 'ovr'],
 'solver': ['lbfgs', 'liblinear', 'newton-cg', 'sag', 'saga']}
LogisticRegressionCV
{'dual': [False, True],
 'fit_intercept': [False, True],
 'multi_class': ['auto', 'multinomial', 'ovr'],
 'solver': ['lbfgs', 'liblinear', 'newton-cg', 'sag', 'saga']}
MLPClassifier
{'shuffle': [False, True], 'solver': ['adam', 'lbfgs', 'sgd']}
MLPRegressor
{'shuffle': [False, True], 'solver': ['adam', 'lbfgs', 'sgd']}
MultiTaskElasticNet
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'selection': ['cyclic', 'random']}
MultiTaskElasticNetCV
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'selection': ['cyclic', 'random']}
MultiTaskLasso
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'selection': ['cyclic', 'random']}
MultiTaskLassoCV
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'selection': ['cyclic', 'random']}
MultinomialNB
{'fit_prior': [False, True]}
NuSVC
{'kernel': ['linear', 'poly', 'precomputed', 'rbf', 'sigmoid']}
NuSVR
{'kernel': ['linear', 'poly', 'precomputed', 'rbf', 'sigmoid']}
OrthogonalMatchingPursuit
{'fit_intercept': [False, True], 'normalize': [False, True]}
OrthogonalMatchingPursuitCV
{'fit_intercept': [False, True], 'normalize': [False, True]}
PLSCanonical
{'algorithm': ['nipals', 'svd']}
PassiveAggressiveClassifier
{'average': [False, True],
 'fit_intercept': [False, True],
 'loss': ['hinge', 'squared_hinge'],
 'shuffle': [False, True]}
PassiveAggressiveRegressor
{'average': [False, True],
 'fit_intercept': [False, True],
 'loss': ['epsilon_insensitive', 'squared_epsilon_insensitive'],
 'shuffle': [False, True]}
Perceptron
{'fit_intercept': [False, True], 'shuffle': [False, True]}
PoissonRegressor
{'fit_intercept': [False, True]}
RANSACRegressor
{'loss': ['absolute_loss', 'squared_loss']}
RadiusNeighborsClassifier
{'algorithm': ['auto', 'ball_tree', 'brute', 'kd_tree']}
RadiusNeighborsRegressor
{'algorithm': ['auto', 'ball_tree', 'brute', 'kd_tree']}
RandomForestClassifier
{'criterion': ['gini', 'entropy']}
RandomForestRegressor
{'criterion': ['mse', 'friedman_mse', 'mae']}
Ridge
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'solver': ['auto', 'cholesky', 'lsqr', 'sag', 'saga', 'sparse_cg', 'svd']}
RidgeCV
{'fit_intercept': [False, True], 'normalize': [False, True]}
RidgeClassifier
{'fit_intercept': [False, True],
 'normalize': [False, True],
 'solver': ['auto', 'cholesky', 'lsqr', 'sag', 'saga', 'sparse_cg', 'svd']}
RidgeClassifierCV
{'fit_intercept': [False, True], 'normalize': [False, True]}
SGDClassifier
{'average': [False, True],
 'fit_intercept': [False, True],
 'loss': ['hinge', 'log', 'modified_huber', 'squared_hinge', 'perceptron'],
 'shuffle': [False, True]}
SGDRegressor
{'average': [False, True],
 'fit_intercept': [False, True],
 'loss': ['squared_loss',
          'huber',
          'epsilon_insensitive',
          'squared_epsilon_insensitive'],
 'shuffle': [False, True]}
SVC
{'kernel': ['linear', 'poly', 'precomputed', 'rbf', 'sigmoid']}
SVR
{'kernel': ['linear', 'poly', 'precomputed', 'rbf', 'sigmoid']}
TheilSenRegressor
{'fit_intercept': [False, True]}
TweedieRegressor
{'fit_intercept': [False, True]}
```
</details>
This step can likely be improved further, but it's a start.

2. Compute the Cartesian product of all valid parameters for each estimator.
3. Run estimator checks on the obtained estimators with non default parameters.

This generates 26424 additional tests (the scikit-learn test suite has 16052 tests) which runs in 11 min. The run time can likely be improved by using pytest-xdist on multi-core CPUs .

I think passing these checks would both help detecting new bugs and make our common checks more robust.

This is a somewhat orthogonal solution to https://github.com/scikit-learn/scikit-learn/pull/11324 although they both address the same problem.

There are 2858 errors / 26424. I haven't checked the errors in detail and some might be due to parameter detection failure (in particular some parameters might be incompatible). The logs (without tracebacks) can be found in [pytest.log](https://github.com/scikit-learn/scikit-learn/files/4726732/pytest.log).


cc @NicolasHug @thomasjpfan @jeremiedbb @jnothman 

**TODO:**
 - [ ] run these tests conditionally in CI (maybe in some Cron job)
 - [x] support other types of estimators besides to classifiers and regressors