### PR TITLE
TST Sets random_state in test_rfe_wrapped_estimator

### DIFF
--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -416,7 +416,7 @@ def test_rfe_wrapped_estimator(importance_getter, selector,
     # Non-regression test for
     # https://github.com/scikit-learn/scikit-learn/issues/15312
     X, y = make_friedman1(n_samples=50, n_features=10, random_state=0)
-    estimator = LinearSVR()
+    estimator = LinearSVR(random_state=0)
 
     log_estimator = TransformedTargetRegressor(regressor=estimator,
                                                func=np.log,


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/18095

This PR sets random state in `test_rfe_wrapped_estimator`.

Check fails with the following seed:

```py
estimator = LinearSVR(random_state=1430)
```