### PR TITLE
MNT Use substitutions for minimum dependencies in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,8 @@ doc/_build/
 doc/auto_examples/
 doc/modules/generated/
 doc/datasets/generated/
-doc/min_dependency.rst
+doc/min_dependency_table.rst
+doc/min_dependency_substitutions.rst
 *.pdf
 pip-log.txt
 scikit_learn.egg-info/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -430,8 +430,26 @@ def generate_min_dependency_table(app):
     output.write('\n')
     output = output.getvalue()
 
-    with (Path('.') / 'min_dependency.rst').open('w') as f:
+    with (Path('.') / 'min_dependency_table.rst').open('w') as f:
         f.write(output)
+
+
+def generate_min_dependency_substitutions(app):
+    """Generate min dependency substitutions for docs."""
+    from sklearn._build_utils.min_dependencies import dependent_packages
+
+    output = StringIO()
+
+    for package, (version, _) in dependent_packages.items():
+        package = package.capitalize()
+        output.write(f'|{package}MinVersion| replace:: {version}')
+        output.write('\n')
+
+    output = output.getvalue()
+
+    with (Path('.') / 'min_dependency_substitutions.rst').open('w') as f:
+        f.write(output)
+
 
 # Config for sphinx_issues
 
@@ -441,6 +459,7 @@ issues_github_path = 'scikit-learn/scikit-learn'
 
 def setup(app):
     app.connect('builder-inited', generate_min_dependency_table)
+    app.connect('builder-inited', generate_min_dependency_substitutions)
     # to hide/show the prompt in code examples:
     app.connect('build-finished', make_carousel_thumbs)
     app.connect('build-finished', filter_search_index)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -442,7 +442,7 @@ def generate_min_dependency_substitutions(app):
 
     for package, (version, _) in dependent_packages.items():
         package = package.capitalize()
-        output.write(f'|{package}MinVersion| replace:: {version}')
+        output.write(f'.. |{package}MinVersion| replace:: {version}')
         output.write('\n')
 
     output = output.getvalue()

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -1,6 +1,8 @@
 
 .. _advanced-installation:
 
+.. include:: ../min_dependency_substitutions.rst
+
 ==================================================
 Installing the development version of scikit-learn
 ==================================================
@@ -87,10 +89,10 @@ Scikit-learn requires the following dependencies both at build time and at
 runtime:
 
 - Python (>= 3.6),
-- NumPy (>= 1.13.3),
-- SciPy (>= 0.19),
-- Joblib (>= 0.11),
-- threadpoolctl (>= 2.0.0).
+- NumPy (>= |NumpyMinVersion|),
+- SciPy (>= |ScipyMinVersion|),
+- Joblib (>= |JoblibMinVersion|),
+- threadpoolctl (>= |ThreadpoolctlMinVersion|).
 
 Those dependencies are **automatically installed by pip** if they were missing
 when building scikit-learn from source.
@@ -111,7 +113,7 @@ Building Scikit-learn also requires:
     # - sklearn/_build_utils/__init__.py
     # - advanced installation guide
 
-- Cython >= 0.28.5
+- Cython >= |CythonMinVersion|
 - A C/C++ compiler and a matching OpenMP_ runtime library. See the
   :ref:`platform system specific instructions
   <platform_specific_instructions>` for more details.
@@ -135,9 +137,7 @@ Test dependencies
 
 Running tests requires:
 
-.. |PytestMinVersion| replace:: 4.6.2
-
-- pytest >=\ |PytestMinVersion|
+- pytest >= |PytestMinVersion|
 
 Some tests also require `pandas <https://pandas.pydata.org>`_.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -137,7 +137,7 @@ Matplotlib and some examples require scikit-image, pandas, or seaborn. The
 minimum version of Scikit-learn dependencies are listed below along with its
 purpose.
 
-.. include:: min_dependency.rst
+.. include:: min_dependency_table.rst
 
 .. warning::
 


### PR DESCRIPTION
#### Reference Issues/PRs

Similar to #17573.

#### What does this implement/fix? Explain your changes.

This PR uses `rst` substitutions to specify the minimum dependencies inside the documentation.

#### Any other comments?

CC @thomasjpfan.