### PR TITLE
FIX Specify C++11 compiler for sklearn/svm/_newrand

### DIFF
--- a/sklearn/svm/setup.py
+++ b/sklearn/svm/setup.py
@@ -18,7 +18,7 @@ def configuration(parent_package='', top_path=None):
                          depends=[join('src', 'newrand', 'newrand.h')],
                          language='c++',
                          # Use C++11 random number generator fix
-                         extra_compiler_args=['-std=c++11']
+                         extra_compile_args=['-std=c++11']
                          )
 
     # Section LibSVM

--- a/sklearn/svm/setup.py
+++ b/sklearn/svm/setup.py
@@ -17,6 +17,8 @@ def configuration(parent_package='', top_path=None):
                                        join('src', 'newrand')],
                          depends=[join('src', 'newrand', 'newrand.h')],
                          language='c++',
+                         # Use C++11 random number generator fix
+                         extra_compiler_args=['-std=c++11']
                          )
 
     # Section LibSVM


### PR DESCRIPTION
#### Reference Issues/PRs

Related with #17157.

#### What does this implement/fix? Explain your changes.

This PR specifies that the `sklearn/svm/_newrand` module need to be compiled against the C++11 standard (with the `extra_compile_args` directive). IIRC, this is required for `g++ <= 4.7`.

#### Any other comments?

With these changes, the [wheel builder](https://dev.azure.com/scikit-learn/scikit-learn/_build) and the [`travis-ci` job](https://travis-ci.org/github/scikit-learn/scikit-learn/builds/702914375?utm_source=github_status&utm_medium=notification) should be working again 😄.

Quick review @thomasjpfan @glemaitre @rth?
