### PR TITLE
[MRG] MNT Initialize histograms in parallel and don't call np.zero in Hist-GBDT

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -198,8 +198,9 @@ Changelog
 - |Efficiency| Histogram initialization is now done in parallel in
   :class:`ensemble.HistGradientBoostingRegressor` and
   :class:`ensemble.HistGradientBoostingClassifier` which results in speed
-  improvement for problems that build a lot of nodes.
-  :pr:`18341` by `Olivier Grisel`_, `Nicolas Hug`_, `Thomas Fan`_.
+  improvement for problems that build a lot of nodes on multicore machines.
+  :pr:`18341` by `Olivier Grisel`_, `Nicolas Hug`_, `Thomas Fan`_, and
+  :user:`Egor Smirnov <SmirnovEgorRu>`.
 
 - |API|: The parameter ``n_classes_`` is now deprecated in
   :class:`ensemble.GradientBoostingRegressor` and returns `1`.

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -199,7 +199,7 @@ Changelog
   :class:`ensemble.HistGradientBoostingRegressor` and
   :class:`ensemble.HistGradientBoostingClassifier` which results in speed
   improvement for problems that build a lot of nodes.
-   :pr:`18341` by `Olivier Grisel`_, `Nicolas Hug`_, `Thomas Fan`_.
+  :pr:`18341` by `Olivier Grisel`_, `Nicolas Hug`_, `Thomas Fan`_.
 
 - |API|: The parameter ``n_classes_`` is now deprecated in
   :class:`ensemble.GradientBoostingRegressor` and returns `1`.

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -195,6 +195,12 @@ Changelog
   usage in `fit`. :pr:`18334` by `Olivier Grisel`_ `Nicolas Hug`_, `Thomas
   Fan`_ and `Andreas Müller`_.
 
+- |Efficiency| Histogram initialization is now done in parallel in
+  :class:`ensemble.HistGradientBoostingRegressor` and
+  :class:`ensemble.HistGradientBoostingClassifier` which results in speed
+  improvement for problems that build a lot of nodes.
+   :pr:`18341` by `Olivier Grisel`_, `Nicolas Hug`_, `Thomas Fan`_.
+
 - |API|: The parameter ``n_classes_`` is now deprecated in
   :class:`ensemble.GradientBoostingRegressor` and returns `1`.
   :pr:`17702` by :user:`Simona Maggio <simonamaggio>`.

--- a/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
@@ -132,7 +132,7 @@ cdef class HistogramBuilder:
             G_H_DTYPE_C [::1] gradients = self.gradients
             G_H_DTYPE_C [::1] ordered_hessians = self.ordered_hessians
             G_H_DTYPE_C [::1] hessians = self.hessians
-            hist_struct [:, ::1] histograms = np.zeros(
+            hist_struct [:, ::1] histograms = np.empty(
                 shape=(self.n_features, self.n_bins),
                 dtype=HISTOGRAM_DTYPE
             )
@@ -177,6 +177,12 @@ cdef class HistogramBuilder:
                 self.ordered_hessians[:n_samples]
             unsigned char hessians_are_constant = \
                 self.hessians_are_constant
+            unsigned int bin_idx = 0
+        
+        for bin_idx in range(self.n_bins):
+            histograms[feature_idx, bin_idx].sum_gradients = 0.
+            histograms[feature_idx, bin_idx].sum_hessians = 0.
+            histograms[feature_idx, bin_idx].count = 0
 
         if root_node:
             if hessians_are_constant:
@@ -227,7 +233,7 @@ cdef class HistogramBuilder:
         cdef:
             int feature_idx
             int n_features = self.n_features
-            hist_struct [:, ::1] histograms = np.zeros(
+            hist_struct [:, ::1] histograms = np.empty(
                 shape=(self.n_features, self.n_bins),
                 dtype=HISTOGRAM_DTYPE
             )

--- a/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
@@ -132,6 +132,7 @@ cdef class HistogramBuilder:
             G_H_DTYPE_C [::1] gradients = self.gradients
             G_H_DTYPE_C [::1] ordered_hessians = self.ordered_hessians
             G_H_DTYPE_C [::1] hessians = self.hessians
+            # Histograms will be initialized to zero later within a prange
             hist_struct [:, ::1] histograms = np.empty(
                 shape=(self.n_features, self.n_bins),
                 dtype=HISTOGRAM_DTYPE


### PR DESCRIPTION
To keep things more unitary, this PR extracts out the histogram initialization from https://github.com/scikit-learn/scikit-learn/pull/18242 which was already proposed in https://github.com/scikit-learn/scikit-learn/pull/14392

Memory usage is the same as in master but runs in 40s instead of 45s (across many runs) on the following benchmarks on my laptop (4 threads):


```py
from sklearn.datasets import make_classification
from sklearn.experimental import enable_hist_gradient_boosting
from sklearn.ensemble import HistGradientBoostingClassifier
from memory_profiler import memory_usage

X, y = make_classification(n_classes=5,
                           n_samples=3_000,
                           n_features=400,
                           random_state=0,
                           n_clusters_per_class=1,
                           n_informative=5)

hgb = HistGradientBoostingClassifier(
    max_iter=100,
    max_leaf_nodes=256,
    learning_rate=.1,
    random_state=0,
    verbose=1,
)

mems = memory_usage((hgb.fit, (X, y)))
print(f"{max(mems):.2f}, {max(mems) - min(mems):.2f} MB")
```

Other benchmarks welcome, especially one with 88 hyperthreads as in https://github.com/scikit-learn/scikit-learn/pull/14392#issuecomment-512345250.

CC @ogrisel @thomasjpfan 