### PR TITLE
FIX Fix support for code in API elements

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -36,7 +36,6 @@ code {
   color: #222;
   background-color: #ecf0f3;
   border-radius: 0.2rem;
-  white-space: nowrap;
   padding: 0.15rem;
 }
 

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -36,6 +36,7 @@ code {
   color: #222;
   background-color: #ecf0f3;
   border-radius: 0.2rem;
+  white-space: nowrap;
   padding: 0.15rem;
 }
 
@@ -71,6 +72,7 @@ a code {
   color: #2878A2;
   border-radius: 0;
   padding: 0;
+  white-space: nowrap;
 }
 
 img {


### PR DESCRIPTION
#### Reference Issues/PRs

Coming from #17607.

#### What does this implement/fix? Explain your changes.

This PR fixes the tables for the API elements that were unintentionally broke up. See for instance [API Reference](https://scikit-learn.org/dev/modules/classes.html) or the "Methods" section in [`sklearn.tree.DecisionTreeClassifier`](https://scikit-learn.org/dev/modules/generated/sklearn.tree.DecisionTreeClassifier.html#sklearn.tree.DecisionTreeClassifier).

#### Any other comments?

Note that this PR still maintains the improvement for mobile support for code, but fixes the code elements within tables.

CC @thomasjpfan.