### PR TITLE
DOC: Fix numpydoc section name Return -> Returns

### DIFF
--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -15,8 +15,8 @@ from ._openmp_helpers import _openmp_parallelism_enabled
 def _get_sys_info():
     """System information
 
-    Return
-    ------
+    Returns
+    -------
     sys_info : dict
         system and Python version information
 


### PR DESCRIPTION
From a cursory glance this is the only place I found in sklearn (and to a wider extend scipy/numpy) that uses Return instead of Returns as described in the numpydoc format.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->


<!--
#### Reference Issues/PRs

Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->




<!--

#### What does this implement/fix? Explain your changes.

#### Any other comments?


Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
