### PR TITLE
CI Ignore tostring deprecation in numpy 1.19 caused by joblib and scipy. 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,34 +92,34 @@ jobs:
     dependsOn: [linting]
     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
     matrix:
-#       # Linux environment to test that scikit-learn can be built against
-#       # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
-#       # i.e. numpy 1.13.3 and scipy 0.19
-#       py36_ubuntu_atlas:
-#         DISTRIB: 'ubuntu'
-#         PYTHON_VERSION: '3.6'
-#         JOBLIB_VERSION: '0.11'
-#         PYTEST_XDIST: 'false'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#       # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
-#       py36_conda_openblas:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '3.6'
-#         BLAS: 'openblas'
-#         NUMPY_VERSION: '1.13.3'
-#         SCIPY_VERSION: '0.19.1'
-#         PANDAS_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         # temporary pin pytest due to unknown failure with pytest 5.3
-#         PYTEST_VERSION: '5.2'
-#         PILLOW_VERSION: '4.2.1'
-#         MATPLOTLIB_VERSION: '2.1.1'
-#         SCIKIT_IMAGE_VERSION: '*'
-#         # latest version of joblib available in conda for Python 3.6
-#         JOBLIB_VERSION: '0.13.2'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         PYTEST_XDIST: 'false'
-#         COVERAGE: 'true'
+      # Linux environment to test that scikit-learn can be built against
+      # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
+      # i.e. numpy 1.13.3 and scipy 0.19
+      py36_ubuntu_atlas:
+        DISTRIB: 'ubuntu'
+        PYTHON_VERSION: '3.6'
+        JOBLIB_VERSION: '0.11'
+        PYTEST_XDIST: 'false'
+        THREADPOOLCTL_VERSION: '2.0.0'
+      # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
+      py36_conda_openblas:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '3.6'
+        BLAS: 'openblas'
+        NUMPY_VERSION: '1.13.3'
+        SCIPY_VERSION: '0.19.1'
+        PANDAS_VERSION: '*'
+        CYTHON_VERSION: '*'
+        # temporary pin pytest due to unknown failure with pytest 5.3
+        PYTEST_VERSION: '5.2'
+        PILLOW_VERSION: '4.2.1'
+        MATPLOTLIB_VERSION: '2.1.1'
+        SCIKIT_IMAGE_VERSION: '*'
+        # latest version of joblib available in conda for Python 3.6
+        JOBLIB_VERSION: '0.13.2'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        PYTEST_XDIST: 'false'
+        COVERAGE: 'true'
       # Linux environment to test the latest available dependencies and MKL.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:
@@ -131,52 +131,52 @@ jobs:
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
 
-# - template: build_tools/azure/posix-32.yml
-#   parameters:
-#     name: Linux32
-#     vmImage: ubuntu-18.04
-#     dependsOn: [linting]
-#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-#     matrix:
-#       py36_ubuntu_atlas_32bit:
-#         DISTRIB: 'ubuntu-32'
-#         PYTHON_VERSION: '3.6'
-#         JOBLIB_VERSION: '0.13'
-#         THREADPOOLCTL_VERSION: '2.0.0'
+- template: build_tools/azure/posix-32.yml
+  parameters:
+    name: Linux32
+    vmImage: ubuntu-18.04
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      py36_ubuntu_atlas_32bit:
+        DISTRIB: 'ubuntu-32'
+        PYTHON_VERSION: '3.6'
+        JOBLIB_VERSION: '0.13'
+        THREADPOOLCTL_VERSION: '2.0.0'
 
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: macOS
-#     vmImage: macOS-10.14
-#     dependsOn: [linting]
-#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-#     matrix:
-#       pylatest_conda_mkl:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#       pylatest_conda_mkl_no_openmp:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#         SKLEARN_TEST_NO_OPENMP: 'true'
-#         SKLEARN_SKIP_OPENMP_TEST: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: macOS
+    vmImage: macOS-10.14
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      pylatest_conda_mkl:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+      pylatest_conda_mkl_no_openmp:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+        SKLEARN_TEST_NO_OPENMP: 'true'
+        SKLEARN_SKIP_OPENMP_TEST: 'true'
 
 - template: build_tools/azure/windows.yml
   parameters:
