### PR TITLE
DOC Specify meaning of default in cov_init for graphical_lasso

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -98,7 +98,8 @@ def graphical_lasso(emp_cov, alpha, *, cov_init=None, mode='cd', tol=1e-4,
         Range is (0, inf].
 
     cov_init : array of shape (n_features, n_features), default=None
-        The initial guess for the covariance.
+        The initial guess for the covariance. If None, then the empirical
+        covariance is used.
 
     mode : {'cd', 'lars'}, default='cd'
         The Lasso solver to use: coordinate descent or LARS. Use LARS for


### PR DESCRIPTION
#### Reference Issues/PRs

Partially addresses #17295.

#### What does this implement/fix? Explain your changes.

This PR specifies the meaning of `default=None` for `cov_init` in `sklearn.covariance.graphical_lasso`.