### PR TITLE
FIX inconsistent hyperparameter and bounds issue in GP kernels

### DIFF
--- a/examples/gaussian_process/plot_gpr_co2.py
+++ b/examples/gaussian_process/plot_gpr_co2.py
@@ -129,7 +129,7 @@ k2 = 2.0**2 * RBF(length_scale=100.0) \
 k3 = 0.5**2 * RationalQuadratic(length_scale=1.0, alpha=1.0)
 k4 = 0.1**2 * RBF(length_scale=0.1) \
     + WhiteKernel(noise_level=0.1**2,
-                  noise_level_bounds=(1e-3, np.inf))  # noise terms
+                  noise_level_bounds=(1e-5, np.inf))  # noise terms
 kernel = k1 + k2 + k3 + k4
 
 gp = GaussianProcessRegressor(kernel=kernel, alpha=0,

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -395,6 +395,8 @@ class Kernel(metaclass=ABCMeta):
                                 np.atleast_2d(self.theta).T)
         idx = 0
         for hyp in self.hyperparameters:
+            if hyp.fixed:
+                continue
             for dim in range(hyp.n_elements):
                 if list_close[idx, 0]:
                     warnings.warn("The optimal value found for "

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -14,7 +14,7 @@ import pytest
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels \
     import RBF, ConstantKernel as C, WhiteKernel
-from sklearn.gaussian_process.kernels import DotProduct
+from sklearn.gaussian_process.kernels import DotProduct, ExpSineSquared
 from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 from sklearn.exceptions import ConvergenceWarning
 
@@ -525,3 +525,14 @@ def test_warning_bounds():
                                          "specified lower bound 10.0. "
                                          "Decreasing the bound and calling "
                                          "fit again may find a better value.")
+
+
+def test_bound_check_fixed_hyperparameter():
+    # Regression test for issue #17943
+    # Check that having a hyperparameter with fixed bounds doesn't cause an
+    # error
+    k1 = 50.0**2 * RBF(length_scale=50.0)  # long term smooth rising trend
+    k2 = ExpSineSquared(length_scale=1.0, periodicity=1.0,
+                        periodicity_bounds="fixed")  # seasonal component
+    kernel = k1 + k2
+    GaussianProcessRegressor(kernel=kernel).fit(X, y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #17943


#### What does this implement/fix? Explain your changes.
The issue is in `_check_bounds_params` when one or more hyperparameters are _fixed_, in which case there will be more _hyperparameters_ than _bounds_.

The test is also fixed to avoid the warning introduced in that method.

#### Any other comments?
ping @adrinjalali 
