### PR TITLE
MNT Assign inplace_derivative outside of the loop

### DIFF
--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -242,10 +242,10 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         self._compute_loss_grad(
             last, n_samples, activations, deltas, coef_grads, intercept_grads)
 
+        inplace_derivative = DERIVATIVES[self.activation]
         # Iterate over the hidden layers
         for i in range(self.n_layers_ - 2, 0, -1):
             deltas[i - 1] = safe_sparse_dot(deltas[i], self.coefs_[i].T)
-            inplace_derivative = DERIVATIVES[self.activation]
             inplace_derivative(activations[i], deltas[i - 1])
 
             self._compute_loss_grad(


### PR DESCRIPTION
More misleading (and inefficient) code: The derivative function does not change with each iteration. Do the function lookup outside of the loop in `_backprop`, the same as in `_forward_pass`.