### PR TITLE
DOC Specify the meaning of default=None in cluster module

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -199,7 +199,8 @@ class DBSCAN(ClusterMixin, BaseEstimator):
 
     p : float, default=None
         The power of the Minkowski metric to be used to calculate distance
-        between points.
+        between points. If None, then ``p=2`` (equivalent to the Euclidean
+        distance).
 
     n_jobs : int, default=None
         The number of parallel jobs to run.

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -194,7 +194,8 @@ def spectral_clustering(affinity, *, n_clusters=8, n_components=None,
     eigen_solver : {None, 'arpack', 'lobpcg', or 'amg'}
         The eigenvalue decomposition strategy to use. AMG requires pyamg
         to be installed. It can be faster on very large, sparse problems,
-        but may also lead to instabilities
+        but may also lead to instabilities. If None, then ``'arpack'`` is
+        used.
 
     random_state : int, RandomState instance, default=None
         A pseudo random number generator used for the initialization of the
@@ -307,7 +308,8 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
     eigen_solver : {None, 'arpack', 'lobpcg', or 'amg'}
         The eigenvalue decomposition strategy to use. AMG requires pyamg
         to be installed. It can be faster on very large, sparse problems,
-        but may also lead to instabilities.
+        but may also lead to instabilities. If None, then ``'arpack'`` is
+        used.
 
     n_components : integer, optional, default=n_clusters
         Number of eigen vectors to use for the spectral embedding

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -168,7 +168,8 @@ def spectral_embedding(adjacency, *, n_components=8, eigen_solver=None,
     eigen_solver : {None, 'arpack', 'lobpcg', or 'amg'}, default None
         The eigenvalue decomposition strategy to use. AMG requires pyamg
         to be installed. It can be faster on very large, sparse problems,
-        but may also lead to instabilities.
+        but may also lead to instabilities. If None, then ``'arpack'`` is
+        used.
 
     random_state : int, RandomState instance, default=None
         Determines the random number generator used for the initialization of
@@ -394,6 +395,7 @@ class SpectralEmbedding(BaseEstimator):
     eigen_solver : {None, 'arpack', 'lobpcg', or 'amg'}
         The eigenvalue decomposition strategy to use. AMG requires pyamg
         to be installed. It can be faster on very large, sparse problems.
+        If None, then ``'arpack'`` is used.
 
     n_neighbors : int, default : max(n_samples/10 , 1)
         Number of nearest neighbors for nearest_neighbors graph building.


### PR DESCRIPTION
#### Reference Issues/PRs

Partially addresses #17295.

#### What does this implement/fix? Explain your changes.

This PR specify the meaning of `default=None` in the `sklearn.cluster` module. In particular, specify the meaning for `p` in `sklearn.cluster.DBSCAN` and `eigen_solver` in `sklearn.cluster.SpectralClustering` and `sklearn.cluster.spectral_clustering`.

#### Any other comments?

For consistency, the same in `eigen_solver` in `sklearn.manifold.SpectralEmbedding`.