### PR TITLE
DOC Fix mpl in plot_partial_dependence_visualization_api

### DIFF
--- a/examples/miscellaneous/plot_partial_dependence_visualization_api.py
+++ b/examples/miscellaneous/plot_partial_dependence_visualization_api.py
@@ -64,7 +64,7 @@ tree_disp = plot_partial_dependence(tree, X, ["age", "bmi"], ax=ax)
 fig, ax = plt.subplots(figsize=(12, 6))
 ax.set_title("Multi-layer Perceptron")
 mlp_disp = plot_partial_dependence(mlp, X, ["age", "bmi"], ax=ax,
-                                   line_kw={"c": "red"})
+                                   line_kw={"color": "red"})
 
 # %%
 # Plotting partial dependence of the two models together
@@ -88,7 +88,7 @@ mlp_disp = plot_partial_dependence(mlp, X, ["age", "bmi"], ax=ax,
 fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 10))
 tree_disp.plot(ax=ax1)
 ax1.set_title("Decision Tree")
-mlp_disp.plot(ax=ax2, line_kw={"c": "red"})
+mlp_disp.plot(ax=ax2, line_kw={"color": "red"})
 ax2.set_title("Multi-layer Perceptron")
 
 # %%
@@ -102,7 +102,7 @@ ax2.set_title("Multi-layer Perceptron")
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 6))
 tree_disp.plot(ax=[ax1, ax2], line_kw={"label": "Decision Tree"})
 mlp_disp.plot(ax=[ax1, ax2], line_kw={"label": "Multi-layer Perceptron",
-                                      "c": "red"})
+                                      "color": "red"})
 ax1.legend()
 ax2.legend()
 
@@ -115,7 +115,7 @@ ax2.legend()
 # `plot` will only show the y label and y ticks on the left most plot.
 
 tree_disp.plot(line_kw={"label": "Decision Tree"})
-mlp_disp.plot(line_kw={"label": "Multi-layer Perceptron", "c": "red"},
+mlp_disp.plot(line_kw={"label": "Multi-layer Perceptron", "color": "red"},
               ax=tree_disp.axes_)
 tree_disp.figure_.set_size_inches(10, 6)
 tree_disp.axes_[0, 0].legend()
@@ -131,4 +131,5 @@ plt.show()
 # plot function.
 tree_disp = plot_partial_dependence(tree, X, ["age"])
 mlp_disp = plot_partial_dependence(mlp, X, ["age"],
-                                   ax=tree_disp.axes_, line_kw={"c": "red"})
+                                   ax=tree_disp.axes_,
+                                   line_kw={"color": "red"})


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fix a matplotlib error in `examples/miscellaneous/plot_partial_dependence_visualization_api.py`
```
WARNING: /home/cmarmo/software/scikit-learn/examples/miscellaneous/plot_partial_dependence_visualization_api.py failed to execute correctly: Traceback (most recent call last):
  File "/home/cmarmo/skldevenv/lib64/python3.8/site-packages/sphinx_gallery/gen_gallery.py", line 159, in call_memory
    return 0., func()
  File "/home/cmarmo/skldevenv/lib64/python3.8/site-packages/sphinx_gallery/gen_rst.py", line 466, in __call__
    exec(self.code, self.fake_main.__dict__)
  File "/home/cmarmo/software/scikit-learn/examples/miscellaneous/plot_partial_dependence_visualization_api.py", line 66, in <module>
    mlp_disp = plot_partial_dependence(mlp, X, ["age", "bmi"], ax=ax,
  File "/home/cmarmo/software/scikit-learn/sklearn/utils/validation.py", line 60, in inner_f
    return f(*args, **kwargs)
  File "/home/cmarmo/software/scikit-learn/sklearn/inspection/_plot/partial_dependence.py", line 376, in plot_partial_dependence
    return display.plot(ax=ax, n_cols=n_cols, line_kw=line_kw,
  File "/home/cmarmo/software/scikit-learn/sklearn/inspection/_plot/partial_dependence.py", line 680, in plot
    lines_ravel[i] = axi.plot(
  File "/home/cmarmo/skldevenv/lib64/python3.8/site-packages/matplotlib/axes/_axes.py", line 1742, in plot
    kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
  File "/home/cmarmo/skldevenv/lib64/python3.8/site-packages/matplotlib/cbook/deprecation.py", line 411, in wrapper
    return func(*inner_args, **inner_kwargs)
  File "/home/cmarmo/skldevenv/lib64/python3.8/site-packages/matplotlib/cbook/deprecation.py", line 411, in wrapper
    return func(*inner_args, **inner_kwargs)
  File "/home/cmarmo/skldevenv/lib64/python3.8/site-packages/matplotlib/cbook/deprecation.py", line 411, in wrapper
    return func(*inner_args, **inner_kwargs)
  File "/home/cmarmo/skldevenv/lib64/python3.8/site-packages/matplotlib/cbook/__init__.py", line 1733, in normalize_kwargs
    raise TypeError(f"Got both {canonical_to_seen[canonical]!r} and "
TypeError: Got both 'color' and 'c', which are aliases of one another
```

#### Any other comments?
See `DeprecationWarning` in [dev documentation](https://scikit-learn.org/dev/auto_examples/miscellaneous/plot_partial_dependence_visualization_api.html#sphx-glr-auto-examples-miscellaneous-plot-partial-dependence-visualization-api-py)

```
>>> sklearn.show_versions()  

System:
    python: 3.8.3 (default, May 29 2020, 00:00:00)  [GCC 10.1.1 20200507 (Red Hat 10.1.1-1)]
executable: /home/cmarmo/skldevenv/bin/python
   machine: Linux-5.7.9-200.fc32.x86_64-x86_64-with-glibc2.2.5

Python dependencies:
          pip: 20.2.1
   setuptools: 41.6.0
      sklearn: 0.24.dev0
        numpy: 1.19.1
        scipy: 1.5.2
       Cython: None
       pandas: 1.1.0
   matplotlib: 3.3.0
       joblib: 0.16.0
threadpoolctl: 2.1.0

Built with OpenMP: True
```
matplotlib version:
```
>>> matplotlib.__version__
'3.3.0'
```