### PR TITLE
PERF Use np.maximum instead of np.clip in relu function

### DIFF
--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -72,7 +72,7 @@ def relu(X):
     X_new : {array-like, sparse matrix}, shape (n_samples, n_features)
         The transformed data.
     """
-    np.clip(X, 0, np.finfo(X.dtype).max, out=X)
+    np.maximum(X, 0, out=X)
     return X
 
 


### PR DESCRIPTION
Neural net training is about 2% faster without checking in `relu` whether any value is greater than the maximum possible value for the data type (which is always false, so there's no need to check).

Test program:

```
from sklearn.datasets import load_digits
from sklearn.neural_network import MLPClassifier
from neurtu import delayed, Benchmark

digits = load_digits(return_X_y=True)
X = digits[0][:,:10]
y = digits[0][:,11]

clf = MLPClassifier(solver='lbfgs', alpha=1e-5,
                    hidden_layer_sizes=(5, 2), random_state=1, max_iter=1000)

train = delayed(clf).fit(X, y)
print(Benchmark(wall_time=True, cpu_time=True, repeat=10)(train))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   2.116878  2.108431
max    2.126080  2.115298
std    0.004060  0.005196
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   2.080088  2.069779
max    2.088962  2.074299
std    0.004015  0.002257
```