### PR TITLE
MNT Allow pull request labeler to fail

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,8 +7,13 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.4.6
-      if: github.repository == 'scikit-learn/scikit-learn'
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        max-labels: "3"
+      - name: Hello
+        run: |
+          exit 1
+        shell: bash
+    # - uses: thomasjpfan/labeler@v2.4.6
+    #   if: github.repository == 'scikit-learn/scikit-learn'
+    #   continue-on-error: true
+    #   with:
+    #     repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    #     max-labels: "3"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,21 +1,15 @@
 name: "Pull Request Labeler"
-on: push
-
-  # schedule:
-  #   - cron: "*/10 * * * *"
+on:
+  schedule:
+    - cron: "*/10 * * * *"
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - name: Hello
-        continue-on-error: true
-        run: |
-          exit 1
-        shell: bash
-    # - uses: thomasjpfan/labeler@v2.4.6
-    #   if: github.repository == 'scikit-learn/scikit-learn'
-    #   continue-on-error: true
-    #   with:
-    #     repo-token: "${{ secrets.GITHUB_TOKEN }}"
-    #     max-labels: "3"
+    - uses: thomasjpfan/labeler@v2.4.6
+      continue-on-error: true
+      if: github.repository == 'scikit-learn/scikit-learn'
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        max-labels: "3"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,8 @@
 name: "Pull Request Labeler"
-on:
-  schedule:
-    - cron: "*/10 * * * *"
+on: push
+
+  # schedule:
+  #   - cron: "*/10 * * * *"
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Hello
+        continue-on-error: true
         run: |
           exit 1
         shell: bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,146 +49,146 @@ jobs:
       name: gitCommitMessage
       displayName: Determine to run scipy-dev
 
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: Linux_Nightly
-#     vmImage: ubuntu-18.04
-#     dependsOn: [linting]
-#     condition: eq(dependencies['linting']['outputs']['gitCommitMessage.runScipyDev'], 'true')
-#     matrix:
-#       pylatest_pip_scipy_dev:
-#         DISTRIB: 'conda-pip-scipy-dev'
-#         PYTHON_VERSION: '*'
-#         CHECK_WARNINGS: 'true'
-#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-#         TEST_DOCSTRINGS: 'true'
-#         # Tests that require large downloads over the networks are skipped in CI.
-#         # Here we make sure, that they are still run on a regular basis.
-#         SKLEARN_SKIP_NETWORK_TESTS: '0'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: Linux_Nightly
+    vmImage: ubuntu-18.04
+    dependsOn: [linting]
+    condition: eq(dependencies['linting']['outputs']['gitCommitMessage.runScipyDev'], 'true')
+    matrix:
+      pylatest_pip_scipy_dev:
+        DISTRIB: 'conda-pip-scipy-dev'
+        PYTHON_VERSION: '*'
+        CHECK_WARNINGS: 'true'
+        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+        TEST_DOCSTRINGS: 'true'
+        # Tests that require large downloads over the networks are skipped in CI.
+        # Here we make sure, that they are still run on a regular basis.
+        SKLEARN_SKIP_NETWORK_TESTS: '0'
 
