### PR TITLE
DOC cleaning parameter docstring in sklearn/multiclass.py

### DIFF
--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -100,7 +100,7 @@ def isotonic_regression(y, *, sample_weight=None, y_min=None, y_max=None,
         Upper bound on the highest predicted value (the maximum may still be
         lower). If not set, defaults to +inf.
 
-    increasing : boolean, optional, default: True
+    increasing : boolean, optional, default=True
         Whether to compute ``y_`` is increasing (if set to True) or decreasing
         (if set to False)
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -100,7 +100,7 @@ def isotonic_regression(y, *, sample_weight=None, y_min=None, y_max=None,
         Upper bound on the highest predicted value (the maximum may still be
         lower). If not set, defaults to +inf.
 
-    increasing : boolean, optional, default=True
+    increasing : bool, default=True
         Whether to compute ``y_`` is increasing (if set to True) or decreasing
         (if set to False)
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -729,7 +729,7 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         one-vs-the-rest. A number greater than 1 will require more classifiers
         than one-vs-the-rest.
 
-    random_state : int, RandomState instance or None, optional, default: None
+    random_state : int, RandomState instance or None, optional, default=None
         The generator used to initialize the codebook.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -729,7 +729,7 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         one-vs-the-rest. A number greater than 1 will require more classifiers
         than one-vs-the-rest.
 
-    random_state : int, RandomState instance or None, optional, default=None
+    random_state : int, RandomState instance or None, default=None
         The generator used to initialize the codebook.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.


### PR DESCRIPTION
Reference Issues/PRs
References #15761

What does this implement/fix? Explain your changes.
Please reference row 732 of sklearn/multiclass.py. I've updated for consistency one of the default params of the OutputCodeClassifier class.

Any other comments?
With help from @Mariam-ke, @mobigelow 
