### PR TITLE
DOC Remove signature from base and mixin classes in API Reference

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -23,6 +23,7 @@ Base classes
 .. currentmodule:: sklearn
 
 .. autosummary::
+   :nosignatures:
    :toctree: generated/
    :template: class.rst
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR removes the class signature from base and mixing classes in the API Reference section of the documentation.

#### Any other comments?

`stable`

<img width="618" alt="Captura de pantalla 2020-09-04 a las 18 38 42" src="https://user-images.githubusercontent.com/32649176/92264046-e24b7300-eedd-11ea-9cd8-248909335b39.png">

`dev`

<img width="618" alt="Captura de pantalla 2020-09-04 a las 18 34 40" src="https://user-images.githubusercontent.com/32649176/92263949-bf20c380-eedd-11ea-955f-2c2b37eba507.png">

`This PR`

<img width="618" alt="Captura de pantalla 2020-09-04 a las 18 39 56" src="https://user-images.githubusercontent.com/32649176/92264140-0eff8a80-eede-11ea-9e90-a54bc52f59cc.png">