-# Will run all the time regardless of linting outcome.
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: Linux_Runs
-#     vmImage: ubuntu-18.04
-#     matrix:
-#       pylatest_conda_mkl:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
+Will run all the time regardless of linting outcome.
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: Linux_Runs
+    vmImage: ubuntu-18.04
+    matrix:
+      pylatest_conda_mkl:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
 
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: Linux
-#     vmImage: ubuntu-18.04
-#     dependsOn: [linting]
-#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-#     matrix:
-#       # Linux environment to test that scikit-learn can be built against
-#       # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
-#       # i.e. numpy 1.13.3 and scipy 0.19
-#       py36_ubuntu_atlas:
-#         DISTRIB: 'ubuntu'
-#         PYTHON_VERSION: '3.6'
-#         JOBLIB_VERSION: '0.11'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#       # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
-#       py36_conda_openblas:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '3.6'
-#         BLAS: 'openblas'
-#         NUMPY_VERSION: '1.13.3'
-#         SCIPY_VERSION: '0.19.1'
-#         PANDAS_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         # temporary pin pytest due to unknown failure with pytest 5.3
-#         PYTEST_VERSION: '5.2'
-#         PILLOW_VERSION: '4.2.1'
-#         MATPLOTLIB_VERSION: '2.1.1'
-#         SCIKIT_IMAGE_VERSION: '*'
-#         # latest version of joblib available in conda for Python 3.6
-#         JOBLIB_VERSION: '0.13.2'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#       # Linux environment to test the latest available dependencies and MKL.
-#       # It runs tests requiring lightgbm, pandas and PyAMG.
-#       pylatest_pip_openblas_pandas:
-#         DISTRIB: 'conda-pip-latest'
-#         PYTHON_VERSION: '3.8'
-#         PYTEST_VERSION: '4.6.2'
-#         COVERAGE: 'true'
-#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-#         TEST_DOCSTRINGS: 'true'
-#         CHECK_WARNINGS: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: Linux
+    vmImage: ubuntu-18.04
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      # Linux environment to test that scikit-learn can be built against
+      # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
+      # i.e. numpy 1.13.3 and scipy 0.19
+      py36_ubuntu_atlas:
+        DISTRIB: 'ubuntu'
+        PYTHON_VERSION: '3.6'
+        JOBLIB_VERSION: '0.11'
+        THREADPOOLCTL_VERSION: '2.0.0'
+      # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
+      py36_conda_openblas:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '3.6'
+        BLAS: 'openblas'
+        NUMPY_VERSION: '1.13.3'
+        SCIPY_VERSION: '0.19.1'
+        PANDAS_VERSION: '*'
+        CYTHON_VERSION: '*'
+        # temporary pin pytest due to unknown failure with pytest 5.3
+        PYTEST_VERSION: '5.2'
+        PILLOW_VERSION: '4.2.1'
+        MATPLOTLIB_VERSION: '2.1.1'
+        SCIKIT_IMAGE_VERSION: '*'
+        # latest version of joblib available in conda for Python 3.6
+        JOBLIB_VERSION: '0.13.2'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+      # Linux environment to test the latest available dependencies and MKL.
+      # It runs tests requiring lightgbm, pandas and PyAMG.
+      pylatest_pip_openblas_pandas:
+        DISTRIB: 'conda-pip-latest'
+        PYTHON_VERSION: '3.8'
+        PYTEST_VERSION: '4.6.2'
+        COVERAGE: 'true'
+        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+        TEST_DOCSTRINGS: 'true'
+        CHECK_WARNINGS: 'true'
 
-# - template: build_tools/azure/posix-32.yml
-#   parameters:
-#     name: Linux32
-#     vmImage: ubuntu-18.04
-#     dependsOn: [linting]
-#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-#     matrix:
-#       py36_ubuntu_atlas_32bit:
-#         DISTRIB: 'ubuntu-32'
-#         PYTHON_VERSION: '3.6'
-#         JOBLIB_VERSION: '0.13'
-#         THREADPOOLCTL_VERSION: '2.0.0'
+- template: build_tools/azure/posix-32.yml
+  parameters:
+    name: Linux32
+    vmImage: ubuntu-18.04
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      py36_ubuntu_atlas_32bit:
+        DISTRIB: 'ubuntu-32'
+        PYTHON_VERSION: '3.6'
+        JOBLIB_VERSION: '0.13'
+        THREADPOOLCTL_VERSION: '2.0.0'
 
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: macOS
-#     vmImage: macOS-10.14
-#     dependsOn: [linting]
-#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-#     matrix:
-#       pylatest_conda_mkl:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#       pylatest_conda_mkl_no_openmp:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#         SKLEARN_TEST_NO_OPENMP: 'true'
-#         SKLEARN_SKIP_OPENMP_TEST: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: macOS
+    vmImage: macOS-10.14
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      pylatest_conda_mkl:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+      pylatest_conda_mkl_no_openmp:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+        SKLEARN_TEST_NO_OPENMP: 'true'
+        SKLEARN_SKIP_OPENMP_TEST: 'true'
 
-# - template: build_tools/azure/windows.yml
-#   parameters:
-#     name: Windows
-#     vmImage: vs2017-win2016
-#     dependsOn: [linting]
-#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-#     matrix:
-#       py37_conda_mkl:
-#         PYTHON_VERSION: '3.7'
-#         CHECK_WARNINGS: 'true'
-#         PYTHON_ARCH: '64'
-#         PYTEST_VERSION: '*'
-#         COVERAGE: 'true'
-#       py36_pip_openblas_32bit:
-#         PYTHON_VERSION: '3.6'
-#         PYTHON_ARCH: '32'
+- template: build_tools/azure/windows.yml
+  parameters:
+    name: Windows
+    vmImage: vs2017-win2016
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      py37_conda_mkl:
+        PYTHON_VERSION: '3.7'
+        CHECK_WARNINGS: 'true'
+        PYTHON_ARCH: '64'
+        PYTEST_VERSION: '*'
+        COVERAGE: 'true'
+      py36_pip_openblas_32bit:
+        PYTHON_VERSION: '3.6'
+        PYTHON_ARCH: '32'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
         # Here we make sure, that they are still run on a regular basis.
         SKLEARN_SKIP_NETWORK_TESTS: '0'
 
