### PR TITLE
doc: Standarize default documentation for cross_decomposition

### DIFF
--- a/sklearn/cross_decomposition/_cca.py
+++ b/sklearn/cross_decomposition/_cca.py
@@ -14,19 +14,19 @@ class CCA(_UnstableArchMixin, _PLS):
 
     Parameters
     ----------
-    n_components : int, (default 2).
+    n_components : int, default=2
         number of components to keep.
 
-    scale : boolean, (default True)
+    scale : boolean, default=True
         whether to scale the data?
 
-    max_iter : an integer, (default 500)
+    max_iter : an integer, default=500
         the maximum number of iterations of the NIPALS inner loop
 
-    tol : non-negative real, default 1e-06.
+    tol : non-negative real, default=1e-06.
         the tolerance used in the iterative algorithm
 
-    copy : boolean
+    copy : boolean, default=True
         Whether the deflation be done on a copy. Let the default value
         to True unless you don't care about side effects
 

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -159,28 +159,32 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
         with two algo. (a) the inner loop of the original NIPALS algo. or (b) a
         SVD on residuals cross-covariance matrices.
 
-    n_components : int, number of components to keep. (default 2).
+    n_components : int, default=2
+        Number of components to keep.
 
-    scale : boolean, scale data? (default True)
+    scale : boolean, default=True
+        scale data
 
-    deflation_mode : str, "canonical" or "regression". See notes.
+    deflation_mode : str, default='regression'
+        "canonical" or "regression". See notes.
 
-    mode : "A" classical PLS and "B" CCA. See notes.
+    mode : { "A", "B" }, default="A"
+        classical PLS and "B" CCA. See notes.
 
     norm_y_weights : boolean, normalize Y weights to one? (default False)
 
-    algorithm : string, "nipals" or "svd"
+    algorithm : string, "nipals" or "svd", default='nipals'
         The algorithm used to estimate the weights. It will be called
         n_components times, i.e. once for each iteration of the outer loop.
 
-    max_iter : int (default 500)
+    max_iter : int, default=500
         The maximum number of iterations
         of the NIPALS inner loop (used only if algorithm="nipals")
 
-    tol : non-negative real, default 1e-06
+    tol : non-negative real, default=1e-06
         The tolerance used in the iterative algorithm.
 
-    copy : boolean, default True
+    copy : boolean, default=True
         Whether the deflation should be done on a copy. Let the default
         value to True unless you don't care about side effects.
 
@@ -418,11 +422,11 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
             Training vectors, where n_samples is the number of samples and
             n_features is the number of predictors.
 
-        Y : array-like of shape (n_samples, n_targets)
+        Y : array-like of shape (n_samples, n_targets), default=None
             Target vectors, where n_samples is the number of samples and
             n_targets is the number of response variables.
 
-        copy : boolean, default True
+        copy : boolean, default=True
             Whether to copy X and Y, or perform in-place normalization.
 
         Returns
@@ -483,7 +487,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
             Training vectors, where n_samples is the number of samples and
             n_features is the number of predictors.
 
-        copy : boolean, default True
+        copy : boolean, default=True
             Whether to copy X and Y, or perform in-place normalization.
 
         Notes
@@ -508,7 +512,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
             Training vectors, where n_samples is the number of samples and
             n_features is the number of predictors.
 
-        y : array-like of shape (n_samples, n_targets)
+        y : array-like of shape (n_samples, n_targets), default=None
             Target vectors, where n_samples is the number of samples and
             n_targets is the number of response variables.
 
@@ -537,20 +541,20 @@ class PLSRegression(_PLS):
 
     Parameters
     ----------
-    n_components : int, (default 2)
+    n_components : int, default=2
         Number of components to keep.
 
-    scale : boolean, (default True)
+    scale : boolean, default=True
         whether to scale the data
 
-    max_iter : an integer, (default 500)
+    max_iter : int, default=500
         the maximum number of iterations of the NIPALS inner loop (used
         only if algorithm="nipals")
 
-    tol : non-negative real
+    tol : non-negative real, default=1e-06
         Tolerance used in the iterative algorithm default 1e-06.
 
-    copy : boolean, default True
+    copy : boolean, default=True
         Whether the deflation should be done on a copy. Let the default
         value to True unless you don't care about side effect
 
@@ -677,24 +681,24 @@ class PLSCanonical(_PLS):
 
     Parameters
     ----------
-    n_components : int, (default 2).
+    n_components : int, default=2
         Number of components to keep
 
-    scale : boolean, (default True)
+    scale : boolean, default=True
         Option to scale data
 
-    algorithm : string, "nipals" or "svd"
+    algorithm : string, "nipals" or "svd", default='nipals'
         The algorithm used to estimate the weights. It will be called
         n_components times, i.e. once for each iteration of the outer loop.
 
-    max_iter : an integer, (default 500)
+    max_iter : int, default=500
         the maximum number of iterations of the NIPALS inner loop (used
         only if algorithm="nipals")
 
-    tol : non-negative real, default 1e-06
+    tol : non-negative real, default=1e-06
         the tolerance used in the iterative algorithm
 
-    copy : boolean, default True
+    copy : boolean, default=True
         Whether the deflation should be done on a copy. Let the default
         value to True unless you don't care about side effect
 
@@ -824,13 +828,13 @@ class PLSSVD(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_components : int, default 2
+    n_components : int, default=2
         Number of components to keep.
 
-    scale : boolean, default True
+    scale : boolean, default=True
         Whether to scale X and Y.
 
-    copy : boolean, default True
+    copy : boolean, default=True
         Whether to copy X and Y, or perform in-place computations.
 
     Attributes
@@ -936,7 +940,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
             Training vectors, where n_samples is the number of samples and
             n_features is the number of predictors.
 
-        Y : array-like of shape (n_samples, n_targets)
+        Y : array-like of shape (n_samples, n_targets), default=None
             Target vectors, where n_samples is the number of samples and
             n_targets is the number of response variables.
         """
@@ -962,7 +966,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
             Training vectors, where n_samples is the number of samples and
             n_features is the number of predictors.
 
-        y : array-like of shape (n_samples, n_targets)
+        y : array-like of shape (n_samples, n_targets), default=None
             Target vectors, where n_samples is the number of samples and
             n_targets is the number of response variables.
 


### PR DESCRIPTION
- Change default documentation of parameters in
cross_decomposition module to follow default=<value>
template

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
References #15761

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

#DataUmbrella