### PR TITLE
FIX Refactor the check of oob score of forest predictors in unit tests

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -381,10 +381,8 @@ def check_oob_score(name, X, y, n_estimators=20):
     n_samples = X.shape[0]
     est.fit(X[:n_samples // 2, :], y[:n_samples // 2])
     test_score = est.score(X[n_samples // 2:, :], y[n_samples // 2:])
-    if name in FOREST_CLASSIFIERS:
-        assert abs(test_score - est.oob_score_) < 0.1
-    else:
-        assert abs(test_score - est.oob_score_) < 0.1
+
+    assert abs(test_score - est.oob_score_) < 0.1
 
     # Check warning if not enough estimators
     with np.errstate(divide="ignore", invalid="ignore"):

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -382,7 +382,7 @@ def check_oob_score(name, X, y, n_estimators=20):
     est.fit(X[:n_samples // 2, :], y[:n_samples // 2])
     test_score = est.score(X[n_samples // 2:, :], y[n_samples // 2:])
     oob_score = est.oob_score_
-    
+
     assert abs(test_score - oob_score) < 0.1 and oob_score > 0.7
 
     # Check warning if not enough estimators

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -381,10 +381,9 @@ def check_oob_score(name, X, y, n_estimators=20):
     n_samples = X.shape[0]
     est.fit(X[:n_samples // 2, :], y[:n_samples // 2])
     test_score = est.score(X[n_samples // 2:, :], y[n_samples // 2:])
-
     oob_score = est.oob_score_
-    assert abs(test_score - oob_score) < 0.1
-    assert oob_score > 0.5 if name in FOREST_CLASSIFIERS else oob_score > 0.7
+    
+    assert abs(test_score - oob_score) < 0.1 and oob_score > 0.7
 
     # Check warning if not enough estimators
     with np.errstate(divide="ignore", invalid="ignore"):

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -382,7 +382,9 @@ def check_oob_score(name, X, y, n_estimators=20):
     est.fit(X[:n_samples // 2, :], y[:n_samples // 2])
     test_score = est.score(X[n_samples // 2:, :], y[n_samples // 2:])
 
-    assert abs(test_score - est.oob_score_) < 0.1
+    oob_score = est.oob_score_
+    assert abs(test_score - oob_score) < 0.1
+    assert oob_score > 0.5 if name in FOREST_CLASSIFIERS else oob_score > 0.7
 
     # Check warning if not enough estimators
     with np.errstate(divide="ignore", invalid="ignore"):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #17765 

#### What does this implement/fix? Explain your changes.
In forest testing there is a helper function [`check_oob_score`](https://github.com/scikit-learn/scikit-learn/blob/430c2080e81dbf9aacc99dfd83d958030a7c4d07/sklearn/ensemble/tests/test_forest.py#L374) that asserts the quality of the oob_score.
In this function there is an if-else statement that checks the same thing for forest classifiers and forest predictors.
This PR removes the if-else statement and adds one more quality check as discussed with @glemaitre [here](https://github.com/scikit-learn/scikit-learn/issues/17765).


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
