### PR TITLE
Apply `StandarScaler` transformation before splitting data in “Varying regularization in Multi-layer Perceptron” Documentation

### DIFF
--- a/examples/neural_networks/plot_mlp_alpha.py
+++ b/examples/neural_networks/plot_mlp_alpha.py
@@ -60,8 +60,11 @@ i = 1
 # iterate over datasets
 for X, y in datasets:
     # preprocess dataset, split into training and test part
-    X = StandardScaler().fit_transform(X)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=.4)
+    scaler = StandardScaler()
+    scaler.fit(X_train)
+    X_train = scaler.transform(X_train)
+    X_test = scaler.transform(X_test)
 
     x_min, x_max = X[:, 0].min() - .5, X[:, 0].max() + .5
     y_min, y_max = X[:, 1].min() - .5, X[:, 1].max() + .5


### PR DESCRIPTION
#### Reference Issues/PRs
#17619 


#### What does this implement/fix? Explain your changes.
The right way is that apply `StandarScaler` transformation after splitting data.
```
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=.4, random_state=42)
scaler = StandardScaler()
scaler.fit(X_train)
X_train = scaler.transform(X_train)
X_test = scaler.transform(X_test)
```