### PR TITLE
DOC add missing attributes in LatentDirichletAllocation

### DIFF
--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -230,7 +230,7 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
 
     Attributes
     ----------
-    components_ : array, [n_components, n_features]
+    components_ : ndarray of shape (n_components, n_features)
         Variational parameters for topic word distribution. Since the complete
         conditional for topic word distribution is a Dirichlet,
         ``components_[i, j]`` can be viewed as pseudocount that represents the
@@ -239,7 +239,7 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
         after normalization:
         ``model.components_ / model.components_.sum(axis=1)[:, np.newaxis]``.
 
-    exp_dirichlet_component_ : array, [n_components, n_features]
+    exp_dirichlet_component_ : ndarray of shape (n_components, n_features)
         Exponential value of expectation of log topic word distribution.
         In the literature, this is `exp(E[log(beta)])`.
 

--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -259,7 +259,7 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
     random_state_ : RandomState instance
         RandomState instance that is generated either from a seed, the random
         number generator or by `np.random`.
-        
+
     topic_word_prior_ : float
         Prior of topic word distribution `beta`. If the value is None, it is
         `1 / n_components`.

--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -239,6 +239,10 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
         after normalization:
         ``model.components_ / model.components_.sum(axis=1)[:, np.newaxis]``.
 
+    exp_dirichlet_component_ : array, [n_components, n_features]
+        Exponential value of expectation of log topic word distribution.
+        In the literature, this is `exp(E[log(beta)])`.
+
     n_batch_iter_ : int
         Number of iterations of the EM step.
 
@@ -252,6 +256,10 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
         Prior of document topic distribution `theta`. If the value is None,
         it is `1 / n_components`.
 
+    random_state_ : RandomState instance
+        RandomState instance that is generated either from a seed, the random
+        number generator or by `np.random`.
+        
     topic_word_prior_ : float
         Prior of topic word distribution `beta`. If the value is None, it is
         `1 / n_components`.

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -234,7 +234,7 @@ def test_fit_docstring_attributes(name, Estimator):
                'HistGradientBoostingRegressor', 'IsolationForest',
                'KernelCenterer', 'KernelDensity',
                'LarsCV', 'Lasso', 'LassoLarsCV', 'LassoLarsIC',
-               'LatentDirichletAllocation', 'LocalOutlierFactor', 'MDS',
+               'LocalOutlierFactor', 'MDS',
                'MiniBatchKMeans', 'MLPClassifier', 'MLPRegressor',
                'MultiTaskElasticNet', 'MultiTaskElasticNetCV',
                'MultiTaskLasso', 'MultiTaskLassoCV',


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes part of #14312 for LatentDirichletAllocation estimator.

#### What does this implement/fix? Explain your changes.
Added documentation of two missing attributes in LatentDirichletAllocation class: `exp_dirichlet_component_` and `random_state_`.
Removed class name from list in `test_docstring_parameters.py`.
