### PR TITLE
[MRG] FIX len() of ParameterSampler

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -330,7 +330,7 @@ Changelog
 
 - |Fix| Fixed the `len` of :class:`model_selection.ParameterSampler` when
   all distributions are lists and `n_iter` is more than the number of unique
-  paramter combinations.
+  parameter combinations. :pr:`18222` by `Nicolas Hug`_.
 
 :mod:`sklearn.multiclass`
 .........................

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -328,6 +328,10 @@ Changelog
   :pr:`17478` by :user:`Teon Brooks <teonbrooks>` and
   :user:`Mohamed Maskani <maskani-moh>`.
 
+- |Fix| Fixed the `len` of :class:`model_selection.ParameterSampler` when
+  all distributions are lists and `n_iter` is more than the number of unique
+  paramter combinations.
+
 :mod:`sklearn.multiclass`
 .........................
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1489,6 +1489,7 @@ def test_parameters_sampler_replacement():
     assert len(samples) == 8
     for values in ParameterGrid(params):
         assert values in samples
+    assert len(ParameterSampler(params, n_iter=1000)) == 8
 
     # test sampling without replacement in a large grid
     params = {'a': range(10), 'b': range(10), 'c': range(10)}


### PR DESCRIPTION
When the param grid is given as all lists in RandomizedSearchCV, we fall back to a GridSearch-like behaviour. The `__len__` magic was incorrect in this case when we ask for more candidates than what's actually possible.