### PR TITLE
MNT Remove unnecessary try and except block for numpy 1.3

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -250,11 +250,7 @@ def type_of_target(y):
     if is_multilabel(y):
         return 'multilabel-indicator'
 
-    try:
-        y = np.asarray(y)
-    except ValueError:
-        # Known to fail in numpy 1.3 for array of arrays
-        return 'unknown'
+    y = np.asarray(y)
 
     # The old sequence of sequences format
     try:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR removes and unnecessary `try` and `except` block for `numpy==1.3` (`scikit-learn` requires `numpy>=1.13.3`).