### PR TITLE
FIX Fixes cython compile error in 3.0a6

### DIFF
--- a/sklearn/neighbors/_quad_tree.pxd
+++ b/sklearn/neighbors/_quad_tree.pxd
@@ -82,7 +82,7 @@ cdef class _QuadTree:
 
     # Create a summary of the Tree compare to a query point
     cdef long summarize(self, DTYPE_t[3] point, DTYPE_t* results,
-                        float squared_theta=*, int cell_id=*, long idx=*
+                        float squared_theta=*, SIZE_t cell_id=*, long idx=*
                         ) nogil
 
     # Internal cell initialization methods


### PR DESCRIPTION
This is to fix the compiling error in the [travis build](https://travis-ci.org/github/scikit-learn/scikit-learn/builds/722323151?utm_source=github_status&utm_medium=notification) using Cython 3.0a6