### PR TITLE
WIP option to cluster classes in confusion matrix

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -237,8 +237,9 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
         normalized.
 
     cluster_classes : bool, default=False
-        Sort the classes in order for the similar the classes to end up next to
-        each other.
+        Sort the classes in order for the most confused classes to end up next to
+        each other. If True, it will also return the confusion matrix as well as
+        the newly ordered labels. This is mostly useful when there are many classes.
 
     Returns
     -------
@@ -281,6 +282,26 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
     >>> tn, fp, fn, tp = confusion_matrix([0, 1, 0, 1], [1, 1, 1, 0]).ravel()
     >>> (tn, fp, fn, tp)
     (0, 2, 1, 1)
+
+    >>> y_true = ["lion"]*200
+    >>> y_pred = ["lion"]*120 + ["leopard"]*50 + ["cat"]*20 + ["wolf"]*6 + ["dog"]*4
+    >>> y_true += ["leopard"]*200
+    >>> y_pred += ["leopard"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 + ["dog"]*7
+    >>> y_true += ["cat"]*200
+    >>> y_pred += ["cat"]*135 + ["lion"]*25 + ["leopard"]*30 + ["wolf"]*8 + ["dog"]*2
+    >>> y_true += ["wolf"]*200
+    >>> y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["leopard"]*7 + ["cat"]*7
+    >>> y_true += ["dog"]*200
+    >>> y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["leopard"]*10 + ["cat"]*5
+    >>> confusion_matrix(y_true, y_pred, cluster_classes=True)
+    (array([[130,  50,   7,   6,   7],
+            [ 40, 130,  10,  15,   5],
+            [  3,   7, 140,  25,  25],s
+            [  6,   4,  50, 120,  20],
+            [  8,   2,  30,  25, 135]]),
+    ['wolf', 'dog', 'leopard', 'lion', 'cat'])
+
+
 
     """
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -28,7 +28,7 @@ import numpy as np
 from scipy.sparse import coo_matrix
 from scipy.sparse import csr_matrix
 from scipy.spatial.distance import pdist
-from scipy.cluster.hierarchy import leaves_list, linkage, optimal_leaf_ordering
+from scipy.cluster.hierarchy import leaves_list, linkage
 
 from ..preprocessing import LabelBinarizer
 from ..preprocessing import LabelEncoder
@@ -290,19 +290,19 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
 
     >>> y_true = ["lion"]*200
     >>> y_pred = ["lion"]*120 + ["jag"]*50 + ["cat"]*20 + ["wolf"]*6 +\
-    ... ["dog"]*4
+ ["dog"]*4
     >>> y_true += ["jag"]*200
     >>> y_pred += ["jag"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 +\
-    ... ["dog"]*7
+ ["dog"]*7
     >>> y_true += ["cat"]*200
     >>> y_pred += ["cat"]*135 + ["lion"]*25 + ["jag"]*30 + ["wolf"]*8 +\
-    ... ["dog"]*2
+ ["dog"]*2
     >>> y_true += ["wolf"]*200
     >>> y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["jag"]*7 +\
-    ... ["cat"]*7
+ ["cat"]*7
     >>> y_true += ["dog"]*200
     >>> y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["jag"]*10 +\
-    ... ["cat"]*5
+ ["cat"]*5
     >>> confusion_matrix(y_true, y_pred, cluster_classes=True)
     (array([[130,  50,   7,   6,   7],
             [ 40, 130,  10,  15,   5],
@@ -382,7 +382,7 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
             cm_norm = cm
 
         dists = pdist(cm_norm)
-        links = optimal_leaf_ordering(linkage(dists), dists)
+        links = linkage(dists, optimal_ordering=True)
         idx = leaves_list(links)
         cm = cm[idx, :]
         cm = cm[:, idx]

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -309,7 +309,7 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
             [  3,   7, 140,  25,  25],
             [  6,   4,  50, 120,  20],
             [  8,   2,  30,  25, 135]]),
-     ['wolf', 'dog', 'leopard', 'lion', 'cat'])
+     ['wolf', 'dog', 'jag', 'lion', 'cat'])
     """
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
     if y_type not in ("binary", "multiclass"):

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -237,9 +237,10 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
         normalized.
 
     cluster_classes : bool, default=False
-        Sort the classes in order for the most confused classes to end up next to
-        each other. If True, it will also return the confusion matrix as well as
-        the newly ordered labels. This is mostly useful when there are many classes.
+        Sort the classes in order for the most confused classes to end up next
+        to each other. If True, it will also return the confusion matrix as
+        well as the newly ordered labels. This is mostly useful when there are
+        many classes.
 
     Returns
     -------
@@ -249,8 +250,9 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
         samples with true label being i-th class
         and prediced label being j-th class.
 
-    l : list
-        If cluster_classes == True, return a list of the labels in their new order.
+    labels : list
+        If cluster_classes == True, return a list of the labels in their new
+        order.
 
     See Also
     --------
@@ -287,24 +289,27 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
     (0, 2, 1, 1)
 
     >>> y_true = ["lion"]*200
-    >>> y_pred = ["lion"]*120 + ["leopard"]*50 + ["cat"]*20 + ["wolf"]*6 + ["dog"]*4
+    >>> y_pred = ["lion"]*120 + ["leopard"]*50 + ["cat"]*20 + ["wolf"]*6 +
+    ... ["dog"]*4
     >>> y_true += ["leopard"]*200
-    >>> y_pred += ["leopard"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 + ["dog"]*7
+    >>> y_pred += ["leopard"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 +
+    ... ["dog"]*7
     >>> y_true += ["cat"]*200
-    >>> y_pred += ["cat"]*135 + ["lion"]*25 + ["leopard"]*30 + ["wolf"]*8 + ["dog"]*2
+    >>> y_pred += ["cat"]*135 + ["lion"]*25 + ["leopard"]*30 + ["wolf"]*8 +
+    ... ["dog"]*2
     >>> y_true += ["wolf"]*200
-    >>> y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["leopard"]*7 + ["cat"]*7
+    >>> y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["leopard"]*7 +
+    ... ["cat"]*7
     >>> y_true += ["dog"]*200
-    >>> y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["leopard"]*10 + ["cat"]*5
+    >>> y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["leopard"]*10 +
+    ... ["cat"]*5
     >>> confusion_matrix(y_true, y_pred, cluster_classes=True)
     (array([[130,  50,   7,   6,   7],
             [ 40, 130,  10,  15,   5],
             [  3,   7, 140,  25,  25],
             [  6,   4,  50, 120,  20],
-            [  8,   2,  30,  25, 135]]), ['wolf', 'dog', 'leopard', 'lion', 'cat'])
-
-
-
+            [  8,   2,  30,  25, 135]]),
+            ['wolf', 'dog', 'leopard', 'lion', 'cat'])
     """
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
     if y_type not in ("binary", "multiclass"):

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -249,6 +249,9 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
         samples with true label being i-th class
         and prediced label being j-th class.
 
+    l : list
+        If cluster_classes == True, return a list of the labels in their new order.
+
     See Also
     --------
     plot_confusion_matrix : Plot Confusion Matrix
@@ -296,10 +299,9 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
     >>> confusion_matrix(y_true, y_pred, cluster_classes=True)
     (array([[130,  50,   7,   6,   7],
             [ 40, 130,  10,  15,   5],
-            [  3,   7, 140,  25,  25],s
+            [  3,   7, 140,  25,  25],
             [  6,   4,  50, 120,  20],
-            [  8,   2,  30,  25, 135]]),
-    ['wolf', 'dog', 'leopard', 'lion', 'cat'])
+            [  8,   2,  30,  25, 135]]), ['wolf', 'dog', 'leopard', 'lion', 'cat'])
 
 
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -302,7 +302,8 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
     if not isinstance(cluster_classes, bool):
         raise ValueError('cluster_classes should be a Boolean')
     elif cluster_classes is True and y_type != 'multiclass':
-        raise ValueError('cluster_classes can only be done when there are more than 2 classes')
+        raise ValueError('cluster_classes can only be done when there are more '
+                         'than 2 classes')
 
     if sample_weight is None:
         sample_weight = np.ones(y_true.shape[0], dtype=np.int64)

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -382,7 +382,11 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
             cm_norm = cm
 
         dists = pdist(cm_norm)
-        links = linkage(dists, optimal_ordering=True)
+        # In case we are dealing with an older scipy version
+        try:
+            links = linkage(dists, optimal_ordering=True)
+        except TypeError:
+            links = linkage(dists)
         idx = leaves_list(links)
         cm = cm[idx, :]
         cm = cm[:, idx]

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -309,7 +309,7 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
             [  3,   7, 140,  25,  25],
             [  6,   4,  50, 120,  20],
             [  8,   2,  30,  25, 135]]),
-            ['wolf', 'dog', 'leopard', 'lion', 'cat'])
+     ['wolf', 'dog', 'leopard', 'lion', 'cat'])
     """
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
     if y_type not in ("binary", "multiclass"):

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -299,11 +299,9 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
         elif np.all([l not in y_true for l in labels]):
             raise ValueError("At least one label specified must be in y_true")
 
