### PR TITLE
DOC improve the ROC-AUC docstring

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1333,11 +1333,18 @@ For more information see the `Wikipedia article on AUC
 Compared to metrics such as the subset accuracy, the Hamming loss, or the
 F1 score, ROC doesn't require optimizing a threshold for each label.
 
+.. _roc_auc_binary:
+
+Binary case
+```````````
+
 In the **binary case**, you can either provide the probability estimates, using
 the `classifier.predict_proba()` method, or the non-thresholded decision values
 given by the `classifier.decision_function()` method. In the case of providing
-the probability estimates, the probability of the class with the greater label
-should be provided. Therefore, the `y_score` parameter is of size (n_samples,).
+the probability estimates, the probability of the class with the
+"greater label" should be provided. The "greater label" corresponds to
+`classifier.classes_[1]` and thus `classifier.predict_proba(X)[:, 1]`.
+Therefore, the `y_score` parameter is of size (n_samples,).
 
   >>> from sklearn.datasets import load_breast_cancer
   >>> from sklearn.linear_model import LogisticRegression
@@ -1358,27 +1365,10 @@ Otherwise, we can use the non-thresholded decision values
   >>> roc_auc_score(y, clf.decision_function(X))
   0.99...
 
-In **multi-label classification**, the :func:`roc_auc_score` function is
-extended by averaging over the labels as :ref:`above <average>`. In this case,
-you should provide a `y_score` of shape `(n_samples, n_classes)`. Thus, when
-using the probability estimates, one needs to select the probability of the
-class with the greater label for each output.
+.. _roc_auc_multiclass:
 
-  >>> from sklearn.datasets import make_multilabel_classification
-  >>> from sklearn.multioutput import MultiOutputClassifier
-  >>> X, y = make_multilabel_classification(random_state=0)
-  >>> clf = MultiOutputClassifier(clf).fit(X, y)
-  >>> y_score = np.transpose([y_pred[:, 1] for y_pred in clf.predict_proba(X)])
-  >>> roc_auc_score(y, y_score, average=None)
-  array([0.82..., 0.86..., 0.94..., 0.85... , 0.94...])
-
-And the decision values do not require such processing.
-
-  >>> from sklearn.linear_model import RidgeClassifierCV
-  >>> clf = RidgeClassifierCV().fit(X, y)
-  >>> y_score = clf.decision_function(X)
-  >>> roc_auc_score(y, y_score, average=None)
-  array([0.81..., 0.84... , 0.93..., 0.87..., 0.94...])
+Multiclass case
+```````````````
 
 The :func:`roc_auc_score` function can also be used in **multi-class
 classification**. Two averaging strategies are currently supported: the
@@ -1434,6 +1424,33 @@ to the given limit.
    :target: ../auto_examples/model_selection/plot_roc.html
    :scale: 75
    :align: center
+
+.. _roc_auc_multilabel:
+
+Multi-label case
+```````````````
+
+In **multi-label classification**, the :func:`roc_auc_score` function is
+extended by averaging over the labels as :ref:`above <average>`. In this case,
+you should provide a `y_score` of shape `(n_samples, n_classes)`. Thus, when
+using the probability estimates, one needs to select the probability of the
+class with the greater label for each output.
+
+  >>> from sklearn.datasets import make_multilabel_classification
+  >>> from sklearn.multioutput import MultiOutputClassifier
+  >>> X, y = make_multilabel_classification(random_state=0)
+  >>> clf = MultiOutputClassifier(clf).fit(X, y)
+  >>> y_score = np.transpose([y_pred[:, 1] for y_pred in clf.predict_proba(X)])
+  >>> roc_auc_score(y, y_score, average=None)
+  array([0.82..., 0.86..., 0.94..., 0.85... , 0.94...])
+
+And the decision values do not require such processing.
+
+  >>> from sklearn.linear_model import RidgeClassifierCV
+  >>> clf = RidgeClassifierCV().fit(X, y)
+  >>> y_score = clf.decision_function(X)
+  >>> roc_auc_score(y, y_score, average=None)
+  array([0.81..., 0.84... , 0.93..., 0.87..., 0.94...])
 
 .. topic:: Examples:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1345,6 +1345,7 @@ should be provided. Therefore, the `y_score` parameter is of size (n_samples,).
   >>> X, y = load_breast_cancer(return_X_y=True)
   >>> clf = LogisticRegression(solver="liblinear").fit(X, y)
   >>> clf.classes_
