### PR TITLE
DOC Fixes failing examples

### DIFF
--- a/examples/gaussian_process/plot_gpr_co2.py
+++ b/examples/gaussian_process/plot_gpr_co2.py
@@ -74,7 +74,7 @@ print(__doc__)
 
 
 def load_mauna_loa_atmospheric_co2():
-    ml_data = fetch_openml(data_id=41187)
+    ml_data = fetch_openml(data_id=41187, as_frame=False)
     months = []
     ppmv_sums = []
     counts = []

--- a/examples/linear_model/plot_sparse_logistic_regression_mnist.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_mnist.py
@@ -36,7 +36,7 @@ t0 = time.time()
 train_samples = 5000
 
 # Load data from https://www.openml.org/d/554
-X, y = fetch_openml('mnist_784', version=1, return_X_y=True)
+X, y = fetch_openml('mnist_784', version=1, return_X_y=True, as_frame=False)
 
 random_state = check_random_state(0)
 permutation = random_state.permutation(X.shape[0])


### PR DESCRIPTION
This PR fixes the two failing examples on master. Recently, `as_frame` was set to `'auto'` which returns dataframes by default. These examples expects numpy array.