-    if not isinstance(cluster_classes, bool):
-        raise ValueError('cluster_classes should be a Boolean')
-    elif cluster_classes is True and y_type != 'multiclass':
-        raise ValueError('cluster_classes can only be done when there are more '
-                         'than 2 classes')
+    if cluster_classes and y_type != 'multiclass':
+        raise ValueError("cluster_classes can only be used when there are "
+                         "more than 2 classes")
 
     if sample_weight is None:
         sample_weight = np.ones(y_true.shape[0], dtype=np.int64)

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -28,7 +28,7 @@ import numpy as np
 from scipy.sparse import coo_matrix
 from scipy.sparse import csr_matrix
 from scipy.spatial.distance import pdist
-from scipy.cluster.hierarchy import leaves_list, linkage
+from scipy.cluster.hierarchy import leaves_list, linkage, optimal_leaf_ordering
 
 from ..preprocessing import LabelBinarizer
 from ..preprocessing import LabelEncoder
@@ -238,7 +238,7 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
 
     cluster_classes : bool, default=False
         Sort the classes in order for the most confused classes to end up next
-        to each other. If True, it will also return the confusion matrix as
+        to each other. If True, it will return the confusion matrix as
         well as the newly ordered labels. This is mostly useful when there are
         many classes.
 
@@ -289,19 +289,19 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
     (0, 2, 1, 1)
 
     >>> y_true = ["lion"]*200
