### PR TITLE
MNT Fetch numpy and scipy nightly wheels from anaconda

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -104,7 +104,7 @@ elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     echo "Installing numpy and scipy master wheels"
     dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
     pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-    # Cython nightly build should be still fetch from the rackspace container
+    # Cython nightly build should be still fetch from the Rackspace container
     dev_rackspace_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
     pip install --pre --upgrade --timeout=60 -f $dev_rackspace_url cython
     echo "Installing joblib master"

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -104,7 +104,7 @@ elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     echo "Installing numpy and scipy master wheels"
     dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
     pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-    # Cython nightly build should be still fetch from the Rackspace container
+    # Cython nightly build should be still fetched from the Rackspace container
     dev_rackspace_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
     pip install --pre --upgrade --timeout=60 -f $dev_rackspace_url cython
     echo "Installing joblib master"

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -102,8 +102,11 @@ elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     python -m pip install -U pip
     python -m pip install pytest==$PYTEST_VERSION pytest-cov
     echo "Installing numpy and scipy master wheels"
-    dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
-    pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy pandas cython
+    dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
+    # Cython nightly build should be still fetch from the rackspace container
+    dev_rackspace_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
+    pip install --pre --upgrade --timeout=60 -f $dev_rackspace_url cython
     echo "Installing joblib master"
     pip install https://github.com/joblib/joblib/archive/master.zip
     echo "Installing pillow master"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,7 +48,7 @@ pip install --upgrade pip setuptools
 echo "Installing numpy and scipy master wheels"
 dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
 pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-# Cython nightly build should be still fetch from the rackspace container
+# Cython nightly build should be still fetch from the Rackspace container
 dev_rackspace_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
 pip install --pre --upgrade --timeout=60 -f $dev_rackspace_url cython
 echo "Installing joblib master"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -48,7 +48,7 @@ pip install --upgrade pip setuptools
 echo "Installing numpy and scipy master wheels"
 dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
 pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-# Cython nightly build should be still fetch from the Rackspace container
+# Cython nightly build should be still fetched from the Rackspace container
 dev_rackspace_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
 pip install --pre --upgrade --timeout=60 -f $dev_rackspace_url cython
 echo "Installing joblib master"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -46,8 +46,11 @@ source activate testenv
 
 pip install --upgrade pip setuptools
 echo "Installing numpy and scipy master wheels"
-dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
-pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy pandas cython
+dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
+pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
+# Cython nightly build should be still fetch from the rackspace container
+dev_rackspace_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
+pip install --pre --upgrade --timeout=60 -f $dev_rackspace_url cython
 echo "Installing joblib master"
 pip install https://github.com/joblib/joblib/archive/master.zip
 echo "Installing pillow master"


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #16413.

#### What does this implement/fix? Explain your changes.

This PR updates the CRON job to fetch the nightly wheels of `numpy` and `scipy` from Anaconda instead of the Rackspace container.

#### Any other comments?

Cython should be still fetched from the Rackspace container.