### PR TITLE
RidgeCV GCV documentation fix

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -175,13 +175,12 @@ This method has the same order of complexity as
 .. between these
 
 
-Setting the regularization parameter: generalized Cross-Validation
+Setting the regularization parameter: leave-one-out Cross-Validation
 ------------------------------------------------------------------
 
 :class:`RidgeCV` implements ridge regression with built-in
 cross-validation of the alpha parameter. The object works in the same way
-as GridSearchCV except that it defaults to Generalized Cross-Validation
-(GCV), an efficient form of leave-one-out cross-validation::
+as GridSearchCV except that it defaults to Leave-One-Out Cross-Validation::
 
     >>> import numpy as np
     >>> from sklearn import linear_model
@@ -194,7 +193,7 @@ as GridSearchCV except that it defaults to Generalized Cross-Validation
 
 Specifying the value of the :term:`cv` attribute will trigger the use of
 cross-validation with :class:`~sklearn.model_selection.GridSearchCV`, for
-example `cv=10` for 10-fold cross-validation, rather than Generalized
+example `cv=10` for 10-fold cross-validation, rather than Leave-One-Out
 Cross-Validation.
 
 .. topic:: References

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -176,7 +176,7 @@ This method has the same order of complexity as
 
 
 Setting the regularization parameter: leave-one-out Cross-Validation
-------------------------------------------------------------------
+--------------------------------------------------------------------
 
 :class:`RidgeCV` implements ridge regression with built-in
 cross-validation of the alpha parameter. The object works in the same way

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -234,7 +234,7 @@ random sampling procedures.
   seed, including :class:`linear_model.LogisticRegression`,
   :class:`linear_model.LogisticRegressionCV`, :class:`linear_model.Ridge`,
   and :class:`linear_model.RidgeCV` with 'sag' solver. |Fix|
-- :class:`linear_model.RidgeCV` when using generalized cross-validation
+- :class:`linear_model.RidgeCV` when using leave-one-out cross-validation
   with sparse inputs. |Fix|
 
 
@@ -707,7 +707,7 @@ Support for Python 3.4 and below has been officially dropped.
   in version 0.21 and will be removed in version 0.23.
   :pr:`12821` by :user:`Nicolas Hug <NicolasHug>`.
 
-- |Fix| :class:`linear_model.RidgeCV` with generalized cross-validation
+- |Fix| :class:`linear_model.RidgeCV` with leave-one-out cross-validation
   now correctly fits an intercept when ``fit_intercept=True`` and the design
   matrix is sparse. :issue:`13350` by :user:`Jérôme Dockès <jeromedockes>`
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1074,9 +1074,7 @@ class _IdentityClassifier(LinearClassifierMixin):
 
 
 class _RidgeGCV(LinearModel):
-    """Ridge regression with built-in Generalized Cross-Validation.
-
-    It allows efficient Leave-One-Out cross-validation.
+    """Ridge regression with built-in Leave-one-out Cross-Validation.
 
     This class is not intended to be used directly. Use RidgeCV instead.
 
@@ -1621,7 +1619,7 @@ class _BaseRidgeCV(LinearModel):
         Notes
         -----
         When sample_weight is provided, the selected hyperparameter may depend
-        on whether we use generalized cross-validation (cv=None or cv='auto')
+        on whether we use leave-one-out cross-validation (cv=None or cv='auto')
         or another form of cross-validation, because only generalized
         cross-validation takes the sample weights into account when computing
         the validation score.
@@ -1672,7 +1670,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     See glossary entry for :term:`cross-validation estimator`.
 
-    By default, it performs Generalized Cross-Validation, which is a form of
+    By default, it performs Leave-One-Out Cross-Validation, which is a form of
     efficient Leave-One-Out cross-validation.
 
     Read more in the :ref:`User Guide <ridge_regression>`.
@@ -1687,7 +1685,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
         :class:`~sklearn.svm.LinearSVC`.
-        If using generalized cross-validation, alphas must be positive.
+        If using Leave-One-Out cross-validation, alphas must be positive.
 
     fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set
@@ -1707,14 +1705,14 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
         If None, the negative mean squared error if cv is 'auto' or None
-        (i.e. when using generalized cross-validation), and r2 score otherwise.
+        (i.e. when using leave-one-out cross-validation), and r2 score 
+        otherwise.
 
     cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
         - None, to use the efficient Leave-One-Out cross-validation
-          (also known as Generalized Cross-Validation).
         - integer, to specify the number of folds.
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
@@ -1728,7 +1726,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     gcv_mode : {'auto', 'svd', eigen'}, default='auto'
         Flag indicating which strategy to use when performing
-        Generalized Cross-Validation. Options are::
+        Leave-One-Out Cross-Validation. Options are::
 
             'auto' : use 'svd' if n_samples > n_features, otherwise use 'eigen'
             'svd' : force use of singular value decomposition of X when X is
@@ -1742,7 +1740,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         Flag indicating if the cross-validation values corresponding to
         each alpha should be stored in the ``cv_values_`` attribute (see
         below). This flag is only compatible with ``cv=None`` (i.e. using
-        Generalized Cross-Validation).
+        Leave-One-Out Cross-Validation).
 
     alpha_per_target : bool, default=False
         Flag indicating whether to optimize the alpha value (picked from the
@@ -1798,9 +1796,8 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     See glossary entry for :term:`cross-validation estimator`.
 
-    By default, it performs Generalized Cross-Validation, which is a form of
-    efficient Leave-One-Out cross-validation. Currently, only the n_features >
-    n_samples case is handled efficiently.
+    By default, it performs Leave-One-Out Cross-Validation. Currently,
+    only the n_features > n_samples case is handled efficiently.
 
     Read more in the :ref:`User Guide <ridge_regression>`.
 
@@ -1857,7 +1854,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         Flag indicating if the cross-validation values corresponding to
         each alpha should be stored in the ``cv_values_`` attribute (see
         below). This flag is only compatible with ``cv=None`` (i.e. using
-        Generalized Cross-Validation).
+        Leave-One-Out Cross-Validation).
 
     Attributes
     ----------

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1705,7 +1705,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
         If None, the negative mean squared error if cv is 'auto' or None
-        (i.e. when using leave-one-out cross-validation), and r2 score 
+        (i.e. when using leave-one-out cross-validation), and r2 score
         otherwise.
 
     cv : int, cross-validation generator or an iterable, default=None

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1620,7 +1620,7 @@ class _BaseRidgeCV(LinearModel):
         -----
         When sample_weight is provided, the selected hyperparameter may depend
         on whether we use leave-one-out cross-validation (cv=None or cv='auto')
-        or another form of cross-validation, because only generalized
+        or another form of cross-validation, because only leave-one-out
         cross-validation takes the sample weights into account when computing
         the validation score.
         """


### PR DESCRIPTION
Resolves #18079 

RidgeCV doesn't use Generalised cross-validation but instead uses Leave-One-Out cross-validation. This is a documentation fix to reflect the same.