### PR TITLE
BUILD Make sure PKG-INFO contains Requires-Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ import os
 import platform
 import shutil
 from distutils.command.clean import clean as Clean
+from distutils.command.sdist import sdist
 from pkg_resources import parse_version
 import traceback
 import importlib
@@ -132,7 +133,7 @@ class CleanCommand(Clean):
                     shutil.rmtree(os.path.join(dirpath, dirname))
 
 
-cmdclass = {'clean': CleanCommand}
+cmdclass = {'clean': CleanCommand, 'sdist': sdist}
 
 # custom build_ext command to set OpenMP compile flags depending on os and
 # compiler
@@ -310,6 +311,7 @@ def setup_package():
 
         check_package_status('scipy', SCIPY_MIN_VERSION)
 
+        import setuptools  # noqa
         from numpy.distutils.core import setup
 
         metadata['configuration'] = configuration

--- a/setup.py
+++ b/setup.py
@@ -294,10 +294,7 @@ def setup_package():
         # They are required to succeed without Numpy for example when
         # pip is used to install Scikit-learn when Numpy is not yet present in
         # the system.
-        try:
-            from setuptools import setup
-        except ImportError:
-            from distutils.core import setup
+        from setuptools import setup
 
         metadata['version'] = VERSION
     else:


### PR DESCRIPTION
Fixes #17663 

In #13861 we added `python_requires` to the setup metadata but it does not show up in the PKG-INFO when we make the sdist.

Importing setuptools first fixes it because it does some monkeypatching. I took inspiration from what numpy does [https://github.com/numpy/numpy/blob/master/setup.py#L474](https://github.com/numpy/numpy/blob/master/setup.py#L474)

I checked the difference of the sdist generated without and with this PR and the only diff is in PKG-INFO:
```
$ diff -r dist dist2
diff -r dist/scikit-learn-0.24.dev0/PKG-INFO dist2/scikit-learn-0.24.dev0/PKG-INFO
1c1
< Metadata-Version: 1.1
---
> Metadata-Version: 1.2
6,7c6,7
< Author: Andreas Mueller
< Author-email: amueller@ais.uni-bonn.de
---
> Maintainer: Andreas Mueller
> Maintainer-email: amueller@ais.uni-bonn.de
9a10,12
> Project-URL: Bug Tracker, https://github.com/scikit-learn/scikit-learn/issues
> Project-URL: Documentation, https://scikit-learn.org/stable/documentation.html
> Project-URL: Source Code, https://github.com/scikit-learn/scikit-learn
199a203
> Requires-Python: >=3.6
```

I've seen that we import setuptools conditionnaly somewhere else. Isn't it safe to assume setuptools is installed ?