### PR TITLE
ENH add score_samples method in base search CV and add tests

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -91,6 +91,11 @@ Changelog
   samples between the train and test set on each fold.
   :pr:`13204` by :user:`Kyle Kosic <kykosic>`.
 
+- |Feature| :class:`model_selection.RandomizedSearchCV` and
+  :class:`model_selection.GridSearchCV` now have the method, ``score_samples``
+  :pr:`17478` by :user:`Teon Brooks <teonbrooks>` and
+  :user:`Mohamed Maskani <maskani-moh>`.
+
 :mod:`sklearn.preprocessing`
 ............................
 
@@ -122,7 +127,7 @@ Changelog
 :mod:`sklearn.svm`
 ....................
 - |Enhancement| invoke scipy blas api for svm kernel function in ``fit``,
-  ``predict`` and related methods of :class:`svm.SVC`, :class:`svm.NuSVC`, 
+  ``predict`` and related methods of :class:`svm.SVC`, :class:`svm.NuSVC`,
   :class:`svm.SVR`, :class:`svm.NuSVR`, :class:`OneClassSVM`.
   :pr:`16530` by :user:`Shuhua Fan <jim0421>`.
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -457,6 +457,30 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
         return score(self.best_estimator_, X, y)
 
+    @if_delegate_has_method(delegate=('best_estimator_', 'estimator'))
+    def score_samples(self, X):
+        """Call score_samples on the estimator with the best found parameters.
+
+        Only available if ``refit=True`` and the underlying estimator supports
+        ``score_samples``.
+
+        Parameters
+        ----------
+        X : iterable
+            Data to predict on. Must fulfill input requirements of first step
+            of the pipeline.
+        Returns
+        -------
+        y_score : ndarray, shape (n_samples,)
+        """
+        self._check_is_fitted('score_samples')
+        if self.scorer_ is None:
+            raise ValueError("No score function explicitly defined, "
+                             "and the estimator doesn't provide one %s"
+                             % self.best_estimator_)
+        score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
+        return score(self.best_estimator_, X)
+
     def _check_is_fitted(self, method_name):
         if not self.refit:
             raise NotFittedError('This %s instance was initialized '
@@ -861,7 +885,7 @@ class GridSearchCV(BaseSearchCV):
     Important members are fit, predict.
 
     GridSearchCV implements a "fit" and a "score" method.
-    It also implements "predict", "predict_proba", "decision_function",
+    It also implements "score_samples", "predict", "predict_proba", "decision_function",
     "transform" and "inverse_transform" if they are implemented in the
     estimator used.
 
@@ -1174,7 +1198,7 @@ class RandomizedSearchCV(BaseSearchCV):
     """Randomized search on hyper parameters.
 
     RandomizedSearchCV implements a "fit" and a "score" method.
-    It also implements "predict", "predict_proba", "decision_function",
+    It also implements "score_samples", "predict", "predict_proba", "decision_function",
     "transform" and "inverse_transform" if they are implemented in the
     estimator used.
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -880,9 +880,9 @@ class GridSearchCV(BaseSearchCV):
     Important members are fit, predict.
 
     GridSearchCV implements a "fit" and a "score" method.
-    It also implements "score_samples", "predict", "predict_proba", "decision_function",
-    "transform" and "inverse_transform" if they are implemented in the
-    estimator used.
+    It also implements "score_samples", "predict", "predict_proba",
+    "decision_function", "transform" and "inverse_transform" if they are
+    implemented in the estimator used.
 
     The parameters of the estimator used to apply these methods are optimized
     by cross-validated grid-search over a parameter grid.
@@ -1193,9 +1193,9 @@ class RandomizedSearchCV(BaseSearchCV):
     """Randomized search on hyper parameters.
 
     RandomizedSearchCV implements a "fit" and a "score" method.
-    It also implements "score_samples", "predict", "predict_proba", "decision_function",
-    "transform" and "inverse_transform" if they are implemented in the
-    estimator used.
+    It also implements "score_samples", "predict", "predict_proba",
+    "decision_function", "transform" and "inverse_transform" if they are
+    implemented in the estimator used.
 
     The parameters of the estimator used to apply these methods are optimized
     by cross-validated search over parameter settings.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -467,8 +467,8 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         Parameters
         ----------
         X : iterable
-            Data to predict on. Must fulfill input requirements of first step
-            of the pipeline.
+            Data to predict on. Must fulfill input requirements
+            of the underlying estimator.
         Returns
         -------
         y_score : ndarray, shape (n_samples,)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -469,6 +469,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         X : iterable
             Data to predict on. Must fulfill input requirements
             of the underlying estimator.
+
         Returns
         -------
         y_score : ndarray, shape (n_samples,)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -474,12 +474,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         y_score : ndarray, shape (n_samples,)
         """
         self._check_is_fitted('score_samples')
-        if self.scorer_ is None:
-            raise ValueError("No score function explicitly defined, "
-                             "and the estimator doesn't provide one %s"
-                             % self.best_estimator_)
-        score = self.scorer_[self.refit] if self.multimetric_ else self.scorer_
-        return score(self.best_estimator_, X)
+        return self.best_estimator_.score_samples(X)
 
     def _check_is_fitted(self, method_name):
         if not self.refit:

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1099,12 +1099,12 @@ def compare_refit_methods_when_refit_with_acc(search_multi, search_acc, refit):
         assert getattr(search_multi, key) == getattr(search_acc, key)
 
 
-@pytest.mark.parametrize('search_cv',
-                         [RandomizedSearchCV(estimator=DecisionTreeClassifier(),
-                                             param_distributions={'max_depth': [5, 10]}),
-                          GridSearchCV(estimator=DecisionTreeClassifier(),
-                                       param_grid={'max_depth': [5, 10]})
-                          ])
+@pytest.mark.parametrize('search_cv', [
+    RandomizedSearchCV(estimator=DecisionTreeClassifier(),
+                       param_distributions={'max_depth': [5, 10]}),
+    GridSearchCV(estimator=DecisionTreeClassifier(),
+                 param_grid={'max_depth': [5, 10]})
+])
 def test_search_cv_score_samples_error(search_cv):
     X, y = make_blobs(n_samples=100, n_features=4, random_state=42)
     search_cv.fit(X, y)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1098,17 +1098,16 @@ def compare_refit_methods_when_refit_with_acc(search_multi, search_acc, refit):
         assert getattr(search_multi, key) == getattr(search_acc, key)
 
 
-@pytest.mark.filterwarnings("ignore:The parameter 'iid' is deprecated")  # 0.24
-@pytest.mark.parametrize('search_cv', [RandomizedSearchCV, GridSearchCV])
+@pytest.mark.parametrize('search_cv',
+[
+    RandomizedSearchCV(estimator=DecisionTreeClassifier(),
+                       param_distributions={'max_depth': [5, 10]}),
+    GridSearchCV(estimator=DecisionTreeClassifier(),
+                 param_grid={'max_depth': [5, 10]})
+])
 def test_search_cv_score_samples_error(search_cv):
-    if search_cv == RandomizedSearchCV:
-        clf = search_cv(estimator=DecisionTreeClassifier(),
-                        param_distributions={'max_depth': [5, 10]})
-    else:
-        clf = search_cv(estimator=DecisionTreeClassifier(),
-                        param_grid={'max_depth': [5, 10]})
-
     X, y = make_blobs(n_samples=100, n_features=4, random_state=42)
+    clf = search_cv
     clf.fit(X, y)
 
     # Make sure to error out when underlying estimator does not implement
@@ -1120,8 +1119,14 @@ def test_search_cv_score_samples_error(search_cv):
         clf.score_samples(X)
 
 
-@pytest.mark.filterwarnings("ignore:The parameter 'iid' is deprecated")  # 0.24
-@pytest.mark.parametrize('search_cv', [RandomizedSearchCV, GridSearchCV])
+@pytest.mark.parametrize('search_cv',
+[RandomizedSearchCV(estimator=LocalOutlierFactor(novelty=True),
+                        param_distributions={'n_neighbors': [5, 10]},
+                        scoring="precision"),
+GridSearchCV(estimator=LocalOutlierFactor(novelty=True),
+                        param_grid={'n_neighbors': [5, 10]},
+                        scoring="precision")
+])
 def test_search_cv_score_samples_method(search_cv):
     # Set parameters
     rng = np.random.RandomState(42)
@@ -1142,14 +1147,8 @@ def test_search_cv_score_samples_method(search_cv):
     y_true = np.array([1] * n_samples)
     y_true[-n_outliers:] = [-1] * n_outliers
 
-    if search_cv == RandomizedSearchCV:
-        clf = search_cv(estimator=LocalOutlierFactor(novelty=True),
-                        param_distributions={'n_neighbors': [5, 10]},
-                        scoring="precision")
-    else:
-        clf = search_cv(estimator=LocalOutlierFactor(novelty=True),
-                        param_grid={'n_neighbors': [5, 10]},
-                        scoring="precision")
+    clf = search_cv
+
     # Fit on data
     clf.fit(X, y_true)
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -77,6 +77,7 @@ from sklearn.model_selection.tests.common import OneTimeSplitter
 # to test hyperparameter search on user-defined classifiers.
 class MockClassifier:
     """Dummy classifier to test the parameter search algorithms"""
+
     def __init__(self, foo_param=0):
         self.foo_param = foo_param
 
@@ -161,8 +162,8 @@ def test_parameter_grid():
         # tuple + chain transforms {"a": 1, "b": 2} to ("a", 1, "b", 2)
         points = set(tuple(chain(*(sorted(p.items())))) for p in grid2)
         assert (points ==
-                     set(("bar", x, "foo", y)
-                         for x, y in product(params2["bar"], params2["foo"])))
+                set(("bar", x, "foo", y)
+                    for x, y in product(params2["bar"], params2["foo"])))
     assert_grid_iter_equals_getitem(grid2)
 
     # Special case: empty grid (useful to get default estimator settings)
@@ -691,8 +692,8 @@ def test_gridsearch_nd():
     # Pass X as list in GridSearchCV
     X_4d = np.arange(10 * 5 * 3 * 2).reshape(10, 5, 3, 2)
     y_3d = np.arange(10 * 7 * 11).reshape(10, 7, 11)
-    check_X = lambda x: x.shape[1:] == (5, 3, 2)
-    check_y = lambda x: x.shape[1:] == (7, 11)
+    def check_X(x): return x.shape[1:] == (5, 3, 2)
+    def check_y(x): return x.shape[1:] == (7, 11)
     clf = CheckingClassifier(
         check_X=check_X, check_y=check_y, methods_to_check=["fit"],
     )
@@ -1099,16 +1100,14 @@ def compare_refit_methods_when_refit_with_acc(search_multi, search_acc, refit):
 
 
 @pytest.mark.parametrize('search_cv',
-[
-    RandomizedSearchCV(estimator=DecisionTreeClassifier(),
-                       param_distributions={'max_depth': [5, 10]}),
-    GridSearchCV(estimator=DecisionTreeClassifier(),
-                 param_grid={'max_depth': [5, 10]})
-])
+                         [RandomizedSearchCV(estimator=DecisionTreeClassifier(),
+                                             param_distributions={'max_depth': [5, 10]}),
+                          GridSearchCV(estimator=DecisionTreeClassifier(),
+                                       param_grid={'max_depth': [5, 10]})
+                          ])
 def test_search_cv_score_samples_error(search_cv):
     X, y = make_blobs(n_samples=100, n_features=4, random_state=42)
-    clf = search_cv
-    clf.fit(X, y)
+    search_cv.fit(X, y)
 
     # Make sure to error out when underlying estimator does not implement
     # the method `score_samples`
@@ -1116,17 +1115,18 @@ def test_search_cv_score_samples_error(search_cv):
                "'score_samples'")
 
     with pytest.raises(AttributeError, match=err_msg):
-        clf.score_samples(X)
+        search_cv.score_samples(X)
 
 
 @pytest.mark.parametrize('search_cv',
-[RandomizedSearchCV(estimator=LocalOutlierFactor(novelty=True),
-                        param_distributions={'n_neighbors': [5, 10]},
-                        scoring="precision"),
-GridSearchCV(estimator=LocalOutlierFactor(novelty=True),
-                        param_grid={'n_neighbors': [5, 10]},
-                        scoring="precision")
-])
+                         [RandomizedSearchCV(estimator=LocalOutlierFactor(novelty=True),
+                                             param_distributions={
+                                                 'n_neighbors': [5, 10]},
+                                             scoring="precision"),
+                          GridSearchCV(estimator=LocalOutlierFactor(novelty=True),
+                                       param_grid={'n_neighbors': [5, 10]},
+                                       scoring="precision")
+                          ])
 def test_search_cv_score_samples_method(search_cv):
     # Set parameters
     rng = np.random.RandomState(42)
@@ -1136,9 +1136,8 @@ def test_search_cv_score_samples_method(search_cv):
     n_inliers = n_samples - n_outliers
 
     # Create dataset
-    blobs_params = dict(random_state=0, n_samples=n_inliers, n_features=2)
-    X = make_blobs(centers=[[0, 0], [0, 0]], cluster_std=0.5,
-                   **blobs_params)[0]
+    X = make_blobs(n_samples=n_inliers, n_features=2, centers=[[0, 0], [0, 0]],
+                   cluster_std=0.5, random_state=0)[0]
     # Add some noisy points
     X = np.concatenate([X, rng.uniform(low=-6, high=6,
                                        size=(n_outliers, 2))], axis=0)
@@ -1147,22 +1146,15 @@ def test_search_cv_score_samples_method(search_cv):
     y_true = np.array([1] * n_samples)
     y_true[-n_outliers:] = [-1] * n_outliers
 
-    clf = search_cv
-
     # Fit on data
-    clf.fit(X, y_true)
-
-    # Define estimator with the best params obtained in
-    # the *SearchCV
-    lof = LocalOutlierFactor(novelty=True,
-                             n_neighbors=clf.best_params_["n_neighbors"])
+    search_cv.fit(X, y_true)
 
     # Fit the estimator
-    lof.fit(X)
+    lof = search_cv.best_estimator_
 
     # Verify that the stand alone estimator yields the same results
     # as the ones obtained with *SearchCV
-    assert_allclose(clf.score_samples(X), lof.score_samples(X))
+    assert_allclose(search_cv.score_samples(X), lof.score_samples(X))
 
 
 def test_search_cv_results_rank_tie_breaking():

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1113,9 +1113,11 @@ def test_search_cv_score_samples_error(search_cv):
 
     # Make sure to error out when underlying estimator does not implement
     # the method `score_samples`
-    err_msg = "AttributeError: 'DecisionTreeClassifier' object has " \
-              "no attribute 'score_samples'"
-    assert_raise_message(AttributeError, err_msg, clf.score_samples, X)
+    err_msg = ("'DecisionTreeClassifier' object has no attribute "
+               "'score_samples'")
+
+    with pytest.raises(AttributeError, match=err_msg):
+        clf.score_samples(X)
 
 
 @pytest.mark.filterwarnings("ignore:The parameter 'iid' is deprecated")  # 0.24

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1148,12 +1148,10 @@ def test_search_cv_score_samples_method(search_cv):
     # Fit on data
     search_cv.fit(X, y_true)
 
-    # Fit the estimator
-    lof = search_cv.best_estimator_
-
     # Verify that the stand alone estimator yields the same results
     # as the ones obtained with *SearchCV
-    assert_allclose(search_cv.score_samples(X), lof.score_samples(X))
+    assert_allclose(search_cv.score_samples(X),
+                    search_cv.best_estimator_.score_samples(X))
 
 
 def test_search_cv_results_rank_tie_breaking():

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1118,15 +1118,14 @@ def test_search_cv_score_samples_error(search_cv):
         search_cv.score_samples(X)
 
 
-@pytest.mark.parametrize('search_cv',
-                         [RandomizedSearchCV(estimator=LocalOutlierFactor(novelty=True),
-                                             param_distributions={
-                                                 'n_neighbors': [5, 10]},
-                                             scoring="precision"),
-                          GridSearchCV(estimator=LocalOutlierFactor(novelty=True),
-                                       param_grid={'n_neighbors': [5, 10]},
-                                       scoring="precision")
-                          ])
+@pytest.mark.parametrize('search_cv', [
+    RandomizedSearchCV(estimator=LocalOutlierFactor(novelty=True),
+                       param_distributions={'n_neighbors': [5, 10]},
+                       scoring="precision"),
+    GridSearchCV(estimator=LocalOutlierFactor(novelty=True),
+                 param_grid={'n_neighbors': [5, 10]},
+                 scoring="precision")
+])
 def test_search_cv_score_samples_method(search_cv):
     # Set parameters
     rng = np.random.RandomState(42)
@@ -1144,7 +1143,7 @@ def test_search_cv_score_samples_method(search_cv):
 
     # Define labels to be able to score the estimator with `search_cv`
     y_true = np.array([1] * n_samples)
-    y_true[-n_outliers:] = [-1] * n_outliers
+    y_true[-n_outliers:] = -1
 
     # Fit on data
     search_cv.fit(X, y_true)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/12542.
Building on and closes https://github.com/scikit-learn/scikit-learn/pull/16275.


#### What does this implement/fix? Explain your changes.
This adds the ability to call `score_samples` on the estimator with the best found parameters in *SearchCV instances.