### PR TITLE
DOC Fix documentation of defaults in sklearn.utils.class_weight

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -24,13 +24,13 @@ def compute_class_weight(class_weight, *, classes, y):
         Array of the classes occurring in the data, as given by
         ``np.unique(y_org)`` with ``y_org`` the original class labels.
 
-    y : array-like, shape (n_samples,)
-        Array of original class labels per sample;
+    y : array-like of shape (n_samples,)
+        Array of original class labels per sample.
 
     Returns
     -------
-    class_weight_vect : ndarray, shape (n_classes,)
-        Array with class_weight_vect[i] the weight for i-th class
+    class_weight_vect : ndarray of shape (n_classes,)
+        Array with class_weight_vect[i] the weight for i-th class.
 
     References
     ----------
@@ -78,7 +78,7 @@ def compute_sample_weight(class_weight, y, *, indices=None):
 
     Parameters
     ----------
-    class_weight : dict, list of dicts, "balanced", or None, optional
+    class_weight : dict, list of dicts, "balanced", or None
         Weights associated with classes in the form ``{class_label: weight}``.
         If not given, all classes are supposed to have weight one. For
         multi-output problems, a list of dicts can be provided in the same
@@ -99,7 +99,7 @@ def compute_sample_weight(class_weight, y, *, indices=None):
     y : array-like of shape (n_samples,) or (n_samples, n_outputs)
         Array of original class labels per sample.
 
-    indices : array-like, shape (n_subsample,), or None
+    indices : array-like of shape (n_subsample,), default=None
         Array of indices to be used in a subsample. Can be of length less than
         n_samples in the case of a subsample, or equal to n_samples in the
         case of a bootstrap subsample with repeated indices. If None, the
@@ -108,8 +108,8 @@ def compute_sample_weight(class_weight, y, *, indices=None):
 
     Returns
     -------
-    sample_weight_vect : ndarray, shape (n_samples,)
-        Array with sample weights as applied to the original y
+    sample_weight_vect : ndarray of shape (n_samples,)
+        Array with sample weights as applied to the original y.
     """
 
     y = np.atleast_1d(y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See #15761

#### What does this implement/fix? Explain your changes.
This PR change how default values are documented in sklearn.utils.class_weight.py and update docstring according to guideline.

#### Any other comments?
Removed "optional" for compute_sample_weight since it must be given even though it can be None. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
