### PR TITLE
Remove single-target assertion in LinearModelCV

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -23,7 +23,6 @@ from ..model_selection import check_cv
 from ..utils.extmath import safe_sparse_dot
 from ..utils.fixes import _astype_copy_false, _joblib_parallel_args
 from ..utils.validation import check_is_fitted, _check_sample_weight
-from ..utils.validation import column_or_1d
 from ..utils.validation import _deprecate_positional_args
 
 # mypy error: Module 'sklearn.linear_model' has no attribute '_cd_fast'

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1173,8 +1173,8 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
         """Model to be fitted after the best alpha has been determined."""
 
     @abstractmethod
-    def _is_multitask(self):
-        """Bool indicating if class is meant for multidimensional target."""
+    def _accepts_sparse(self):
+        """Bool indicating if class supports sparse inputs."""
 
     def fit(self, X, y):
         """Fit linear model with coordinate descent
@@ -1240,18 +1240,8 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
         if y.shape[0] == 0:
             raise ValueError("y has 0 samples: %r" % y)
 
-        if not self._is_multitask():
-            if y.ndim > 1 and y.shape[1] > 1:
-                raise ValueError("For multi-task outputs, use "
-                                 "MultiTask%s" % self.__class__.__name__)
-            y = column_or_1d(y, warn=True)
-        else:
-            if sparse.isspmatrix(X):
-                raise TypeError("X should be dense but a sparse matrix was"
-                                "passed")
-            elif y.ndim == 1:
-                raise ValueError("For mono-task outputs, use "
-                                 "%sCV" % self.__class__.__name__[9:])
+        if not self._accepts_sparse() and sparse.isspmatrix(X):
+            raise TypeError("X should be dense but a sparse matrix was passed")
 
         model = self._get_estimator()
 
@@ -1523,8 +1513,8 @@ class LassoCV(RegressorMixin, LinearModelCV):
     def _get_estimator(self):
         return Lasso()
 
-    def _is_multitask(self):
-        return False
+    def _accepts_sparse(self):
+        return True
 
     def _more_tags(self):
         return {'multioutput': False}
@@ -1740,8 +1730,8 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
     def _get_estimator(self):
         return ElasticNet()
 
-    def _is_multitask(self):
-        return False
+    def _accepts_sparse(self):
+        return True
 
     def _more_tags(self):
         return {'multioutput': False}
@@ -2275,8 +2265,8 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
     def _get_estimator(self):
         return MultiTaskElasticNet()
 
-    def _is_multitask(self):
-        return True
+    def _accepts_sparse(self):
+        return False
 
     def _more_tags(self):
         return {'multioutput_only': True}
@@ -2448,8 +2438,8 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
     def _get_estimator(self):
         return MultiTaskLasso()
 
-    def _is_multitask(self):
-        return True
+    def _accepts_sparse(self):
+        return False
 
     def _more_tags(self):
         return {'multioutput_only': True}

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -23,6 +23,7 @@ from ..model_selection import check_cv
 from ..utils.extmath import safe_sparse_dot
 from ..utils.fixes import _astype_copy_false, _joblib_parallel_args
 from ..utils.validation import check_is_fitted, _check_sample_weight
+from ..utils.validation import column_or_1d
 from ..utils.validation import _deprecate_positional_args
 
 # mypy error: Module 'sklearn.linear_model' has no attribute '_cd_fast'
@@ -1238,6 +1239,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
 
         if y.shape[0] == 0:
             raise ValueError("y has 0 samples: %r" % y)
+        y = column_or_1d(y, warn=True)
 
         if not self._accepts_sparse() and sparse.isspmatrix(X):
             raise TypeError("X should be dense but a sparse matrix was passed")

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -655,12 +655,21 @@ def test_enet_multitarget():
         assert_array_almost_equal(dual_gap[k], estimator.dual_gap_)
 
 
-def test_multioutput_enetcv_error():
-    rng = np.random.RandomState(0)
-    X = rng.randn(10, 2)
-    y = rng.randn(10, 2)
-    clf = ElasticNetCV()
-    assert_raises(ValueError, clf.fit, X, y)
+@pytest.mark.parametrize("LinearModel", (RidgeCV, ElasticNetCV))
+def test_linear_model_cv_multitarget(LinearModel):
+    n_targets = 3
+    X, y, _, _ = build_dataset(n_samples=10, n_features=8,
+                               n_informative_features=10, n_targets=n_targets)
+    estimator = LinearModel(cv=3)
+    estimator.fit(X, y)
+    coef, intercept, alpha = (estimator.coef_, estimator.intercept_,
+                              estimator.alpha_)
+
+    estimator.set_params(alphas=[alpha])
+    for k in range(n_targets):
+        estimator.fit(X, y[:, k])
+        assert_array_almost_equal(coef[k, :], estimator.coef_)
+        assert_array_almost_equal(intercept[k], estimator.intercept_)
 
 
 def test_multitask_enet_and_lasso_cv():


### PR DESCRIPTION
Fixes #17965.

As far as I can tell this works just fine as-is; the only other change I made was removing the recently added `_is_multitask` since that seems no longer needed, and replacing with `_accepts_sparse` which before (as far as I can tell) was implicitly `not _is_multitask`.

I could maybe see an argument for keeping a warning but to be honest I think that's also overkill; I think adding a note to `ElasticNetCV` and `MultiTaskElasticNetCV` saying that one enforces the same sparsity pattern across both sets of coefficients while the other does not.

@drorcohengithub RidgeCV also seems to work fine as well FYI 🙂 