### PR TITLE
ENH Raises warning when getting non-finite score in SearchCV

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -354,7 +354,8 @@ Changelog
   parameter combinations. :pr:`18222` by `Nicolas Hug`_.
 
 - |Fix| A fix to raise warning when one or more CV splits of
-  :class:`model_selection.GridSearchCV` and :class:`model_selection.RandomizedSearchCV` results in non-finite scores.
+  :class:`model_selection.GridSearchCV` and
+  :class:`model_selection.RandomizedSearchCV` results in non-finite scores.
   :pr:`18266` by :user:`Subrat Sahu <subrat93>`,
   :user:`Nirvan <Nirvan101>` and :user:`Arthur Book <ArthurBook>`.
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -354,7 +354,7 @@ Changelog
   parameter combinations. :pr:`18222` by `Nicolas Hug`_.
 
 - |Fix| A fix to raise warning when one or more CV splits of
-  :class:`GridSearchCV` results in inf or -inf.
+  :class:`GridSearchCV` results in non-finite scores.
   :pr:`18266` by :user:`Subrat Sahu <subrat93>`,
   :user:`Nirvan <Nirvan101>` and :user:`Arthur Book <ArthurBook>`.
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -353,6 +353,11 @@ Changelog
   all distributions are lists and `n_iter` is more than the number of unique
   parameter combinations. :pr:`18222` by `Nicolas Hug`_.
 
+- |Fix| A fix to raise warning when one or more CV splits of
+  :class:`GridSearchCV` results in inf or -inf.
+  :pr:`18266` by :user:`Subrat Sahu <subrat93>`,
+  :user:`Nirvan <Nirvan101>` and :user:`Arthur Book <ArthurBook>`.
+
 :mod:`sklearn.multiclass`
 .........................
 
@@ -364,7 +369,7 @@ Changelog
 - |Enhancement| :class:`multiclass.OneVsOneClassifier` now accepts
   the inputs with missing values. Hence, estimators which can handle
   missing values (may be a pipeline with imputation step) can be used as
-  a estimator for multiclass wrappers. 
+  a estimator for multiclass wrappers.
   :pr:`17987` by :user:`Venkatachalam N <venkyyuvy>`.
 
 :mod:`sklearn.multioutput`
@@ -375,11 +380,11 @@ Changelog
   :pr:`18124` by :user:`Gus Brocchini <boldloop>` and
   :user:`Amanda Dsouza <amy12xx>`.
 
-- |Enhancement| :class:`multioutput.MultiOutputClassifier` and 
+- |Enhancement| :class:`multioutput.MultiOutputClassifier` and
   :class:`multioutput.MultiOutputRegressor` now accepts the inputs
   with missing values. Hence, estimators which can handle missing
   values (may be a pipeline with imputation step, HistGradientBoosting
-  estimators) can be used as a estimator for multiclass wrappers. 
+  estimators) can be used as a estimator for multiclass wrappers.
   :pr:`17987` by :user:`Venkatachalam N <venkyyuvy>`.
 
 :mod:`sklearn.naive_bayes`

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -354,7 +354,7 @@ Changelog
   parameter combinations. :pr:`18222` by `Nicolas Hug`_.
 
 - |Fix| A fix to raise warning when one or more CV splits of
-  :class:`GridSearchCV` results in non-finite scores.
+  :class:`model_selection.GridSearchCV` and :class:`model_selection.RandomizedSearchCV` results in non-finite scores.
   :pr:`18266` by :user:`Subrat Sahu <subrat93>`,
   :user:`Nirvan <Nirvan101>` and :user:`Arthur Book <ArthurBook>`.
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -863,6 +863,11 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
             array_means = np.average(array, axis=1, weights=weights)
             results['mean_%s' % key_name] = array_means
+
+            if (np.isinf(array_means)).any():
+                warnings.warn("One or more of the test scores are not finite {}"
+                              .format(array_means), category=UserWarning)
+
             # Weighted std is not directly available in numpy
             array_stds = np.sqrt(np.average((array -
                                              array_means[:, np.newaxis]) ** 2,

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -864,9 +864,13 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             array_means = np.average(array, axis=1, weights=weights)
             results['mean_%s' % key_name] = array_means
 
-            if (np.isinf(array_means)).any():
-                warnings.warn("One or more of the test scores are infinite {}"
-                              .format(array_means), category=UserWarning)
+            if (key_name.startswith(("train_", "test_")) and
+                    np.any(~np.isfinite(array_means))):
+                warnings.warn(
+                    f"One or more of the {key_name.split('_')[0]} scores "
+                    f"are non-finite: {array_means}",
+                    category=UserWarning
+                )
 
             # Weighted std is not directly available in numpy
             array_stds = np.sqrt(np.average((array -

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -865,7 +865,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             results['mean_%s' % key_name] = array_means
 
             if (np.isinf(array_means)).any():
-                warnings.warn("One or more of the test scores are not finite {}"
+                warnings.warn("One or more of the test scores are infinite {}"
                               .format(array_means), category=UserWarning)
 
             # Weighted std is not directly available in numpy

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1756,7 +1756,7 @@ def test_random_search_bad_cv():
     "return_train_score, regex_str",
     [(False, ('One or more of the test scores are non-finite')),
      (True, ("One or more of the test scores are non-finite",
-        "One or more of the train scores are non-finite"))]
+            "One or more of the train scores are non-finite"))]
 )
 def test_gridsearchcv_raise_warning_with_non_finite_score():
     # Non-regression test for:
@@ -1780,7 +1780,6 @@ def test_gridsearchcv_raise_warning_with_non_finite_score():
         grid.fit(X[:, np.newaxis])
 
     warnings = list(map(lambda warning: warning.message, warnings)).join(",")
-    # expected_msgs = regex_str.split(",")
     assert expected_msgs[0] in warnings
 
     if return_train_score:

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1758,7 +1758,7 @@ def test_random_search_bad_cv():
      (True, ("One or more of the test scores are non-finite",
             "One or more of the train scores are non-finite"))]
 )
