### PR TITLE
ENH Removed redundant int()

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -107,7 +107,7 @@ def _get_n_samples_bootstrap(n_samples, max_samples):
         if not (0 < max_samples < 1):
             msg = "`max_samples` must be in range (0, 1) but got value {}"
             raise ValueError(msg.format(max_samples))
-        return int(round(n_samples * max_samples))
+        return round(n_samples * max_samples)
 
     msg = "`max_samples` should be int or float, but got type '{}'"
     raise TypeError(msg.format(type(max_samples)))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #17538

#### What does this implement/fix? Explain your changes.
removed redundant `int()` from  `return int(round(n_samples * max_samples))` from [sklearn/ensemble/_forest.py](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/ensemble/_forest.py#L106)  
So, new code will look like
```python
if isinstance(max_samples, numbers.Real):
  if not (0 < max_samples < 1):
    msg = "`max_samples` must be in range (0, 1) but got value {}"
    raise ValueError(msg.format(max_samples))
  return round(n_samples * max_samples)
```
As [`round()`](https://docs.python.org/3/library/functions.html#round) returns `int` so, it doesn't make any sense in casting again with `int()`
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
