### PR TITLE
[MRG] Issue #17345: Added keyword arguments to make_pipeline

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -664,7 +664,7 @@ def _name_estimators(estimators):
     return list(zip(names, estimators))
 
 
-def make_pipeline(*steps, **kwargs):
+def make_pipeline(*steps, memory=None, verbose=False):
     """Construct a Pipeline from the given estimators.
 
     This is a shorthand for the Pipeline constructor; it does not require, and
@@ -706,11 +706,6 @@ def make_pipeline(*steps, **kwargs):
     -------
     p : Pipeline
     """
-    memory = kwargs.pop('memory', None)
-    verbose = kwargs.pop('verbose', False)
-    if kwargs:
-        raise TypeError('Unknown keyword arguments: "{}"'
-                        .format(list(kwargs.keys())[0]))
     return Pipeline(_name_estimators(steps), memory=memory, verbose=verbose)
 
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -757,12 +757,6 @@ def test_make_pipeline():
     assert pipe.steps[1][0] == "transf-2"
     assert pipe.steps[2][0] == "fitparamt"
 
-    assert_raise_message(
-        TypeError,
-        'Unknown keyword arguments: "random_parameter"',
-        make_pipeline, t1, t2, random_parameter='rnd'
-    )
-
 
 def test_feature_union_weights():
     # test feature union with transformer weights


### PR DESCRIPTION
#DataUmbrella
Work with: https://github.com/madelgi
cc: @madelgi 
Added memory and verbose
Modified call to make_pipeline

Reference Issues/PRs
Issue #17345

What does this implement/fix? Explain your changes.
Adds keyword arguments to make_pipeline function to for Issue #17345

Any other comments?