### PR TITLE
RFC Renames reset to in_fit in _validate_data

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -347,21 +347,21 @@ class BaseEstimator:
                 collected_tags.update(more_tags)
         return collected_tags
 
-    def _check_n_features(self, X, reset):
+    def _check_n_features(self, X, in_fit):
         """Set the `n_features_in_` attribute, or check against it.
 
         Parameters
         ----------
         X : {ndarray, sparse matrix} of shape (n_samples, n_features)
             The input samples.
-        reset : bool
+        in_fit : bool
             If True, the `n_features_in_` attribute is set to `X.shape[1]`.
             Else, the attribute must already exist and the function checks
             that it is equal to `X.shape[1]`.
         """
         n_features = X.shape[1]
 
-        if reset:
+        if in_fit:
             self.n_features_in_ = n_features
         else:
             if not hasattr(self, 'n_features_in_'):
@@ -376,7 +376,7 @@ class BaseEstimator:
                                        self.n_features_in_)
                 )
 
-    def _validate_data(self, X, y=None, reset=True,
+    def _validate_data(self, X, y=None, in_fit=True,
                        validate_separately=False, **check_params):
         """Validate input data and set or check the `n_features_in_` attribute.
 
@@ -388,10 +388,10 @@ class BaseEstimator:
         y : array-like of shape (n_samples,), default=None
             The targets. If None, `check_array` is called on `X` and
             `check_X_y` is called otherwise.
-        reset : bool, default=True
-            Whether to reset the `n_features_in_` attribute.
+        in_fit : bool, default=True
+            Whether to fit `n_features_in_` attribute.
             If False, the input will be checked for consistency with data
-            provided when reset was last True.
+            provided when in_fit was last True.
         validate_separately : False or tuple of dicts, default=False
             Only used if y is not None.
             If False, call validate_X_y(). Else, it must be a tuple of kwargs
@@ -408,7 +408,7 @@ class BaseEstimator:
         """
 
         if y is None:
-            if self._get_tags()['requires_y']:
+            if in_fit and self._get_tags()['requires_y']:
                 raise ValueError(
                     f"This {self.__class__.__name__} estimator "
                     f"requires y to be passed, but the target y is None."
@@ -429,7 +429,7 @@ class BaseEstimator:
             out = X, y
 
         if check_params.get('ensure_2d', True):
-            self._check_n_features(X, reset=reset)
+            self._check_n_features(X, in_fit=in_fit)
 
         return out
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1788,7 +1788,7 @@ class MiniBatchKMeans(KMeans):
         X = self._validate_data(X, accept_sparse='csr',
                                 dtype=[np.float64, np.float32],
                                 order='C', accept_large_sparse=False,
-                                reset=is_first_call_to_partial_fit)
+                                in_fit=is_first_call_to_partial_fit)
 
         self._random_state = getattr(self, "_random_state",
                                      check_random_state(self.random_state))

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -523,7 +523,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             self._feature_names_in = None
         X = _check_X(X)
         # set n_features_in_ attribute
-        self._check_n_features(X, reset=True)
+        self._check_n_features(X, in_fit=True)
         self._validate_transformers()
         self._validate_column_callables(X)
         self._validate_remainder(X)
@@ -599,7 +599,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                                  'and for transform when using the '
                                  'remainder keyword')
 
-        # TODO: also call _check_n_features(reset=False) in 0.24
+        # TODO: also call _check_n_features(in_fit=False) in 0.24
         self._validate_features(X.shape[1], X_feature_names)
         Xs = self._fit_transform(X, None, _transform_one, fitted=True)
         self._validate_output(Xs)

