### PR TITLE
DOC shorten class links in docstring using tilde

### DIFF
--- a/doc/datasets/index.rst
+++ b/doc/datasets/index.rst
@@ -30,14 +30,14 @@ described in the :ref:`toy_datasets` section.
 **The dataset fetchers.** They can be used to download and load larger datasets,
 described in the :ref:`real_world_datasets` section.
 
-Both loaders and fetchers functions return a :class:`sklearn.utils.Bunch`
+Both loaders and fetchers functions return a :class:`~sklearn.utils.Bunch`
 object holding at least two items:
 an array of shape ``n_samples`` * ``n_features`` with
 key ``data`` (except for 20newsgroups) and a numpy array of
 length ``n_samples``, containing the target values, with key ``target``.
 
 The Bunch object is a dictionary that exposes its keys are attributes.
-For more information about Bunch object, see :class:`sklearn.utils.Bunch`:
+For more information about Bunch object, see :class:`~sklearn.utils.Bunch`:
 
 It's also possible for almost all of these function to constrain the output
 to be a tuple containing only the data and the target, by setting the
@@ -519,8 +519,8 @@ refer to:
   for reading WAV files into a numpy array
 
 Categorical (or nominal) features stored as strings (common in pandas DataFrames)
-will need converting to numerical features using :class:`sklearn.preprocessing.OneHotEncoder`
-or :class:`sklearn.preprocessing.OrdinalEncoder` or similar.
+will need converting to numerical features using :class:`~sklearn.preprocessing.OneHotEncoder`
+or :class:`~sklearn.preprocessing.OrdinalEncoder` or similar.
 See :ref:`preprocessing`.
 
 Note: if you manage your own numerical data it is recommended to use an

--- a/examples/decomposition/plot_beta_divergence.py
+++ b/examples/decomposition/plot_beta_divergence.py
@@ -4,7 +4,7 @@ Beta-divergence loss functions
 ==============================
 
 A plot that compares the various Beta-divergence loss functions supported by
-the Multiplicative-Update ('mu') solver in :class:`sklearn.decomposition.NMF`.
+the Multiplicative-Update ('mu') solver in :class:`~sklearn.decomposition.NMF`.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/decomposition/plot_sparse_coding.py
+++ b/examples/decomposition/plot_sparse_coding.py
@@ -5,7 +5,7 @@ Sparse coding with a precomputed dictionary
 
 Transform a signal as a sparse combination of Ricker wavelets. This example
 visually compares different sparse coding methods using the
