### PR TITLE
[DOC] remove ref to CodeCov browser extension

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,11 +12,8 @@ coverage:
       default:
         # Be tolerant on slight code coverage diff on PRs to limit
         # noisy red coverage status on github PRs.
-        # Note The coverage stats are still uploaded
+        # Note: The coverage stats are still uploaded
         # to codecov so that PR reviewers can see uncovered lines
-        # in the github diff if they install the codecov browser
-        # extension:
-        # https://github.com/codecov/browser-extension
         target: auto
         threshold: 1%
 


### PR DESCRIPTION
The Codecov browser extension has been deprecated, and covered/uncovered lines are now shown directly in the reports.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

References None.

#### What does this implement/fix? Explain your changes.

Removes reference to deprecated CodeCov browser extension. This comment may confuse future maintainers / developers re how to view covered / uncovered lines.

#### Any other comments?

Submitted with @annejeevan for the #DataUmbrella sprint

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
