### PR TITLE
DOC fixed linear_model._least_angle.py parameters consistency

### DIFF
--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -30,10 +30,23 @@ SOLVE_TRIANGULAR_ARGS = {'check_finite': False}
 
 
 @_deprecate_positional_args
-def lars_path(X, y, Xy=None, *, Gram=None, max_iter=500, alpha_min=0,
-              method='lars', copy_X=True, eps=np.finfo(float).eps,
-              copy_Gram=True, verbose=0, return_path=True,
-              return_n_iter=False, positive=False):
+def lars_path(
+    X,
+    y,
+    Xy=None,
+    *,
+    Gram=None,
+    max_iter=500,
+    alpha_min=0,
+    method="lar",
+    copy_X=True,
+    eps=np.finfo(float).eps,
+    copy_Gram=True,
+    verbose=0,
+    return_path=True,
+    return_n_iter=False,
+    positive=False
+):
     """Compute Least Angle Regression or Lasso path using LARS algorithm [1]
 
     The optimization objective for the case method='lasso' is::
@@ -72,8 +85,8 @@ def lars_path(X, y, Xy=None, *, Gram=None, max_iter=500, alpha_min=0,
         Minimum correlation along the path. It corresponds to the
         regularization parameter alpha parameter in the Lasso.
 
-    method : {'lars', 'lasso'}, default='lars'
-        Specifies the returned model. Select ``'lars'`` for Least Angle
+    method : {'lar', 'lasso'}, default='lar'
+        Specifies the returned model. Select ``'lar'`` for Least Angle
         Regression, ``'lasso'`` for the Lasso.
 
     copy_X : bool, default=True
@@ -162,10 +175,22 @@ def lars_path(X, y, Xy=None, *, Gram=None, max_iter=500, alpha_min=0,
 
 
 @_deprecate_positional_args
-def lars_path_gram(Xy, Gram, *, n_samples, max_iter=500, alpha_min=0,
-                   method='lars', copy_X=True, eps=np.finfo(float).eps,
-                   copy_Gram=True, verbose=0, return_path=True,
-                   return_n_iter=False, positive=False):
+def lars_path_gram(
+    Xy,
+    Gram,
+    *,
+    n_samples,
+    max_iter=500,
+    alpha_min=0,
+    method="lar",
+    copy_X=True,
+    eps=np.finfo(float).eps,
+    copy_Gram=True,
+    verbose=0,
+    return_path=True,
+    return_n_iter=False,
+    positive=False
+):
     """lars_path in the sufficient stats mode [1]
 
     The optimization objective for the case method='lasso' is::
