### PR TITLE
MNT Centralize all param checks in KMeans

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -949,12 +949,12 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
                              f"got {self.algorithm} instead.")
 
         self._algorithm = self.algorithm
+        if self._algorithm == "auto":
+            self._algorithm = "full" if self.n_clusters == 1 else "elkan"
         if self._algorithm == "elkan" and self.n_clusters == 1:
             warnings.warn("algorithm='elkan' doesn't make sense for a single "
                           "cluster. Using 'full' instead.", RuntimeWarning)
             self._algorithm = "full"
-        if self._algorithm == "auto":
-            self._algorithm = "full" if self.n_clusters == 1 else "elkan"
 
         # init
         if not (hasattr(self.init, '__array__') or callable(self.init)
@@ -1619,6 +1619,7 @@ class MiniBatchKMeans(KMeans):
                 RuntimeWarning, stacklevel=2)
             self._init_size = 3 * self.n_clusters
         self._init_size = min(self._init_size, X.shape[0])
+        # FIXME: init_size_ will be deprecated and this line will be removed
         self.init_size_ = self._init_size
 
         # reassignment_ratio

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -22,7 +22,7 @@ from ..metrics.pairwise import euclidean_distances
 from ..utils.extmath import row_norms, stable_cumsum
 from ..utils.sparsefuncs_fast import assign_rows_csr
 from ..utils.sparsefuncs import mean_variance_axis
-from ..utils.validation import _num_samples, _deprecate_positional_args
+from ..utils.validation import _deprecate_positional_args
 from ..utils import check_array
 from ..utils import gen_batches
 from ..utils import check_random_state
@@ -1678,7 +1678,8 @@ class MiniBatchKMeans(KMeans):
         n_batches = int(np.ceil(float(n_samples) / self.batch_size))
         n_iter = int(self.max_iter * n_batches)
 
-        validation_indices = random_state.randint(0, n_samples, self._init_size)
+        validation_indices = random_state.randint(0, n_samples,
+                                                  self._init_size)
         X_valid = X[validation_indices]
         sample_weight_valid = sample_weight[validation_indices]
         x_squared_norms_valid = x_squared_norms[validation_indices]

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -973,9 +973,9 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         n_samples, n_features = X.shape
         expected_n_features = self.cluster_centers_.shape[1]
         if not n_features == expected_n_features:
-            raise ValueError("Incorrect number of features. "
-                             "Got %d features, expected %d" % (
-                                 n_features, expected_n_features))
+            raise ValueError(
+                f"Incorrect number of features. Got {n_features} features, "
+                f"expected {expected_n_features}.")
 
         return X
 
@@ -1689,7 +1689,7 @@ class MiniBatchKMeans(KMeans):
         for init_idx in range(self._n_init):
             if self.verbose:
                 print("Init %d/%d with method: %s"
-                      % (init_idx + 1, self._n_init, self.init))
+                      % (init_idx + 1, self._n_init, init))
             weight_sums = np.zeros(self.n_clusters, dtype=sample_weight.dtype)
 
             # TODO: once the `k_means` function works with sparse input we
@@ -1698,7 +1698,7 @@ class MiniBatchKMeans(KMeans):
             # Initialize the centers using only a fraction of the data as we
             # expect n_samples to be very large when using MiniBatchKMeans
             cluster_centers = _init_centroids(
-                X, self.n_clusters, self.init,
+                X, self.n_clusters, init,
                 random_state=random_state,
                 x_squared_norms=x_squared_norms,
                 init_size=self._init_size)
@@ -1841,7 +1841,7 @@ class MiniBatchKMeans(KMeans):
 
             # initialize the cluster centers
             self.cluster_centers_ = _init_centroids(
-                X, self.n_clusters, self.init,
+                X, self.n_clusters, init,
                 random_state=self.random_state_,
                 x_squared_norms=x_squared_norms, init_size=self.init_size)
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -909,11 +909,13 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         self.algorithm = algorithm
 
     def _check_params(self, X):
+        # precompute_distances
         if self.precompute_distances != 'deprecated':
             warnings.warn("'precompute_distances' was deprecated in version "
                           "0.23 and will be removed in 0.25. It has no "
                           "effect", FutureWarning)
 
+        # n_jobs
         if self.n_jobs != 'deprecated':
             warnings.warn("'n_jobs' was deprecated in version 0.23 and will be"
                           " removed in 0.25.", FutureWarning)
@@ -922,23 +924,26 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
             self._n_threads = None
         self._n_threads = _openmp_effective_n_threads(self._n_threads)
 
