### PR TITLE
STY Move horizontal space for mobile

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -718,6 +718,16 @@ dd {
   padding-left: 1rem;
 }
 
+dl.class > dd {
+  padding-left: 0;
+}
+
+@media screen and (min-width: 768px) {
+  dl.class > dd {
+    padding-left: 1rem;
+  }
+}
+
 .rubric {
   font-weight: bold;
   margin-top: 1rem;


### PR DESCRIPTION
Increases horizontal space for API docs on mobile:

## PR

<img width="488" alt="Screen Shot 2020-06-19 at 5 05 26 PM" src="https://user-images.githubusercontent.com/5402633/85179566-42bc0400-b24f-11ea-80da-bb9b65247e06.png">

## master

<img width="497" alt="Screen Shot 2020-06-19 at 5 05 50 PM" src="https://user-images.githubusercontent.com/5402633/85179581-49e31200-b24f-11ea-9b8b-fd19628c17d3.png">
