### PR TITLE
MNT Renames remaining numpy alias

### DIFF
--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -285,7 +285,7 @@ some missing values to it.
   >>> from sklearn.pipeline import FeatureUnion, make_pipeline
   >>> from sklearn.tree import DecisionTreeClassifier
   >>> X, y = load_iris(return_X_y=True)
-  >>> mask = np.random.randint(0, 2, size=X.shape).astype(np.bool)
+  >>> mask = np.random.randint(0, 2, size=X.shape).astype(bool)
   >>> X[mask] = np.nan
   >>> X_train, X_test, y_train, _ = train_test_split(X, y, test_size=100,
   ...                                                random_state=0)

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -83,8 +83,7 @@ cpdef _sample_without_replacement_with_tracking_selection(
 
     cdef np.int_t i
     cdef np.int_t j
-    cdef np.ndarray[np.int_t, ndim=1] out = np.empty((n_samples, ),
-                                                     dtype=np.int)
+    cdef np.ndarray[np.int_t, ndim=1] out = np.empty((n_samples, ), dtype=int)
 
     rng = check_random_state(random_state)
     rng_randint = rng.randint
@@ -139,11 +138,10 @@ cpdef _sample_without_replacement_with_pool(np.int_t n_population,
 
     cdef np.int_t i
     cdef np.int_t j
-    cdef np.ndarray[np.int_t, ndim=1] out = np.empty((n_samples, ),
-                                                     dtype=np.int)
+    cdef np.ndarray[np.int_t, ndim=1] out = np.empty((n_samples, ), dtype=int)
 
     cdef np.ndarray[np.int_t, ndim=1] pool = np.empty((n_population, ),
-                                                      dtype=np.int)
+                                                      dtype=int)
 
     rng = check_random_state(random_state)
     rng_randint = rng.randint
@@ -202,8 +200,7 @@ cpdef _sample_without_replacement_with_reservoir_sampling(
 
     cdef np.int_t i
     cdef np.int_t j
-    cdef np.ndarray[np.int_t, ndim=1] out = np.empty((n_samples, ),
-                                                     dtype=np.int)
+    cdef np.ndarray[np.int_t, ndim=1] out = np.empty((n_samples, ), dtype=int)
 
     rng = check_random_state(random_state)
     rng_randint = rng.randint


### PR DESCRIPTION
Missed some in https://github.com/scikit-learn/scikit-learn/pull/17687 that were not in `*.py` files.