+        # n_init
         if self.n_init <= 0:
             raise ValueError(
                 f"n_init should be > 0, got {self.n_init} instead.")
         self._n_init = self.n_init
 
+        # max_iter
         if self.max_iter <= 0:
             raise ValueError(
                 f"max_iter should be > 0, got {self.max_iter} instead.")
 
+        # n_clusters
         if X.shape[0] < self.n_clusters:
             raise ValueError(f"n_samples={X.shape[0]} should be >= "
                              f"n_clusters={self.n_clusters}.")
 
-        if self.tol < 0:
-            raise ValueError(f"tol should be >= 0, got {self.tol} instead.")
+        # tol
         self._tol = _tolerance(X, self.tol)
 
+        # algorithm
         if self.algorithm not in ("auto", "full", "elkan"):
             raise ValueError(f"Algorithm must be 'auto', 'full' or 'elkan', "
                              f"got {self.algorithm} instead.")
@@ -951,6 +956,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         if self._algorithm == "auto":
             self._algorithm = "full" if self.n_clusters == 1 else "elkan"
 
+        # init
         if not (hasattr(self.init, '__array__') or callable(self.init)
                 or (isinstance(self.init, str)
                     and self.init in ["k-means++", "random"])):
@@ -1587,15 +1593,18 @@ class MiniBatchKMeans(KMeans):
     def _check_params(self, X):
         super()._check_params(X)
 
+        # max_no_improvement
         if self.max_no_improvement is not None and self.max_no_improvement < 0:
             raise ValueError(
                 f"max_no_improvement should be >= 0, got "
                 f"{self.max_no_improvement} instead.")
 
+        # batch_size
         if self.batch_size <= 0:
             raise ValueError(
                 f"batch_size should be > 0, got {self.batch_size} instead.")
 
+        # init_size
         if self.init_size is not None and self.init_size <= 0:
             raise ValueError(
                 f"init_size should be > 0, got {self.init_size} instead.")
@@ -1614,6 +1623,7 @@ class MiniBatchKMeans(KMeans):
         self._init_size = min(self._init_size, X.shape[0])
         self.init_size_ = self._init_size
 
+        # reassignment_ratio
         if self.reassignment_ratio < 0:
             raise ValueError(
                 f"reassignment_ratio should be >= 0, got "

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1831,9 +1831,6 @@ class MiniBatchKMeans(KMeans):
                                 order='C', accept_large_sparse=False,
                                 reset=is_first_call_to_partial_fit)
 
-        if X.shape[0] == 0:
-            return self
-
         self.random_state_ = getattr(self, "random_state_",
                                      check_random_state(self.random_state))
         sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1021,7 +1021,6 @@ def test_sample_weight_unchanged():
     ({"n_init": 0}, r"n_init should be > 0"),
     ({"max_iter": 0}, r"max_iter should be > 0"),
     ({"n_clusters": n_samples + 1}, r"n_samples.* should be >= n_clusters"),
-    ({"tol": -1}, r"tol should be >= 0"),
     ({"init": X[:2]},
      r"The shape of the initial centers .* does not match "
      r"the number of clusters"),

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1016,7 +1016,7 @@ def test_sample_weight_unchanged():
     assert_array_equal(sample_weight, np.array([0.5, 0.2, 0.3]))
 
 
-@pytest.mark.parametrize("estimator", [KMeans, MiniBatchKMeans])
+@pytest.mark.parametrize("Estimator", [KMeans, MiniBatchKMeans])
 @pytest.mark.parametrize("param, match", [
     ({"n_init": 0}, r"n_init should be > 0"),
     ({"max_iter": 0}, r"max_iter should be > 0"),
@@ -1038,11 +1038,11 @@ def test_sample_weight_unchanged():
      r"init should be either 'k-means\+\+', 'random', "
      r"a ndarray or a callable")]
 )
-def test_wrong_params(estimator, param, match):
+def test_wrong_params(Estimator, param, match):
     # Check that error are raised with clear error message when wrong values
     # are passed for the parameters
     with pytest.raises(ValueError, match=match):
