### PR TITLE
TST Test for both solvers in test_nmf_sparse_input

### DIFF
--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -166,7 +166,8 @@ def test_n_components_greater_n_features():
     NMF(n_components=15, random_state=0, tol=1e-2).fit(A)
 
 
-def test_nmf_sparse_input():
+@pytest.mark.parametrize('solver', ['cd', 'mu'])
+def test_nmf_sparse_input(solver):
     # Test that sparse matrices are accepted as input
     from scipy.sparse import csc_matrix
 
@@ -175,10 +176,9 @@ def test_nmf_sparse_input():
     A[:, 2 * np.arange(5)] = 0
     A_sparse = csc_matrix(A)
 
-    for solver in ('cd', 'mu'):
-        est1 = NMF(solver=solver, n_components=5, init='random',
-                   random_state=0, tol=1e-2)
-        est2 = clone(est1)
+    est1 = NMF(solver=solver, n_components=5, init='random',
+               random_state=0, tol=1e-2)
+    est2 = clone(est1)
 
     W1 = est1.fit_transform(A)
     W2 = est2.fit_transform(A_sparse)


### PR DESCRIPTION
Small fix to make sure the test checks for both solvers in nmf