### PR TITLE
MNT Fix documentation build

### DIFF
--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -70,7 +70,7 @@ def plot_samples(S, axis_list=None):
             x_axis, y_axis = axis
             # Trick to get legend to work
             plt.plot(0.1 * x_axis, 0.1 * y_axis, linewidth=2, color=color)
-            plt.quiver([0, 0], [0, 0], x_axis, y_axis, zorder=11, width=0.01,
+            plt.quiver((0, 0), (0, 0), x_axis, y_axis, zorder=11, width=0.01,
                        scale=6, color=color)
 
     plt.hlines(0, -3, 3)

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -70,8 +70,8 @@ def plot_samples(S, axis_list=None):
             x_axis, y_axis = axis
             # Trick to get legend to work
             plt.plot(0.1 * x_axis, 0.1 * y_axis, linewidth=2, color=color)
-            plt.quiver(0, 0, x_axis, y_axis, zorder=11, width=0.01, scale=6,
-                       color=color)
+            plt.quiver([0, 0], [0, 0], x_axis, y_axis, zorder=11, width=0.01,
+                       scale=6, color=color)
 
     plt.hlines(0, -3, 3)
     plt.vlines(0, -3, 3)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The documentation build is failing because in the `sklearn/examples/decomposition/plot_ica_vs_pca.py` example, the arrow locations (`X`, `Y`) in the `matplotlib.pyplot.quiver` method should have the same size than the arrow vectors (`U`, `V`).

This example was triggered from PR #17620.