-        estimator(**param).fit(X)
+        Estimator(**param).fit(X)
 
 
 @pytest.mark.parametrize("param, match", [

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -288,7 +288,7 @@ def test_all_init(Estimator, data, init):
     # Check KMeans and MiniBatchKMeans with all possible init.
     n_init = 10 if type(init) is str else 1
     km = Estimator(init=init, n_clusters=n_clusters, random_state=42,
-                   n_init=n_init)
+                   n_init=n_init).fit(data)
     _check_fitted_model(km)
 
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -344,49 +344,6 @@ def test_k_means_init(data, init):
     _check_fitted_model(km)
 
 
-def test_k_means_n_init():
-    rnd = np.random.RandomState(0)
-    X = rnd.normal(size=(40, 2))
-
-    # two regression tests on bad n_init argument
-    # previous bug: n_init <= 0 threw non-informative TypeError (#3858)
-    with pytest.raises(ValueError, match="n_init"):
-        KMeans(n_init=0).fit(X)
-    with pytest.raises(ValueError, match="n_init"):
-        KMeans(n_init=-1).fit(X)
-
-
-@pytest.mark.parametrize('Class', [KMeans, MiniBatchKMeans])
-def test_k_means_explicit_init_shape(Class):
-    # test for sensible errors when giving explicit init
-    # with wrong number of features or clusters
-    rnd = np.random.RandomState(0)
-    X = rnd.normal(size=(40, 3))
-
-    # mismatch of number of features
-    km = Class(n_init=1, init=X[:, :2], n_clusters=len(X))
-    msg = "does not match the number of features of the data"
-    with pytest.raises(ValueError, match=msg):
-        km.fit(X)
-    # for callable init
-    km = Class(n_init=1,
-               init=lambda X_, k, random_state: X_[:, :2],
-               n_clusters=len(X))
-    with pytest.raises(ValueError, match=msg):
-        km.fit(X)
-    # mismatch of number of clusters
-    msg = "does not match the number of clusters"
-    km = Class(n_init=1, init=X[:2, :], n_clusters=3)
-    with pytest.raises(ValueError, match=msg):
-        km.fit(X)
-    # for callable init
-    km = Class(n_init=1,
-               init=lambda X_, k, random_state: X_[:2, :],
-               n_clusters=3)
-    with pytest.raises(ValueError, match=msg):
-        km.fit(X)
-
-
 def test_k_means_fortran_aligned_data():
     # Check the KMeans will work well, even if X is a fortran-aligned data.
     X = np.asfortranarray([[0, 0], [0, 1], [0, 1]])
@@ -573,13 +530,6 @@ def test_sparse_mb_k_means_callable_init():
     def test_init(X, k, random_state):
         return centers
 
-    # Small test to check that giving the wrong number of centers
-    # raises a meaningful error
-    msg = "does not match the number of clusters"
-    with pytest.raises(ValueError, match=msg):
-        MiniBatchKMeans(init=test_init, random_state=42).fit(X_csr)
-
-    # Now check that the fit actually works
     mb_k_means = MiniBatchKMeans(n_clusters=3, init=test_init,
                                  random_state=42).fit(X_csr)
     _check_fitted_model(mb_k_means)
@@ -618,13 +568,6 @@ def test_minibatch_set_init_size():
     assert mb_k_means.init_size == 666
     assert mb_k_means.init_size_ == n_samples
     _check_fitted_model(mb_k_means)
-
-
-@pytest.mark.parametrize("Estimator", [KMeans, MiniBatchKMeans])
-def test_k_means_invalid_init(Estimator):
-    km = Estimator(init="invalid", n_init=1, n_clusters=n_clusters)
-    with pytest.raises(ValueError):
-        km.fit(X)
 
 
 def test_k_means_copyx():
@@ -806,10 +749,6 @@ def test_k_means_function():
     assert_warns(RuntimeWarning, k_means, X, n_clusters=n_clusters,
                  sample_weight=None, init=centers)
 
-    # to many clusters desired
-    with pytest.raises(ValueError):
-        k_means(X, n_clusters=X.shape[0] + 1, sample_weight=None)
-
 
 def test_x_squared_norms_init_centroids():
     # Test that x_squared_norms can be None in _init_centroids
@@ -821,12 +760,6 @@ def test_x_squared_norms_init_centroids():
     assert_array_almost_equal(
         precompute,
         _init_centroids(X, 3, "k-means++", random_state=0))
-
-
-def test_max_iter_error():
-    km = KMeans(max_iter=-1)
-    assert_raise_message(ValueError, 'Number of iterations should be',
-                         km.fit, X)
 
 
 @pytest.mark.parametrize("data", [X, X_csr], ids=["dense", "sparse"])
@@ -889,24 +822,6 @@ def test_k_means_init_fitted_centers(data):
     new_centers = KMeans(n_clusters=3, init=centers,
                          n_init=1).fit(X).cluster_centers_
     assert_array_almost_equal(centers, new_centers)
-
-
-def test_sparse_validate_centers():
-    from sklearn.datasets import load_iris
-
-    iris = load_iris()
-    X = iris.data
-
-    # Get a local optimum
-    centers = KMeans(n_clusters=4).fit(X).cluster_centers_
-
-    # Test that a ValueError is raised for validate_center_shape
-    classifier = KMeans(n_clusters=3, init=centers, n_init=1)
-
-    msg = r"The shape of the initial centers \(\(4L?, 4L?\)\) " \
-          "does not match the number of clusters 3"
-    with pytest.raises(ValueError, match=msg):
-        classifier.fit(X)
 
 
 def test_less_centers_than_unique_points():
@@ -982,15 +897,6 @@ def test_scaled_weights():
         assert_almost_equal(v_measure_score(est_1.labels_, est_2.labels_), 1.0)
         assert_almost_equal(_sort_centers(est_1.cluster_centers_),
                             _sort_centers(est_2.cluster_centers_))
-
-
-def test_sample_weight_length():
-    # check that an error is raised when passing sample weights
-    # with an incompatible shape
-    km = KMeans(n_clusters=n_clusters, random_state=42)
-    msg = r'sample_weight.shape == \(2,\), expected \(100,\)'
-    with pytest.raises(ValueError, match=msg):
-        km.fit(X, sample_weight=np.ones(2))
 
 
 def test_check_normalize_sample_weight():
@@ -1175,3 +1081,55 @@ def test_sample_weight_unchanged():
 
     # internally, sample_weight is rescale to sum up to n_samples = 3
     assert_array_equal(sample_weight, np.array([0.5, 0.2, 0.3]))
+
+
+@pytest.mark.parametrize("estimator", [KMeans, MiniBatchKMeans])
+@pytest.mark.parametrize("param, match", [
+    ({"n_init": 0}, r"n_init should be > 0"),
+    ({"max_iter": 0}, r"max_iter should be > 0"),
+    ({"n_clusters": n_samples + 1}, r"n_samples.* should be >= n_clusters"),
+    ({"tol": -1}, r"tol should be >= 0"),
+    ({"init": X[:2]},
+     r"The shape of the initial centers .* does not match "
+     r"the number of clusters"),
+    ({"init": lambda X_, k, random_state: X_[:2]},
+     r"The shape of the initial centers .* does not match "
+     r"the number of clusters"),
+    ({"init": X[:8, :2]},
+     r"The shape of the initial centers .* does not match "
+     r"the number of features of the data"),
+    ({"init": lambda X_, k, random_state: X_[:8, :2]},
+     r"The shape of the initial centers .* does not match "
+     r"the number of features of the data"),
+    ({"init": "wrong"},
+     r"init should be either 'k-means\+\+', 'random', "
+     r"a ndarray or a callable")]
+)
+def test_wrong_params(estimator, param, match):
+    # Check that error are raised with clear error message when wrong values
+    # are passed for the parameters
+    with pytest.raises(ValueError, match=match):
+        estimator(**param).fit(X)
+
+
+@pytest.mark.parametrize("param, match", [
+    ({"algorithm": "wrong"}, r"Algorithm must be 'auto', 'full' or 'elkan'")]
+)
+def test_kmeans_wrong_params(param, match):
+    # Check that error are raised with clear error message when wrong values
+    # are passed for the KMeans specific parameters
+    with pytest.raises(ValueError, match=match):
+        KMeans(**param).fit(X)
+
+
+@pytest.mark.parametrize("param, match", [
+    ({"max_no_improvement": -1}, r"max_no_improvement should be >= 0"),
+    ({"batch_size": -1}, r"batch_size should be > 0"),
+    ({"init_size": -1}, r"init_size should be > 0"),
+    ({"reassignment_ratio": -1}, r"reassignment_ratio should be >= 0")]
+)
+def test_minibatch_kmeans_wrong_params(param, match):
+    # Check that error are raised with clear error message when wrong values
+    # are passed for the MiniBatchKMeans specific parameters
+    with pytest.raises(ValueError, match=match):
+        MiniBatchKMeans(**param).fit(X)


### PR DESCRIPTION
move all checks of init parameters for KMeans and MiniBatchKMeans in a dedicated method (and add missing checks).
Make a single parametrized test to check that error messages are raised appropriately.

Extracted from #17622 to facilitate the reviews