### PR TITLE
CI Build with cython prerelease

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -87,9 +87,7 @@ elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     echo "Installing numpy and scipy master wheels"
     dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
     pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-    # Cython nightly build should be still fetched from the Rackspace container
-    dev_rackspace_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
-    pip install --pre --upgrade --timeout=60 -f $dev_rackspace_url cython
+    pip install --pre cython
     echo "Installing joblib master"
     pip install https://github.com/joblib/joblib/archive/master.zip
     echo "Installing pillow master"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -51,9 +51,7 @@ pip install --upgrade pip setuptools
 echo "Installing numpy and scipy master wheels"
 dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
 pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-# Cython nightly build should be still fetched from the Rackspace container
-dev_rackspace_url=https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
-pip install --pre --upgrade --timeout=60 -f $dev_rackspace_url cython
+pip install --pre cython
 echo "Installing joblib master"
 pip install https://github.com/joblib/joblib/archive/master.zip
 echo "Installing pillow master"


### PR DESCRIPTION
Cython now has prereleases on pypi!

https://pypi.org/project/Cython/#history

Partially addresses https://github.com/scikit-learn/scikit-learn/issues/17102