@@ -191,6 +191,6 @@ jobs:
         PYTHON_ARCH: '64'
         PYTEST_VERSION: '*'
         COVERAGE: 'true'
-      # py36_pip_openblas_32bit:
-      #   PYTHON_VERSION: '3.6'
-      #   PYTHON_ARCH: '32'
+      py36_pip_openblas_32bit:
+        PYTHON_VERSION: '3.6'
+        PYTHON_ARCH: '32'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,69 +67,69 @@ jobs:
         SKLEARN_SKIP_NETWORK_TESTS: '0'
 
 # Will run all the time regardless of linting outcome.
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: Linux_Runs
-#     vmImage: ubuntu-18.04
-#     matrix:
-#       pylatest_conda_mkl:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-
 - template: build_tools/azure/posix.yml
   parameters:
-    name: Linux
+    name: Linux_Runs
     vmImage: ubuntu-18.04
-    dependsOn: [linting]
-    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
     matrix:
-      # Linux environment to test that scikit-learn can be built against
-      # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
-      # i.e. numpy 1.13.3 and scipy 0.19
-      # py36_ubuntu_atlas:
-      #   DISTRIB: 'ubuntu'
-      #   PYTHON_VERSION: '3.6'
-      #   JOBLIB_VERSION: '0.11'
-      #   PYTEST_XDIST: 'false'
-      #   THREADPOOLCTL_VERSION: '2.0.0'
-      # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
-      # py36_conda_openblas:
-      #   DISTRIB: 'conda'
-      #   PYTHON_VERSION: '3.6'
-      #   BLAS: 'openblas'
-      #   NUMPY_VERSION: '1.13.3'
-      #   SCIPY_VERSION: '0.19.1'
-      #   PANDAS_VERSION: '*'
-      #   CYTHON_VERSION: '*'
-      #   # temporary pin pytest due to unknown failure with pytest 5.3
-      #   PYTEST_VERSION: '5.2'
-      #   PILLOW_VERSION: '4.2.1'
-      #   MATPLOTLIB_VERSION: '2.1.1'
-      #   SCIKIT_IMAGE_VERSION: '*'
-      #   # latest version of joblib available in conda for Python 3.6
-      #   JOBLIB_VERSION: '0.13.2'
-      #   THREADPOOLCTL_VERSION: '2.0.0'
-      #   PYTEST_XDIST: 'false'
-      #   COVERAGE: 'true'
-      # Linux environment to test the latest available dependencies and MKL.
-      # It runs tests requiring lightgbm, pandas and PyAMG.
-      # pylatest_pip_openblas_pandas:
-      #   DISTRIB: 'conda-pip-latest'
-      #   PYTHON_VERSION: '3.8'
-      #   PYTEST_VERSION: '4.6.2'
-      #   COVERAGE: 'true'
-      #   CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-      #   TEST_DOCSTRINGS: 'true'
-      #   CHECK_WARNINGS: 'true'
+      pylatest_conda_mkl:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: Linux
+#     vmImage: ubuntu-18.04
+#     dependsOn: [linting]
+#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+#     matrix:
+#       # Linux environment to test that scikit-learn can be built against
+#       # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
+#       # i.e. numpy 1.13.3 and scipy 0.19
+#       py36_ubuntu_atlas:
+#         DISTRIB: 'ubuntu'
+#         PYTHON_VERSION: '3.6'
+#         JOBLIB_VERSION: '0.11'
+#         PYTEST_XDIST: 'false'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#       # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
+#       py36_conda_openblas:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '3.6'
+#         BLAS: 'openblas'
+#         NUMPY_VERSION: '1.13.3'
+#         SCIPY_VERSION: '0.19.1'
+#         PANDAS_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         # temporary pin pytest due to unknown failure with pytest 5.3
+#         PYTEST_VERSION: '5.2'
+#         PILLOW_VERSION: '4.2.1'
+#         MATPLOTLIB_VERSION: '2.1.1'
+#         SCIKIT_IMAGE_VERSION: '*'
+#         # latest version of joblib available in conda for Python 3.6
+#         JOBLIB_VERSION: '0.13.2'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         PYTEST_XDIST: 'false'
+#         COVERAGE: 'true'
+#       # Linux environment to test the latest available dependencies and MKL.
+#       # It runs tests requiring lightgbm, pandas and PyAMG.
+#       pylatest_pip_openblas_pandas:
+#         DISTRIB: 'conda-pip-latest'
+#         PYTHON_VERSION: '3.8'
+#         PYTEST_VERSION: '4.6.2'
+#         COVERAGE: 'true'
+#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+#         TEST_DOCSTRINGS: 'true'
+#         CHECK_WARNINGS: 'true'
 
 # - template: build_tools/azure/posix-32.yml
 #   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,23 +67,23 @@ jobs:
         SKLEARN_SKIP_NETWORK_TESTS: '0'
 
 # Will run all the time regardless of linting outcome.
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: Linux_Runs
-    vmImage: ubuntu-18.04
-    matrix:
-      pylatest_conda_mkl:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: Linux_Runs
+#     vmImage: ubuntu-18.04
+#     matrix:
+#       pylatest_conda_mkl:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
 
 - template: build_tools/azure/posix.yml
   parameters:
