### PR TITLE
Fix MemoryError exception when calling barycenter_weights with large inputs

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -235,8 +235,8 @@ Changelog
   will be removed in 0.28. :pr:`17662` by
   :user:`Joshua Newton <joshuacwnewton>`.
 
-- |Fix| Fix :issue:`10493`. MemoryError exception was raised when 
-  calling barycenter_weights with large inputs. 
+- |Fix| Fix :issue:`10493`. Fix Local Linear Embedding (LLE) 
+  that raised `MemoryError` exception when used with large inputs.
   :pr:`17997` by :user:`Bertrand Maisonneuve <bmaisonn>`.
 
 :mod:`sklearn.metrics`

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -235,7 +235,7 @@ Changelog
   will be removed in 0.28. :pr:`17662` by
   :user:`Joshua Newton <joshuacwnewton>`.
 
-- |Fix| Fix :issue:`10493`. Fix Local Linear Embedding (LLE) 
+- |Efficiency| Fixed :issue:`10493`. Improve Local Linear Embedding (LLE) 
   that raised `MemoryError` exception when used with large inputs.
   :pr:`17997` by :user:`Bertrand Maisonneuve <bmaisonn>`.
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -235,6 +235,10 @@ Changelog
   will be removed in 0.28. :pr:`17662` by
   :user:`Joshua Newton <joshuacwnewton>`.
 
