### PR TITLE
[MRG] Fix error text when null_space fails with ARPACK

### DIFF
--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -166,10 +166,11 @@ def null_space(M, k, k_skip=1, eigen_solver='arpack', tol=1E-6, max_iter=100,
         except RuntimeError as msg:
             raise ValueError("Error in determining null-space with ARPACK. "
                              "Error message: '%s'. "
-                             "Note that method='arpack' can fail when the "
-                             "weight matrix is singular or otherwise "
-                             "ill-behaved.  method='dense' is recommended. "
-                             "See online documentation for more information."
+                             "Note that eigen_solver='arpack' can fail when "
+                             "the weight matrix is singular or otherwise "
+                             "ill-behaved. In that case, eigen_solver='dense' "
+                             "is recommended. See online documentation for "
+                             "more information."
                              % msg)
 
         return eigen_vectors[:, k_skip:], np.sum(eigen_values[k_skip:])


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

When ARPACK solver fails to find a null space, it throws a slightly confusing error message mentioning `method` parameter instead of `eigen_solver`. Since the only place where `null_space` function is used is `locally_linear_embedding` and both functions use parameter named `eigen_solver`, I believe the error message should also refer to `eigen_solver`.

#### Any other comments?

This PR doesn't change any code logic, only a user-visible error text. Flake8 doesn't report any new coding-style violations.