### PR TITLE
FIX Extract estimator objects before aggregating dict of scores

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -247,12 +247,9 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
             error_score=error_score)
         for train, test in cv.split(X, y, groups))
 
-    if return_estimator:
-        # Extract the estimator objects for each cv split because the
-        # "_aggregate_score_dicts" converts nested estimators to arrays
-        fitted_estimators = [result["estimator"] for result in results]
-
     results = _aggregate_score_dicts(results)
+    if return_estimator:
+        fitted_estimators = results["estimator"]
 
     ret = {}
     ret['fit_time'] = results["fit_time"]
@@ -1562,5 +1559,9 @@ def _aggregate_score_dicts(scores):
     {'a': array([1, 2, 3, 10]),
      'b': array([10, 2, 3, 10])}
     """
-    return {key: np.asarray([score[key] for score in scores])
-            for key in scores[0]}
+    return {
+        key: np.asarray([score[key] for score in scores])
+        if key.endswith(("time", "score"))
+        else [score[key] for score in scores]
+        for key in scores[0]
+    }

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -262,7 +262,6 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
         ret['estimator'] = fitted_estimators
 
     test_scores = _aggregate_score_dicts(results["test_scores"])
-
     if return_train_score:
         train_scores = _aggregate_score_dicts(results["train_scores"])
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -247,9 +247,12 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
             error_score=error_score)
         for train, test in cv.split(X, y, groups))
 
-    results = _aggregate_score_dicts(results)
     if return_estimator:
-        fitted_estimators = results["estimator"]
+        # Extract the estimator objects for each cv split because the
+        # "_aggregate_score_dicts" converts nested estimators to arrays
+        fitted_estimators = [result["estimator"] for result in results]
+
+    results = _aggregate_score_dicts(results)
 
     ret = {}
     ret['fit_time'] = results["fit_time"]
@@ -259,6 +262,7 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
         ret['estimator'] = fitted_estimators
 
     test_scores = _aggregate_score_dicts(results["test_scores"])
+
     if return_train_score:
         train_scores = _aggregate_score_dicts(results["train_scores"])
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1539,7 +1539,7 @@ def validation_curve(estimator, X, y, *, param_name, param_range, groups=None,
 def _aggregate_score_dicts(scores):
     """Aggregate the list of dict to dict of np ndarray
 
-    The aggregated output of _fit_and_score will be a list of dict
+    The aggregated output of _aggregate_score_dicts will be a list of dict
     of form [{'prec': 0.1, 'acc':1.0}, {'prec': 0.1, 'acc':1.0}, ...]
     Convert it to a dict of array {'prec': np.array([0.1 ...]), ...}
 
@@ -1561,7 +1561,7 @@ def _aggregate_score_dicts(scores):
     """
     return {
         key: np.asarray([score[key] for score in scores])
-        if key.endswith(("time", "score"))
+        if isinstance(scores[0][key], numbers.Number)
         else [score[key] for score in scores]
         for key in scores[0]
     }

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -356,6 +356,22 @@ def test_cross_validate_invalid_scoring_param():
                         cross_validate, SVC(), X, y, scoring="mse")
 
 
+def test_cross_validate_nested_estimator():
+    # Non-regression test to ensure that nested
+    # estimators are properly returned in a list
+    (X, y) = load_iris(return_X_y=True)
+    pipeline = Pipeline([
+        ("imputer", SimpleImputer()),
+        ("classifier", MockClassifier()),
+    ])
+
+    results = cross_validate(pipeline, X, y, return_estimator=True)
+    estimators = results["estimator"]
+
+    assert isinstance(estimators, list)
+    assert all(isinstance(estimator, Pipeline) for estimator in estimators)
+
+
 def test_cross_validate():
     # Compute train and test mse/r2 scores
     cv = KFold()

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -359,6 +359,7 @@ def test_cross_validate_invalid_scoring_param():
 def test_cross_validate_nested_estimator():
     # Non-regression test to ensure that nested
     # estimators are properly returned in a list
+    # https://github.com/scikit-learn/scikit-learn/pull/17745
     (X, y) = load_iris(return_X_y=True)
     pipeline = Pipeline([
         ("imputer", SimpleImputer()),


### PR DESCRIPTION
#### Reference Issues/PRs

Coming from #17332.

#### What does this implement/fix? Explain your changes.

This PR extracts the estimator objects for each cross-validation split before executing the `_aggregate_score_dicts` in `cross_validation` function to avoid that nested estimators are converted to arrays.

#### Any other comments?

WDYT @thomasjpfan about this solution?

Another idea to solve this issue?