### PR TITLE
[MRG] Cast pandas `BooleanDtype` to `np.bool` in classification targets

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1213,3 +1213,26 @@ def test_check_sparse_pandas_sp_format(sp_format):
     assert sp.issparse(result)
     assert result.format == sp_format
     assert_allclose_dense_sparse(sp_mat, result)
+
+
+def test_check_X_y_pandas_boolean_casting():
+    pd = pytest.importorskip('pandas')
+    df = pd.DataFrame({
+        "y": pd.Series([False, True, False, True], dtype="boolean"),
+        "x1": pd.Series([1, 2, 3, 4]),
+        "x2": pd.Series([5, 6, 7, 8])
+    })
+    X, y = check_X_y(df[["x1", "x2"]], df["y"])
+    assert y.dtype == np.bool
+
+
+def test_check_X_y_pandas_boolean_casting_na():
+    pd = pytest.importorskip('pandas')
+    df = pd.DataFrame({
+        "y": pd.Series([False, True, pd.NA, True], dtype="boolean"),
+        "x1": pd.Series([1, 2, 3, 4]),
+        "x2": pd.Series([5, 6, 7, 8])
+    })
+    msg = "y cannot have values of type `pd.NA`"
+    with pytest.raises(ValueError, match=msg):
+        X, y = check_X_y(df[["x1", "x2"]], df["y"])

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1216,7 +1216,7 @@ def test_check_sparse_pandas_sp_format(sp_format):
 
 
 def test_check_X_y_pandas_boolean_casting():
-    pd = pytest.importorskip('pandas')
+    pd = pytest.importorskip('pandas', minversion="1.0")
     df = pd.DataFrame({
         "y": pd.Series([False, True, False, True], dtype="boolean"),
         "x1": pd.Series([1, 2, 3, 4]),
@@ -1227,9 +1227,10 @@ def test_check_X_y_pandas_boolean_casting():
 
 
 def test_check_X_y_pandas_boolean_casting_na():
-    pd = pytest.importorskip('pandas')
+    pd = pytest.importorskip('pandas', minversion="1.0")
+    print(pd.__version__)
     df = pd.DataFrame({
-        "y": pd.Series([False, True, pd.NA, True], dtype="boolean"),
+        "y": pd.Series([False, True, np.nan, True], dtype="boolean"),
         "x1": pd.Series([1, 2, 3, 4]),
         "x2": pd.Series([5, 6, 7, 8])
     })

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -805,6 +805,11 @@ def check_X_y(X, y, accept_sparse=False, *, accept_large_sparse=True,
         y = check_array(y, accept_sparse='csr', force_all_finite=True,
                         ensure_2d=False, dtype=None)
     else:
+        if hasattr(y, 'dtype') and type(y.dtype).__name__ == 'BooleanDtype':
+            if not y.isna().any():
+                y = np.asarray(y, dtype=np.bool)
+            else:
+                raise ValueError("y cannot have values of type `pd.NA`")
         y = column_or_1d(y, warn=True)
         _assert_all_finite(y)
     if y_numeric and y.dtype.kind == 'O':


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #17675

#### What does this implement/fix? Explain your changes.
The changes done are inside `check_X_y` - which is used in `LogisticRegression` 
instead of `check_array`.

