### PR TITLE
[MRG] MNT change bin_thresholds param name

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
@@ -53,7 +53,7 @@ cdef inline Y_DTYPE_C _predict_one_from_numeric_data(
             else:
                 node = nodes[node.right]
         else:
-            if numeric_data[row, node.feature_idx] <= node.threshold:
+            if numeric_data[row, node.feature_idx] <= node.num_threshold:
                 node = nodes[node.left]
             else:
                 node = nodes[node.right]
@@ -177,7 +177,7 @@ def _compute_partial_dependence(
 
                 if is_target_feature:
                     # In this case, we push left or right child on stack
-                    if X[sample_idx, feature_idx] <= current_node.threshold:
+                    if X[sample_idx, feature_idx] <= current_node.num_threshold:
                         node_idx_stack[stack_size] = current_node.left
                     else:
                         node_idx_stack[stack_size] = current_node.right

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pxd
@@ -24,7 +24,7 @@ cdef packed struct node_struct:
     Y_DTYPE_C value
     unsigned int count
     unsigned int feature_idx
-    X_DTYPE_C threshold
+    X_DTYPE_C num_threshold
     unsigned char missing_go_to_left
     unsigned int left
     unsigned int right

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pyx
@@ -19,7 +19,7 @@ PREDICTOR_RECORD_DTYPE = np.dtype([
     ('value', Y_DTYPE),
     ('count', np.uint32),
     ('feature_idx', np.uint32),
-    ('threshold', X_DTYPE),
+    ('num_threshold', X_DTYPE),
     ('missing_go_to_left', np.uint8),
     ('left', np.uint32),
     ('right', np.uint32),

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -381,7 +381,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                                                     sample_weight_train)
 
                 predictor = grower.make_predictor(
-                    bin_thresholds=self._bin_mapper.bin_thresholds_
+                    num_thresholds=self._bin_mapper.bin_thresholds_
                 )
                 predictors[-1].append(predictor)
 

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -552,7 +552,7 @@ def _fill_predictor_node_array(predictor_nodes, grower_node,
             # Split is on the last non-missing bin: it's a "split on nans". All
             # nans go to the right, the rest go to the left.
             node['num_threshold'] = np.inf
-        elif num_thresholds is not None:
+        else:
             node['num_threshold'] = num_thresholds[feature_idx][bin_idx]
 
         next_free_idx += 1

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -504,16 +504,13 @@ class TreeGrower:
             node = self.splittable_nodes.pop()
             self._finalize_leaf(node)
 
-    def make_predictor(self, num_thresholds=None):
+    def make_predictor(self, num_thresholds):
         """Make a TreePredictor object out of the current tree.
 
         Parameters
         ----------
-        num_thresholds : array-like of floats (default=None)
-            The real-valued thresholds of each bin. Passing None is only
-            useful in unit tests where the BinMapper isn't used. In this
-            case, only the 'bin_threshold' field of the nodes will be set and
-            the 'num_threshold' field will be undefined.
+        num_thresholds : array-like of floats
+            The real-valued thresholds of each bin.
 
         Returns
         -------

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -176,6 +176,7 @@ class TreeGrower:
         The shrinkage parameter to apply to the leaves values, also known as
         learning rate.
     """
+
     def __init__(self, X_binned, gradients, hessians, max_leaf_nodes=None,
                  max_depth=None, min_samples_leaf=20, min_gain_to_split=0.,
                  n_bins=256, n_bins_non_missing=None, has_missing_values=False,
@@ -503,13 +504,16 @@ class TreeGrower:
             node = self.splittable_nodes.pop()
             self._finalize_leaf(node)
 
-    def make_predictor(self, bin_thresholds=None):
+    def make_predictor(self, num_thresholds=None):
         """Make a TreePredictor object out of the current tree.
 
         Parameters
         ----------
-        bin_thresholds : array-like of floats, optional (default=None)
-            The actual thresholds values of each bin.
+        num_thresholds : array-like of floats (default=None)
+            The real-valued thresholds of each bin. Passing None is only
+            useful in unit tests where the BinMapper isn't used. In this
+            case, only the 'bin_threshold' field of the nodes will be set and
+            the 'num_threshold' field will be undefined.
 
         Returns
         -------
@@ -517,12 +521,12 @@ class TreeGrower:
         """
         predictor_nodes = np.zeros(self.n_nodes, dtype=PREDICTOR_RECORD_DTYPE)
         _fill_predictor_node_array(predictor_nodes, self.root,
-                                   bin_thresholds, self.n_bins_non_missing)
+                                   num_thresholds, self.n_bins_non_missing)
         return TreePredictor(predictor_nodes)
 
 
 def _fill_predictor_node_array(predictor_nodes, grower_node,
-                               bin_thresholds, n_bins_non_missing,
+                               num_thresholds, n_bins_non_missing,
                                next_free_idx=0):
     """Helper used in make_predictor to set the TreePredictor fields."""
     node = predictor_nodes[next_free_idx]
@@ -550,22 +554,22 @@ def _fill_predictor_node_array(predictor_nodes, grower_node,
         if split_info.bin_idx == n_bins_non_missing[feature_idx] - 1:
             # Split is on the last non-missing bin: it's a "split on nans". All
             # nans go to the right, the rest go to the left.
-            node['threshold'] = np.inf
-        elif bin_thresholds is not None:
-            node['threshold'] = bin_thresholds[feature_idx][bin_idx]
+            node['num_threshold'] = np.inf
+        elif num_thresholds is not None:
+            node['num_threshold'] = num_thresholds[feature_idx][bin_idx]
 
         next_free_idx += 1
 
         node['left'] = next_free_idx
         next_free_idx = _fill_predictor_node_array(
             predictor_nodes, grower_node.left_child,
-            bin_thresholds=bin_thresholds,
+            num_thresholds=num_thresholds,
             n_bins_non_missing=n_bins_non_missing,
             next_free_idx=next_free_idx)
 
         node['right'] = next_free_idx
         return _fill_predictor_node_array(
             predictor_nodes, grower_node.right_child,
-            bin_thresholds=bin_thresholds,
+            num_thresholds=num_thresholds,
             n_bins_non_missing=n_bins_non_missing,
             next_free_idx=next_free_idx)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
@@ -156,7 +156,10 @@ def test_predictor_from_grower():
 
     # Check that the node structure can be converted into a predictor
     # object to perform predictions at scale
-    predictor = grower.make_predictor()
+    # We pass undefined num_thresholds because we won't use predict() anyway
+    predictor = grower.make_predictor(
+        num_thresholds=np.zeros((X_binned.shape[1], n_bins))
+    )
     assert predictor.nodes.shape[0] == 5
     assert predictor.nodes['is_leaf'].sum() == 3
 
@@ -339,7 +342,10 @@ def test_missing_value_predict_only():
                         has_missing_values=False)
     grower.grow()
 
-    predictor = grower.make_predictor()
+    # We pass undefined num_thresholds because we won't use predict() anyway
+    predictor = grower.make_predictor(
+        num_thresholds=np.zeros((X_binned.shape[1], X_binned.max() + 1))
+    )
 
     # go from root to a leaf, always following node with the most samples.
     # That's the path nans are supposed to take

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
@@ -218,7 +218,7 @@ def test_min_samples_leaf(n_samples, min_samples_leaf, n_bins,
                         max_leaf_nodes=n_samples)
     grower.grow()
     predictor = grower.make_predictor(
-        bin_thresholds=mapper.bin_thresholds_)
+        num_thresholds=mapper.bin_thresholds_)
 
     if n_samples >= min_samples_leaf:
         for node in predictor.nodes:
@@ -382,11 +382,11 @@ def test_split_on_nan_with_infinite_values():
     grower.grow()
 
     predictor = grower.make_predictor(
-        bin_thresholds=bin_mapper.bin_thresholds_
+        num_thresholds=bin_mapper.bin_thresholds_
     )
 
     # sanity check: this was a split on nan
-    assert predictor.nodes[0]['threshold'] == np.inf
+    assert predictor.nodes[0]['num_threshold'] == np.inf
     assert predictor.nodes[0]['bin_threshold'] == n_bins_non_missing - 1
 
     # Make sure in particular that the +inf sample is mapped to the left child

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -176,13 +176,17 @@ def test_nodes_values(monotonic_cst, seed):
     for leave in grower.finalized_leaves:
         leave.value /= grower.shrinkage
 
+    # We pass undefined num_thresholds because we won't use predict() anyway
+    predictor = grower.make_predictor(
+        num_thresholds=np.zeros((X_binned.shape[1], X_binned.max() + 1))
+    )
+
     # The consistency of the bounds can only be checked on the tree grower
     # as the node bounds are not copied into the predictor tree. The
     # consistency checks on the values of node children and leaves can be
     # done either on the grower tree or on the predictor tree. We only
     # do those checks on the predictor tree as the latter is derived from
     # the former.
-    predictor = grower.make_predictor()
     assert_children_values_monotonic(predictor, monotonic_cst)
     assert_children_values_bounded(grower, monotonic_cst)
     assert_leaves_values_monotonic(predictor, monotonic_cst)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -33,20 +33,20 @@ def test_regression_dataset(n_bins):
                         n_bins_non_missing=mapper.n_bins_non_missing_)
     grower.grow()
 
-    predictor = grower.make_predictor(bin_thresholds=mapper.bin_thresholds_)
+    predictor = grower.make_predictor(num_thresholds=mapper.bin_thresholds_)
 
     assert r2_score(y_train, predictor.predict(X_train)) > 0.82
     assert r2_score(y_test, predictor.predict(X_test)) > 0.67
 
 
-@pytest.mark.parametrize('threshold, expected_predictions', [
+@pytest.mark.parametrize('num_threshold, expected_predictions', [
     (-np.inf, [0, 1, 1, 1]),
     (10, [0, 0, 1, 1]),
     (20, [0, 0, 0, 1]),
     (ALMOST_INF, [0, 0, 0, 1]),
     (np.inf, [0, 0, 0, 0]),
 ])
-def test_infinite_values_and_thresholds(threshold, expected_predictions):
+def test_infinite_values_and_thresholds(num_threshold, expected_predictions):
     # Make sure infinite values and infinite thresholds are handled properly.
     # In particular, if a value is +inf and the threshold is ALMOST_INF the
     # sample should go to the right child. If the threshold is inf (split on
@@ -60,7 +60,7 @@ def test_infinite_values_and_thresholds(threshold, expected_predictions):
     nodes[0]['left'] = 1
     nodes[0]['right'] = 2
     nodes[0]['feature_idx'] = 0
-    nodes[0]['threshold'] = threshold
+    nodes[0]['num_threshold'] = num_threshold
 
     # left child
     nodes[1]['is_leaf'] = True


### PR DESCRIPTION
This PR just renames a few stuff in the hist GBDT code for clarity:

- the `threshold` field of the nodes is renamed to `num_thresdhold`
- the `bin_thresholds` parameter of `make_predictor` is renamed to `num_threshold`. This one was a bit ambiguous because `bin_thresholds` was actually used to set the `threshold` field of the node (now `num_threshold`), while the `bin_threshold` field was set by something else, thus potentially causing confusion.


Note that we expect the `bin_thresholds_` field of the mapper to change in https://github.com/scikit-learn/scikit-learn/pull/16909, which is why I didn't touch it.

EDIT: this PR also removes the possibility to pass `bin_thresholds=None` (now `num_thresholds`) in the hope to avoid ambiguity. This doesn't compromise the tests.

CC @thomasjpfan @ogrisel