### PR TITLE
DOC Fix LaTeX hyperref error: "\pdfendlink ended up in different nesting level than \pdfstartlink"

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -240,6 +240,8 @@ latex_elements = {
     'preamble': r"""
         \usepackage{amsmath}\usepackage{amsfonts}\usepackage{bm}
         \usepackage{morefloats}\usepackage{enumitem} \setlistdepth{10}
+        \let\oldhref\href
+        \renewcommand{\href}[2]{\oldhref{#1}{\hbox{#2}}}
         """
 }
 

--- a/doc/developers/bug_triaging.rst
+++ b/doc/developers/bug_triaging.rst
@@ -91,7 +91,7 @@ See the github description for `roles in the organization
 A typical workflow for triaging issues
 ----------------------------------------
 
-The following workflow [*]_ is a good way to approach issue triaging:
+The following workflow [1]_ is a good way to approach issue triaging:
 
 #. Thank the reporter for opening an issue
 
@@ -148,5 +148,5 @@ The following workflow [*]_ is a good way to approach issue triaging:
    An additional useful step can be to tag the corresponding module e.g.
    `sklearn.linear_models` when relevant.
 
-.. [*] Adapted from the pandas project `maintainers guide
+.. [1] Adapted from the pandas project `maintainers guide
        <https://dev.pandas.io/docs/development/maintaining.html>`_


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Since 618e6258751b20cd65514c69a473816b60ad0992 latex build is failing with error 
```latex
\pdfendlink ended up in different nesting level than \pdfstartlink
```
This PR fix this issue forcing references in a `\hbox` and fixing a unnumbered reference.

#### Any other comments?
Thanks [stackoverflow](https://tex.stackexchange.com/questions/1522/pdfendlink-ended-up-in-different-nesting-level-than-pdfstartlink/443034#443034)... :)