### PR TITLE
[WIP] POC for Factory-style construction of composite estimators

### DIFF
--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -76,10 +76,10 @@ categorical_transformer = Pipeline(steps=[
     ('imputer', SimpleImputer(strategy='constant', fill_value='missing')),
     ('onehot', OneHotEncoder(handle_unknown='ignore'))])
 
-preprocessor = ColumnTransformer(
-    transformers=[
-        ('num', numeric_transformer, numeric_features),
-        ('cat', categorical_transformer, categorical_features)])
+preprocessor = (ColumnTransformer()
+                .append(numeric_transformer, numeric_features, name='num')
+                .append(categorical_transformer, categorical_features,
+                        name='cat'))
 
 # Append classifier to preprocessing pipeline.
 # Now we have a full prediction pipeline.
@@ -136,10 +136,13 @@ X_train.info()
 
 from sklearn.compose import make_column_selector as selector
 
-preprocessor = ColumnTransformer(transformers=[
-    ('num', numeric_transformer, selector(dtype_exclude="category")),
-    ('cat', categorical_transformer, selector(dtype_include="category"))
-])
+preprocessor = (ColumnTransformer()
+                .append(numeric_transformer,
+                        selector(dtype_exclude="category"),
+                        name='num')
+                .append(categorical_transformer,
+                        selector(dtype_include="category"),
+                        name='cat'))
 clf = Pipeline(steps=[('preprocessor', preprocessor),
                       ('classifier', LogisticRegression())])
 

--- a/examples/ensemble/plot_stack_predictors.py
+++ b/examples/ensemble/plot_stack_predictors.py
@@ -86,7 +86,7 @@ X, y = load_ames_housing()
 # not need preprocessing
 
 
-from sklearn.compose import make_column_transformer
+from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import OneHotEncoder
@@ -124,16 +124,14 @@ num_proc_lin = make_pipeline(
 )
 
 # transformation to use for non-linear estimators
-processor_nlin = make_column_transformer(
-    (cat_proc_nlin, cat_cols),
-    (num_proc_nlin, num_cols),
-    remainder='passthrough')
+processor_nlin = (ColumnTransformer(remainder='passthrough')
+                  .append(cat_proc_nlin, cat_cols)
+                  .append(num_proc_nlin, num_cols))
 
 # transformation to use for linear estimators
-processor_lin = make_column_transformer(
-    (cat_proc_lin, cat_cols),
-    (num_proc_lin, num_cols),
-    remainder='passthrough')
+processor_lin = (ColumnTransformer(remainder='passthrough')
+                 .append(cat_proc_lin, cat_cols)
+                 .append(num_proc_lin, num_cols))
 
 
 # %%

--- a/examples/inspection/plot_linear_model_coefficient_interpretation.py
+++ b/examples/inspection/plot_linear_model_coefficient_interpretation.py
@@ -128,17 +128,15 @@ survey.data.info()
 # - as a first approach (we will see after how the normalisation of numerical
 #   values will affect our discussion), keep numerical values as they are.
 
-from sklearn.compose import make_column_transformer
+from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder
 
 categorical_columns = ['RACE', 'OCCUPATION', 'SECTOR',
                        'MARR', 'UNION', 'SEX', 'SOUTH']
 numerical_columns = ['EDUCATION', 'EXPERIENCE', 'AGE']
 
-preprocessor = make_column_transformer(
-    (OneHotEncoder(drop='if_binary'), categorical_columns),
-    remainder='passthrough'
-)
+preprocessor = (ColumnTransformer(remainder='passthrough')
+                .append(OneHotEncoder(drop='if_binary'), categorical_columns))
 
 # %%
 # To describe the dataset as a linear model we use a ridge regressor
@@ -401,11 +399,9 @@ plt.subplots_adjust(left=.3)
 
 from sklearn.preprocessing import StandardScaler
 
-preprocessor = make_column_transformer(
-    (OneHotEncoder(drop='if_binary'), categorical_columns),
-    (StandardScaler(), numerical_columns),
-    remainder='passthrough'
-)
+preprocessor = (ColumnTransformer(remainder='passthrough')
+                .append(OneHotEncoder(drop='if_binary'), categorical_columns)
+                .append(StandardScaler(), numerical_columns))
 
 # %%
 # The model will stay unchanged.

--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -71,9 +71,9 @@ numerical_pipe = Pipeline([
     ('imputer', SimpleImputer(strategy='mean'))
 ])
 
-preprocessing = ColumnTransformer(
-    [('cat', categorical_pipe, categorical_columns),
-     ('num', numerical_pipe, numerical_columns)])
+preprocessing = (ColumnTransformer()
+                 .append(categorical_pipe, categorical_columns, name='cat')
+                 .append(numerical_pipe, numerical_columns, name='num'))
 
 rf = Pipeline([
     ('preprocess', preprocessing),

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -104,6 +104,7 @@ log_scale_transformer = make_pipeline(
     StandardScaler()
 )
 
+# TODO
 linear_model_preprocessor = ColumnTransformer(
     [
         ("passthrough_numeric", "passthrough",

--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -217,6 +217,7 @@ log_scale_transformer = make_pipeline(
     StandardScaler()
 )
 
+# TODO
 column_trans = ColumnTransformer(
     [
         ("binned_numeric", KBinsDiscretizer(n_bins=10),


### PR DESCRIPTION
Implemented ColumnTransformer.append(), demonstrated in examples.

#### Reference Issues/PRs

Proof of concept demonstration of #16301

#### What does this implement/fix? Explain your changes.

This offers an alternative to choosing between listing ColumnTransformer transformers or Pipeline steps as tuples, and the simplified `make_*` invocation, by adding an `append()` method with explicit parameters and documentation.
