### PR TITLE
DOC use conda-forge instead of the main channel in the docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ the easiest way to install scikit-learn is using ``pip``   ::
 
 or ``conda``::
 
-    conda install scikit-learn
+    conda install -c conda-forge scikit-learn
 
 The documentation includes more detailed `installation instructions <https://scikit-learn.org/stable/install.html>`_.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -79,7 +79,7 @@ Then run:
         ><span class="sk-expandable" data-packager="pip" data-os="linux" data-venv="no">pip3 install -U scikit-learn</span
         ><span class="sk-expandable" data-packager="conda" data-venv="">conda create -n sklearn-env</span
         ><span class="sk-expandable" data-packager="conda" data-venv="">conda activate sklearn-env</span
-        ><span class="sk-expandable" data-packager="conda">conda install scikit-learn </span
+        ><span class="sk-expandable" data-packager="conda">conda install -c conda-forge scikit-learn </span
        ></code></pre></div>
 
 In order to check your installation you can use

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -16,7 +16,7 @@ To install the latest version (with pip)::
 
 or with conda::
 
-    conda install scikit-learn
+    conda install -c conda-forge scikit-learn
 """
 
 # %%

--- a/examples/release_highlights/plot_release_highlights_0_23_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_23_0.py
@@ -17,7 +17,7 @@ To install the latest version (with pip)::
 
 or with conda::
 
-    conda install scikit-learn
+    conda install -c conda-forge scikit-learn
 """
 
 ##############################################################################


### PR DESCRIPTION
This PR changes the `conda install scikit-learn` to `conda install -c conda-forge scikit-learn`, because:

- The main (anaconda) channel is not updated frequently, 0.22.2post1 and 0.23 are skipped all together for instance. This results in users installing an older version for quite a while after each release.
- Using the main channel is not _free_ anymore.

ping @rth @ogrisel @amueller 