### PR TITLE
DOC add warning note regarding data leakage by using scale and robust_scale

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -137,6 +137,18 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
     see :ref:`examples/preprocessing/plot_all_scaling.py
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.
 
+    .. warning:: Risk of data leak
+
+        Do not use :func:`~sklearn.preprocessing.scale` unless you know
+        what you are doing. A common mistake is to apply it to the entire data
+        *before* splitting into training and test sets. This will bias the
+        model evaluation because information would have leaked from the test
+        set to the training set.
+        In general, we recommend using
+        :class:`~sklearn.preprocessing.StandardScaler` within a
+        :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+        leaking: `pipe = make_pipeline(StandardScaler(), LogisticRegression())`.
+
     See also
     --------
     StandardScaler: Performs scaling to unit variance using the``Transformer`` API
@@ -1454,6 +1466,18 @@ def robust_scale(X, *, axis=0, with_centering=True, with_scaling=True,
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.
+
+    .. warning:: Risk of data leak
+
+        Do not use :func:`~sklearn.preprocessing.robust_scale` unless you know
+        what you are doing. A common mistake is to apply it to the entire data
+        *before* splitting into training and test sets. This will bias the
+        model evaluation because information would have leaked from the test
+        set to the training set.
+        In general, we recommend using
+        :class:`~sklearn.preprocessing.RobustScaler` within a
+        :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+        leaking: `pipe = make_pipeline(RobustScaler(), LogisticRegression())`.
 
     See also
     --------


### PR DESCRIPTION
Partially addresses #17402

#### What does this implement/fix? Explain your changes.
Add warning notes to `scale` and `robust_scale` functions in sklearn\preprocessing\_data.py.

#### Any other comments?
My previous PR on this same issue was made with an out of synch branch, which I could not resolve.
Creating this new branch was my solution.

#DataUmbrella
