### PR TITLE
[MRG] DOC clarify the kernel gradient for GaussianProcesses

### DIFF
--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -385,12 +385,14 @@ equivalent call to ``__call__``: ``np.diag(k(X, X)) == k.diag(X)``
 Kernels are parameterized by a vector :math:`\theta` of hyperparameters. These
 hyperparameters can for instance control length-scales or periodicity of a
 kernel (see below). All kernels support computing analytic gradients 
-of the kernel's auto-covariance with respect to :math:`\theta` via setting
-``eval_gradient=True`` in the ``__call__`` method. This gradient is used by the
-Gaussian process (both regressor and classifier) in computing the gradient
-of the log-marginal-likelihood, which in turn is used to determine the
-value of :math:`\theta`, which maximizes the log-marginal-likelihood,  via
-gradient ascent. For each hyperparameter, the initial value and the
+of the kernel's auto-covariance with respect to :math:`log(\theta)` via setting
+``eval_gradient=True`` in the ``__call__`` method.
+That is, a ``(len(X), len(X), len(theta))`` array is returned where the entry
+``[i, j, l]`` contains :math:`\frac{\partial k_\theta(x_i, x_j)}{\partial log(\theta_l)}`.
+This gradient is used by the Gaussian process (both regressor and classifier)
+in computing the gradient of the log-marginal-likelihood, which in turn is used
+to determine the value of :math:`\theta`, which maximizes the log-marginal-likelihood,
+via gradient ascent. For each hyperparameter, the initial value and the
 bounds need to be specified when creating an instance of the kernel. The
 current value of :math:`\theta` can be get and set via the property
 ``theta`` of the kernel object. Moreover, the bounds of the hyperparameters can be

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -572,8 +572,8 @@ class CompoundKernel(Kernel):
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
-            hyperparameter is determined.
+            Determines whether the gradient with respect to the log of the
+            kernel hyperparameter is determined.
 
         Returns
         -------
@@ -796,7 +796,7 @@ class Sum(KernelOperator):
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined.
 
         Returns
@@ -894,7 +894,7 @@ class Product(KernelOperator):
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined.
 
         Returns
@@ -1072,7 +1072,7 @@ class Exponentiation(Kernel):
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined.
 
         Returns
