### PR TITLE
[MRG] Fix documentation of default values in multioutput.py

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -221,7 +221,7 @@ class MultiOutputRegressor(RegressorMixin, _MultiOutputEstimator):
     estimator : estimator object
         An estimator object implementing :term:`fit` and :term:`predict`.
 
-    n_jobs : int, default=None
+    n_jobs : int or None, optional (default=None)
         The number of jobs to run in parallel for :meth:`fit`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -293,7 +293,7 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
         An estimator object implementing :term:`fit`, :term:`score` and
         :term:`predict_proba`.
 
-    n_jobs : int, default=None
+    n_jobs : int or None, optional (default=None)
         The number of jobs to use for the computation.
         It does each target variable in y in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
@@ -575,7 +575,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-    random_state : int, RandomState instance, default=None
+    random_state : int, RandomState instance or None, optional (default=None)
         If ``order='random'``, determines random number generation for the
         chain order.
         In addition, it controls the random seed given at each `base_estimator`
@@ -759,7 +759,7 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-    random_state : int, RandomState instance, default=None
+    random_state : int, RandomState instance or None, optional (default=None)
         If ``order='random'``, determines random number generation for the
         chain order.
         In addition, it controls the random seed given at each `base_estimator`

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -75,13 +75,13 @@ class _MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
 
         Parameters
         ----------
-        X : (sparse) array-like, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Data.
 
-        y : (sparse) array-like, shape (n_samples, n_outputs)
+        y : {array-like, sparse matrix} of shape (n_samples, n_outputs)
             Multi-output targets.
 
-        classes : list of numpy arrays, shape (n_outputs)
+        classes : list of numpy arrays of shape (n_outputs)
             Each array is unique classes for one output in str/int
             Can be obtained by via
             ``[np.unique(y[:, i]) for i in range(y.shape[1])]``, where y is the
@@ -128,10 +128,10 @@ class _MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
 
         Parameters
         ----------
-        X : (sparse) array-like, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Data.
 
-        y : (sparse) array-like, shape (n_samples, n_outputs)
+        y : {array-like, sparse matrix} of shape (n_samples, n_outputs)
             Multi-output targets. An indicator matrix turns on multilabel
             estimation.
 
@@ -181,12 +181,12 @@ class _MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
 
         Parameters
         ----------
-        X : (sparse) array-like, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Data.
 
         Returns
         -------
-        y : (sparse) array-like, shape (n_samples, n_outputs)
+        y : {array-like, sparse matrix} of shape (n_samples, n_outputs)
             Multi-output targets predicted across multiple predictors.
             Note: Separate models are generated for each predictor.
         """
@@ -221,7 +221,7 @@ class MultiOutputRegressor(RegressorMixin, _MultiOutputEstimator):
     estimator : estimator object
         An estimator object implementing :term:`fit` and :term:`predict`.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int, default=None
         The number of jobs to run in parallel for :meth:`fit`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -261,10 +261,10 @@ class MultiOutputRegressor(RegressorMixin, _MultiOutputEstimator):
 
         Parameters
         ----------
-        X : (sparse) array-like, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Data.
 
-        y : (sparse) array-like, shape (n_samples, n_outputs)
+        y : {array-like, sparse matrix} of shape (n_samples, n_outputs)
             Multi-output targets.
 
         sample_weight : array-like of shape (n_samples,), default=None
@@ -293,7 +293,7 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
         An estimator object implementing :term:`fit`, :term:`score` and
         :term:`predict_proba`.
 
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int, default=None
         The number of jobs to use for the computation.
         It does each target variable in y in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
@@ -305,7 +305,7 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
 
     Attributes
     ----------
-    classes_ : array, shape = (n_classes,)
+    classes_ : array of shape (n_classes,)
         Class labels.
 
     estimators_ : list of ``n_output`` estimators
@@ -336,7 +336,7 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
             The input data.
         Y : array-like of shape (n_samples, n_classes)
             The target values.
-        sample_weight : array-like of shape (n_samples,) or None
+        sample_weight : array-like of shape (n_samples,), default=None
             Sample weights. If None, then samples are equally weighted.
             Only supported if the underlying classifier supports sample
             weights.
@@ -361,7 +361,7 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
 
         Parameters
         ----------
-        X : array-like, shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features)
             Data
 
         Returns
@@ -393,10 +393,10 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
 
         Parameters
         ----------
-        X : array-like, shape [n_samples, n_features]
+        X : array-like of shape (n_samples, n_features)
             Test samples
 
-        y : array-like, shape [n_samples, n_outputs]
+        y : array-like of shape (n_samples, n_outputs)
             True values for X
 
         Returns
@@ -436,9 +436,9 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The input data.
-        Y : array-like, shape (n_samples, n_classes)
+        Y : array-like of shape (n_samples, n_classes)
             The target values.
         **fit_params : dict of string -> object
             Parameters passed to the `fit` method of each step.
@@ -502,12 +502,12 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The input data.
 
         Returns
         -------
-        Y_pred : array-like, shape (n_samples, n_classes)
+        Y_pred : array-like of shape (n_samples, n_classes)
             The predicted values.
 
         """
@@ -548,8 +548,8 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
     base_estimator : estimator
         The base estimator from which the classifier chain is built.
 
