### PR TITLE
[MRG] MCC-F1 Curve

### DIFF
--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -152,6 +152,7 @@ __all__ = [
     'RocCurveDisplay',
     'roc_auc_score',
     'roc_curve',
+    'mcc_f1_curve',
     'SCORERS',
     'silhouette_samples',
     'silhouette_score',

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -14,6 +14,7 @@ from ._ranking import ndcg_score
 from ._ranking import precision_recall_curve
 from ._ranking import roc_auc_score
 from ._ranking import roc_curve
+from ._ranking import mcc_f1_curve
 
 from ._classification import accuracy_score
 from ._classification import balanced_accuracy_score

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -893,9 +893,9 @@ def mcc_f1_curve(y_true, y_score, *, pos_label=None, sample_weight=None,
     fps, tps, thresholds = _binary_clf_curve(
         y_true, y_score, pos_label=pos_label, sample_weight=sample_weight)
 
-    ps = tps + fps   # Array of total positive predictions
-    p = tps[-1]      # No of positives in ground truth
-    n = fps[-1]      # No of negatives in ground truth
+    ps = tps + fps              # Array of total positive predictions
+    p = tps[-1]                 # No of positives in ground truth
+    n = fps[-1]                 # No of negatives in ground truth
 
     if p == 0:
         raise ValueError("No positive samples in y_true, "

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -827,9 +827,59 @@ def roc_curve(y_true, y_score, *, pos_label=None, sample_weight=None,
 
 
 @_deprecate_positional_args
-def mcc_f1_curve(y_true, y_score, *, pos_label=None, sample_weight=None):
-    """foapispfjaoisd
-    """
+def mcc_f1_curve(y_true, y_score, *, pos_label=None, sample_weight=None,
+                 unit_normalize_mcc=True):
+    """Compute the MCC-F1 curve
+
+    The MCC-F1 curve combines the Matthews correlation coefficient and the
+    F1-Score to clearly differentiate good and bad *binary* classifiers,
+    especially with imbalanced ground truths.
+
+    It has been recently proposed as a better alternative for the receiver
+    operating characteristic (ROC) curve and the precision-recall (PR) curves.
+    [1]
+
+    Parameters
+    ----------
+    y_true : array, shape = [n_samples]
+        True binary labels. If labels are not either {-1, 1} or {0, 1}, then
+        pos_label should be explicitly given.
+
+    y_score : array, shape = [n_samples]
+        Estimated probabilities or decision function.
+
+    pos_label : int or str, default=None
+        The label of the positive class.
+        When ``pos_label=None``, if y_true is in {-1, 1} or {0, 1},
+        ``pos_label`` is set to 1, otherwise an error will be raised.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    unit_normalize_mcc : bool, default=True
+        Whether to unit-normalize the MCC values, as in the original paper.
+
+    Returns
+    -------
+    mcc : array, shape = [n_thresholds]
+        MCC values such that element i is the MCC of predictions with
+        score >= thresholds[i].
+
+    f1 : array, shape = [n_thresholds]
+        F1-Score values such that element i is the F1-Score of predictions with
+        score >= thresholds[i].
+
+    thresholds : array, shape = [n_thresholds <= len(np.unique(probas_pred))]
+        Increasing thresholds on the decision function used to compute
+        MCC and F1.
+
+    References
+    ----------
+    .. [1] `Chang Cao and Davide Chicco and Michael M. Hoffman. (2020)
+            The MCC-F1 curve: a performance evaluation technique for binary
+            classification.
+            <https://arxiv.org/pdf/2006.11278>`_
+"""
     fps, tps, thresholds = _binary_clf_curve(
         y_true, y_score, pos_label=pos_label, sample_weight=sample_weight)
 
@@ -841,9 +891,10 @@ def mcc_f1_curve(y_true, y_score, *, pos_label=None, sample_weight=None):
     with np.errstate(divide='ignore', invalid='ignore'):
         mccs = np.divide(n*tps - p*fps, np.sqrt(p*n*ps*(p + n - ps)))
     np.nan_to_num(mccs, nan=0., copy=False)
-    mccs = (mccs + 1) / 2   # Unit-normalize MCC values
+    if unit_normalize_mcc:
+        mccs = (mccs + 1) / 2   # Unit-normalize MCC values
 
-    # Compute F1-Score
+    # Compute F1
     f1s = 2*tps / (ps + p)
 
     return mccs, f1s, thresholds

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -428,11 +428,12 @@ def test_mcc_f1_curve():
 
 def _mcc_f1_calc(y_true, probas_pred, thresholds):
     # Alternative calculation of (unit-normalized) MCC and F1 scores
-    pp = probas_pred; ts = thresholds
+    pp = probas_pred
+    ts = thresholds
     tps = np.array([np.logical_and(pp >= t, y_true == 1).sum() for t in ts])
     fps = np.array([np.logical_and(pp >= t, y_true == 0).sum() for t in ts])
-    tns = np.array([np.logical_and(pp <  t, y_true == 0).sum() for t in ts])
-    fns = np.array([np.logical_and(pp <  t, y_true == 1).sum() for t in ts])
+    tns = np.array([np.logical_and(pp < t, y_true == 0).sum() for t in ts])
+    fns = np.array([np.logical_and(pp < t, y_true == 1).sum() for t in ts])
 
     with np.errstate(divide='ignore', invalid='ignore'):
         f1s = 2*tps / (2*tps + fps + fns)
@@ -440,7 +441,7 @@ def _mcc_f1_calc(y_true, probas_pred, thresholds):
         d = np.sqrt((tps+fps)*(tps+fns)*(tns+fps)*(tns+fns))
         d = np.array([1 if di == 0 else di for di in d])
         mccs = (tps*tns - fps*fns) / d
-        mccs = (mccs + 1) / 2 # Unit-normalize MCC
+        mccs = (mccs + 1) / 2   # Unit-normalize MCC
 
     return mccs, f1s
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -26,6 +26,7 @@ from sklearn.metrics import precision_recall_curve
 from sklearn.metrics import label_ranking_loss
 from sklearn.metrics import roc_auc_score
 from sklearn.metrics import roc_curve
+from sklearn.metrics import mcc_f1_curve
 from sklearn.metrics._ranking import _ndcg_sample_scores, _dcg_sample_scores
 from sklearn.metrics import ndcg_score, dcg_score
 
@@ -412,6 +413,94 @@ def test_roc_curve_fpr_tpr_increasing():
     fpr, tpr, _ = roc_curve(y_true, y_score, sample_weight=sample_weight)
     assert (np.diff(fpr) < 0).sum() == 0
     assert (np.diff(tpr) < 0).sum() == 0
+
+
+def test_mcc_f1_curve():
+    # Test MCC and F1 values for all points of the curve
+    y_true, _, probas_pred = make_prediction(binary=True)
+    mcc, f1, thres = mcc_f1_curve(y_true, probas_pred)
+    check_consistent_length(mcc, f1, thres)
+
+    expected_mcc, expected_f1 = _mcc_f1_calc(y_true, probas_pred, thres)
+    assert_array_almost_equal(f1, expected_f1)
+    assert_array_almost_equal(mcc, expected_mcc)
+
+
+def _mcc_f1_calc(y_true, probas_pred, thresholds):
+    # Alternative calculation of (unit-normalized) MCC and F1 scores
+    pp = probas_pred; ts = thresholds
+    tps = np.array([np.logical_and(pp >= t, y_true == 1).sum() for t in ts])
+    fps = np.array([np.logical_and(pp >= t, y_true == 0).sum() for t in ts])
+    tns = np.array([np.logical_and(pp <  t, y_true == 0).sum() for t in ts])
+    fns = np.array([np.logical_and(pp <  t, y_true == 1).sum() for t in ts])
+
+    with np.errstate(divide='ignore', invalid='ignore'):
+        f1s = 2*tps / (2*tps + fps + fns)
+
+        d = np.sqrt((tps+fps)*(tps+fns)*(tns+fps)*(tns+fns))
+        d = np.array([1 if di == 0 else di for di in d])
+        mccs = (tps*tns - fps*fns) / d
+        mccs = (mccs + 1) / 2 # Unit-normalize MCC
+
+    return mccs, f1s
+
+
+def test_mcc_f1_curve_errors():
+    # Contains non-binary labels
+    with pytest.raises(ValueError):
+        mcc_f1_curve([0, 1, 2], [[0.0], [1.0], [1.0]])
+
+
+def test_mcc_f1_curve_threshold_range():
+    # Check a large enough range of thresholds was used
+    y_true, _, probas_pred = make_prediction(binary=True)
+    _, _, thres = mcc_f1_curve(y_true, probas_pred)
+    score_range = probas_pred.max() - probas_pred.min()
+    thres_range = thres.max() - thres.min()
+    assert thres_range >= score_range
+
+
+def test_mcc_f1_curve_toydata():
+    with np.errstate(all="raise"):
+        y_true = [0, 1]
+        y_score = [0, 1]
+        mcc, f1, _ = mcc_f1_curve(y_true, y_score)
+        assert_array_almost_equal(mcc, [1, .5])
+        assert_array_almost_equal(f1, [1, 2/3])
+
+        y_true = [0, 1]
+        y_score = [1, 0]
+        mcc, f1, _ = mcc_f1_curve(y_true, y_score)
+        assert_array_almost_equal(mcc, [0, .5])
+        assert_array_almost_equal(f1, [0, 2/3])
+
+        y_true = [1, 0]
+        y_score = [1, 1]
+        mcc, f1, _ = mcc_f1_curve(y_true, y_score)
+        assert_array_almost_equal(mcc, [.5])
+        assert_array_almost_equal(f1, [2/3])
+
+        y_true = [1, 0]
+        y_score = [1, 0]
+        mcc, f1, _ = mcc_f1_curve(y_true, y_score)
+        assert_array_almost_equal(mcc, [1, .5])
+        assert_array_almost_equal(f1, [1, 2/3])
+
+        y_true = [1, 0]
+        y_score = [0.5, 0.5]
+        mcc, f1, _ = mcc_f1_curve(y_true, y_score)
+        assert_array_almost_equal(mcc, [.5])
+        assert_array_almost_equal(f1, [2/3])
+
+        y_true = [0, 0]
+        y_score = [0.25, 0.75]
+        with pytest.raises(ValueError):
+            mcc_f1_curve(y_true, y_score)
+
+        y_true = [1, 1]
+        y_score = [0.25, 0.75]
+        with pytest.raises(ValueError):
+            mcc_f1_curve(y_true, y_score)
 
 
 def test_auc():


### PR DESCRIPTION
Recently the [MCC-F1](https://arxiv.org/pdf/2006.11278) curve has been proposed as an alternative, better way of assessing the performance of score-based binary classifiers.

This MR implements a function to compute the MCC-F1 curve, namely `mcc_f1_curve`, similarly to how it is done for the Precision-Recall (`precision_recall_curve`) and the ROC (`roc_curve`) curves. Further comments and details are present in the function's docstring.

Further enhancements to be performed are:
1. Function to plot the MCC-F1 curve, (e.g., `plot_precision_recall_curve`), similar to `sklearn/metrics/_plot/precision_recall_curve.py` and `sklearn/metrics/_plot/roc_curve.py`
2. Function to compute the MCC-F1 metric, as defined in section 2.2 of the [original paper](https://arxiv.org/pdf/2006.11278).

P.S.: I also intend to contribute with the abovementioned enhancements soon, but, since the `mcc_f1_curve` function is already working (and can be meaningfully used in a data science project), I opened this as [MRG]. Please let me know if I should have opened it as [WIP] instead.