### PR TITLE
DOC Fix minor typos in Release Notes for 0.23

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -362,7 +362,7 @@ Changelog
   for each feature. :pr:`16403` by :user:`Narendra Mukherjee <narendramukherjee>`.
 
 - |Enhancement| :class:`impute.SimpleImputer`, :class:`impute.KNNImputer`, and
-  :class:`impute.SimpleImputer` accepts pandas' nullable integer dtype with
+  :class:`impute.IterativeImputer` accepts pandas' nullable integer dtype with
   missing values. :pr:`16508` by `Thomas Fan`_.
 
 :mod:`sklearn.inspection`
@@ -465,7 +465,7 @@ Changelog
   an error when `y_true` and `y_pred` were length zero and `labels` was
   not `None`. In addition, we raise an error when an empty list is given to
   the `labels` parameter.
-  :pr:`16442` by `Kyle Parsons <parsons-kyle-89>`.
+  :pr:`16442` by :user:`Kyle Parsons <parsons-kyle-89>`.
 
 - |API| Changed the formatting of values in
   :meth:`metrics.ConfusionMatrixDisplay.plot` and


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

None

#### What does this implement/fix? Explain your changes.

Fix two minor typos in Release Notes for 0.23

#### Any other comments?

Regarding the first typo, I inferred that IterativeImputer was supposed to be listed (instead of SimpleImputer being listed twice), but pinging @thomasjpfan just to confirm!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
