### PR TITLE
[MRG] DEP deprecate "mae" criterion in GadientBoosting estimators

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -192,6 +192,11 @@ Changelog
   :class:`ensemble.GradientBoostingRegressor` and returns `1`.
   :pr:`17702` by :user:`Simona Maggio <simonamaggio>`.
 
+- |API|: Mean absolute error ('mae') is now deprecated for the parameter
+  ``criterion`` in :class:`ensemble.GradientBoostingRegressor` and
+  :class:`ensemble.GradientBoostingClassifier`.
+  :pr:`18326` by :user:`Madhura Jayaratne <madhuracj>`.
+
 :mod:`sklearn.exceptions`
 .........................
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -358,6 +358,10 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         """Check that the estimator is initialized, raising an error if not."""
         check_is_fitted(self)
 
+    @abstractmethod
+    def _warn_mae_for_criterion(self):
+        pass
+
     def fit(self, X, y, sample_weight=None, monitor=None):
         """Fit the gradient boosting model.
 
@@ -395,8 +399,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         """
         if self.criterion == 'mae':
             # TODO: This should raise an error from 0.26
-            warnings.warn("criterion='mae' was deprecated in version 0.24 and "
-                          "will be removed in version 0.26.", FutureWarning)
+            self._warn_mae_for_criterion()
 
         # if not warmstart - clear the estimator state
         if not self.warm_start:
@@ -1111,6 +1114,14 @@ shape (n_estimators, ``loss_.K``)
         self.n_classes_ = self._n_classes
         return y
 
+    def _warn_mae_for_criterion(self):
+        # TODO: This should raise an error from 0.26
+        warnings.warn("criterion='mae' was deprecated in version 0.24 and "
+                      "will be removed in version 0.26. Use "
+                      "criterion='friedman_mse' or 'mse' instead, as trees "
+                      "should use a least-square criterion in Gradient "
+                      "Boosting.", FutureWarning)
+
     def decision_function(self, X):
         """Compute the decision function of ``X``.
 
@@ -1613,6 +1624,13 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         if y.dtype.kind == 'O':
             y = y.astype(DOUBLE)
         return y
+
+    def _warn_mae_for_criterion(self):
+        # TODO: This should raise an error from 0.26
+        warnings.warn("criterion='mae' was deprecated in version 0.24 and "
+                      "will be removed in version 0.26. The correct way of "
+                      "minimizing the absolute error is to use loss='lad' "
+                      "instead.", FutureWarning)
 
     def predict(self, X):
         """Predict regression target for X.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -809,7 +809,8 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         .. versionadded:: 0.18
         .. deprecated:: 0.24
             `criterion='mae'` is deprecated and will be removed in version
-            0.26.
+            0.26. Use `criterion='friedman_mse'` or `'mse'` instead, as trees
+            should use a least-square criterion in Gradient Boosting.
 
     min_samples_split : int or float, default=2
         The minimum number of samples required to split an internal node:
@@ -1330,7 +1331,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         .. versionadded:: 0.18
         .. deprecated:: 0.24
             `criterion='mae'` is deprecated and will be removed in version
-            0.26.
+            0.26. The correct way of minimizing the absolute error is to use
+            `loss='lad'` instead.
 
     min_samples_split : int or float, default=2
         The minimum number of samples required to split an internal node:

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -393,6 +393,11 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         -------
         self : object
         """
+        if self.criterion == 'mae':
+            # TODO: This should raise an error from 0.26
+            warnings.warn("criterion='mae' was deprecated in version 0.24 and "
+                          "will be removed in version 0.26.", FutureWarning)
+
         # if not warmstart - clear the estimator state
         if not self.warm_start:
             self._clear_state()
@@ -802,6 +807,9 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         some cases.
 
         .. versionadded:: 0.18
+        .. deprecated:: 0.24
+            `criterion='mae'` is deprecated and will be removed in version
+            0.26.
 
     min_samples_split : int or float, default=2
         The minimum number of samples required to split an internal node:
@@ -1320,6 +1328,9 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         some cases.
 
         .. versionadded:: 0.18
+        .. deprecated:: 0.24
+            `criterion='mae'` is deprecated and will be removed in version
+            0.26.
 
     min_samples_split : int or float, default=2
         The minimum number of samples required to split an internal node:

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1333,3 +1333,17 @@ def test_attr_error_raised_if_not_fitted():
     )
     with pytest.raises(AttributeError, match=msg):
         gbr.n_classes_
+
+
+# TODO: Update in 0.26 to check for the error raised
+@pytest.mark.parametrize('estimator', [
+    GradientBoostingClassifier(criterion='mae'),
+    GradientBoostingRegressor(criterion='mae')
+])
+def test_criterion_mae_deprecation(estimator):
+    # checks whether a deprecation warning is issues when criterion='mae'
+    # is used.
+    msg = ("criterion='mae' was deprecated in version 0.24 and "
+           "will be removed in version 0.26.")
+    with pytest.warns(FutureWarning, match=msg):
+        estimator.fit(X, y)


### PR DESCRIPTION
…oostingRegressor

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixed #18263


#### What does this implement/fix? Explain your changes.
Deprecate criterion='mae' in GradientBoostingClassifier and GradientBoostingRegressor

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
