### PR TITLE
TST Change expected result type np.int64 -> np.int

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,6 @@ jobs:
       py36_ubuntu_atlas_32bit:
         DISTRIB: 'ubuntu-32'
         PYTHON_VERSION: '3.6'
-        PANDAS_VERSION: 'none'
         JOBLIB_VERSION: 'min'
         # temporary pin pytest due to unknown failure with pytest 5.4 and
         # python 3.6

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -50,7 +50,8 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
 
 elif [[ "$DISTRIB" == "ubuntu-32" ]]; then
     apt-get update
-    apt-get install -y python3-dev python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev python3-virtualenv
+    apt-get install -y python3-dev python3-scipy python3-matplotlib libatlas3-base libatlas-base-dev python3-virtualenv python3-pandas
+
     python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
     source $VIRTUALENV/bin/activate
     python -m pip install $(get_dep cython $CYTHON_VERSION) \

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -186,12 +186,12 @@ def test_loader(loader_func, data_shape, target_shape, n_target, has_descr,
 
 
 @pytest.mark.parametrize("loader_func, data_dtype, target_dtype", [
-    (load_breast_cancer, np.float64, np.int64),
+    (load_breast_cancer, np.float64, int),
     (load_diabetes, np.float64, np.float64),
-    (load_digits, np.float64, np.int64),
-    (load_iris, np.float64, np.int64),
+    (load_digits, np.float64, int),
+    (load_iris, np.float64, int),
     (load_linnerud, np.float64, np.float64),
-    (load_wine, np.float64, np.int64),
+    (load_wine, np.float64, int),
 ])
 def test_toy_dataset_frame_dtype(loader_func, data_dtype, target_dtype):
     default_result = loader_func()

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1200,7 +1200,7 @@ def test_check_fit_params(indices):
 def test_check_sparse_pandas_sp_format(sp_format):
     # check_array converts pandas dataframe with only sparse arrays into
     # sparse matrix
-    pd = pytest.importorskip("pandas")
+    pd = pytest.importorskip("pandas", minversion="0.25.0")
     sp_mat = _sparse_random_matrix(10, 3)
 
     sdf = pd.DataFrame.sparse.from_spmatrix(sp_mat)


### PR DESCRIPTION
The function being tested uses np.int, so match that in the test. The
test otherwise fails on 32-bit architectures.

Closes: #18084