### PR TITLE
[MRG] Change the colors to default matplotlib #DataUmbrella

### DIFF
--- a/examples/cross_decomposition/plot_compare_cross_decomposition.py
+++ b/examples/cross_decomposition/plot_compare_cross_decomposition.py
@@ -62,9 +62,9 @@ X_test_r, Y_test_r = plsca.transform(X_test, Y_test)
 plt.figure(figsize=(12, 8))
 plt.subplot(221)
 plt.scatter(X_train_r[:, 0], Y_train_r[:, 0], label="train",
-            marker="o", c="b", s=25)
+            marker="o", s=25)
 plt.scatter(X_test_r[:, 0], Y_test_r[:, 0], label="test",
-            marker="o", c="r", s=25)
+            marker="o", s=25)
 plt.xlabel("x scores")
 plt.ylabel("y scores")
 plt.title('Comp. 1: X vs Y (test corr = %.2f)' %
@@ -75,9 +75,9 @@ plt.legend(loc="best")
 
 plt.subplot(224)
 plt.scatter(X_train_r[:, 1], Y_train_r[:, 1], label="train",
-            marker="o", c="b", s=25)
+            marker="o", s=25)
 plt.scatter(X_test_r[:, 1], Y_test_r[:, 1], label="test",
-            marker="o", c="r", s=25)
+            marker="o", s=25)
 plt.xlabel("x scores")
 plt.ylabel("y scores")
 plt.title('Comp. 2: X vs Y (test corr = %.2f)' %
@@ -89,9 +89,9 @@ plt.legend(loc="best")
 # 2) Off diagonal plot components 1 vs 2 for X and Y
 plt.subplot(222)
 plt.scatter(X_train_r[:, 0], X_train_r[:, 1], label="train",
-            marker="*", c="b", s=50)
+            marker="*", s=50)
 plt.scatter(X_test_r[:, 0], X_test_r[:, 1], label="test",
-            marker="*", c="r", s=50)
+            marker="*", s=50)
 plt.xlabel("X comp. 1")
 plt.ylabel("X comp. 2")
 plt.title('X comp. 1 vs X comp. 2 (test corr = %.2f)'
@@ -102,9 +102,9 @@ plt.yticks(())
 
 plt.subplot(223)
 plt.scatter(Y_train_r[:, 0], Y_train_r[:, 1], label="train",
-            marker="*", c="b", s=50)
+            marker="*", s=50)
 plt.scatter(Y_test_r[:, 0], Y_test_r[:, 1], label="test",
-            marker="*", c="r", s=50)
+            marker="*", s=50)
 plt.xlabel("Y comp. 1")
 plt.ylabel("Y comp. 2")
 plt.title('Y comp. 1 vs Y comp. 2 , (test corr = %.2f)'


### PR DESCRIPTION
Use matplotlib default colors in examples
#17303 
#DataUmbrella

#### Reference Issues/PRs
<!--
Fixes first example of #17303 

https://scikit-learn.org/stable/auto_examples/cross_decomposition/plot_compare_cross_decomposition.html#sphx-glr-auto-examples-cross-decomposition-plot-compare-cross-decomposition-py

https://github.com/scikit-learn/scikit-learn/issues/17303
-->


#### What does this implement/fix? Explain your changes.
It changes the blue and red colors to the default matplotlib colors for the cross decomposition example
