### PR TITLE
MNT fix pandas error in asv benchmark suite

### DIFF
--- a/asv_benchmarks/benchmarks/datasets.py
+++ b/asv_benchmarks/benchmarks/datasets.py
@@ -55,7 +55,8 @@ def _20newsgroups_lowdim_dataset(n_components=100, ngrams=(1, 1),
 
 @M.cache
 def _mnist_dataset(dtype=np.float32):
-    X, y = fetch_openml('mnist_784', version=1, return_X_y=True)
+    X, y = fetch_openml('mnist_784', version=1, return_X_y=True,
+                        as_frame=False)
     X = X.astype(dtype, copy=False)
     X = MaxAbsScaler().fit_transform(X)
 


### PR DESCRIPTION
A recent change in the `fetch_openml` function makes it output dataframes by default.