### PR TITLE
[MRG] Add codes to raise error when l1_ratio is out-of-range in elasticnet

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -754,7 +754,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         if (not isinstance(self.l1_ratio, numbers.Number) or
                 self.l1_ratio < 0 or self.l1_ratio > 1):
             raise ValueError("l1_ratio must be between 0 and 1;"
-                             " got (l1_ratio=%r)" % self.l1_ratio)
+                             f" got (l1_ratio={self.l1_ratio})")
 
         # Remember if X is copied
         X_copied = False

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -751,6 +751,11 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
             raise ValueError('precompute should be one of True, False or'
                              ' array-like. Got %r' % self.precompute)
 
+        if (not isinstance(self.l1_ratio, numbers.Number) or
+                self.l1_ratio < 0 or self.l1_ratio > 1):
+            raise ValueError("l1_ratio must be between 0 and 1;"
+                             " got (l1_ratio=%r)" % self.l1_ratio)
+
         # Remember if X is copied
         X_copied = False
         # We expect X and y to be float64 or float32 Fortran ordered arrays

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -757,8 +757,8 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
         if (not isinstance(self.l1_ratio, numbers.Number) or
                 self.l1_ratio < 0 or self.l1_ratio > 1):
-            raise ValueError("l1_ratio must be between 0 and 1;"
-                             f" got (l1_ratio={self.l1_ratio})")
+            raise ValueError("l1_ratio must be between 0 and 1; "
+                             f"got l1_ratio={self.l1_ratio}")
 
         # Remember if X is copied
         X_copied = False

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -7,7 +7,6 @@ import pytest
 from scipy import interpolate, sparse
 from copy import deepcopy
 import joblib
-import re
 
 from sklearn.base import is_classifier
 from sklearn.datasets import load_diabetes
@@ -66,9 +65,9 @@ def test_l1_ratio_param(l1_ratio):
     X = np.array([[-1.], [0.], [1.]])
     Y = [-1, 0, 1]       # just a straight line
 
-    msg = "l1_ratio must be between 0 and 1;"f" got (l1_ratio={l1_ratio})"
+    msg = "l1_ratio must be between 0 and 1; "f"got l1_ratio={l1_ratio}"
     clf = ElasticNet(alpha=0.1, l1_ratio=l1_ratio)
-    with pytest.raises(ValueError, match=re.escape(msg)):
+    with pytest.raises(ValueError, match=msg):
         clf.fit(X, Y)
 
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -58,6 +58,18 @@ from sklearn.linear_model._coordinate_descent import _set_order
 from sklearn.utils import check_array
 
 
+@pytest.mark.parametrize('l1_ratio', (-1, 2, None, 10, 'something_wrong'))
+def test_l1_ratio_param(l1_ratio):
+    # Check that correct error is raised when l1_ratio in ElasticNet
+    # is outside the correct range
+    X = np.array([[-1.], [0.], [1.]])
+    Y = [-1, 0, 1]       # just a straight line
+
+    msg = "l1_ratio must be between 0 and 1; got (l1_ratio=%r)" % l1_ratio
+    assert_raise_message(ValueError, msg,
+                         ElasticNet(alpha=0.1, l1_ratio=l1_ratio).fit, X, Y)
+
+
 @pytest.mark.parametrize('order', ['C', 'F'])
 @pytest.mark.parametrize('input_order', ['C', 'F'])
 def test_set_order_dense(order, input_order):

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -7,6 +7,7 @@ import pytest
 from scipy import interpolate, sparse
 from copy import deepcopy
 import joblib
+import re
 
 from sklearn.base import is_classifier
 from sklearn.datasets import load_diabetes
@@ -66,8 +67,9 @@ def test_l1_ratio_param(l1_ratio):
     Y = [-1, 0, 1]       # just a straight line
 
     msg = "l1_ratio must be between 0 and 1;"f" got (l1_ratio={l1_ratio})"
-    assert_raise_message(ValueError, msg,
-                         ElasticNet(alpha=0.1, l1_ratio=l1_ratio).fit, X, Y)
+    clf = ElasticNet(alpha=0.1, l1_ratio=l1_ratio)
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        clf.fit(X, Y)
 
 
 @pytest.mark.parametrize('order', ['C', 'F'])

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -65,7 +65,7 @@ def test_l1_ratio_param_invalid(l1_ratio):
     X = np.array([[-1.], [0.], [1.]])
     Y = [-1, 0, 1]       # just a straight line
 
-    msg = "l1_ratio must be between 0 and 1; "f"got l1_ratio={l1_ratio}"
+    msg = "l1_ratio must be between 0 and 1; got l1_ratio={l1_ratio}"
     clf = ElasticNet(alpha=0.1, l1_ratio=l1_ratio)
     with pytest.raises(ValueError, match=msg):
         clf.fit(X, Y)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -65,7 +65,7 @@ def test_l1_ratio_param_invalid(l1_ratio):
     X = np.array([[-1.], [0.], [1.]])
     Y = [-1, 0, 1]       # just a straight line
 
-    msg = "l1_ratio must be between 0 and 1; got l1_ratio={l1_ratio}"
+    msg = "l1_ratio must be between 0 and 1; got l1_ratio="
     clf = ElasticNet(alpha=0.1, l1_ratio=l1_ratio)
     with pytest.raises(ValueError, match=msg):
         clf.fit(X, Y)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -59,7 +59,7 @@ from sklearn.utils import check_array
 
 
 @pytest.mark.parametrize('l1_ratio', (-1, 2, None, 10, 'something_wrong'))
-def test_l1_ratio_param(l1_ratio):
+def test_l1_ratio_param_invalid(l1_ratio):
     # Check that correct error is raised when l1_ratio in ElasticNet
     # is outside the correct range
     X = np.array([[-1.], [0.], [1.]])

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -65,7 +65,7 @@ def test_l1_ratio_param(l1_ratio):
     X = np.array([[-1.], [0.], [1.]])
     Y = [-1, 0, 1]       # just a straight line
 
-    msg="l1_ratio must be between 0 and 1;"f" got (l1_ratio={l1_ratio})"
+    msg = "l1_ratio must be between 0 and 1;"f" got (l1_ratio={l1_ratio})"
     assert_raise_message(ValueError, msg,
                          ElasticNet(alpha=0.1, l1_ratio=l1_ratio).fit, X, Y)
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -65,7 +65,7 @@ def test_l1_ratio_param(l1_ratio):
     X = np.array([[-1.], [0.], [1.]])
     Y = [-1, 0, 1]       # just a straight line
 
-    msg = "l1_ratio must be between 0 and 1; got (l1_ratio=%r)" % l1_ratio
+    msg="l1_ratio must be between 0 and 1;"f" got (l1_ratio={l1_ratio})"
     assert_raise_message(ValueError, msg,
                          ElasticNet(alpha=0.1, l1_ratio=l1_ratio).fit, X, Y)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #17814 

#### What does this implement/fix? Explain your changes.

This PR added codes (mainly copied from `sklearn/linearmodel/_logistic.py`) to raise `ValueError` in the Elasticnet implementation in `sklearn/linearmodel/_coordinate_descent.py` when the range is outside of `0<l1_ratio<1` or not numeric.  I also added a unit test in `sklearn/linearmodel/test/test_coordinate_descent.py` following similar test in `sklearn/linearmodel/test/test_logistic.py` called `test_l1_ratio_param` which exactly tests the raised message.

#### Any other comments?

There might be other functions/estimators which take `l1_ratio` as input (as raised by @rth in #17814) which should have similar `ValueError` raised. If I found such needs/issues, I'll raise another issue thread after I systematically went through the codebase for that.