-def test_gridsearchcv_raise_warning_with_non_finite_score():
+def test_gridsearchcv_raise_warning_with_non_finite_score(return_train_score, regex_str):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/10529
     # Check that we raise a UserWarning when a non-finite score is

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1766,7 +1766,7 @@ def test_inf_warnings_in_GridSearchCV():
                         )
 
     with pytest.warns(UserWarning,
-                      match='One or more of the test scores are not finite\\d+'):
+                      match='One or more of the test scores are infinite\\d+'):
         grid.fit(X[:, np.newaxis])
 
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -26,7 +26,6 @@ from sklearn.utils._mocking import CheckingClassifier, MockDataFrame
 
 from scipy.stats import bernoulli, expon, uniform
 
-
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.base import clone
 from sklearn.exceptions import NotFittedError

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1755,7 +1755,7 @@ def test_gridsearchcv_raise_warning_with_non_finite_score(return_train_score):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/10529
     # Check that we raise a UserWarning when a non-finite score is
-    # computed in the GridSearchCV
+    # computed in the SearchCV
     X, y = make_classification(n_classes=2, random_state=0)
 
     class FailingScorer:

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1752,18 +1752,22 @@ def test_random_search_bad_cv():
         ridge.fit(X[:train_size], y[:train_size])
 
 
-def test_inf_warnings_in_GridSearchCV():
-
+def test_gridserchcv_raise_warning_with_non_finite_score():
+    # Non-regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/10529
+    # Check that we raise a UserWarning when a non-finite score is
+    # computed in the GridSearchCV
     X = norm(-1, 0.5).rvs(100, random_state=np.random.RandomState(28))
     kernel = 'epanechnikov'
     steps = 10
     lower = 0.0194867441113
     upper = 0.0974337205567
     bandwidth_range = np.linspace(lower, upper, steps)
-    grid = GridSearchCV(KernelDensity(kernel=kernel),
-                        {'bandwidth': bandwidth_range},
-                        cv=20
-                        )
+    grid = GridSearchCV(
+        KernelDensity(kernel=kernel),
+        param_grid={'bandwidth': bandwidth_range},
+        cv=20,
+    )
 
     with pytest.warns(UserWarning,
                       match='One or more of the test scores are infinite'):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1758,7 +1758,7 @@ def test_random_search_bad_cv():
      (True, ("One or more of the test scores are non-finite",
             "One or more of the train scores are non-finite"))]
 )
-def test_gridsearchcv_raise_warning_with_non_finite_score(return_train_score, regex_str):
+def test_gridsearchcv_raise_warning_with_non_finite_score(return_train_score, expected_msgs):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/10529
     # Check that we raise a UserWarning when a non-finite score is

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1766,7 +1766,7 @@ def test_inf_warnings_in_GridSearchCV():
                         )
 
     with pytest.warns(UserWarning,
-                      match='One or more of the test scores are infinite\\d+'):
+                      match='One or more of the test scores are infinite'):
         grid.fit(X[:, np.newaxis])
 
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -25,7 +25,6 @@ from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._mocking import CheckingClassifier, MockDataFrame
 
 from scipy.stats import bernoulli, expon, uniform
-from scipy.stats.distributions import norm
 
 
 from sklearn.base import BaseEstimator, ClassifierMixin
@@ -1787,8 +1786,8 @@ def test_gridsearchcv_raise_warning_with_non_finite_score(return_train_score):
     for msg, dataset in zip(warn_msg, set_with_warning):
         assert (f"One or more of the {dataset} scores are non-finite" in
                 str(msg.message))
-    
-    
+
+
 def test_callable_multimetric_confusion_matrix():
     # Test callable with many metrics inserts the correct names and metrics
     # into the search cv object

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1751,7 +1751,13 @@ def test_random_search_bad_cv():
 
 
 @pytest.mark.parametrize("return_train_score", [False, True])
-def test_gridsearchcv_raise_warning_with_non_finite_score(return_train_score):
+@pytest.mark.parametrize(
+    "SearchCV, specialized_params",
+    [(GridSearchCV, {"param_grid": {"max_depth": [2, 3]}}),
+     (RandomizedSearchCV,
+      {"param_distributions": {"max_depth": [2, 3]}, "n_iter": 2})])
+def test_searchcv_raise_warning_with_non_finite_score(
+        SearchCV, specialized_params, return_train_score):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/10529
     # Check that we raise a UserWarning when a non-finite score is
