### PR TITLE
sklearn.metrics.silhouette_score function negative labels 

### DIFF
--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -65,6 +65,7 @@ def silhouette_score(X, labels, *, metric='euclidean', sample_size=None,
 
     labels : array-like of shape (n_samples,)
         Predicted labels for each sample.
+        The labels should be greater than or equal to 0.
 
     metric : str or callable, default='euclidean'
         The metric to use when calculating distance between instances in a


### PR DESCRIPTION
fixes #18350 

Added a line in the documentation page of sklearn.metrics.silhouette_score function specifying that values of labels should be greater than 0.
 Documentation Page: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.silhouette_score.html