### PR TITLE
PERF Don't return anything from neural net activation functions

### DIFF
--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -10,94 +10,69 @@ from scipy.special import expit as logistic_sigmoid
 from scipy.special import xlogy
 
 
-def identity(X):
-    """Simply return the input array.
+def inplace_identity(X):
+    """Simply leave the input array unchanged.
 
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
         Data, where n_samples is the number of samples
         and n_features is the number of features.
-
-    Returns
-    -------
-    X : {array-like, sparse matrix}, shape (n_samples, n_features)
-        Same as the input data.
     """
-    return X
+    # Nothing to do
 
 
-def logistic(X):
+def inplace_logistic(X):
     """Compute the logistic function inplace.
 
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
         The input data.
-
-    Returns
-    -------
-    X_new : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The transformed data.
     """
-    return logistic_sigmoid(X, out=X)
+    logistic_sigmoid(X, out=X)
 
 
-def tanh(X):
+def inplace_tanh(X):
     """Compute the hyperbolic tan function inplace.
 
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
         The input data.
-
-    Returns
-    -------
-    X_new : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The transformed data.
     """
-    return np.tanh(X, out=X)
+    np.tanh(X, out=X)
 
 
-def relu(X):
+def inplace_relu(X):
     """Compute the rectified linear unit function inplace.
 
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
         The input data.
-
-    Returns
-    -------
-    X_new : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The transformed data.
     """
     np.maximum(X, 0, out=X)
-    return X
 
 
-def softmax(X):
+def inplace_softmax(X):
     """Compute the K-way softmax function inplace.
 
     Parameters
     ----------
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
         The input data.
-
-    Returns
-    -------
-    X_new : {array-like, sparse matrix}, shape (n_samples, n_features)
-        The transformed data.
     """
     tmp = X - X.max(axis=1)[:, np.newaxis]
     np.exp(tmp, out=X)
     X /= X.sum(axis=1)[:, np.newaxis]
 
-    return X
 
-
-ACTIVATIONS = {'identity': identity, 'tanh': tanh, 'logistic': logistic,
-               'relu': relu, 'softmax': softmax}
+ACTIVATIONS = {'identity': inplace_identity,
+               'tanh': inplace_tanh,
+               'logistic': inplace_logistic,
+               'relu': inplace_relu,
+               'softmax': inplace_softmax}
 
 
 def inplace_identity_derivative(Z, delta):

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -107,11 +107,11 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
 
             # For the hidden layers
             if (i + 1) != (self.n_layers_ - 1):
-                activations[i + 1] = hidden_activation(activations[i + 1])
+                hidden_activation(activations[i + 1])
 
         # For the last layer
         output_activation = ACTIVATIONS[self.out_activation_]
-        activations[i + 1] = output_activation(activations[i + 1])
+        output_activation(activations[i + 1])
 
         return activations
 


### PR DESCRIPTION
This pull request is similar to pull request #17604: Returning a reference to X from the activation functions is unnecessary and creates the false impression that they make copies. The activiation functions should have the same interface as the derivative functions, which were already returning nothing. Furthermore, dropping the return values improves the performance of neural net training by about 3%.

Test program:

```
from sklearn.datasets import load_digits
from sklearn.neural_network import MLPClassifier
from neurtu import delayed, Benchmark

digits = load_digits(return_X_y=True)
X = digits[0][:,:10]
y = digits[0][:,11]

clf = MLPClassifier(solver='lbfgs', alpha=1e-5,
                    hidden_layer_sizes=(5, 2), random_state=1, max_iter=1000)

train = delayed(clf).fit(X, y)
print(Benchmark(wall_time=True, cpu_time=True, repeat=10)(train))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   2.036008  2.028113
max    2.060196  2.031687
std    0.008858  0.002375
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   1.976324  1.970528
max    1.982843  1.977816
std    0.002903  0.003813
```