### PR TITLE
Fix documentation of default values in sklearn.utils.validation

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -135,7 +135,7 @@ def as_float_array(X, *, copy=True, force_all_finite=True):
         If True, a copy of X will be created. If False, a copy may still be
         returned if X's dtype is not a floating point type.
 
-    force_all_finite : boolean or 'allow-nan', (default=True)
+    force_all_finite : boolean or 'allow-nan', default=True
         Whether to raise an error on np.inf, np.nan, pd.NA in X. The
         possibilities are:
 
@@ -320,7 +320,7 @@ def _ensure_sparse_format(spmatrix, accept_sparse, dtype, copy,
         Whether a forced copy will be triggered. If copy=False, a copy might
         be triggered by a conversion.
 
-    force_all_finite : boolean or 'allow-nan', (default=True)
+    force_all_finite : boolean or 'allow-nan', default=True
         Whether to raise an error on np.inf, np.nan, pd.NA in X. The
         possibilities are:
 
@@ -413,38 +413,38 @@ def check_array(array, accept_sparse=False, *, accept_large_sparse=True,
     array : object
         Input object to check / convert.
 
-    accept_sparse : string, boolean or list/tuple of strings (default=False)
+    accept_sparse : string, boolean or list/tuple of strings, default=False
         String[s] representing allowed sparse matrix formats, such as 'csc',
         'csr', etc. If the input is sparse but not in the allowed format,
         it will be converted to the first listed format. True allows the input
         to be any format. False means that a sparse matrix input will
         raise an error.
 
-    accept_large_sparse : bool (default=True)
+    accept_large_sparse : bool, default=True
         If a CSR, CSC, COO or BSR sparse matrix is supplied and accepted by
         accept_sparse, accept_large_sparse=False will cause it to be accepted
         only if its indices are stored with a 32-bit dtype.
 
         .. versionadded:: 0.20
 
-    dtype : string, type, list of types or None (default="numeric")
+    dtype : string, type, list of types or None, default="numeric"
         Data type of result. If None, the dtype of the input is preserved.
         If "numeric", dtype is preserved unless array.dtype is object.
         If dtype is a list of types, conversion on the first type is only
         performed if the dtype of the input is not in the list.
 
-    order : 'F', 'C' or None (default=None)
+    order : 'F', 'C' or None, default=None
         Whether an array will be forced to be fortran or c-style.
         When order is None (default), then if copy=False, nothing is ensured
         about the memory layout of the output array; otherwise (copy=True)
         the memory layout of the returned array is kept as close as possible
         to the original array.
 
-    copy : boolean (default=False)
+    copy : boolean, default=False
         Whether a forced copy will be triggered. If copy=False, a copy might
         be triggered by a conversion.
 
-    force_all_finite : boolean or 'allow-nan', (default=True)
+    force_all_finite : boolean or 'allow-nan', default=True
         Whether to raise an error on np.inf, np.nan, pd.NA in array. The
         possibilities are:
 
@@ -459,24 +459,24 @@ def check_array(array, accept_sparse=False, *, accept_large_sparse=True,
         .. versionchanged:: 0.23
            Accepts `pd.NA` and converts it into `np.nan`
 
-    ensure_2d : boolean (default=True)
+    ensure_2d : boolean, default=True
         Whether to raise a value error if array is not 2D.
 
-    allow_nd : boolean (default=False)
+    allow_nd : boolean, default=False
         Whether to allow array.ndim > 2.
 
-    ensure_min_samples : int (default=1)
+    ensure_min_samples : int, default=1
         Make sure that the array has a minimum number of samples in its first
         axis (rows for a 2D array). Setting to 0 disables this check.
 
-    ensure_min_features : int (default=1)
+    ensure_min_features : int, default=1
         Make sure that the 2D array has some minimum number of features
         (columns). The default value of 1 rejects empty datasets.
         This check is only enforced when the input data has effectively 2
         dimensions or is originally 1D and ``ensure_2d`` is True. Setting to 0
         disables this check.
 
-    estimator : str or estimator instance (default=None)
+    estimator : str or estimator instance, default=None
         If passed, include the name of the estimator in warning messages.
 
     Returns
@@ -710,34 +710,34 @@ def check_X_y(X, y, accept_sparse=False, *, accept_large_sparse=True,
     y : nd-array, list or sparse matrix
         Labels.
 
-    accept_sparse : string, boolean or list of string (default=False)
+    accept_sparse : string, boolean or list of string, default=False
         String[s] representing allowed sparse matrix formats, such as 'csc',
         'csr', etc. If the input is sparse but not in the allowed format,
         it will be converted to the first listed format. True allows the input
         to be any format. False means that a sparse matrix input will
         raise an error.
 
-    accept_large_sparse : bool (default=True)
+    accept_large_sparse : bool, default=True
         If a CSR, CSC, COO or BSR sparse matrix is supplied and accepted by
         accept_sparse, accept_large_sparse will cause it to be accepted only
         if its indices are stored with a 32-bit dtype.
 
         .. versionadded:: 0.20
 
-    dtype : string, type, list of types or None (default="numeric")
+    dtype : string, type, list of types or None, default="numeric"
         Data type of result. If None, the dtype of the input is preserved.
         If "numeric", dtype is preserved unless array.dtype is object.
         If dtype is a list of types, conversion on the first type is only
         performed if the dtype of the input is not in the list.
 
-    order : 'F', 'C' or None (default=None)
+    order : 'F', 'C' or None, default=None
         Whether an array will be forced to be fortran or c-style.
 
-    copy : boolean (default=False)
+    copy : boolean, default=False
         Whether a forced copy will be triggered. If copy=False, a copy might
         be triggered by a conversion.
 
-    force_all_finite : boolean or 'allow-nan', (default=True)
+    force_all_finite : boolean or 'allow-nan', default=True
         Whether to raise an error on np.inf, np.nan, pd.NA in X. This parameter
         does not influence whether y can have np.inf, np.nan, pd.NA values.
         The possibilities are:
@@ -753,34 +753,34 @@ def check_X_y(X, y, accept_sparse=False, *, accept_large_sparse=True,
         .. versionchanged:: 0.23
            Accepts `pd.NA` and converts it into `np.nan`
 
-    ensure_2d : boolean (default=True)
+    ensure_2d : boolean, default=True
         Whether to raise a value error if X is not 2D.
 
-    allow_nd : boolean (default=False)
+    allow_nd : boolean, default=False
         Whether to allow X.ndim > 2.
 
-    multi_output : boolean (default=False)
+    multi_output : boolean, default=False
         Whether to allow 2D y (array or sparse matrix). If false, y will be
         validated as a vector. y cannot have np.nan or np.inf values if
         multi_output=True.
 
-    ensure_min_samples : int (default=1)
+    ensure_min_samples : int, default=1
         Make sure that X has a minimum number of samples in its first
         axis (rows for a 2D array).
 
-    ensure_min_features : int (default=1)
+    ensure_min_features : int, default=1
         Make sure that the 2D array has some minimum number of features
         (columns). The default value of 1 rejects empty datasets.
         This check is only enforced when X has effectively 2 dimensions or
         is originally 1D and ``ensure_2d`` is True. Setting to 0 disables
         this check.
 
-    y_numeric : boolean (default=False)
+    y_numeric : boolean, default=False
         Whether to ensure that y has a numeric type. If dtype of y is object,
         it is converted to float64. Should only be used for regression
         algorithms.
 
-    estimator : str or estimator instance (default=None)
+    estimator : str or estimator instance, default=None
         If passed, include the name of the estimator in warning messages.
 
     Returns
@@ -913,9 +913,9 @@ def check_symmetric(array, *, tol=1E-10, raise_warning=True,
         otherwise a ValueError will be raised.
     tol : float
         Absolute tolerance for equivalence of arrays. Default = 1E-10.
-    raise_warning : boolean (default=True)
+    raise_warning : boolean, default=True
         If True then raise a warning if conversion is required.
-    raise_exception : boolean (default=False)
+    raise_exception : boolean, default=False
         If True then raise an exception if array is not symmetric.
 
     Returns
@@ -988,7 +988,7 @@ def check_is_fitted(estimator, attributes=None, *, msg=None, all_or_any=all):
 
         Eg. : "Estimator, %(name)s, must be fitted before sparsifying".
 
-    all_or_any : callable, {all, any}, default all
+    all_or_any : callable, {all, any}, default=all
         Specify whether all or any of the given attributes must exist.
 
     Returns

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1062,11 +1062,11 @@ def check_scalar(x, name, target_type, *, min_val=None, max_val=None):
     target_type : type or tuple
         Acceptable data types for the parameter.
 
-    min_val : float or int, optional (default=None)
+    min_val : float or int, default=None
         The minimum valid value the parameter can take. If None (default) it
         is implied that the parameter does not have a lower bound.
 
-    max_val : float or int, optional (default=None)
+    max_val : float or int, default=None
         The maximum valid value the parameter can take. If None (default) it
         is implied that the parameter does not have an upper bound.
 


### PR DESCRIPTION
Fix documentation of default values in sklearn.utils.validation

#### Reference Issues/PRs
#17485

#### What does this implement/fix? Explain your changes.
This changes the documentation of default values from "optional (default=xyz)" to just simply "default=xyz".

Worked on this with @muokicaleb 
#DataUmbrella