@@ -95,88 +95,88 @@ jobs:
       # Linux environment to test that scikit-learn can be built against
       # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
       # i.e. numpy 1.13.3 and scipy 0.19
-      py36_ubuntu_atlas:
-        DISTRIB: 'ubuntu'
-        PYTHON_VERSION: '3.6'
-        JOBLIB_VERSION: '0.11'
-        PYTEST_XDIST: 'false'
-        THREADPOOLCTL_VERSION: '2.0.0'
+      # py36_ubuntu_atlas:
+      #   DISTRIB: 'ubuntu'
+      #   PYTHON_VERSION: '3.6'
+      #   JOBLIB_VERSION: '0.11'
+      #   PYTEST_XDIST: 'false'
+      #   THREADPOOLCTL_VERSION: '2.0.0'
       # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
-      py36_conda_openblas:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '3.6'
-        BLAS: 'openblas'
-        NUMPY_VERSION: '1.13.3'
-        SCIPY_VERSION: '0.19.1'
-        PANDAS_VERSION: '*'
-        CYTHON_VERSION: '*'
-        # temporary pin pytest due to unknown failure with pytest 5.3
-        PYTEST_VERSION: '5.2'
-        PILLOW_VERSION: '4.2.1'
-        MATPLOTLIB_VERSION: '2.1.1'
-        SCIKIT_IMAGE_VERSION: '*'
-        # latest version of joblib available in conda for Python 3.6
-        JOBLIB_VERSION: '0.13.2'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        PYTEST_XDIST: 'false'
-        COVERAGE: 'true'
+      # py36_conda_openblas:
+      #   DISTRIB: 'conda'
+      #   PYTHON_VERSION: '3.6'
+      #   BLAS: 'openblas'
+      #   NUMPY_VERSION: '1.13.3'
+      #   SCIPY_VERSION: '0.19.1'
+      #   PANDAS_VERSION: '*'
+      #   CYTHON_VERSION: '*'
+      #   # temporary pin pytest due to unknown failure with pytest 5.3
+      #   PYTEST_VERSION: '5.2'
+      #   PILLOW_VERSION: '4.2.1'
+      #   MATPLOTLIB_VERSION: '2.1.1'
+      #   SCIKIT_IMAGE_VERSION: '*'
+      #   # latest version of joblib available in conda for Python 3.6
+      #   JOBLIB_VERSION: '0.13.2'
+      #   THREADPOOLCTL_VERSION: '2.0.0'
+      #   PYTEST_XDIST: 'false'
+      #   COVERAGE: 'true'
       # Linux environment to test the latest available dependencies and MKL.
       # It runs tests requiring lightgbm, pandas and PyAMG.
-      pylatest_pip_openblas_pandas:
-        DISTRIB: 'conda-pip-latest'
-        PYTHON_VERSION: '3.8'
-        PYTEST_VERSION: '4.6.2'
-        COVERAGE: 'true'
-        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        TEST_DOCSTRINGS: 'true'
-        CHECK_WARNINGS: 'true'
+      # pylatest_pip_openblas_pandas:
+      #   DISTRIB: 'conda-pip-latest'
+      #   PYTHON_VERSION: '3.8'
+      #   PYTEST_VERSION: '4.6.2'
+      #   COVERAGE: 'true'
+      #   CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+      #   TEST_DOCSTRINGS: 'true'
+      #   CHECK_WARNINGS: 'true'
 
