### PR TITLE
DOC added a warning to maxabs_scale to prevent data leakage

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1094,6 +1094,18 @@ def maxabs_scale(X, *, axis=0, copy=True):
     X_tr : {ndarray, sparse matrix} of shape (n_samples, n_features)
         The transformed data.
 
+    .. warning:: Risk of data leak
+
+        Do not use :func:`~sklearn.preprocessing.maxabs_scale` unless you know what
+        you are doing. A common mistake is to apply it to the entire data
+        *before* splitting into training and test sets. This will bias the
+        model evaluation because information would have leaked from the test
+        set to the training set.
+        In general, we recommend using
+        :class:`~sklearn.preprocessing.MaxAbsScaler` within a
+        :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+        leaking: `pipe = make_pipeline(MaxAbsScaler(), LogisticRegression)`.
+
     See also
     --------
     MaxAbsScaler: Performs scaling to the [-1, 1] range using the``Transformer`` API

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1104,7 +1104,7 @@ def maxabs_scale(X, *, axis=0, copy=True):
         In general, we recommend using
         :class:`~sklearn.preprocessing.MaxAbsScaler` within a
         :ref:`Pipeline <pipeline>` in order to prevent most risks of data
-        leaking: `pipe = make_pipeline(MaxAbsScaler(), LogisticRegression)`.
+        leaking: `pipe = make_pipeline(MaxAbsScaler(), LogisticRegression())`.
 
     See also
     --------


### PR DESCRIPTION
#### Reference Issues/PRs #17402

#### What does this implement/fix? Explain your changes.
I added a warning to maxabs_scale suggesting users to use MaxAbsScaler in Pipeline instead to prevent data leakage

#### Any other comments?
cc: (pair programming partner) @CeeThinwa

