### PR TITLE
TST Increase tolerance for RANSACRegressor test

### DIFF
--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -512,4 +512,4 @@ def test_ransac_final_model_fit_sample_weight():
         sample_weight=sample_weight[mask_samples]
     )
 
-    assert_allclose(ransac.estimator_.coef_, final_model.coef_)
+    assert_allclose(ransac.estimator_.coef_, final_model.coef_, atol=1e-12)


### PR DESCRIPTION
An absolute difference of 1.45081487e-13 has been observed on 64-bit PowerPC. 

I'm assuming that this is another FP issue, so I would like to propose adding a tolerance of 1e-12 absolute to the test.

Failed test result from a Debian build host:
```python
    def test_ransac_final_model_fit_sample_weight():
        X, y = make_regression(n_samples=1000, random_state=10)
        rng = check_random_state(42)
        sample_weight = rng.randint(1, 4, size=y.shape[0])
        sample_weight = sample_weight / sample_weight.sum()
        ransac = RANSACRegressor(base_estimator=LinearRegression(), random_state=0)
        ransac.fit(X, y, sample_weight=sample_weight)
    
        final_model = LinearRegression()
        mask_samples = ransac.inlier_mask_
        final_model.fit(
            X[mask_samples], y[mask_samples],
            sample_weight=sample_weight[mask_samples]
        )
    
>       assert_allclose(ransac.estimator_.coef_, final_model.coef_)
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=0
E       
E       Mismatched elements: 90 / 100 (90%)
E       Max absolute difference: 1.45081487e-13
E       Max relative difference: 377.03946235
E        x: array([ 6.077983e-14, -3.197442e-14,  1.900364e-14,  4.027244e-14,
E               9.389254e+01, -4.600578e-14, -7.524381e-15,  1.031017e-14,
E              -3.010438e-14,  4.917009e-14, -6.014087e-14, -3.965410e-14,...
E        y: array([ 2.178449e-14,  1.776357e-14,  5.664626e-14,  4.164773e-14,
E               9.389254e+01, -7.517679e-14, -5.042223e-16,  4.194108e-14,
E              -3.643036e-14,  1.869087e-14, -8.660231e-14, -5.979280e-14,...
```

