### PR TITLE
DOC improve documentation of get/set params

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -368,6 +368,10 @@ The parameter `deep` will control whether or not the parameters of the
     subestimator__warm_start -> False
     subestimator -> LogisticRegression()
 
+Often, the `subestimator` has a name (as e.g. named steps in a
+:class:`~sklearn.pipeline.Pipeline` object), in which case the key should
+become `<name>__C`, `<name>__class_weight`, etc.
+
 While when `deep=False`, the output will be::
 
     >>> for param, value in my_estimator.get_params(deep=False).items():

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -340,8 +340,9 @@ estimator::
     >>> from sklearn.base import BaseEstimator
     >>> from sklearn.linear_model import LogisticRegression
     >>> class MyEstimator(BaseEstimator):
-    ...     def __init__(self, subestimator=None):
+    ...     def __init__(self, subestimator=None, my_extra_param="random"):
     ...         self.subestimator = subestimator
+    ...         self.my_extra_param = my_extra_param
 
 The parameter `deep` will control whether or not the parameters of the
 `subsestimator` should be reported. Thus when `deep=True`, the output will be::
@@ -349,6 +350,7 @@ The parameter `deep` will control whether or not the parameters of the
     >>> my_estimator = MyEstimator(subestimator=LogisticRegression())
     >>> for param, value in my_estimator.get_params(deep=True).items():
     ...     print(f"{param} -> {value}")
+    my_extra_param -> random
     subestimator__C -> 1.0
     subestimator__class_weight -> None
     subestimator__dual -> False
@@ -370,6 +372,7 @@ While when `deep=False`, the output will be::
 
     >>> for param, value in my_estimator.get_params(deep=False).items():
     ...     print(f"{param} -> {value}")
+    my_extra_param -> random
     subestimator -> LogisticRegression()
 
 The ``set_params`` on the other hand takes as input a dict of the form

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -5,9 +5,9 @@ Developing scikit-learn estimators
 ==================================
 
 Whether you are proposing an estimator for inclusion in scikit-learn,
-developing a separate package compatible with scikit-learn, or 
-implementing custom components for your own projects, this chapter 
-details how to develop objects that safely interact with scikit-learn 
+developing a separate package compatible with scikit-learn, or
+implementing custom components for your own projects, this chapter
+details how to develop objects that safely interact with scikit-learn
 Pipelines and model selection tools.
 
 .. currentmodule:: sklearn
@@ -330,11 +330,47 @@ get_params and set_params
 All scikit-learn estimators have ``get_params`` and ``set_params`` functions.
 The ``get_params`` function takes no arguments and returns a dict of the
 ``__init__`` parameters of the estimator, together with their values.
-It must take one keyword argument, ``deep``,
-which receives a boolean value that determines
-whether the method should return the parameters of sub-estimators
-(for most estimators, this can be ignored).
-The default value for ``deep`` should be true.
+
+It must take one keyword argument, ``deep``, which receives a boolean value
+that determines whether the method should return the parameters of
+sub-estimators (for most estimators, this can be ignored). The default value
+for ``deep`` should be `True`. For instance considering the following
+estimator::
+
+    >>> from sklearn.base import BaseEstimator
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> class MyEstimator(BaseEstimator):
+    ...     def __init__(self, subestimator=None):
+    ...         self.subestimator = subestimator
+
+The parameter `deep` will control whether or not the parameters of the
+`subsestimator` should be reported. Thus when `deep=True`, the output will be::
+
+    >>> my_estimator = MyEstimator(subestimator=LogisticRegression())
+    >>> for param, value in my_estimator.get_params(deep=True).items():
+    ...     print(f"{param} -> {value}")
+    subestimator__C -> 1.0
+    subestimator__class_weight -> None
+    subestimator__dual -> False
+    subestimator__fit_intercept -> True
+    subestimator__intercept_scaling -> 1
+    subestimator__l1_ratio -> None
+    subestimator__max_iter -> 100
+    subestimator__multi_class -> auto
+    subestimator__n_jobs -> None
+    subestimator__penalty -> l2
+    subestimator__random_state -> None
+    subestimator__solver -> lbfgs
+    subestimator__tol -> 0.0001
+    subestimator__verbose -> 0
+    subestimator__warm_start -> False
+    subestimator -> LogisticRegression()
+
+While when `deep=False`, the output will be::
+
+    >>> for param, value in my_estimator.get_params(deep=False).items():
+    ...     print(f"{param} -> {value}")
+    subestimator -> LogisticRegression()
 
 The ``set_params`` on the other hand takes as input a dict of the form
 ``'parameter': value`` and sets the parameter of the estimator using this dict.

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -228,8 +228,8 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         """Set the parameters of this estimator.
 
         Valid parameter keys can be listed with ``get_params()``. Note that you
-        can directly set the parameters of estimator contained in
-        `transformers`.
+        can directly set the parameters of the estimators contained in
+       `transformers` of `ColumnTransformer`.
 
         Returns
         -------

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -207,6 +207,10 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     def get_params(self, deep=True):
         """Get parameters for this estimator.
 
+        Returns the parameters given in the constructor as well as the
+        estimators contained within the `transformers` of the
+        `ColumnTransformer`.
+
         Parameters
         ----------
         deep : bool, default=True
