### PR TITLE
Make ColumnTransformer also handle lists of boolean

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -668,7 +668,8 @@ def _is_empty_column_selection(column):
     elif column.shape == (0,):
         return True
 
-    # Otherwise, column has more than one element, and at least one element is not False
+    # Otherwise, column has more than one element, and at least one element is
+    # not False
     else:
         return False
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -654,13 +654,21 @@ def _check_X(X):
 def _is_empty_column_selection(column):
     """
     Return True if the column selection is empty (empty list or all-False
-    boolean array).
-
+    boolean array or all-False list).
     """
+
+    # Coerce to a numpy array to make the below tests easier
+    column = np.array(column)
+
+    # Check 1: if column is a boolean array that is all False, return True
     if hasattr(column, 'dtype') and np.issubdtype(column.dtype, np.bool_):
         return not column.any()
-    elif hasattr(column, '__len__'):
-        return len(column) == 0
+
+    # Check 2: if column has no elements, return True
+    elif column.shape == (0,):
+        return True
+
+    # Otherwise, column has more than one element, and at least one element is not False
     else:
         return False
 

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -304,7 +304,7 @@ def test_column_transformer_empty_columns(pandas, column):
 
 @pytest.mark.parametrize("use_pandas", [True, False], ids=["pandas", "numpy"])
 @pytest.mark.parametrize(
-    "column_selection",
+    "columns",
     [[], np.array([False]), [False]],
     ids=["list", "numpy_bool", "list_bool"],
 )

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -311,7 +311,7 @@ def test_column_transformer_empty_columns(pandas, column):
 @pytest.mark.parametrize(
     "estimator", [Trans(), SimpleImputer()], ids=["Trans", "SimpleImputer"]
 )
-def test_column_transformer_empty_columns(use_pandas, column_selection, estimator):
+def test_issue_17586(use_pandas, columns, estimator):
     """
     Test case for https://github.com/scikit-learn/scikit-learn/issues/17586
     """
@@ -322,7 +322,7 @@ def test_column_transformer_empty_columns(use_pandas, column_selection, estimato
         pd = pytest.importorskip("pandas")
         data = pd.DataFrame(data)
 
-    ct = ColumnTransformer(transformers=[("noop", estimator, column_selection),])
+    ct = ColumnTransformer(transformers=[("noop", estimator, columns), ])
     data_trans = ct.fit_transform(data)
 
     assert data_trans.shape == (3, 0)

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -254,8 +254,8 @@ def test_column_transformer_dataframe():
 
 
 @pytest.mark.parametrize("pandas", [True, False], ids=['pandas', 'numpy'])
-@pytest.mark.parametrize("column", [[], np.array([False, False])],
-                         ids=['list', 'bool'])
+@pytest.mark.parametrize("column", [[], np.array([False, False]), [False, False]],
+                         ids=['list', 'bool', 'list_of_bool'])
 def test_column_transformer_empty_columns(pandas, column):
     # test case that ensures that the column transformer does also work when
     # a given transformer doesn't have any columns to work on


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/17586


#### What does this implement/fix? Explain your changes.
ColumnTransformer will now treat lists of all False as empty (e.g. `[False, False]` will be treated the same as `[]`)


#### Any other comments?
I'm coercing to a numpy array in `_is_empty_column_selection`.  The test pass, but I wonder if there are there cases where you have a valid selection of columns that CANNOT be coerced to a numpy array?

One interesting note: the test estimator class `Trans()` didn't have any issues.  I had to use `SimpleImputer()` to get a failing test.