### PR TITLE
[MRG] fix incorrect clusters due to dtype mismatch

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -70,6 +70,10 @@ Changelog
   `init_size_`, are deprecated and will be removed in 0.26. :pr:`17864` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |Fix| Fixed a bug in :class:`cluster.AffinityPropagation`, that
+  gives incorrect clusters when the array dtype is float32.
+  :pr:`17995` by :user:`Thomaz Santana  <Wikilicious> and Amanda Dsouza <amy12xx>`.
+
 :mod:`sklearn.covariance`
 .........................
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -72,7 +72,7 @@ Changelog
 
 - |Fix| Fixed a bug in :class:`cluster.AffinityPropagation`, that
   gives incorrect clusters when the array dtype is float32.
-  :pr:`17995` by :user:`Thomaz Santana  <Wikilicious> and Amanda Dsouza <amy12xx>`.
+  :pr:`17995` by :user:`Thomaz Santana  <Wikilicious>` and :user:`Amanda Dsouza <amy12xx>`.
 
 :mod:`sklearn.covariance`
 .........................

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -162,7 +162,7 @@ def affinity_propagation(S, *, preference=None, convergence_iter=15,
     tmp = np.zeros((n_samples, n_samples))
 
     # Remove degeneracies
-    S += ((np.finfo(np.double).eps * S + np.finfo(np.double).tiny * 100) *
+    S += ((np.finfo(S.dtype).eps * S + np.finfo(S.dtype).tiny * 100) *
           random_state.randn(n_samples, n_samples))
 
     # Execute parallel affinity propagation updates

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -232,13 +232,14 @@ def test_affinity_propagation_convergence_warning_dense_sparse(centers):
                            np.zeros(X.shape[0], dtype=int))
     assert len(record) == 0
 
+
 def test_affinity_propagation_float32():
     # Test to fix incorrect clusters due to dtype change
     # (non-regression test for issue #10832)
-    X = np.array([[1,0,0,0],
-                 [0,1,1,0],
-                 [0,1,1,0],
-                 [0,0,0,1]], dtype='float32')
+    X = np.array([[1, 0, 0, 0],
+                  [0, 1, 1, 0],
+                  [0, 1, 1, 0],
+                  [0, 0, 0, 1]], dtype='float32')
     afp = AffinityPropagation(preference=1, affinity='precomputed',
                               random_state=0).fit(X)
     expected = np.array([0, 1, 1, 2])

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -231,3 +231,15 @@ def test_affinity_propagation_convergence_warning_dense_sparse(centers):
         assert_array_equal(ap.predict(X),
                            np.zeros(X.shape[0], dtype=int))
     assert len(record) == 0
+
+def test_affinity_propagation_float32():
+    # Test to fix incorrect clusters due to dtype change
+    # (non-regression test for issue #10832)
+    X = np.array([[1,0,0,0],
+                 [0,1,1,0],
+                 [0,1,1,0],
+                 [0,0,0,1]], dtype='float32')
+    afp = AffinityPropagation(preference=1, affinity='precomputed',
+                              random_state=0).fit(X)
+    expected = np.array([0, 1, 1, 2])
+    assert_array_equal(afp.labels_, expected)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #10832


#### What does this implement/fix? Explain your changes.
Minimal fix for the issue: Incorrect Clusters Due To Dtype Mismatch, by preserving the array dtype while calculating the S matrix.

#### Any other comments?