-Will run all the time regardless of linting outcome.
+# Will run all the time regardless of linting outcome.
 - template: build_tools/azure/posix.yml
   parameters:
     name: Linux_Runs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,146 +49,146 @@ jobs:
       name: gitCommitMessage
       displayName: Determine to run scipy-dev
 
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: Linux_Nightly
-    vmImage: ubuntu-18.04
-    dependsOn: [linting]
-    condition: eq(dependencies['linting']['outputs']['gitCommitMessage.runScipyDev'], 'true')
-    matrix:
-      pylatest_pip_scipy_dev:
-        DISTRIB: 'conda-pip-scipy-dev'
-        PYTHON_VERSION: '*'
-        CHECK_WARNINGS: 'true'
-        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        TEST_DOCSTRINGS: 'true'
-        # Tests that require large downloads over the networks are skipped in CI.
-        # Here we make sure, that they are still run on a regular basis.
-        SKLEARN_SKIP_NETWORK_TESTS: '0'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: Linux_Nightly
+#     vmImage: ubuntu-18.04
+#     dependsOn: [linting]
+#     condition: eq(dependencies['linting']['outputs']['gitCommitMessage.runScipyDev'], 'true')
+#     matrix:
+#       pylatest_pip_scipy_dev:
+#         DISTRIB: 'conda-pip-scipy-dev'
+#         PYTHON_VERSION: '*'
+#         CHECK_WARNINGS: 'true'
+#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+#         TEST_DOCSTRINGS: 'true'
+#         # Tests that require large downloads over the networks are skipped in CI.
+#         # Here we make sure, that they are still run on a regular basis.
+#         SKLEARN_SKIP_NETWORK_TESTS: '0'
 
 # Will run all the time regardless of linting outcome.
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: Linux_Runs
-    vmImage: ubuntu-18.04
-    matrix:
-      pylatest_conda_mkl:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: Linux_Runs
+#     vmImage: ubuntu-18.04
+#     matrix:
+#       pylatest_conda_mkl:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
 
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: Linux
-    vmImage: ubuntu-18.04
-    dependsOn: [linting]
-    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-    matrix:
-      # Linux environment to test that scikit-learn can be built against
-      # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
-      # i.e. numpy 1.13.3 and scipy 0.19
-      py36_ubuntu_atlas:
-        DISTRIB: 'ubuntu'
-        PYTHON_VERSION: '3.6'
-        JOBLIB_VERSION: '0.11'
-        THREADPOOLCTL_VERSION: '2.0.0'
-      # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
-      py36_conda_openblas:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '3.6'
-        BLAS: 'openblas'
-        NUMPY_VERSION: '1.13.3'
-        SCIPY_VERSION: '0.19.1'
-        PANDAS_VERSION: '*'
-        CYTHON_VERSION: '*'
-        # temporary pin pytest due to unknown failure with pytest 5.3
-        PYTEST_VERSION: '5.2'
-        PILLOW_VERSION: '4.2.1'
-        MATPLOTLIB_VERSION: '2.1.1'
-        SCIKIT_IMAGE_VERSION: '*'
-        # latest version of joblib available in conda for Python 3.6
-        JOBLIB_VERSION: '0.13.2'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-      # Linux environment to test the latest available dependencies and MKL.
-      # It runs tests requiring lightgbm, pandas and PyAMG.
-      pylatest_pip_openblas_pandas:
-        DISTRIB: 'conda-pip-latest'
-        PYTHON_VERSION: '3.8'
-        PYTEST_VERSION: '4.6.2'
-        COVERAGE: 'true'
-        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        TEST_DOCSTRINGS: 'true'
-        CHECK_WARNINGS: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: Linux
+#     vmImage: ubuntu-18.04
+#     dependsOn: [linting]
+#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+#     matrix:
+#       # Linux environment to test that scikit-learn can be built against
+#       # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
+#       # i.e. numpy 1.13.3 and scipy 0.19
+#       py36_ubuntu_atlas:
+#         DISTRIB: 'ubuntu'
+#         PYTHON_VERSION: '3.6'
+#         JOBLIB_VERSION: '0.11'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#       # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
+#       py36_conda_openblas:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '3.6'
+#         BLAS: 'openblas'
+#         NUMPY_VERSION: '1.13.3'
+#         SCIPY_VERSION: '0.19.1'
+#         PANDAS_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         # temporary pin pytest due to unknown failure with pytest 5.3
+#         PYTEST_VERSION: '5.2'
+#         PILLOW_VERSION: '4.2.1'
+#         MATPLOTLIB_VERSION: '2.1.1'
+#         SCIKIT_IMAGE_VERSION: '*'
+#         # latest version of joblib available in conda for Python 3.6
+#         JOBLIB_VERSION: '0.13.2'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#       # Linux environment to test the latest available dependencies and MKL.
+#       # It runs tests requiring lightgbm, pandas and PyAMG.
+#       pylatest_pip_openblas_pandas:
+#         DISTRIB: 'conda-pip-latest'
+#         PYTHON_VERSION: '3.8'
+#         PYTEST_VERSION: '4.6.2'
+#         COVERAGE: 'true'
+#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+#         TEST_DOCSTRINGS: 'true'
+#         CHECK_WARNINGS: 'true'
 