@@ -1760,6 +1766,7 @@ def test_gridsearchcv_raise_warning_with_non_finite_score(return_train_score):
 
     class FailingScorer:
         """Scorer that will fail for some split but not all."""
+
         def __init__(self):
             self.n_counts = 0
 
@@ -1769,12 +1776,13 @@ def test_gridsearchcv_raise_warning_with_non_finite_score(return_train_score):
                 return np.nan
             return 1
 
-    grid = GridSearchCV(
+    grid = SearchCV(
         DecisionTreeClassifier(),
         param_grid={"max_depth": [2, 3]},
         scoring=FailingScorer(),
         cv=3,
-        return_train_score=return_train_score
+        return_train_score=return_train_score,
+        **specialized_params
     )
 
     with pytest.warns(UserWarning) as warn_msg:

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1780,7 +1780,7 @@ def test_gridsearchcv_raise_warning_with_non_finite_score(
     with pytest.warns(UserWarning) as warnings:
         grid.fit(X[:, np.newaxis])
 
-    warnings = list(map(lambda warning: warning.message, warnings)).join(",")
+    warnings = ",".join(list(map(lambda warning: warning.message, warnings)))
     assert expected_msgs[0] in warnings
 
     if return_train_score:

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1780,7 +1780,8 @@ def test_gridsearchcv_raise_warning_with_non_finite_score(
     with pytest.warns(UserWarning) as warnings:
         grid.fit(X[:, np.newaxis])
 
-    warnings = ",".join(list(map(lambda warning: str(warning.message), warnings)))
+    warnings = list(map(lambda warning: str(warning.message), warnings))
+    warnings = ",".join(warnings)
     assert expected_msgs[0] in warnings
 
     if return_train_score:

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1778,7 +1778,6 @@ def test_searchcv_raise_warning_with_non_finite_score(
 
     grid = SearchCV(
         DecisionTreeClassifier(),
-        param_grid={"max_depth": [2, 3]},
         scoring=FailingScorer(),
         cv=3,
         return_train_score=return_train_score,

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -25,6 +25,8 @@ from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._mocking import CheckingClassifier, MockDataFrame
 
 from scipy.stats import bernoulli, expon, uniform
+from scipy.stats.distributions import norm
+
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.base import clone
@@ -1748,6 +1750,24 @@ def test_random_search_bad_cv():
                              'inconsistent results. Expected \\d+ '
                              'splits, got \\d+'):
         ridge.fit(X[:train_size], y[:train_size])
+
+
+def test_inf_warnings_in_GridSearchCV():
+
+    X = norm(-1, 0.5).rvs(100, random_state=np.random.RandomState(28))
+    kernel = 'epanechnikov'
+    steps = 10
+    lower = 0.0194867441113
+    upper = 0.0974337205567
+    bandwidth_range = np.linspace(lower, upper, steps)
+    grid = GridSearchCV(KernelDensity(kernel=kernel),
+                        {'bandwidth': bandwidth_range},
+                        cv=20
+                        )
+
+    with pytest.warns(UserWarning,
+                      match='One or more of the test scores are not finite\\d+'):
+        grid.fit(X[:, np.newaxis])
 
 
 def test_callable_multimetric_confusion_matrix():

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1753,7 +1753,7 @@ def test_random_search_bad_cv():
 
 
 @pytest.mark.parametrize(
-    "return_train_score, regex_str",
+    "return_train_score, expected_msgs",
     [(False, ('One or more of the test scores are non-finite')),
      (True, ("One or more of the test scores are non-finite",
             "One or more of the train scores are non-finite"))]

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1780,7 +1780,7 @@ def test_gridsearchcv_raise_warning_with_non_finite_score(
     with pytest.warns(UserWarning) as warnings:
         grid.fit(X[:, np.newaxis])
 
-    warnings = ",".join(list(map(lambda warning: warning.message, warnings)))
+    warnings = ",".join(list(map(lambda warning: str(warning.message), warnings)))
     assert expected_msgs[0] in warnings
 
     if return_train_score:

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1756,9 +1756,10 @@ def test_random_search_bad_cv():
     "return_train_score, expected_msgs",
     [(False, ('One or more of the test scores are non-finite')),
      (True, ("One or more of the test scores are non-finite",
-            "One or more of the train scores are non-finite"))]
+             "One or more of the train scores are non-finite"))]
 )
-def test_gridsearchcv_raise_warning_with_non_finite_score(return_train_score, expected_msgs):
+def test_gridsearchcv_raise_warning_with_non_finite_score(
+        return_train_score, expected_msgs):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/10529
     # Check that we raise a UserWarning when a non-finite score is


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #10529 
Supersedes and closes #10546
Supersedes and closes #15469

#### What does this implement/fix? Explain your changes.
The fix checks for the presence of any inf/-inf values in the mean score calculated after GridSearchCV.
If yes, it raises a warning - "One or more of the test scores are infinite"

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
