### PR TITLE
MNT removed repeated definition of ranked_exposure

### DIFF
--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -477,7 +477,6 @@ def lorenz_curve(y_true, y_pred, exposure):
 
     # order samples by increasing predicted risk:
     ranking = np.argsort(y_pred)
-    ranked_exposure = exposure[ranking]
     ranked_frequencies = y_true[ranking]
     ranked_exposure = exposure[ranking]
     cumulated_claims = np.cumsum(ranked_frequencies * ranked_exposure)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes repeated definition issue from #12167 (LGTM)
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
removes repeated definition of `ranked_exposure` in `root/examples/linear-model/plot_poisson_regression_non_normal_loss.py`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
