### PR TITLE
STY Fix style of download link in examples

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -970,8 +970,8 @@ div.sphx-glr-thumbcontainer {
 @media screen and (min-width: 1540px) {
   .sphx-glr-download-link-note {
     position: absolute;
-    position: absolute;
     left: 98%;
+    top: 150px;
     width: 20ex;
   }
 }


### PR DESCRIPTION
## master and (stable)

![Screen Shot 2020-07-30 at 11 23 14 PM](https://user-images.githubusercontent.com/5402633/88996618-b07e3580-d2bb-11ea-92e1-e26581f1cd0a.png)

## This PR

![Screen Shot 2020-07-30 at 11 23 56 PM](https://user-images.githubusercontent.com/5402633/88996644-c4c23280-d2bb-11ea-9719-7e8438259140.png)

This is not showing up on the [nightly dev build](https://scikit-learn.org/dev/auto_examples/release_highlights/plot_release_highlights_0_23_0.html) because of the dynamic injection of the "This is documentation for the unstable development" div at the top.