### PR TITLE
DOC Fix default values, shape and dtype for preprocessing._discretization.py

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -329,7 +329,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        Xt : array-like of shape (n_sample, n_features), dtype={int, float}
+        Xt : array-like of shape (n_samples, n_features), dtype={int, float}
             Transformed data in the binned space.
 
         Returns

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -28,10 +28,10 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_bins : int or array-like, shape (n_features,) (default=5)
+    n_bins : int or array-like of shape (n_features,), default=5
         The number of bins to produce. Raises ValueError if ``n_bins < 2``.
 
-    encode : {'onehot', 'onehot-dense', 'ordinal'}, (default='onehot')
+    encode : {'onehot', 'onehot-dense', 'ordinal'}, default='onehot'
         Method used to encode the transformed result.
 
         onehot
@@ -45,7 +45,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         ordinal
             Return the bin identifier encoded as an integer value.
 
-    strategy : {'uniform', 'quantile', 'kmeans'}, (default='quantile')
+    strategy : {'uniform', 'quantile', 'kmeans'}, default='quantile'
         Strategy used to define the widths of the bins.
 
         uniform
@@ -63,11 +63,11 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
     Attributes
     ----------
-    n_bins_ : int array, shape (n_features,)
+    n_bins_ : ndarray of shape (n_features,), dtype=np.int_
         Number of bins per feature. Bins whose width are too small
         (i.e., <= 1e-8) are removed with a warning.
 
-    bin_edges_ : array of arrays, shape (n_features, )
+    bin_edges_ : ndarray of ndarray of shape (n_features,)
         The edges of each bin. Contain arrays of varying shapes ``(n_bins_, )``
         Ignored features will have empty arrays.
 
@@ -137,7 +137,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : numeric array-like, shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features), dtype={int, float}
             Data to be discretized.
 
         y : None
@@ -274,13 +274,14 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : numeric array-like, shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features), dtype={int, float}
             Data to be discretized.
 
         Returns
         -------
-        Xt : numeric array-like or sparse matrix
-            Data in the binned space.
+        Xt : {ndarray, sparse matrix}, dtype={np.float32, np.float64}
+            Data in the binned space. Will be a sparse matrix if
+            `self.encode='onehot'` and ndarray otherwise.
         """
         check_is_fitted(self)
 
@@ -328,12 +329,12 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        Xt : numeric array-like, shape (n_sample, n_features)
+        Xt : array-like of shape (n_sample, n_features), dtype={int, float}
             Transformed data in the binned space.
 
         Returns
         -------
-        Xinv : numeric array-like
+        Xinv : ndarray, dtype={np.float32, np.float64}
             Data in the original feature space.
         """
         check_is_fitted(self)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See #15761

#### What does this implement/fix? Explain your changes.
This PR change how default values are documented in sklearn.preprocessing._discretization.py and update dtype in docstring.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
