### PR TITLE
DOC shorten links in examples/* modules

### DIFF
--- a/examples/cluster/plot_optics.py
+++ b/examples/cluster/plot_optics.py
@@ -5,9 +5,9 @@ Demo of OPTICS clustering algorithm
 Finds core samples of high density and expands clusters from them.
 This example uses data that is generated so that the clusters have
 different densities.
-The :class:`sklearn.cluster.OPTICS` is first used with its Xi cluster detection
+The :class:`~sklearn.cluster.OPTICS` is first used with its Xi cluster detection
 method, and then setting specific thresholds on the reachability, which
-corresponds to :class:`sklearn.cluster.DBSCAN`. We can see that the different
+corresponds to :class:`~sklearn.cluster.DBSCAN`. We can see that the different
 clusters of OPTICS's Xi method can be recovered with different choices of
 thresholds in DBSCAN.
 """

--- a/examples/cluster/plot_optics.py
+++ b/examples/cluster/plot_optics.py
@@ -2,12 +2,15 @@
 ===================================
 Demo of OPTICS clustering algorithm
 ===================================
+
+.. currentmodule:: sklearn
+
 Finds core samples of high density and expands clusters from them.
 This example uses data that is generated so that the clusters have
 different densities.
-The :class:`~sklearn.cluster.OPTICS` is first used with its Xi cluster detection
+The :class:`~cluster.OPTICS` is first used with its Xi cluster detection
 method, and then setting specific thresholds on the reachability, which
-corresponds to :class:`~sklearn.cluster.DBSCAN`. We can see that the different
+corresponds to :class:`~cluster.DBSCAN`. We can see that the different
 clusters of OPTICS's Xi method can be recovered with different choices of
 thresholds in DBSCAN.
 """

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -3,9 +3,11 @@
 Column Transformer with Mixed Types
 ===================================
 
+.. currentmodule:: sklearn
+
 This example illustrates how to apply different preprocessing and feature
 extraction pipelines to different subsets of features, using
-:class:`~sklearn.compose.ColumnTransformer`. This is particularly handy for the
+:class:`~compose.ColumnTransformer`. This is particularly handy for the
 case of datasets that contain heterogeneous data types, since we may want to
 scale the numeric features and one-hot encode the categorical ones.
 
@@ -17,7 +19,7 @@ In addition, we show two different ways to dispatch the columns to the
 particular pre-processor: by column names and by column data types.
 
 Finally, the preprocessing pipeline is integrated in a full prediction pipeline
-using :class:`~sklearn.pipeline.Pipeline`, together with a simple classification
+using :class:`~pipeline.Pipeline`, together with a simple classification
 model.
 """
 

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -5,7 +5,7 @@ Column Transformer with Mixed Types
 
 This example illustrates how to apply different preprocessing and feature
 extraction pipelines to different subsets of features, using
-:class:`sklearn.compose.ColumnTransformer`. This is particularly handy for the
+:class:`~sklearn.compose.ColumnTransformer`. This is particularly handy for the
 case of datasets that contain heterogeneous data types, since we may want to
 scale the numeric features and one-hot encode the categorical ones.
 
@@ -17,7 +17,7 @@ In addition, we show two different ways to dispatch the columns to the
 particular pre-processor: by column names and by column data types.
 
 Finally, the preprocessing pipeline is integrated in a full prediction pipeline
-using :class:`sklearn.pipeline.Pipeline`, together with a simple classification
+using :class:`~sklearn.pipeline.Pipeline`, together with a simple classification
 model.
 """
 
@@ -164,7 +164,7 @@ selector(dtype_include="category")(X_train)
 # hyperparameters as part of the ``Pipeline``.
 # We will search for both the imputer strategy of the numeric preprocessing
 # and the regularization parameter of the logistic regression using
-# :class:`sklearn.model_selection.GridSearchCV`.
+# :class:`~sklearn.model_selection.GridSearchCV`.
 
 param_grid = {
     'preprocessor__num__imputer__strategy': ['mean', 'median'],

--- a/examples/covariance/plot_covariance_estimation.py
+++ b/examples/covariance/plot_covariance_estimation.py
@@ -5,7 +5,7 @@ Shrinkage covariance estimation: LedoitWolf vs OAS and max-likelihood
 
 When working with covariance estimation, the usual approach is to use
 a maximum likelihood estimator, such as the
-:class:`sklearn.covariance.EmpiricalCovariance`. It is unbiased, i.e. it
+:class:`~sklearn.covariance.EmpiricalCovariance`. It is unbiased, i.e. it
 converges to the true (population) covariance when given many
 observations. However, it can also be beneficial to regularize it, in
 order to reduce its variance; this, in turn, introduces some bias. This
@@ -21,11 +21,11 @@ Here we compare 3 approaches:
 
 * A close formula proposed by Ledoit and Wolf to compute
   the asymptotically optimal regularization parameter (minimizing a MSE
-  criterion), yielding the :class:`sklearn.covariance.LedoitWolf`
+  criterion), yielding the :class:`~sklearn.covariance.LedoitWolf`
   covariance estimate.
 
 * An improvement of the Ledoit-Wolf shrinkage, the
-  :class:`sklearn.covariance.OAS`, proposed by Chen et al. Its
+  :class:`~sklearn.covariance.OAS`, proposed by Chen et al. Its
   convergence is significantly better under the assumption that the data
   are Gaussian, in particular for small samples.
 

--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -3,12 +3,12 @@
 Imputing missing values with variants of IterativeImputer
 =========================================================
 
-The :class:`sklearn.impute.IterativeImputer` class is very flexible - it can be
+The :class:`~sklearn.impute.IterativeImputer` class is very flexible - it can be
 used with a variety of estimators to do round-robin regression, treating every
 variable as an output in turn.
 
 In this example we compare some estimators for the purpose of missing feature
-imputation with :class:`sklearn.impute.IterativeImputer`:
+imputation with :class:`~sklearn.impute.IterativeImputer`:
 
 * :class:`~sklearn.linear_model.BayesianRidge`: regularized linear regression
 * :class:`~sklearn.tree.DecisionTreeRegressor`: non-linear regression
@@ -17,24 +17,24 @@ imputation with :class:`sklearn.impute.IterativeImputer`:
   imputation approaches
 
 Of particular interest is the ability of
-:class:`sklearn.impute.IterativeImputer` to mimic the behavior of missForest, a
+:class:`~sklearn.impute.IterativeImputer` to mimic the behavior of missForest, a
 popular imputation package for R. In this example, we have chosen to use
-:class:`sklearn.ensemble.ExtraTreesRegressor` instead of
-:class:`sklearn.ensemble.RandomForestRegressor` (as in missForest) due to its
+:class:`~sklearn.ensemble.ExtraTreesRegressor` instead of
+:class:`~sklearn.ensemble.RandomForestRegressor` (as in missForest) due to its
 increased speed.
 
-Note that :class:`sklearn.neighbors.KNeighborsRegressor` is different from KNN
+Note that :class:`~sklearn.neighbors.KNeighborsRegressor` is different from KNN
 imputation, which learns from samples with missing values by using a distance
 metric that accounts for missing values, rather than imputing them.
 
 The goal is to compare different estimators to see which one is best for the
-:class:`sklearn.impute.IterativeImputer` when using a
-:class:`sklearn.linear_model.BayesianRidge` estimator on the California housing
+:class:`~sklearn.impute.IterativeImputer` when using a
+:class:`~sklearn.linear_model.BayesianRidge` estimator on the California housing
 dataset with a single value randomly removed from each row.
 
 For this particular pattern of missing values we see that
-:class:`sklearn.ensemble.ExtraTreesRegressor` and
-:class:`sklearn.linear_model.BayesianRidge` give the best results.
+:class:`~sklearn.ensemble.ExtraTreesRegressor` and
+:class:`~sklearn.linear_model.BayesianRidge` give the best results.
 """
 print(__doc__)
 

--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -3,38 +3,40 @@
 Imputing missing values with variants of IterativeImputer
 =========================================================
 
-The :class:`~sklearn.impute.IterativeImputer` class is very flexible - it can be
+.. currentmodule:: sklearn
+
+The :class:`~impute.IterativeImputer` class is very flexible - it can be
 used with a variety of estimators to do round-robin regression, treating every
 variable as an output in turn.
 
 In this example we compare some estimators for the purpose of missing feature
-imputation with :class:`~sklearn.impute.IterativeImputer`:
+imputation with :class:`~impute.IterativeImputer`:
 
-* :class:`~sklearn.linear_model.BayesianRidge`: regularized linear regression
-* :class:`~sklearn.tree.DecisionTreeRegressor`: non-linear regression
-* :class:`~sklearn.ensemble.ExtraTreesRegressor`: similar to missForest in R
-* :class:`~sklearn.neighbors.KNeighborsRegressor`: comparable to other KNN
+* :class:`~linear_model.BayesianRidge`: regularized linear regression
+* :class:`~tree.DecisionTreeRegressor`: non-linear regression
+* :class:`~ensemble.ExtraTreesRegressor`: similar to missForest in R
+* :class:`~neighbors.KNeighborsRegressor`: comparable to other KNN
   imputation approaches
 
 Of particular interest is the ability of
-:class:`~sklearn.impute.IterativeImputer` to mimic the behavior of missForest, a
+:class:`~impute.IterativeImputer` to mimic the behavior of missForest, a
 popular imputation package for R. In this example, we have chosen to use
-:class:`~sklearn.ensemble.ExtraTreesRegressor` instead of
-:class:`~sklearn.ensemble.RandomForestRegressor` (as in missForest) due to its
+:class:`~ensemble.ExtraTreesRegressor` instead of
+:class:`~ensemble.RandomForestRegressor` (as in missForest) due to its
 increased speed.
 
-Note that :class:`~sklearn.neighbors.KNeighborsRegressor` is different from KNN
+Note that :class:`~neighbors.KNeighborsRegressor` is different from KNN
 imputation, which learns from samples with missing values by using a distance
 metric that accounts for missing values, rather than imputing them.
 
 The goal is to compare different estimators to see which one is best for the
-:class:`~sklearn.impute.IterativeImputer` when using a
-:class:`~sklearn.linear_model.BayesianRidge` estimator on the California housing
+:class:`~impute.IterativeImputer` when using a
+:class:`~linear_model.BayesianRidge` estimator on the California housing
 dataset with a single value randomly removed from each row.
 
 For this particular pattern of missing values we see that
-:class:`~sklearn.ensemble.ExtraTreesRegressor` and
-:class:`~sklearn.linear_model.BayesianRidge` give the best results.
+:class:`~ensemble.ExtraTreesRegressor` and
+:class:`~linear_model.BayesianRidge` give the best results.
 """
 print(__doc__)
 

--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -4,7 +4,7 @@ Imputing missing values before building an estimator
 ====================================================
 
 Missing values can be replaced by the mean, the median or the most frequent
-value using the basic :class:`sklearn.impute.SimpleImputer`.
+value using the basic :class:`~sklearn.impute.SimpleImputer`.
 
 In this example we will investigate different imputation techniques:
 
@@ -178,7 +178,7 @@ mses_diabetes[1], stds_diabetes[1] = get_impute_zero_score(X_miss_diabetes,
 # kNN-imputation of the missing values
 # ------------------------------------
 #
-# :class:`sklearn.impute.KNNImputer` imputes missing values using the weighted
+# :class:`~sklearn.impute.KNNImputer` imputes missing values using the weighted
 # or unweighted mean of the desired number of nearest neighbors.
 
 def get_impute_knn_score(X_missing, y_missing):
@@ -215,7 +215,7 @@ mses_diabetes[3], stds_diabetes[3] = get_impute_mean(X_miss_diabetes,
 # Iterative imputation of the missing values
 # ------------------------------------------
 #
-# Another option is the :class:`sklearn.impute.IterativeImputer`. This uses
+# Another option is the :class:`~sklearn.impute.IterativeImputer`. This uses
 # round-robin linear regression, modeling each feature with missing values as a
 # function of other features, in turn.
 # The version implemented assumes Gaussian (output) variables. If your features

--- a/examples/linear_model/plot_sgd_early_stopping.py
+++ b/examples/linear_model/plot_sgd_early_stopping.py
@@ -29,7 +29,7 @@ until the validation score did not improve by at least ``tol`` during the last
 at the attribute ``n_iter_``.
 
 This example illustrates how the early stopping can used in the
-:class:`sklearn.linear_model.SGDClassifier` model to achieve almost the same
+:class:`~sklearn.linear_model.SGDClassifier` model to achieve almost the same
 accuracy as compared to a model built without early stopping. This can
 significantly reduce training time. Note that scores differ between the
 stopping criteria even from early iterations because some of the training data

--- a/examples/linear_model/plot_sgd_loss_functions.py
+++ b/examples/linear_model/plot_sgd_loss_functions.py
@@ -4,7 +4,7 @@ SGD: convex loss functions
 ==========================
 
 A plot that compares the various convex loss functions supported by
-:class:`sklearn.linear_model.SGDClassifier` .
+:class:`~sklearn.linear_model.SGDClassifier` .
 """
 print(__doc__)
 

--- a/examples/miscellaneous/plot_anomaly_comparison.py
+++ b/examples/miscellaneous/plot_anomaly_comparison.py
@@ -14,7 +14,7 @@ Decision boundaries between inliers and outliers are displayed in black
 except for Local Outlier Factor (LOF) as it has no predict method to be applied
 on new data when it is used for outlier detection.
 
-The :class:`sklearn.svm.OneClassSVM` is known to be sensitive to outliers and
+The :class:`~sklearn.svm.OneClassSVM` is known to be sensitive to outliers and
 thus does not perform very well for outlier detection. This estimator is best
 suited for novelty detection when the training set is not contaminated by
 outliers. That said, outlier detection in high-dimension, or without any
@@ -22,14 +22,14 @@ assumptions on the distribution of the inlying data is very challenging, and a
 One-class SVM might give useful results in these situations depending on the
 value of its hyperparameters.
 
-:class:`sklearn.covariance.EllipticEnvelope` assumes the data is Gaussian and
+:class:`~sklearn.covariance.EllipticEnvelope` assumes the data is Gaussian and
 learns an ellipse. It thus degrades when the data is not unimodal. Notice
 however that this estimator is robust to outliers.
 
-:class:`sklearn.ensemble.IsolationForest` and
-:class:`sklearn.neighbors.LocalOutlierFactor` seem to perform reasonably well
+:class:`~sklearn.ensemble.IsolationForest` and
+:class:`~sklearn.neighbors.LocalOutlierFactor` seem to perform reasonably well
 for multi-modal data sets. The advantage of
-:class:`sklearn.neighbors.LocalOutlierFactor` over the other estimators is
+:class:`~sklearn.neighbors.LocalOutlierFactor` over the other estimators is
 shown for the third data set, where the two modes have different densities.
 This advantage is explained by the local aspect of LOF, meaning that it only
 compares the score of abnormality of one sample with the scores of its
@@ -37,7 +37,7 @@ neighbors.
 
 Finally, for the last data set, it is hard to say that one sample is more
 abnormal than another sample as they are uniformly distributed in a
-hypercube. Except for the :class:`sklearn.svm.OneClassSVM` which overfits a
+hypercube. Except for the :class:`~sklearn.svm.OneClassSVM` which overfits a
 little, all estimators present decent solutions for this situation. In such a
 case, it would be wise to look more closely at the scores of abnormality of
 the samples as a good estimator should assign similar scores to all the

--- a/examples/miscellaneous/plot_kernel_approximation.py
+++ b/examples/miscellaneous/plot_kernel_approximation.py
@@ -24,7 +24,7 @@ Sampling more dimensions clearly leads to better classification results, but
 comes at a greater cost. This means there is a tradeoff between runtime and
 accuracy, given by the parameter n_components. Note that solving the Linear
 SVM and also the approximate kernel SVM could be greatly accelerated by using
-stochastic gradient descent via :class:`sklearn.linear_model.SGDClassifier`.
+stochastic gradient descent via :class:`~sklearn.linear_model.SGDClassifier`.
 This is not easily possible for the case of the kernelized SVM.
 
 """

--- a/examples/miscellaneous/plot_multilabel.py
+++ b/examples/miscellaneous/plot_multilabel.py
@@ -20,7 +20,7 @@ classes are plotted surrounded by two colored circles.
 
 The classification is performed by projecting to the first two principal
 components found by PCA and CCA for visualisation purposes, followed by using
-the :class:`sklearn.multiclass.OneVsRestClassifier` metaclassifier using two
+the :class:`~sklearn.multiclass.OneVsRestClassifier` metaclassifier using two
 SVCs with linear kernels to learn a discriminative model for each class.
 Note that PCA is used to perform an unsupervised dimensionality reduction,
 while CCA is used to perform a supervised one.

--- a/examples/model_selection/plot_grid_search_digits.py
+++ b/examples/model_selection/plot_grid_search_digits.py
@@ -4,7 +4,7 @@ Parameter estimation using grid search with cross-validation
 ============================================================
 
 This examples shows how a classifier is optimized by cross-validation,
-which is done using the :class:`sklearn.model_selection.GridSearchCV` object
+which is done using the :class:`~sklearn.model_selection.GridSearchCV` object
 on a development set that comprises only half of the available labeled data.
 
 The performance of the selected hyper-parameters and trained model is

--- a/examples/neighbors/plot_kde_1d.py
+++ b/examples/neighbors/plot_kde_1d.py
@@ -2,7 +2,7 @@
 ===================================
 Simple 1D Kernel Density Estimation
 ===================================
-This example uses the :class:`sklearn.neighbors.KernelDensity` class to
+This example uses the :class:`~sklearn.neighbors.KernelDensity` class to
 demonstrate the principles of Kernel Density Estimation in one dimension.
 
 The first plot shows one of the problems with using histograms to visualize
@@ -18,7 +18,7 @@ kernel density estimate over the same distribution.
 
 Scikit-learn implements efficient kernel density estimation using either
 a Ball Tree or KD Tree structure, through the
-:class:`sklearn.neighbors.KernelDensity` estimator.  The available kernels
+:class:`~sklearn.neighbors.KernelDensity` estimator.  The available kernels
 are shown in the second figure of this example.
 
 The third figure compares kernel density estimates for a distribution of 100


### PR DESCRIPTION
#### Reference Issues/PRs
References #17302 

#### What does this implement/fix? Explain your changes.
Shortens links to classes in the modules `examples/*`

#### Any other comments?
A few documentation lines in some of the modules are now too long by one character because of the changes I made. I ignored this for now because I don't know if you fix these kinds of problems by hand or if you use a code formatter. If this is an issue let me know how to best fix this. 

#DataUmbrella
