### PR TITLE
FIX MLPClassifier not iterating to max_iter if warm started

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -433,6 +433,11 @@ Changelog
   :class:`neural_network.MLPRegressor`.
   :pr:`17759` by :user:`Srimukh Sripada <d3b0unce>`.
 
+- |Fix| Fix method  :func:`fit` of :class:`neural_network.MLPClassifier`
+  not iterating to ``max_iter`` if warm started.
+  :pr:`18269` by :user:`Norbert Preining <norbusan>` and
+  :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.pipeline`
 .......................
 

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -1009,12 +1009,14 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
             classes = unique_labels(y)
             if self.warm_start:
                 if set(classes) != set(self.classes_):
-                    raise ValueError("warm_start can only be used where `y` has "
-                                     "the same classes as in the previous "
-                                     "call to fit. Previously got %s, `y` has %s" %
+                    raise ValueError("warm_start can only be used where `y` "
+                                     "has the same classes as in the previous "
+                                     "call to fit. Previously got %s, `y` has "
+                                     "%s" %
                                      (self.classes_, classes))
             else:
-                if len(np.setdiff1d(classes, self.classes_, assume_unique=True)):
+                if len(np.setdiff1d(classes, self.classes_,
+                                    assume_unique=True)):
                     raise ValueError("`y` has classes not in `self.classes_`."
                                      " `self.classes_` has %s. 'y' has %s." %
                                      (self.classes_, classes))

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -379,10 +379,6 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
                                            incremental):
             # First time training the model
             self._initialize(y, layer_units, X.dtype)
-        if self.warm_start and not incremental:
-            # only the number of iteration should be initialized since
-            # weights are already allocated due to the warm start.
-            self.n_iter_ = 0
 
         # Initialize lists
         activations = [X] + [None] * (len(layer_units) - 1)

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -1027,24 +1027,6 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
 
         return self._label_binarizer.inverse_transform(y_pred)
 
-    def fit(self, X, y):
-        """Fit the model to data matrix X and target(s) y.
-
-        Parameters
-        ----------
-        X : ndarray or sparse matrix of shape (n_samples, n_features)
-            The input data.
-
-        y : ndarray of shape (n_samples,) or (n_samples, n_outputs)
-            The target values (class labels in classification, real numbers in
-            regression).
-
-        Returns
-        -------
-        self : returns a trained MLP model.
-        """
-        return self._fit(X, y, incremental=False)
-
     @property
     def partial_fit(self):
         """Update the model with a single iteration over the given data.

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -982,24 +982,42 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         if y.ndim == 2 and y.shape[1] == 1:
             y = column_or_1d(y, warn=True)
 
-        if self.warm_start and (incremental or hasattr(self, "classes_")):
-            classes = unique_labels(y)
-            if set(classes) != set(self.classes_):
-                raise ValueError("warm_start can only be used where `y` has "
-                                 "the same classes as in the previous "
-                                 "call to fit. Previously got %s, `y` has %s" %
-                                 (self.classes_, classes))
-
-        if not incremental:
+        # Matrix of actions to be taken under the possible combinations:
+        # The case that incremental == True and classes_ not defined is
+        # already checked by _check_partial_fit_first_call that is called
+        # in _partial_fit below.
+        # The cases are already grouped into the respective if blocks below.
+        #
+        # incremental warm_start classes_ def  action
+        #    0            0         0        define classes_
+        #    0            1         0        define classes_
+        #    0            0         1        redefine classes_
+        #
+        #    0            1         1        check compat warm_start
+        #    1            1         1        check compat warm_start
+        #
+        #    1            0         1        check compat last fit
+        #
+        # Note the reliance on short-circuiting here, so that the second
+        # or part implies that classes_ is defined.
+        if (not hasattr(self, "classes_")) or (not self.warm_start and
+                                               not incremental):
             self._label_binarizer = LabelBinarizer()
             self._label_binarizer.fit(y)
             self.classes_ = self._label_binarizer.classes_
         else:
             classes = unique_labels(y)
-            if len(np.setdiff1d(classes, self.classes_, assume_unique=True)):
-                raise ValueError("`y` has classes not in `self.classes_`."
-                                 " `self.classes_` has %s. 'y' has %s." %
-                                 (self.classes_, classes))
+            if self.warm_start:
+                if set(classes) != set(self.classes_):
+                    raise ValueError("warm_start can only be used where `y` has "
+                                     "the same classes as in the previous "
+                                     "call to fit. Previously got %s, `y` has %s" %
+                                     (self.classes_, classes))
+            else:
+                if len(np.setdiff1d(classes, self.classes_, assume_unique=True)):
+                    raise ValueError("`y` has classes not in `self.classes_`."
+                                     " `self.classes_` has %s. 'y' has %s." %
+                                     (self.classes_, classes))
 
         # This downcast to bool is to prevent upcasting when working with
         # float32 data

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -662,12 +662,17 @@ def test_warm_start():
             clf.fit(X, y_i)
 
 
-def test_warm_start_full_iteration():
+@pytest.mark.parametrize("MLPEstimator", [MLPClassifier, MLPRegressor])
+def test_warm_start_full_iteration(MLPEstimator):
+    # Non-regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/16812
+    # Check that the MLP estimator accomplish `max_iter` with a
+    # warm started estimator.
     X = X_iris
     y = y_iris
     max_iter = 3
-    clf = MLPClassifier(hidden_layer_sizes=2, solver='sgd',
-                        warm_start=True, max_iter=max_iter)
+    clf = MLPEstimator(hidden_layer_sizes=2, solver='sgd',
+                       warm_start=True, max_iter=max_iter)
     clf.fit(X, y)
     clf.fit(X, y)
     assert max_iter == clf.n_iter_

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -676,7 +676,7 @@ def test_warm_start_full_iteration(MLPEstimator):
     clf.fit(X, y)
     assert max_iter == clf.n_iter_
     clf.fit(X, y)
-    assert max_iter == clf.n_iter_
+    assert 2 * max_iter == clf.n_iter_
 
 
 def test_n_iter_no_change():

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -662,6 +662,17 @@ def test_warm_start():
             clf.fit(X, y_i)
 
 
+def test_warm_start_full_iteration():
+    X = X_iris
+    y = y_iris
+    max_iter = 3
+    clf = MLPClassifier(hidden_layer_sizes=2, solver='sgd',
+                        warm_start=True, max_iter=max_iter)
+    clf.fit(X, y)
+    clf.fit(X, y)
+    assert max_iter == clf.n_iter_
+
+
 def test_n_iter_no_change():
     # test n_iter_no_change using binary data set
     # the classifying fitting process is not prone to loss curve fluctuations

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -674,6 +674,7 @@ def test_warm_start_full_iteration(MLPEstimator):
     clf = MLPEstimator(hidden_layer_sizes=2, solver='sgd',
                        warm_start=True, max_iter=max_iter)
     clf.fit(X, y)
+    assert max_iter == clf.n_iter_
     clf.fit(X, y)
     assert max_iter == clf.n_iter_
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -668,11 +668,11 @@ def test_warm_start_full_iteration(MLPEstimator):
     # https://github.com/scikit-learn/scikit-learn/issues/16812
     # Check that the MLP estimator accomplish `max_iter` with a
     # warm started estimator.
-    X = X_iris
-    y = y_iris
+    X, y = X_iris, y_iris
     max_iter = 3
-    clf = MLPEstimator(hidden_layer_sizes=2, solver='sgd',
-                       warm_start=True, max_iter=max_iter)
+    clf = MLPEstimator(
+        hidden_layer_sizes=2, solver='sgd', warm_start=True, max_iter=max_iter
+    )
     clf.fit(X, y)
     assert max_iter == clf.n_iter_
     clf.fit(X, y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #16812

#### What does this implement/fix? Explain your changes.

MLPClassifier's `_fit` routine uses
```
 incremental = (self.warm_start and hasattr(self, "classes_"))
```
which, in the case of warm_start and a previous fit call evaluates to
true, thus the fit routine breaks after one iteration instead of
continuing to `max_iter`.
    
The solution requires three changes:
- `MLPClassifier.fit` calls `self._fit` with `incremental = False`
  (similar to MLPRegressor)
- Input validation needs to be updated so that the check for
  compatibility of classes with previous calls is done when `warm_start`
  is true, and either incremental is True or previously created
  results from fit are available in `classes_`
- internal iteration counter needs to be reset to 0 if incremental
  is False, but `warm_start` is True.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
