### PR TITLE
DOC Update doc for LinearSVC and supported loss with l1 penalty

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -453,7 +453,7 @@ Tips on Practical Use
     set to ``False`` the underlying implementation of :class:`LinearSVC` is
     not random and ``random_state`` has no effect on the results.
 
-  * Using L1 penalization as provided by ``LinearSVC(loss='l2', penalty='l1',
+  * Using L1 penalization as provided by ``LinearSVC(loss='squared_hinge', penalty='l1',
     dual=False)`` yields a sparse solution, i.e. only a subset of feature
     weights is different from zero and contribute to the decision function.
     Increasing ``C`` yields a more complex model (more features are selected).

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -453,7 +453,7 @@ Tips on Practical Use
     set to ``False`` the underlying implementation of :class:`LinearSVC` is
     not random and ``random_state`` has no effect on the results.
 
-  * Using L1 penalization as provided by ``LinearSVC(loss='squared_hinge', penalty='l1',
+  * Using L1 penalization as provided by ``LinearSVC(penalty='l1',
     dual=False)`` yields a sparse solution, i.e. only a subset of feature
     weights is different from zero and contribute to the decision function.
     Increasing ``C`` yields a more complex model (more features are selected).


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #18320


#### What does this implement/fix? Explain your changes.
Documentation for LinearSVC is wrong for the loss function used with 'l1' penalty, currently is say to use l2 loss function.
Changed to use squared_hinge loss function.
.../doc/modules/svm.rst
LinearSVC(loss='squared_hinge', penalty='l1', dual=False)


#### Any other comments?