-- template: build_tools/azure/posix-32.yml
-  parameters:
-    name: Linux32
-    vmImage: ubuntu-18.04
-    dependsOn: [linting]
-    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-    matrix:
-      py36_ubuntu_atlas_32bit:
-        DISTRIB: 'ubuntu-32'
-        PYTHON_VERSION: '3.6'
-        JOBLIB_VERSION: '0.13'
-        THREADPOOLCTL_VERSION: '2.0.0'
+# - template: build_tools/azure/posix-32.yml
+#   parameters:
+#     name: Linux32
+#     vmImage: ubuntu-18.04
+#     dependsOn: [linting]
+#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+#     matrix:
+#       py36_ubuntu_atlas_32bit:
+#         DISTRIB: 'ubuntu-32'
+#         PYTHON_VERSION: '3.6'
+#         JOBLIB_VERSION: '0.13'
+#         THREADPOOLCTL_VERSION: '2.0.0'
 
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: macOS
-    vmImage: macOS-10.14
-    dependsOn: [linting]
-    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-    matrix:
-      pylatest_conda_mkl:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-      pylatest_conda_mkl_no_openmp:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-        SKLEARN_TEST_NO_OPENMP: 'true'
-        SKLEARN_SKIP_OPENMP_TEST: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: macOS
+#     vmImage: macOS-10.14
+#     dependsOn: [linting]
+#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+#     matrix:
+#       pylatest_conda_mkl:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#       pylatest_conda_mkl_no_openmp:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#         SKLEARN_TEST_NO_OPENMP: 'true'
+#         SKLEARN_SKIP_OPENMP_TEST: 'true'
 
-- template: build_tools/azure/windows.yml
-  parameters:
-    name: Windows
-    vmImage: vs2017-win2016
-    dependsOn: [linting]
-    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-    matrix:
-      py37_conda_mkl:
-        PYTHON_VERSION: '3.7'
-        CHECK_WARNINGS: 'true'
-        PYTHON_ARCH: '64'
-        PYTEST_VERSION: '*'
-        COVERAGE: 'true'
-      py36_pip_openblas_32bit:
-        PYTHON_VERSION: '3.6'
-        PYTHON_ARCH: '32'
+# - template: build_tools/azure/windows.yml
+#   parameters:
+#     name: Windows
+#     vmImage: vs2017-win2016
+#     dependsOn: [linting]
+#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+#     matrix:
+#       py37_conda_mkl:
+#         PYTHON_VERSION: '3.7'
+#         CHECK_WARNINGS: 'true'
+#         PYTHON_ARCH: '64'
+#         PYTEST_VERSION: '*'
+#         COVERAGE: 'true'
+#       py36_pip_openblas_32bit:
+#         PYTHON_VERSION: '3.6'
+#         PYTHON_ARCH: '32'


### PR DESCRIPTION
Allow failures in the pull request labeler to not trigger a failing build.

This is due to a HTTP error that can randomly happen. The next run of the pull request labeler will work anyways.

CC @adrinjalali 