### PR TITLE
CI Only adds help wanted when issue gets unassigned

### DIFF
--- a/.github/workflows/unassign.yml
+++ b/.github/workflows/unassign.yml
@@ -1,5 +1,5 @@
 name: Unassign
-#Runs when a contributor has unassigned themselves from the issue and adds 'help wanted' and 'stalled' tags
+#Runs when a contributor has unassigned themselves from the issue and adds 'help wanted'
 on:
   issues:
     types: unassigned

--- a/.github/workflows/unassign.yml
+++ b/.github/workflows/unassign.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - name:
         run: |
-          echo "Marking issue ${{ github.event.issue.number }} as stalled"
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["help wanted","Stalled"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels
+          echo "Marking issue ${{ github.event.issue.number }} as help wanted"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["help wanted"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels


### PR DESCRIPTION
I have been seeing @cmarmo removing the stalled label frequently after the bot adds it. Maybe we want to the bot not to add the stalled label at all.

CC: @glemaitre 