### PR TITLE
Changed default eps value in log_loss

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2121,7 +2121,7 @@ def hamming_loss(y_true, y_pred, *, sample_weight=None):
 
 
 @_deprecate_positional_args
-def log_loss(y_true, y_pred, *, eps=1e-15, normalize=True, sample_weight=None,
+def log_loss(y_true, y_pred, *, eps=1e-3, normalize=True, sample_weight=None,
              labels=None):
     """Log loss, aka logistic loss or cross-entropy loss.
 


### PR DESCRIPTION
Address #17399

This PR isn't really for bug or inconsistency, it's just that the default value of `eps=1e-15` can lead to very high loss values for a few mispredicted samples when predicted probability is either 0.0 or 1.0, the normalization carried out afterwards can get strongly influenced by those outliers. For example:

`log_loss([1,1,1,0,0],[0.0,.7,.6,.2,.3]) = 7.197`

If we change first probability from 0. to .001, the new loss is:

`log_loss([1,1,1,0,0],[0.001,.7,.6,.2,.3]) = 1.671`

This can exaggerate the loss of classifiers that tends to produce discrete probabilities: like `KNeighborsClassifier(n_neighbors=1)`. Here is a full example:

```
from sklearn.datasets import make_classification
from sklearn.tree import DecisionTreeClassifier
from sklearn.neighbors import KNeighborsClassifier
from sklearn.model_selection import train_test_split
from sklearn.metrics import accuracy_score, log_loss, brier_score_loss

X, y = make_classification(400,4, random_state=42)

Xtr,Xte, ytr, yte = train_test_split(X,y,test_size=.5, random_state=42)
    
CLFS = [KNeighborsClassifier(n_neighbors=1), DecisionTreeClassifier(max_depth=2, random_state=42)]
for c in CLFS:
    print(c.__class__.__name__)
    c.fit(Xtr,ytr)
    ypc = c.predict_proba(Xte)[:,1]
    yp = c.predict(Xte)
    print("acc: {:.3f}".format(accuracy_score(yte,yp)))
    print("brier: {:.3f}".format(brier_score_loss(yte, ypc)))
    print("log: {:.3f}".format(log_loss(yte,ypc)))
    print()
```
Here's the output, KNN is better with accuracy, slightly worse with brier- which is expected, but appears significantly worse with `log_loss`:
```
KNeighborsClassifier
acc: 0.930
brier: 0.070
log: 2.418

DecisionTreeClassifier
acc: 0.925
brier: 0.050
log: 0.173
```
In my particular case, which I couldn't compress to a small example, an otherwise well performing classifier performed noticeably worse than a dummy estimator.