### PR TITLE
Enable links to objects in docstrings (Sprint Issue #17417)

### DIFF
--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -268,7 +268,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
 
     final_estimator : estimator, default=None
         A classifier which will be used to combine the base estimators.
-        The default classifier is a `LogisticRegression`.
+        The default classifier is a :class:`~sklearn.linear_model.LogisticRegression`.
 
     cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy used in
@@ -281,8 +281,8 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
         * An iterable yielding train, test splits.
 
         For integer/None inputs, if the estimator is a classifier and y is
-        either binary or multiclass, `StratifiedKFold` is used. In all other
-        cases, `KFold` is used.
+        either binary or multiclass, :class:`~sklearn.model_selection.StratifiedKFold` is used.
+        In all other cases, :class:`~sklearn.model_selection.KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -540,7 +540,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
 
     final_estimator : estimator, default=None
         A regressor which will be used to combine the base estimators.
-        The default regressor is a `RidgeCV`.
+        The default regressor is a :class:`~sklearn.linear_model.RidgeCV`.
 
     cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy used in
@@ -553,8 +553,8 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         * An iterable yielding train, test splits.
 
         For integer/None inputs, if the estimator is a classifier and y is
-        either binary or multiclass, `StratifiedKFold` is used. In all other
-        cases, `KFold` is used.
+        either binary or multiclass, :class:`~sklearn.model_selection.StratifiedKFold` is used.
+        In all other cases, :class:`~sklearn.model_selection.KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
         cross-validation strategies that can be used here.

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -268,7 +268,8 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
 
     final_estimator : estimator, default=None
         A classifier which will be used to combine the base estimators.
-        The default classifier is a :class:`~sklearn.linear_model.LogisticRegression`.
+        The default classifier is a
+        :class:`~sklearn.linear_model.LogisticRegression`.
 
     cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy used in
@@ -281,7 +282,8 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
         * An iterable yielding train, test splits.
 
         For integer/None inputs, if the estimator is a classifier and y is
-        either binary or multiclass, :class:`~sklearn.model_selection.StratifiedKFold` is used.
+        either binary or multiclass,
+        :class:`~sklearn.model_selection.StratifiedKFold` is used.
         In all other cases, :class:`~sklearn.model_selection.KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various
@@ -553,7 +555,8 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         * An iterable yielding train, test splits.
 
         For integer/None inputs, if the estimator is a classifier and y is
-        either binary or multiclass, :class:`~sklearn.model_selection.StratifiedKFold` is used.
+        either binary or multiclass,
+        :class:`~sklearn.model_selection.StratifiedKFold` is used.
         In all other cases, :class:`~sklearn.model_selection.KFold` is used.
 
         Refer :ref:`User Guide <cross_validation>` for the various

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -5,15 +5,15 @@ regression.
 
 The module structure is the following:
 
-- The :class:`~sklearn.ensemble.BaseWeightBoosting` base class implements a common ``fit`` method
+- The `BaseWeightBoosting` base class implements a common ``fit`` method
   for all the estimators in the module. Regression and classification
   only differ from each other in the loss function that is optimized.
 
-- :class:`~sklearn.ensemble.AdaBoostClassifier` implements adaptive boosting (AdaBoost-SAMME) for
-  classification problems.
+- :class:`~sklearn.ensemble.AdaBoostClassifier` implements adaptive boosting
+  (AdaBoost-SAMME) for classification problems.
 
-- :class:`~sklearn.ensemble.AdaBoostRegressor` implements adaptive boosting (AdaBoost.R2) for
-  regression problems.
+- :class:`~sklearn.ensemble.AdaBoostRegressor` implements adaptive boosting
+  (AdaBoost.R2) for regression problems.
 """
 
 # Authors: Noel Dawe <noel@dawe.me>
@@ -303,8 +303,8 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         The base estimator from which the boosted ensemble is built.
         Support for sample weighting is required, as well as proper
         ``classes_`` and ``n_classes_`` attributes. If ``None``, then
-        the base estimator is :class:`~sklearn.tree.DecisionTreeClassifier` initialized with
-        `max_depth=1`.
+        the base estimator is :class:`~sklearn.tree.DecisionTreeClassifier`
+        initialized with `max_depth=1`.
 
     n_estimators : int, default=50
         The maximum number of estimators at which boosting is terminated.
@@ -360,19 +360,19 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
 
     See Also
     --------
-    :class:`~sklearn.ensemble.AdaBoostRegressor`
+    AdaBoostRegressor
         An AdaBoost regressor that begins by fitting a regressor on the
         original dataset and then fits additional copies of the regressor
         on the same dataset but where the weights of instances are
         adjusted according to the error of the current prediction.
 
-    :class:`~sklearn.ensemble.GradientBoostingClassifier`
+    GradientBoostingClassifier
         GB builds an additive model in a forward stage-wise fashion. Regression
         trees are fit on the negative gradient of the binomial or multinomial
         deviance loss function. Binary classification is a special case where
         only a single regression tree is induced.
 
-    :class:`~sklearn.tree.DecisionTreeClassifier`
+    sklearn.tree.DecisionTreeClassifier
         A non-parametric supervised learning method used for classification.
         Creates a model that predicts the value of a target variable by
         learning simple decision rules inferred from the data features.
@@ -889,7 +889,8 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
     base_estimator : object, default=None
         The base estimator from which the boosted ensemble is built.
         If ``None``, then the base estimator is
-        :class:`~sklearn.tree.DecisionTreeRegressor` initialized with `max_depth=3`.
+        :class:`~sklearn.tree.DecisionTreeRegressor` initialized with
+        `max_depth=3`.
 
     n_estimators : int, default=50
         The maximum number of estimators at which boosting is terminated.
@@ -951,9 +952,8 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
 
     See also
     --------
-    :class:`~sklearn.ensemble.AdaBoostClassifier`,
-    :class:`~sklearn.ensemble.GradientBoostingRegressor`,
-    :class:`~sklearn.tree.DecisionTreeRegressor`
+    AdaBoostClassifier, GradientBoostingRegressor,
+    sklearn.tree.DecisionTreeRegressor
 
     References
     ----------

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -888,7 +888,7 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
     base_estimator : object, default=None
         The base estimator from which the boosted ensemble is built.
         If ``None``, then the base estimator is
-        ``DecisionTreeRegressor(max_depth=3)``.
+        :class:`~sklearn.tree.DecisionTreeRegressor` initialized with `max_depth=3`.
 
     n_estimators : int, default=50
         The maximum number of estimators at which boosting is terminated.
@@ -950,8 +950,9 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
 
     See also
     --------
-    AdaBoostClassifier, GradientBoostingRegressor,
-    sklearn.tree.DecisionTreeRegressor
+    :class:`~sklearn.ensemble.AdaBoostClassifier`,
+    :class:`~sklearn.ensemble.GradientBoostingRegressor`,
+    :class:`~sklearn.tree.DecisionTreeRegressor`
 
     References
     ----------

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -5,14 +5,14 @@ regression.
 
 The module structure is the following:
 
-- The ``BaseWeightBoosting`` base class implements a common ``fit`` method
+- The :class:`~sklearn.ensemble.BaseWeightBoosting` base class implements a common ``fit`` method
   for all the estimators in the module. Regression and classification
   only differ from each other in the loss function that is optimized.
 
-- ``AdaBoostClassifier`` implements adaptive boosting (AdaBoost-SAMME) for
+- :class:`~sklearn.ensemble.AdaBoostClassifier` implements adaptive boosting (AdaBoost-SAMME) for
   classification problems.
 
-- ``AdaBoostRegressor`` implements adaptive boosting (AdaBoost.R2) for
+- :class:`~sklearn.ensemble.AdaBoostRegressor` implements adaptive boosting (AdaBoost.R2) for
   regression problems.
 """
 
@@ -303,7 +303,8 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         The base estimator from which the boosted ensemble is built.
         Support for sample weighting is required, as well as proper
         ``classes_`` and ``n_classes_`` attributes. If ``None``, then
-        the base estimator is ``DecisionTreeClassifier(max_depth=1)``.
+        the base estimator is :class:`~sklearn.tree.DecisionTreeClassifier` initialized with
+        `max_depth=1`.
 
     n_estimators : int, default=50
         The maximum number of estimators at which boosting is terminated.
@@ -359,19 +360,19 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
 
     See Also
     --------
-    AdaBoostRegressor
+    :class:`~sklearn.ensemble.AdaBoostRegressor`
         An AdaBoost regressor that begins by fitting a regressor on the
         original dataset and then fits additional copies of the regressor
         on the same dataset but where the weights of instances are
         adjusted according to the error of the current prediction.
 
-    GradientBoostingClassifier
+    :class:`~sklearn.ensemble.GradientBoostingClassifier`
         GB builds an additive model in a forward stage-wise fashion. Regression
         trees are fit on the negative gradient of the binomial or multinomial
         deviance loss function. Binary classification is a special case where
         only a single regression tree is induced.
 
-    sklearn.tree.DecisionTreeClassifier
+    :class:`~sklearn.tree.DecisionTreeClassifier`
         A non-parametric supervised learning method used for classification.
         Creates a model that predicts the value of a target variable by
         learning simple decision rules inferred from the data features.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

Submitted as part of an sklearn open source sprint. Pair programming with @anilkumarteegala.

#### Reference Issues/PRs
Partially addresses #17417 (for a subset of classes).



#### What does this implement/fix? Explain your changes.
This PR adds docstring links to the following classes:

```python
sklearn.ensemble.StackingRegressor
sklearn.ensemble.StackingClassifer
sklearn.ensemble.AdaBoostClassifier
sklearn.ensemble.AdaBoostRegressor
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