-- template: build_tools/azure/posix-32.yml
-  parameters:
-    name: Linux32
-    vmImage: ubuntu-18.04
-    dependsOn: [linting]
-    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-    matrix:
-      py36_ubuntu_atlas_32bit:
-        DISTRIB: 'ubuntu-32'
-        PYTHON_VERSION: '3.6'
-        JOBLIB_VERSION: '0.13'
-        THREADPOOLCTL_VERSION: '2.0.0'
+# - template: build_tools/azure/posix-32.yml
+#   parameters:
+#     name: Linux32
+#     vmImage: ubuntu-18.04
+#     dependsOn: [linting]
+#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+#     matrix:
+#       py36_ubuntu_atlas_32bit:
+#         DISTRIB: 'ubuntu-32'
+#         PYTHON_VERSION: '3.6'
+#         JOBLIB_VERSION: '0.13'
+#         THREADPOOLCTL_VERSION: '2.0.0'
 
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: macOS
-    vmImage: macOS-10.14
-    dependsOn: [linting]
-    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-    matrix:
-      pylatest_conda_mkl:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-      pylatest_conda_mkl_no_openmp:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-        SKLEARN_TEST_NO_OPENMP: 'true'
-        SKLEARN_SKIP_OPENMP_TEST: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: macOS
+#     vmImage: macOS-10.14
+#     dependsOn: [linting]
+#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+#     matrix:
+#       pylatest_conda_mkl:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#       pylatest_conda_mkl_no_openmp:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#         SKLEARN_TEST_NO_OPENMP: 'true'
+#         SKLEARN_SKIP_OPENMP_TEST: 'true'
 
 - template: build_tools/azure/windows.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,23 +67,23 @@ jobs:
         SKLEARN_SKIP_NETWORK_TESTS: '0'
 
 # Will run all the time regardless of linting outcome.
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: Linux_Runs
-#     vmImage: ubuntu-18.04
-#     matrix:
-#       pylatest_conda_mkl:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: Linux_Runs
+    vmImage: ubuntu-18.04
+    matrix:
+      pylatest_conda_mkl:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
 
 - template: build_tools/azure/posix.yml
   parameters:
@@ -95,31 +95,31 @@ jobs:
       # Linux environment to test that scikit-learn can be built against
       # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
       # i.e. numpy 1.13.3 and scipy 0.19
-      # py36_ubuntu_atlas:
-      #   DISTRIB: 'ubuntu'
-      #   PYTHON_VERSION: '3.6'
-      #   JOBLIB_VERSION: '0.11'
-      #   PYTEST_XDIST: 'false'
-      #   THREADPOOLCTL_VERSION: '2.0.0'
-      # # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
-      # py36_conda_openblas:
-      #   DISTRIB: 'conda'
-      #   PYTHON_VERSION: '3.6'
-      #   BLAS: 'openblas'
-      #   NUMPY_VERSION: '1.13.3'
-      #   SCIPY_VERSION: '0.19.1'
-      #   PANDAS_VERSION: '*'
-      #   CYTHON_VERSION: '*'
-      #   # temporary pin pytest due to unknown failure with pytest 5.3
-      #   PYTEST_VERSION: '5.2'
-      #   PILLOW_VERSION: '4.2.1'
-      #   MATPLOTLIB_VERSION: '2.1.1'
-      #   SCIKIT_IMAGE_VERSION: '*'
-      #   # latest version of joblib available in conda for Python 3.6
-      #   JOBLIB_VERSION: '0.13.2'
-      #   THREADPOOLCTL_VERSION: '2.0.0'
-      #   PYTEST_XDIST: 'false'
-      #   COVERAGE: 'true'
+      py36_ubuntu_atlas:
+        DISTRIB: 'ubuntu'
+        PYTHON_VERSION: '3.6'
+        JOBLIB_VERSION: '0.11'
+        PYTEST_XDIST: 'false'
+        THREADPOOLCTL_VERSION: '2.0.0'
+      # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
+      py36_conda_openblas:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '3.6'
+        BLAS: 'openblas'
+        NUMPY_VERSION: '1.13.3'
+        SCIPY_VERSION: '0.19.1'
+        PANDAS_VERSION: '*'
+        CYTHON_VERSION: '*'
+        # temporary pin pytest due to unknown failure with pytest 5.3
+        PYTEST_VERSION: '5.2'
+        PILLOW_VERSION: '4.2.1'
+        MATPLOTLIB_VERSION: '2.1.1'
+        SCIKIT_IMAGE_VERSION: '*'
+        # latest version of joblib available in conda for Python 3.6
+        JOBLIB_VERSION: '0.13.2'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        PYTEST_XDIST: 'false'
+        COVERAGE: 'true'
       # Linux environment to test the latest available dependencies and MKL.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:
