### PR TITLE
DOC Mark add_toctree_function safe for parallel read and write

### DIFF
--- a/doc/sphinxext/add_toctree_functions.py
+++ b/doc/sphinxext/add_toctree_functions.py
@@ -150,3 +150,5 @@ def docutils_node_to_jinja(list_item, only_pages=False, numbered=False):
 
 def setup(app):
     app.connect("html-page-context", add_toctree_functions)
+
+    return {'parallel_read_safe': True, 'parallel_write_safe': True}


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Running Sphinx v3.2.0 to build the documentation throws the following warning
```
WARNING: the add_toctree_functions extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read
```
This PR marks the add_toctree_functions extension as safe for parallel reading and writing, allowing parallel building: see [sphinx extension metadata](https://www.sphinx-doc.org/en/master/extdev/#extension-metadata) for more details and the [same issue in readthedocs sphinx theme](https://github.com/readthedocs/sphinx_rtd_theme/pull/874).