### PR TITLE
PERF Discard old layers immediately when making neural net predictions

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -205,9 +205,9 @@ Changelog
 :mod:`sklearn.neural_network`
 .............................
 
-- |Efficiency| Neural net training is now a little faster.
-  :pr:`17603`, :pr:`17604`, :pr:`17606`, :pr:`17608`, :pr:`17609`, :pr:`17633`
-  by :user:`Alex Henrie <alexhenrie>`.
+- |Efficiency| Neural net training and prediction are now a little faster.
+  :pr:`17603`, :pr:`17604`, :pr:`17606`, :pr:`17608`, :pr:`17609`, :pr:`17633`,
+  :pr:`17661` by :user:`Alex Henrie <alexhenrie>`.
 
 - |Enhancement| Avoid converting float32 input to float64 in
   :class:`neural_network.BernoulliRBM`.


### PR DESCRIPTION
This function does not need to hold any layer in memory except the current one, and discarding the previous layers immediately after use makes neural net predictions about 3% faster.

Test program:

```
from sklearn.datasets import load_digits
from sklearn.neural_network import MLPClassifier
from neurtu import delayed, Benchmark

digits = load_digits(return_X_y=True)
X = digits[0][:,:50]
y = digits[0][:,50]

clf = MLPClassifier(solver='lbfgs', alpha=1e-5,
                    hidden_layer_sizes=(50, 20), random_state=1, max_iter=1000)
clf.fit(X, y)

train = delayed(clf).predict([[x for x in range(50)] for y in range(50)])
print(Benchmark(wall_time=True, cpu_time=True, repeat=100)(train))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   0.000455  0.000454
max    0.000466  0.000467
std    0.000002  0.000002
```

After:

```
mean   0.000439  0.000439
max    0.000454  0.000458
std    0.000002  0.000003
```