### PR TITLE
EHN Provide a pos_label parameter in plot_precision_recall_curve

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -102,6 +102,11 @@ Changelog
   :class:`metrics.median_absolute_error`. :pr:`17225` by
   :user:`Lucy Liu <lucyleeow>`.
 
+- |Enhancement| Add `pos_label` parameter in
+  :func:`metrics.plot_precision_recall_curve` in order to specify the positive
+  class to be used when computing the precision and recall statistics.
+  :pr:`17569` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -184,20 +184,25 @@ def plot_precision_recall_curve(estimator, X, y, *,
     prediction_method = _check_classifier_response_method(estimator,
                                                           response_method)
     y_pred = prediction_method(X)
-    if y_pred.ndim != 1 and y_pred.shape[1] != 2:
-        raise ValueError(classification_error)
 
-    if pos_label is None:
-        pos_label = estimator.classes_[1]
-        y_pred = y_pred[:, 1]
-    else:
-        if pos_label not in estimator.classes_:
-            raise ValueError(
-                f"The class provided by 'pos_label' is unknown. Got "
-                f"{pos_label} instead of one of {estimator.classes_}"
-            )
-        class_idx = np.flatnonzero(estimator.classes_ == pos_label)
-        y_pred = y_pred[:, class_idx]
+    if pos_label is not None and pos_label not in estimator.classes_:
+        raise ValueError(
+            f"The class provided by 'pos_label' is unknown. Got "
+            f"{pos_label} instead of one of {estimator.classes_}"
+        )
+
+    if y_pred.ndim != 1:  # `predict_proba`
+        if y_pred.shape[1] != 2:
+            raise ValueError(classification_error)
+        if pos_label is None:
+            pos_label = estimator.classes_[1]
+            y_pred = y_pred[:, 1]
+        else:
+            class_idx = np.flatnonzero(estimator.classes_ == pos_label)
+            y_pred = y_pred[:, class_idx]
+    else:  # `decision_function`
+        if pos_label is None:
+            pos_label = estimator.classes_[1]
 
     precision, recall, _ = precision_recall_curve(y, y_pred,
                                                   pos_label=pos_label,

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -35,7 +35,7 @@ class PrecisionRecallDisplay:
     pos_label : str or int, default=None
         The class considered as the positive class. If None, the class will not
         be shown in the legend.
-        
+
         .. versionadded:: 0.24
 
     Attributes

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -175,6 +175,8 @@ def plot_precision_recall_curve(estimator, X, y, *,
         and recall metrics. By default, `estimators.classes_[1]` is considered
         as the positive class.
 
+        .. versionadded:: 0.24
+
     **kwargs : dict
         Keyword arguments to be passed to matplotlib's `plot`.
 

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -212,6 +212,8 @@ def plot_precision_recall_curve(estimator, X, y, *,
     else:  # `decision_function`
         if pos_label is None:
             pos_label = estimator.classes_[1]
+        elif pos_label == estimator.classes_[0]:
+            y_pred *= -1
 
     precision, recall, _ = precision_recall_curve(y, y_pred,
                                                   pos_label=pos_label,

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -32,6 +32,10 @@ class PrecisionRecallDisplay:
     estimator_name : str, default=None
         Name of estimator. If None, then the estimator name is not shown.
 
+    pos_label : str or int, default=None
+        The class considered as the positive class. If None, the class will not
+        be shown in the legend.
+
     Attributes
     ----------
     line_ : matplotlib Artist
@@ -62,11 +66,12 @@ class PrecisionRecallDisplay:
     >>> disp.plot() # doctest: +SKIP
     """
     def __init__(self, precision, recall, *,
-                 average_precision=None, estimator_name=None):
+                 average_precision=None, estimator_name=None, pos_label=None):
         self.precision = precision
         self.recall = recall
         self.average_precision = average_precision
         self.estimator_name = estimator_name
+        self.pos_label = pos_label
 
     @_deprecate_positional_args
     def plot(self, ax=None, *, name=None, **kwargs):
@@ -112,7 +117,11 @@ class PrecisionRecallDisplay:
         line_kwargs.update(**kwargs)
 
         self.line_, = ax.plot(self.recall, self.precision, **line_kwargs)
-        ax.set(xlabel="Recall", ylabel="Precision")
+        info_pos_label = (f" (Positive label: {self.pos_label})"
+                          if self.pos_label is not None else "")
+        xlabel = "Recall" + info_pos_label
+        ylabel = "Precision" + info_pos_label
+        ax.set(xlabel=xlabel, ylabel=ylabel)
 
         if "label" in line_kwargs:
             ax.legend(loc='lower left')
@@ -213,6 +222,7 @@ def plot_precision_recall_curve(estimator, X, y, *,
     name = name if name is not None else estimator.__class__.__name__
     viz = PrecisionRecallDisplay(
         precision=precision, recall=recall,
-        average_precision=average_precision, estimator_name=name
+        average_precision=average_precision, estimator_name=name,
+        pos_label=pos_label,
     )
     return viz.plot(ax=ax, name=name, **kwargs)

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -35,6 +35,8 @@ class PrecisionRecallDisplay:
     pos_label : str or int, default=None
         The class considered as the positive class. If None, the class will not
         be shown in the legend.
+        
+        .. versionadded:: 0.24
 
     Attributes
     ----------

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -117,8 +117,8 @@ def test_plot_precision_recall(pyplot, response_method, with_sample_weight):
 
     expected_label = "LogisticRegression (AP = {:0.2f})".format(avg_prec)
     assert disp.line_.get_label() == expected_label
-    assert disp.ax_.get_xlabel() == "Recall"
-    assert disp.ax_.get_ylabel() == "Precision"
+    assert disp.ax_.get_xlabel() == "Recall (Positive label: 1)"
+    assert disp.ax_.get_ylabel() == "Precision (Positive label: 1)"
 
     # draw again with another label
     disp.plot(name="MySpecialEstimator")

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -201,7 +201,7 @@ def test_plot_precision_recall_pos_label(pyplot, response_method):
     # check that we can provide the positive label and display the proper
     # statistics
     X, y = load_breast_cancer(return_X_y=True)
-    # create an highly imbalanced
+    # create an highly imbalanced version of the breast cancer dataset
     idx_positive = np.flatnonzero(y == 1)
     idx_negative = np.flatnonzero(y == 0)
     idx_selected = np.hstack([idx_negative, idx_positive[:25]])

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -3,17 +3,21 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.metrics import balanced_accuracy_score
 from sklearn.metrics import plot_precision_recall_curve
 from sklearn.metrics import PrecisionRecallDisplay
 from sklearn.metrics import average_precision_score
 from sklearn.metrics import precision_recall_curve
 from sklearn.datasets import make_classification
 from sklearn.datasets import load_breast_cancer
+from sklearn.dummy import DummyClassifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
 from sklearn.exceptions import NotFittedError
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
+from sklearn.utils import shuffle
 from sklearn.compose import make_column_transformer
 
 
@@ -190,3 +194,39 @@ def test_default_labels(pyplot, average_precision, estimator_name,
                                   estimator_name=estimator_name)
     disp.plot()
     assert disp.line_.get_label() == expected_label
+
+
+def test_plot_precision_recall_pos_label(pyplot):
+    # check that we can provide the positive label and display the proper
+    # statistics
+    X, y = load_breast_cancer(return_X_y=True)
+    # create an highly imbalanced
+    idx_positive = np.flatnonzero(y == 1)
+    idx_negative = np.flatnonzero(y == 0)
+    idx_selected = np.hstack([idx_negative, idx_positive[:25]])
+    X, y = X[idx_selected], y[idx_selected]
+    X, y = shuffle(X, y, random_state=42)
+    y = np.array(
+        ["cancer" if c == 1 else "not cancer" for c in y], dtype=object
+    )
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, stratify=y, random_state=0,
+    )
+
+    classifier = DummyClassifier(strategy="stratified", random_state=42)
+    classifier.fit(X_train, y_train)
+    y_pred = classifier.predict(X_test)
+
+    # sanity check to be sure the positive class is classes_[0] and that we
+    # are betrayed by the class imbalance
+    assert classifier.classes_.tolist() == ["cancer", "not cancer"]
+
+    disp = plot_precision_recall_curve(
+        classifier, X_test, y_test, pos_label="cancer",
+    )
+    # we should obtain the statistics of the "cancer" class
+    assert disp.average_precision < 0.15
+
+    # otherwise we should obtain the statistics of the "not cancer" class
+    disp = plot_precision_recall_curve(classifier, X_test, y_test)
+    assert disp.average_precision > 0.85

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -3,7 +3,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.metrics import balanced_accuracy_score
 from sklearn.metrics import plot_precision_recall_curve
 from sklearn.metrics import PrecisionRecallDisplay
 from sklearn.metrics import average_precision_score
@@ -215,7 +214,6 @@ def test_plot_precision_recall_pos_label(pyplot):
 
     classifier = DummyClassifier(strategy="stratified", random_state=42)
     classifier.fit(X_train, y_train)
-    y_pred = classifier.predict(X_test)
 
     # sanity check to be sure the positive class is classes_[0] and that we
     # are betrayed by the class imbalance

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -9,7 +9,6 @@ from sklearn.metrics import average_precision_score
 from sklearn.metrics import precision_recall_curve
 from sklearn.datasets import make_classification
 from sklearn.datasets import load_breast_cancer
-from sklearn.dummy import DummyClassifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split


### PR DESCRIPTION
closes #17565 
partially addressing #15573

Add a `pos_label` parameter to specify which class to be the positive class when `estimator.classes_[1]` is not the right choice.