@@ -223,7 +227,9 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     def set_params(self, **kwargs):
         """Set the parameters of this estimator.
 
-        Valid parameter keys can be listed with ``get_params()``.
+        Valid parameter keys can be listed with ``get_params()``. Note that you
+        can directly set the parameters of estimator contained in
+        `transformers`.
 
         Returns
         -------

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -229,7 +229,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
         Valid parameter keys can be listed with ``get_params()``. Note that you
         can directly set the parameters of the estimators contained in
-       `transformers` of `ColumnTransformer`.
+        `transformers` of `ColumnTransformer`.
 
         Returns
         -------

--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -250,16 +250,17 @@ class _BaseHeterogeneousEnsemble(MetaEstimatorMixin, _BaseComposition,
         """
         Set the parameters of an estimator from the ensemble.
 
-        Valid parameter keys can be listed with `get_params()`.
+        Valid parameter keys can be listed with `get_params()`. Note that you
+        can directly set the parameters of estimator contained in `estimators`.
 
         Parameters
         ----------
         **params : keyword arguments
             Specific parameters using e.g.
             `set_params(parameter_name=new_value)`. In addition, to setting the
-            parameters of the stacking estimator, the individual estimator of
-            the stacking estimators can also be set, or can be removed by
-            setting them to 'drop'.
+            parameters of the estimator, the individual estimator of the
+            estimators can also be set, or can be removed by setting them to
+            'drop'.
         """
         super()._set_params('estimators', **params)
         return self
@@ -268,10 +269,13 @@ class _BaseHeterogeneousEnsemble(MetaEstimatorMixin, _BaseComposition,
         """
         Get the parameters of an estimator from the ensemble.
 
+        Returns the parameters given in the constructor as well as the
+        estimators contained within the `estimators` parameter.
+
         Parameters
         ----------
         deep : bool, default=True
-            Setting it to True gets the various classifiers and the parameters
-            of the classifiers as well.
+            Setting it to True gets the various estimators and the parameters
+            of the estimators as well.
         """
         return super()._get_params('estimators', deep=deep)

--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -251,7 +251,7 @@ class _BaseHeterogeneousEnsemble(MetaEstimatorMixin, _BaseComposition,
         Set the parameters of an estimator from the ensemble.
 
         Valid parameter keys can be listed with `get_params()`. Note that you
-        can directly set the parameters of estimator contained in `estimators`.
+        can directly set the parameters of the estimators contained in `estimators`.
 
         Parameters
         ----------

--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -251,7 +251,8 @@ class _BaseHeterogeneousEnsemble(MetaEstimatorMixin, _BaseComposition,
         Set the parameters of an estimator from the ensemble.
 
         Valid parameter keys can be listed with `get_params()`. Note that you
-        can directly set the parameters of the estimators contained in `estimators`.
+        can directly set the parameters of the estimators contained in
+        `estimators`.
 
         Parameters
         ----------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -115,6 +115,9 @@ class Pipeline(_BaseComposition):
     def get_params(self, deep=True):
         """Get parameters for this estimator.
 
+        Returns the parameters given in the constructor as well as the
+        estimators contained within the `steps` of the `Pipeline`.
+
         Parameters
         ----------
         deep : bool, default=True
@@ -131,7 +134,8 @@ class Pipeline(_BaseComposition):
     def set_params(self, **kwargs):
         """Set the parameters of this estimator.
 
-        Valid parameter keys can be listed with ``get_params()``.
+        Valid parameter keys can be listed with ``get_params()``. Note that
+        you can directly set the parameters of estimator contained in `steps`.
 
         Returns
         -------
@@ -828,6 +832,10 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
     def get_params(self, deep=True):
         """Get parameters for this estimator.
 
+        Returns the parameters given in the constructor as well as the
+        estimators contained within the `transformer_list` of the
+        `FeatureUnion`.
+
         Parameters
         ----------
         deep : bool, default=True
@@ -844,7 +852,9 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
     def set_params(self, **kwargs):
         """Set the parameters of this estimator.
 
-        Valid parameter keys can be listed with ``get_params()``.
+        Valid parameter keys can be listed with ``get_params()``. Note that
+        you can directly set the parameters of estimator contained in
+        `tranformer_list`.
 
         Returns
         -------

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -135,7 +135,7 @@ class Pipeline(_BaseComposition):
         """Set the parameters of this estimator.
 
         Valid parameter keys can be listed with ``get_params()``. Note that
-        you can directly set the parameters of estimator contained in `steps`.
+        you can directly set the parameters of the estimators contained in `steps`.
 
         Returns
         -------
@@ -853,7 +853,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         """Set the parameters of this estimator.
 
         Valid parameter keys can be listed with ``get_params()``. Note that
-        you can directly set the parameters of estimator contained in
+        you can directly set the parameters of the estimators contained in
         `tranformer_list`.
 
         Returns

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -135,7 +135,8 @@ class Pipeline(_BaseComposition):
         """Set the parameters of this estimator.
 
         Valid parameter keys can be listed with ``get_params()``. Note that
-        you can directly set the parameters of the estimators contained in `steps`.
+        you can directly set the parameters of the estimators contained in
+        `steps`.
 
         Returns
         -------


### PR DESCRIPTION
closes #18272 

Improve the documentation in the developer guide to show the impact of the parameter `deep` in `get_params`.
In addition, the documentation of the estimator inherited from `_BaseComposition` is updated to specify which parameters are exposed from which container.
It makes it a bit more explicit.