### PR TITLE
replaced array_like to array-like

### DIFF
--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -51,7 +51,7 @@ def f_oneway(*args):
 
     Parameters
     ----------
-    *args : array_like, sparse matrices
+    *args : array-like, sparse matrices
         sample1, sample2... The sample measurements should be given as
         arguments.
 


### PR DESCRIPTION
Replaced array_like to array-like in sklearn/feature_selection/_univariate_selection.py
#### Reference Issues/PRs
 #17300 
