### PR TITLE
[MRG] Factor out concatenation of Xs after feature union transformations

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -946,11 +946,8 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         Xs, transformers = zip(*results)
         self._update_transformer_list(transformers)
 
-        if any(sparse.issparse(f) for f in Xs):
-            Xs = sparse.hstack(Xs).tocsr()
-        else:
-            Xs = np.hstack(Xs)
-        return Xs
+        X_t = self._concat(Xs)
+        return X_t
 
     def _log_message(self, name, idx, total):
         if not self.verbose:
@@ -991,6 +988,11 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         if not Xs:
             # All transformers are None
             return np.zeros((X.shape[0], 0))
+
+        X_t = self._concat(Xs)
+        return X_t
+
+    def _concat(self, Xs):
         if any(sparse.issparse(f) for f in Xs):
             Xs = sparse.hstack(Xs).tocsr()
         else:

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -946,8 +946,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         Xs, transformers = zip(*results)
         self._update_transformer_list(transformers)
 
-        X_t = self._concat(Xs)
-        return X_t
+        return self._hstack(Xs)
 
     def _log_message(self, name, idx, total):
         if not self.verbose:
@@ -989,10 +988,9 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
             # All transformers are None
             return np.zeros((X.shape[0], 0))
 
-        X_t = self._concat(Xs)
-        return X_t
+        return self._hstack(Xs)
 
-    def _concat(self, Xs):
+    def _hstack(self, Xs):
         if any(sparse.issparse(f) for f in Xs):
             Xs = sparse.hstack(Xs).tocsr()
         else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->


<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Refactor the logic which concatenates the transformer results in a FeatureUnion into a single method. This is small change, but it enables overriding a single method if you want to change the data structures that a FeatureUnion can handle. It also has the added benefit of more making the code read more like the doc strings describe it:
```python
def fit_transform(self, X, y=None, **fit_params):
        """Fit all transformers, transform the data and concatenate results.
```
```python
def transform(self, X):
        """Transform X separately by each transformer, concatenate results.
```
Plus it makes `X_t`, referenced in the doc strings, a named variable in the method bodies, making the code more readable.
```python
Returns                                                      
-------                                                      
X_t : array-like or sparse matrix of \                       
        shape (n_samples, sum_n_components)                  
    hstack of results of transformers. sum_n_components is the
    sum of n_components (output dimension) over transformers.
```

#### Any other comments?
I use sklearn's pipelines a lot, frequently with many custom transformers that return pandas dataframes. When I use these transformers in a `FeatureUnion`, the dataframe information gets lost when they results of the transformations get run through `np.hstack`.

I currently address this limitation by overloading FeatureUnion's `fit` and `fit_transform`, looks a lot like this public solution [0]. I therefore have to keep up to date with the internals of those two methods as library updates happen. With this change, dealing with updates should be required less often.

[0] https://github.com/marrrcin/pandas-feature-union/blob/master/pandas_feature_union.py
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.
Thanks for contributing!
-->