### PR TITLE
DOC add missing attributes in KernelDensity

### DIFF
--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -72,6 +72,11 @@ class KernelDensity(BaseEstimator):
         metric.  For more information, see the documentation of
         :class:`BallTree` or :class:`KDTree`.
 
+    Attributes
+    ----------
+    tree_ : BinaryTree
+        The tree algorithm for fast generalized N-point problems.
+
     See Also
     --------
     sklearn.neighbors.KDTree : K-dimensional tree for fast generalized N-point

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -74,7 +74,7 @@ class KernelDensity(BaseEstimator):
 
     Attributes
     ----------
-    tree_ : BinaryTree
+    tree_ : ``BinaryTree`` instance
         The tree algorithm for fast generalized N-point problems.
 
     See Also

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -232,7 +232,7 @@ def test_fit_docstring_attributes(name, Estimator):
                'ElasticNetCV', 'GaussianProcessClassifier',
                'HistGradientBoostingClassifier',
                'HistGradientBoostingRegressor',
-               'KernelCenterer', 'KernelDensity',
+               'KernelCenterer',
                'LarsCV', 'Lasso', 'LassoLarsCV', 'LassoLarsIC',
                'LocalOutlierFactor', 'MDS',
                'MiniBatchKMeans',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #14312

#### What does this implement/fix? Explain your changes.
Documents missing attribute `tree_` in `KernelDensity`.

#### Any other comments?
Discussion: What type should be documented for `tree_`?
It is either `BallTree` or `KDTree`, both inheriting `BinaryTree`.
Currently, I documented as `BinaryTree`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
