### PR TITLE
Add data leakage warning in robust_scale and scale.

### DIFF
--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -135,15 +135,15 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
 
     .. warning:: Risk of data leak
 
-    Do not use :func:`~sklearn.preprocessing.scale` unless you know
-    what you are doing. A common mistake is to apply it to the entire data
-    *before* splitting into training and test sets. This will bias the model
-    evaluation because information would have leaked from the test set to
-    the training set.
-    In general, we recommend using
-    :class:`~sklearn.preprocessing.StandardScaler` within a
-    :ref:`Pipeline <pipeline>` in order to prevent most risks of data
-    leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
+        Do not use :func:`~sklearn.preprocessing.scale` unless you know what
+        you are doing. A common mistake is to apply it to the entire data
+        *before* splitting into training and test sets. This will bias the
+        model evaluation because information would have leaked from the test
+        set to the training set.
+        In general, we recommend using
+        :class:`~sklearn.preprocessing.StandardScaler` within a
+        :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+        leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
 
     See also
     --------
@@ -1287,15 +1287,15 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
 
     .. warning:: Risk of data leak
 
-    Do not use :func:`~sklearn.preprocessing.robust_scale` unless you know
-    what you are doing. A common mistake is to apply it to the entire data
-    *before* splitting into training and test sets. This will bias the model
-    evaluation because information would have leaked from the test set to
-    the training set.
-    In general, we recommend using
-    :class:`~sklearn.preprocessing.StandardScaler` within a
-    :ref:`Pipeline <pipeline>` in order to prevent most risks of data
-    leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
+        Do not use :func:`~sklearn.preprocessing.robust_scale` unless you know
+        what you are doing. A common mistake is to apply it to the entire data
+        *before* splitting into training and test sets. This will bias the
+        model evaluation because information would have leaked from the test
+        set to the training set.
+        In general, we recommend using
+        :class:`~sklearn.preprocessing.StandardScaler` within a
+        :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+        leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
 
     See also
     --------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -133,6 +133,18 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
     see :ref:`examples/preprocessing/plot_all_scaling.py
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.
 
+    .. warning:: Risk of data leak
+
+    Do not use :func:`~sklearn.preprocessing.scale` unless you know
+    what you are doing. A common mistake is to apply it to the entire data
+    *before* splitting into training and test sets. This will bias the model
+    evaluation because information would have leaked from the test set to
+    the training set.
+    In general, we recommend using
+    :class:`~sklearn.preprocessing.StandardScaler` within a
+    :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+    leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
+
     See also
     --------
     StandardScaler: Performs scaling to unit variance using the``Transformer`` API
@@ -1272,6 +1284,18 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.
+
+    .. warning:: Risk of data leak
+
+    Do not use :func:`~sklearn.preprocessing.robust_scale` unless you know
+    what you are doing. A common mistake is to apply it to the entire data
+    *before* splitting into training and test sets. This will bias the model
+    evaluation because information would have leaked from the test set to
+    the training set.
+    In general, we recommend using
+    :class:`~sklearn.preprocessing.StandardScaler` within a
+    :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+    leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
 
     See also
     --------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -135,15 +135,15 @@ def scale(X, axis=0, with_mean=True, with_std=True, copy=True):
 
     .. warning:: Risk of data leak
 
-        Do not use :func:`~sklearn.preprocessing.scale` unless you know what
-        you are doing. A common mistake is to apply it to the entire data
-        *before* splitting into training and test sets. This will bias the
-        model evaluation because information would have leaked from the test
-        set to the training set.
-        In general, we recommend using
-        :class:`~sklearn.preprocessing.StandardScaler` within a
-        :ref:`Pipeline <pipeline>` in order to prevent most risks of data
-        leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
+    Do not use :func:`~sklearn.preprocessing.scale` unless you know what
+    you are doing. A common mistake is to apply it to the entire data
+    *before* splitting into training and test sets. This will bias the
+    model evaluation because information would have leaked from the test
+    set to the training set.
+    In general, we recommend using, for example:
+    :class:`~sklearn.preprocessing.StandardScaler` within a
+    :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+    leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
 
     See also
     --------
@@ -1287,15 +1287,15 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
 
     .. warning:: Risk of data leak
 
-        Do not use :func:`~sklearn.preprocessing.robust_scale` unless you know
-        what you are doing. A common mistake is to apply it to the entire data
-        *before* splitting into training and test sets. This will bias the
-        model evaluation because information would have leaked from the test
-        set to the training set.
-        In general, we recommend using
-        :class:`~sklearn.preprocessing.StandardScaler` within a
-        :ref:`Pipeline <pipeline>` in order to prevent most risks of data
-        leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
+    Do not use :func:`~sklearn.preprocessing.robust_scale` unless you know
+    what you are doing. A common mistake is to apply it to the entire data
+    *before* splitting into training and test sets. This will bias the
+    model evaluation because information would have leaked from the test
+    set to the training set.
+    In general, we recommend using, for example:
+    :class:`~sklearn.preprocessing.RobustScaler` within a
+    :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+    leaking: `pipe = make_pipeline(RobustScaler(), LogisticRegression)`.
 
     See also
     --------

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1293,7 +1293,7 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
         model evaluation because information would have leaked from the test
         set to the training set.
         In general, we recommend using
-        :class:`~sklearn.preprocessing.StandardScaler` within a
+        :class:`~sklearn.preprocessing.RobustScaler` within a
         :ref:`Pipeline <pipeline>` in order to prevent most risks of data
         leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
 

--- a/sklearn/preprocessing/data.py
+++ b/sklearn/preprocessing/data.py
@@ -1295,7 +1295,7 @@ def robust_scale(X, axis=0, with_centering=True, with_scaling=True,
         In general, we recommend using
         :class:`~sklearn.preprocessing.RobustScaler` within a
         :ref:`Pipeline <pipeline>` in order to prevent most risks of data
-        leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression)`.
+        leaking: `pipe = make_pipeline(RobustScaler(), LogisticRegression())`.
 
     See also
     --------


### PR DESCRIPTION
partially addresses #17402  (scale and robust_scale items).

Added warning in docsctring of scale() and robut_scale() in sklearn/preprocessing/data.py as per template.
#DataUmbrella