### PR TITLE
fix: Reduce warnings for k_means and discriminant_analysis

### DIFF
--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -193,7 +193,7 @@ def test_dbscan_metric_params():
     assert_array_equal(labels_1, labels_3)
 
     with pytest.warns(SyntaxWarning):
-        # Test that checks p is ignored in favor of metric_params={'p': <value>}
+        # Test that checks p is ignored in favor of metric_params={'p': <val>}
         db = DBSCAN(metric='minkowski', metric_params={'p': p}, eps=eps, p=p+1,
                     min_samples=min_samples, algorithm='ball_tree').fit(X)
         core_sample_4, labels_4 = db.core_sample_indices_, db.labels_

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -172,7 +172,7 @@ def test_dbscan_metric_params():
     p = 1
 
     # Compute DBSCAN with metric_params arg
-    db = DBSCAN(metric='minkowski', metric_params={'p': p}, eps=eps,
+    db = DBSCAN(metric='minkowski', metric_params={'p': p}, eps=eps, p=None,
                 min_samples=min_samples, algorithm='ball_tree').fit(X)
     core_sample_1, labels_1 = db.core_sample_indices_, db.labels_
 

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -176,8 +176,10 @@ def test_dbscan_metric_params():
     # Compute DBSCAN with metric_params arg
 
     with warnings.catch_warnings(record=True) as warns:
-        db = DBSCAN(metric='minkowski', metric_params={'p': p}, eps=eps, p=None,
-                    min_samples=min_samples, algorithm='ball_tree').fit(X)
+        db = DBSCAN(
+            metric='minkowski', metric_params={'p': p}, eps=eps,
+            p=None, min_samples=min_samples, algorithm='ball_tree'
+            ).fit(X)
     assert not warns
     core_sample_1, labels_1 = db.core_sample_indices_, db.labels_
 
@@ -197,9 +199,11 @@ def test_dbscan_metric_params():
     assert_array_equal(core_sample_1, core_sample_3)
     assert_array_equal(labels_1, labels_3)
 
-    with pytest.warns(SyntaxWarning, match="Parameter p is found in metric_params. "
-                              "The corresponding parameter from __init__ "
-                              "is ignored."):
+    with pytest.warns(
+        SyntaxWarning,
+        match="Parameter p is found in metric_params. "
+              "The corresponding parameter from __init__ "
+              "is ignored."):
         # Test that checks p is ignored in favor of metric_params={'p': <val>}
         db = DBSCAN(metric='minkowski', metric_params={'p': p}, eps=eps, p=p+1,
                     min_samples=min_samples, algorithm='ball_tree').fit(X)

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -6,6 +6,8 @@ import pickle
 
 import numpy as np
 
+import warnings
+
 from scipy.spatial import distance
 from scipy import sparse
 
@@ -172,8 +174,11 @@ def test_dbscan_metric_params():
     p = 1
 
     # Compute DBSCAN with metric_params arg
-    db = DBSCAN(metric='minkowski', metric_params={'p': p}, eps=eps, p=None,
-                min_samples=min_samples, algorithm='ball_tree').fit(X)
+
+    with warnings.catch_warnings(record=True) as warns:
+        db = DBSCAN(metric='minkowski', metric_params={'p': p}, eps=eps, p=None,
+                    min_samples=min_samples, algorithm='ball_tree').fit(X)
+    assert not warns
     core_sample_1, labels_1 = db.core_sample_indices_, db.labels_
 
     # Test that sample labels are the same as passing Minkowski 'p' directly
@@ -192,7 +197,9 @@ def test_dbscan_metric_params():
     assert_array_equal(core_sample_1, core_sample_3)
     assert_array_equal(labels_1, labels_3)
 
-    with pytest.warns(SyntaxWarning):
+    with pytest.warns(SyntaxWarning, match="Parameter p is found in metric_params. "
+                              "The corresponding parameter from __init__ "
+                              "is ignored."):
         # Test that checks p is ignored in favor of metric_params={'p': <val>}
         db = DBSCAN(metric='minkowski', metric_params={'p': p}, eps=eps, p=p+1,
                     min_samples=min_samples, algorithm='ball_tree').fit(X)

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -192,6 +192,15 @@ def test_dbscan_metric_params():
     assert_array_equal(core_sample_1, core_sample_3)
     assert_array_equal(labels_1, labels_3)
 
+    with pytest.warns(SyntaxWarning):
+        # Test that checks p is ignored in favor of metric_params={'p': <value>}
+        db = DBSCAN(metric='minkowski', metric_params={'p': p}, eps=eps, p=p+1,
+                    min_samples=min_samples, algorithm='ball_tree').fit(X)
+        core_sample_4, labels_4 = db.core_sample_indices_, db.labels_
+
+    assert_array_equal(core_sample_1, core_sample_4)
+    assert_array_equal(labels_1, labels_4)
+
 
 def test_dbscan_balltree():
     # Tests the DBSCAN algorithm with balltree for neighbor calculation.

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -466,8 +466,9 @@ def test_minibatch_k_means_init_multiple_runs_with_explicit_centers():
 @pytest.mark.parametrize('data', [X, X_csr], ids=['dense', 'sparse'])
 @pytest.mark.parametrize('init', ["random", 'k-means++', centers.copy()])
 def test_minibatch_k_means_init(data, init):
+    n_init = 10 if type(init) is str else 1
     mb_k_means = MiniBatchKMeans(init=init, n_clusters=n_clusters,
-                                 random_state=42, n_init=10)
+                                 random_state=42, n_init=n_init)
     mb_k_means.fit(data)
     _check_fitted_model(mb_k_means)
 
