### PR TITLE
DOC alphas_ documentation of LassoLarsIC

### DIFF
--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -1766,12 +1766,11 @@ class LassoLarsIC(LassoLars):
     alpha_ : float
         the alpha parameter chosen by the information criterion
 
-    alphas_ : array-like of shape (n_alphas + 1,) or list of thereof of shape \
-            (n_targets,)
+    alphas_ : array-like of shape (n_alphas + 1,) or list thereof
         Maximum of covariances (in absolute value) at each iteration.
         ``n_alphas`` is either ``max_iter``, ``n_features`` or the
         number of nodes in the path with ``alpha >= alpha_min``, whichever
-        is smaller.
+        is smaller. If a list, it will be of length `n_targets`.
 
     n_iter_ : int
         number of iterations run by lars_path to find the grid of

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -861,9 +861,10 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
     ----------
     alphas_ : array-like of shape (n_alphas + 1,) or list of thereof of \
             shape (n_targets,)
-        Maximum of covariances (in absolute value) at each iteration. \
-        ``n_alphas`` is either ``n_nonzero_coefs`` or ``n_features``, \
-        whichever is smaller.
+        Maximum of covariances (in absolute value) at each iteration.
+        ``n_alphas`` is either ``max_iter``, ``n_features`` or the
+        number of nodes in the path with ``alpha >= alpha_min``, whichever
+        is smaller.
 
     active_ : list of shape (n_alphas,) or list of thereof of shape \
             (n_targets,)
@@ -1113,9 +1114,9 @@ class LassoLars(Lars):
     ----------
     alphas_ : array-like of shape (n_alphas + 1,) or list of thereof of shape \
             (n_targets,)
-        Maximum of covariances (in absolute value) at each iteration. \
-        ``n_alphas`` is either ``max_iter``, ``n_features``, or the number of \
-        nodes in the path with correlation greater than ``alpha``, whichever \
+        Maximum of covariances (in absolute value) at each iteration.
+        ``n_alphas`` is either ``max_iter``, ``n_features`` or the
+        number of nodes in the path with ``alpha >= alpha_min``, whichever
         is smaller.
 
     active_ : list of length n_alphas or list of thereof of shape (n_targets,)
@@ -1764,6 +1765,13 @@ class LassoLarsIC(LassoLars):
 
     alpha_ : float
         the alpha parameter chosen by the information criterion
+
+    alphas_ : array-like of shape (n_alphas + 1,) or list of thereof of shape \
+            (n_targets,)
+        Maximum of covariances (in absolute value) at each iteration.
+        ``n_alphas`` is either ``max_iter``, ``n_features`` or the
+        number of nodes in the path with ``alpha >= alpha_min``, whichever
+        is smaller.
 
     n_iter_ : int
         number of iterations run by lars_path to find the grid of

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -233,7 +233,7 @@ def test_fit_docstring_attributes(name, Estimator):
             assert hasattr(est, attr.name)
 
     IGNORED = {'BayesianRidge', 'Birch', 'CCA',
-               'LarsCV', 'Lasso', 'LassoLarsIC',
+               'LarsCV', 'Lasso',
                'OrthogonalMatchingPursuit',
                'PLSCanonical', 'PLSSVD'}
 


### PR DESCRIPTION
#### Reference Issues/PRs 
References #14312 


#### What does this implement/fix? Explain your changes.
Documents the attribute alphas_ in class LassoLarsIC

#### Any other comments?
I copied the code from the function `lars_path` in `_least_angle.py`. Since this documentation is the most up to date I also updated the documentation of the `alphas_` attributes in the classes `Lars` and `LassoLars`. 