### PR TITLE
Added min_features variable to RFECV example

### DIFF
--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -38,5 +38,5 @@ plt.xlabel("Number of features selected")
 plt.ylabel("Cross validation score (nb of correct classifications)")
 plt.plot(range(min_features_to_select,
                len(rfecv.grid_scores_) + min_features_to_select)),
-               rfecv.grid_scores_)
+         rfecv.grid_scores_)
 plt.show()

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -37,6 +37,6 @@ plt.figure()
 plt.xlabel("Number of features selected")
 plt.ylabel("Cross validation score (nb of correct classifications)")
 plt.plot(range(min_features_to_select,
-               len(rfecv.grid_scores_) + min_features_to_select)),
+               len(rfecv.grid_scores_) + min_features_to_select), 
          rfecv.grid_scores_)
 plt.show()

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -26,7 +26,8 @@ svc = SVC(kernel="linear")
 
 min_features_to_select = 1 # Minimum number of features to consider 
 rfecv = RFECV(estimator=svc, step=1, cv=StratifiedKFold(2),
-              scoring='accuracy', min_features_to_select=min_features)
+              scoring='accuracy',
+              min_features_to_select= min_features_to_select)
 rfecv.fit(X, y)
 
 print("Optimal number of features : %d" % rfecv.n_features_)

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -36,7 +36,7 @@ print("Optimal number of features : %d" % rfecv.n_features_)
 plt.figure()
 plt.xlabel("Number of features selected")
 plt.ylabel("Cross validation score (nb of correct classifications)")
-plt.plot(range(min_features_to_select, 
+plt.plot(range(min_features_to_select,
                len(rfecv.grid_scores_) + min_features_to_select)),
          rfecv.grid_scores_)
 plt.show()

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -23,8 +23,10 @@ X, y = make_classification(n_samples=1000, n_features=25, n_informative=3,
 svc = SVC(kernel="linear")
 # The "accuracy" scoring is proportional to the number of correct
 # classifications
+
+min_features = 1 # Minimum number of features to consider 
 rfecv = RFECV(estimator=svc, step=1, cv=StratifiedKFold(2),
-              scoring='accuracy')
+              scoring='accuracy', min_features_to_select=min_features)
 rfecv.fit(X, y)
 
 print("Optimal number of features : %d" % rfecv.n_features_)
@@ -33,5 +35,5 @@ print("Optimal number of features : %d" % rfecv.n_features_)
 plt.figure()
 plt.xlabel("Number of features selected")
 plt.ylabel("Cross validation score (nb of correct classifications)")
-plt.plot(range(1, len(rfecv.grid_scores_) + 1), rfecv.grid_scores_)
+plt.plot(range(min_features, len(rfecv.grid_scores_) + min_features), rfecv.grid_scores_)
 plt.show()

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -24,7 +24,7 @@ svc = SVC(kernel="linear")
 # The "accuracy" scoring is proportional to the number of correct
 # classifications
 
-min_features_to_select = 1 # Minimum number of features to consider 
+min_features_to_select = 1  # Minimum number of features to consider 
 rfecv = RFECV(estimator=svc, step=1, cv=StratifiedKFold(2),
               scoring='accuracy',
               min_features_to_select= min_features_to_select)

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -35,5 +35,7 @@ print("Optimal number of features : %d" % rfecv.n_features_)
 plt.figure()
 plt.xlabel("Number of features selected")
 plt.ylabel("Cross validation score (nb of correct classifications)")
-plt.plot(range(min_features, len(rfecv.grid_scores_) + min_features), rfecv.grid_scores_)
+plt.plot(range(min_features_to_select, 
+               len(rfecv.grid_scores_) + min_features_to_select)),
+         rfecv.grid_scores_)
 plt.show()

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -38,5 +38,5 @@ plt.xlabel("Number of features selected")
 plt.ylabel("Cross validation score (nb of correct classifications)")
 plt.plot(range(min_features_to_select,
                len(rfecv.grid_scores_) + min_features_to_select)),
-         rfecv.grid_scores_)
+               rfecv.grid_scores_)
 plt.show()

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -24,7 +24,7 @@ svc = SVC(kernel="linear")
 # The "accuracy" scoring is proportional to the number of correct
 # classifications
 
-min_features_to_select = 1  # Minimum number of features to consider 
+min_features_to_select = 1  # Minimum number of features to consider
 rfecv = RFECV(estimator=svc, step=1, cv=StratifiedKFold(2),
               scoring='accuracy',
               min_features_to_select=min_features_to_select)

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -24,7 +24,7 @@ svc = SVC(kernel="linear")
 # The "accuracy" scoring is proportional to the number of correct
 # classifications
 
-min_features = 1 # Minimum number of features to consider 
+min_features_to_select = 1 # Minimum number of features to consider 
 rfecv = RFECV(estimator=svc, step=1, cv=StratifiedKFold(2),
               scoring='accuracy', min_features_to_select=min_features)
 rfecv.fit(X, y)

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -37,6 +37,6 @@ plt.figure()
 plt.xlabel("Number of features selected")
 plt.ylabel("Cross validation score (nb of correct classifications)")
 plt.plot(range(min_features_to_select,
-               len(rfecv.grid_scores_) + min_features_to_select), 
+               len(rfecv.grid_scores_) + min_features_to_select),
          rfecv.grid_scores_)
 plt.show()

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -27,7 +27,7 @@ svc = SVC(kernel="linear")
 min_features_to_select = 1  # Minimum number of features to consider 
 rfecv = RFECV(estimator=svc, step=1, cv=StratifiedKFold(2),
               scoring='accuracy',
-              min_features_to_select= min_features_to_select)
+              min_features_to_select=min_features_to_select)
 rfecv.fit(X, y)
 
 print("Optimal number of features : %d" % rfecv.n_features_)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

The current [example code](https://scikit-learn.org/stable/auto_examples/feature_selection/plot_rfe_with_cross_validation.html#sphx-glr-auto-examples-feature-selection-plot-rfe-with-cross-validation-py) for `sklearn.feature_selection.RFECV` produces confusing results if a non-default min_features_to_select parameter is added, as the example plot will be produced with an incorrect axis. Since it is not clear that the 1s in `plt.plot(range(1, len(rfecv.grid_scores_) + 1), rfecv.grid_scores_)` refer to the default `min_features_to_select` I believe it would be more informative if this were made explicit.

This is my first pull request to a public repo, so please let me know if I'm being an ass or otherwise violating etiquette. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
