### PR TITLE
DOC Missing input_type to FeatureHasher

### DIFF
--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -52,7 +52,7 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-    input_type : {"dict", "pair"}, default="dict"
+    input_type : {"dict", "pair", "string"}, default="dict"
         Either "dict" (the default) to accept dictionaries over
         (feature_name, value); "pair" to accept pairs of (feature_name, value);
         or "string" to accept single strings.


### PR DESCRIPTION
The `FeatureHasher` accepts different parameters for its argument `input_type`. In particular, the docstring and the code mention that it accepts `"string"`, but at the top of the docstring it is not mentioned. This short PR adds it there.