### PR TITLE
DOC Fix typo in the KNeighborsClassifier documentation

### DIFF
--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -356,7 +356,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin,
     classes_ : ndarray of shape (n_classes,)
         Class labels known to the classifier.
 
-    effective_metric_ : str or callble
+    effective_metric_ : str or callable
         The distance metric used. It will be same as the `metric` parameter
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR just fix a typo found in the `sklearn.neighbors.KNeighborsClassifier` documentation.