### PR TITLE
`check_psd_eigenvalues` : fixed issue with `small_pos_ratio` on mac os x with python >= 3.7

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1130,8 +1130,8 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
       ``PositiveSpectrumWarning`` when ``enable_warnings=True``.
 
     Finally, all the positive eigenvalues that are too small (with a value
-    smaller than the maximum eigenvalue divided by 1e12) are set to zero.
-    This operation is traced with a ``PositiveSpectrumWarning`` when
+    smaller than the maximum eigenvalue multiplied by 1e-12 (2e-7)) are set to
+    zero. This operation is traced with a ``PositiveSpectrumWarning`` when
     ``enable_warnings=True``.
 
     Parameters
@@ -1194,7 +1194,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
     significant_imag_ratio = 1e-5
     significant_neg_ratio = 1e-5 if is_double_precision else 5e-3
     significant_neg_value = 1e-10 if is_double_precision else 1e-6
-    small_pos_ratio = 1e-12 if is_double_precision else 1e-7
+    small_pos_ratio = 1e-12 if is_double_precision else 2e-7
 
     # Check that there are no significant imaginary parts
     if not np.isreal(lambdas).all():


### PR DESCRIPTION
Fixed issue with small_pos_ratio on mac os x with python >= 3.7 by slightly raising threshold as discussed in #18149. 
Updated docstring accordingly.
