### PR TITLE
ENH allow to pass str or scorer to make_scorer

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -202,6 +202,26 @@ Here is an example of building custom scorers, and of using the
     >>> score(clf, X, y)
     -0.69...
 
+You can as well used predefined metrics, shown in the table above, where the
+parameters `greater_is_better`, `needs_proba`, and `needs_threshold` will not
+be required. Only the additional scoring function parameters should be given if
+there is any::
+
+    >>> precision_scorer = make_scorer("precision", average="micro")
+    >>> from sklearn.datasets import make_classification
+    >>> X, y = make_classification(
+    ...     n_classes=3, n_informative=3, random_state=0
+    ... )
+    >>> clf.fit(X, y)
+    DummyClassifier(random_state=0, strategy='most_frequent')
+    >>> precision_scorer(clf, X, y)
+    0.35...
+
+Similarly, you can use a scorer to create a new scorer::
+
+    >>> new_scorer = make_scorer(precision_scorer, average="macro")
+    >>> new_scorer(clf, X, y)
+    0.11...
 
 .. _diy_scoring:
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -280,6 +280,10 @@ Changelog
   class to be used when computing the roc auc statistics.
   :pr:`17651` by :user:`Clara Matos <claramatos>`.
 
+- |Enhancement| Allow to pass a scorer or a string to create a new scorer in
+  :func:`metrics.make_scorer`.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -282,7 +282,7 @@ Changelog
 
 - |Enhancement| Allow to pass a scorer or a string to create a new scorer in
   :func:`metrics.make_scorer`.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`18141` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.model_selection`
 ..............................

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -558,6 +558,8 @@ def make_scorer(score_func, *, greater_is_better=True, needs_proba=False,
 
     Examples
     --------
+    You can create a scorer from a callable function:
+
     >>> from sklearn.metrics import fbeta_score, make_scorer
     >>> ftwo_scorer = make_scorer(fbeta_score, beta=2)
     >>> ftwo_scorer
@@ -566,6 +568,23 @@ def make_scorer(score_func, *, greater_is_better=True, needs_proba=False,
     >>> from sklearn.svm import LinearSVC
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]},
     ...                     scoring=ftwo_scorer)
+
+    Otherwise, you can use a string avoiding to pass the parameters required
+    by `make_scorer`:
+
+    >>> from sklearn.datasets import load_breast_cancer
+    >>> X, y = load_breast_cancer(return_X_y=True)
+    >>> roc_auc_scorer = make_scorer("roc_auc")
+    >>> clf = LinearSVC().fit(X, y)
+    >>> roc_auc_scorer(clf, X, y)
+    0.98...
+
+    Similarly, you can use a scorer obtained with :func:`get_scorer`:
+
+    >>> from sklearn.metrics import get_scorer
+    >>> roc_auc_scorer = get_scorer("roc_auc")
+    >>> roc_auc_scorer(clf, X, y)
+    0.98...
 
     Notes
     -----

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -575,7 +575,7 @@ def make_scorer(score_func, *, greater_is_better=True, needs_proba=False,
     >>> from sklearn.datasets import load_breast_cancer
     >>> X, y = load_breast_cancer(return_X_y=True)
     >>> roc_auc_scorer = make_scorer("roc_auc")
-    >>> clf = LinearSVC().fit(X, y)
+    >>> clf = LinearSVC(random_state=0).fit(X, y)
     >>> roc_auc_scorer(clf, X, y)
     0.98...
 

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -577,19 +577,15 @@ def make_scorer(score_func, *, greater_is_better=True, needs_proba=False,
     `needs_threshold=True`, the score function is supposed to accept the
     output of :term:`decision_function`.
     """
-    if isinstance(score_func, str):
-        base_scorer = get_scorer(score_func)
-        return base_scorer.__class__(
-            score_func=base_scorer._score_func,
-            sign=base_scorer._sign,
-            kwargs=kwargs
+    if isinstance(score_func, (str, _BaseScorer)):
+        base_scorer = (
+            get_scorer(score_func)
+            if isinstance(score_func, str)
+            else score_func
         )
-    elif isinstance(score_func, _BaseScorer):
-        return score_func.__class__(
-            score_func=score_func._score_func,
-            sign=score_func._sign,
-            kwargs=kwargs
-        )
+        cls = base_scorer.__class__
+        score_func = base_scorer._score_func
+        sign = base_scorer._sign
     else:
         sign = 1 if greater_is_better else -1
         if needs_proba and needs_threshold:
@@ -603,7 +599,7 @@ def make_scorer(score_func, *, greater_is_better=True, needs_proba=False,
             cls = _ThresholdScorer
         else:
             cls = _PredictScorer
-        return cls(score_func, sign, kwargs)
+    return cls(score_func, sign, kwargs)
 
 
 # Standard regression scores


### PR DESCRIPTION
This PR proposes to add the option to pass a scoring function name or a scorer in order to build a scorer via `make_scorer`.
In some way, it would simplify the scorer API. For instance, the following example is raising an error because the class 9 is not present in the fold during cross-validation:

```python
import sklearn.datasets
import sklearn.linear_model
import numpy as np

X, y = sklearn.datasets.load_digits(return_X_y=True)

n9 = 2

y9 = y[y == 9]
X9 = X[y == 9]

X = X[y != 9]
y = y[y != 9]

X = np.vstack([X, X9[0:n9]])
y = np.hstack([y, y9[0:n9]])

multi_class = "multinomial"
scoring = "neg_log_loss"
random_state = 1

model = sklearn.linear_model.LogisticRegressionCV(
    multi_class=multi_class, scoring=scoring, random_state=random_state
)
model.fit(X, y)
```

The way to solve it is to use a scorer. However, one needs to know what all the `make_scorer` parameters mean:

```python
    multi_class = "multinomial"
    labels = np.unique(y)
    scoring = make_scorer(
        log_loss, greater_is_better=False, labels=labels, needs_proba=True
    )
    random_state = 1

    model = LogisticRegressionCV(
        multi_class=multi_class, scoring=scoring, random_state=random_state
    )
    model.fit(X, y)
```

I am thinking that the following would be simpler where some parameters can be inferred from the base scorer.


```python
    multi_class = "multinomial"
    labels = np.unique(y)
    scoring = make_scorer("neg_log_loss", labels=labels)
    random_state = 1

    model = LogisticRegressionCV(
        multi_class=multi_class, scoring=scoring, random_state=random_state
    )
    model.fit(X, y)
```