### PR TITLE
CI Temporary fix for conda-forge:: compilers on osx

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -38,10 +38,10 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$SKLEARN_TEST_NO_OPENMP" != "true" ]]; then
             # on macOS, install an OpenMP-enabled clang/llvm from conda-forge.
-            # TODO: Remove <1.1.0 when the following is fixed:
+            # TODO: Remove !=1.1.0 when the following is fixed:
             # sklearn/svm/_libsvm.cpython-38-darwin.so,
             # 2): Symbol not found: _svm_check_parameter error
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers>=1.0.4,<1.1.0 \
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers>=1.0.4,!=1.1.0 \
                         conda-forge::llvm-openmp"
         fi
     fi

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -38,7 +38,10 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$SKLEARN_TEST_NO_OPENMP" != "true" ]]; then
             # on macOS, install an OpenMP-enabled clang/llvm from conda-forge.
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers>=1.0.4 \
+            # TODO: Remove <1.1.0 when the following is fixed:
+            # sklearn/svm/_libsvm.cpython-38-darwin.so,
+            # 2): Symbol not found: _svm_check_parameter error
+            TO_INSTALL="$TO_INSTALL conda-forge::compilers>=1.0.4,<1.1.0 \
                         conda-forge::llvm-openmp"
         fi
     fi

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -241,7 +241,7 @@ It is recommended to use a dedicated `conda environment`_ to build
 scikit-learn from source::
 
     conda create -n sklearn-dev python numpy scipy cython joblib pytest \
-        "conda-forge::compilers>=1.0.4,<1.1.0" conda-forge::llvm-openmp
+        "conda-forge::compilers>=1.0.4,!=1.1.0" conda-forge::llvm-openmp
     conda activate sklearn-dev
     make clean
     pip install --verbose --no-build-isolation --editable .

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -241,7 +241,7 @@ It is recommended to use a dedicated `conda environment`_ to build
 scikit-learn from source::
 
     conda create -n sklearn-dev python numpy scipy cython joblib pytest \
-        "conda-forge::compilers>=1.0.4" conda-forge::llvm-openmp
+        "conda-forge::compilers>=1.0.4,<1.1.0" conda-forge::llvm-openmp
     conda activate sklearn-dev
     make clean
     pip install --verbose --no-build-isolation --editable .


### PR DESCRIPTION
Temporary fix caused by `conda-forge::compilers==1.1.0` that has been [failing on master](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=19779&view=logs&j=e775feff-013f-5eb3-fb09-8d69845fed08&t=fdff6e8e-d191-594a-c2c8-0c8da5a76bf1&l=283285)

```bash
from .import _liblinear as liblinear  # type: ignore
ImportError: dlopen(/Users/runner/work/1/s/sklearn/svm/_liblinear.cpython-37m-darwin.so, 2): Symbol not found: _check_parameter
  Referenced from: /Users/runner/work/1/s/sklearn/svm/_liblinear.cpython-37m-darwin.so
  Expected in: flat namespace
 in /Users/runner/work/1/s/sklearn/svm/_liblinear.cpython-37m-darwin.so
/Users/runner/work/1/s/sklearn/metrics/_classification.py:132: UnexpectedException
```