### PR TITLE
Fix #16998 classification_report with output_dict=True should not raise AttributeError 

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -147,9 +147,9 @@ Changelog
   average of multiple MSE values.
   :pr:`17309` by :user:`Swier Heeres <swierh>`
   
-- |Fix| Fixed a bug #16998 in 
+- |Fix| Fixed a bug in 
   :func:`metrics.classification_report` which was raising AttributeError
-  when called with `output_dict=True` for 0 length values.
+  when called with `output_dict=True` for 0-length values.
   :pr:`17777` by :user:`Shubhanshu Mishra <napsternxg>`
 
 - |Enhancement| Add `sample_weight` parameter to

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -146,6 +146,11 @@ Changelog
   average of multiple RMSE values was incorrectly calculated as the root of the
   average of multiple MSE values.
   :pr:`17309` by :user:`Swier Heeres <swierh>`
+  
+- |Fix| Fixed a bug #16998 in 
+  :func:`metrics.classification_report` which was raising AttributeError
+  when called with `output_dict=True` for 0 length values.
+  :pr:`17777` by :user:`Shubhanshu Mishra <napsternxg>`
 
 - |Enhancement| Add `sample_weight` parameter to
   :func:`metrics.median_absolute_error`. :pr:`17225` by

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1977,7 +1977,7 @@ def classification_report(y_true, y_pred, *, labels=None, target_names=None,
         report_dict = {label[0]: label[1:] for label in rows}
         for label, scores in report_dict.items():
             report_dict[label] = dict(zip(headers,
-                                          [i.item() for i in scores]))
+                                          [float(i) for i in scores]))
     else:
         longest_last_line_heading = 'weighted avg'
         name_width = max(len(cn) for cn in target_names)

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1488,10 +1488,16 @@ def precision_recall_fscore_support(y_true, y_pred, *, beta=1.0, labels=None,
             # recall is zero_division if there are no positive labels
             # fscore is zero_division if all labels AND predictions are
             # negative
-            return (zero_division_value if pred_sum.sum() == 0 else np.float64(0),
-                    zero_division_value,
-                    zero_division_value if pred_sum.sum() == 0 else np.float64(0),
-                    None)
+            if pred_sum.sum() == 0:
+                return (zero_division_value,
+                        zero_division_value,
+                        zero_division_value,
+                        None)
+            else:
+                return (np.float64(0),
+                        zero_division_value,
+                        np.float64(0),
+                        None)
 
     elif average == 'samples':
         weights = sample_weight

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2006,7 +2006,7 @@ def classification_report(y_true, y_pred, *, labels=None, target_names=None,
 
         if output_dict:
             report_dict[line_heading] = dict(
-                zip(headers, [i.item() for i in avg]))
+                zip(headers, [float(i) for i in avg]))
         else:
             if line_heading == 'accuracy':
                 row_fmt_accuracy = '{:>{width}s} ' + \

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1488,9 +1488,9 @@ def precision_recall_fscore_support(y_true, y_pred, *, beta=1.0, labels=None,
             # recall is zero_division if there are no positive labels
             # fscore is zero_division if all labels AND predictions are
             # negative
-            return (zero_division_value if pred_sum.sum() == 0 else 0,
+            return (zero_division_value if pred_sum.sum() == 0 else np.float64(0),
                     zero_division_value,
-                    zero_division_value if pred_sum.sum() == 0 else 0,
+                    zero_division_value if pred_sum.sum() == 0 else np.float64(0),
                     None)
 
     elif average == 'samples':

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1977,7 +1977,7 @@ def classification_report(y_true, y_pred, *, labels=None, target_names=None,
         report_dict = {label[0]: label[1:] for label in rows}
         for label, scores in report_dict.items():
             report_dict[label] = dict(zip(headers,
-                                          [float(i) for i in scores]))
+                                          [i.item() for i in scores]))
     else:
         longest_last_line_heading = 'weighted avg'
         name_width = max(len(cn) for cn in target_names)
@@ -2006,7 +2006,7 @@ def classification_report(y_true, y_pred, *, labels=None, target_names=None,
 
         if output_dict:
             report_dict[line_heading] = dict(
-                zip(headers, [float(i) for i in avg]))
+                zip(headers, [i.item() for i in avg]))
         else:
             if line_heading == 'accuracy':
                 row_fmt_accuracy = '{:>{width}s} ' + \

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1483,7 +1483,9 @@ def precision_recall_fscore_support(y_true, y_pred, *, beta=1.0, labels=None,
     if average == 'weighted':
         weights = true_sum
         if weights.sum() == 0:
-            zero_division_value = 0.0 if zero_division in ["warn", 0] else 1.0
+            zero_division_value = np.float64(1.0)
+            if zero_division in ["warn", 0]:
+                zero_division_value = np.float64(0.0)
             # precision is zero_division if there are no positive predictions
             # recall is zero_division if there are no positive labels
             # fscore is zero_division if all labels AND predictions are
@@ -1494,9 +1496,9 @@ def precision_recall_fscore_support(y_true, y_pred, *, beta=1.0, labels=None,
                         zero_division_value,
                         None)
             else:
-                return (np.float64(0),
+                return (np.float64(0.0),
                         zero_division_value,
-                        np.float64(0),
+                        np.float64(0.0),
                         None)
 
     elif average == 'samples':

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -151,7 +151,12 @@ def test_classification_report_dictionary_output():
     assert type(expected_report['macro avg']['precision']) == float
     assert type(expected_report['setosa']['support']) == int
     assert type(expected_report['macro avg']['support']) == int
-
+    
+    
+def test_classification_report_output_dict_empty_input():
+    report = classification_report(y_true=[], y_pred=[], output_dict=True)
+    assert isinstance(report, dict)
+  
 
 @pytest.mark.parametrize('zero_division', ["warn", 0, 1])
 def test_classification_report_zero_division_warning(zero_division):

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -151,12 +151,12 @@ def test_classification_report_dictionary_output():
     assert type(expected_report['macro avg']['precision']) == float
     assert type(expected_report['setosa']['support']) == int
     assert type(expected_report['macro avg']['support']) == int
-    
-    
+
+
 def test_classification_report_output_dict_empty_input():
     report = classification_report(y_true=[], y_pred=[], output_dict=True)
     assert isinstance(report, dict)
-  
+
 
 @pytest.mark.parametrize('zero_division', ["warn", 0, 1])
 def test_classification_report_zero_division_warning(zero_division):

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -163,10 +163,19 @@ def test_classification_report_output_dict_empty_input():
                        'weighted avg': {'f1-score': 0.0,
                                         'precision': 0.0,
                                         'recall': 0.0,
-                                        'support': 0.0}
-                      }
+                                        'support': 0.0}}
     assert isinstance(report, dict)
-    assert report == expected_report
+    # assert the 2 dicts are equal.
+    assert(report.keys() == expected_report.keys())
+    for key in expected_report:
+        if key == 'accuracy':
+            assert isinstance(report[key], float)
+            assert report[key] == expected_report[key]
+        else:
+            assert report[key].keys() == expected_report[key].keys()
+            for metric in expected_report[key]:
+                assert_almost_equal(expected_report[key][metric],
+                                    report[key][metric])
 
 
 @pytest.mark.parametrize('zero_division', ["warn", 0, 1])

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -155,7 +155,18 @@ def test_classification_report_dictionary_output():
 
 def test_classification_report_output_dict_empty_input():
     report = classification_report(y_true=[], y_pred=[], output_dict=True)
+    expected_report = {'accuracy': 0.0,
+                       'macro avg': {'f1-score': np.nan,
+                                     'precision': np.nan,
+                                     'recall': np.nan,
+                                     'support': 0.0},
+                       'weighted avg': {'f1-score': 0.0,
+                                        'precision': 0.0,
+                                        'recall': 0.0,
+                                        'support': 0.0}
+                      }
     assert isinstance(report, dict)
+    assert report == expected_report
 
 
 @pytest.mark.parametrize('zero_division', ["warn", 0, 1])

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -159,11 +159,11 @@ def test_classification_report_output_dict_empty_input():
                        'macro avg': {'f1-score': np.nan,
                                      'precision': np.nan,
                                      'recall': np.nan,
-                                     'support': 0.0},
+                                     'support': 0},
                        'weighted avg': {'f1-score': 0.0,
                                         'precision': 0.0,
                                         'recall': 0.0,
-                                        'support': 0.0}}
+                                        'support': 0}}
     assert isinstance(report, dict)
     # assert the 2 dicts are equal.
     assert(report.keys() == expected_report.keys())

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -166,7 +166,7 @@ def test_classification_report_output_dict_empty_input():
                                         'support': 0}}
     assert isinstance(report, dict)
     # assert the 2 dicts are equal.
-    assert(report.keys() == expected_report.keys())
+    assert report.keys() == expected_report.keys()
     for key in expected_report:
         if key == 'accuracy':
             assert isinstance(report[key], float)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fix #16998 classification_report with output_dict=True should not raise AttributeError 


#### What does this implement/fix? Explain your changes.

When the `average == 'weighted':` we are returning some values which are `int` and `float` which do not have `i.item()` . The suggested change is that always return `np.dtype(value)` which will always have `i.item()`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
