### PR TITLE
TST Moves testing code in quad_tree to test_quad_tree

### DIFF
--- a/sklearn/neighbors/_quad_tree.pyx
+++ b/sklearn/neighbors/_quad_tree.pyx
@@ -596,59 +596,15 @@ cdef class _QuadTree:
         self.capacity = capacity
         return 0
 
-    @staticmethod
-    def test_summarize():
-
+    def _py_summarize(self, DTYPE_t[:] query_pt, DTYPE_t[:, :] X, float angle):
+        # Used for testing summarize
         cdef:
-            DTYPE_t[3] query_pt
-            float* summary
-            int i, n_samples, n_dimensions
+            DTYPE_t[:] summary
+            int n_samples, n_dimensions
 
-        n_dimensions = 2
-        n_samples = 4
-        angle = 0.9
-        offset = n_dimensions + 2
-        X = np.array([[-10., -10.], [9., 10.], [10., 9.], [10., 10.]])
-
+        n_samples = X.shape[0]
         n_dimensions = X.shape[1]
-        qt = _QuadTree(n_dimensions, verbose=0)
-        qt.build_tree(X)
+        summary = np.empty(4 * n_samples, dtype=np.float32)
 
-        summary = <float*> malloc(sizeof(float) * n_samples * 4)
-
-        for i in range(n_dimensions):
-            query_pt[i] = X[0, i]
-
-        # Summary should contain only 1 node with size 3 and distance to
-        # X[1:] barycenter
-        idx = qt.summarize(query_pt, summary, angle * angle)
-
-        node_dist = summary[n_dimensions]
-        node_size = summary[n_dimensions + 1]
-
-        barycenter = X[1:].mean(axis=0)
-        ds2c = ((X[0] - barycenter) ** 2).sum()
-
-        assert idx == offset
-        assert node_size == 3, "summary size = {}".format(node_size)
-        assert np.isclose(node_dist, ds2c)
-
-        # Summary should contain all 3 node with size 1 and distance to
-        # each point in X[1:] for ``angle=0``
-        idx = qt.summarize(query_pt, summary, 0)
-
-        node_dist = summary[n_dimensions]
-        node_size = summary[n_dimensions + 1]
-
-        barycenter = X[1:].mean(axis=0)
-        ds2c = ((X[0] - barycenter) ** 2).sum()
-
-        assert idx == 3 * (offset)
-        for i in range(3):
-            node_dist = summary[i * offset + n_dimensions]
-            node_size = summary[i * offset + n_dimensions + 1]
-
-            ds2c = ((X[0] - X[i + 1]) ** 2).sum()
-
-            assert node_size == 1, "summary size = {}".format(node_size)
-            assert np.isclose(node_dist, ds2c)
+        idx = self.summarize(&query_pt[0], &summary[0], angle * angle)
+        return idx, summary

--- a/sklearn/neighbors/tests/test_quad_tree.py
+++ b/sklearn/neighbors/tests/test_quad_tree.py
@@ -101,4 +101,44 @@ def test_qt_insert_duplicate(n_dimensions):
 
 
 def test_summarize():
-    _QuadTree.test_summarize()
+    # Simple check for quad tree's summarize
+
+    angle = 0.9
+    X = np.array([[-10., -10.], [9., 10.], [10., 9.], [10., 10.]],
+                 dtype=np.float32)
+    query_pt = X[0, :]
+    n_dimensions = X.shape[1]
+    offset = n_dimensions + 2
+
+    qt = _QuadTree(n_dimensions, verbose=0)
+    qt.build_tree(X)
+
+    idx, summary = qt._py_summarize(query_pt, X, angle)
+
+    node_dist = summary[n_dimensions]
+    node_size = summary[n_dimensions + 1]
+
+    # Summary should contain only 1 node with size 3 and distance to
+    # X[1:] barycenter
+    barycenter = X[1:].mean(axis=0)
+    ds2c = ((X[0] - barycenter) ** 2).sum()
+
+    assert idx == offset
+    assert node_size == 3, "summary size = {}".format(node_size)
+    assert np.isclose(node_dist, ds2c)
+
+    # Summary should contain all 3 node with size 1 and distance to
+    # each point in X[1:] for ``angle=0``
+    idx, summary = qt._py_summarize(query_pt, X, 0.)
+    barycenter = X[1:].mean(axis=0)
+    ds2c = ((X[0] - barycenter) ** 2).sum()
+
+    assert idx == 3 * (offset)
+    for i in range(3):
+        node_dist = summary[i * offset + n_dimensions]
+        node_size = summary[i * offset + n_dimensions + 1]
+
+        ds2c = ((X[0] - X[i + 1]) ** 2).sum()
+
+        assert node_size == 1, "summary size = {}".format(node_size)
+        assert np.isclose(node_dist, ds2c)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/17967


#### What does this implement/fix? Explain your changes.
Moves test_summary to `test_quad_tree`, and adds a private python accessible method to `quad_tree` for testing.

#### Any other comments?
The original version does not free `summary` after mallocing it.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
