### PR TITLE
DOC Specify shape with parentheses in decision tree guide

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -91,8 +91,8 @@ Classification
 classification on a dataset.
 
 As with other classifiers, :class:`DecisionTreeClassifier` takes as input two arrays:
-an array X, sparse or dense, of shape ``(n_samples, n_features)``  holding the
-training samples, and an array Y of integer values, shape ``(n_samples)``,
+an array X, sparse or dense, of shape ``(n_samples, n_features)`` holding the
+training samples, and an array Y of integer values, shape ``(n_samples,)``,
 holding the class labels for the training samples::
 
     >>> from sklearn import tree

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -91,8 +91,8 @@ Classification
 classification on a dataset.
 
 As with other classifiers, :class:`DecisionTreeClassifier` takes as input two arrays:
-an array X, sparse or dense, of size ``[n_samples, n_features]``  holding the
-training samples, and an array Y of integer values, size ``[n_samples]``,
+an array X, sparse or dense, of shape ``(n_samples, n_features)``  holding the
+training samples, and an array Y of integer values, shape ``(n_samples)``,
 holding the class labels for the training samples::
 
     >>> from sklearn import tree

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -92,7 +92,7 @@ classification on a dataset.
 
 As with other classifiers, :class:`DecisionTreeClassifier` takes as input two arrays:
 an array X, sparse or dense, of shape ``(n_samples, n_features)`` holding the
-training samples, and an array y of integer values, shape ``(n_samples,)``,
+training samples, and an array Y of integer values, shape ``(n_samples,)``,
 holding the class labels for the training samples::
 
     >>> from sklearn import tree
@@ -246,7 +246,7 @@ Multi-output problems
 =====================
 
 A multi-output problem is a supervised learning problem with several outputs
-to predict, that is when Y is a 2d array of size ``[n_samples, n_outputs]``.
+to predict, that is when Y is a 2d array of shape ``(n_samples, n_outputs)``.
 
 When there is no correlation between the outputs, a very simple way to solve
 this kind of problem is to build n independent models, i.e. one for each
@@ -267,7 +267,7 @@ multi-output problems. This requires the following changes:
 This module offers support for multi-output problems by implementing this
 strategy in both :class:`DecisionTreeClassifier` and
 :class:`DecisionTreeRegressor`. If a decision tree is fit on an output array Y
-of size ``[n_samples, n_outputs]`` then the resulting estimator will:
+of shape ``(n_samples, n_outputs)`` then the resulting estimator will:
 
   * Output n_output values upon ``predict``;
 

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -92,7 +92,7 @@ classification on a dataset.
 
 As with other classifiers, :class:`DecisionTreeClassifier` takes as input two arrays:
 an array X, sparse or dense, of shape ``(n_samples, n_features)`` holding the
-training samples, and an array Y of integer values, shape ``(n_samples,)``,
+training samples, and an array y of integer values, shape ``(n_samples,)``,
 holding the class labels for the training samples::
 
     >>> from sklearn import tree


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR uses parentheses to specify the shape of `X` and `y` in the [user guide for decision trees](https://scikit-learn.org/stable/modules/tree.html). Previously, brackets were employed.