### PR TITLE
DOC shorten links in examples/applications/* modules

### DIFF
--- a/examples/applications/plot_species_distribution_modeling.py
+++ b/examples/applications/plot_species_distribution_modeling.py
@@ -9,7 +9,7 @@ model the geographic distribution of two south american
 mammals given past observations and 14 environmental
 variables. Since we have only positive examples (there are
 no unsuccessful observations), we cast this problem as a
-density estimation problem and use the :class:`sklearn.svm.OneClassSVM`
+density estimation problem and use the :class:`~sklearn.svm.OneClassSVM`
 as our modeling tool. The dataset is provided by Phillips et. al. (2006).
 If available, the example uses
 `basemap <https://matplotlib.org/basemap/>`_

--- a/examples/applications/plot_tomography_l1_reconstruction.py
+++ b/examples/applications/plot_tomography_l1_reconstruction.py
@@ -21,14 +21,14 @@ The tomography projection operation is a linear transformation. In
 addition to the data-fidelity term corresponding to a linear regression,
 we penalize the L1 norm of the image to account for its sparsity. The
 resulting optimization problem is called the :ref:`lasso`. We use the
-class :class:`sklearn.linear_model.Lasso`, that uses the coordinate descent
+class :class:`~sklearn.linear_model.Lasso`, that uses the coordinate descent
 algorithm. Importantly, this implementation is more computationally efficient
 on a sparse matrix, than the projection operator used here.
 
 The reconstruction with L1 penalization gives a result with zero error
 (all pixels are successfully labeled with 0 or 1), even if noise was
 added to the projections. In comparison, an L2 penalization
-(:class:`sklearn.linear_model.Ridge`) produces a large number of labeling
+(:class:`~sklearn.linear_model.Ridge`) produces a large number of labeling
 errors for the pixels. Important artifacts are observed on the
 reconstructed image, contrary to the L1 penalization. Note in particular
 the circular artifact separating the pixels in the corners, that have

--- a/examples/applications/plot_topics_extraction_with_nmf_lda.py
+++ b/examples/applications/plot_topics_extraction_with_nmf_lda.py
@@ -3,8 +3,8 @@
 Topic extraction with Non-negative Matrix Factorization and Latent Dirichlet Allocation
 =======================================================================================
 
-This is an example of applying :class:`sklearn.decomposition.NMF` and
-:class:`sklearn.decomposition.LatentDirichletAllocation` on a corpus
+This is an example of applying :class:`~sklearn.decomposition.NMF` and
+:class:`~sklearn.decomposition.LatentDirichletAllocation` on a corpus
 of documents and extract additive models of the topic structure of the
 corpus.  The output is a list of topics, each represented as a list of
 terms (weights are not shown).


### PR DESCRIPTION
#### Reference Issues/PRs
References #17302 

#### What does this implement/fix? Explain your changes.
Shortened links to classes in the modules `examples/applications/*`