-    >>> y_pred = ["lion"]*120 + ["leopard"]*50 + ["cat"]*20 + ["wolf"]*6 +
+    >>> y_pred = ["lion"]*120 + ["jag"]*50 + ["cat"]*20 + ["wolf"]*6 +\
     ... ["dog"]*4
-    >>> y_true += ["leopard"]*200
-    >>> y_pred += ["leopard"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 +
+    >>> y_true += ["jag"]*200
+    >>> y_pred += ["jag"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 +\
     ... ["dog"]*7
     >>> y_true += ["cat"]*200
-    >>> y_pred += ["cat"]*135 + ["lion"]*25 + ["leopard"]*30 + ["wolf"]*8 +
+    >>> y_pred += ["cat"]*135 + ["lion"]*25 + ["jag"]*30 + ["wolf"]*8 +\
     ... ["dog"]*2
     >>> y_true += ["wolf"]*200
-    >>> y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["leopard"]*7 +
+    >>> y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["jag"]*7 +\
     ... ["cat"]*7
     >>> y_true += ["dog"]*200
-    >>> y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["leopard"]*10 +
+    >>> y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["jag"]*10 +\
     ... ["cat"]*5
     >>> confusion_matrix(y_true, y_pred, cluster_classes=True)
     (array([[130,  50,   7,   6,   7],
@@ -382,7 +382,7 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
             cm_norm = cm
 
         dists = pdist(cm_norm)
-        links = linkage(dists, optimal_ordering=True)
+        links = optimal_leaf_ordering(linkage(dists), dists)
         idx = leaves_list(links)
         cm = cm[idx, :]
         cm = cm[:, idx]

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -386,7 +386,7 @@ def confusion_matrix(y_true, y_pred, *, labels=None, sample_weight=None,
         try:
             links = linkage(dists, optimal_ordering=True)
         except TypeError:
-            links = linkage(dists)
+            raise ValueError("Old version of Scipy")
         idx = leaves_list(links)
         cm = cm[idx, :]
         cm = cm[:, idx]

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -580,12 +580,10 @@ def test_confusion_matrix_cluster_classes():
     y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["jag"]*10 + ["cat"]*5
 
     cm, labels = confusion_matrix(y_true, y_pred, cluster_classes=True)
-    assert_array_equal(cm, [[130, 50, 7, 6, 7],
-                            [40, 130, 10, 15, 5],
-                            [3, 7, 140, 25, 25],
-                            [6, 4, 50, 120, 20],
-                            [8, 2, 30, 25, 135]])
-    assert labels == ['wolf', 'dog', 'jag', 'lion', 'cat']
+
+    # The doglike animals should occur together either at the end or start
+    idx_doglikes = np.sort([labels.index('dog'), labels.index('wolf')])
+    assert idx_doglikes.tolist() in ([0, 1], [3, 4])
 
 
 def test_cohen_kappa():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -569,45 +569,23 @@ def test_confusion_matrix_normalize_single_class():
 def test_confusion_matrix_cluster_classes():
     # Test the cluster classes functionality of confusion matrix
     y_true = ["lion"]*200
-    y_pred = ["lion"]*120 + ["leopard"]*50 + ["cat"]*20 + ["wolf"]*6 + ["dog"]*4
-    y_true += ["leopard"]*200
-    y_pred += ["leopard"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 + ["dog"]*7
+    y_pred = ["lion"]*120 + ["jag"]*50 + ["cat"]*20 + ["wolf"]*6 + ["dog"]*4
+    y_true += ["jag"]*200
+    y_pred += ["jag"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 + ["dog"]*7
     y_true += ["cat"]*200
-    y_pred += ["cat"]*135 + ["lion"]*25 + ["leopard"]*30 + ["wolf"]*8 + ["dog"]*2
+    y_pred += ["cat"]*135 + ["lion"]*25 + ["jag"]*30 + ["wolf"]*8 + ["dog"]*2
     y_true += ["wolf"]*200
-    y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["leopard"]*7 + ["cat"]*7
+    y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["jag"]*7 + ["cat"]*7
     y_true += ["dog"]*200
-    y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["leopard"]*10 + ["cat"]*5
+    y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["jag"]*10 + ["cat"]*5
 
     cm, labels = confusion_matrix(y_true, y_pred, cluster_classes=True)
-    assert_array_equal(cm, [[130,  50,   7,   6,   7],
-                            [ 40, 130,  10,  15,   5],
-                            [  3,   7, 140,  25,  25],
-                            [  6,   4,  50, 120,  20],
-                            [  8,   2,  30,  25, 135]])
-    assert labels == ['wolf', 'dog', 'leopard', 'lion', 'cat']
-
-
-def test_confusion_matrix_cluster_classes():
-    # Test the cluster classes functionality of confusion matrix
-    y_true = ["lion"]*200
-    y_pred = ["lion"]*120 + ["leopard"]*50 + ["cat"]*20 + ["wolf"]*6 + ["dog"]*4
-    y_true += ["leopard"]*200
-    y_pred += ["leopard"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 + ["dog"]*7
-    y_true += ["cat"]*200
-    y_pred += ["cat"]*135 + ["lion"]*25 + ["leopard"]*30 + ["wolf"]*8 + ["dog"]*2
-    y_true += ["wolf"]*200
-    y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["leopard"]*7 + ["cat"]*7
-    y_true += ["dog"]*200
-    y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["leopard"]*10 + ["cat"]*5
-
-    cm, labels = confusion_matrix(y_true, y_pred, cluster_classes=True)
-    assert_array_equal(cm, [[130,  50,   7,   6,   7],
-                            [ 40, 130,  10,  15,   5],
-                            [  3,   7, 140,  25,  25],
-                            [  6,   4,  50, 120,  20],
-                            [  8,   2,  30,  25, 135]])
-    assert labels == ['wolf', 'dog', 'leopard', 'lion', 'cat']
+    assert_array_equal(cm, [[130, 50, 7, 6, 7],
+                            [40, 130, 10, 15, 5],
+                            [3, 7, 140, 25, 25],
+                            [6, 4, 50, 120, 20],
+                            [8, 2, 30, 25, 135]])
+    assert labels == ['wolf', 'dog', 'jag', 'lion', 'cat']
 
 
 def test_cohen_kappa():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -566,6 +566,50 @@ def test_confusion_matrix_normalize_single_class():
     assert not rec
 
 
+def test_confusion_matrix_cluster_classes():
+    # Test the cluster classes functionality of confusion matrix
+    y_true = ["lion"]*200
+    y_pred = ["lion"]*120 + ["leopard"]*50 + ["cat"]*20 + ["wolf"]*6 + ["dog"]*4
+    y_true += ["leopard"]*200
+    y_pred += ["leopard"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 + ["dog"]*7
+    y_true += ["cat"]*200
+    y_pred += ["cat"]*135 + ["lion"]*25 + ["leopard"]*30 + ["wolf"]*8 + ["dog"]*2
+    y_true += ["wolf"]*200
+    y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["leopard"]*7 + ["cat"]*7
+    y_true += ["dog"]*200
+    y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["leopard"]*10 + ["cat"]*5
+
+    cm, labels = confusion_matrix(y_true, y_pred, cluster_classes=True)
+    assert_array_equal(cm, [[130,  50,   7,   6,   7],
+                            [ 40, 130,  10,  15,   5],
+                            [  3,   7, 140,  25,  25],
+                            [  6,   4,  50, 120,  20],
+                            [  8,   2,  30,  25, 135]])
+    assert labels == ['wolf', 'dog', 'leopard', 'lion', 'cat']
+
+
+def test_confusion_matrix_cluster_classes():
+    # Test the cluster classes functionality of confusion matrix
+    y_true = ["lion"]*200
+    y_pred = ["lion"]*120 + ["leopard"]*50 + ["cat"]*20 + ["wolf"]*6 + ["dog"]*4
+    y_true += ["leopard"]*200
+    y_pred += ["leopard"]*140 + ["lion"]*25 + ["cat"]*25 + ["wolf"]*3 + ["dog"]*7
+    y_true += ["cat"]*200
+    y_pred += ["cat"]*135 + ["lion"]*25 + ["leopard"]*30 + ["wolf"]*8 + ["dog"]*2
+    y_true += ["wolf"]*200
+    y_pred += ["wolf"]*130 + ["dog"]*50 + ["lion"]*6 + ["leopard"]*7 + ["cat"]*7
+    y_true += ["dog"]*200
+    y_pred += ["dog"]*130 + ["wolf"]*40 + ["lion"]*15 + ["leopard"]*10 + ["cat"]*5
+
+    cm, labels = confusion_matrix(y_true, y_pred, cluster_classes=True)
+    assert_array_equal(cm, [[130,  50,   7,   6,   7],
+                            [ 40, 130,  10,  15,   5],
+                            [  3,   7, 140,  25,  25],
+                            [  6,   4,  50, 120,  20],
+                            [  8,   2,  30,  25, 135]])
+    assert labels == ['wolf', 'dog', 'leopard', 'lion', 'cat']
+
+
 def test_cohen_kappa():
     # These label vectors reproduce the contingency matrix from Artstein and
     # Poesio (2008), Table 1: np.array([[20, 20], [10, 50]]).


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
When there are many classes and you plot the confusion matrix; it is rather hard to interpret the results. The new feature clusters the classes based on how often one is misclassified for the other, the similar classes end up next to each other. This results in a clearer and easier to interpret plot.

#### Any other comments?
The problem, however, is that we will change the order of the classes, and the function normally only returns the confusion matrix without the labels. We choose to return the matrix as well as the labels, which is not in line with what happens now.
Suggestions on how to handle this differently are more than welcome.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
