### PR TITLE
FIX use specific threshold to discard eigenvalues with 32 bits fp

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -121,7 +121,7 @@ Changelog
   between 32-bits and 64-bits data input when the kernel has small positive
   eigenvalues. Small positive eigenvalues were not correctly discarded for
   32-bits data.
-  :pr:`xxxx` by :user:`Sylvain Marié <smarie>`.
+  :pr:`18149` by :user:`Sylvain Marié <smarie>`.
 
 - |Fix| Fix :class:`decomposition.SparseCoder` such that it follows
   scikit-learn API and support cloning. The attribute `components_` is

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -22,8 +22,9 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-- item
-- item
+- |Fix| :class:`decomposition.KernelPCA` behaviour is now more consistent
+  between 32-bits and 64-bits data when the kernel has small positive
+  eigenvalues.
 
 Details are listed in the changelog below.
 
@@ -115,6 +116,12 @@ Changelog
 
 :mod:`sklearn.decomposition`
 ............................
+
+- |Fix| :class:`decomposition.KernelPCA` behaviour is now more consistent
+  between 32-bits and 64-bits data input when the kernel has small positive
+  eigenvalues. Small positive eigenvalues were not correctly discarded for
+  32-bits data.
+  :pr:`xxxx` by :user:`Sylvain Marié <smarie>`.
 
 - |Fix| Fix :class:`decomposition.SparseCoder` such that it follows
   scikit-learn API and support cloning. The attribute `components_` is

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -10,6 +10,7 @@ from sklearn.datasets import make_circles
 from sklearn.datasets import make_blobs
 from sklearn.linear_model import Perceptron
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import GridSearchCV
 from sklearn.metrics.pairwise import rbf_kernel
 from sklearn.utils.validation import _check_psd_eigenvalues
@@ -295,3 +296,21 @@ def test_kernel_pca_inverse_transform(kernel):
     X_trans = kp.fit_transform(X)
     X_inv = kp.inverse_transform(X_trans)
     assert_allclose(X, X_inv)
+
+
+def test_32_64_decomposition_shape():
+    """ Test that the decomposition is similar for 32 and 64 bits data """
+    # see https://github.com/scikit-learn/scikit-learn/issues/18146
+    X, y = make_blobs(
+        n_samples=30,
+        centers=[[0, 0, 0], [1, 1, 1]],
+        random_state=0,
+        cluster_std=0.1
+    )
+    X = StandardScaler().fit_transform(X)
+    X -= X.min()
+
+    # Compare the shapes (corresponds to the number of non-zero eigenvalues)
+    kpca = KernelPCA()
+    assert (kpca.fit_transform(X).shape ==
+            kpca.fit_transform(X.astype(np.float32)).shape)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1183,7 +1183,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
     significant_imag_ratio = 1e-5
     significant_neg_ratio = 1e-5 if is_double_precision else 5e-3
     significant_neg_value = 1e-10 if is_double_precision else 1e-6
-    small_pos_ratio = 1e-12
+    small_pos_ratio = 1e-12 if is_double_precision else 1e-7
 
     # Check that there are no significant imaginary parts
     if not np.isreal(lambdas).all():


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #18146

#### What does this implement/fix? Explain your changes.

Fixed 32/64bit consistency for `KernelPCA` and other models using `_check_psd_eigenvalues`. Small positive eigenvalues were not correctly discarded by `_check_psd_eigenvalues` for 32bit data.

#### Any other comments?

Note that all of these rules are just "rule of thumb" validated/confirmed by experience (although strongly influenced by the minimum value available in single and double precision) so it is very important to add this example (and other failing ones if we find any) in the test harness to ensure non-regression over time.

Reminder:

 - single-precision: `np.finfo('float32').eps` = `1.2e-07`
 - double-precision: `np.finfo('float64').eps` = `2.2e-16`


Another note: we could imagine to extend the proposed test to generate various toy dataset configurations, in order to be even more sure of the thresholds used.
