### PR TITLE
ENH Add inverse_transform feature to SimpleImputer

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -92,7 +92,8 @@ Changelog
   :pr:`17526` by :user:`Ayako YAGI <yagi-3>` and :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
 
 - |Feature| :class:`impute.SimpleImputer` now supports ``inverse_transform``
-  functionality to revert imputed data to original.
+  functionality to revert imputed data to original when instantiated
+  with `add_indicator=True`.
   :pr:`17612` by :user:`Srimukh Sripada <d3b0unce>`
 
 :mod:`sklearn.inspection`

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -91,6 +91,10 @@ Changelog
   when ``strategy='most_frequent'`` or ``strategy='constant'``.
   :pr:`17526` by :user:`Ayako YAGI <yagi-3>` and :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
 
+- |Feature| :class:`impute.SimpleImputer` now supports ``inverse_transform``
+  functionality to revert imputed data to original.
+  :pr:`17612` by :user:`Srimukh Sripada <d3b0unce>`
+
 :mod:`sklearn.inspection`
 .........................
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -181,7 +181,7 @@ class SimpleImputer(_BaseImputer):
         During :meth:`transform`, features corresponding to `np.nan`
         statistics will be discarded.
 
-    indicator_ : :class:`sklearn.impute.MissingIndicator`
+    indicator_ : :class:`~sklearn.impute.MissingIndicator`
         Indicator used to add binary indicators for missing values.
         ``None`` if add_indicator is False.
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -181,7 +181,7 @@ class SimpleImputer(_BaseImputer):
         During :meth:`transform`, features corresponding to `np.nan`
         statistics will be discarded.
 
-    indicator_ : :class:`~sklearn.impute.MissingIndicator`
+    indicator_ : :class:`sklearn.impute.MissingIndicator`
         Indicator used to add binary indicators for missing values.
         ``None`` if add_indicator is False.
 
@@ -468,36 +468,36 @@ class SimpleImputer(_BaseImputer):
             X[coordinates] = values
 
         return super()._concatenate_indicator(X, X_indicator)
-    
+
     def inverse_transform(self, X):
         """Convert the data back to the original representation.
-        
+
         Inverts the `fit_transform` operation performed on an array.
         This operation can only be performed after :class:`SimpleImputer` is
         used with `add_indicator` set to `True`.
 
         Parameters
         ----------
-        X : array-like, 
+        X : array-like,
             shape (n_samples, n_features + missing_feature_count)
             The imputed data to be reverted to original data. It has to be
             an augmented array of imputed data and the missing indicator mask.
         """
         check_is_fitted(self)
         missing_feature_count = len(self.indicator_.features_)
-        
+
         # Split the augmented array into imputed array and it's missing
         # indicator mask.
         feature_count = X.shape[1] - missing_feature_count
         imputed_arr = X[:, :feature_count].copy()
         missing_mask = X[:, feature_count:].copy()
         missing_mask = missing_mask.astype(np.bool)
-        
+
         # Iterate over features and replace the imputed values
         # with original missing value types.
         for i in range(missing_feature_count):
             f_idx = self.indicator_.features_[i]
-            imputed_arr[:,f_idx][missing_mask[:,i]] = self.missing_values
+            imputed_arr[:, f_idx][missing_mask[:, i]] = self.missing_values
         return imputed_arr
 
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -480,7 +480,7 @@ class SimpleImputer(_BaseImputer):
         features that have binary indicators for missing values. If a feature
         has no missing values at ``fit`` time, the feature won't have a binary
         indicator, and the imputation done at ``transform`` time won't be
-        inverted. 
+        inverted.
 
         Parameters
         ----------

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -476,11 +476,11 @@ class SimpleImputer(_BaseImputer):
         This operation can only be performed after :class:`SimpleImputer` is
         instantiated with ``add_indicator`` parameter set to `True`.
 
-        Note that ``inverse_transform`` can only regenerate data for the
-        features that have missing indicators present in the fitting data.
-        This limitation exists because the imputer learns missing indicators
-        based on features of fitting-data, and they are only set during
-        the ``fit`` phase.
+        Note that ``inverse_transform`` can only invert the transform in
+        features that have binary indicators for missing values. If a feature
+        has no missing values at ``fit`` time, the feature won't have a binary
+        indicator, and the imputation done at ``transform`` time won't be
+        inverted. 
 
         Parameters
         ----------

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -472,7 +472,7 @@ class SimpleImputer(_BaseImputer):
     def inverse_transform(self, X):
         """Convert the data back to the original representation.
 
-        Inverts the ``fit_transform`` operation performed on an array.
+        Inverts the `transform` operation performed on an array.
         This operation can only be performed after :class:`SimpleImputer` is
         instantiated with ``add_indicator`` parameter set to `True`.
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -472,9 +472,15 @@ class SimpleImputer(_BaseImputer):
     def inverse_transform(self, X):
         """Convert the data back to the original representation.
 
