### PR TITLE
TST Skip test_common_check_return_X_y if pillow not installed

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -50,8 +50,8 @@ dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.ra
 pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy pandas cython
 echo "Installing joblib master"
 pip install https://github.com/joblib/joblib/archive/master.zip
-echo "Installing pillow master"
-pip install https://github.com/python-pillow/Pillow/archive/master.zip
+# echo "Installing pillow master"
+# pip install https://github.com/python-pillow/Pillow/archive/master.zip
 pip install pytest==4.6.4 pytest-cov
 
 # Build scikit-learn in the install.sh script to collapse the verbose

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -50,8 +50,8 @@ dev_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.ra
 pip install --pre --upgrade --timeout=60 -f $dev_url numpy scipy pandas cython
 echo "Installing joblib master"
 pip install https://github.com/joblib/joblib/archive/master.zip
-# echo "Installing pillow master"
-# pip install https://github.com/python-pillow/Pillow/archive/master.zip
+echo "Installing pillow master"
+pip install https://github.com/python-pillow/Pillow/archive/master.zip
 pip install pytest==4.6.4 pytest-cov
 
 # Build scikit-learn in the install.sh script to collapse the verbose

--- a/sklearn/datasets/tests/test_common.py
+++ b/sklearn/datasets/tests/test_common.py
@@ -8,7 +8,15 @@ import numpy as np
 import sklearn.datasets
 
 
-FETCH_MARKERS = {
+def is_pillow_installed():
+    try:
+        import PIL  # noqa
+        return True
+    except ImportError:
+        return False
+
+
+FETCH_PYTEST_MARKERS = {
     "return_X_y": {
         "fetch_20newsgroups": pytest.mark.xfail(
             reason="X is a list and does not have a shape argument"
@@ -70,14 +78,6 @@ def check_as_frame(bunch, dataset_func,
 
 def _has_network():
     return bool(os.environ.get("SKLEARN_SKIP_NETWORK_TESTS", False))
-
-
-def is_pillow_installed():
-    try:
-        import PIL  # noqa
-        return True
-    except ImportError:
-        return False
 
 
 def _generate_func_supporting_param(param, dataset_type=("load", "fetch")):

--- a/sklearn/datasets/tests/test_common.py
+++ b/sklearn/datasets/tests/test_common.py
@@ -87,6 +87,7 @@ def _generate_func_supporting_param(param, dataset_type=("load", "fetch")):
             yield pytest.param(name, obj, marks=marks)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "name, dataset_func", _generate_func_supporting_param("return_X_y")
 )

--- a/sklearn/datasets/tests/test_common.py
+++ b/sklearn/datasets/tests/test_common.py
@@ -81,7 +81,7 @@ def _has_network():
 
 
 def _generate_func_supporting_param(param, dataset_type=("load", "fetch")):
-    markers_fetch = FETCH_MARKERS.get(param, {})
+    markers_fetch = FETCH_PYTEST_MARKERS.get(param, {})
     for name, obj in inspect.getmembers(sklearn.datasets):
         if not inspect.isfunction(obj):
             continue

--- a/sklearn/datasets/tests/test_common.py
+++ b/sklearn/datasets/tests/test_common.py
@@ -16,6 +16,9 @@ KNOWN_FAILURE = {
         "fetch_openml": pytest.mark.xfail(
             reason="fetch_opeml requires a dataset name or id"
         ),
+        "fetch_lfw_people": pytest.mark.xfail(
+            reason="fetch_lfw_people can fail if pillow is not installed"
+        )
     },
     "as_frame": {
         "fetch_openml": pytest.mark.xfail(
@@ -87,7 +90,6 @@ def _generate_func_supporting_param(param, dataset_type=("load", "fetch")):
             yield pytest.param(name, obj, marks=marks)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "name, dataset_func", _generate_func_supporting_param("return_X_y")
 )


### PR DESCRIPTION
#### Reference Issues/PRs

Close #17680.

#### What does this implement/fix? Explain your changes.

This PR skip the `sklearn/datasets/tests/test_common.py::test_common_check_return_X_y[fetch_lfw_people-fetch_lfw_people]` test if `Pillow` is not installed.

#### Any other comments?

After merging this PR, the wheel builder should pass the tests and upload the wheels to the Anaconda index. 