### PR TITLE
TST Default skip network tests in datatests' common tests 

### DIFF
--- a/sklearn/datasets/tests/test_common.py
+++ b/sklearn/datasets/tests/test_common.py
@@ -76,8 +76,8 @@ def check_as_frame(bunch, dataset_func,
         assert np.all(frame_bunch.target.dtypes == expected_target_dtype)
 
 
-def _has_network():
-    return bool(os.environ.get("SKLEARN_SKIP_NETWORK_TESTS", False))
+def _skip_network_tests():
+    return os.environ.get('SKLEARN_SKIP_NETWORK_TESTS', '1') == '1'
 
 
 def _generate_func_supporting_param(param, dataset_type=("load", "fetch")):
@@ -91,7 +91,7 @@ def _generate_func_supporting_param(param, dataset_type=("load", "fetch")):
         if is_dataset_type and is_support_param:
             # check if we should skip if we don't have network support
             marks = [pytest.mark.skipif(
-                condition=name.startswith("fetch") and _has_network(),
+                condition=name.startswith("fetch") and _skip_network_tests(),
                 reason="Skip because fetcher requires internet network",
             )]
             if name in markers_fetch:


### PR DESCRIPTION
Skips network tests by default for dataset common test.

CC @glemaitre 

Related to https://github.com/scikit-learn/scikit-learn/pull/17996