### PR TITLE
[MRG] DOC Revamp statistical inference tutorial pages

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -1198,7 +1198,7 @@ div.sk-page-content img.map {
 
 /* sponsors and testimonials */
 
-div.sk-sponsor-div, div.sk-testimonial-div, div.sk-doc-div {
+div.sk-sponsor-div, div.sk-testimonial-div {
   display: flex;
   flex-wrap: wrap;
   -webkit-flex-align: center;
@@ -1212,6 +1212,16 @@ div.sk-doc-div-box {
   width: 100%;
 }
 
+div.sk-doc-div {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+div.sk-doc-div-box {
+  padding: 0.30rem;
+  overflow: auto;
+}
+
 @media screen and (min-width: 500px) {
   div.sk-sponsor-div-box, div.sk-testimonial-div-box {
     width: 50%;
@@ -1222,11 +1232,6 @@ div.sk-doc-div-box {
   div.sk-doc-div-box {
     width: 50%;
   }
-}
-
-div.sk-doc-div-box {
-  padding: 0.30rem;
-  overflow: auto;
 }
 
 table.sk-sponsor-table tr, table.sk-sponsor-table tr:nth-child(odd) {

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -76,6 +76,7 @@ a code {
 
 img {
    max-width: 100%;
+   border-radius: 0.25rem;
 }
 
 span.highlighted {
@@ -836,10 +837,6 @@ div.highlight:hover span.copybutton:hover {
     background-color: #20252B;
 }
 
-div.body img.align-center {
-  max-width: 800px;
-}
-
 div.body img {
     max-width: 100%;
     height: unset!important; /* Needed because sphinx sets the height */
@@ -1201,7 +1198,7 @@ div.sk-page-content img.map {
 
 /* sponsors and testimonials */
 
-div.sk-sponsor-div, div.sk-testimonial-div {
+div.sk-sponsor-div, div.sk-testimonial-div, div.sk-doc-div {
   display: flex;
   flex-wrap: wrap;
   -webkit-flex-align: center;
@@ -1210,7 +1207,8 @@ div.sk-sponsor-div, div.sk-testimonial-div {
   align-items: center;
 }
 
-div.sk-sponsor-div-box, div.sk-testimonial-div-box {
+div.sk-sponsor-div-box, div.sk-testimonial-div-box,
+div.sk-doc-div-box {
   width: 100%;
 }
 
@@ -1218,6 +1216,17 @@ div.sk-sponsor-div-box, div.sk-testimonial-div-box {
   div.sk-sponsor-div-box, div.sk-testimonial-div-box {
     width: 50%;
   }
+}
+
+@media screen and (min-width: 1200px) {
+  div.sk-doc-div-box {
+    width: 50%;
+  }
+}
+
+div.sk-doc-div-box {
+  padding: 0.30rem;
+  overflow: auto;
 }
 
 table.sk-sponsor-table tr, table.sk-sponsor-table tr:nth-child(odd) {

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -1215,6 +1215,7 @@ div.sk-doc-div-box {
 div.sk-doc-div {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
 }
 
 div.sk-doc-div-box {

--- a/doc/tutorial/statistical_inference/finding_help.rst
+++ b/doc/tutorial/statistical_inference/finding_help.rst
@@ -27,6 +27,6 @@ Q&A communities with Machine Learning practitioners
 
 .. _`multiple subdomains for Machine Learning questions`: https://meta.stackexchange.com/q/130524
 
--- _'An excellent free online course for Machine Learning taught by Professor Andrew Ng of Stanford': https://www.coursera.org/learn/machine-learning
+- `An excellent free online course for Machine Learning taught by Professor Andrew Ng of Stanford <https://www.coursera.org/learn/machine-learning>`_
 
--- _'Another excellent free online course that takes a more general approach to Artificial Intelligence': https://www.udacity.com/course/intro-to-artificial-intelligence--cs271
+- `Another excellent free online course that takes a more general approach to Artificial Intelligence <https://www.udacity.com/course/intro-to-artificial-intelligence--cs271>`_

--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -179,24 +179,37 @@ scoring method.
 
 .. currentmodule:: sklearn.svm
 
-.. topic:: **Exercise**
+.. topic:: Exercise
    :class: green
 
-   .. image:: /auto_examples/exercises/images/sphx_glr_plot_cv_digits_001.png
-        :target: ../../auto_examples/exercises/plot_cv_digits.html
-        :align: right
-        :scale: 90
+    .. raw :: html
+
+       <div class="sk-doc-div">
+         <div class="sk-doc-div-box">
 
    On the digits dataset, plot the cross-validation score of a :class:`SVC`
    estimator with an linear kernel as a function of parameter ``C`` (use a
    logarithmic grid of points, from 1 to 10).
 
-   .. literalinclude:: ../../auto_examples/exercises/plot_cv_digits.py
-       :lines: 13-23
+        .. literalinclude:: ../../auto_examples/exercises/plot_cv_digits.py
+            :lines: 13-23
 
-   **Solution:** :ref:`sphx_glr_auto_examples_exercises_plot_cv_digits.py`
+    .. raw :: html
 
+         </div>
+           <div class="sk-doc-div-box">
 
+    .. image:: /auto_examples/exercises/images/sphx_glr_plot_cv_digits_001.png
+        :target: ../../auto_examples/exercises/plot_cv_digits.html
+        :align: center
+        :scale: 90
+
+    .. raw :: html
+
+         </div>
+       </div>
+
+    **Solution:** :ref:`sphx_glr_auto_examples_exercises_plot_cv_digits.py`
 
 Grid-search and cross-validated estimators
 ============================================

--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -179,17 +179,16 @@ scoring method.
 
 .. currentmodule:: sklearn.svm
 
-.. topic:: Exercise
-   :class: green
+.. topic:: **Exercise**
 
     .. raw :: html
 
        <div class="sk-doc-div">
          <div class="sk-doc-div-box">
 
-   On the digits dataset, plot the cross-validation score of a :class:`SVC`
-   estimator with an linear kernel as a function of parameter ``C`` (use a
-   logarithmic grid of points, from 1 to 10).
+    On the digits dataset, plot the cross-validation score of a :class:`SVC`
+    estimator with an linear kernel as a function of parameter ``C`` (use a
+    logarithmic grid of points, from 1 to 10).
 
         .. literalinclude:: ../../auto_examples/exercises/plot_cv_digits.py
             :lines: 13-23
@@ -286,7 +285,6 @@ These estimators are called similarly to their counterparts, with 'CV'
 appended to their name.
 
 .. topic:: **Exercise**
-   :class: green
 
    On the diabetes dataset, find the optimal regularization parameter
    alpha.

--- a/doc/tutorial/statistical_inference/putting_together.rst
+++ b/doc/tutorial/statistical_inference/putting_together.rst
@@ -11,16 +11,28 @@ Pipelining
 We have seen that some estimators can transform data and that some estimators
 can predict variables. We can also create combined estimators:
 
-.. image:: ../../auto_examples/compose/images/sphx_glr_plot_digits_pipe_001.png
-   :target: ../../auto_examples/compose/plot_digits_pipe.html
-   :scale: 65
-   :align: right
+.. raw :: html
+
+   <div class="sk-doc-div">
+    <div class="sk-doc-div-box">
 
 .. literalinclude:: ../../auto_examples/compose/plot_digits_pipe.py
     :lines: 23-63
 
+.. raw :: html
 
+    </div>
+      <div class="sk-doc-div-box">
 
+.. image:: ../../auto_examples/compose/images/sphx_glr_plot_digits_pipe_001.png
+   :target: ../../auto_examples/compose/plot_digits_pipe.html
+   :scale: 65
+   :align: center
+
+.. raw :: html
+
+     </div>
+   </div>
 
 Face recognition with eigenfaces
 =================================

--- a/doc/tutorial/statistical_inference/putting_together.rst
+++ b/doc/tutorial/statistical_inference/putting_together.rst
@@ -11,28 +11,13 @@ Pipelining
 We have seen that some estimators can transform data and that some estimators
 can predict variables. We can also create combined estimators:
 
-.. raw :: html
-
-   <div class="sk-doc-div">
-    <div class="sk-doc-div-box">
-
 .. literalinclude:: ../../auto_examples/compose/plot_digits_pipe.py
     :lines: 23-63
-
-.. raw :: html
-
-    </div>
-      <div class="sk-doc-div-box">
 
 .. image:: ../../auto_examples/compose/images/sphx_glr_plot_digits_pipe_001.png
    :target: ../../auto_examples/compose/plot_digits_pipe.html
    :scale: 65
    :align: center
-
-.. raw :: html
-
-     </div>
-   </div>
 
 Face recognition with eigenfaces
 =================================
@@ -52,20 +37,28 @@ The dataset used in this example is a preprocessed excerpt of the
 .. |eigenfaces| image:: ../../images/plot_face_recognition_2.png
    :scale: 50
 
-.. list-table::
-   :class: centered
+.. raw :: html
 
-   *
+   <div class="sk-doc-div">
+    <div class="sk-doc-div-box">
 
-     - |prediction|
+     <h4>Prediction</h4>
 
-     - |eigenfaces|
+|prediction|
 
-   *
+.. raw :: html
 
-     - **Prediction**
+    </div>
+      <div class="sk-doc-div-box">
 
-     - **Eigenfaces**
+     <h4>Eigenfaces</h4>
+
+|eigenfaces|
+
+.. raw :: html
+
+     </div>
+    </div>
 
 Expected results for the top 5 most represented people in the dataset::
 

--- a/doc/tutorial/statistical_inference/settings.rst
+++ b/doc/tutorial/statistical_inference/settings.rst
@@ -31,10 +31,10 @@ needs to be preprocessed in order to be used by scikit-learn.
 
 .. topic:: An example of reshaping data would be the digits dataset
 
-    .. image:: /auto_examples/datasets/images/sphx_glr_plot_digits_last_image_001.png
-        :target: ../../auto_examples/datasets/plot_digits_last_image.html
-        :align: right
-        :scale: 60
+    .. raw :: html
+
+       <div class="sk-doc-div">
+         <div class="sk-doc-div-box">
 
     The digits dataset is made of 1797 8x8 images of hand-written
     digits ::
@@ -50,6 +50,20 @@ needs to be preprocessed in order to be used by scikit-learn.
     feature vector of length 64 ::
 
         >>> data = digits.images.reshape((digits.images.shape[0], -1))
+
+    .. raw :: html
+
+         </div>
+         <div class="sk-doc-div-box">
+
+    .. image:: /auto_examples/datasets/images/sphx_glr_plot_digits_last_image_001.png
+        :target: ../../auto_examples/datasets/plot_digits_last_image.html
+        :align: center
+
+    .. raw :: html
+
+         </div>
+       </div>
 
 
 Estimators objects

--- a/doc/tutorial/statistical_inference/settings.rst
+++ b/doc/tutorial/statistical_inference/settings.rst
@@ -46,11 +46,6 @@ needs to be preprocessed in order to be used by scikit-learn.
         >>> plt.imshow(digits.images[-1], cmap=plt.cm.gray_r) #doctest: +SKIP
         <matplotlib.image.AxesImage object at ...>
     
-    .. image:: /auto_examples/datasets/images/sphx_glr_plot_digits_last_image_001.png
-        :target: ../../auto_examples/datasets/plot_digits_last_image.html
-        :align: left
-        :scale: 60
-    
     To use this dataset with scikit-learn, we transform each 8x8 image into a
     feature vector of length 64 ::
 

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -257,6 +257,7 @@ induces high variance:
 
 .. image:: /auto_examples/linear_model/images/sphx_glr_plot_ols_ridge_variance_001.png
    :target: ../../auto_examples/linear_model/plot_ols_ridge_variance.html
+   :align: center
 
 .. raw :: html
 
@@ -295,6 +296,7 @@ regression:
 
 .. image:: /auto_examples/linear_model/images/sphx_glr_plot_ols_ridge_variance_002.png
    :target: ../../auto_examples/linear_model/plot_ols_ridge_variance.html
+   :align: center
 
 .. raw :: html
 

--- a/doc/tutorial/statistical_inference/supervised_learning.rst
+++ b/doc/tutorial/statistical_inference/supervised_learning.rst
@@ -38,10 +38,10 @@ Nearest neighbor and the curse of dimensionality
 
 .. topic:: Classifying irises:
 
-    .. image:: /auto_examples/datasets/images/sphx_glr_plot_iris_dataset_001.png
-        :target: ../../auto_examples/datasets/plot_iris_dataset.html
-        :align: right
-	:scale: 65
+    .. raw :: html
+
+       <div class="sk-doc-div">
+         <div class="sk-doc-div-box">
 
     The iris dataset is a classification task consisting in identifying 3
     different types of irises (Setosa, Versicolour, and Virginica) from
@@ -52,6 +52,22 @@ Nearest neighbor and the curse of dimensionality
         >>> iris_X, iris_y = datasets.load_iris(return_X_y=True)
         >>> np.unique(iris_y)
         array([0, 1, 2])
+
+    .. raw :: html
+
+         </div>
+         <div class="sk-doc-div-box">
+
+    .. image:: /auto_examples/datasets/images/sphx_glr_plot_iris_dataset_001.png
+        :target: ../../auto_examples/datasets/plot_iris_dataset.html
+        :align: center
+	:scale: 50
+
+    .. raw :: html
+
+         </div>
+       </div>
+
 
 k-Nearest neighbors classifier
 -------------------------------
@@ -155,10 +171,10 @@ in its simplest form, fits a linear model to the data set by adjusting
 a set of parameters in order to make the sum of the squared residuals
 of the model as small as possible.
 
-.. image:: /auto_examples/linear_model/images/sphx_glr_plot_ols_001.png
-   :target: ../../auto_examples/linear_model/plot_ols.html
-   :scale: 40
-   :align: right
+.. raw :: html
+
+   <div class="sk-doc-div">
+     <div class="sk-doc-div-box">
 
 Linear models: :math:`y = X\beta + \epsilon`
 
@@ -166,6 +182,21 @@ Linear models: :math:`y = X\beta + \epsilon`
  * :math:`y`: target variable
  * :math:`\beta`: Coefficients
  * :math:`\epsilon`: Observation noise
+
+.. raw :: html
+
+     </div>
+     <div class="sk-doc-div-box">
+
+.. image:: /auto_examples/linear_model/images/sphx_glr_plot_ols_001.png
+   :target: ../../auto_examples/linear_model/plot_ols.html
+   :scale: 50
+   :align: center
+
+.. raw :: html
+
+     </div>
+   </div>
 
 ::
 
@@ -197,10 +228,10 @@ Shrinkage
 If there are few data points per dimension, noise in the observations
 induces high variance:
 
-.. image:: /auto_examples/linear_model/images/sphx_glr_plot_ols_ridge_variance_001.png
-   :target: ../../auto_examples/linear_model/plot_ols_ridge_variance.html
-   :scale: 70
-   :align: right
+.. raw :: html
+
+   <div class="sk-doc-div">
+     <div class="sk-doc-div-box">
 
 ::
 
@@ -219,6 +250,18 @@ induces high variance:
     ...     plt.plot(test, regr.predict(test)) # doctest: +SKIP
     ...     plt.scatter(this_X, y, s=3)  # doctest: +SKIP
 
+.. raw :: html
+
+     </div>
+     <div class="sk-doc-div-box">
+
+.. image:: /auto_examples/linear_model/images/sphx_glr_plot_ols_ridge_variance_001.png
+   :target: ../../auto_examples/linear_model/plot_ols_ridge_variance.html
+
+.. raw :: html
+
+     </div>
+    </div>
 
 
 A solution in high-dimensional statistical learning is to *shrink* the
@@ -226,10 +269,11 @@ regression coefficients to zero: any two randomly chosen set of
 observations are likely to be uncorrelated. This is called :class:`Ridge`
 regression:
 
-.. image:: /auto_examples/linear_model/images/sphx_glr_plot_ols_ridge_variance_002.png
-   :target: ../../auto_examples/linear_model/plot_ols_ridge_variance.html
-   :scale: 70
-   :align: right
+.. raw :: html
+
+   <div class="sk-doc-div">
+     <div class="sk-doc-div-box">
+
 
 ::
 
@@ -243,6 +287,20 @@ regression:
     ...     regr.fit(this_X, y)
     ...     plt.plot(test, regr.predict(test)) # doctest: +SKIP
     ...     plt.scatter(this_X, y, s=3) # doctest: +SKIP
+
+.. raw :: html
+
+     </div>
+     <div class="sk-doc-div-box">
+
+.. image:: /auto_examples/linear_model/images/sphx_glr_plot_ols_ridge_variance_002.png
+   :target: ../../auto_examples/linear_model/plot_ols_ridge_variance.html
+
+.. raw :: html
+
+     </div>
+   </div>
+
 
 This is an example of **bias/variance tradeoff**: the larger the ridge
 ``alpha`` parameter, the higher the bias and the lower the variance.
@@ -346,16 +404,31 @@ application of Occam's razor: *prefer simpler models*.
 Classification
 ---------------
 
-.. image:: /auto_examples/linear_model/images/sphx_glr_plot_logistic_001.png
-   :target: ../../auto_examples/linear_model/plot_logistic.html
-   :scale: 65
-   :align: right
+.. raw :: html
+
+   <div class="sk-doc-div">
+     <div class="sk-doc-div-box">
 
 For classification, as in the labeling
 `iris <https://en.wikipedia.org/wiki/Iris_flower_data_set>`_ task, linear
 regression is not the right approach as it will give too much weight to
 data far from the decision frontier. A linear approach is to fit a sigmoid
 function or **logistic** function:
+
+.. raw :: html
+
+     </div>
+     <div class="sk-doc-div-box">
+
+.. image:: /auto_examples/linear_model/images/sphx_glr_plot_logistic_001.png
+   :target: ../../auto_examples/linear_model/plot_logistic.html
+   :scale: 70
+   :align: center
+
+.. raw :: html
+
+     </div>
+   </div>
 
 .. math::
 
@@ -373,6 +446,7 @@ This is known as :class:`LogisticRegression`.
 .. image:: /auto_examples/linear_model/images/sphx_glr_plot_iris_logistic_001.png
    :target: ../../auto_examples/linear_model/plot_iris_logistic.html
    :scale: 83
+   :align: center
 
 .. topic:: Multiclass classification
 
@@ -420,19 +494,31 @@ the separating line (less regularization).
 
 .. |svm_margin_unreg| image:: /auto_examples/svm/images/sphx_glr_plot_svm_margin_001.png
    :target: ../../auto_examples/svm/plot_svm_margin.html
-   :scale: 70
 
 .. |svm_margin_reg| image:: /auto_examples/svm/images/sphx_glr_plot_svm_margin_002.png
    :target: ../../auto_examples/svm/plot_svm_margin.html
-   :scale: 70
 
-.. rst-class:: centered
+.. raw :: html
 
-    ============================= ==============================
-     **Unregularized SVM**         **Regularized SVM (default)**
-    ============================= ==============================
-    |svm_margin_unreg|  	  |svm_margin_reg|
-    ============================= ==============================
+   <div class="sk-doc-div">
+     <div class="sk-doc-div-box">
+      <h4>Unregularized SVM</h4>
+
+|svm_margin_unreg|
+
+.. raw :: html
+
+     </div>
+     <div class="sk-doc-div-box">
+      <h4>Regularized SVM (default)</h4>
+
+|svm_margin_reg|
+
+.. raw :: html
+
+     </div>
+    </div>
+
 
 .. topic:: Example:
 
@@ -459,7 +545,7 @@ classification --:class:`SVC` (Support Vector Classification).
 .. _using_kernels_tut:
 
 Using kernels
---------------
+-------------
 
 Classes are not always linearly separable in feature space. The solution is to
 build a decision function that is not linear but may be polynomial instead.
@@ -468,72 +554,58 @@ creating a decision energy by positioning *kernels* on observations:
 
 .. |svm_kernel_linear| image:: /auto_examples/svm/images/sphx_glr_plot_svm_kernels_001.png
    :target: ../../auto_examples/svm/plot_svm_kernels.html
-   :scale: 65
 
 .. |svm_kernel_poly| image:: /auto_examples/svm/images/sphx_glr_plot_svm_kernels_002.png
    :target: ../../auto_examples/svm/plot_svm_kernels.html
-   :scale: 65
-
-.. rst-class:: centered
-
-  .. list-table::
-
-     *
-
-       - **Linear kernel**
-
-       - **Polynomial kernel**
-
-
-
-     *
-
-       - |svm_kernel_linear|
-
-       - |svm_kernel_poly|
-
-
-
-     *
-
-       - ::
-
-            >>> svc = svm.SVC(kernel='linear')
-
-       - ::
-
-            >>> svc = svm.SVC(kernel='poly',
-            ...               degree=3)
-            >>> # degree: polynomial degree
-
-
 
 .. |svm_kernel_rbf| image:: /auto_examples/svm/images/sphx_glr_plot_svm_kernels_003.png
    :target: ../../auto_examples/svm/plot_svm_kernels.html
-   :scale: 65
 
-.. rst-class:: centered
+.. raw :: html
 
-  .. list-table::
+   <div class="sk-doc-div">
+     <div class="sk-doc-div-box">
+      <h4>Linear kernel</h4>
 
-     *
+|svm_kernel_linear|
 
-       - **RBF kernel (Radial Basis Function)**
+::
 
-
-     *
-
-       - |svm_kernel_rbf|
-
-     *
-
-       - ::
-
-            >>> svc = svm.SVC(kernel='rbf')
-            >>> # gamma: inverse of size of
-            >>> # radial kernel
+    >>> svc = svm.SVC(kernel='linear')
 
 
+.. raw :: html
+
+     </div>
+     <div class="sk-doc-div-box">
+      <h4>Polynomial kernel</h4>
+
+|svm_kernel_poly|
+
+::
+
+    >>> svc = svm.SVC(kernel='poly',
+    ...               degree=3)
+    >>> # degree: polynomial degree
+
+.. raw :: html
+
+     </div>
+     <div class="sk-doc-div-box">
+      <h4>RBF kernel (Radial Basis Function)</h4>
+
+|svm_kernel_rbf|
+
+::
+
+    >>> svc = svm.SVC(kernel='rbf')
+    >>> # gamma: inverse of size of
+    >>> # radial kernel
+
+.. raw :: html
+
+     </div>
+    </div>
 
 .. topic:: **Interactive example**
 
@@ -543,7 +615,7 @@ creating a decision energy by positioning *kernels* on observations:
 
 .. image:: /auto_examples/datasets/images/sphx_glr_plot_iris_dataset_001.png
     :target: ../../auto_examples/datasets/plot_iris_dataset.html
-    :align: right
+    :align: center
     :scale: 70
 
 .. topic:: **Exercise**

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -60,42 +60,49 @@ algorithms. The simplest clustering algorithm is :ref:`k_means`.
     is sensitive to initialization, and can fall into local minima,
     although scikit-learn employs several tricks to mitigate this issue.
 
-    .. list-table::
-        :class: centered
+    .. raw :: html
 
-        *
+       <div class="sk-doc-div">
+        <div class="sk-doc-div-box">
 
-            - |k_means_iris_bad_init|
+          <h4>Bad initialization</h4>
 
-            - |k_means_iris_8|
+    |k_means_iris_bad_init|
 
-            - |cluster_iris_truth|
+    .. raw :: html
 
-        *
+       </div>
+        <div class="sk-doc-div-box">
+         <h4>8 clusters</h4>
 
-            - **Bad initialization**
+    |k_means_iris_8|
 
-            - **8 clusters**
+    .. raw :: html
 
-            - **Ground truth**
+       </div>
+        <div class="sk-doc-div-box">
+         <h4>Ground truth</h4>
+
+    |cluster_iris_truth|
+
+    .. raw :: html
+
+        </div>
+       </div>
 
     **Don't over-interpret clustering results**
 
 .. |face| image:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_001.png
    :target: ../../auto_examples/cluster/plot_face_compress.html
-   :scale: 60
 
 .. |face_regular| image:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_002.png
    :target: ../../auto_examples/cluster/plot_face_compress.html
-   :scale: 60
 
 .. |face_compressed| image:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_003.png
    :target: ../../auto_examples/cluster/plot_face_compress.html
-   :scale: 60
 
 .. |face_histogram| image:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_004.png
    :target: ../../auto_examples/cluster/plot_face_compress.html
-   :scale: 60
 
 .. topic:: **Application example: vector quantization**
 
@@ -120,28 +127,43 @@ algorithms. The simplest clustering algorithm is :ref:`k_means`.
     	>>> face_compressed = np.choose(labels, values)
     	>>> face_compressed.shape = face.shape
 
-    .. list-table::
-      :class: centered
+    .. raw :: html
 
-      *
-        - |face|
+       <div class="sk-doc-div">
+        <div class="sk-doc-div-box">
 
-        - |face_compressed|
+          <h4>Raw image</h4>
 
-        - |face_regular|
+    |face|
 
-        - |face_histogram|
+    .. raw :: html
 
-      *
+       </div>
+        <div class="sk-doc-div-box">
+         <h4>K-means quantization</h4>
 
-        - Raw image
+    |face_compressed|
 
-        - K-means quantization
+    .. raw :: html
 
-        - Equal bins
+       </div>
+        <div class="sk-doc-div-box">
+         <h4>Equal bins</h4>
 
-        - Image histogram
+    |face_regular|
 
+    .. raw :: html
+
+       </div>
+        <div class="sk-doc-div-box">
+         <h4>Image histogram</h4>
+
+    |face_histogram|
+
+    .. raw :: html
+
+        </div>
+       </div>
 
 Hierarchical agglomerative clustering: Ward
 ---------------------------------------------


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR update the display style of statistical inference pages:
- [x] [supervised learning](https://scikit-learn.org/dev/tutorial/statistical_inference/supervised_learning.html),
- [x] [settings](https://scikit-learn.org/dev/tutorial/statistical_inference/settings.html),
- [x] [model selection](https://scikit-learn.org/stable/tutorial/statistical_inference/model_selection.html),
- [x] [unsupervised learning](https://scikit-learn.org/stable/tutorial/statistical_inference/unsupervised_learning.html) (tables are no longer recommended for responsive reasons)
- [x] [putting all together](https://scikit-learn.org/stable/tutorial/statistical_inference/putting_together.html)
- [x] [finding help](https://scikit-learn.org/stable/tutorial/statistical_inference/finding_help.html) (link problems)

Currently images and codeblocks have issues and the pages are not responsive at all.


#### Any other comments?
Contents haven't been modified, only the rendering has changed.