### PR TITLE
HistGradientBoosting memory improvement

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -3,7 +3,6 @@
 
 from abc import ABC, abstractmethod
 from functools import partial
-import gc
 
 import numpy as np
 from timeit import default_timer as time

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -342,6 +342,14 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
             sample_weight=sample_weight_train
         )
 
+        def del_hists(node):
+            if node is None:
+                return
+            if getattr(node, 'histograms', None) is not None:
+                del node.histograms
+            del_hists(node.left_child)
+            del_hists(node.right_child)
+
         for iteration in range(begin_at_stage, self.max_iter):
 
             if self.verbose:
@@ -392,8 +400,9 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                 _update_raw_predictions(raw_predictions[k, :], grower)
                 toc_pred = time()
                 acc_prediction_time += toc_pred - tic_pred
+
+                del_hists(grower.root)
                 del grower
-                gc.collect()
 
             should_early_stop = False
             if self.do_early_stopping_:

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 from functools import partial
+import gc
 
 import numpy as np
 from timeit import default_timer as time
@@ -391,6 +392,8 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                 _update_raw_predictions(raw_predictions[k, :], grower)
                 toc_pred = time()
                 acc_prediction_time += toc_pred - tic_pred
+                del grower
+                gc.collect()
 
             should_early_stop = False
             if self.do_early_stopping_:

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -6,6 +6,8 @@ the gradients and hessians of the training data.
 """
 # Author: Nicolas Hug
 
+from memory_profiler import profile
+
 from heapq import heappush, heappop
 import numpy as np
 from timeit import default_timer as time
@@ -485,6 +487,7 @@ class TreeGrower:
             if should_split_right:
                 self._compute_best_split_and_push(right_child_node)
             self.total_find_split_time += time() - tic
+        del node.histograms
 
         return left_child_node, right_child_node
 

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -492,7 +492,6 @@ class TreeGrower:
                     del child.histograms
         del node.histograms
 
-
         return left_child_node, right_child_node
 
     def _finalize_leaf(self, node):

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -6,7 +6,6 @@ the gradients and hessians of the training data.
 """
 # Author: Nicolas Hug
 
-from memory_profiler import profile
 
 from heapq import heappush, heappop
 import numpy as np

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -487,7 +487,12 @@ class TreeGrower:
             if should_split_right:
                 self._compute_best_split_and_push(right_child_node)
             self.total_find_split_time += time() - tic
+
+            for child in [left_child_node, right_child_node]:
+                if child.is_leaf:
+                    del child.histograms
         del node.histograms
+
 
         return left_child_node, right_child_node
 


### PR DESCRIPTION
Starting to investigate #18152.

This change reduces the memory usage for the example provided there by not keeping around histograms for inner nodes and leafs. That reduces the memory by a factor of about 4.
Honestly not sure how to get around storing the histograms for the splittable active nodes, or if there's another issue/trick we're overlooking.