### PR TITLE
DOC coef_ and intercept_ doc for BernoulliNB

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -935,6 +935,10 @@ class BernoulliNB(_BaseDiscreteNB):
     classes_ : ndarray of shape (n_classes,)
         Class labels known to the classifier
 
+    coef_ : ndarray of shape (n_classes, n_features)
+        Mirrors ``feature_log_prob_`` for interpreting `BernoulliNB`
+        as a linear model.
+
     feature_count_ : ndarray of shape (n_classes, n_features)
         Number of samples encountered for each (class, feature)
         during fitting. This value is weighted by the sample weight when
@@ -942,6 +946,10 @@ class BernoulliNB(_BaseDiscreteNB):
 
     feature_log_prob_ : ndarray of shape (n_classes, n_features)
         Empirical log probability of features given a class, P(x_i|y).
+
+    intercept_ : ndarray of shape (n_classes,)
+        Mirrors ``class_log_prior_`` for interpreting `BernoulliNB`
+        as a linear model.
 
     n_features_ : int
         Number of features of each sample.


### PR DESCRIPTION
#### Reference Issues/PRs
References #14312 
Compare #17722 

#### What does this implement/fix? Explain your changes.
Documents the attributes coef_ and intercept_ in class BernoulliNB.

#### Any other comments?
The documentation of the attributes coef_ and intercept_ is almost identical to the documentation of these attributes in MultinomialNB and ComplementNB.

ping @adrinjalali
