### PR TITLE
DOC Add Feature engine to Related Projects page

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -225,7 +225,7 @@ and tasks.
   <https://github.com/scikit-learn-contrib/imbalanced-learn>`_ Various
   methods to under- and over-sample datasets.
 
- - `Feature-engine <https://github.com/solegalli/feature_engine>`_ A library
+- `Feature-engine <https://github.com/solegalli/feature_engine>`_ A library
   of sklearn compatible transformers for missing data imputation, categorical
   encoding, variable transformation, discretization, outlier handling and more.
   Feature-engine allows the application of preprocessing steps to selected groups

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -225,6 +225,12 @@ and tasks.
   <https://github.com/scikit-learn-contrib/imbalanced-learn>`_ Various
   methods to under- and over-sample datasets.
 
+ - `Feature-engine <https://github.com/solegalli/feature_engine>`_ A library
+  of sklearn compatible transformers for missing data imputation, categorical
+  encoding, variable transformation, discretization, outlier handling and more.
+  Feature-engine allows the application of preprocessing steps to selected groups
+  of variables and it is fully compatible with the Scikit-learn Pipeline.
+
 Statistical learning with Python
 --------------------------------
 Other packages useful for data analysis and machine learning.


### PR DESCRIPTION
Hi team!

A small addition to the Related Projects page. I  suggest the inclusion of Feature-engine. I brought this you your attention last year in the email list. The package includes transformers for missing data imputation, categorical encoding, variable transformation and discretisation and outlier handling. While many of these techniques are contemplated in the SimpleImputer, PowerTransformer, FunctionTransformer and KBinsDiscretiser, Feature-engine includes some additional imputation, encoding and discretisation techniques not yet present in sklearn. And it allows the user to select which variables to modify within the transfomer (like the package category-encoders), which is (my opinion) quite handy. Fully compatible with the sklearn Pipeline, and with quite extensive documentation :)

Let me know if you would be happy to have this addition to the list. Thank you!