### PR TITLE
[MRG] MNT remove duplicated call to children_impurity()

### DIFF
--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -62,7 +62,9 @@ cdef class Criterion:
     cdef void children_impurity(self, double* impurity_left,
                                 double* impurity_right) nogil
     cdef void node_value(self, double* dest) nogil
-    cdef double impurity_improvement(self, double impurity) nogil
+    cdef double impurity_improvement(self, double impurity_parent,
+                                     double impurity_left,
+                                     double impurity_right) nogil
     cdef double proxy_impurity_improvement(self) nogil
 
 cdef class ClassificationCriterion(Criterion):

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -191,10 +191,10 @@ cdef class Criterion:
         impurity_parent : double
             The initial impurity of the parent node before the split
 
-        impurity_parent : double
+        impurity_left : double
             The impurity of the left child
 
-        impurity_parent : double
+        impurity_right : double
             The impurity of the right child
 
         Return

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1308,3 +1308,25 @@ cdef class FriedmanMSE(MSE):
                 self.weighted_n_left * total_sum_right)
 
         return diff * diff / (self.weighted_n_left * self.weighted_n_right)
+
+    cdef double impurity_improvement(self, double impurity_parent, double
+                                     impurity_left, double impurity_right) nogil:
+        # Note: none of the arguments are used here
+        cdef double* sum_left = self.sum_left
+        cdef double* sum_right = self.sum_right
+
+        cdef double total_sum_left = 0.0
+        cdef double total_sum_right = 0.0
+
+        cdef SIZE_t k
+        cdef double diff = 0.0
+
+        for k in range(self.n_outputs):
+            total_sum_left += sum_left[k]
+            total_sum_right += sum_right[k]
+
+        diff = (self.weighted_n_right * total_sum_left -
+                self.weighted_n_left * total_sum_right) / self.n_outputs
+
+        return (diff * diff / (self.weighted_n_left * self.weighted_n_right *
+                               self.weighted_n_node_samples))

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -434,9 +434,10 @@ cdef class BestSplitter(BaseDenseSplitter):
 
             self.criterion.reset()
             self.criterion.update(best.pos)
-            best.improvement = self.criterion.impurity_improvement(impurity)
             self.criterion.children_impurity(&best.impurity_left,
                                              &best.impurity_right)
+            best.improvement = self.criterion.impurity_improvement(
+                impurity, best.impurity_left, best.impurity_right)
 
         # Respect invariant for constant features: the original order of
         # element in features[:n_known_constants] must be preserved for sibling
@@ -745,9 +746,10 @@ cdef class RandomSplitter(BaseDenseSplitter):
 
             self.criterion.reset()
             self.criterion.update(best.pos)
-            best.improvement = self.criterion.impurity_improvement(impurity)
             self.criterion.children_impurity(&best.impurity_left,
                                              &best.impurity_right)
+            best.improvement = self.criterion.impurity_improvement(
+                impurity, best.impurity_left, best.impurity_right)
 
         # Respect invariant for constant features: the original order of
         # element in features[:n_known_constants] must be preserved for sibling
@@ -1293,9 +1295,10 @@ cdef class BestSparseSplitter(BaseSparseSplitter):
 
             self.criterion.reset()
             self.criterion.update(best.pos)
-            best.improvement = self.criterion.impurity_improvement(impurity)
             self.criterion.children_impurity(&best.impurity_left,
                                              &best.impurity_right)
+            best.improvement = self.criterion.impurity_improvement(
+                impurity, best.impurity_left, best.impurity_right)
 
         # Respect invariant for constant features: the original order of
         # element in features[:n_known_constants] must be preserved for sibling
@@ -1504,10 +1507,10 @@ cdef class RandomSparseSplitter(BaseSparseSplitter):
 
                     if current_proxy_improvement > best_proxy_improvement:
                         best_proxy_improvement = current_proxy_improvement
-                        current.improvement = self.criterion.impurity_improvement(impurity)
-
                         self.criterion.children_impurity(&current.impurity_left,
                                                          &current.impurity_right)
+                        current.improvement = self.criterion.impurity_improvement(
+                            impurity, current.impurity_left, current.impurity_right)
                         best = current
 
         # Reorganize into samples[start:best.pos] + samples[best.pos:end]
@@ -1521,9 +1524,10 @@ cdef class RandomSparseSplitter(BaseSparseSplitter):
 
             self.criterion.reset()
             self.criterion.update(best.pos)
-            best.improvement = self.criterion.impurity_improvement(impurity)
             self.criterion.children_impurity(&best.impurity_left,
                                              &best.impurity_right)
+            best.improvement = self.criterion.impurity_improvement(
+                impurity, best.impurity_left, best.impurity_right)
 
         # Respect invariant for constant features: the original order of
         # element in features[:n_known_constants] must be preserved for sibling


### PR DESCRIPTION
In the tree Splitter we call `impurity_improvement()` and then `children_impurity()`.

But `impurity_improvement()` itself will call `children_impurity()` internally so this PR removes the duplicated work.

CC @lorentzenchr @thomasjpfan 