### PR TITLE
PERF Remove redundant if statement from neural net log_loss function

### DIFF
--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -216,8 +216,6 @@ def log_loss(y_true, y_prob):
     y_prob = np.clip(y_prob, eps, 1 - eps)
     if y_prob.shape[1] == 1:
         y_prob = np.append(1 - y_prob, y_prob, axis=1)
-
-    if y_true.shape[1] == 1:
         y_true = np.append(1 - y_true, y_true, axis=1)
 
     return - xlogy(y_true, y_prob).sum() / y_prob.shape[0]


### PR DESCRIPTION
The dimensions of `y_prob` and `y_true` must match or an error will result with or without the second if statement, and removing this if statement makes neural net training slightly faster.

Test program:

```
from sklearn.datasets import load_digits
from sklearn.neural_network import MLPClassifier
from neurtu import delayed, Benchmark

digits = load_digits(return_X_y=True)
X = digits[0][:,:10]
y = digits[0][:,11]

clf = MLPClassifier(solver='lbfgs', alpha=1e-5,
                    hidden_layer_sizes=(5, 2), random_state=1, max_iter=1000)

train = delayed(clf).fit(X, y)
print(Benchmark(wall_time=True, cpu_time=True, repeat=10)(train))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   1.981676  1.972737
max    1.988189  1.978370
std    0.003873  0.003459
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   1.972946  1.964178
max    1.979209  1.971954
std    0.003789  0.004218
```