### PR TITLE
PERF Ravel each array only once in BaseMultilayerPerceptron._backprop

### DIFF
--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -225,8 +225,10 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
             loss_func_name = 'binary_log_loss'
         loss = LOSS_FUNCTIONS[loss_func_name](y, activations[-1])
         # Add L2 regularization term to loss
-        values = np.sum(
-            np.array([np.dot(s.ravel(), s.ravel()) for s in self.coefs_]))
+        values = 0
+        for s in self.coefs_:
+            s = s.ravel()
+            values += np.dot(s, s)
         loss += (0.5 * self.alpha) * values / n_samples
 
         # Backward propagate


### PR DESCRIPTION
This change decreases neural net training time by about 1%.

Test program:

```
from sklearn.datasets import load_digits
from sklearn.neural_network import MLPClassifier
from neurtu import delayed, Benchmark

digits = load_digits(return_X_y=True)
X = digits[0][:,:10]
y = digits[0][:,11]

clf = MLPClassifier(solver='lbfgs', alpha=1e-5,
                    hidden_layer_sizes=(5, 2), random_state=1, max_iter=1000)

train = delayed(clf).fit(X, y)
print(Benchmark(wall_time=True, cpu_time=True, repeat=10)(train))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   2.060248  2.052360
max    2.069880  2.054955
std    0.004758  0.001587
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   2.042922  2.038958
max    2.045680  2.053701
std    0.002014  0.005943
```