+  array([0, 1])
 
 We can use the probability estimates corresponding to `clf.classes_[1]`.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1330,21 +1330,57 @@ area under the roc curve, the curve information is summarized in one number.
 For more information see the `Wikipedia article on AUC
 <https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve>`_.
 
-  >>> import numpy as np
-  >>> from sklearn.metrics import roc_auc_score
-  >>> y_true = np.array([0, 0, 1, 1])
-  >>> y_scores = np.array([0.1, 0.4, 0.35, 0.8])
-  >>> roc_auc_score(y_true, y_scores)
-  0.75
-
-In multi-label classification, the :func:`roc_auc_score` function is
-extended by averaging over the labels as :ref:`above <average>`.
-
 Compared to metrics such as the subset accuracy, the Hamming loss, or the
 F1 score, ROC doesn't require optimizing a threshold for each label.
 
-The :func:`roc_auc_score` function can also be used in multi-class
-classification. Two averaging strategies are currently supported: the
+In the **binary case**, you can either provide the probability estimates, using
+the `classifier.predict_proba()` method, or the non-thresholded decision values
+given by the `classifier.decision_function()` method. In the case of providing
+the probability estimates, the probability of the class with the greater label
+should be provided. Therefore, the `y_score` parameter is of size (n_samples,).
+
+  >>> from sklearn.datasets import load_breast_cancer
+  >>> from sklearn.linear_model import LogisticRegression
+  >>> from sklearn.metrics import roc_auc_score
+  >>> X, y = load_breast_cancer(return_X_y=True)
+  >>> clf = LogisticRegression(solver="liblinear").fit(X, y)
+  >>> clf.classes_
+
+We can use the probability estimates corresponding to `clf.classes_[1]`.
+
+  >>> y_score = clf.predict_proba(X)[:, 1]
+  >>> roc_auc_score(y, y_score)
+  0.99...
+
+Otherwise, we can use the non-thresholded decision values
+
+  >>> roc_auc_score(y, clf.decision_function(X))
+  0.99...
+
+In **multi-label classification**, the :func:`roc_auc_score` function is
+extended by averaging over the labels as :ref:`above <average>`. In this case,
+you should provide a `y_score` of shape `(n_samples, n_classes)`. Thus, when
+using the probability estimates, one needs to select the probability of the
+class with the greater label for each output.
+
+  >>> from sklearn.datasets import make_multilabel_classification
+  >>> from sklearn.multioutput import MultiOutputClassifier
+  >>> X, y = make_multilabel_classification(random_state=0)
+  >>> clf = MultiOutputClassifier(clf).fit(X, y)
+  >>> y_score = np.transpose([y_pred[:, 1] for y_pred in clf.predict_proba(X)])
+  >>> roc_auc_score(y, y_score, average=None)
+  array([0.82..., 0.86..., 0.94..., 0.85... , 0.94...])
+
+And the decision values do not require such processing.
+
+  >>> from sklearn.linear_model import RidgeClassifierCV
+  >>> clf = RidgeClassifierCV().fit(X, y)
+  >>> y_score = clf.decision_function(X)
+  >>> roc_auc_score(y, y_score, average=None)
+  array([0.81..., 0.84... , 0.93..., 0.87..., 0.94...])
+
+The :func:`roc_auc_score` function can also be used in **multi-class
+classification**. Two averaging strategies are currently supported: the
 one-vs-one algorithm computes the average of the pairwise ROC AUC scores, and
 the one-vs-rest algorithm computes the average of the ROC AUC scores for each
 class against all other classes. In both cases, the predicted labels are

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1439,7 +1439,8 @@ class with the greater label for each output.
   >>> from sklearn.datasets import make_multilabel_classification
   >>> from sklearn.multioutput import MultiOutputClassifier
   >>> X, y = make_multilabel_classification(random_state=0)