@@ -131,52 +131,52 @@ jobs:
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
 
-# - template: build_tools/azure/posix-32.yml
-#   parameters:
-#     name: Linux32
-#     vmImage: ubuntu-18.04
-#     dependsOn: [linting]
-#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-#     matrix:
-#       py36_ubuntu_atlas_32bit:
-#         DISTRIB: 'ubuntu-32'
-#         PYTHON_VERSION: '3.6'
-#         JOBLIB_VERSION: '0.13'
-#         THREADPOOLCTL_VERSION: '2.0.0'
+- template: build_tools/azure/posix-32.yml
+  parameters:
+    name: Linux32
+    vmImage: ubuntu-18.04
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      py36_ubuntu_atlas_32bit:
+        DISTRIB: 'ubuntu-32'
+        PYTHON_VERSION: '3.6'
+        JOBLIB_VERSION: '0.13'
+        THREADPOOLCTL_VERSION: '2.0.0'
 
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: macOS
-#     vmImage: macOS-10.14
-#     dependsOn: [linting]
-#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-#     matrix:
-#       pylatest_conda_mkl:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#       pylatest_conda_mkl_no_openmp:
-#         DISTRIB: 'conda'
-#         PYTHON_VERSION: '*'
-#         BLAS: 'mkl'
-#         NUMPY_VERSION: '*'
-#         SCIPY_VERSION: '*'
-#         CYTHON_VERSION: '*'
-#         PILLOW_VERSION: '*'
-#         PYTEST_VERSION: '*'
-#         JOBLIB_VERSION: '*'
-#         THREADPOOLCTL_VERSION: '2.0.0'
-#         COVERAGE: 'true'
-#         SKLEARN_TEST_NO_OPENMP: 'true'
-#         SKLEARN_SKIP_OPENMP_TEST: 'true'
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: macOS
+    vmImage: macOS-10.14
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
+      pylatest_conda_mkl:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+      pylatest_conda_mkl_no_openmp:
+        DISTRIB: 'conda'
+        PYTHON_VERSION: '*'
+        BLAS: 'mkl'
+        NUMPY_VERSION: '*'
+        SCIPY_VERSION: '*'
+        CYTHON_VERSION: '*'
+        PILLOW_VERSION: '*'
+        PYTEST_VERSION: '*'
+        JOBLIB_VERSION: '*'
+        THREADPOOLCTL_VERSION: '2.0.0'
+        COVERAGE: 'true'
+        SKLEARN_TEST_NO_OPENMP: 'true'
+        SKLEARN_SKIP_OPENMP_TEST: 'true'
 
 - template: build_tools/azure/windows.yml
   parameters:
@@ -191,6 +191,6 @@ jobs:
         PYTHON_ARCH: '64'
         PYTEST_VERSION: '*'
         COVERAGE: 'true'
-      # py36_pip_openblas_32bit:
-      #   PYTHON_VERSION: '3.6'
-      #   PYTHON_ARCH: '32'
+      py36_pip_openblas_32bit:
+        PYTHON_VERSION: '3.6'
+        PYTHON_ARCH: '32'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,23 +67,23 @@ jobs:
         SKLEARN_SKIP_NETWORK_TESTS: '0'
 
 # Will run all the time regardless of linting outcome.
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: Linux_Runs
-    vmImage: ubuntu-18.04
-    matrix:
-      pylatest_conda_mkl:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: Linux_Runs
+#     vmImage: ubuntu-18.04
+#     matrix:
+#       pylatest_conda_mkl:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
 
 - template: build_tools/azure/posix.yml
   parameters:
