### PR TITLE
Fix test_check_pandas_sparse_valid - handle correctly platform defined numpy types. issue #18271

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1252,27 +1252,27 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2):
 
 
 @pytest.mark.parametrize(
-    "ntype1, ntype2",
+    "ntype1, ntype2, expected_subtype",
     [
-        ("longfloat", "longdouble"),
-        ("float16", "half"),
-        ("single", "float32"),
-        ("double", "float64"),
-        ("int8", "byte"),
-        ("short", "int16"),
-        ("intc", "int32"),
-        ("int0", "long"),
-        ("int", "long"),
-        ("int64", "longlong"),
-        ("int_", "intp"),
-        ("ubyte", "uint8"),
-        ("uint16", "ushort"),
-        ("uintc", "uint32"),
-        ("uint", "uint64"),
-        ("uintp", "ulonglong"),
+        ("longfloat", "longdouble", np.floating),
+        ("float16", "half", np.floating),
+        ("single", "float32", np.floating),
+        ("double", "float64", np.floating),
+        ("int8", "byte", np.integer),
+        ("short", "int16", np.integer),
+        ("intc", "int32", np.integer),
+        ("int0", "long", np.integer),
+        ("int", "long", np.integer),
+        ("int64", "longlong", np.integer),
+        ("int_", "intp", np.integer),
+        ("ubyte", "uint8", np.unsignedinteger),
+        ("uint16", "ushort", np.unsignedinteger),
+        ("uintc", "uint32", np.unsignedinteger),
+        ("uint", "uint64", np.unsignedinteger),
+        ("uintp", "ulonglong", np.unsignedinteger)
     ]
 )
-def test_check_pandas_sparse_valid(ntype1, ntype2):
+def test_check_pandas_sparse_valid(ntype1, ntype2, expected_subtype):
     # check that we support the conversion of sparse dataframe with mixed
     # type which can be converted safely.
     pd = pytest.importorskip("pandas", minversion="0.25.0")
@@ -1280,4 +1280,5 @@ def test_check_pandas_sparse_valid(ntype1, ntype2):
                                                      dtype=ntype1),
                        'col2': pd.arrays.SparseArray([1, 0, 1],
                                                      dtype=ntype2)})
-    check_array(df, accept_sparse=['csr', 'csc'])
+    arr = check_array(df, accept_sparse=['csr', 'csc'])
+    assert np.issubdtype(arr.dtype, expected_subtype)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1252,27 +1252,27 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2):
 
 
 @pytest.mark.parametrize(
-    "ntype1, ntype2, expected_dtype",
+    "ntype1, ntype2",
     [
-        ("longfloat", "longdouble", "float128"),
-        ("float16", "half", "float16"),
-        ("single", "float32", "float32"),
-        ("double", "float64", "float64"),
-        ("int8", "byte", "int8"),
-        ("short", "int16", "int16"),
-        ("intc", "int32", "int32"),
-        ("int0", "long", "int64"),
-        ("int", "long", "int64"),
-        ("int64", "longlong", "int64"),
-        ("int_", "intp", "int64"),
-        ("ubyte", "uint8", "uint8"),
-        ("uint16", "ushort", "uint16"),
-        ("uintc", "uint32", "uint32"),
-        ("uint", "uint64", "uint64"),
-        ("uintp", "ulonglong", "uint64"),
+        ("longfloat", "longdouble"),
+        ("float16", "half"),
+        ("single", "float32"),
+        ("double", "float64"),
+        ("int8", "byte"),
+        ("short", "int16"),
+        ("intc", "int32"),
+        ("int0", "long"),
+        ("int", "long"),
+        ("int64", "longlong"),
+        ("int_", "intp"),
+        ("ubyte", "uint8"),
+        ("uint16", "ushort"),
+        ("uintc", "uint32"),
+        ("uint", "uint64"),
+        ("uintp", "ulonglong"),
     ]
 )
-def test_check_pandas_sparse_valid(ntype1, ntype2, expected_dtype):
+def test_check_pandas_sparse_valid(ntype1, ntype2):
     # check that we support the conversion of sparse dataframe with mixed
     # type which can be converted safely.
     pd = pytest.importorskip("pandas", minversion="0.25.0")
@@ -1280,5 +1280,4 @@ def test_check_pandas_sparse_valid(ntype1, ntype2, expected_dtype):
                                                      dtype=ntype1),
                        'col2': pd.arrays.SparseArray([1, 0, 1],
                                                      dtype=ntype2)})
-    arr = check_array(df, accept_sparse=['csr', 'csc'])
-    assert arr.dtype.name == expected_dtype
+    check_array(df, accept_sparse=['csr', 'csc'])


### PR DESCRIPTION
`test_check_pandas_sparse_valid` verifies that 2 different numpy types map to the same numpy dtype, and therefore scikit-learn `check_array()` succeeds. The test also assumes to know what is the dtype to which the numy types are mapped to.
For example:

```
@pytest.mark.parametrize(
        "ntype1, ntype2, expected_dtype",
        [
           ...
            ("int0", "long", "int64"),
            ...
        ]
    )
    def test_check_pandas_sparse_valid(ntype1, ntype2, expected_dtype):
```
assumes that numpy types "int0" and "long" will map to dtype "int64".

And in most cases this is true and that is why circleci succeeded. But there are environments like  in issue #18271 where these numy types are mapped to dtype "int32", and the test will fail.

I think that the important part of the test is not to guess the dtype that the numpy types map to, but to verify that both numpy types map to the same dtype. This is what makes `check_array() ` succeed.
So instead of not testing for platform defined numpy types, I would prefer to remove from the test the part that "guesses" the result dtype.