### PR TITLE
Fix "GaussianProcessRegressor doesn't work with multidemensional output when normalize_y=True"

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -313,7 +313,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
             fitted with normalize_y =True.
             Only returned when `return_std` is True.
 
-        y_cov : ndarray of shape (n_samples, n_samples, [n_output_dims]), optional
+        y_cov : ndarray of shape (n_samples, n_samples, [n_output_dims]),
+        optional
             Covariance of joint predictive distribution a query points.
             Identical for all output dimensions unless
             fitted with normalize_y =True.

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -357,8 +357,12 @@ def test_y_multioutput():
     assert_almost_equal(y_pred_1d, y_pred_2d[:, 1] / 2)
 
     # Standard deviation and covariance do not depend on output
-    assert_almost_equal(y_std_1d, y_std_2d)
-    assert_almost_equal(y_cov_1d, y_cov_2d)
+    assert_almost_equal(y_std_1d, y_std_2d[:, 0])
+    assert_almost_equal(y_std_1d, y_std_2d[:, 1])
+
+    assert_almost_equal(y_cov_1d, y_cov_2d[:, :, 0])
+    assert_almost_equal(y_cov_1d, y_cov_2d[:, :, 1])
+
 
     y_sample_1d = gpr.sample_y(X2, n_samples=10)
     y_sample_2d = gpr_2d.sample_y(X2, n_samples=10)
@@ -536,3 +540,15 @@ def test_bound_check_fixed_hyperparameter():
                         periodicity_bounds="fixed")  # seasonal component
     kernel = k1 + k2
     GaussianProcessRegressor(kernel=kernel).fit(X, y)
+
+
+def test_y_normalized_multioutput():
+    # Test that GPR can deal with multi-dimensional target values when
+    # output is normalized
+    y_2d = np.vstack((y, y * 2)).T
+    kernel = RBF(length_scale=1.0)
+    gpr_2d = GaussianProcessRegressor(kernel=kernel, optimizer=None,
+                                      normalize_y=True)
+    gpr_2d.fit(X, y_2d)
+    y_pred_2d, y_std_2d = gpr_2d.predict(X2, return_std=True)
+    y_pred_2d, y_std_2d = gpr_2d.predict(X2, return_cov=True)


### PR DESCRIPTION
### Reference Issues/PRs

Fixes #18065

### What does this implement/fix? Explain your changes.

The current GaussianProcessRegressor doesn't work with multidimensional output when normalize_y=True, and either y_std or y_cov is queried.

y_std depends on the std of the target if the target is normalized.
Hence it was necessary to add a dimension to y_std if the target is multidimensional, to allow a different set of values for each of the dimensions of the target.

The same problem arose for y_cov, and was fixed similarly by adding a dimension when the target is multidimensional.

### Any other comments?

My first contribution here. Sorry in advance if I misunderstood any of the guidelines.

I am not sure of what should happen when the target is multidimensional but not normalized (normalize_y=False)
In the hereby submitted code, a dimension is added to y_std and y_cov if the target is multidimensional, regardless of the value of normalize_y.
The drawback is that if normalize_y=False, values of y_std and y_cov will be identical for all values of this new dimension, which seems redundant.