@@ -195,8 +220,8 @@ def lars_path_gram(Xy, Gram, *, n_samples, max_iter=500, alpha_min=0,
         Minimum correlation along the path. It corresponds to the
         regularization parameter alpha parameter in the Lasso.
 
-    method : {'lars', 'lasso'}, default='lars'
-        Specifies the returned model. Select ``'lars'`` for Least Angle
+    method : {'lar', 'lasso'}, default='lar'
+        Specifies the returned model. Select ``'lar'`` for Least Angle
         Regression, ``'lasso'`` for the Lasso.
 
     copy_X : bool, default=True
@@ -280,10 +305,23 @@ def lars_path_gram(Xy, Gram, *, n_samples, max_iter=500, alpha_min=0,
         return_n_iter=return_n_iter, positive=positive)
 
 
-def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
-                      alpha_min=0, method='lars', copy_X=True,
-                      eps=np.finfo(float).eps, copy_Gram=True, verbose=0,
-                      return_path=True, return_n_iter=False, positive=False):
+def _lars_path_solver(
+    X,
+    y,
+    Xy=None,
+    Gram=None,
+    n_samples=None,
+    max_iter=500,
+    alpha_min=0,
+    method="lar",
+    copy_X=True,
+    eps=np.finfo(float).eps,
+    copy_Gram=True,
+    verbose=0,
+    return_path=True,
+    return_n_iter=False,
+    positive=False,
+):
     """Compute Least Angle Regression or Lasso path using LARS algorithm [1]
 
     The optimization objective for the case method='lasso' is::
@@ -297,26 +335,26 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
 
     Parameters
     ----------
-    X : None or ndarray, of shape (n_samples, n_features)
+    X : None or ndarray of shape (n_samples, n_features)
         Input data. Note that if X is None then Gram must be specified,
         i.e., cannot be None or False.
 
-    y : None or ndarray, of shape (n_samples,)
+    y : None or ndarray of shape (n_samples,)
         Input targets.
 
     Xy : array-like of shape (n_samples,) or (n_samples, n_targets), \
             default=None
-        Xy = np.dot(X.T, y) that can be precomputed. It is useful
+        `Xy = np.dot(X.T, y)` that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
     Gram : None, 'auto' or array-like of shape (n_features, n_features), \
             default=None
-        Precomputed Gram matrix (X' * X), if ``'auto'``, the Gram
+        Precomputed Gram matrix `(X' * X)`, if ``'auto'``, the Gram
         matrix is precomputed from the given X, if there are more samples
         than features.
 
     n_samples : int or float, default=None
-        Equivalent size of sample.
+        Equivalent size of sample. If `None`, it will be `n_samples`.
 
     max_iter : int, default=500
         Maximum number of iterations to perform, set to infinity for no limit.
@@ -325,8 +363,8 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
         Minimum correlation along the path. It corresponds to the
         regularization parameter alpha parameter in the Lasso.
 
-    method : {'lars', 'lasso'}, default='lars'
-        Specifies the returned model. Select ``'lars'`` for Least Angle
+    method : {'lar', 'lasso'}, default='lar'
+        Specifies the returned model. Select ``'lar'`` for Least Angle
         Regression, ``'lasso'`` for the Lasso.
 
     copy_X : bool, default=True
@@ -400,11 +438,10 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
            <https://en.wikipedia.org/wiki/Lasso_(statistics)>`_
 
     """
-    if method == 'lars' and positive:
+    if method == "lar" and positive:
         raise ValueError(
-                "Positive constraint not supported for 'lars' "
-                "coding method."
-            )
+            "Positive constraint not supported for 'lar' " "coding method."
+        )
 
     n_samples = n_samples if n_samples is not None else y.size
 
@@ -665,7 +702,7 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
             # some coefficients have changed sign
             idx = np.where(z == z_pos)[0][::-1]
 
-            # update the sign, important for LARS
+            # update the sign, important for LAR
             sign_active[idx] = -sign_active[idx]
 
             if method == 'lasso':
@@ -764,7 +801,7 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
 # Estimator classes
 
 class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
-    """Least Angle Regression model a.k.a. LARS
+    """Least Angle Regression model a.k.a. LAR
 
     Read more in the :ref:`User Guide <least_angle_regression>`.
 
@@ -822,17 +859,18 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
 
     Attributes
     ----------
-    alphas_ : array-like of shape (n_alphas + 1,) | list of n_targets such \
-            arrays
+    alphas_ : array-like of shape (n_alphas + 1,) or list of thereof of \
+            shape (n_targets,)
         Maximum of covariances (in absolute value) at each iteration. \
         ``n_alphas`` is either ``n_nonzero_coefs`` or ``n_features``, \
         whichever is smaller.
 
-    active_ : list of length n_alphas or list of n_targets such lists
+    active_ : list of shape (n_alphas,) or list of thereof of shape \
+            (n_targets,)
         Indices of active variables at the end of the path.
 
-    coef_path_ : array-like of shape (n_features, n_alphas + 1) \
-        | list of n_targets such arrays
+    coef_path_ : array-like of shape (n_features, n_alphas + 1) or list of \
+            thereof of shape (n_targets,)
         The varying values of the coefficients along the path. It is not
         present if the ``fit_path`` parameter is ``False``.
 