@@ -95,31 +95,31 @@ jobs:
       # Linux environment to test that scikit-learn can be built against
       # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
       # i.e. numpy 1.13.3 and scipy 0.19
-      py36_ubuntu_atlas:
-        DISTRIB: 'ubuntu'
-        PYTHON_VERSION: '3.6'
-        JOBLIB_VERSION: '0.11'
-        PYTEST_XDIST: 'false'
-        THREADPOOLCTL_VERSION: '2.0.0'
-      # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
-      py36_conda_openblas:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '3.6'
-        BLAS: 'openblas'
-        NUMPY_VERSION: '1.13.3'
-        SCIPY_VERSION: '0.19.1'
-        PANDAS_VERSION: '*'
-        CYTHON_VERSION: '*'
-        # temporary pin pytest due to unknown failure with pytest 5.3
-        PYTEST_VERSION: '5.2'
-        PILLOW_VERSION: '4.2.1'
-        MATPLOTLIB_VERSION: '2.1.1'
-        SCIKIT_IMAGE_VERSION: '*'
-        # latest version of joblib available in conda for Python 3.6
-        JOBLIB_VERSION: '0.13.2'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        PYTEST_XDIST: 'false'
-        COVERAGE: 'true'
+      # py36_ubuntu_atlas:
+      #   DISTRIB: 'ubuntu'
+      #   PYTHON_VERSION: '3.6'
+      #   JOBLIB_VERSION: '0.11'
+      #   PYTEST_XDIST: 'false'
+      #   THREADPOOLCTL_VERSION: '2.0.0'
+      # # Linux + Python 3.6 build with OpenBLAS and without SITE_JOBLIB
+      # py36_conda_openblas:
+      #   DISTRIB: 'conda'
+      #   PYTHON_VERSION: '3.6'
+      #   BLAS: 'openblas'
+      #   NUMPY_VERSION: '1.13.3'
+      #   SCIPY_VERSION: '0.19.1'
+      #   PANDAS_VERSION: '*'
+      #   CYTHON_VERSION: '*'
+      #   # temporary pin pytest due to unknown failure with pytest 5.3
+      #   PYTEST_VERSION: '5.2'
+      #   PILLOW_VERSION: '4.2.1'
+      #   MATPLOTLIB_VERSION: '2.1.1'
+      #   SCIKIT_IMAGE_VERSION: '*'
+      #   # latest version of joblib available in conda for Python 3.6
+      #   JOBLIB_VERSION: '0.13.2'
+      #   THREADPOOLCTL_VERSION: '2.0.0'
+      #   PYTEST_XDIST: 'false'
+      #   COVERAGE: 'true'
       # Linux environment to test the latest available dependencies and MKL.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:
@@ -131,52 +131,52 @@ jobs:
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
 
-- template: build_tools/azure/posix-32.yml
-  parameters:
-    name: Linux32
-    vmImage: ubuntu-18.04
-    dependsOn: [linting]
-    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-    matrix:
-      py36_ubuntu_atlas_32bit:
-        DISTRIB: 'ubuntu-32'
-        PYTHON_VERSION: '3.6'
-        JOBLIB_VERSION: '0.13'
-        THREADPOOLCTL_VERSION: '2.0.0'
+# - template: build_tools/azure/posix-32.yml
+#   parameters:
+#     name: Linux32
+#     vmImage: ubuntu-18.04
+#     dependsOn: [linting]
+#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+#     matrix:
+#       py36_ubuntu_atlas_32bit:
+#         DISTRIB: 'ubuntu-32'
+#         PYTHON_VERSION: '3.6'
+#         JOBLIB_VERSION: '0.13'
+#         THREADPOOLCTL_VERSION: '2.0.0'
 