@@ -672,8 +673,9 @@ def test_score(algo):
 @pytest.mark.parametrize('data', [X, X_csr], ids=['dense', 'sparse'])
 @pytest.mark.parametrize('init', ['random', 'k-means++', centers.copy()])
 def test_predict(Estimator, data, init):
+    n_init = 10 if type(init) is str else 1
     k_means = Estimator(n_clusters=n_clusters, init=init,
-                        n_init=10, random_state=0).fit(data)
+                        n_init=n_init, random_state=0).fit(data)
 
     # sanity check: re-predict labeling for training set samples
     assert_array_equal(k_means.predict(data), k_means.labels_)
@@ -691,8 +693,9 @@ def test_predict(Estimator, data, init):
 def test_predict_minibatch_dense_sparse(init):
     # check that models trained on sparse input also works for dense input at
     # predict time
+    n_init = 10 if type(init) is str else 1
     mb_k_means = MiniBatchKMeans(n_clusters=n_clusters, init=init,
-                                 n_init=10, random_state=0).fit(X_csr)
+                                 n_init=n_init, random_state=0).fit(X_csr)
 
     assert_array_equal(mb_k_means.predict(X), mb_k_means.labels_)
 
@@ -946,7 +949,7 @@ def test_weighted_vs_repeated():
                   KMeans(init="random", n_clusters=n_clusters,
                          random_state=42),
                   KMeans(init=centers.copy(), n_clusters=n_clusters,
-                         random_state=42),
+                         random_state=42, n_init=1),
                   MiniBatchKMeans(n_clusters=n_clusters, batch_size=10,
                                   random_state=42)]
     for estimator in estimators:

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -537,7 +537,9 @@ class LinearDiscriminantAnalysis(BaseEstimator, LinearClassifierMixin,
         C : ndarray of shape (n_samples, n_classes)
             Estimated log probabilities.
         """
-        return np.log(self.predict_proba(X))
+        prediction = self.predict_proba(X)
+        prediction[prediction == 0.0] += np.finfo(prediction.dtype).tiny
+        return np.log(prediction)
 
     def decision_function(self, X):
         """Apply decision function to an array of samples.

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -338,8 +338,8 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         if self.metric_params is not None and 'p' in self.metric_params:
             if self.p is not None:
                 warnings.warn("Parameter p is found in metric_params. "
-                            "The corresponding parameter from __init__ "
-                            "is ignored.", SyntaxWarning, stacklevel=3)
+                              "The corresponding parameter from __init__ "
+                              "is ignored.", SyntaxWarning, stacklevel=3)
             effective_p = self.metric_params['p']
         else:
             effective_p = self.p

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -336,9 +336,10 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                              % (self.metric, alg_check))
 
         if self.metric_params is not None and 'p' in self.metric_params:
-            warnings.warn("Parameter p is found in metric_params. "
-                          "The corresponding parameter from __init__ "
-                          "is ignored.", SyntaxWarning, stacklevel=3)
+            if self.p is not None:
+                warnings.warn("Parameter p is found in metric_params. "
+                            "The corresponding parameter from __init__ "
+                            "is ignored.", SyntaxWarning, stacklevel=3)
             effective_p = self.metric_params['p']
         else:
             effective_p = self.p

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -74,7 +74,7 @@ def test_lda_predict():
                            'solver %s' % solver)
         y_log_proba_pred1 = clf.predict_log_proba(X1)
         assert_allclose(np.exp(y_log_proba_pred1), y_proba_pred1,
-                        rtol=1e-6, err_msg='solver %s' % solver)
+                        rtol=1e-6, atol=1e-6, err_msg='solver %s' % solver)
 
         # Primarily test for commit 2f34950 -- "reuse" of priors
         y_pred3 = clf.fit(X, y3).predict(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

References #5685

#### What does this implement/fix? Explain your changes.

- Reduce the number of warnings for k_means by setting n_init to 1
when proviging initialization centers
- Remove discriminant_analysis test warnings by guarding against zero
division for `predict_log_proba`
- Print `p` parameter ignore warning only when different than `None`

#### Any other comments?

#DataUmbrella

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
