### PR TITLE
Fixed -> inf or -inf values in CV ruin the mean and std

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -863,6 +863,11 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
             array_means = np.average(array, axis=1, weights=weights)
             results['mean_%s' % key_name] = array_means
+
+            if (np.isinf(array_means)).any():
+                warnings.warn("One or more of the test scores are not finite {}"
+                              .format(array_means), category=UserWarning)
+
             # Weighted std is not directly available in numpy
             array_stds = np.sqrt(np.average((array -
                                              array_means[:, np.newaxis]) ** 2,

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -865,7 +865,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             results['mean_%s' % key_name] = array_means
 
             if (np.isinf(array_means)).any():
-                warnings.warn("One or more of the test scores are not finite {}"
+                warnings.warn("One or more of the test scores are infinite {}"
                               .format(array_means), category=UserWarning)
 
             # Weighted std is not directly available in numpy

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1766,7 +1766,7 @@ def test_inf_warnings_in_GridSearchCV():
                         )
 
     with pytest.warns(UserWarning,
-                      match='One or more of the test scores are not finite\\d+'):
+                      match='One or more of the test scores are infinite\\d+'):
         grid.fit(X[:, np.newaxis])
 
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -25,6 +25,8 @@ from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._mocking import CheckingClassifier, MockDataFrame
 
 from scipy.stats import bernoulli, expon, uniform
+from scipy.stats.distributions import norm
+
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.base import clone
@@ -1748,6 +1750,24 @@ def test_random_search_bad_cv():
                              'inconsistent results. Expected \\d+ '
                              'splits, got \\d+'):
         ridge.fit(X[:train_size], y[:train_size])
+
+
+def test_inf_warnings_in_GridSearchCV():
+
+    X = norm(-1, 0.5).rvs(100, random_state=np.random.RandomState(28))
+    kernel = 'epanechnikov'
+    steps = 10
+    lower = 0.0194867441113
+    upper = 0.0974337205567
+    bandwidth_range = np.linspace(lower, upper, steps)
+    grid = GridSearchCV(KernelDensity(kernel=kernel),
+                        {'bandwidth': bandwidth_range},
+                        cv=20
+                        )
+
+    with pytest.warns(UserWarning,
+                      match='One or more of the test scores are not finite\\d+'):
+        grid.fit(X[:, np.newaxis])
 
 
 def test_callable_multimetric_confusion_matrix():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10529 

#### What does this implement/fix? Explain your changes.
The fix checks for the presence of any inf/-inf values in the mean score calculated after GridSearchCV.
If yes, it raises a warning - "One or more of the test scores are infinite"

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
