### PR TITLE
MNT Make field lists x-scrollable to render nicer on mobile

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -662,6 +662,7 @@ code.descclassname {
 dl.field-list {
   display: flex;
   flex-wrap: wrap;
+  overflow-x: scroll;
 }
 
 dl.field-list > dt {


### PR DESCRIPTION
#### Reference Issues/PRs

Similar to #17632.

#### What does this implement/fix? Explain your changes.

This PR makes the fields lists (`Parameters` and `Returns` sections in the API) look nicer on mobile, since they are overflowing (see the screenshot below):

![2020-06-19 18 29 52](https://user-images.githubusercontent.com/32649176/85156836-eced5900-b25a-11ea-8967-baa4ab429c4b.jpg)