### PR TITLE
MNT Removed arguments from matplotlib.use()

### DIFF
--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -20,7 +20,7 @@ def pyplot():
         The ``matplotlib.pyplot`` module.
     """
     matplotlib = pytest.importorskip('matplotlib')
-    matplotlib.use('agg', warn=False, force=True)
+    matplotlib.use('agg')
     pyplot = pytest.importorskip('matplotlib.pyplot')
     yield pyplot
     pyplot.close('all')


### PR DESCRIPTION
<!--
Thanks for contributing to a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #17751


#### What does this implement/fix? Explain your changes.
Removed `warn` and `force` arguments from `matplotlib.use('agg', warn=False, force=True)` which cause `MatplotlibDeprecationWarning` and made it default.

#### Any other comments?
[matplotlib.use()](https://matplotlib.org/_modules/matplotlib.html#use)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
