### PR TITLE
Multiple dtype values example

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -719,6 +719,8 @@ Finally, follow the formatting rules below to make it consistently good:
 
     typed_ndarray : ndarray of shape (n_samples,), dtype=np.int32
 
+    samples : ndarray of shape (n_samples,), dtype={np.int32, np.float32}
+
     sample_weight : array-like of shape (n_samples,), default=None
 
 In general have the following in mind:


### PR DESCRIPTION
#### Reference Issues/PRs
FYI, see  [discussion](https://github.com/scikit-learn/scikit-learn/pull/18251#discussion_r476422667)
Related to #18175 


#### What does this implement/fix? Explain your changes.
Expand the documentation guidelines with an example of how to specify multiple values of the dtype parameter.