-  >>> clf = MultiOutputClassifier(clf).fit(X, y)
+  >>> inner_clf = LogisticRegression(solver="liblinear", random_state=0)
+  >>> clf = MultiOutputClassifier(inner_clf).fit(X, y)
   >>> y_score = np.transpose([y_pred[:, 1] for y_pred in clf.predict_proba(X)])
   >>> roc_auc_score(y, y_score, average=None)
   array([0.82..., 0.86..., 0.94..., 0.85... , 0.94...])

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1336,7 +1336,7 @@ F1 score, ROC doesn't require optimizing a threshold for each label.
 .. _roc_auc_binary:
 
 Binary case
-```````````
+^^^^^^^^^^^
 
 In the **binary case**, you can either provide the probability estimates, using
 the `classifier.predict_proba()` method, or the non-thresholded decision values
@@ -1367,8 +1367,8 @@ Otherwise, we can use the non-thresholded decision values
 
 .. _roc_auc_multiclass:
 
-Multiclass case
-```````````````
+Multi-class case
+^^^^^^^^^^^^^^^^
 
 The :func:`roc_auc_score` function can also be used in **multi-class
 classification**. Two averaging strategies are currently supported: the
@@ -1428,7 +1428,7 @@ to the given limit.
 .. _roc_auc_multilabel:
 
 Multi-label case
