### PR TITLE
MNT Prevent coverage status update on each upload to codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,7 @@ coverage:
     # Prevent coverage status to upload multiple times for parallel and long
     # running CI pipelines. This configuration is particularly useful on PRs
     # to avoid confusion. Note that this value is set to the number of Azure
-    # Pipeline jobs
+    # Pipeline jobs uploading coverage reports.
     after_n_builds: 6
 
 ignore:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,6 +16,12 @@ coverage:
         # to codecov so that PR reviewers can see uncovered lines
         target: auto
         threshold: 1%
+  notify:
+    # Prevent coverage status to upload multiple times for parallel and long
+    # running CI pipelines. This configuration is particularly useful on PRs
+    # to avoid confusion. Note that this value is set to the number of Azure
+    # Pipeline jobs
+    after_n_builds: 6
 
 ignore:
 - "sklearn/externals"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,6 +16,8 @@ coverage:
         # to codecov so that PR reviewers can see uncovered lines
         target: auto
         threshold: 1%
+
+codecov:
   notify:
     # Prevent coverage status to upload multiple times for parallel and long
     # running CI pipelines. This configuration is particularly useful on PRs


### PR DESCRIPTION
#### Reference Issues/PRs

https://github.com/scikit-learn/scikit-learn/pull/17818#issuecomment-653207647

#### What does this implement/fix? Explain your changes.

This PR prevents that `codecov` status information is sent on each upload, but after a specific number of CI instances have finished.

#### Any other comments?

CC @thomasjpfan