-    order : array-like of shape (n_outputs,) or 'random', optional
-        By default the order will be determined by the order of columns in
+    order : array-like of shape (n_outputs,) or 'random', default=None
+        If None, the order will be determined by the order of columns in
         the label matrix Y.::
 
             order = [0, 1, 2, ..., Y.shape[1] - 1]
@@ -565,18 +565,17 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         If order is 'random' a random ordering will be used.
 
-    cv : int, cross-validation generator or an iterable, optional \
-    (default=None)
+    cv : int, cross-validation generator or an iterable, default=None
         Determines whether to use cross validated predictions or true
         labels for the results of previous estimators in the chain.
-        If cv is None the true labels are used when fitting. Otherwise
+        If None, the true labels are used when fitting. Otherwise
         possible inputs for cv are:
 
         - integer, to specify the number of folds in a (Stratified)KFold,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance, default=None
         If ``order='random'``, determines random number generation for the
         chain order.
         In addition, it controls the random seed given at each `base_estimator`
@@ -637,9 +636,9 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The input data.
-        Y : array-like, shape (n_samples, n_classes)
+        Y : array-like of shape (n_samples, n_classes)
             The target values.
 
         Returns
@@ -658,11 +657,11 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
 
         Returns
         -------
-        Y_prob : array-like, shape (n_samples, n_classes)
+        Y_prob : array-like of shape (n_samples, n_classes)
         """
         X = check_array(X, accept_sparse=True)
         Y_prob_chain = np.zeros((X.shape[0], len(self.estimators_)))
@@ -687,11 +686,11 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         Parameters
         ----------
-        X : array-like, shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features)
 
         Returns
         -------
-        Y_decision : array-like, shape (n_samples, n_classes )
+        Y_decision : array-like of shape (n_samples, n_classes)
             Returns the decision function of the sample for each model
             in the chain.
         """
@@ -733,8 +732,8 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
     base_estimator : estimator
         The base estimator from which the classifier chain is built.
 
-    order : array-like of shape (n_outputs,) or 'random', optional
-        By default the order will be determined by the order of columns in
+    order : array-like of shape (n_outputs,) or 'random', default=None
+        If None, the order will be determined by the order of columns in
         the label matrix Y.::
 
             order = [0, 1, 2, ..., Y.shape[1] - 1]
@@ -750,18 +749,17 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
 
         If order is 'random' a random ordering will be used.
 
-    cv : int, cross-validation generator or an iterable, optional \
-    (default=None)
+    cv : int, cross-validation generator or an iterable, default=None
         Determines whether to use cross validated predictions or true
         labels for the results of previous estimators in the chain.
-        If cv is None the true labels are used when fitting. Otherwise
+        If None, the true labels are used when fitting. Otherwise
         possible inputs for cv are:
 
         - integer, to specify the number of folds in a (Stratified)KFold,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance, default=None
         If ``order='random'``, determines random number generation for the
         chain order.
         In addition, it controls the random seed given at each `base_estimator`
@@ -803,9 +801,9 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The input data.
-        Y : array-like, shape (n_samples, n_classes)
+        Y : array-like of shape (n_samples, n_classes)
             The target values.
 
         **fit_params : dict of string -> object

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -81,7 +81,7 @@ class _MultiOutputEstimator(BaseEstimator, MetaEstimatorMixin,
         y : {array-like, sparse matrix} of shape (n_samples, n_outputs)
             Multi-output targets.
 
-        classes : list of numpy arrays of shape (n_outputs)
+        classes : list of ndarray of shape (n_outputs,)
             Each array is unique classes for one output in str/int
             Can be obtained by via
             ``[np.unique(y[:, i]) for i in range(y.shape[1])]``, where y is the

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -568,9 +568,9 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
     cv : int, cross-validation generator or an iterable, default=None
         Determines whether to use cross validated predictions or true
         labels for the results of previous estimators in the chain.
-        If None, the true labels are used when fitting. Otherwise
-        possible inputs for cv are:
+        Possible inputs for cv are:
 
+        - None, to use true labels when fitting,
         - integer, to specify the number of folds in a (Stratified)KFold,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
@@ -752,9 +752,9 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
     cv : int, cross-validation generator or an iterable, default=None
         Determines whether to use cross validated predictions or true
         labels for the results of previous estimators in the chain.
-        If None, the true labels are used when fitting. Otherwise
-        possible inputs for cv are:
+        Possible inputs for cv are:
 
+        - None, to use true labels when fitting,
         - integer, to specify the number of folds in a (Stratified)KFold,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -305,7 +305,7 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
 
     Attributes
     ----------
-    classes_ : array of shape (n_classes,)
+    classes_ : ndarray of shape (n_classes,)
         Class labels.
 
     estimators_ : list of ``n_output`` estimators


### PR DESCRIPTION
#### Reference Issues/PRs
See #15761 

#### What does this implement/fix? Explain your changes.
This PR changes optional parameters to default in multioutput.py and makes sure that default values are documented consistent. Also, replaced "(sparse) array-like" with "{array-like, sparse matrix}" when relevant to be consistent with other docstrings in multioutput.py. 

#### Any other comments?
