### PR TITLE
Update description of OneClassSVM for outlier detection

### DIFF
--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -106,8 +106,7 @@ detection.
 :class:`ensemble.IsolationForest` and :class:`neighbors.LocalOutlierFactor`
 perform reasonably well on the data sets considered here.
 The :class:`svm.OneClassSVM` is known to be sensitive to outliers and thus
-does not perform very well for outlier detection. Finally,
-:class:`covariance.EllipticEnvelope` assumes the data is Gaussian and learns
+does not perform very well for outlier detection. That being said, outlier detection in high-dimension, or without any assumptions on the distribution of the inlying data is very challenging. Thus, a :class:`svm.OneClassSVM` might give useful results in these situations depending on the value of its hyperparameters. Finally, :class:`covariance.EllipticEnvelope` assumes the data is Gaussian and learns
 an ellipse. For more details on the different estimators refer to the example
 :ref:`sphx_glr_auto_examples_miscellaneous_plot_anomaly_comparison.py` and the
 sections hereunder.
@@ -378,4 +377,3 @@ Novelty detection with Local Outlier Factor is illustrated below.
      :target: ../auto_examples/neighbors/sphx_glr_plot_lof_novelty_detection.html
      :align: center
      :scale: 75%
-


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes part of #3466

#### What does this implement/fix? Explain your changes.
This PR clarifies that One Class SVM can be used for outlier detection and novelty detection. Originally, the doc incorrectly suggested One Class SVM should only be used for novelty detection. I utilized the explanation on One Class SVM from [here](https://scikit-learn.org/stable/auto_examples/miscellaneous/plot_anomaly_comparison.html#sphx-glr-auto-examples-miscellaneous-plot-anomaly-comparison-py), which was already linked as an example.



#### Any other comments?