### PR TITLE
DOC document and deprecate missing attributes in MiniBatchKMeans

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -54,11 +54,15 @@ Changelog
   :user:`Lucy Liu <lucyleeow>`.
 
 :mod:`sklearn.cluster`
-.........................
+......................
 
 - |Fix| Fixed a bug in :class:`cluster.KMeans` and
   :class:`cluster.MiniBatchKMeans` where the reported inertia was incorrectly
   weighted by the sample weights. :pr:`17848` by
+  :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
+- |API| :class:`cluster.MiniBatchKMeans` attributes, `counts_` and
+  `init_size_`, are deprecated and will be removed in 0.26. :pr:`17864` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.covariance`

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1521,8 +1521,14 @@ class MiniBatchKMeans(KMeans):
     counts_ : ndarray of shape (n_clusters,)
         Weigth sum of each cluster.
 
+        .. deprecated:: 0.24
+           This attribute is deprecated in 0.24 and will be removed in 0.26.
+
     init_size_ : int
         The effective number of samples used for the initialization.
+
+        .. deprecated:: 0.24
+           This attribute is deprecated in 0.24 and will be removed in 0.26.
 
     See Also
     --------
@@ -1581,14 +1587,14 @@ class MiniBatchKMeans(KMeans):
         self.init_size = init_size
         self.reassignment_ratio = reassignment_ratio
 
-    @deprecated("The attribute 'counts_' is deprecated in 0.24 and will be "
-                "removed in 0.26.")
+    @deprecated("The attribute 'counts_' is deprecated in 0.24"  # type: ignore
+                " and will be removed in 0.26.")
     @property
     def counts_(self):
         return self._counts
 
-    @deprecated("The attribute 'init_size_' is deprecated in 0.24 and will be "
-                "removed in 0.26.")
+    @deprecated("The attribute 'init_size_' is deprecated in "  # type: ignore
+                "0.24 and will be removed in 0.26.")
     @property
     def init_size_(self):
         return self._init_size

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1532,6 +1532,9 @@ class MiniBatchKMeans(KMeans):
         defined as the sum of square distances of samples to their nearest
         neighbor.
 
+    n_iter_ : int
+        Number of batches processed.
+
     counts_ : ndarray of shape (n_clusters,)
         Weigth sum of each cluster.
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1857,7 +1857,7 @@ class MiniBatchKMeans(KMeans):
                                 order='C', accept_large_sparse=False,
                                 reset=is_first_call_to_partial_fit)
 
-        self.random_state_ = getattr(self, "random_state_",
+        self._random_state = getattr(self, "_random_state",
                                      check_random_state(self.random_state))
         sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 
@@ -1876,7 +1876,7 @@ class MiniBatchKMeans(KMeans):
             # initialize the cluster centers
             self.cluster_centers_ = _init_centroids(
                 X, self.n_clusters, init,
-                random_state=self.random_state_,
+                random_state=self._random_state,
                 x_squared_norms=x_squared_norms, init_size=self.init_size)
 
             self._counts = np.zeros(self.n_clusters,

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1616,6 +1616,12 @@ class MiniBatchKMeans(KMeans):
     def init_size_(self):
         return self._init_size
 
+    @deprecated("The attribute 'random_state_' is deprecated "  # type: ignore
+                "in 0.24 and will be removed in 0.26.")
+    @property
+    def random_state_(self):
+        return getattr(self, "_random_state", None)
+
     def _check_params(self, X):
         super()._check_params(X)
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -465,7 +465,7 @@ def test_minibatch_reassign():
             # Turn on verbosity to smoke test the display code
             _mini_batch_step(this_X, sample_weight, (X ** 2).sum(axis=1),
                              mb_k_means.cluster_centers_,
-                             mb_k_means.counts_,
+                             mb_k_means._counts,
                              np.zeros(X.shape[1], np.double),
                              False, distances=np.zeros(X.shape[0]),
                              random_reassign=True, random_state=42,
@@ -485,7 +485,7 @@ def test_minibatch_reassign():
         # Turn on verbosity to smoke test the display code
         _mini_batch_step(this_X, sample_weight, (X ** 2).sum(axis=1),
                          mb_k_means.cluster_centers_,
-                         mb_k_means.counts_,
+                         mb_k_means._counts,
                          np.zeros(X.shape[1], np.double),
                          False, distances=np.zeros(X.shape[0]),
                          random_reassign=True, random_state=42,
@@ -543,7 +543,7 @@ def test_minibatch_default_init_size():
     mb_k_means = MiniBatchKMeans(init=centers.copy(), n_clusters=n_clusters,
                                  batch_size=10, random_state=42,
                                  n_init=1).fit(X)
-    assert mb_k_means.init_size_ == 3 * mb_k_means.batch_size
+    assert mb_k_means._init_size == 3 * mb_k_means.batch_size
     _check_fitted_model(mb_k_means)
 
 
@@ -558,7 +558,7 @@ def test_minibatch_set_init_size():
                                  init_size=666, random_state=42,
                                  n_init=1).fit(X)
     assert mb_k_means.init_size == 666
-    assert mb_k_means.init_size_ == n_samples
+    assert mb_k_means._init_size == n_samples
     _check_fitted_model(mb_k_means)
 
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1108,3 +1108,16 @@ def test_sample_weight_unchanged():
 
     # internally, sample_weight is rescale to sum up to n_samples = 3
     assert_array_equal(sample_weight, np.array([0.5, 0.2, 0.3]))
+
+
+@pytest.mark.parametrize("attr", ["counts_", "init_size_"])
+def test_minibatch_kmeans_deprecated_attributes(attr):
+    # check that we raise a deprecation warning when accessing `init_size_`
+    # FIXME: remove in 0.26
+    depr_msg = (f"The attribute '{attr}' is deprecated in 0.24 and will be "
+                f"removed in 0.26.")
+    km = MiniBatchKMeans(n_clusters=2, n_init=1, init='random', random_state=0)
+    km.fit(X)
+
+    with pytest.warns(FutureWarning, match=depr_msg):
+        getattr(km, attr)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -933,7 +933,7 @@ def test_n_jobs_deprecated(n_jobs):
         kmeans.fit(X)
 
 
-@pytest.mark.parametrize("attr", ["counts_", "init_size_"])
+@pytest.mark.parametrize("attr", ["counts_", "init_size_", "random_state_"])
 def test_minibatch_kmeans_deprecated_attributes(attr):
     # check that we raise a deprecation warning when accessing `init_size_`
     # FIXME: remove in 0.26

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -235,7 +235,6 @@ def test_fit_docstring_attributes(name, Estimator):
     IGNORED = {'BayesianRidge', 'Birch', 'CCA', 'CategoricalNB',
                'KernelCenterer',
                'LarsCV', 'Lasso', 'LassoLarsCV', 'LassoLarsIC',
-               'MiniBatchKMeans',
                'OrthogonalMatchingPursuit',
                'PLSCanonical', 'PLSSVD',
                'PassiveAggressiveClassifier'}

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -232,12 +232,10 @@ def test_fit_docstring_attributes(name, Estimator):
         with ignore_warnings(category=FutureWarning):
             assert hasattr(est, attr.name)
 
-    IGNORED = {'BayesianRidge', 'Birch', 'CCA', 'CategoricalNB',
-               'KernelCenterer',
+    IGNORED = {'BayesianRidge', 'Birch', 'CCA',
                'LarsCV', 'Lasso', 'LassoLarsCV', 'LassoLarsIC',
                'OrthogonalMatchingPursuit',
-               'PLSCanonical', 'PLSSVD',
-               'PassiveAggressiveClassifier'}
+               'PLSCanonical', 'PLSSVD'}
 
     if Estimator.__name__ in IGNORED:
         pytest.xfail(

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -233,7 +233,7 @@ def test_fit_docstring_attributes(name, Estimator):
             assert hasattr(est, attr.name)
 
     IGNORED = {'BayesianRidge', 'Birch', 'CCA',
-               'LarsCV', 'Lasso', 'LassoLarsCV', 'LassoLarsIC',
+               'LarsCV', 'Lasso', 'LassoLarsIC',
                'OrthogonalMatchingPursuit',
                'PLSCanonical', 'PLSSVD'}
 


### PR DESCRIPTION
Part of #14312

`counts_` and `init_size_` are not documented as MiniBatchKMeans attributes.
They are not useful for the user so I propose to deprecate them.

`random_state_` is only created and used in `partial_fit`. I think it's safe to directly privatize it. What do you think ?

Extracted from #17622 to facilitate the reviews.

ping @glemaitre 