### PR TITLE
DOC add missing attributes in RBFSampler

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -47,9 +47,6 @@ class RBFSampler(TransformerMixin, BaseEstimator):
 
     Attributes
     ----------
-    n_features_in_: int,
-        Number of input features, set to `X.shape[1]`.
-
     random_offset_ : ndarray of shape (n_components,), dtype=float64
         Random offset used to compute the projection in the `n_components`
         dimensions of the feature space.

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -47,6 +47,9 @@ class RBFSampler(TransformerMixin, BaseEstimator):
 
     Attributes
     ----------
+    n_features_in_: int,
+        Number of input features, set to `X.shape[1]`.
+
     random_offset_ : ndarray of shape (n_components,), dtype=float64
         Random offset used to compute the projection in the `n_components`
         dimensions of the feature space.

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -240,7 +240,7 @@ def test_fit_docstring_attributes(name, Estimator):
                'MultiTaskLasso', 'MultiTaskLassoCV',
                'OrthogonalMatchingPursuit',
                'PLSCanonical', 'PLSRegression', 'PLSSVD',
-               'PassiveAggressiveClassifier', 'RBFSampler'}
+               'PassiveAggressiveClassifier'}
     if Estimator.__name__ in IGNORED:
         pytest.xfail(
             reason="Estimator has too many undocumented attributes.")


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes part of #14312 for RBFSampler estimator.

#### What does this implement/fix? Explain your changes.

`RBFSampler` removed from the list of estimators in test_docstring_parameters.py, as all attributes look documented.
`pytest -v sklearn/tests/test_docstring_parameters.py` marks a failure for `RBFSampler`, but when running `pytest -v --runxfail -k RBFSampler sklearn/tests/test_docstring_parameters.py`, the test is actually successful.

