### PR TITLE
Adding parameter to calculating TP and FP rates with weights for False Positives

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -501,7 +501,8 @@ def _multiclass_roc_auc_score(y_true, y_score, labels,
                                      sample_weight=sample_weight)
 
 
-def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None, sample_fp_weight=None):
+def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None,
+                      sample_fp_weight=None):
     """Calculate true and false positives per binary classification threshold.
 
     Parameters

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -26,7 +26,9 @@ from sklearn.metrics import precision_recall_curve
 from sklearn.metrics import label_ranking_loss
 from sklearn.metrics import roc_auc_score
 from sklearn.metrics import roc_curve
-from sklearn.metrics._ranking import _ndcg_sample_scores, _dcg_sample_scores, _binary_clf_curve
+from sklearn.metrics._ranking import (
+    _ndcg_sample_scores, _dcg_sample_scores, _binary_clf_curve
+)
 from sklearn.metrics import ndcg_score, dcg_score
 
 from sklearn.exceptions import UndefinedMetricWarning

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -770,7 +770,8 @@ def test_binary_clf_curve():
         assert_array_almost_equal(p, [2, 2])
         assert_array_almost_equal(r, [0, 2])
 
-        p, r, _ = _binary_clf_curve(y_true, y_score, sample_weight=[2, 2], sample_fp_weight=[3, 3])
+        p, r, _ = _binary_clf_curve(y_true, y_score, sample_weight=[2, 2],
+                                    sample_fp_weight=[3, 3])
         assert_array_almost_equal(p, [3, 3])
         assert_array_almost_equal(r, [0, 2])
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -26,7 +26,7 @@ from sklearn.metrics import precision_recall_curve
 from sklearn.metrics import label_ranking_loss
 from sklearn.metrics import roc_auc_score
 from sklearn.metrics import roc_curve
-from sklearn.metrics._ranking import _ndcg_sample_scores, _dcg_sample_scores
+from sklearn.metrics._ranking import _ndcg_sample_scores, _dcg_sample_scores, _binary_clf_curve
 from sklearn.metrics import ndcg_score, dcg_score
 
 from sklearn.exceptions import UndefinedMetricWarning
@@ -753,6 +753,26 @@ def test_precision_recall_curve_errors():
     # Contains non-binary labels
     with pytest.raises(ValueError):
         precision_recall_curve([0, 1, 2], [[0.0], [1.0], [1.0]])
+
+
+def test_binary_clf_curve():
+    with np.errstate(all="raise"):
+        # Binary classification
+        y_true = [0, 1]
+        y_score = [0, 1]
+        p, r, _ = _binary_clf_curve(y_true, y_score)
+        assert_array_almost_equal(p, [0, 1])
+        assert_array_almost_equal(r, [1, 1])
+
+        y_true = [0, 1]
+        y_score = [1, 0]
+        p, r, _ = _binary_clf_curve(y_true, y_score, sample_weight=[2, 2])
+        assert_array_almost_equal(p, [2, 2])
+        assert_array_almost_equal(r, [0, 2])
+
+        p, r, _ = _binary_clf_curve(y_true, y_score, sample_weight=[2, 2], sample_fp_weight=[3, 3])
+        assert_array_almost_equal(p, [3, 3])
+        assert_array_almost_equal(r, [0, 2])
 
 
 def test_precision_recall_curve_toydata():


### PR DESCRIPTION
Adding parameter to calculating TP and FP rates with weights for False Positives to differentiate from True Positives. Sometimes the cost of making a mistake as an FP is different than a TP or FN.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Adding parameter to calculating TP and FP rates with weights for False Positives to differentiate from True Positives. Sometimes the cost of making a mistake as an FP is different than a TP or FN.

#### Any other comments?
New tests added to verify consistent behavior. Tests all pass

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