-        Inverts the `fit_transform` operation performed on an array.
+        Inverts the ``fit_transform`` operation performed on an array.
         This operation can only be performed after :class:`SimpleImputer` is
-        used with `add_indicator` set to `True`.
+        instantiated with ``add_indicator`` parameter set to `True`.
+
+        Note that ``inverse_transform`` can only regenerate data for the
+        features that have missing indicators present in the fitting data.
+        This limitation exists because the imputer learns missing indicators
+        based on features of fitting-data, and they are only set during
+        the ``fit`` phase.
 
         Parameters
         ----------

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -474,7 +474,7 @@ class SimpleImputer(_BaseImputer):
 
         Inverts the `transform` operation performed on an array.
         This operation can only be performed after :class:`SimpleImputer` is
-        instantiated with ``add_indicator`` parameter set to `True`.
+        instantiated with `add_indicator=True`.
 
         Note that ``inverse_transform`` can only invert the transform in
         features that have binary indicators for missing values. If a feature

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -484,8 +484,8 @@ class SimpleImputer(_BaseImputer):
 
         Parameters
         ----------
-        X : array-like, \
-            shape (n_samples, n_features + missing_feature_count)
+        X : array-like of shape \
+                (n_samples, n_features + n_features_missing_indicator)
             The imputed data to be reverted to original data. It has to be
             an augmented array of imputed data and the missing indicator mask.
         """

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -484,7 +484,7 @@ class SimpleImputer(_BaseImputer):
 
         Parameters
         ----------
-        X : array-like,
+        X : array-like, \
             shape (n_samples, n_features + missing_feature_count)
             The imputed data to be reverted to original data. It has to be
             an augmented array of imputed data and the missing indicator mask.

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -486,18 +486,16 @@ class SimpleImputer(_BaseImputer):
         check_is_fitted(self)
         missing_feature_count = len(self.indicator_.features_)
 
-        # Split the augmented array into imputed array and it's missing
+        # Split the augmented array into imputed array and its missing
         # indicator mask.
         feature_count = X.shape[1] - missing_feature_count
         imputed_arr = X[:, :feature_count].copy()
-        missing_mask = X[:, feature_count:].copy()
-        missing_mask = missing_mask.astype(np.bool)
+        missing_mask = X[:, feature_count:].astype(np.bool)
 
-        # Iterate over features and replace the imputed values
-        # with original missing value types.
-        for i in range(missing_feature_count):
-            f_idx = self.indicator_.features_[i]
-            imputed_arr[:, f_idx][missing_mask[:, i]] = self.missing_values
+        # Replace the imputed values with original missing value types.
+        full_mask = np.zeros(imputed_arr.shape, dtype=np.bool)
+        full_mask[:, self.indicator_.features_] = missing_mask
+        imputed_arr[full_mask] = self.missing_values
         return imputed_arr
 
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -515,14 +515,14 @@ class SimpleImputer(_BaseImputer):
         X_original[:, self.indicator_.features_] = missing_mask
         full_mask = X_original.astype(np.bool)
 
-        imputed_idx, orig_idx = 0, 0
+        imputed_idx, original_idx = 0, 0
         while imputed_idx < len(array_imputed.T):
-            if not np.all(X_original[:, orig_idx]):
-                X_original[:, orig_idx] = array_imputed.T[imputed_idx]
+            if not np.all(X_original[:, original_idx]):
+                X_original[:, original_idx] = array_imputed.T[imputed_idx]
                 imputed_idx += 1
-                orig_idx += 1
+                original_idx += 1
             else:
-                orig_idx += 1
+                original_idx += 1
 
         X_original[full_mask] = self.missing_values
         return X_original

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1383,3 +1383,20 @@ def test_imputation_order(order, idx_order):
                                random_state=0).fit(X)
         idx = [x.feat_idx for x in trs.imputation_sequence_]
         assert idx == idx_order
+
+
+def test_simple_imputation_inverse_transform():
+    # Test inverse_transform feature for np.nan
+    X = np.array([
+        [-1, np.nan, 3, -1],
+        [4, -1, 5, -1],
+        [6, 7, np.nan, -1],
+        [8, 9, 0, np.nan]
+    ])
+
+    imputer = SimpleImputer(missing_values=np.nan, strategy='mean',
+                            add_indicator=True)
+    X_trans = imputer.fit_transform(X)
+    X_orig = imputer.inverse_transform(X_trans)
+
+    assert_array_equal(X_orig, X)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1387,16 +1387,29 @@ def test_imputation_order(order, idx_order):
 
 def test_simple_imputation_inverse_transform():
     # Test inverse_transform feature for np.nan
-    X = np.array([
-        [-1, np.nan, 3, -1],
+    X_1 = np.array([
+        [9, np.nan, 3, -1],
         [4, -1, 5, -1],
         [6, 7, np.nan, -1],
         [8, 9, 0, np.nan]
     ])
+    X_2 = np.array([
+        [np.nan, 4, 2, 1],
+        [2, 1, np.nan, 3],
+        [9, np.nan, 7, 1],
+        [6, 4, 2, np.nan]
+    ])
 
-    imputer = SimpleImputer(missing_values=np.nan, strategy='mean',
-                            add_indicator=True)
-    X_trans = imputer.fit_transform(X)
-    X_orig = imputer.inverse_transform(X_trans)
+    imputer_1 = SimpleImputer(missing_values=np.nan, strategy='mean',
+                              add_indicator=True)
+    X_1_trans = imputer_1.fit_transform(X_1)
+    X_1_orig = imputer_1.inverse_transform(X_1_trans)
 
-    assert_array_equal(X_orig, X)
+    imputer_2 = SimpleImputer(missing_values=np.nan, strategy='mean',
+                              add_indicator=True)
+    imputer_2.fit(X_2)
+    X_2_trans = imputer_2.transform(X_2)
+    X_2_orig = imputer_2.inverse_transform(X_2_trans)
+
+    assert_array_equal(X_1_orig, X_1)
+    assert_array_equal(X_2_orig, X_2)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1385,28 +1385,62 @@ def test_imputation_order(order, idx_order):
         assert idx == idx_order
 
 
-def test_simple_imputation_inverse_transform():
+@pytest.mark.parametrize(
+    "missing_value",
+    [-1, np.nan]
+)
+def test_simple_imputation_inverse_transform(missing_value):
     # Test inverse_transform feature for np.nan
     X_1 = np.array([
-        [9, np.nan, 3, -1],
-        [4, -1, 5, -1],
-        [6, 7, np.nan, -1],
-        [8, 9, 0, np.nan]
-    ])
-    X_2 = np.array([
-        [5, 4, 2, 1],
-        [2, 1, np.nan, 3],
-        [9, np.nan, 7, 1],
-        [6, 4, 2, np.nan]
+        [9, missing_value, 3, -1],
+        [4, -1, 5, 4],
+        [6, 7, missing_value, -1],
+        [8, 9, 0, missing_value]
     ])
 
-    imputer = SimpleImputer(missing_values=np.nan, strategy='mean',
+    X_2 = np.array([
+        [5, 4, 2, 1],
+        [2, 1, missing_value, 3],
+        [9, missing_value, 7, 1],
+        [6, 4, 2, missing_value]
+    ])
+
+    X_3 = np.array([
+        [missing_value, missing_value, missing_value, missing_value],
+        [missing_value, missing_value, missing_value, missing_value],
+        [missing_value, missing_value, missing_value, missing_value],
+        [missing_value, missing_value, missing_value, missing_value]
+    ])
+
+    X_4 = np.array([
+        [missing_value, missing_value, 2, missing_value, missing_value, 5],
+        [missing_value, missing_value, 3, missing_value, missing_value, 6],
+        [missing_value, missing_value, 4, missing_value, missing_value, 7],
+        [missing_value, missing_value, 5, missing_value, missing_value, 8]
+    ])
+
+    imputer = SimpleImputer(missing_values=missing_value, strategy='mean',
                             add_indicator=True)
+
     X_1_trans = imputer.fit_transform(X_1)
     X_1_orig = imputer.inverse_transform(X_1_trans)
 
     X_2_trans = imputer.transform(X_2)
     X_2_orig = imputer.inverse_transform(X_2_trans)
 
+    X_3_trans = imputer.fit_transform(X_3)
+    X_3_orig = imputer.inverse_transform(X_3_trans)
+
+    X_4_trans = imputer.fit_transform(X_4)
+    X_4_orig = imputer.inverse_transform(X_4_trans)
+
     assert_array_equal(X_1_orig, X_1)
     assert_array_equal(X_2_orig, X_2)
+    assert_array_equal(X_3_orig, X_3)
+    assert_array_equal(X_4_orig, X_4)
+
+    with pytest.raises(ValueError, match="add_indicator=True"):
+        imputer = SimpleImputer(missing_values=missing_value,
+                                strategy="mean")
+        X_1_trans = imputer.fit_transform(X_1)
+        X_1_orig = imputer.inverse_transform(X_1_trans)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1420,18 +1420,18 @@ def test_simple_imputation_inverse_transform(missing_value):
                             add_indicator=True)
 
     X_1_trans = imputer.fit_transform(X_1)
-    X_1_orig = imputer.inverse_transform(X_1_trans)
+    X_1_inv_trans = imputer.inverse_transform(X_1_trans)
 
     X_2_trans = imputer.transform(X_2)
-    X_2_orig = imputer.inverse_transform(X_2_trans)
+    X_2_inv_trans = imputer.inverse_transform(X_2_trans)
 
-    assert_array_equal(X_1_orig, X_1)
-    assert_array_equal(X_2_orig, X_2)
+    assert_array_equal(X_1_inv_trans, X_1)
+    assert_array_equal(X_2_inv_trans, X_2)
 
     for X in [X_3, X_4]:
         X_trans = imputer.fit_transform(X)
-        X_orig = imputer.inverse_transform(X_trans)
-        assert_array_equal(X_orig, X)
+        X_inv_trans = imputer.inverse_transform(X_trans)
+        assert_array_equal(X_inv_trans, X)
 
 
 @pytest.mark.parametrize("missing_value", [-1, np.nan])
@@ -1442,8 +1442,9 @@ def test_simple_imputation_inverse_transform_exceptions(missing_value):
         [6, 7, missing_value, -1],
         [8, 9, 0, missing_value]
     ])
-    with pytest.raises(ValueError, match="add_indicator=True"):
-        imputer = SimpleImputer(missing_values=missing_value,
-                                strategy="mean")
-        X_1_trans = imputer.fit_transform(X_1)
+
+    imputer = SimpleImputer(missing_values=missing_value, strategy="mean")
+    X_1_trans = imputer.fit_transform(X_1)
+    with pytest.raises(ValueError,
+                       match=f"Got 'add_indicator={imputer.add_indicator}'"):
         imputer.inverse_transform(X_1_trans)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1394,7 +1394,7 @@ def test_simple_imputation_inverse_transform():
         [8, 9, 0, np.nan]
     ])
     X_2 = np.array([
-        [np.nan, 4, 2, 1],
+        [5, 4, 2, 1],
         [2, 1, np.nan, 3],
         [9, np.nan, 7, 1],
         [6, 4, 2, np.nan]
@@ -1405,11 +1405,8 @@ def test_simple_imputation_inverse_transform():
     X_1_trans = imputer_1.fit_transform(X_1)
     X_1_orig = imputer_1.inverse_transform(X_1_trans)
 
-    imputer_2 = SimpleImputer(missing_values=np.nan, strategy='mean',
-                              add_indicator=True)
-    imputer_2.fit(X_2)
-    X_2_trans = imputer_2.transform(X_2)
-    X_2_orig = imputer_2.inverse_transform(X_2_trans)
+    X_2_trans = imputer_1.transform(X_2)
+    X_2_orig = imputer_1.inverse_transform(X_2_trans)
 
     assert_array_equal(X_1_orig, X_1)
     assert_array_equal(X_2_orig, X_2)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1400,13 +1400,13 @@ def test_simple_imputation_inverse_transform():
         [6, 4, 2, np.nan]
     ])
 
-    imputer_1 = SimpleImputer(missing_values=np.nan, strategy='mean',
-                              add_indicator=True)
-    X_1_trans = imputer_1.fit_transform(X_1)
-    X_1_orig = imputer_1.inverse_transform(X_1_trans)
+    imputer = SimpleImputer(missing_values=np.nan, strategy='mean',
+                            add_indicator=True)
+    X_1_trans = imputer.fit_transform(X_1)
+    X_1_orig = imputer.inverse_transform(X_1_trans)
 
-    X_2_trans = imputer_1.transform(X_2)
-    X_2_orig = imputer_1.inverse_transform(X_2_trans)
+    X_2_trans = imputer.transform(X_2)
+    X_2_orig = imputer.inverse_transform(X_2_trans)
 
     assert_array_equal(X_1_orig, X_1)
     assert_array_equal(X_2_orig, X_2)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1385,10 +1385,7 @@ def test_imputation_order(order, idx_order):
         assert idx == idx_order
 
 
-@pytest.mark.parametrize(
-    "missing_value",
-    [-1, np.nan]
-)
+@pytest.mark.parametrize("missing_value", [-1, np.nan])
 def test_simple_imputation_inverse_transform(missing_value):
     # Test inverse_transform feature for np.nan
     X_1 = np.array([
@@ -1406,17 +1403,17 @@ def test_simple_imputation_inverse_transform(missing_value):
     ])
 
     X_3 = np.array([
-        [missing_value, missing_value, missing_value, missing_value],
-        [missing_value, missing_value, missing_value, missing_value],
-        [missing_value, missing_value, missing_value, missing_value],
-        [missing_value, missing_value, missing_value, missing_value]
+        [1, missing_value, 5, 9],
+        [missing_value, 4, missing_value, missing_value],
+        [2, missing_value, 7, missing_value],
+        [missing_value, 3, missing_value, 8]
     ])
 
     X_4 = np.array([
-        [missing_value, missing_value, 2, missing_value, missing_value, 5],
-        [missing_value, missing_value, 3, missing_value, missing_value, 6],
-        [missing_value, missing_value, 4, missing_value, missing_value, 7],
-        [missing_value, missing_value, 5, missing_value, missing_value, 8]
+        [1, 1, 1, 3],
+        [missing_value, 2, missing_value, 1],
+        [2, 3, 3, 4],
+        [missing_value, 4, missing_value, 2]
     ])
 
     imputer = SimpleImputer(missing_values=missing_value, strategy='mean',
@@ -1428,19 +1425,25 @@ def test_simple_imputation_inverse_transform(missing_value):
     X_2_trans = imputer.transform(X_2)
     X_2_orig = imputer.inverse_transform(X_2_trans)
 
-    X_3_trans = imputer.fit_transform(X_3)
-    X_3_orig = imputer.inverse_transform(X_3_trans)
-
-    X_4_trans = imputer.fit_transform(X_4)
-    X_4_orig = imputer.inverse_transform(X_4_trans)
-
     assert_array_equal(X_1_orig, X_1)
     assert_array_equal(X_2_orig, X_2)
-    assert_array_equal(X_3_orig, X_3)
-    assert_array_equal(X_4_orig, X_4)
 
+    for X in [X_3, X_4]:
+        X_trans = imputer.fit_transform(X)
+        X_orig = imputer.inverse_transform(X_trans)
+        assert_array_equal(X_orig, X)
+
+
+@pytest.mark.parametrize("missing_value", [-1, np.nan])
+def test_simple_imputation_inverse_transform_exceptions(missing_value):
+    X_1 = np.array([
+        [9, missing_value, 3, -1],
+        [4, -1, 5, 4],
+        [6, 7, missing_value, -1],
+        [8, 9, 0, missing_value]
+    ])
     with pytest.raises(ValueError, match="add_indicator=True"):
         imputer = SimpleImputer(missing_values=missing_value,
                                 strategy="mean")
         X_1_trans = imputer.fit_transform(X_1)
-        X_1_orig = imputer.inverse_transform(X_1_trans)
+        imputer.inverse_transform(X_1_trans)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1422,7 +1422,7 @@ def test_simple_imputation_inverse_transform(missing_value):
     X_1_trans = imputer.fit_transform(X_1)
     X_1_inv_trans = imputer.inverse_transform(X_1_trans)
 
-    X_2_trans = imputer.transform(X_2)
+    X_2_trans = imputer.transform(X_2)  # test on new data
     X_2_inv_trans = imputer.inverse_transform(X_2_trans)
 
     assert_array_equal(X_1_inv_trans, X_1)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes  #17590

#### What does this implement/fix? Explain your changes.
Implements `inverse_transform` feature in SimpleImputer. The behavior of this method 
is such that it returns a new array with the imputed values replaced with the original
missing_values.

- [x] Add `inverse_transform` method to SimpleImputer
- [x] Add test cases for `inverse_transform`

#### Any other comments?
Can this feature be implemented for other imputers? Also, I would like to evaluate the performance once the approach is finalized.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