+- |Fix| Fix :issue:`10493`. MemoryError exception was raised when 
+  calling barycenter_weights with large inputs. 
+  :pr:`17997` by :user:`Bertrand Maisonneuve <bmaisonn>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -31,6 +31,7 @@ def barycenter_weights(X, Y, indices, reg=1e-3):
     Y : array-like, shape (n_samples, n_dim)
 
     indices : array-like, shape (n_samples, n_dim)
+            Indices of the points in Y used to compute the barycenter
 
     reg : float, default=1e-3
         amount of regularization to add for the problem to be

--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -21,7 +21,7 @@ from ..neighbors import NearestNeighbors
 def barycenter_weights(X, indices, reg=1e-3):
     """Compute barycenter weights of X from indices along the first axis
 
-    We estimate the weights to assign to each point in [i] to recover
+    We estimate the weights to assign to each point in X[indices][i] to recover
     the point X[i]. The barycenter weights sum to 1.
 
     Parameters

--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -50,7 +50,7 @@ def barycenter_weights(X, Y, indices, reg=1e-3):
 
     n_samples, n_neighbors = indices.shape
     assert X.shape[0] == n_samples
-    
+
     B = np.empty((n_samples, n_neighbors), dtype=X.dtype)
     v = np.ones(n_neighbors, dtype=X.dtype)
 
@@ -69,7 +69,6 @@ def barycenter_weights(X, Y, indices, reg=1e-3):
         w = solve(G, v, sym_pos=True)
         B[i, :] = w / np.sum(w)
     return B
-
 
 def barycenter_kneighbors_graph(X, n_neighbors, reg=1e-3, n_jobs=None):
     """Computes the barycenter weighted graph of k-Neighbors for points in X

--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -18,17 +18,19 @@ from ..utils.validation import _deprecate_positional_args
 from ..neighbors import NearestNeighbors
 
 
-def barycenter_weights(X, indices, reg=1e-3):
-    """Compute barycenter weights of X from indices along the first axis
+def barycenter_weights(X, Y, indices, reg=1e-3):
+    """Compute barycenter weights of X from Y along the first axis
 
-    We estimate the weights to assign to each point in X[indices][i] to recover
+    We estimate the weights to assign to each point in Y[indices] to recover
     the point X[i]. The barycenter weights sum to 1.
 
     Parameters
     ----------
     X : array-like, shape (n_samples, n_dim)
 
-    indices : array-like, shape (n_samples, n_neighbors)
+    Y : array-like, shape (n_samples, n_dim)
+
+    indices : array-like, shape (n_samples, n_dim)
 
     reg : float, default=1e-3
         amount of regularization to add for the problem to be
@@ -43,16 +45,19 @@ def barycenter_weights(X, indices, reg=1e-3):
     See developers note for more information.
     """
     X = check_array(X, dtype=FLOAT_DTYPES)
+    Y = check_array(Y, dtype=FLOAT_DTYPES)
     indices = check_array(indices, dtype=int)
 
-    n_samples, n_neighbors = X.shape[0], indices.shape[1]
+    n_samples, n_neighbors = indices.shape
+    assert X.shape[0] == n_samples
+    
     B = np.empty((n_samples, n_neighbors), dtype=X.dtype)
     v = np.ones(n_neighbors, dtype=X.dtype)
 
     # this might raise a LinalgError if G is singular and has trace
     # zero
     for i, ind in enumerate(indices):
-        A = X[ind]
+        A = Y[ind]
         C = A - X[i]  # broadcasting
         G = np.dot(C, C.T)
         trace = np.trace(G)
@@ -103,7 +108,7 @@ def barycenter_kneighbors_graph(X, n_neighbors, reg=1e-3, n_jobs=None):
     X = knn._fit_X
     n_samples = knn.n_samples_fit_
     ind = knn.kneighbors(X, return_distance=False)[:, 1:]
-    data = barycenter_weights(X, ind, reg=reg)
+    data = barycenter_weights(X, X, ind, reg=reg)
     indptr = np.arange(0, n_samples * n_neighbors + 1, n_neighbors)
     return csr_matrix((data.ravel(), ind.ravel(), indptr),
                       shape=(n_samples, n_samples))
@@ -724,7 +729,7 @@ class LocallyLinearEmbedding(TransformerMixin,
         X = check_array(X)
         ind = self.nbrs_.kneighbors(X, n_neighbors=self.n_neighbors,
                                     return_distance=False)
-        weights = barycenter_weights(X, ind, reg=self.reg)
+        weights = barycenter_weights(X, self.nbrs_._fit_X, ind, reg=self.reg)
         X_new = np.empty((X.shape[0], self.n_components))
         for i in range(X.shape[0]):
             X_new[i] = np.dot(self.embedding_[ind[i]].T, weights[i])

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -31,13 +31,6 @@ def test_barycenter_kneighbors_graph():
     pred = np.dot(A.toarray(), X)
     assert linalg.norm(pred - X) / X.shape[0] < 1
     
-    # X = np.random.rand(12000, 12000)
-    
-    # # check that it won't fail for large inputs
-    # # and large amount of neighbors
-    # with pytest.raises(MemoryError):
-    #     A = barycenter_kneighbors_graph(X, 500)
-    
 
 
 # ----------------------------------------------------------------------

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -30,6 +30,14 @@ def test_barycenter_kneighbors_graph():
     assert_array_almost_equal(np.sum(A.toarray(), 1), np.ones(3))
     pred = np.dot(A.toarray(), X)
     assert linalg.norm(pred - X) / X.shape[0] < 1
+    
+    # X = np.random.rand(12000, 12000)
+    
+    # # check that it won't fail for large inputs
+    # # and large amount of neighbors
+    # with pytest.raises(MemoryError):
+    #     A = barycenter_kneighbors_graph(X, 500)
+    
 
 
 # ----------------------------------------------------------------------

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -30,7 +30,6 @@ def test_barycenter_kneighbors_graph():
     assert_array_almost_equal(np.sum(A.toarray(), 1), np.ones(3))
     pred = np.dot(A.toarray(), X)
     assert linalg.norm(pred - X) / X.shape[0] < 1
-    
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes  #10493

#### What does this implement/fix? Explain your changes.

`barycenter_weiths` was expecting a `(n_samples, n_neighbors, n_dim)` array as a second argument. With large number of samples, dimensions and neighbors this provoked `MemoryError` exceptions.
See a call example here https://github.com/scikit-learn/scikit-learn/blob/6ddaaedc60b0d0d98bcf2696158952f61055ed06/sklearn/manifold/_locally_linear.py#L105

As noticed in the issue this array is only used to iterate over the first axis so instead of building this huge array we can simply pass the list of indices to the method, then iterate over the indices instead.
The code below is simply changed by building A for each indice.
https://github.com/scikit-learn/scikit-learn/blob/6ddaaedc60b0d0d98bcf2696158952f61055ed06/sklearn/manifold/_locally_linear.py#L54

#### Any other comments?

This method is private in the module so we can afford changing its signature.
No test was added for this specific use case because doing this computation for large arrays is very long.
In another PR i'll try to improve the time it takes to perform this calculation by leverage n_jobs parameter when it's available.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
