### PR TITLE
DOC cleaned descriptive paragraph for linear regression example

### DIFF
--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -5,7 +5,7 @@
 =========================================================
 Linear Regression Example
 =========================================================
-The example below uses only the first feature of the `diabetes` dataset, 
+The example below uses only the first feature of the `diabetes` dataset,
 in order to illustrate the data points within the two-dimensional plot. 
 The straight line can be seen in the plot, showing how linear regression 
 attempts to draw a straight line that will best minimize the residual sum of squares 

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -14,8 +14,6 @@ and the responses predicted by the linear approximation.
 
 The coefficients, residual sum of squares and the coefficient of
 determination are also calculated.
-
-
 """
 print(__doc__)
 

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -8,11 +8,11 @@ Linear Regression Example
 The example below uses only the first feature of the `diabetes` dataset,
 in order to illustrate the data points within the two-dimensional plot.
 The straight line can be seen in the plot, showing how linear regression
-attempts to draw a straight line that will best minimize the 
+attempts to draw a straight line that will best minimize the
 residual sum of squares between the observed responses in the dataset,
 and the responses predicted by the linear approximation.
 
-The coefficients, residual sum of squares and the coefficient of 
+The coefficients, residual sum of squares and the coefficient of
 determination are also calculated.
 
 

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -6,12 +6,14 @@
 Linear Regression Example
 =========================================================
 The example below uses only the first feature of the `diabetes` dataset,
-in order to illustrate the data points within the two-dimensional plot. 
-The straight line can be seen in the plot, showing how linear regression 
-attempts to draw a straight line that will best minimize the residual sum of squares 
-between the observed responses in the dataset, and the responses predicted by the linear approximation.
+in order to illustrate the data points within the two-dimensional plot.
+The straight line can be seen in the plot, showing how linear regression
+attempts to draw a straight line that will best minimize the 
+residual sum of squares between the observed responses in the dataset,
+and the responses predicted by the linear approximation.
 
-The coefficients, residual sum of squares and the coefficient of determination are also calculated.
+The coefficients, residual sum of squares and the coefficient of 
+determination are also calculated.
 
 
 """

--- a/examples/linear_model/plot_ols.py
+++ b/examples/linear_model/plot_ols.py
@@ -5,15 +5,14 @@
 =========================================================
 Linear Regression Example
 =========================================================
-This example uses the only the first feature of the `diabetes` dataset, in
-order to illustrate a two-dimensional plot of this regression technique. The
-straight line can be seen in the plot, showing how linear regression attempts
-to draw a straight line that will best minimize the residual sum of squares
-between the observed responses in the dataset, and the responses predicted by
-the linear approximation.
+The example below uses only the first feature of the `diabetes` dataset, 
+in order to illustrate the data points within the two-dimensional plot. 
+The straight line can be seen in the plot, showing how linear regression 
+attempts to draw a straight line that will best minimize the residual sum of squares 
+between the observed responses in the dataset, and the responses predicted by the linear approximation.
 
-The coefficients, the residual sum of squares and the coefficient
-of determination are also calculated.
+The coefficients, residual sum of squares and the coefficient of determination are also calculated.
+
 
 """
 print(__doc__)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Updated the Linear regression example documentation. The original documentation had
duplicated work "the" and following sentence seemed choppy therefore modified to a more
appealing tone.

