### PR TITLE
MNT Don't return anything from _compute_loss_grad

### DIFF
--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -129,8 +129,6 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
 
         intercept_grads[layer] = np.mean(deltas[layer], 0)
 
-        return coef_grads, intercept_grads
-
     def _loss_grad_lbfgs(self, packed_coef_inter, X, y, activations, deltas,
                          coef_grads, intercept_grads):
         """Compute the MLP loss function and its corresponding derivatives
@@ -241,7 +239,7 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         deltas[last] = activations[-1] - y
 
         # Compute gradient for the last layer
-        coef_grads, intercept_grads = self._compute_loss_grad(
+        self._compute_loss_grad(
             last, n_samples, activations, deltas, coef_grads, intercept_grads)
 
         # Iterate over the hidden layers
@@ -250,7 +248,7 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
             inplace_derivative = DERIVATIVES[self.activation]
             inplace_derivative(activations[i], deltas[i - 1])
 
-            coef_grads, intercept_grads = self._compute_loss_grad(
+            self._compute_loss_grad(
                 i - 1, n_samples, activations, deltas, coef_grads,
                 intercept_grads)
 


### PR DESCRIPTION
`_compute_loss_grad` modifies `coef_grads` and `intercept_grads` in place, but returning the variables that were passed in gives the false impression that it makes copies.