### PR TITLE
DOC Avoid atypical usage of cross_validate

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -278,7 +278,7 @@ permitted and will require a wrapper to return a single metric::
     >>> def tp(y_true, y_pred): return confusion_matrix(y_true, y_pred)[1, 1]
     >>> scoring = {'tp': make_scorer(tp), 'tn': make_scorer(tn),
     ...            'fp': make_scorer(fp), 'fn': make_scorer(fn)}
-    >>> cv_results = cross_validate(svm.fit(X, y), X, y, cv=5, scoring=scoring)
+    >>> cv_results = cross_validate(svm, X, y, cv=5, scoring=scoring)
     >>> # Getting the test set true positive scores
     >>> print(cv_results['test_tp'])
     [10  9  8  7  8]


### PR DESCRIPTION
#### Reference Issues/PRs

To my knowledge, this PR does not address a tracked issue.

#### What does this implement/fix? Explain your changes.

This PR is a minor improvement to the documentation, specifically the `model_evaluation` module.

Training a model before passing it to `cross_validate` is not wrong, but also is not necessary. A user can be expected to infer typical usage or best practices from examples in the manual, so this usage should be avoided in the manual in this example.

I have verified that the results of this REPL session do not change with the modification I am proposing. I am using sklearn version 0.22.1.