### PR TITLE
Doc shorten estimators links for sklearn/feature_selection/* and sklearn/experimental/* modules

### DIFF
--- a/sklearn/experimental/enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/enable_hist_gradient_boosting.py
@@ -4,8 +4,8 @@ The API and results of these estimators might change without any deprecation
 cycle.
 
 Importing this file dynamically sets the
-:class:`sklearn.ensemble.HistGradientBoostingClassifier` and
-:class:`sklearn.ensemble.HistGradientBoostingRegressor` as attributes of the
+:class:`~sklearn.ensemble.HistGradientBoostingClassifier` and
+:class:`~sklearn.ensemble.HistGradientBoostingRegressor` as attributes of the
 ensemble module::
 
     >>> # explicitly require this experimental feature

--- a/sklearn/experimental/enable_iterative_imputer.py
+++ b/sklearn/experimental/enable_iterative_imputer.py
@@ -3,7 +3,7 @@
 The API and results of this estimator might change without any deprecation
 cycle.
 
-Importing this file dynamically sets :class:`sklearn.impute.IterativeImputer`
+Importing this file dynamically sets :class:`~sklearn.impute.IterativeImputer`
 as an attribute of the impute module::
 
     >>> # explicitly require this experimental feature

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -109,9 +109,9 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
         Also accepts a string that specifies an attribute name/path
         for extracting feature importance (implemented with `attrgetter`).
         For example, give `regressor_.coef_` in case of
-        :class:`sklearn.compose.TransformedTargetRegressor`  or
+        :class:`~sklearn.compose.TransformedTargetRegressor`  or
         `named_steps.clf.feature_importances_` in case of
-        :class:`sklearn.pipeline.Pipeline` with its last step named `clf`.
+        :class:`~sklearn.pipeline.Pipeline` with its last step named `clf`.
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -77,9 +77,9 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         Also accepts a string that specifies an attribute name/path
         for extracting feature importance (implemented with `attrgetter`).
         For example, give `regressor_.coef_` in case of
-        :class:`sklearn.compose.TransformedTargetRegressor`  or
+        :class:`~sklearn.compose.TransformedTargetRegressor`  or
         `named_steps.clf.feature_importances_` in case of
-        class:`sklearn.pipeline.Pipeline` with its last step named `clf`.
+        class:`~sklearn.pipeline.Pipeline` with its last step named `clf`.
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should
@@ -394,9 +394,9 @@ class RFECV(RFE):
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
-        :class:`sklearn.model_selection.StratifiedKFold` is used. If the
+        :class:`~sklearn.model_selection.StratifiedKFold` is used. If the
         estimator is a classifier or if ``y`` is neither binary nor multiclass,
-        :class:`sklearn.model_selection.KFold` is used.
+        :class:`~sklearn.model_selection.KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
@@ -427,9 +427,9 @@ class RFECV(RFE):
         Also accepts a string that specifies an attribute name/path
         for extracting feature importance.
         For example, give `regressor_.coef_` in case of
-        :class:`sklearn.compose.TransformedTargetRegressor`  or
+        :class:`~sklearn.compose.TransformedTargetRegressor`  or
         `named_steps.clf.feature_importances_` in case of
-        :class:`sklearn.pipeline.Pipeline` with its last step named `clf`.
+        :class:`~sklearn.pipeline.Pipeline` with its last step named `clf`.
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should


### PR DESCRIPTION
#### Reference Issues/PRs
References #17302 

#### What does this implement/fix? Explain your changes.
This PR updates the docstrings in sklearn/experimental/* and sklearn/feature_selection/* modules to shorten the Estimator's references in the docstrings.