### PR TITLE
[MRG] sklearn.metrics.normalized_mutual_info_score for continuous data does not return a warning #17892

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -15,6 +15,7 @@ better.
 # License: BSD 3 clause
 
 
+import warnings
 from math import log
 
 import numpy as np
@@ -863,9 +864,9 @@ def normalized_mutual_info_score(labels_true, labels_pred, *,
     type_pred = type_of_target(labels_pred)
 
     if type_pred or type_pred == 'continous':
-        raise Warning('Classification metrics expects discrete values received {} '
-                      'for label, and {} for target'.format(type_label, type_label))
-
+        warnings.warn(UserWarning('Expects discrete values received {} '
+                                  'for label, and {} for target'
+                                  .format(type_label, type_label)))
 
     # Special limit cases: no clustering since the data is not split.
     # This is a perfect match hence return 1.0.

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -25,6 +25,8 @@ from ._expected_mutual_info_fast import expected_mutual_information
 from ...utils.validation import check_array, check_consistent_length
 from ...utils.validation import _deprecate_positional_args
 from ...utils.fixes import _astype_copy_false
+from ...utils.multiclass import type_of_target
+import warnings
 
 
 def _comb2(n):
@@ -50,6 +52,13 @@ def check_clusterings(labels_true, labels_pred):
     labels_pred = check_array(
         labels_pred, ensure_2d=False, ensure_min_samples=0, dtype=None,
     )
+
+    type_label = type_of_target(labels_true)
+    type_pred = type_of_target(labels_pred)
+
+    if type_pred or type_pred == 'continous':
+        warnings.warn('Classification metrics expects discrete values received {} for label, '
+                      'and {} for target'.format(type_label, type_label))
 
     # input checks
     if labels_true.ndim != 1:

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -58,8 +58,9 @@ def check_clusterings(labels_true, labels_pred):
     type_pred = type_of_target(labels_pred)
 
     if 'continuous' in (type_pred, type_label):
-        msg = f'Expects discrete values but received {type_label} ' \
-              f'values for label, and {type_pred} values for target'
+        msg = f'Clustering metrics expects discrete values but received' \
+              f' {type_label} values for label, and {type_pred} values ' \
+              f'for target'
         warnings.warn(msg, UserWarning)
 
     # input checks

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -22,11 +22,10 @@ from scipy import sparse as sp
 from scipy.special import comb
 
 from ._expected_mutual_info_fast import expected_mutual_information
-from ...utils.validation import check_array, check_consistent_length
-from ...utils.validation import _deprecate_positional_args
 from ...utils.fixes import _astype_copy_false
 from ...utils.multiclass import type_of_target
-import warnings
+from ...utils.validation import _deprecate_positional_args
+from ...utils.validation import check_array, check_consistent_length
 
 
 def _comb2(n):
@@ -49,16 +48,17 @@ def check_clusterings(labels_true, labels_pred):
     labels_true = check_array(
         labels_true, ensure_2d=False, ensure_min_samples=0, dtype=None,
     )
+
     labels_pred = check_array(
-        labels_pred, ensure_2d=False, ensure_min_samples=0, dtype=None,
+        labels_pred, ensure_2d=False, ensure_min_samples=0, dtype=None
     )
 
     type_label = type_of_target(labels_true)
     type_pred = type_of_target(labels_pred)
 
     if type_pred or type_pred == 'continous':
-        warnings.warn('Classification metrics expects discrete values received {} for label, '
-                      'and {} for target'.format(type_label, type_label))
+        raise Warning('Classification metrics expects discrete values received {} '
+                      'for label, and {} for target'.format(type_label, type_label))
 
     # input checks
     if labels_true.ndim != 1:

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -57,10 +57,11 @@ def check_clusterings(labels_true, labels_pred):
     type_label = type_of_target(labels_true)
     type_pred = type_of_target(labels_pred)
 
-    if type_pred or type_pred == 'continous':
-        warnings.warn(UserWarning('Expects discrete values received {} '
-                                  'for label, and {} for target'
-                                  .format(type_label, type_label)))
+    if 'continuous' in (type_pred, type_label):
+        msg = f'Expects discrete values but received {type_label} ' \
+              f'values for label, and {type_pred} values for target'
+        warnings.warn(msg, UserWarning)
+
     # input checks
     if labels_true.ndim != 1:
         raise ValueError(

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -54,6 +54,13 @@ def check_clusterings(labels_true, labels_pred):
         labels_pred, ensure_2d=False, ensure_min_samples=0, dtype=None,
     )
 
+    type_label = type_of_target(labels_true)
+    type_pred = type_of_target(labels_pred)
+
+    if type_pred or type_pred == 'continous':
+        warnings.warn(UserWarning('Expects discrete values received {} '
+                                  'for label, and {} for target'
+                                  .format(type_label, type_label)))
     # input checks
     if labels_true.ndim != 1:
         raise ValueError(
@@ -859,14 +866,6 @@ def normalized_mutual_info_score(labels_true, labels_pred, *,
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
     classes = np.unique(labels_true)
     clusters = np.unique(labels_pred)
-
-    type_label = type_of_target(labels_true)
-    type_pred = type_of_target(labels_pred)
-
-    if type_pred or type_pred == 'continous':
-        warnings.warn(UserWarning('Expects discrete values received {} '
-                                  'for label, and {} for target'
-                                  .format(type_label, type_label)))
 
     # Special limit cases: no clustering since the data is not split.
     # This is a perfect match hence return 1.0.

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -50,15 +50,8 @@ def check_clusterings(labels_true, labels_pred):
     )
 
     labels_pred = check_array(
-        labels_pred, ensure_2d=False, ensure_min_samples=0, dtype=None
+        labels_pred, ensure_2d=False, ensure_min_samples=0, dtype=None,
     )
-
-    type_label = type_of_target(labels_true)
-    type_pred = type_of_target(labels_pred)
-
-    if type_pred or type_pred == 'continous':
-        raise Warning('Classification metrics expects discrete values received {} '
-                      'for label, and {} for target'.format(type_label, type_label))
 
     # input checks
     if labels_true.ndim != 1:
@@ -865,6 +858,15 @@ def normalized_mutual_info_score(labels_true, labels_pred, *,
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
     classes = np.unique(labels_true)
     clusters = np.unique(labels_pred)
+
+    type_label = type_of_target(labels_true)
+    type_pred = type_of_target(labels_pred)
+
+    if type_pred or type_pred == 'continous':
+        raise Warning('Classification metrics expects discrete values received {} '
+                      'for label, and {} for target'.format(type_label, type_label))
+
+
     # Special limit cases: no clustering since the data is not split.
     # This is a perfect match hence return 1.0.
     if (classes.shape[0] == clusters.shape[0] == 1 or

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -356,7 +356,9 @@ def test_check_clustering_error():
     rng = np.random.RandomState(42)
     noise = rng.rand(500)
     wavelength = np.linspace(0.01, 1, 500) * 1e-6
-    msg = 'Expects discrete values but received continuous values for' \
-          ' label, and continuous values for target'
+    msg = 'Clustering metrics expects discrete values but received ' \
+          'continuous values for label, and continuous values for ' \
+          'target'
+
     with pytest.warns(UserWarning, match=msg):
         check_clusterings(wavelength, noise)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -14,6 +14,7 @@ from sklearn.metrics.cluster import mutual_info_score
 from sklearn.metrics.cluster import normalized_mutual_info_score
 from sklearn.metrics.cluster import v_measure_score
 from sklearn.metrics.cluster._supervised import _generalized_average
+from sklearn.metrics.cluster._supervised import check_clusterings
 
 from sklearn.utils import assert_all_finite
 from sklearn.utils._testing import (
@@ -352,8 +353,10 @@ def test_mutual_info_score_positive_constant_label(labels_true, labels_pred):
 
 def test_check_clustering_error():
     # Test warning message for continuous values
-    noise = np.random.rand(500)
+    rng = np.random.RandomState(42)
+    noise = rng.rand(500)
     wavelength = np.linspace(0.01, 1, 500) * 1e-6
-
-    with pytest.warns(UserWarning):
-        normalized_mutual_info_score(wavelength, noise)
+    msg = 'Expects discrete values but received continuous values for' \
+          ' label, and continuous values for target'
+    with pytest.warns(UserWarning, match=msg):
+        check_clusterings(wavelength, noise)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -351,8 +351,9 @@ def test_mutual_info_score_positive_constant_label(labels_true, labels_pred):
 
 
 def test_check_clustering_error():
+    # Test warning message for continuous values
     noise = np.random.rand(500)
     wavelength = np.linspace(0.01, 1, 500) * 1e-6
 
-    with pytest.raises(Warning):
+    with pytest(UserWarning):
         normalized_mutual_info_score(wavelength, noise)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -355,5 +355,5 @@ def test_check_clustering_error():
     noise = np.random.rand(500)
     wavelength = np.linspace(0.01, 1, 500) * 1e-6
 
-    with pytest(UserWarning):
+    with pytest.warns(UserWarning):
         normalized_mutual_info_score(wavelength, noise)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -348,3 +348,11 @@ def test_fowlkes_mallows_score_properties():
 def test_mutual_info_score_positive_constant_label(labels_true, labels_pred):
     # non-regression test for #16355
     assert mutual_info_score(labels_true, labels_pred) >= 0
+
+
+def test_check_clusterings_error():
+    noise = np.random.rand(500)
+    wavelength = np.linspace(0.01, 1, 500) * 1e-6
+
+    with pytest.raises(Warning):
+        normalized_mutual_info_score(wavelength, noise)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -350,7 +350,7 @@ def test_mutual_info_score_positive_constant_label(labels_true, labels_pred):
     assert mutual_info_score(labels_true, labels_pred) >= 0
 
 
-def test_check_clusterings_error():
+def test_check_clustering_error():
     noise = np.random.rand(500)
     wavelength = np.linspace(0.01, 1, 500) * 1e-6
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes [#17892](https://github.com/scikit-learn/scikit-learn/issues/17892)

#### What does this implement/fix? Explain your changes.
Fixes an an error where normalized_mutual_info_score for continuous data does not return a warning for continous values

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