-```````````````
+^^^^^^^^^^^^^^^^
 
 In **multi-label classification**, the :func:`roc_auc_score` function is
 extended by averaging over the labels as :ref:`above <average>`. In this case,

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -383,7 +383,7 @@ def roc_auc_score(y_true, y_score, *, average="macro", sample_weight=None,
     >>> from sklearn.linear_model import LogisticRegression
     >>> from sklearn.metrics import roc_auc_score
     >>> X, y = load_breast_cancer(return_X_y=True)
-    >>> clf = LogisticRegression(solver="liblinear").fit(X, y)
+    >>> clf = LogisticRegression(solver="liblinear", random_state=0).fit(X, y)
     >>> roc_auc_score(y, clf.predict_proba(X)[:, 1])
     0.99...
     >>> roc_auc_score(y, clf.decision_function(X))

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -267,24 +267,24 @@ def roc_auc_score(y_true, y_score, *, average="macro", sample_weight=None,
     y_score : array-like of shape (n_samples,) or (n_samples, n_classes)
         Target scores.
 
-        * In the binary case, it corresponds to an array of shape (n_samples,).
-          Both probability estimates and non-thresholded decision values can
-          be provided. The probability estimates correspond to the
-          **probability of the class with the greater label**,
+        * In the binary case, it corresponds to an array of shape
+          `(n_samples,)`. Both probability estimates and non-thresholded
+          decision values can be provided. The probability estimates correspond
+          to the **probability of the class with the greater label**,
           i.e. `estimator.classes_[1]` and thus
           `estimator.predict_proba(X, y)[:, 1]`. The decision values
           corresponds to the output of `estimator.decision_function(X, y)`.
           See more information in the :ref:`User guide <roc_auc_binary>`;
         * In the multiclass case, it corresponds to an array of shape
-          (n_samples, n_classes) of probability estimates provided by the
+          `(n_samples, n_classes)` of probability estimates provided by the
           `predict_proba` method. The probability estimates **must**
           sum to 1 across the possible classes. In addition, the order of the
           class scores must correspond to the order of ``labels``,
           if provided, or else to the numerical or lexicographical order of
           the labels in ``y_true``. See more information in the
           :ref:`User guide <roc_auc_multiclass>`;
-          * In the multilabel case, it corresponds to an array of shape
-          (n_samples, n_classes). Probability estimates are provided by the
+        * In the multilabel case, it corresponds to an array of shape
+          `(n_samples, n_classes)`. Probability estimates are provided by the
           `predict_proba` method and the non-thresholded decision values by
           the `decision_function` method. The probability estimates correspond
           to the **probability of the class with the greater label for each

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -372,69 +372,38 @@ def roc_auc_score(y_true, y_score, *, average="macro", sample_weight=None,
 
     Examples
     --------
-    ROC-AUC can be computed in different problem. In binary case, both
-    probability estimates and non-thresholded decision values can be used:
+    Binary case:
 
     >>> from sklearn.datasets import load_breast_cancer
     >>> from sklearn.linear_model import LogisticRegression
     >>> from sklearn.metrics import roc_auc_score
     >>> X, y = load_breast_cancer(return_X_y=True)
     >>> clf = LogisticRegression(solver="liblinear").fit(X, y)
-    >>> y_probability_estimates = clf.predict_proba(X)
-    >>> print(
-    ...     f"Shape of the probability estimates in binary case: "
-    ...     f"{y_probability_estimates.shape}"
-    ... )
-    Shape of the probability estimates in binary case: (569, 2)
-    >>> print(
-    ...     f"The labels learn by the classifierare: {clf.classes_}"
-    ... )
-    The labels learn by the classifierare: [0 1]
+    >>> roc_auc_score(y, clf.predict_proba(X)[:, 1])
+    0.99...
+    >>> roc_auc_score(y, clf.decision_function(X))
+    0.99...
 
-    In the binary case, we need to pass the probability estimates corresponding
-    to the greater label which is always `y_probability_estimates[:, 1]`
-    corresponding to `clf.classes_[1]`.
-
-    >>> print(
-    ...     f"ROC-AUC score using probability estimate: "
-    ...     f"{roc_auc_score(y, y_probability_estimates[:, 1])}"
-    ... )
-    ROC-AUC score using probability estimate: 0.99...
-
-    Otherwise, you can passed the decision values directly:
-
-    >>> y_decision_values = clf.decision_function(X)
-    >>> print(
-    ...     f"Shape of the non-thresholded decision values in binary case: "
-    ...     f"{y_decision_values.shape}"
-    ... )
-    Shape of the non-thresholded decision values in binary case: (569,)
-    >>> print(
-    ...     f"ROC-AUC score using non-thresholded decision values: "
-    ...     f"{roc_auc_score(y, y_decision_values)}"
-    ... )
-    ROC-AUC score using non-thresholded decision values: 0.99...
-
-    In the multiclass case, one need to pass probability estimates which
-    should sum to 1 across class. In addition, you need to specify the
-    `multi_class` strategy to use.
+    Multiclass case:
 
     >>> from sklearn.datasets import load_iris
     >>> X, y = load_iris(return_X_y=True)
     >>> clf = LogisticRegression(solver="liblinear").fit(X, y)
-    >>> y_probability_estimates = clf.predict_proba(X)
-    >>> print(
-    ...     f"Shape of the probability estimates in multiclass case: "
-    ...     f"{y_probability_estimates.shape}"
+    >>> roc_auc_score(y, clf.predict_proba(X), multi_class='ovr')
+    0.99...
+
+    Multilabel case:
+
+    >>> from sklearn.datasets import make_multilabel_classification
+    >>> from sklearn.multioutput import MultiOutputClassifier
+    >>> X, y = make_multilabel_classification(random_state=0)
+    >>> clf = MultiOutputClassifier(clf).fit(X, y)
+    >>> roc_auc_score(
+    ...     y,
+    ...     np.transpose([y_pred[:, 1] for y_pred in clf.predict_proba(X)]),
+    ...     average=None
     ... )
-    Shape of the probability estimates in multiclass case: (150, 3)
-    >>> y_probability_estimates.sum(axis=1)
-    array([1., 1., 1., 1., ...])
-    >>> print(
-    ...     f"ROC-AUC score using probability estimate: "
-    ...     f"{roc_auc_score(y, y_probability_estimates, multi_class='ovr')}"
-    ... )
-    ROC-AUC score using probability estimate: 0.99...
+    array([0.82..., 0.86..., 0.94..., 0.85... , 0.94...])
     """
 
     y_type = type_of_target(y_true)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -277,7 +277,9 @@ def roc_auc_score(y_true, y_score, *, average="macro", sample_weight=None,
         * In the multilabel case, it corresponds to an array of shape
           (n_samples, n_classes). Probability estimates are provided by the
           `predict_proba` method and the non-thresholded decision values by
-          the `decision_function` method;
+          the `decision_function` method. The probability estimates correspond
+          to the **probability of the class with the greater label for each
+          output** of the classifier;
         * In the multiclass case, it corresponds to an array of shape
           (n_samples, n_classes) of probability estimates provided by the
           `predict_proba` method. The probability estimates **must**

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -404,6 +404,10 @@ def roc_auc_score(y_true, y_score, *, average="macro", sample_weight=None,
     ...     average=None
     ... )
     array([0.82..., 0.86..., 0.94..., 0.85... , 0.94...])
+    >>> from sklearn.linear_model import RidgeClassifierCV
+    >>> clf = RidgeClassifierCV().fit(X, y)
+    >>> roc_auc_score(y, clf.decision_function(X), average=None)
+    array([0.81..., 0.84... , 0.93..., 0.87..., 0.94...])
     """
 
     y_type = type_of_target(y_true)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -273,20 +273,23 @@ def roc_auc_score(y_true, y_score, *, average="macro", sample_weight=None,
           **probability of the class with the greater label**,
           i.e. `estimator.classes_[1]` and thus
           `estimator.predict_proba(X, y)[:, 1]`. The decision values
-          corresponds to the output of `estimator.decision_function(X, y)`;
-        * In the multilabel case, it corresponds to an array of shape
-          (n_samples, n_classes). Probability estimates are provided by the
-          `predict_proba` method and the non-thresholded decision values by
-          the `decision_function` method. The probability estimates correspond
-          to the **probability of the class with the greater label for each
-          output** of the classifier;
+          corresponds to the output of `estimator.decision_function(X, y)`.
+          See more information in the :ref:`User guide <roc_auc_binary>`;
         * In the multiclass case, it corresponds to an array of shape
           (n_samples, n_classes) of probability estimates provided by the
           `predict_proba` method. The probability estimates **must**
           sum to 1 across the possible classes. In addition, the order of the
           class scores must correspond to the order of ``labels``,
           if provided, or else to the numerical or lexicographical order of
-          the labels in ``y_true``.
+          the labels in ``y_true``. See more information in the
+          :ref:`User guide <roc_auc_multiclass>`;
+          * In the multilabel case, it corresponds to an array of shape
+          (n_samples, n_classes). Probability estimates are provided by the
+          `predict_proba` method and the non-thresholded decision values by
+          the `decision_function` method. The probability estimates correspond
+          to the **probability of the class with the greater label for each
+          output** of the classifier. See more information in the
+          :ref:`User guide <roc_auc_multilabel>`.
 
     average : {'micro', 'macro', 'samples', 'weighted'} or None, \
             default='macro'
@@ -402,7 +405,9 @@ def roc_auc_score(y_true, y_score, *, average="macro", sample_weight=None,
     >>> clf = MultiOutputClassifier(clf).fit(X, y)
     >>> roc_auc_score(
     ...     y,
-    ...     np.transpose([y_pred[:, 1] for y_pred in clf.predict_proba(X)]),
+    ...     np.transpose([
+    ...         y_pred[:, 1] for y_pred in clf.predict_proba(X)
+    ...     ]),
     ...     average=None
     ... )
     array([0.82..., 0.86..., 0.94..., 0.85... , 0.94...])

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -403,13 +403,12 @@ def roc_auc_score(y_true, y_score, *, average="macro", sample_weight=None,
     >>> from sklearn.multioutput import MultiOutputClassifier
     >>> X, y = make_multilabel_classification(random_state=0)
     >>> clf = MultiOutputClassifier(clf).fit(X, y)
-    >>> roc_auc_score(
-    ...     y,
-    ...     np.transpose([
-    ...         y_pred[:, 1] for y_pred in clf.predict_proba(X)
-    ...     ]),
-    ...     average=None
-    ... )
+    >>> # get a list of n_output containing probability arrays of shape
+    >>> # (n_samples, n_classes)
+    >>> y_pred = clf.predict_proba(X)
+    >>> # extract the positive columns for each output
+    >>> y_pred = np.transpose([pred[:, 1] for pred in y_pred])
+    >>> roc_auc_score(y, y_pred, average=None)
     array([0.82..., 0.86..., 0.94..., 0.85... , 0.94...])
     >>> from sklearn.linear_model import RidgeClassifierCV
     >>> clf = RidgeClassifierCV().fit(X, y)


### PR DESCRIPTION
Improving the ROC-AUC docstring to be more explicit regarding what to pass in the binary case.

The idea is to make it more obvious that `y_pred[:, 1]` should always be given and not the positive class as in other metrics.