### PR TITLE
ENH Break cyclic references in Histogram GBRT

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -188,6 +188,13 @@ Changelog
   method `staged_predict`, which allows monitoring of each stage.
   :pr:`16985` by :user:`Hao Chun Chang <haochunchang>`.
 
+- |Efficiency| break cyclic references in the tree nodes used internally in
+  :class:`ensemble.HistGradientBoostingRegressor` and
+  :class:`ensemble.HistGradientBoostingClassifier` to allow for the timely
+  garbage collection of large intermediate datastructures and to improve memory
+  usage in `fit`. :pr:`18334` by `Olivier Grisel`_ `Nicolas Hug`_, `Thomas
+  Fan`_ and `Andreas Müller`_.
+
 - |API|: The parameter ``n_classes_`` is now deprecated in
   :class:`ensemble.GradientBoostingRegressor` and returns `1`.
   :pr:`17702` by :user:`Simona Maggio <simonamaggio>`.

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -482,7 +482,7 @@ class TreeGrower:
             self.total_find_split_time += time() - tic
 
             # Release memory used by histograms as they are no longer needed
-            # for leaf nodes once the optimal split has been found.
+            # for leaf nodes since they won't be split.
             for child in (left_child_node, right_child_node):
                 if child.is_leaf:
                     del child.histograms

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -39,8 +39,6 @@ class TreeNode:
         The sum of the gradients of the samples at the node.
     sum_hessians : float
         The sum of the hessians of the samples at the node.
-    parent : TreeNode, default=None
-        The parent of the node. None for root.
 
     Attributes
     ----------
@@ -52,8 +50,6 @@ class TreeNode:
         The sum of the gradients of the samples at the node.
     sum_hessians : float
         The sum of the hessians of the samples at the node.
-    parent : TreeNode or None
-        The parent of the node. None for root.
     split_info : SplitInfo or None
         The result of the split evaluation.
     left_child : TreeNode or None
@@ -73,8 +69,6 @@ class TreeNode:
     left_child = None
     right_child = None
     histograms = None
-    sibling = None
-    parent = None
 
     # start and stop indices of the node in the splitter.partition
     # array. Concretely,
@@ -88,13 +82,12 @@ class TreeNode:
     partition_stop = 0
 
     def __init__(self, depth, sample_indices, sum_gradients,
-                 sum_hessians, parent=None, value=None):
+                 sum_hessians, value=None):
         self.depth = depth
         self.sample_indices = sample_indices
         self.n_samples = sample_indices.shape[0]
         self.sum_gradients = sum_gradients
         self.sum_hessians = sum_hessians
-        self.parent = parent
         self.value = value
         self.is_leaf = False
         self.set_children_bounds(float('-inf'), float('+inf'))
@@ -388,19 +381,15 @@ class TreeGrower:
                                    sample_indices_left,
                                    node.split_info.sum_gradient_left,
                                    node.split_info.sum_hessian_left,
-                                   parent=node,
                                    value=node.split_info.value_left,
                                    )
         right_child_node = TreeNode(depth,
                                     sample_indices_right,
                                     node.split_info.sum_gradient_right,
                                     node.split_info.sum_hessian_right,
-                                    parent=node,
                                     value=node.split_info.value_right,
                                     )
 
-        left_child_node.sibling = right_child_node
-        right_child_node.sibling = left_child_node
         node.right_child = right_child_node
         node.left_child = left_child_node
 

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -481,13 +481,13 @@ class TreeGrower:
                 self._compute_best_split_and_push(right_child_node)
             self.total_find_split_time += time() - tic
 
-            # Free memory used by histograms as they are no longer needed for
-            # leaf nodes once the optimal split has been found.
+            # Release memory used by histograms as they are no longer needed
+            # for leaf nodes once the optimal split has been found.
             for child in (left_child_node, right_child_node):
                 if child.is_leaf:
                     del child.histograms
 
-        # Free memory used by histograms as they are no longer needed for
+        # Release memory used by histograms as they are no longer needed for
         # internal nodes once children histograms have been computed.
         del node.histograms
 

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -481,6 +481,16 @@ class TreeGrower:
                 self._compute_best_split_and_push(right_child_node)
             self.total_find_split_time += time() - tic
 
+            # Free memory used by histograms as they are no longer needed for
+            # leaf nodes once the optimal split has been found.
+            for child in (left_child_node, right_child_node):
+                if child.is_leaf:
+                    del child.histograms
+
+        # Free memory used by histograms as they are no longer needed for
+        # internal nodes once children histograms have been computed.
+        del node.histograms
+
         return left_child_node, right_child_node
 
     def _finalize_leaf(self, node):

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -100,30 +100,30 @@ def assert_children_values_bounded(grower, monotonic_cst):
     if monotonic_cst == MonotonicConstraint.NO_CST:
         return
 
-    def recursively_check_children_node_values(node):
+    def recursively_check_children_node_values(node, right_sibling=None):
         if node.is_leaf:
             return
-        if node is not grower.root and node is node.parent.left_child:
-            sibling = node.sibling  # on the right
-            middle = (node.value + sibling.value) / 2
+        if right_sibling is not None:
+            middle = (node.value + right_sibling.value) / 2
             if monotonic_cst == MonotonicConstraint.POS:
                 assert (node.left_child.value <=
                         node.right_child.value <=
                         middle)
-                if not sibling.is_leaf:
+                if not right_sibling.is_leaf:
                     assert (middle <=
-                            sibling.left_child.value <=
-                            sibling.right_child.value)
+                            right_sibling.left_child.value <=
+                            right_sibling.right_child.value)
             else:  # NEG
                 assert (node.left_child.value >=
                         node.right_child.value >=
                         middle)
-                if not sibling.is_leaf:
+                if not right_sibling.is_leaf:
                     assert (middle >=
-                            sibling.left_child.value >=
-                            sibling.right_child.value)
+                            right_sibling.left_child.value >=
+                            right_sibling.right_child.value)
 
-        recursively_check_children_node_values(node.left_child)
+        recursively_check_children_node_values(node.left_child,
+                                               right_sibling=node.right_child)
         recursively_check_children_node_values(node.right_child)
 
     recursively_check_children_node_values(grower.root)


### PR DESCRIPTION
Resolves #18152
This is an alternative to #18163 and #18242 

This is a minimal fix to:

- break the cyclic references that cause the GC to fail to collect all the TreeNode instances (and there histogram attributes) for all the TreeGrower instances (as an alternative to the manual memory management workaround implemented in #18242).
- early delete the references to the histograms attribute of each `TreeNode` instance as soon as no longer needed (as done in #18163).

For the reproducer snippet of #18242:

```python
from sklearn.datasets import make_classification
from sklearn.experimental import enable_hist_gradient_boosting
from sklearn.ensemble import HistGradientBoostingClassifier
from memory_profiler import memory_usage

X, y = make_classification(n_classes=2,
                           n_samples=10_000,
                           n_features=400,
                           random_state=0)

hgb = HistGradientBoostingClassifier(
    max_iter=100,
    max_leaf_nodes=127,
    learning_rate=.1,
    random_state=0,
    verbose=1,
)

mems = memory_usage((hgb.fit, (X, y)))
print(f"{max(mems):.2f}, {max(mems) - min(mems):.2f} MB")
```

I get:

```
Fit 100 trees in 36.711 s, (12700 total leaves)
Time spent computing histograms: 28.150s
Time spent finding best splits:  5.183s
Time spent applying splits:      1.046s
Time spent predicting:           0.016s
282.35, 144.09 MB
```

(instead of 6GB+ on master).