-:class:`sklearn.decomposition.SparseCoder` estimator. The Ricker (also known
+:class:`~sklearn.decomposition.SparseCoder` estimator. The Ricker (also known
 as Mexican hat or the second derivative of a Gaussian) is not a particularly
 good kernel to represent piecewise constant signals like this one. It can
 therefore be seen how much adding different widths of atoms matters and it

--- a/examples/ensemble/plot_gradient_boosting_early_stopping.py
+++ b/examples/ensemble/plot_gradient_boosting_early_stopping.py
@@ -25,7 +25,7 @@ The number of stages of the final model is available at the attribute
 ``n_estimators_``.
 
 This example illustrates how the early stopping can used in the
-:class:`sklearn.ensemble.GradientBoostingClassifier` model to achieve
+:class:`~sklearn.ensemble.GradientBoostingClassifier` model to achieve
 almost the same accuracy as compared to a model built without early stopping
 using many fewer estimators. This can significantly reduce training time,
 memory usage and prediction latency.

--- a/examples/ensemble/plot_gradient_boosting_regression.py
+++ b/examples/ensemble/plot_gradient_boosting_regression.py
@@ -11,7 +11,7 @@ tackle a diabetes regression task. We will obtain the results from
 and 500 regression trees of depth 4.
 
 Note: For larger datasets (n_samples >= 10000), please refer to
-:class:`sklearn.ensemble.HistGradientBoostingRegressor`.
+:class:`~sklearn.ensemble.HistGradientBoostingRegressor`.
 """
 print(__doc__)
 

--- a/examples/ensemble/plot_isolation_forest.py
+++ b/examples/ensemble/plot_isolation_forest.py
@@ -3,7 +3,7 @@
 IsolationForest example
 ==========================================
 
-An example using :class:`sklearn.ensemble.IsolationForest` for anomaly
+An example using :class:`~sklearn.ensemble.IsolationForest` for anomaly
 detection.
 
 The IsolationForest 'isolates' observations by randomly selecting a feature

--- a/examples/ensemble/plot_stack_predictors.py
+++ b/examples/ensemble/plot_stack_predictors.py
@@ -80,7 +80,7 @@ X, y = load_ames_housing()
 # <sklearn.preprocessing.OneHotEncoder>` or
 # :class:`~sklearn.preprocessing.OrdinalEncoder
 # <sklearn.preprocessing.OrdinalEncoder>` depending for which type of model we
-# will use them (linear or non-linear model). To falicitate this preprocessing
+# will use them (linear or non-linear model). To facilitate this preprocessing
 # we will make two pipelines.
 # You can skip this section if your data is ready to use and does
 # not need preprocessing

--- a/examples/ensemble/plot_stack_predictors.py
+++ b/examples/ensemble/plot_stack_predictors.py
@@ -76,9 +76,9 @@ X, y = load_ames_housing()
 # First, the dataset has many missing values. To impute them, we will exchange
 # categorical missing values with the new category 'missing' while the
 # numerical missing values with the 'mean' of the column. We will also encode
-# the categories with either :class:`sklearn.preprocessing.OneHotEncoder
+# the categories with either :class:`~sklearn.preprocessing.OneHotEncoder
 # <sklearn.preprocessing.OneHotEncoder>` or
-# :class:`sklearn.preprocessing.OrdinalEncoder
+# :class:`~sklearn.preprocessing.OrdinalEncoder
 # <sklearn.preprocessing.OrdinalEncoder>` depending for which type of model we
 # will use them (linear or non-linear model). To falicitate this preprocessing
 # we will make two pipelines.

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -73,8 +73,8 @@ class CalibratedClassifierCV(BaseEstimator, ClassifierMixin,
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
-        :class:`sklearn.model_selection.StratifiedKFold` is used. If ``y`` is
-        neither binary nor multiclass, :class:`sklearn.model_selection.KFold`
+        :class:`~sklearn.model_selection.StratifiedKFold` is used. If ``y`` is
+        neither binary nor multiclass, :class:`~sklearn.model_selection.KFold`
         is used.
 
         Refer to the :ref:`User Guide <cross_validation>` for the various

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -84,7 +84,7 @@ class OPTICS(ClusterMixin, BaseEstimator):
 
     p : int, optional (default=2)
         Parameter for the Minkowski metric from
-        :class:`sklearn.metrics.pairwise_distances`. When p = 1, this is
+        :class:`~sklearn.metrics.pairwise_distances`. When p = 1, this is
         equivalent to using manhattan_distance (l1), and euclidean_distance
         (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
 
@@ -391,7 +391,7 @@ if metric=’precomputed’.
 
     p : integer, optional (default=2)
         Parameter for the Minkowski metric from
-        :class:`sklearn.metrics.pairwise_distances`. When p = 1, this is
+        :class:`~sklearn.metrics.pairwise_distances`. When p = 1, this is
         equivalent to using manhattan_distance (l1), and euclidean_distance
         (l2) for p = 2. For arbitrary p, minkowski_distance (l_p) is used.
 

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -335,13 +335,13 @@ def fetch_20newsgroups_vectorized(*, subset="train", remove=(), data_home=None,
 
     This is a convenience function; the transformation is done using the
     default settings for
-    :class:`sklearn.feature_extraction.text.CountVectorizer`. For more
+    :class:`~sklearn.feature_extraction.text.CountVectorizer`. For more
     advanced usage (stopword filtering, n-gram extraction, etc.), combine
     fetch_20newsgroups with a custom
-    :class:`sklearn.feature_extraction.text.CountVectorizer`,
-    :class:`sklearn.feature_extraction.text.HashingVectorizer`,
-    :class:`sklearn.feature_extraction.text.TfidfTransformer` or
-    :class:`sklearn.feature_extraction.text.TfidfVectorizer`.
+    :class:`~sklearn.feature_extraction.text.CountVectorizer`,
+    :class:`~sklearn.feature_extraction.text.HashingVectorizer`,
+    :class:`~sklearn.feature_extraction.text.TfidfTransformer` or
+    :class:`~sklearn.feature_extraction.text.TfidfVectorizer`.
 
     The resulting counts are normalized using
     :func:`sklearn.preprocessing.normalize` unless normalize is set to False.

--- a/sklearn/datasets/descr/twenty_newsgroups.rst
+++ b/sklearn/datasets/descr/twenty_newsgroups.rst
@@ -12,7 +12,7 @@ and after a specific date.
 This module contains two loaders. The first one,
 :func:`sklearn.datasets.fetch_20newsgroups`,
 returns a list of the raw texts that can be fed to text feature
-extractors such as :class:`sklearn.feature_extraction.text.CountVectorizer`
+extractors such as :class:`~sklearn.feature_extraction.text.CountVectorizer`
 with custom parameters so as to extract feature vectors.
 The second one, :func:`sklearn.datasets.fetch_20newsgroups_vectorized`,
 returns ready-to-use features, i.e., it is not necessary to use a feature

--- a/sklearn/feature_extraction/_dict_vectorizer.py
+++ b/sklearn/feature_extraction/_dict_vectorizer.py
@@ -38,7 +38,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
     However, note that this transformer will only do a binary one-hot encoding
     when feature values are of type string. If categorical features are
     represented as numeric values such as int, the DictVectorizer can be
-    followed by :class:`sklearn.preprocessing.OneHotEncoder` to complete
+    followed by :class:`~sklearn.preprocessing.OneHotEncoder` to complete
     binary one-hot encoding.
 
     Features that do not occur in a sample (mapping) will have a zero value

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -181,7 +181,7 @@ class SimpleImputer(_BaseImputer):
         During :meth:`transform`, features corresponding to `np.nan`
         statistics will be discarded.
 
-    indicator_ : :class:`sklearn.impute.MissingIndicator`
+    indicator_ : :class:`~sklearn.impute.MissingIndicator`
         Indicator used to add binary indicators for missing values.
         ``None`` if add_indicator is False.
 

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -87,7 +87,7 @@ class IterativeImputer(_BaseImputer):
 
     initial_strategy : str, default='mean'
         Which strategy to use to initialize the missing values. Same as the
-        ``strategy`` parameter in :class:`sklearn.impute.SimpleImputer`
+        ``strategy`` parameter in :class:`~sklearn.impute.SimpleImputer`
         Valid values: {"mean", "median", "most_frequent", or "constant"}.
 
     imputation_order : str, default='ascending'
@@ -143,7 +143,7 @@ class IterativeImputer(_BaseImputer):
 
     Attributes
     ----------
-    initial_imputer_ : object of type :class:`sklearn.impute.SimpleImputer`
+    initial_imputer_ : object of type :class:`~sklearn.impute.SimpleImputer`
         Imputer used to initialize the missing values.
 
     imputation_sequence_ : list of tuples
@@ -161,7 +161,7 @@ class IterativeImputer(_BaseImputer):
     n_features_with_missing_ : int
         Number of features with missing values.
 
-    indicator_ : :class:`sklearn.impute.MissingIndicator`
+    indicator_ : :class:`~sklearn.impute.MissingIndicator`
         Indicator used to add binary indicators for missing values.
         ``None`` if add_indicator is False.
 

--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -74,7 +74,7 @@ class KNNImputer(_BaseImputer):
 
     Attributes
     ----------
-    indicator_ : :class:`sklearn.impute.MissingIndicator`
+    indicator_ : :class:`~sklearn.impute.MissingIndicator`
         Indicator used to add binary indicators for missing values.
         ``None`` if add_indicator is False.
 

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -44,13 +44,13 @@ class KernelRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
-        :class:`sklearn.svm.LinearSVC`. If an array is passed, penalties are
+        :class:`~sklearn.svm.LinearSVC`. If an array is passed, penalties are
         assumed to be specific to the targets. Hence they must correspond in
         number. See :ref:`ridge_regression` for formula.
 
     kernel : string or callable, default="linear"
         Kernel mapping used internally. This parameter is directly passed to
-        :class:`sklearn.metrics.pairwise.pairwise_kernel`.
+        :class:`~sklearn.metrics.pairwise.pairwise_kernel`.
         If `kernel` is a string, it must be one of the metrics
         in `pairwise.PAIRWISE_KERNEL_FUNCTIONS`.
         If `kernel` is "precomputed", X is assumed to be a kernel matrix.

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -406,8 +406,8 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit`` on
-        an estimator with ``normalize=False``.
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
+        on an estimator with ``normalize=False``.
 
     copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -406,7 +406,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit`` on
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit`` on
         an estimator with ``normalize=False``.
 
     copy_X : bool, default=True

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -81,7 +81,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     copy_X : bool, default=True
@@ -433,7 +433,7 @@ class ARDRegression(RegressorMixin, LinearModel):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     copy_X : bool, default=True

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -114,7 +114,7 @@ def _alpha_grid(X, y, Xy=None, l1_ratio=1.0, fit_intercept=True,
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     copy_X : bool, default=True
@@ -604,7 +604,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : bool or array-like of shape (n_features, n_features),\
@@ -920,7 +920,7 @@ class Lasso(ElasticNet):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : 'auto', bool or array-like of shape (n_features, n_features),\
@@ -1376,7 +1376,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : 'auto', bool or array-like of shape (n_features, n_features),\
@@ -1558,7 +1558,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : 'auto', bool or array-like of shape (n_features, n_features),\
@@ -1771,7 +1771,7 @@ class MultiTaskElasticNet(Lasso):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     copy_X : bool, default=True
@@ -1961,7 +1961,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     copy_X : bool, default=True
@@ -2103,7 +2103,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     max_iter : int, default=1000
@@ -2284,7 +2284,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     max_iter : int, default=1000

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -776,7 +776,7 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : bool, 'auto' or array-like , default='auto'
@@ -1017,7 +1017,7 @@ class LassoLars(Lars):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : bool, 'auto' or array-like, default='auto'
@@ -1196,7 +1196,7 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     max_iter : int, default=500
@@ -1282,7 +1282,7 @@ class LarsCV(Lars):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : bool, 'auto' or array-like , default='auto'
@@ -1500,7 +1500,7 @@ class LassoLarsCV(LarsCV):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : bool or 'auto' , default='auto'
@@ -1667,7 +1667,7 @@ class LassoLarsIC(LassoLars):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : bool, 'auto' or array-like, default='auto'

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -567,7 +567,7 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     precompute : {True, False, 'auto'}, default 'auto'
@@ -713,7 +713,7 @@ def _omp_path_residues(X_train, y_train, X_test, y_test, copy=True,
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     max_iter : integer, optional
@@ -782,7 +782,7 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     max_iter : integer, optional

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -259,7 +259,7 @@ def ridge_regression(X, y, alpha, *, sample_weight=None, solver='auto',
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
-        :class:`sklearn.svm.LinearSVC`. If an array is passed, penalties are
+        :class:`~sklearn.svm.LinearSVC`. If an array is passed, penalties are
         assumed to be specific to the targets. Hence they must correspond in
         number.
 
@@ -623,7 +623,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
-        :class:`sklearn.svm.LinearSVC`. If an array is passed, penalties are
+        :class:`~sklearn.svm.LinearSVC`. If an array is passed, penalties are
         assumed to be specific to the targets. Hence they must correspond in
         number.
 
@@ -637,7 +637,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     copy_X : bool, default=True
@@ -715,7 +715,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
     --------
     RidgeClassifier : Ridge classifier
     RidgeCV : Ridge regression with built-in cross validation
-    :class:`sklearn.kernel_ridge.KernelRidge` : Kernel ridge regression
+    :class:`~sklearn.kernel_ridge.KernelRidge` : Kernel ridge regression
         combines ridge regression with the kernel trick
 
     Examples
@@ -779,7 +779,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
-        :class:`sklearn.svm.LinearSVC`.
+        :class:`~sklearn.svm.LinearSVC`.
 
     fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set to false, no
@@ -791,7 +791,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     copy_X : bool, default=True
@@ -1646,7 +1646,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
-        :class:`sklearn.svm.LinearSVC`.
+        :class:`~sklearn.svm.LinearSVC`.
         If using generalized cross-validation, alphas must be positive.
 
     fit_intercept : bool, default=True
@@ -1659,7 +1659,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     scoring : string, callable, default=None
@@ -1680,8 +1680,8 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         - An iterable yielding (train, test) splits as arrays of indices.
 
         For integer/None inputs, if ``y`` is binary or multiclass,
-        :class:`sklearn.model_selection.StratifiedKFold` is used, else,
-        :class:`sklearn.model_selection.KFold` is used.
+        :class:`~sklearn.model_selection.StratifiedKFold` is used, else,
+        :class:`~sklearn.model_selection.KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.
@@ -1764,7 +1764,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         the estimates. Larger values specify stronger regularization.
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
-        :class:`sklearn.svm.LinearSVC`.
+        :class:`~sklearn.svm.LinearSVC`.
 
     fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set
@@ -1776,7 +1776,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         If True, the regressors X will be normalized before regression by
         subtracting the mean and dividing by the l2-norm.
         If you wish to standardize, please use
-        :class:`sklearn.preprocessing.StandardScaler` before calling ``fit``
+        :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
     scoring : string, callable, default=None

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -997,7 +997,7 @@ class SGDClassifier(BaseSGDClassifier):
         (clip(decision_function(X), -1, 1) + 1) / 2. For other loss functions
         it is necessary to perform proper probability calibration by wrapping
         the classifier with
-        :class:`sklearn.calibration.CalibratedClassifierCV` instead.
+        :class:`~sklearn.calibration.CalibratedClassifierCV` instead.
 
         Parameters
         ----------

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -4,7 +4,7 @@ interface for model selection and evaluation using
 arbitrary score functions.
 
 A scorer object is a callable that can be passed to
-:class:`sklearn.model_selection.GridSearchCV` or
+:class:`~sklearn.model_selection.GridSearchCV` or
 :func:`sklearn.model_selection.cross_val_score` as the ``scoring``
 parameter, to specify how a model should be evaluated.
 

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -147,7 +147,7 @@ class KernelDensity(BaseEstimator):
             :class:`~sklearn.pipeline.Pipeline`.
         sample_weight : array-like, shape (n_samples,), optional
             List of sample weights attached to the data X
-            
+
             .. versionadded:: 0.20
 
         Returns

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -144,7 +144,7 @@ class KernelDensity(BaseEstimator):
             corresponds to a single data point.
         y : None
             Ignored. This parameter exists only for compatibility with
-            :class:`sklearn.pipeline.Pipeline`.
+            :class:`~sklearn.pipeline.Pipeline`.
         sample_weight : array_like, shape (n_samples,), optional
             List of sample weights attached to the data X.
 
@@ -214,7 +214,7 @@ class KernelDensity(BaseEstimator):
             corresponds to a single data point.
         y : None
             Ignored. This parameter exists only for compatibility with
-            :class:`sklearn.pipeline.Pipeline`.
+            :class:`~sklearn.pipeline.Pipeline`.
 
         Returns
         -------

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -145,8 +145,9 @@ class KernelDensity(BaseEstimator):
         y : None
             Ignored. This parameter exists only for compatibility with
             :class:`~sklearn.pipeline.Pipeline`.
-        sample_weight : array_like, shape (n_samples,), optional
-            List of sample weights attached to the data X.
+        sample_weight : array-like, shape (n_samples,), optional
+            List of sample weights attached to the data X
+            
             .. versionadded:: 0.20
 
         Returns

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -146,7 +146,7 @@ class KernelDensity(BaseEstimator):
             Ignored. This parameter exists only for compatibility with
             :class:`~sklearn.pipeline.Pipeline`.
         sample_weight : array-like, shape (n_samples,), optional
-            List of sample weights attached to the data X
+            List of sample weights attached to the data X.
 
             .. versionadded:: 0.20
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -140,7 +140,7 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
     See also
     --------
     StandardScaler: Performs scaling to unit variance using the``Transformer`` API
-        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
+        (e.g. as part of a preprocessing :class:`~sklearn.pipeline.Pipeline`).
 
     """  # noqa
     X = check_array(X, accept_sparse='csc', copy=copy, ensure_2d=False,
@@ -469,7 +469,7 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
 
     .. versionadded:: 0.17
        *minmax_scale* function interface
-       to :class:`sklearn.preprocessing.MinMaxScaler`.
+       to :class:`~sklearn.preprocessing.MinMaxScaler`.
 
     Parameters
     ----------
@@ -495,7 +495,7 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
     See also
     --------
     MinMaxScaler: Performs scaling to a given range using the``Transformer`` API
-        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
+        (e.g. as part of a preprocessing :class:`~sklearn.pipeline.Pipeline`).
 
     Notes
     -----
@@ -622,7 +622,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
     --------
     scale: Equivalent function without the estimator API.
 
-    :class:`sklearn.decomposition.PCA`
+    :class:`~sklearn.decomposition.PCA`
         Further removes the linear correlation across features with 'whiten=True'.
 
     Notes
@@ -1097,7 +1097,7 @@ def maxabs_scale(X, *, axis=0, copy=True):
     See also
     --------
     MaxAbsScaler: Performs scaling to the [-1, 1] range using the``Transformer`` API
-        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
+        (e.g. as part of a preprocessing :class:`~sklearn.pipeline.Pipeline`).
 
     Notes
     -----
@@ -1216,7 +1216,7 @@ class RobustScaler(TransformerMixin, BaseEstimator):
     --------
     robust_scale: Equivalent function without the estimator API.
 
-    :class:`sklearn.decomposition.PCA`
+    :class:`~sklearn.decomposition.PCA`
         Further removes the linear correlation across features with
         'whiten=True'.
 
@@ -1434,7 +1434,7 @@ def robust_scale(X, *, axis=0, with_centering=True, with_scaling=True,
     See also
     --------
     RobustScaler: Performs centering and scaling using the ``Transformer`` API
-        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
+        (e.g. as part of a preprocessing :class:`~sklearn.pipeline.Pipeline`).
     """
     X = check_array(X, accept_sparse=('csr', 'csc'), copy=False,
                     ensure_2d=False, dtype=FLOAT_DTYPES,
@@ -1782,7 +1782,7 @@ def normalize(X, norm='l2', *, axis=1, copy=True, return_norm=False):
     See also
     --------
     Normalizer: Performs normalization using the ``Transformer`` API
-        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
+        (e.g. as part of a preprocessing :class:`~sklearn.pipeline.Pipeline`).
 
     Notes
     -----
@@ -1981,7 +1981,7 @@ def binarize(X, *, threshold=0.0, copy=True):
     See also
     --------
     Binarizer: Performs binarization using the ``Transformer`` API
-        (e.g. as part of a preprocessing :class:`sklearn.pipeline.Pipeline`).
+        (e.g. as part of a preprocessing :class:`~sklearn.pipeline.Pipeline`).
     """
     X = check_array(X, accept_sparse=['csr', 'csc'], copy=copy)
     if sparse.issparse(X):
@@ -2797,7 +2797,7 @@ def quantile_transform(X, *, axis=0, n_quantiles=1000,
     --------
     QuantileTransformer : Performs quantile-based scaling using the
         ``Transformer`` API (e.g. as part of a preprocessing
-        :class:`sklearn.pipeline.Pipeline`).
+        :class:`~sklearn.pipeline.Pipeline`).
     power_transform : Maps data to a normal distribution using a
         power transformation.
     scale : Performs standardization that is faster, but less robust
@@ -3246,7 +3246,7 @@ def power_transform(X, method='yeo-johnson', *, standardize=True, copy=True):
     --------
     PowerTransformer : Equivalent transformation with the
         ``Transformer`` API (e.g. as part of a preprocessing
-        :class:`sklearn.pipeline.Pipeline`).
+        :class:`~sklearn.pipeline.Pipeline`).
 
     quantile_transform : Maps data to a standard normal distribution with
         the parameter `output_distribution='normal'`.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -139,8 +139,9 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
 
     See also
     --------
-    StandardScaler: Performs scaling to unit variance using the``Transformer`` API
-        (e.g. as part of a preprocessing :class:`~sklearn.pipeline.Pipeline`).
+    StandardScaler: Performs scaling to unit variance using the``Transformer``
+        API (e.g. as part of a preprocessing
+        :class:`~sklearn.pipeline.Pipeline`).
 
     """  # noqa
     X = check_array(X, accept_sparse='csc', copy=copy, ensure_2d=False,
@@ -494,8 +495,9 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
 
     See also
     --------
-    MinMaxScaler: Performs scaling to a given range using the``Transformer`` API
-        (e.g. as part of a preprocessing :class:`~sklearn.pipeline.Pipeline`).
+    MinMaxScaler: Performs scaling to a given range using the``Transformer``
+        API (e.g. as part of a preprocessing
+        :class:`~sklearn.pipeline.Pipeline`).
 
     Notes
     -----
@@ -622,8 +624,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
     --------
     scale: Equivalent function without the estimator API.
 
-    :class:`~sklearn.decomposition.PCA`
-        Further removes the linear correlation across features with 'whiten=True'.
+    :class:`~sklearn.decomposition.PCA`: Further removes the linear correlation
+        across features with 'whiten=True'.
 
     Notes
     -----
@@ -1096,8 +1098,9 @@ def maxabs_scale(X, *, axis=0, copy=True):
 
     See also
     --------
-    MaxAbsScaler: Performs scaling to the [-1, 1] range using the``Transformer`` API
-        (e.g. as part of a preprocessing :class:`~sklearn.pipeline.Pipeline`).
+    MaxAbsScaler: Performs scaling to the [-1, 1] range using
+        the``Transformer`` API (e.g. as part of a preprocessing
+        :class:`~sklearn.pipeline.Pipeline`).
 
     Notes
     -----

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -80,13 +80,13 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
       np.concatenate([-np.inf, bin_edges_[i][1:-1], np.inf])
 
     You can combine ``KBinsDiscretizer`` with
-    :class:`sklearn.compose.ColumnTransformer` if you only want to preprocess
+    :class:`~sklearn.compose.ColumnTransformer` if you only want to preprocess
     part of the features.
 
     ``KBinsDiscretizer`` might produce constant features (e.g., when
     ``encode = 'onehot'`` and certain bins do not contain any data).
     These features can be removed with feature selection algorithms
-    (e.g., :class:`sklearn.feature_selection.VarianceThreshold`).
+    (e.g., :class:`~sklearn.feature_selection.VarianceThreshold`).
 
     Examples
     --------
@@ -136,7 +136,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         y : None
             Ignored. This parameter exists only for compatibility with
-            :class:`sklearn.pipeline.Pipeline`.
+            :class:`~sklearn.pipeline.Pipeline`.
 
         Returns
         -------

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -374,7 +374,7 @@ class OneHotEncoder(_BaseEncoder):
 
         y : None
             Ignored. This parameter exists only for compatibility with
-            :class:`sklearn.pipeline.Pipeline`.
+            :class:`~sklearn.pipeline.Pipeline`.
 
         Returns
         -------
@@ -398,7 +398,7 @@ class OneHotEncoder(_BaseEncoder):
 
         y : None
             Ignored. This parameter exists only for compatibility with
-            :class:`sklearn.pipeline.Pipeline`.
+            :class:`~sklearn.pipeline.Pipeline`.
 
         Returns
         -------
@@ -672,7 +672,7 @@ class OrdinalEncoder(_BaseEncoder):
 
         y : None
             Ignored. This parameter exists only for compatibility with
-            :class:`sklearn.pipeline.Pipeline`.
+            :class:`~sklearn.pipeline.Pipeline`.
 
         Returns
         -------

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -127,7 +127,7 @@ class LinearSVC(BaseEstimator, LinearClassifierMixin,
         Furthermore SVC multi-class mode is implemented using one
         vs one scheme while LinearSVC uses one vs the rest. It is
         possible to implement one vs the rest with SVC by using the
-        :class:`sklearn.multiclass.OneVsRestClassifier` wrapper.
+        :class:`~sklearn.multiclass.OneVsRestClassifier` wrapper.
 
         Finally SVC can fit dense data without memory copy if the input
         is C-contiguous. Sparse data will still incur memory copy though.
@@ -447,9 +447,9 @@ class SVC(BaseSVC):
     The implementation is based on libsvm. The fit time scales at least
     quadratically with the number of samples and may be impractical
     beyond tens of thousands of samples. For large datasets
-    consider using :class:`sklearn.svm.LinearSVC` or
-    :class:`sklearn.linear_model.SGDClassifier` instead, possibly after a
-    :class:`sklearn.kernel_approximation.Nystroem` transformer.
+    consider using :class:`~sklearn.svm.LinearSVC` or
+    :class:`~sklearn.linear_model.SGDClassifier` instead, possibly after a
+    :class:`~sklearn.kernel_approximation.Nystroem` transformer.
 
     The multiclass support is handled according to a one-vs-one scheme.
 
@@ -905,9 +905,9 @@ class SVR(RegressorMixin, BaseLibSVM):
     The implementation is based on libsvm. The fit time complexity
     is more than quadratic with the number of samples which makes it hard
     to scale to datasets with more than a couple of 10000 samples. For large
-    datasets consider using :class:`sklearn.svm.LinearSVR` or
-    :class:`sklearn.linear_model.SGDRegressor` instead, possibly after a
-    :class:`sklearn.kernel_approximation.Nystroem` transformer.
+    datasets consider using :class:`~sklearn.svm.LinearSVR` or
+    :class:`~sklearn.linear_model.SGDRegressor` instead, possibly after a
+    :class:`~sklearn.kernel_approximation.Nystroem` transformer.
 
     Read more in the :ref:`User Guide <svm_regression>`.
 


### PR DESCRIPTION
#DataUmbrella
#### What does this implement/fix? Explain your changes.
Added `~` before the class name so that it is rendered properly.

#### Any other comments?
Address this issue #17302 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