-- template: build_tools/azure/posix.yml
-  parameters:
-    name: macOS
-    vmImage: macOS-10.14
-    dependsOn: [linting]
-    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-    matrix:
-      pylatest_conda_mkl:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-      pylatest_conda_mkl_no_openmp:
-        DISTRIB: 'conda'
-        PYTHON_VERSION: '*'
-        BLAS: 'mkl'
-        NUMPY_VERSION: '*'
-        SCIPY_VERSION: '*'
-        CYTHON_VERSION: '*'
-        PILLOW_VERSION: '*'
-        PYTEST_VERSION: '*'
-        JOBLIB_VERSION: '*'
-        THREADPOOLCTL_VERSION: '2.0.0'
-        COVERAGE: 'true'
-        SKLEARN_TEST_NO_OPENMP: 'true'
-        SKLEARN_SKIP_OPENMP_TEST: 'true'
+# - template: build_tools/azure/posix.yml
+#   parameters:
+#     name: macOS
+#     vmImage: macOS-10.14
+#     dependsOn: [linting]
+#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+#     matrix:
+#       pylatest_conda_mkl:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#       pylatest_conda_mkl_no_openmp:
+#         DISTRIB: 'conda'
+#         PYTHON_VERSION: '*'
+#         BLAS: 'mkl'
+#         NUMPY_VERSION: '*'
+#         SCIPY_VERSION: '*'
+#         CYTHON_VERSION: '*'
+#         PILLOW_VERSION: '*'
+#         PYTEST_VERSION: '*'
+#         JOBLIB_VERSION: '*'
+#         THREADPOOLCTL_VERSION: '2.0.0'
+#         COVERAGE: 'true'
+#         SKLEARN_TEST_NO_OPENMP: 'true'
+#         SKLEARN_SKIP_OPENMP_TEST: 'true'
 
 - template: build_tools/azure/windows.yml
   parameters:
@@ -191,6 +191,6 @@ jobs:
         PYTHON_ARCH: '64'
         PYTEST_VERSION: '*'
         COVERAGE: 'true'
-      py36_pip_openblas_32bit:
-        PYTHON_VERSION: '3.6'
-        PYTHON_ARCH: '32'
+      # py36_pip_openblas_32bit:
+      #   PYTHON_VERSION: '3.6'
+      #   PYTHON_ARCH: '32'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,13 +85,13 @@ jobs:
         THREADPOOLCTL_VERSION: '2.0.0'
         COVERAGE: 'true'
 
-# - template: build_tools/azure/posix.yml
-#   parameters:
-#     name: Linux
-#     vmImage: ubuntu-18.04
-#     dependsOn: [linting]
-#     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
-#     matrix:
+- template: build_tools/azure/posix.yml
+  parameters:
+    name: Linux
+    vmImage: ubuntu-18.04
+    dependsOn: [linting]
+    condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
+    matrix:
 #       # Linux environment to test that scikit-learn can be built against
 #       # versions of numpy, scipy with ATLAS that comes with Ubuntu Bionic 18.04
 #       # i.e. numpy 1.13.3 and scipy 0.19
@@ -120,16 +120,16 @@ jobs:
 #         THREADPOOLCTL_VERSION: '2.0.0'
 #         PYTEST_XDIST: 'false'
 #         COVERAGE: 'true'
-#       # Linux environment to test the latest available dependencies and MKL.
-#       # It runs tests requiring lightgbm, pandas and PyAMG.
-#       pylatest_pip_openblas_pandas:
-#         DISTRIB: 'conda-pip-latest'
-#         PYTHON_VERSION: '3.8'
-#         PYTEST_VERSION: '4.6.2'
-#         COVERAGE: 'true'
-#         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-#         TEST_DOCSTRINGS: 'true'
-#         CHECK_WARNINGS: 'true'
+      # Linux environment to test the latest available dependencies and MKL.
+      # It runs tests requiring lightgbm, pandas and PyAMG.
+      pylatest_pip_openblas_pandas:
+        DISTRIB: 'conda-pip-latest'
+        PYTHON_VERSION: '3.8'
+        PYTEST_VERSION: '4.6.2'
+        COVERAGE: 'true'
+        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+        TEST_DOCSTRINGS: 'true'
+        CHECK_WARNINGS: 'true'
 
 # - template: build_tools/azure/posix-32.yml
 #   parameters:
@@ -191,6 +191,6 @@ jobs:
         PYTHON_ARCH: '64'
         PYTEST_VERSION: '*'
         COVERAGE: 'true'