@@ -1200,7 +1200,7 @@ class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
@@ -1319,7 +1319,7 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
@@ -1466,7 +1466,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
@@ -1620,7 +1620,7 @@ class Matern(RBF):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
@@ -1809,7 +1809,7 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
@@ -1954,7 +1954,7 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
@@ -2086,7 +2086,7 @@ class DotProduct(Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns
@@ -2240,7 +2240,7 @@ class PairwiseKernel(Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the kernel
+            Determines whether the gradient with respect to the log of the kernel
             hyperparameter is determined. Only supported when Y is None.
 
         Returns

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -573,7 +573,7 @@ class CompoundKernel(Kernel):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of the
-            kernel hyperparameter is determined.
+            kernel hyperparameter is computed.
 
         Returns
         -------
@@ -797,7 +797,7 @@ class Sum(KernelOperator):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
 
         Returns
         -------
@@ -895,7 +895,7 @@ class Product(KernelOperator):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
 
         Returns
         -------
@@ -1073,7 +1073,7 @@ class Exponentiation(Kernel):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
 
         Returns
         -------
@@ -1201,7 +1201,7 @@ class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
             Only supported when Y is None.
 
         Returns
@@ -1321,7 +1321,7 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
             Only supported when Y is None.
 
         Returns
@@ -1469,7 +1469,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
             Only supported when Y is None.
 
         Returns
@@ -1624,7 +1624,7 @@ class Matern(RBF):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
             Only supported when Y is None.
 
         Returns
@@ -1814,7 +1814,7 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
             Only supported when Y is None.
 
         Returns
@@ -1960,7 +1960,7 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
             Only supported when Y is None.
 
         Returns
@@ -2093,7 +2093,7 @@ class DotProduct(Kernel):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
             Only supported when Y is None.
 
         Returns
@@ -2248,7 +2248,7 @@ class PairwiseKernel(Kernel):
 
         eval_gradient : bool, default=False
             Determines whether the gradient with respect to the log of
-            the kernel hyperparameter is determined.
+            the kernel hyperparameter is computed.
             Only supported when Y is None.
 
         Returns

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -796,8 +796,8 @@ class Sum(KernelOperator):
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
 
         Returns
         -------
@@ -894,8 +894,8 @@ class Product(KernelOperator):
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
 
         Returns
         -------
@@ -1072,8 +1072,8 @@ class Exponentiation(Kernel):
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
 
         Returns
         -------
@@ -1200,8 +1200,9 @@ class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined. Only supported when Y is None.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
+            Only supported when Y is None.
 
         Returns
         -------
@@ -1319,8 +1320,9 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
             is evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined. Only supported when Y is None.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
+            Only supported when Y is None.
 
         Returns
         -------
@@ -1466,8 +1468,9 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined. Only supported when Y is None.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
+            Only supported when Y is None.
 
         Returns
         -------
@@ -1620,8 +1623,9 @@ class Matern(RBF):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined. Only supported when Y is None.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
+            Only supported when Y is None.
 
         Returns
         -------
@@ -1809,8 +1813,9 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined. Only supported when Y is None.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
+            Only supported when Y is None.
 
         Returns
         -------
@@ -1954,8 +1959,9 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined. Only supported when Y is None.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
+            Only supported when Y is None.
 
         Returns
         -------
@@ -2086,8 +2092,9 @@ class DotProduct(Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined. Only supported when Y is None.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
+            Only supported when Y is None.
 
         Returns
         -------
@@ -2240,8 +2247,9 @@ class PairwiseKernel(Kernel):
             if evaluated instead.
 
         eval_gradient : bool, default=False
-            Determines whether the gradient with respect to the log of the kernel
-            hyperparameter is determined. Only supported when Y is None.
+            Determines whether the gradient with respect to the log of
+            the kernel hyperparameter is determined.
+            Only supported when Y is None.
 
         Returns
         -------

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -582,7 +582,7 @@ class CompoundKernel(Kernel):
 
         K_gradient : ndarray of shape \
                 (n_samples_X, n_samples_X, n_dims, n_kernels), optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
@@ -806,7 +806,7 @@ class Sum(KernelOperator):
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
                 optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
@@ -904,7 +904,7 @@ class Product(KernelOperator):
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
                 optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
@@ -1082,7 +1082,7 @@ class Exponentiation(Kernel):
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
                 optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
@@ -1210,7 +1210,7 @@ class ConstantKernel(StationaryKernelMixin, GenericKernelMixin,
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
             optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
         """
@@ -1329,7 +1329,7 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin,
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
             optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
         """
@@ -1476,7 +1476,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
                 optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
@@ -1630,7 +1630,7 @@ class Matern(RBF):
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
                 optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
@@ -1818,7 +1818,7 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             Kernel k(X, Y)
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims)
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when eval_gradient
             is True.
         """
@@ -1964,7 +1964,7 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims), \
                 optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
@@ -2096,7 +2096,7 @@ class DotProduct(Kernel):
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
                 optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """
@@ -2250,7 +2250,7 @@ class PairwiseKernel(Kernel):
 
         K_gradient : ndarray of shape (n_samples_X, n_samples_X, n_dims),\
                 optional
-            The gradient of the kernel k(X, X) with respect to the
+            The gradient of the kernel k(X, X) with respect to the log of the
             hyperparameter of the kernel. Only returned when `eval_gradient`
             is True.
         """


### PR DESCRIPTION
### Reference Issues/PRs
Fixes #11581 
Fixes #8393
Fixes #11116
Also see [this comment](https://github.com/scikit-learn/scikit-learn/pull/11116#issuecomment-476340143)

#### What does this implement/fix? Explain your changes.
The gradients of the kernels in the gaussian process module are computed with regard to the **log-transformed** hyper-parameter. So far this is not reflected clearly in the documentation and is thus confusing for people wanting to implement their own custom kernels. See for example the following issues:
#14206
#8373
#8359

Here I add 2 lines of explanation to the user guide, that specify the equation for the kernel gradient and emphasise the log-transform of the parameters. Further I add a mention of the log-transform to the doc string of the __call__ method of existing kernels.

#### Any other comments?
See the discussion [in this issue](https://github.com/scikit-learn/scikit-learn/pull/11116#issuecomment-476340143) for a more detailed reasoning of this necessary documentation change. 

