### PR TITLE
DOC Minor documentation fixes

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -526,7 +526,7 @@ Stalled and Unclaimed Issues
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Generally speaking, issues which are up for grabs will have a
-`"help wanted" <https://github.com/scikit-learn/scikit-learn/labels/help%20wanted>`__ .
+`"help wanted" <https://github.com/scikit-learn/scikit-learn/labels/help%20wanted>`_.
 tag. However, not all issues which need contributors will have this tag,
 as the "help wanted" tag is not always up-to-date with the state
 of the issue. Contributors can find issues which are still up for grabs
@@ -586,7 +586,7 @@ underestimate how easy an issue is to solve!
     we use the help wanted tag to mark Pull Requests which have been abandoned
     by their original contributor and are available for someone to pick up where the original
     contributor left off. The list of issues with the help wanted tag can be found
-    `here <https://github.com/scikit-learn/scikit-learn/labels/help%20wanted>`__ .
+    `here <https://github.com/scikit-learn/scikit-learn/labels/help%20wanted>`_.
 
     Note that not all issues which need contributors will have this tag.
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -427,9 +427,9 @@ You can check for common programming errors with the following tools:
   see also :ref:`testing_coverage`
 
 * A moderate use of type annotations is encouraged but is not mandatory. See
-  [mypy quickstart](https://mypy.readthedocs.io/en/latest/getting_started.html)
-  for an introduction, as well as [pandas contributing documentation](
-  https://pandas.pydata.org/pandas-docs/stable/development/contributing.html#type-hints)
+  `mypy quickstart <https://mypy.readthedocs.io/en/latest/getting_started.html>`_
+  for an introduction, as well as `pandas contributing documentation
+  <https://pandas.pydata.org/pandas-docs/stable/development/contributing.html#type-hints>`_
   for style guidelines. Whether you add type annotation or not::
 
     mypy --ignore-missing-import sklearn

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -102,7 +102,7 @@ the test data::
   >>> # create a pipeline object
   >>> pipe = make_pipeline(
   ...     StandardScaler(),
-  ...     LogisticRegression(random_state=0)
+  ...     LogisticRegression()
   ... )
   ...
   >>> # load the iris dataset and split it into train and test sets

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -112,7 +112,7 @@ the test data::
   >>> # fit the whole pipeline
   >>> pipe.fit(X_train, y_train)
   Pipeline(steps=[('standardscaler', StandardScaler()),
-                  ('logisticregression', LogisticRegression(random_state=0))])
+                  ('logisticregression', LogisticRegression())])
   >>> # we can now use it like any other estimator
   >>> accuracy_score(pipe.predict(X_test), y_test)
   0.97...

--- a/doc/tutorial/statistical_inference/model_selection.rst
+++ b/doc/tutorial/statistical_inference/model_selection.rst
@@ -227,10 +227,9 @@ estimator during the construction and exposes an estimator API::
     0.943...
 
 
-By default, the :class:`GridSearchCV` uses a 3-fold cross-validation. However,
+By default, the :class:`GridSearchCV` uses a 5-fold cross-validation. However,
 if it detects that a classifier is passed, rather than a regressor, it uses
-a stratified 3-fold. The default will change to a 5-fold cross-validation in
-version 0.22.
+a stratified 5-fold.
 
 .. topic:: Nested cross-validation
 


### PR DESCRIPTION
#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

- **contributing.rst:** Fix links that weren't properly formatted, and remove a space between the end of the sentence and the period
- **getting_started.rst:** Removed `random_state` parameter from `LogisticRegression`, since `random_state` has no effect when using the default solver of `'lbfgs'`
- **model_selection.rst:** Updated to say that `GridSearchCV` uses 5-fold cross-validation by default
