### PR TITLE
[MRG] MNT Support None in resample

### DIFF
--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -181,6 +181,22 @@ def test_resample_stratify_sparse_error():
                         stratify=stratify)
 
 
+def test_resample_none_support():
+    # Make sure passing None as an array is OK.
+    X = np.arange(100)
+    y = groups = None
+
+    X, y, groups = resample(X, y, groups, n_samples=50)
+    assert y is groups is None
+
+    # first array may be None
+    y, X, groups = resample(y, X, groups, n_samples=50)
+    assert y is groups is None
+
+    assert resample(None) is None
+    assert resample(None, None) == (None, None)
+
+
 def test_safe_mask():
     random_state = check_random_state(0)
     X = random_state.rand(5, 4)

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -188,10 +188,12 @@ def test_resample_none_support():
 
     X, y, groups = resample(X, y, groups, n_samples=50)
     assert y is groups is None
+    assert X.shape[0] == 50
 
     # first array may be None
     y, X, groups = resample(y, X, groups, n_samples=50)
     assert y is groups is None
+    assert X.shape[0] == 50
 
     assert resample(None) is None
     assert resample(None, None) == (None, None)


### PR DESCRIPTION
This PR makes `resample` support arrays that are None. It's mostly for convenience: I need this in SuccessiveHalving https://github.com/scikit-learn/scikit-learn/pull/13900 to subsample `X, y, group` while `y` and `groups` may be `None`. This avoid having 3 special cases.

Not sure that's worth a what's new?