### PR TITLE
DOC add missing attributes in GaussianProcessClassifier (#14312)

### DIFF
--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -555,7 +555,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     Attributes
     ----------
-    base_estimator_ : ``_BinaryGaussianProcessClassifierLaplace``
+    base_estimator_ : ``Estimator``
         The estimator template that defines the likelihood function
         using the observed data.
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -556,7 +556,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
     Attributes
     ----------
     base_estimator_ : ``_BinaryGaussianProcessClassifierLaplace``
-        The estimator template that defines the likelihood function
+        The estimator instance that defines the likelihood function
         using the observed data.
 
     kernel_ : kernel instance

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -555,6 +555,10 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     Attributes
     ----------
+    base_estimator_ : ``_BinaryGaussianProcessClassifierLaplace``
+        The estimator template that defines the likelihood function
+        using the observed data.
+
     kernel_ : kernel instance
         The kernel used for prediction. In case of binary classification,
         the structure of the kernel is the same as the one passed as parameter

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -555,7 +555,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     Attributes
     ----------
-    base_estimator_ : ``Estimator``
+    base_estimator_ : ``_BinaryGaussianProcessClassifierLaplace``
         The estimator template that defines the likelihood function
         using the observed data.
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -555,7 +555,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     Attributes
     ----------
-    base_estimator_ : ``_BinaryGaussianProcessClassifierLaplace``
+    base_estimator_ : ``Estimator``
         The estimator instance that defines the likelihood function
         using the observed data.
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -555,7 +555,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     Attributes
     ----------
-    base_estimator_ : ``Estimator``
+    base_estimator_ : ``Estimator`` instance
         The estimator instance that defines the likelihood function
         using the observed data.
 

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -229,7 +229,7 @@ def test_fit_docstring_attributes(name, Estimator):
             assert hasattr(est, attr.name)
 
     IGNORED = {'BayesianRidge', 'Birch', 'CCA', 'CategoricalNB', 'ElasticNet',
-               'ElasticNetCV', 'GaussianProcessClassifier',
+               'ElasticNetCV',
                'HistGradientBoostingClassifier',
                'HistGradientBoostingRegressor',
                'KernelCenterer', 'KernelDensity',


### PR DESCRIPTION
#### Reference Issues
Add attributes for the GaussianProcessClassifier #14312.

#### What does this implement/fix? Explain your changes.
Add description for `base_estimator_` attribute.

#### Any other comments?
Co-authored-by: Beatriz San Miguel (<beatriz.sanmiguelgonzalez@uk.fujitsu.com>)

