### PR TITLE
DOC fix docsting of fit_transform in Voting estimator

### DIFF
--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -100,17 +100,20 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
         ----------
         X : {array-like, sparse matrix, dataframe} of shape \
                 (n_samples, n_features)
-            Input samples.
+            Input samples
+
         y : ndarray of shape (n_samples,), default=None
             Target values (None for unsupervised transformations).
+
         **fit_params : dict
             Additional fit parameters.
+
         Returns
         -------
         X_new : ndarray array of shape (n_samples, n_features_new)
             Transformed array.
         """
-        super().fit_transform(X, y, **fit_params)
+        return super().fit_transform(X, y, **fit_params)
 
     @property
     def n_features_in_(self):

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -90,7 +90,36 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
             self.named_estimators_[name] = current_est
 
         return self
-
+    
+    def fit_transform(self, X, y=None, **fit_params):
+        """
+        Return class labels or probabilities for X for each estimator.
+        
+        Return predictions for X for each estimator.
+        
+        Parameters
+        ----------
+        X : {array-like, sparse matrix, dataframe} of shape \
+                (n_samples, n_features)
+            Input samples.
+        y : ndarray of shape (n_samples,), default=None
+            Target values (None for unsupervised transformations).
+        **fit_params : dict
+            Additional fit parameters.
+        Returns
+        -------
+        X_new : ndarray array of shape (n_samples, n_features_new)
+            Transformed array.
+        """
+        # non-optimized default implementation; override when a better
+        # method is possible for a given clustering algorithm
+        if y is None:
+            # fit method of arity 1 (unsupervised transformation)
+            return self.fit(X, **fit_params).transform(X)
+        else:
+            # fit method of arity 2 (supervised transformation)
+            return self.fit(X, y, **fit_params).transform(X)
+    
     @property
     def n_features_in_(self):
         # For consistency with other estimators we raise a AttributeError so

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -90,12 +90,12 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
             self.named_estimators_[name] = current_est
 
         return self
-                 
+
     def fit_transform(self, X, y=None, **fit_params):
-        """ Return class labels or probabilities for X for each estimator.
-                       
+        """Return class labels or probabilities for each estimator.
+
         Return predictions for X for each estimator.
-                   
+
         Parameters
         ----------
         X : {array-like, sparse matrix, dataframe} of shape \
@@ -111,7 +111,7 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
             Transformed array.
         """
         super().fit_transform(X, y=None, **fit_params)
-            
+
     @property
     def n_features_in_(self):
         # For consistency with other estimators we raise a AttributeError so

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -90,13 +90,12 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
             self.named_estimators_[name] = current_est
 
         return self
-    
+                 
     def fit_transform(self, X, y=None, **fit_params):
-        """
-        Return class labels or probabilities for X for each estimator.
-        
+        """ Return class labels or probabilities for X for each estimator.
+                       
         Return predictions for X for each estimator.
-        
+                   
         Parameters
         ----------
         X : {array-like, sparse matrix, dataframe} of shape \
@@ -111,15 +110,8 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
         X_new : ndarray array of shape (n_samples, n_features_new)
             Transformed array.
         """
-        # non-optimized default implementation; override when a better
-        # method is possible for a given clustering algorithm
-        if y is None:
-            # fit method of arity 1 (unsupervised transformation)
-            return self.fit(X, **fit_params).transform(X)
-        else:
-            # fit method of arity 2 (supervised transformation)
-            return self.fit(X, y, **fit_params).transform(X)
-    
+        super().fit_transform(X, y=None, **fit_params)
+            
     @property
     def n_features_in_(self):
         # For consistency with other estimators we raise a AttributeError so

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -110,7 +110,7 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
         X_new : ndarray array of shape (n_samples, n_features_new)
             Transformed array.
         """
-        super().fit_transform(X, y=None, **fit_params)
+        super().fit_transform(X, y, **fit_params)
 
     @property
     def n_features_in_(self):


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Improve fit_transform docstring in VotingClassifier and VotingRegressor #18150
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
updated docstring of <code>fit_transfrom</code> method by overriding the whole method which was inherited from the<code> TransformerMixin</code>



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
