### PR TITLE
MNT Use version less than 3.0.0 for lightgbm

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -66,7 +66,8 @@ elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
 
     python -m pip install pandas matplotlib pyamg scikit-image
     # do not install dependencies for lightgbm since it requires scikit-learn
-    python -m pip install lightgbm --no-deps
+    # and install a version less than 3.0.0 until the issue #18316 is solved.
+    python -m pip install lightgbm < 3.0.0 --no-deps
 elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     make_conda "python=$PYTHON_VERSION"
     python -m pip install -U pip

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -67,7 +67,7 @@ elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     python -m pip install pandas matplotlib pyamg scikit-image
     # do not install dependencies for lightgbm since it requires scikit-learn
     # and install a version less than 3.0.0 until the issue #18316 is solved.
-    python -m pip install lightgbm < 3.0.0 --no-deps
+    python -m pip install lightgbm<3.0.0 --no-deps
 elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     make_conda "python=$PYTHON_VERSION"
     python -m pip install -U pip

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -67,7 +67,7 @@ elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     python -m pip install pandas matplotlib pyamg scikit-image
     # do not install dependencies for lightgbm since it requires scikit-learn
     # and install a version less than 3.0.0 until the issue #18316 is solved.
-    python -m pip install lightgbm<3.0.0 --no-deps
+    python -m pip install "lightgbm<3.0.0" --no-deps
 elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     make_conda "python=$PYTHON_VERSION"
     python -m pip install -U pip


### PR DESCRIPTION
#### Reference Issues/PRs

See #18316 and https://github.com/scikit-learn/scikit-learn/issues/18316#issuecomment-684776224.

#### What does this implement/fix? Explain your changes.

This PR installs in the CI a version less than `3.0.0` for `lightgbm`.

#### Any other comments?

CC @rth.