### PR TITLE
PERF Get rid of intermediate array in binary_log_loss

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -283,7 +283,7 @@ Changelog
 
 - |Efficiency| Neural net training and prediction are now a little faster.
   :pr:`17603`, :pr:`17604`, :pr:`17606`, :pr:`17608`, :pr:`17609`, :pr:`17633`,
-  :pr:`17661` by :user:`Alex Henrie <alexhenrie>`.
+  :pr:`17661`, :pr:`17932` by :user:`Alex Henrie <alexhenrie>`.
 
 - |Enhancement| Avoid converting float32 input to float64 in
   :class:`neural_network.BernoulliRBM`.

--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -220,8 +220,8 @@ def binary_log_loss(y_true, y_prob):
     """
     eps = np.finfo(y_prob.dtype).eps
     y_prob = np.clip(y_prob, eps, 1 - eps)
-    return -(xlogy(y_true, y_prob) +
-             xlogy(1 - y_true, 1 - y_prob)).sum() / y_prob.shape[0]
+    return -(xlogy(y_true, y_prob).sum() +
+             xlogy(1 - y_true, 1 - y_prob).sum()) / y_prob.shape[0]
 
 
 LOSS_FUNCTIONS = {'squared_loss': squared_loss, 'log_loss': log_loss,


### PR DESCRIPTION
This decreases by about 10% the time required to train an example neural network from binary data. It also saves memory!

Test program:

```
from sklearn.datasets import load_digits
from sklearn.neural_network import MLPClassifier
from neurtu import delayed, Benchmark

digits = load_digits(return_X_y=True)
X = digits[0][:,:50].astype(bool).astype(int)
y = digits[0][:,50].astype(bool).astype(int)

clf = MLPClassifier(solver='lbfgs', alpha=1e-5,
                    hidden_layer_sizes=(50, 20), random_state=1, max_iter=1000)

train = delayed(clf).fit(X, y)
print(Benchmark(wall_time=True, cpu_time=True, repeat=5)(train))
```

Before:

```
      wall_time  cpu_time                                                                                                     
mean   8.084272  8.149094
max    8.106030  8.485355
std    0.016399  0.188559
```

After:

```
      wall_time  cpu_time                                                                                                     
mean   7.310994  7.283616
max    7.332577  7.296908
std    0.014912  0.014172
```