### PR TITLE
MNT Use mypy --allow-redefinition + config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,7 @@ repos:
         # the code is not fully PEP8 compatible
         args: [--select=F401]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.780
+    rev: v0.782
     hooks:
      -  id: mypy
-        args:
-          - --ignore-missing-imports
         files: sklearn/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
       inputs:
         versionSpec: '3.8'
     - bash: |
-        pip install flake8 mypy==0.780
+        pip install flake8 mypy==0.782
       displayName: Install linters
     - bash: |
         set -ex
@@ -49,7 +49,7 @@ jobs:
           echo "Skipping mypy linting"
           exit 0
         else
-          mypy sklearn/ --ignore-missing-imports
+          mypy sklearn/
         fi
       displayName: Run mypy
     - bash: |

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -437,7 +437,7 @@ You can check for common programming errors with the following tools:
   <https://pandas.pydata.org/pandas-docs/stable/development/contributing.html#type-hints>`_
   for style guidelines. Whether you add type annotation or not::
 
-    mypy --ignore-missing-import sklearn
+    mypy sklearn
 
   must not produce new errors in your pull request. Using `# type: ignore`
   annotation can be a workaround for a few cases that are not supported by
@@ -820,7 +820,7 @@ To test code coverage, you need to install the `coverage
 Monitoring performance
 ======================
 
-*This section is heavily inspired from the* `pandas documentation 
+*This section is heavily inspired from the* `pandas documentation
 <https://pandas.pydata.org/docs/development/contributing.html#running-the-performance-test-suite>`_.
 
 When proposing changes to the existing code base, it's important to make sure

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,7 @@ artifact_indexes=
 [flake8]
 # Default flake8 3.5 ignored flags
 ignore=E121,E123,E126,E226,E24,E704,W503,W504
+
+[mypy]
+ignore_missing_imports = True
+allow_redefinition = True

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -812,11 +812,12 @@ def fetch_openml(
         in 'target' are represented as NaN's (numerical target) or None
         (categorical target)
     """
-    data_home = get_data_home(data_home=data_home)
-    data_home = join(data_home, 'openml')
     if cache is False:
         # no caching will be applied
         data_home = None
+    else:
+        data_home = get_data_home(data_home=data_home)
+        data_home = join(data_home, 'openml')
 
     # check valid function arguments. data_id XOR (name, version) should be
     # provided


### PR DESCRIPTION
Several mypy related changes,

 - Makes mypy a bit less restrictive for variable redefinition to address https://github.com/scikit-learn/scikit-learn/issues/16705#issuecomment-683477933 by adding the [`--allow-redefinition`](https://mypy.readthedocs.io/en/latest/command_line.html#cmdoption-mypy-allow-redefinition) option.  For instance, without this flag,
   ```py
   x = [1, 2, 3]
   x.append(2)
   x = set(x)
   ```
   would fail with,
   ```
   error: Incompatible types in assignment (expression has type "Set[int]", variable has type "List[int]")
   ```
   while it doesn't with this flag.
- moves the required mypy flags to `setup.cfg` to make usage a bit more user friendly.
- update to latest mypy version in CI and pre-commit.  