@@ -861,7 +899,8 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
     sklearn.decomposition.sparse_encode
 
     """
-    method = 'lars'
+
+    method = "lar"
     positive = False
 
     @_deprecate_positional_args
@@ -1065,24 +1104,25 @@ class LassoLars(Lars):
         `y` values, to satisfy the model's assumption of
         one-at-a-time computations. Might help with stability.
 
-    random_state : int, RandomState instance, default=None
+    random_state : int, RandomState instance or None, default=None
         Determines random number generation for jittering. Pass an int
         for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`. Ignored if `jitter` is None.
 
     Attributes
     ----------
-    alphas_ : array-like of shape (n_alphas + 1,) | list of n_targets such \
-            arrays
+    alphas_ : array-like of shape (n_alphas + 1,) or list of thereof of shape \
+            (n_targets,)
         Maximum of covariances (in absolute value) at each iteration. \
         ``n_alphas`` is either ``max_iter``, ``n_features``, or the number of \
         nodes in the path with correlation greater than ``alpha``, whichever \
         is smaller.
 
-    active_ : list of length n_alphas or list of n_targets such lists
+    active_ : list of length n_alphas or list of thereof of shape (n_targets,)
         Indices of active variables at the end of the path.
 
-    coef_path_ : array-like of shape (n_features, n_alphas + 1) or list
+    coef_path_ : array-like of shape (n_features, n_alphas + 1) or list of \
+            thereof of shape (n_targets,)
         If a list is passed it's expected to be one of n_targets such arrays.
         The varying values of the coefficients along the path. It is not
         present if the ``fit_path`` parameter is ``False``.
@@ -1093,7 +1133,7 @@ class LassoLars(Lars):
     intercept_ : float or array-like of shape (n_targets,)
         Independent term in decision function.
 
-    n_iter_ : array-like or int.
+    n_iter_ : array-like or int
         The number of iterations taken by lars_path to find the
         grid of alphas for each target.
 
@@ -1177,8 +1217,8 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
         Whether X_train, X_test, y_train and y_test should be copied;
         if False, they may be overwritten.
 
-    method : {'lars' , 'lasso'}, default='lars'
-        Specifies the returned model. Select ``'lars'`` for Least Angle
+    method : {'lar' , 'lasso'}, default='lar'
+        Specifies the returned model. Select ``'lar'`` for Least Angle
         Regression, ``'lasso'`` for the Lasso.
 
     verbose : bool or int, default=False
@@ -1332,7 +1372,7 @@ class LarsCV(Lars):
 
     Attributes
     ----------
-    active_ : list of length n_alphas or list of n_targets such lists
+    active_ : list of length n_alphas or list of thereof of shape (n_targets,)
         Indices of active variables at the end of the path.
 
     coef_ : array-like of shape (n_features,)
@@ -1378,7 +1418,7 @@ class LarsCV(Lars):
     lars_path, LassoLars, LassoLarsCV
     """
 