--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -487,7 +487,7 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
         X :  array-like or sparse matrix
 
         """
-        X = self._validate_data(X, reset=reset_n_features,
+        X = self._validate_data(X, in_fit=reset_n_features,
                                 accept_sparse='csr')
         check_non_negative(X, whom)
         return X
@@ -514,7 +514,7 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
         # string, which is not the same one raised by check_n_features. So we
         # don't check n_features_in_ here for now (it's done with adhoc code in
         # the estimator anyway).
-        # TODO: set reset=first_time when addressing reset in
+        # TODO: set in_fit=first_time when addressing reset in
         # predict/transform/etc.
         reset_n_features = True
         X = self._check_non_neg_array(X, reset_n_features,

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -246,7 +246,7 @@ class SimpleImputer(_BaseImputer):
             force_all_finite = "allow-nan"
 
         try:
-            X = self._validate_data(X, reset=in_fit,
+            X = self._validate_data(X, in_fit=in_fit,
                                     accept_sparse='csc', dtype=dtype,
                                     force_all_finite=force_all_finite,
                                     copy=self.copy)
@@ -663,7 +663,7 @@ class MissingIndicator(TransformerMixin, BaseEstimator):
             force_all_finite = True
         else:
             force_all_finite = "allow-nan"
-        X = self._validate_data(X, reset=in_fit,
+        X = self._validate_data(X, in_fit=in_fit,
                                 accept_sparse=('csc', 'csr'), dtype=None,
                                 force_all_finite=force_all_finite)
         _check_inputs_dtype(X, self.missing_values)

--- a/sklearn/mixture/_base.py
+++ b/sklearn/mixture/_base.py
@@ -218,7 +218,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
             Component labels.
         """
         X = _check_X(X, self.n_components, ensure_min_samples=2)
-        self._check_n_features(X, reset=True)
+        self._check_n_features(X, in_fit=True)
         self._check_initial_parameters(X)
 
         # if we enable warm_start, we will have a unique initialisation

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -389,7 +389,7 @@ class MinMaxScaler(TransformerMixin, BaseEstimator):
                             "Consider using MaxAbsScaler instead.")
 
         first_pass = not hasattr(self, 'n_samples_seen_')
-        X = self._validate_data(X, reset=first_pass,
+        X = self._validate_data(X, in_fit=first_pass,
                                 estimator=self, dtype=FLOAT_DTYPES,
                                 force_all_finite="allow-nan")
 
@@ -841,7 +841,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
         check_is_fitted(self)
 
         copy = copy if copy is not None else self.copy
-        X = self._validate_data(X, reset=False,
+        X = self._validate_data(X, in_fit=False,
                                 accept_sparse='csr', copy=copy,
                                 estimator=self, dtype=FLOAT_DTYPES,
                                 force_all_finite='allow-nan')
@@ -1026,7 +1026,7 @@ class MaxAbsScaler(TransformerMixin, BaseEstimator):
             Fitted scaler.
         """
         first_pass = not hasattr(self, 'n_samples_seen_')
-        X = self._validate_data(X, reset=first_pass,
+        X = self._validate_data(X, in_fit=first_pass,
                                 accept_sparse=('csr', 'csc'), estimator=self,
                                 dtype=FLOAT_DTYPES,
                                 force_all_finite='allow-nan')
@@ -2651,11 +2651,11 @@ class QuantileTransformer(TransformerMixin, BaseEstimator):
         # string, which is not the same one raised by check_n_features. So we
         # don't check n_features_in_ here for now (it's done with adhoc code in
         # the estimator anyway).
-        # TODO: set reset=in_fit when addressing reset in
+        # TODO: set in_fit=in_fit when addressing reset in
         # predict/transform/etc.
         reset = True
 
-        X = self._validate_data(X, reset=reset,
+        X = self._validate_data(X, in_fit=reset,
                                 accept_sparse='csc', copy=copy,
                                 dtype=FLOAT_DTYPES,
                                 force_all_finite='allow-nan')


### PR DESCRIPTION
I think `in_fit` or `fitting` has clearer semantics than `reset` when thinking of `_validate_data`.

The small code change is to check y only when fitting:

```py
if in_fit and self._get_tags()['requires_y']:
```

CC @NicolasHug 