### PR TITLE
Remove code for scipy legacy version

### DIFF
--- a/sklearn/feature_extraction/_hashing_fast.pyx
+++ b/sklearn/feature_extraction/_hashing_fast.pyx
@@ -12,7 +12,6 @@ cimport numpy as np
 import numpy as np
 
 from ..utils.murmurhash cimport murmurhash3_bytes_s32
-from ..utils.fixes import sp_version
 
 np.import_array()
 
@@ -90,11 +89,6 @@ def transform(raw_X, Py_ssize_t n_features, dtype,
 
     if indptr[-1] > np.iinfo(np.int32).max:  # = 2**31 - 1
         if sp_version < (0, 14):
-            raise ValueError(('sparse CSR array has {} non-zero '
-                              'elements and requires 64 bit indexing, '
-                              ' which is unsupported with scipy {}. '
-                              'Please upgrade to scipy >=0.14')
-                             .format(indptr[-1], '.'.join(sp_version)))
         # both indices and indptr have the same dtype in CSR arrays
         indices_a = indices_a.astype(np.int64, copy=False)
     else:

--- a/sklearn/feature_extraction/_hashing_fast.pyx
+++ b/sklearn/feature_extraction/_hashing_fast.pyx
@@ -88,7 +88,6 @@ def transform(raw_X, Py_ssize_t n_features, dtype,
     indptr_a = np.frombuffer(indptr, dtype=indices_np_dtype)
 
     if indptr[-1] > np.iinfo(np.int32).max:  # = 2**31 - 1
-        if sp_version < (0, 14):
         # both indices and indptr have the same dtype in CSR arrays
         indices_a = indices_a.astype(np.int64, copy=False)
     else:


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #17674

#### What does this implement/fix? Explain your changes.
Minimum Scipy supported version is 0.19.1. I removed older Scipy code.