### PR TITLE
DOC add missing attributes in GradientBoostingRegressor

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1494,6 +1494,16 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, 1)
         The collection of fitted sub-estimators.
 
+    n_classes_ : int
+        The number of classes, set to 1 in regression tasks.
+
+    n_estimators_ : int
+        The number of estimators as selected by early stopping (if
+        ``n_iter_no_change`` is specified). Otherwise it is set to
+        ``n_estimators``.
+
+        .. versionadded:: 0.20
+
     n_features_ : int
         The number of data features.
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1502,8 +1502,6 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         ``n_iter_no_change`` is specified). Otherwise it is set to
         ``n_estimators``.
 
-        .. versionadded:: 0.20
-
     n_features_ : int
         The number of data features.
 

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -230,7 +230,7 @@ def test_fit_docstring_attributes(name, Estimator):
 
     IGNORED = {'BayesianRidge', 'Birch', 'CCA', 'CategoricalNB', 'ElasticNet',
                'ElasticNetCV', 'GaussianProcessClassifier',
-               'GradientBoostingRegressor', 'HistGradientBoostingClassifier',
+               'HistGradientBoostingClassifier',
                'HistGradientBoostingRegressor', 'IsolationForest',
                'KernelCenterer', 'KernelDensity',
                'LarsCV', 'Lasso', 'LassoLarsCV', 'LassoLarsIC',


### PR DESCRIPTION
Fixes part of #14312 for GradientBoostingRegressor estimator.

Added `n_classes_` and `n_estimators_` to docstring in `GradientBoostingRegressor`.
`GradientBoostingRegressor` removed from the list of estimators in `test_docstring_parameters.py`.