### PR TITLE
DOC Use tuple for shape in roc_curve docstring

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -710,7 +710,7 @@ def roc_curve(y_true, y_score, *, pos_label=None, sample_weight=None,
 
     pos_label : int or str, default=None
         The label of the positive class.
-        When ``pos_label=None``, if y_true is in {-1, 1} or {0, 1},
+        When ``pos_label=None``, if `y_true` is in {-1, 1} or {0, 1},
         ``pos_label`` is set to 1, otherwise an error will be raised.
 
     sample_weight : array-like of shape (n_samples,), default=None

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -699,11 +699,11 @@ def roc_curve(y_true, y_score, *, pos_label=None, sample_weight=None,
     Parameters
     ----------
 
-    y_true : array, shape = [n_samples]
+    y_true : array, shape (n_samples,)
         True binary labels. If labels are not either {-1, 1} or {0, 1}, then
         pos_label should be explicitly given.
 
-    y_score : array, shape = [n_samples]
+    y_score : array, shape (n_samples,)
         Target scores, can either be probability estimates of the positive
         class, confidence values, or non-thresholded measure of decisions
         (as returned by "decision_function" on some classifiers).
@@ -726,15 +726,15 @@ def roc_curve(y_true, y_score, *, pos_label=None, sample_weight=None,
 
     Returns
     -------
-    fpr : array, shape = [>2]
+    fpr : array, shape = (>2,)
         Increasing false positive rates such that element i is the false
         positive rate of predictions with score >= thresholds[i].
 
-    tpr : array, shape = [>2]
-        Increasing true positive rates such that element i is the true
-        positive rate of predictions with score >= thresholds[i].
+    tpr : array, shape = (>2,)
+        Increasing true positive rates such that element `i` is the true
+        positive rate of predictions with score >= `thresholds[i]`.
 
-    thresholds : array, shape = [n_thresholds]
+    thresholds : array, shape = (n_thresholds,)
         Decreasing thresholds on the decision function used to compute
         fpr and tpr. `thresholds[0]` represents no instances being predicted
         and is arbitrarily set to `max(y_score) + 1`.

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -728,7 +728,7 @@ def roc_curve(y_true, y_score, *, pos_label=None, sample_weight=None,
     -------
     fpr : array, shape = (>2,)
         Increasing false positive rates such that element i is the false
-        positive rate of predictions with score >= thresholds[i].
+        positive rate of predictions with score >= `thresholds[i]`.
 
     tpr : array, shape = (>2,)
         Increasing true positive rates such that element `i` is the true


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Use tuple to indicate shape to be consistent with other docstrings
Add code markup to be consistent

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
