### PR TITLE
CI Uses dev version of pytest-cov

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,6 +146,9 @@ jobs:
         DISTRIB: 'ubuntu-32'
         PYTHON_VERSION: '3.6'
         JOBLIB_VERSION: 'min'
+        # Do not use pytest xdist because of a bug in pytest-xdist==2.0
+        # in this 32bit docker container
+        PYTEST_XDIST_VERSION: 'none'
         # temporary pin pytest due to unknown failure with pytest 5.4 and
         # python 3.6
         PYTEST_VERSION: 'min'

--- a/build_tools/azure/install.cmd
+++ b/build_tools/azure/install.cmd
@@ -32,7 +32,6 @@ IF "%PYTEST_XDIST%" == "true" (
 
 if "%COVERAGE%" == "true" (
     pip install coverage codecov
-    pip install coverage codecov
     REM Use master pytest-cov until 2.10.1 is released that fixes a bug with
     REM  pytest-xdist 2.0.0
     pip install git+https://github.com/pytest-dev/pytest-cov

--- a/build_tools/azure/install.cmd
+++ b/build_tools/azure/install.cmd
@@ -31,7 +31,11 @@ IF "%PYTEST_XDIST%" == "true" (
 )
 
 if "%COVERAGE%" == "true" (
-    pip install coverage codecov pytest-cov
+    pip install coverage codecov
+    pip install coverage codecov
+    REM Use master pytest-cov until 2.10.1 is released that fixes a bug with
+    REM  pytest-xdist 2.0.0
+    pip install git+https://github.com/pytest-dev/pytest-cov
 )
 python --version
 pip --version

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -85,7 +85,11 @@ python -m pip install $(get_dep threadpoolctl $THREADPOOLCTL_VERSION) \
                       $(get_dep pytest-xdist $PYTEST_XDIST_VERSION)
 
 if [[ "$COVERAGE" == "true" ]]; then
-    python -m pip install codecov pytest-cov
+    python -m pip install codecov
+    # TODO: Remove when pytest-cov 2.10.1 is released
+    # Use master pytest-cov until 2.10.1 is released that fixes a bug with
+    # pytest-xdist 2.0.0
+    python -m pip install git+https://github.com/pytest-dev/pytest-cov
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then


### PR DESCRIPTION
Fixes issue on master with pytest-cov + pytest-xdist 2.0. The dev version of pytest-cov fixes this issue. This PR should be reverted when pytest-cov=2.10.1 is released.

XREF https://github.com/pytest-dev/pytest-cov/issues/411