### PR TITLE
DOC Add icc-build commit message marker to documentation

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -485,7 +485,7 @@ message, the following actions are taken.
     [ci skip]              CI is skipped completely
     [lint skip]            Azure pipeline skips linting
     [scipy-dev]            Add a Travis build with our dependencies (numpy, scipy, etc ...) development builds
-    [icc-build]            Add a Travis build for the Intel C compiler
+    [icc-build]            Add a Travis build with the Intel C compiler (ICC)
     [arm64]                Add a Travis build for the ARM64 / aarch64 little endian architecture
     [doc skip]             Docs are not built
     [doc quick]            Docs built, but excludes example gallery plots

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -485,6 +485,7 @@ message, the following actions are taken.
     [ci skip]              CI is skipped completely
     [lint skip]            Azure pipeline skips linting
     [scipy-dev]            Add a Travis build with our dependencies (numpy, scipy, etc ...) development builds
+    [icc-build]            Add a Travis build for the Intel C compiler
     [arm64]                Add a Travis build for the ARM64 / aarch64 little endian architecture
     [doc skip]             Docs are not built
     [doc quick]            Docs built, but excludes example gallery plots


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR add the `[icc-build]` commit message marker to the documentation (`doc/developers/contributing.rst` file).