### PR TITLE
DOC Add "see also" links to and from new plotting functions

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -242,6 +242,10 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
         samples with true label being i-th class
         and prediced label being j-th class.
 
+    See Also
+    --------
+    plot_confusion_matrix : Plot Confusion Matrix
+
     References
     ----------
     .. [1] `Wikipedia entry for the Confusion matrix

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -213,6 +213,11 @@ def plot_confusion_matrix(estimator, X, y_true, *, labels=None,
     -------
     display : :class:`~sklearn.metrics.ConfusionMatrixDisplay`
 
+    See Also
+    --------
+    confusion_matrix :
+        Compute confusion matrix to evaluate the accuracy of a classification
+
     Examples
     --------
     >>> import matplotlib.pyplot as plt  # doctest: +SKIP

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -166,6 +166,11 @@ def plot_precision_recall_curve(estimator, X, y, *,
     -------
     display : :class:`~sklearn.metrics.PrecisionRecallDisplay`
         Object that stores computed values.
+
+    See Also
+    --------
+    precision_recall_curve :
+        Compute precision-recall pairs for different probability thresholds
     """
     check_matplotlib_support("plot_precision_recall_curve")
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -659,6 +659,9 @@ def precision_recall_curve(y_true, probas_pred, *, pos_label=None,
 
     roc_curve : Compute Receiver operating characteristic (ROC) curve
 
+    plot_precision_recall_curve :
+        Plot Precision Recall Curve for binary classifiers
+
     Examples
     --------
     >>> import numpy as np


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Similar to #17585 

#### What does this implement/fix? Explain your changes.

Add new links to the "See Also" section of the documentation:

- Link to `plot_confusion_matrix` from `confusion_matrix`
- Link to `confusion_matrix` from `plot_confusion_matrix`
- Link to `plot_precision_recall_curve` from `precision_recall_curve`
- Link to `precision_recall_curve` from `plot_precision_recall_curve`

#### Any other comments?

These are all "See Also" links that I would personally find useful, which is why I added them!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
