### PR TITLE
Implement probability estimates for NearestCentroid classifier

### DIFF
--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -89,7 +89,8 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
     Science 18(1), p. 104-117.
     """
 
-    def __init__(self, metric='euclidean', shrink_threshold=None, prob=False, prior='sample'):
+    @_deprecate_positional_args
+    def __init__(self, metric='euclidean', *, shrink_threshold=None, prob=False, prior='sample'):
         self.metric = metric
         self.shrink_threshold = shrink_threshold
         self.prob_ = prob
@@ -115,9 +116,9 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
         # If X is sparse and the metric is "manhattan", store it in a csc
         # format is easier to calculate the median.
         if self.metric == 'manhattan':
-            X, y = check_X_y(X, y, ['csc'])
+            X, y = self._validate_data(X, y, accept_sparse=['csc'])
         else:
-            X, y = check_X_y(X, y, ['csr', 'csc'])
+            X, y = self._validate_data(X, y, accept_sparse=['csr', 'csc'])
         is_X_sparse = sp.issparse(X)
         if is_X_sparse and self.shrink_threshold:
             raise ValueError("threshold shrinking not supported"

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -64,7 +64,7 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
     >>> y = np.array([1, 1, 1, 2, 2, 2])
     >>> clf = NearestCentroid()
     >>> clf.fit(X, y)
-    NearestCentroid()
+    NearestCentroid(prior=None, prob=None)
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -234,7 +234,7 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
             where classes are ordered as they are in ``self.classes_``.
         """
 
-        check_is_fitted(self, 'centroids_')
+        check_is_fitted(self, 's_')
 
         # Tibshirani et al. (2002b), p. 109
         if self.prior_ == 'uninformative':

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -65,7 +65,7 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
     >>> y = np.array([1, 1, 1, 2, 2, 2])
     >>> clf = NearestCentroid()
     >>> clf.fit(X, y)
-    NearestCentroid(prior=None, prob=None)
+    NearestCentroid()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -5,6 +5,7 @@ Nearest Centroid Classification
 
 # Author: Robert Layton <robertlayton@gmail.com>
 #         Olivier Grisel <olivier.grisel@ensta.org>
+#         Andreas W. Kempa-Liehr <a.kempa-liehr@auckland.ac.nz>
 #
 # License: BSD 3 clause
 

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -225,11 +225,11 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like, shape = [n_samples, n_features]
+        X : array-like, shape = (n_samples, n_features)
 
         Returns
         -------
-        T : array-like, shape = [n_samples, n_classes]
+        T : ndarray of shape (n_samples, n_classes)
             Returns the probability of the sample for each class in the model,
             where classes are ordered as they are in ``self.classes_``.
         """

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -65,7 +65,7 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
     >>> y = np.array([1, 1, 1, 2, 2, 2])
     >>> clf = NearestCentroid()
     >>> clf.fit(X, y)
-    NearestCentroid()
+    NearestCentroid(...)
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
 

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -53,6 +53,13 @@ def test_classification_toy():
     clf.fit(X_csr.tocoo(), y)
     assert_array_equal(clf.predict(T_csr.tolil()), true_result)
 
+    # Fit and predict probability estimates
+    clf = NearestCentroid(prob=True)
+    probabilities = clf.predict_proba(X)
+    assert probabilities.shape == (n_samples, n_classes)
+    assert_array_almost_equal(probabilities.sum(axis=1), np.ones(n_samples))
+    assert_array_equal(probabilities.argmax(axis=1), y)
+
 
 def test_precomputed():
     clf = NearestCentroid(metric='precomputed')

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -14,6 +14,8 @@ from sklearn.utils._testing import assert_raises
 X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
 X_csr = sp.csr_matrix(X)  # Sparse matrix
 y = [-1, -1, -1, 1, 1, 1]
+n_samples = len(X)
+n_classes = len(set(y))
 T = [[-1, -1], [2, 2], [3, 2]]
 T_csr = sp.csr_matrix(T)
 true_result = [-1, 1, 1]
@@ -55,10 +57,12 @@ def test_classification_toy():
 
     # Fit and predict probability estimates
     clf = NearestCentroid(prob=True)
+    clf.fit(X, y)
     probabilities = clf.predict_proba(X)
     assert probabilities.shape == (n_samples, n_classes)
-    assert_array_almost_equal(probabilities.sum(axis=1), np.ones(n_samples))
-    assert_array_equal(probabilities.argmax(axis=1), y)
+    print(probabilities)
+    np.testing.assert_array_almost_equal(probabilities.sum(axis=1), np.ones(n_samples))
+    np.testing.assert_array_equal(np.choose(probabilities.argmax(axis=1), [-1, 1]), y)
 
 
 def test_precomputed():


### PR DESCRIPTION
#### Reference Issues/PRs
There are no related issues or PRs.

#### What does this implement/fix? Explain your changes.
This contribution implements the .predict_proba() method for the NearestCentroid() classifier based on the contribution of 
_Tibshirani, R., Hastie, T., Narasimhan, B., & Chu, G. (2002). Class Prediction by Nearest Shrunken Centroids, with Applications to DNA Microaarrays. Statistical Science 18(1), p. 104-117._


#### Any other comments?
Currently, the estimation of probabilities is optional and has to be enabled at the instantiation of the classifier. However, this is a design decision and any advise is welcome.