-    method = 'lars'
+    method = "lar"
 
     @_deprecate_positional_args
     def __init__(self, *, fit_intercept=True, verbose=False, max_iter=500,

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -31,7 +31,7 @@ SOLVE_TRIANGULAR_ARGS = {'check_finite': False}
 
 @_deprecate_positional_args
 def lars_path(X, y, Xy=None, *, Gram=None, max_iter=500, alpha_min=0,
-              method='lar', copy_X=True, eps=np.finfo(float).eps,
+              method='lars', copy_X=True, eps=np.finfo(float).eps,
               copy_Gram=True, verbose=0, return_path=True,
               return_n_iter=False, positive=False):
     """Compute Least Angle Regression or Lasso path using LARS algorithm [1]
@@ -72,17 +72,19 @@ def lars_path(X, y, Xy=None, *, Gram=None, max_iter=500, alpha_min=0,
         Minimum correlation along the path. It corresponds to the
         regularization parameter alpha parameter in the Lasso.
 
-    method : {'lar', 'lasso'}, default='lar'
-        Specifies the returned model. Select ``'lar'`` for Least Angle
+    method : {'lars', 'lasso'}, default='lars'
+        Specifies the returned model. Select ``'lars'`` for Least Angle
         Regression, ``'lasso'`` for the Lasso.
 
     copy_X : bool, default=True
         If ``False``, ``X`` is overwritten.
 
-    eps : float, optional
+    eps : float, default=np.finfo(float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
-        systems. By default, ``np.finfo(float).eps`` is used.
+        systems. Unlike the ``tol`` parameter in some iterative
+        optimization-based algorithms, this parameter does not control
+        the tolerance of the optimization.
 
     copy_Gram : bool, default=True
         If ``False``, ``Gram`` is overwritten.
@@ -161,7 +163,7 @@ def lars_path(X, y, Xy=None, *, Gram=None, max_iter=500, alpha_min=0,
 
 @_deprecate_positional_args
 def lars_path_gram(Xy, Gram, *, n_samples, max_iter=500, alpha_min=0,
-                   method='lar', copy_X=True, eps=np.finfo(float).eps,
+                   method='lars', copy_X=True, eps=np.finfo(float).eps,
                    copy_Gram=True, verbose=0, return_path=True,
                    return_n_iter=False, positive=False):
     """lars_path in the sufficient stats mode [1]
@@ -193,17 +195,19 @@ def lars_path_gram(Xy, Gram, *, n_samples, max_iter=500, alpha_min=0,
         Minimum correlation along the path. It corresponds to the
         regularization parameter alpha parameter in the Lasso.
 
-    method : {'lar', 'lasso'}, default='lar'
-        Specifies the returned model. Select ``'lar'`` for Least Angle
+    method : {'lars', 'lasso'}, default='lars'
+        Specifies the returned model. Select ``'lars'`` for Least Angle
         Regression, ``'lasso'`` for the Lasso.
 
     copy_X : bool, default=True
         If ``False``, ``X`` is overwritten.
 
-    eps : float, optional
+    eps : float, default=np.finfo(float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
-        systems. By default, ``np.finfo(float).eps`` is used.
+        systems. Unlike the ``tol`` parameter in some iterative
+        optimization-based algorithms, this parameter does not control
+        the tolerance of the optimization.
 
     copy_Gram : bool, default=True
         If ``False``, ``Gram`` is overwritten.
@@ -277,7 +281,7 @@ def lars_path_gram(Xy, Gram, *, n_samples, max_iter=500, alpha_min=0,
 
 
 def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
-                      alpha_min=0, method='lar', copy_X=True,
+                      alpha_min=0, method='lars', copy_X=True,
                       eps=np.finfo(float).eps, copy_Gram=True, verbose=0,
                       return_path=True, return_n_iter=False, positive=False):
     """Compute Least Angle Regression or Lasso path using LARS algorithm [1]
@@ -321,17 +325,19 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
         Minimum correlation along the path. It corresponds to the
         regularization parameter alpha parameter in the Lasso.
 
-    method : {'lar', 'lasso'}, default='lar'
-        Specifies the returned model. Select ``'lar'`` for Least Angle
+    method : {'lars', 'lasso'}, default='lars'
+        Specifies the returned model. Select ``'lars'`` for Least Angle
         Regression, ``'lasso'`` for the Lasso.
 
     copy_X : bool, default=True
         If ``False``, ``X`` is overwritten.
 
-    eps : float, optional
+    eps : float, default=np.finfo(float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
-        systems. By default, ``np.finfo(float).eps`` is used
+        systems. Unlike the ``tol`` parameter in some iterative
+        optimization-based algorithms, this parameter does not control
+        the tolerance of the optimization.
 
     copy_Gram : bool, default=True
         If ``False``, ``Gram`` is overwritten.
@@ -394,9 +400,9 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
            <https://en.wikipedia.org/wiki/Lasso_(statistics)>`_
 
     """
-    if method == 'lar' and positive:
+    if method == 'lars' and positive:
         raise ValueError(
-                "Positive constraint not supported for 'lar' "
+                "Positive constraint not supported for 'lars' "
                 "coding method."
             )
 
@@ -659,7 +665,7 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
             # some coefficients have changed sign
             idx = np.where(z == z_pos)[0][::-1]
 
-            # update the sign, important for LAR
+            # update the sign, important for LARS
             sign_active[idx] = -sign_active[idx]
 
             if method == 'lasso':
@@ -758,7 +764,7 @@ def _lars_path_solver(X, y, Xy=None, Gram=None, n_samples=None, max_iter=500,
 # Estimator classes
 
 class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
-    """Least Angle Regression model a.k.a. LAR
+    """Least Angle Regression model a.k.a. LARS
 
     Read more in the :ref:`User Guide <least_angle_regression>`.
 
@@ -770,7 +776,7 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
         (i.e. data is expected to be centered).
 
     verbose : bool or int, default=False
-        Sets the verbosity amount
+        Sets the verbosity amount.
 
     normalize : bool, default=True
         This parameter is ignored when ``fit_intercept`` is set to False.
@@ -788,13 +794,12 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
     n_nonzero_coefs : int, default=500
         Target number of non-zero coefficients. Use ``np.inf`` for no limit.
 
-    eps : float, optional
+    eps : float, default=np.finfo(float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. Unlike the ``tol`` parameter in some iterative
         optimization-based algorithms, this parameter does not control
         the tolerance of the optimization.
-        By default, ``np.finfo(float).eps`` is used.
 
     copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
@@ -810,7 +815,7 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
         `y` values, to satisfy the model's assumption of
         one-at-a-time computations. Might help with stability.
 
-    random_state : int, RandomState instance or None (default)
+    random_state : int, RandomState instance or None, default=None
         Determines random number generation for jittering. Pass an int
         for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`. Ignored if `jitter` is None.
@@ -856,7 +861,7 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
     sklearn.decomposition.sparse_encode
 
     """
-    method = 'lar'
+    method = 'lars'
     positive = False
 
     @_deprecate_positional_args
@@ -1011,7 +1016,7 @@ class LassoLars(Lars):
         (i.e. data is expected to be centered).
 
     verbose : bool or int, default=False
-        Sets the verbosity amount
+        Sets the verbosity amount.
 
     normalize : bool, default=True
         This parameter is ignored when ``fit_intercept`` is set to False.
@@ -1035,7 +1040,6 @@ class LassoLars(Lars):
         systems. Unlike the ``tol`` parameter in some iterative
         optimization-based algorithms, this parameter does not control
         the tolerance of the optimization.
-        By default, ``np.finfo(float).eps`` is used.
 
     copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.
@@ -1173,8 +1177,8 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
         Whether X_train, X_test, y_train and y_test should be copied;
         if False, they may be overwritten.
 
-    method : {'lar' , 'lasso'}, default='lar'
-        Specifies the returned model. Select ``'lar'`` for Least Angle
+    method : {'lars' , 'lasso'}, default='lars'
+        Specifies the returned model. Select ``'lars'`` for Least Angle
         Regression, ``'lasso'`` for the Lasso.
 
     verbose : bool or int, default=False
@@ -1203,14 +1207,12 @@ def _lars_path_residues(X_train, y_train, X_test, y_test, Gram=None,
     max_iter : int, default=500
         Maximum number of iterations to perform.
 
-    eps : float, optional
+    eps : float, default=np.finfo(float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. Unlike the ``tol`` parameter in some iterative
         optimization-based algorithms, this parameter does not control
         the tolerance of the optimization.
-        By default, ``np.finfo(float).eps`` is used
-
 
     Returns
     --------
@@ -1273,7 +1275,7 @@ class LarsCV(Lars):
         (i.e. data is expected to be centered).
 
     verbose : bool or int, default=False
-        Sets the verbosity amount
+        Sets the verbosity amount.
 
     max_iter : int, default=500
         Maximum number of iterations to perform.
@@ -1318,10 +1320,12 @@ class LarsCV(Lars):
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    eps : float, optional
+    eps : float, default=np.finfo(float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
-        systems. By default, ``np.finfo(float).eps`` is used.
+        systems. Unlike the ``tol`` parameter in some iterative
+        optimization-based algorithms, this parameter does not control
+        the tolerance of the optimization.
 
     copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
@@ -1374,7 +1378,7 @@ class LarsCV(Lars):
     lars_path, LassoLars, LassoLarsCV
     """
 
-    method = 'lar'
+    method = 'lars'
 
     @_deprecate_positional_args
     def __init__(self, *, fit_intercept=True, verbose=False, max_iter=500,
@@ -1494,7 +1498,7 @@ class LassoLarsCV(LarsCV):
         (i.e. data is expected to be centered).
 
     verbose : bool or int, default=False
-        Sets the verbosity amount
+        Sets the verbosity amount.
 
     max_iter : int, default=500
         Maximum number of iterations to perform.
@@ -1539,10 +1543,12 @@ class LassoLarsCV(LarsCV):
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
-    eps : float, optional
+    eps : float, default=np.finfo(float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
-        systems. By default, ``np.finfo(float).eps`` is used.
+        systems. Unlike the ``tol`` parameter in some iterative
+        optimization-based algorithms, this parameter does not control
+        the tolerance of the optimization.
 
     copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.
@@ -1667,7 +1673,7 @@ class LassoLarsIC(LassoLars):
         (i.e. data is expected to be centered).
 
     verbose : bool or int, default=False
-        Sets the verbosity amount
+        Sets the verbosity amount.
 
     normalize : bool, default=True
         This parameter is ignored when ``fit_intercept`` is set to False.
@@ -1686,13 +1692,12 @@ class LassoLarsIC(LassoLars):
         Maximum number of iterations to perform. Can be used for
         early stopping.
 
-    eps : float, optional
+    eps : float, default=np.finfo(float).eps
         The machine-precision regularization in the computation of the
         Cholesky diagonal factors. Increase this for very ill-conditioned
         systems. Unlike the ``tol`` parameter in some iterative
         optimization-based algorithms, this parameter does not control
         the tolerance of the optimization.
-        By default, ``np.finfo(float).eps`` is used
 
     copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -38,7 +38,8 @@ def test_simple():
         sys.stdout = StringIO()
 
         _, _, coef_path_ = linear_model.lars_path(
-            X, y, method='lars', verbose=10)
+            X, y, method="lar", verbose=10
+        )
 
         sys.stdout = old_stdout
 
@@ -60,8 +61,7 @@ def test_simple():
 def test_simple_precomputed():
     # The same, with precomputed Gram matrix
 
-    _, _, coef_path_ = linear_model.lars_path(
-        X, y, Gram=G, method='lars')
+    _, _, coef_path_ = linear_model.lars_path(X, y, Gram=G, method="lar")
 
     for i, coef_ in enumerate(coef_path_.T):
         res = y - np.dot(X, coef_)
@@ -82,8 +82,8 @@ def _assert_same_lars_path_result(output1, output2):
         assert_allclose(o1, o2)
 
 
-@pytest.mark.parametrize('method', ['lars', 'lasso'])
-@pytest.mark.parametrize('return_path', [True, False])
+@pytest.mark.parametrize("method", ["lar", "lasso"])
+@pytest.mark.parametrize("return_path", [True, False])
 def test_lars_path_gram_equivalent(method, return_path):
     _assert_same_lars_path_result(
         linear_model.lars_path_gram(
@@ -105,7 +105,7 @@ def test_all_precomputed():
     # Test that lars_path with precomputed Gram and Xy gives the right answer
     G = np.dot(X.T, X)
     Xy = np.dot(X.T, y)
-    for method in 'lars', 'lasso':
+    for method in "lar", "lasso":
         output = linear_model.lars_path(X, y, method=method)
         output_pre = linear_model.lars_path(X, y, Gram=G, Xy=Xy,
                                             method=method)
@@ -163,10 +163,10 @@ def test_collinearity():
 
 def test_no_path():
     # Test that the ``return_path=False`` option returns the correct output
-    alphas_, _, coef_path_ = linear_model.lars_path(
-        X, y, method='lars')
+    alphas_, _, coef_path_ = linear_model.lars_path(X, y, method="lar")
     alpha_, _, coef = linear_model.lars_path(
-        X, y, method='lars', return_path=False)
+        X, y, method="lar", return_path=False
+    )
 
     assert_array_almost_equal(coef, coef_path_[:, -1])
     assert alpha_ == alphas_[-1]
@@ -174,10 +174,10 @@ def test_no_path():
 
 def test_no_path_precomputed():
     # Test that the ``return_path=False`` option with Gram remains correct
-    alphas_, _, coef_path_ = linear_model.lars_path(
-        X, y, method='lars', Gram=G)
+    alphas_, _, coef_path_ = linear_model.lars_path(X, y, method="lar", Gram=G)
     alpha_, _, coef = linear_model.lars_path(
-        X, y, method='lars', Gram=G, return_path=False)
+        X, y, method="lar", Gram=G, return_path=False
+    )
 
     assert_array_almost_equal(coef, coef_path_[:, -1])
     assert alpha_ == alphas_[-1]
@@ -508,12 +508,13 @@ def test_lars_path_positive_constraint():
 
     # ensure that we get negative coefficients when positive=False
     # and all positive when positive=True
-    # for method 'lars' (default) and lasso
+    # for method 'lar' (default) and lasso
 
-    err_msg = "Positive constraint not supported for 'lars' coding method."
+    err_msg = "Positive constraint not supported for 'lar' coding method."
     with pytest.raises(ValueError, match=err_msg):
-        linear_model.lars_path(diabetes['data'], diabetes['target'],
-                               method='lars', positive=True)
+        linear_model.lars_path(
+            diabetes["data"], diabetes["target"], method="lar", positive=True
+        )
 
     method = 'lasso'
     _, _, coefs = \

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -38,7 +38,7 @@ def test_simple():
         sys.stdout = StringIO()
 
         _, _, coef_path_ = linear_model.lars_path(
-            X, y, method='lar', verbose=10)
+            X, y, method='lars', verbose=10)
 
         sys.stdout = old_stdout
 
@@ -61,7 +61,7 @@ def test_simple_precomputed():
     # The same, with precomputed Gram matrix
 
     _, _, coef_path_ = linear_model.lars_path(
-        X, y, Gram=G, method='lar')
+        X, y, Gram=G, method='lars')
 
     for i, coef_ in enumerate(coef_path_.T):
         res = y - np.dot(X, coef_)
@@ -82,7 +82,7 @@ def _assert_same_lars_path_result(output1, output2):
         assert_allclose(o1, o2)
 
 
-@pytest.mark.parametrize('method', ['lar', 'lasso'])
+@pytest.mark.parametrize('method', ['lars', 'lasso'])
 @pytest.mark.parametrize('return_path', [True, False])
 def test_lars_path_gram_equivalent(method, return_path):
     _assert_same_lars_path_result(
@@ -105,7 +105,7 @@ def test_all_precomputed():
     # Test that lars_path with precomputed Gram and Xy gives the right answer
     G = np.dot(X.T, X)
     Xy = np.dot(X.T, y)
-    for method in 'lar', 'lasso':
+    for method in 'lars', 'lasso':
         output = linear_model.lars_path(X, y, method=method)
         output_pre = linear_model.lars_path(X, y, Gram=G, Xy=Xy,
                                             method=method)
@@ -164,9 +164,9 @@ def test_collinearity():
 def test_no_path():
     # Test that the ``return_path=False`` option returns the correct output
     alphas_, _, coef_path_ = linear_model.lars_path(
-        X, y, method='lar')
+        X, y, method='lars')
     alpha_, _, coef = linear_model.lars_path(
-        X, y, method='lar', return_path=False)
+        X, y, method='lars', return_path=False)
 
     assert_array_almost_equal(coef, coef_path_[:, -1])
     assert alpha_ == alphas_[-1]
@@ -175,9 +175,9 @@ def test_no_path():
 def test_no_path_precomputed():
     # Test that the ``return_path=False`` option with Gram remains correct
     alphas_, _, coef_path_ = linear_model.lars_path(
-        X, y, method='lar', Gram=G)
+        X, y, method='lars', Gram=G)
     alpha_, _, coef = linear_model.lars_path(
-        X, y, method='lar', Gram=G, return_path=False)
+        X, y, method='lars', Gram=G, return_path=False)
 
     assert_array_almost_equal(coef, coef_path_[:, -1])
     assert alpha_ == alphas_[-1]
@@ -508,12 +508,12 @@ def test_lars_path_positive_constraint():
 
     # ensure that we get negative coefficients when positive=False
     # and all positive when positive=True
-    # for method 'lar' (default) and lasso
+    # for method 'lars' (default) and lasso
 
-    err_msg = "Positive constraint not supported for 'lar' coding method."
+    err_msg = "Positive constraint not supported for 'lars' coding method."
     with pytest.raises(ValueError, match=err_msg):
         linear_model.lars_path(diabetes['data'], diabetes['target'],
-                               method='lar', positive=True)
+                               method='lars', positive=True)
 
     method = 'lasso'
     _, _, coefs = \


### PR DESCRIPTION
fixed method='lars' inconsistency in __least_angle.py and its test file, fixed eps and random_state parameters to <default=value> format

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

#15761


#### What does this implement/fix? Explain your changes.

+ DOC fixed linear_model._least_angle.py default value for eps and random_state.


+ Inconsistency of the value of parameter `method`, `method` has possible two values {'lasso','lars'}. but in the code sometimes  `lar` is used other times `lars` is used. Replaced all to `lars`  in doc, code and test file. 


#### Any other comments?

