### PR TITLE
DOC Add "see also" links to and from "plot_roc_curve"

### DIFF
--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -160,7 +160,7 @@ def plot_roc_curve(estimator, X, y, *, sample_weight=None,
     display : :class:`~sklearn.metrics.RocCurveDisplay`
         Object that stores computed values.
 
-    See also
+    See Also
     --------
     roc_auc_score : Compute the area under the ROC curve
 

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -160,6 +160,12 @@ def plot_roc_curve(estimator, X, y, *, sample_weight=None,
     display : :class:`~sklearn.metrics.RocCurveDisplay`
         Object that stores computed values.
 
+    See also
+    --------
+    roc_auc_score : Compute the area under the ROC curve
+
+    roc_curve : Compute Receiver operating characteristic (ROC) curve
+
     Examples
     --------
     >>> import matplotlib.pyplot as plt  # doctest: +SKIP

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -357,6 +357,8 @@ def roc_auc_score(y_true, y_score, *, average="macro", sample_weight=None,
 
     roc_curve : Compute Receiver operating characteristic (ROC) curve
 
+    plot_roc_curve : Plot Receiver operating characteristic (ROC) curve
+
     Examples
     --------
     >>> import numpy as np
@@ -742,6 +744,8 @@ def roc_curve(y_true, y_score, *, pos_label=None, sample_weight=None,
     See also
     --------
     roc_auc_score : Compute the area under the ROC curve
+
+    plot_roc_curve : Plot Receiver operating characteristic (ROC) curve
 
     Notes
     -----


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

None

#### What does this implement/fix? Explain your changes.

Add new links to the "See Also" section of the documentation:

- Link to `roc_auc_score` and `roc_curve` from `plot_roc_curve`
- Link to `plot_roc_curve` from `roc_auc_score`
- Link to `plot_roc_curve` from `roc_curve`

#### Any other comments?

These are all "See Also" links that I would personally find useful, which is why I added them!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
