### PR TITLE
DOC Fix documentation of default values in sklearn.utils._mocking.py

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -599,7 +599,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         will be removed from the resulting tokens.
         Only applies if ``analyzer == 'word'``.
 
-    token_pattern : string
+    token_pattern : string, default=r"(?u)\b\w\w+\b"
         Regular expression denoting what constitutes a "token", only used
         if ``analyzer == 'word'``. The default regexp selects tokens of 2
         or more alphanumeric characters (punctuation is completely ignored

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -599,7 +599,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         will be removed from the resulting tokens.
         Only applies if ``analyzer == 'word'``.
 
-    token_pattern : string, default=r"(?u)\b\w\w+\b"
+    token_pattern : string
         Regular expression denoting what constitutes a "token", only used
         if ``analyzer == 'word'``. The default regexp selects tokens of 2
         or more alphanumeric characters (punctuation is completely ignored

--- a/sklearn/utils/_mocking.py
+++ b/sklearn/utils/_mocking.py
@@ -168,7 +168,7 @@ class CheckingClassifier(ClassifierMixin, BaseEstimator):
 
         y : array-like of shape (n_samples, n_output) or (n_samples,), default=None
             Target relative to X for classification or regression;
-            None is for unsupervised learning.
+            None for unsupervised learning.
 
         **fit_params : dict of string -> object
             Parameters passed to the ``fit`` method of the estimator

--- a/sklearn/utils/_mocking.py
+++ b/sklearn/utils/_mocking.py
@@ -166,9 +166,9 @@ class CheckingClassifier(ClassifierMixin, BaseEstimator):
             Training vector, where n_samples is the number of samples and
             n_features is the number of features.
 
-        y : array-like of shape (n_samples, n_output) or (n_samples,), optional
+        y : array-like of shape (n_samples, n_output) or (n_samples,), default=None
             Target relative to X for classification or regression;
-            None for unsupervised learning.
+            None is for unsupervised learning.
 
         **fit_params : dict of string -> object
             Parameters passed to the ``fit`` method of the estimator

--- a/sklearn/utils/_mocking.py
+++ b/sklearn/utils/_mocking.py
@@ -166,9 +166,10 @@ class CheckingClassifier(ClassifierMixin, BaseEstimator):
             Training vector, where n_samples is the number of samples and
             n_features is the number of features.
 
-        y : array-like of shape (n_samples, n_output) or (n_samples,), default=None
+        y : array-like of shape (n_samples, n_output) or (n_samples,), \
+        default=None
             Target relative to X for classification or regression;
-            None is for unsupervised learning.
+            None for unsupervised learning.
 
         **fit_params : dict of string -> object
             Parameters passed to the ``fit`` method of the estimator

--- a/sklearn/utils/_mocking.py
+++ b/sklearn/utils/_mocking.py
@@ -166,7 +166,8 @@ class CheckingClassifier(ClassifierMixin, BaseEstimator):
             Training vector, where n_samples is the number of samples and
             n_features is the number of features.
 
-        y : array-like of shape (n_samples, n_output) or (n_samples,), default=None
+        y : array-like of shape (n_samples, n_outputs) or (n_samples,), \
+                default=None
             Target relative to X for classification or regression;
             None for unsupervised learning.
 


### PR DESCRIPTION
#### Reference Issues/PRs
Partially addresses #15761

#### What does this implement/fix? Explain your changes.

Added one default=None where needed

#### Any other comments?

It is not in the public API as I understand but it may still help. 
 It is also the last file left from sklearn.utils so it can be check from @alfaro96 's checklist.
