### PR TITLE
DOC add warning note regarding data leakage by using quantile_transform

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2821,7 +2821,8 @@ def quantile_transform(X, *, axis=0, n_quantiles=1000,
         In general, we recommend using
         :class:`~sklearn.preprocessing.QuantileTransformer` within a
         :ref:`Pipeline <pipeline>` in order to prevent most risks of data
-        leaking:`pipe=make_pipeline(QuantileTransformer(),LogisticRegression)`.
+        leaking:`pipe = make_pipeline(QuantileTransformer(),
+        LogisticRegression())`.
 
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2810,6 +2810,19 @@ def quantile_transform(X, *, axis=0, n_quantiles=1000,
     NaNs are treated as missing values: disregarded in fit, and maintained in
     transform.
 
+    .. warning:: Risk of data leak
+
+        Do not use :func:`~sklearn.preprocessing.quantile_transform` unless
+        you know what you are doing. A common mistake is to apply it
+        to the entire data *before* splitting into training and
+        test sets. This will bias the model evaluation because
+        information would have leaked from the test set to the
+        training set.
+        In general, we recommend using
+        :class:`~sklearn.preprocessing.QuantileTransformer` within a
+        :ref:`Pipeline <pipeline>` in order to prevent most risks of data
+        leaking:`pipe=make_pipeline(QuantileTransformer(),LogisticRegression)`.
+
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py
     <sphx_glr_auto_examples_preprocessing_plot_all_scaling.py>`.


### PR DESCRIPTION
Added a warning to docstring of quantile_transform to use
QuantileTransformer instead


#### Reference Issues/PRs
Addresses issue #17402
adds data leakage warning to quantile_transform in preprocessing/_data.py 

In collaboration with @asubramaniyan 
#DataUmbrella