-      py36_pip_openblas_32bit:
-        PYTHON_VERSION: '3.6'
-        PYTHON_ARCH: '32'
+      # py36_pip_openblas_32bit:
+      #   PYTHON_VERSION: '3.6'
+      #   PYTHON_ARCH: '32'

--- a/build_tools/azure/test_script.cmd
+++ b/build_tools/azure/test_script.cmd
@@ -14,7 +14,7 @@ if "%PYTEST_XDIST%" == "true" (
 
 if "%CHECK_WARNINGS%" == "true" (
     REM numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning
+    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring() is deprecated:DeprecationWarning
 )
 
 if "%COVERAGE%" == "true" (

--- a/build_tools/azure/test_script.cmd
+++ b/build_tools/azure/test_script.cmd
@@ -14,7 +14,7 @@ if "%PYTEST_XDIST%" == "true" (
 
 if "%CHECK_WARNINGS%" == "true" (
     REM numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring() is deprecated:DeprecationWarning
+    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning
 )
 
 if "%COVERAGE%" == "true" (

--- a/build_tools/azure/test_script.cmd
+++ b/build_tools/azure/test_script.cmd
@@ -13,7 +13,8 @@ if "%PYTEST_XDIST%" == "true" (
 )
 
 if "%CHECK_WARNINGS%" == "true" (
-    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning
+    REM numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
+    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring() is deprecated.:DeprecationWarning
 )
 
 if "%COVERAGE%" == "true" (

--- a/build_tools/azure/test_script.cmd
+++ b/build_tools/azure/test_script.cmd
@@ -14,7 +14,7 @@ if "%PYTEST_XDIST%" == "true" (
 
 if "%CHECK_WARNINGS%" == "true" (
     REM numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning "-Wignore:tostring() is deprecated.:DeprecationWarning"
+    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning
 )
 
 if "%COVERAGE%" == "true" (

--- a/build_tools/azure/test_script.cmd
+++ b/build_tools/azure/test_script.cmd
@@ -14,7 +14,7 @@ if "%PYTEST_XDIST%" == "true" (
 
 if "%CHECK_WARNINGS%" == "true" (
     REM numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning -W"ignore:tostring() is deprecated.:DeprecationWarning"
+    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning "-Wignore:tostring() is deprecated.:DeprecationWarning"
 )
 
 if "%COVERAGE%" == "true" (

--- a/build_tools/azure/test_script.cmd
+++ b/build_tools/azure/test_script.cmd
@@ -14,7 +14,7 @@ if "%PYTEST_XDIST%" == "true" (
 
 if "%CHECK_WARNINGS%" == "true" (
     REM numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring() is deprecated.:DeprecationWarning
+    set PYTEST_ARGS=%PYTEST_ARGS% -Werror::DeprecationWarning -Werror::FutureWarning -W"ignore:tostring() is deprecated.:DeprecationWarning"
 )
 
 if "%COVERAGE%" == "true" (

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then
     # numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring\(\)\ is\ deprecated:DeprecationWarning"
+    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST" == "true" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -29,7 +29,8 @@ if [[ "$COVERAGE" == "true" ]]; then
 fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then
-    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning"
+    # numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
+    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring() is deprecated.:DeprecationWarning:scipy"
 fi
 
 if [[ "$PYTEST_XDIST" == "true" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then
     # numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -W'ignore:tostring() is deprecated.:DeprecationWarning'"
+    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST" == "true" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then
     # numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring() is deprecated.:DeprecationWarning"
+    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -W'ignore:tostring() is deprecated.:DeprecationWarning'"
 fi
 
 if [[ "$PYTEST_XDIST" == "true" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then
     # numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring() is deprecated.:DeprecationWarning:scipy"
+    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring() is deprecated.:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST" == "true" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then
     # numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
-    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
+    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring\(\)\ is\ deprecated:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST" == "true" ]]; then


### PR DESCRIPTION
PRs and master are failing because scipy and joblib are using `tostring` which has been deprecated in numpy 1.19.

This quick patch is to ignore the deprecation warnings the starts with 'tostring'.