### PR TITLE
[MRG] Fix KMeans convergence when tol==0

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -70,6 +70,10 @@ Changelog
   `init_size_`, are deprecated and will be removed in 0.26. :pr:`17864` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |Fix| Fixed a bug in :class:`cluster.KMeans` where rounding errors could
+  prevent convergence to be declared when `tol=0`. :pr:`17959` by
+  :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 :mod:`sklearn.covariance`
 .........................
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -226,8 +226,6 @@ def k_means(X, n_clusters, *, sample_weight=None, init='k-means++',
         Relative tolerance with regards to Frobenius norm of the difference
         in the cluster centers of two consecutive iterations to declare
         convergence.
-        If set to 0, convergence will be declared when the labels are the
-        same between two consecutive iterations.
 
     random_state : int, RandomState instance, default=None
         Determines random number generation for centroid initialization. Use
@@ -399,8 +397,7 @@ def _kmeans_single_elkan(X, sample_weight, centers_init, max_iter=300,
         centers, centers_new = centers_new, centers
 
         if np.array_equal(labels, labels_old):
-            # First check the labels for strict convergence because
-            # center_shift might not be exactly 0 due to rounding errors.
+            # First check the labels for strict convergence.
             if verbose:
                 print(f"Converged at iteration {i}: strict convergence.")
             strict_convergence = True
@@ -514,8 +511,7 @@ def _kmeans_single_lloyd(X, sample_weight, centers_init, max_iter=300,
             centers, centers_new = centers_new, centers
 
             if np.array_equal(labels, labels_old):
-                # First check the labels for strict convergence because
-                # center_shift might not be exactly 0 due to rounding errors.
+                # First check the labels for strict convergence.
                 if verbose:
                     print(f"Converged at iteration {i}: strict convergence.")
                 strict_convergence = True
@@ -644,8 +640,6 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         Relative tolerance with regards to Frobenius norm of the difference
         in the cluster centers of two consecutive iterations to declare
         convergence.
-        If set to 0, convergence will be declared when the labels are the
-        same between two consecutive iterations.
 
     precompute_distances : {'auto', True, False}, default='auto'
         Precompute distances (faster but takes more memory).

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -226,8 +226,8 @@ def k_means(X, n_clusters, *, sample_weight=None, init='k-means++',
         Relative tolerance with regards to Frobenius norm of the difference
         in the cluster centers of two consecutive iterations to declare
         convergence.
-        It's not advised to set `tol=0` since convergence might never be
-        declared due to rounding errors. Use a very small number instead.
+        If set to 0, convergence will be declared when the labels are the
+        same between two consecutive iterations.
 
     random_state : int, RandomState instance, default=None
         Determines random number generation for centroid initialization. Use
@@ -638,8 +638,8 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         Relative tolerance with regards to Frobenius norm of the difference
         in the cluster centers of two consecutive iterations to declare
         convergence.
-        It's not advised to set `tol=0` since convergence might never be
-        declared due to rounding errors. Use a very small number instead.
+        If set to 0, convergence will be declared when the labels are the
+        same between two consecutive iterations.
 
     precompute_distances : {'auto', True, False}, default='auto'
         Precompute distances (faster but takes more memory).

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -358,6 +358,7 @@ def _kmeans_single_elkan(X, sample_weight, centers_init, max_iter=300,
     centers_new = np.zeros_like(centers)
     weight_in_clusters = np.zeros(n_clusters, dtype=X.dtype)
     labels = np.full(n_samples, -1, dtype=np.int32)
+    labels_old = labels.copy()
     center_half_distances = euclidean_distances(centers) / 2
     distance_next_center = np.partition(np.asarray(center_half_distances),
                                         kth=1, axis=0)[1]
@@ -376,7 +377,6 @@ def _kmeans_single_elkan(X, sample_weight, centers_init, max_iter=300,
 
     init_bounds(X, centers, center_half_distances,
                 labels, upper_bounds, lower_bounds)
-    labels_old = labels.copy()
 
     for i in range(max_iter):
         elkan_iter(X, sample_weight, centers, centers_new,
@@ -507,7 +507,6 @@ def _kmeans_single_lloyd(X, sample_weight, centers_init, max_iter=300,
                 print(f"Iteration {i}, inertia {inertia}.")
 
             centers, centers_new = centers_new, centers
-            labels_old, labels = labels, labels_old
 
             if tol == 0:
                 # When tol = 0 we check that labels did not change because
@@ -515,6 +514,7 @@ def _kmeans_single_lloyd(X, sample_weight, centers_init, max_iter=300,
                 if np.array_equal(labels, labels_old):
                     strict_convergence = True
                     break
+                labels_old = labels.copy()
             else:
                 center_shift_tot = (center_shift**2).sum()
                 if center_shift_tot <= tol:

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -136,7 +136,7 @@ def test_relocate_empty_clusters(array_constr):
 @pytest.mark.parametrize("distribution", ["normal", "blobs"])
 @pytest.mark.parametrize("array_constr", [np.array, sp.csr_matrix],
                          ids=["dense", "sparse"])
-@pytest.mark.parametrize("tol", [1e-2, 1e-4, 1e-8])
+@pytest.mark.parametrize("tol", [1e-2, 1e-4, 1e-8, 0])
 def test_kmeans_elkan_results(distribution, array_constr, tol):
     # Check that results are identical between lloyd and elkan algorithms
     rnd = np.random.RandomState(0)
@@ -163,16 +163,11 @@ def test_kmeans_elkan_results(distribution, array_constr, tol):
 @pytest.mark.parametrize("algorithm", ["full", "elkan"])
 def test_kmeans_convergence(algorithm):
     # Check that KMeans stops when convergence is reached when tol=0. (#16075)
-    # We can only ensure that if the number of threads is not to large,
-    # otherwise the roundings errors coming from the unpredictability of
-    # the order in which chunks are processed make the convergence criterion
-    # to never be exactly 0.
     rnd = np.random.RandomState(0)
     X = rnd.normal(size=(5000, 10))
 
-    with threadpool_limits(limits=1, user_api="openmp"):
-        km = KMeans(algorithm=algorithm, n_clusters=5, random_state=0,
-                    n_init=1, tol=0, max_iter=300).fit(X)
+    km = KMeans(algorithm=algorithm, n_clusters=5, random_state=0,
+                n_init=1, tol=0, max_iter=300).fit(X)
 
     assert km.n_iter_ < 300
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -161,18 +161,17 @@ def test_kmeans_elkan_results(distribution, array_constr, tol):
     assert km_elkan.inertia_ == pytest.approx(km_full.inertia_, rel=1e-6)
 
 
-def test_kmeans_convergence():
+@pytest.mark.parametrize("algorithm", ["full", "elkan"])
+def test_kmeans_convergence(algorithm):
     # Check that KMeans stops when convergence is reached when tol=0. (#16075)
     rnd = np.random.RandomState(0)
     X = rnd.normal(size=(5000, 10))
     max_iter = 300
 
-    km_full = KMeans(algorithm="full", n_clusters=5, random_state=0,
-                     n_init=1, tol=0, max_iter=max_iter).fit(X)
-    km_elkan = KMeans(algorithm="elkan", n_clusters=5, random_state=0,
-                      n_init=1, tol=0, max_iter=max_iter).fit(X)
+    km = KMeans(algorithm=algorithm, n_clusters=5, random_state=0,
+                n_init=1, tol=0, max_iter=max_iter).fit(X)
 
-    assert km_full.n_iter_ == km_elkan.n_iter_ < max_iter
+    assert km.n_iter_ < max_iter
 
 
 def test_minibatch_update_consistency():

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -136,7 +136,7 @@ def test_relocate_empty_clusters(array_constr):
 @pytest.mark.parametrize("distribution", ["normal", "blobs"])
 @pytest.mark.parametrize("array_constr", [np.array, sp.csr_matrix],
                          ids=["dense", "sparse"])
-@pytest.mark.parametrize("tol", [1e-2, 1e-4, 1e-8, 0])
+@pytest.mark.parametrize("tol", [1e-2, 1e-8, 1e-100, 0])
 def test_kmeans_elkan_results(distribution, array_constr, tol):
     # Check that results are identical between lloyd and elkan algorithms
     rnd = np.random.RandomState(0)
@@ -160,16 +160,18 @@ def test_kmeans_elkan_results(distribution, array_constr, tol):
     assert km_elkan.inertia_ == pytest.approx(km_full.inertia_, rel=1e-6)
 
 
-@pytest.mark.parametrize("algorithm", ["full", "elkan"])
-def test_kmeans_convergence(algorithm):
+def test_kmeans_convergence():
     # Check that KMeans stops when convergence is reached when tol=0. (#16075)
     rnd = np.random.RandomState(0)
     X = rnd.normal(size=(5000, 10))
+    max_iter = 300
 
-    km = KMeans(algorithm=algorithm, n_clusters=5, random_state=0,
-                n_init=1, tol=0, max_iter=300).fit(X)
+    km_full = KMeans(algorithm="full", n_clusters=5, random_state=0,
+                     n_init=1, tol=0, max_iter=max_iter).fit(X)
+    km_elkan = KMeans(algorithm="elkan", n_clusters=5, random_state=0,
+                      n_init=1, tol=0, max_iter=max_iter).fit(X)
 
-    assert km.n_iter_ < 300
+    assert km_full.n_iter_ == km_elkan.n_iter_ < max_iter
 
 
 def test_minibatch_update_consistency():

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -338,7 +338,7 @@ def test_k_means_fit_predict(algo, dtype, constructor, seed, max_iter, tol):
 
 
 def test_minibatch_kmeans_verbose():
-    # Check verbose mode of KMeans and MiniBatchKMeans for better coverage.
+    # Check verbose mode of MiniBatchKMeans for better coverage.
     km = MiniBatchKMeans(n_clusters=n_clusters, random_state=42, verbose=1)
     old_stdout = sys.stdout
     sys.stdout = StringIO()


### PR DESCRIPTION
Fixes #17428

When ``tol==0``, convergence based on the norm of the difference of the centers between 2 iterations can fail due to rounding errors making the norm not exactly 0 (and leave iterations go until max_iter is reached).

This PR implements convergence based on the difference of the labels between 2 iterations when tol == 0.

It does not impact performances. Here's a timing comparison between setting tol=0 and tol=1e-16 (both converge after 60 iterations to the same clustering):
```py
from sklearn.cluster import KMeans
from sklearn.datasets import make_blobs

X, _ = make_blobs(n_samples=100000, centers=100, n_features=10)

km = KMeans(n_clusters=100, tol=0, n_init=1, init='random', random_state=0)
%timeit km.fit(X)
2.13 s ± 3.17 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

km = KMeans(n_clusters=100, tol=1e-16, n_init=1, init='random', random_state=0)
%timeit km.fit(X)
2.14 s ± 16.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```