### PR TITLE
[MRG] Nearest Centroid Divide by Zero Fix

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -488,7 +488,7 @@ Changelog
 
 - |Fix| :class:`neighbors.NearestCentroid` with a numerical `shrink_threshold`
   will raise a `ValueError` when fitting on data with all constant features.
-  :pr:`18370` by :user:`Trevor Waite <Trevor-Waite>`.
+  :pr:`18370` by :user:`Trevor Waite <trewaite>`.
 
 :mod:`sklearn.neural_network`
 .............................

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -486,6 +486,11 @@ Changelog
   the data intrinsic dimensionality is too high for tree-based methods.
   :pr:`17148` by :user:`Geoffrey Bolmier <gbolmier>`.
 
+- |Fix| :class:`neighbors.NearestCentroid` calling ``fit`` method on an ``X`` 
+  vector with all features having zero variance will raise ``ValueError`` 
+  preventing divde by zero error downstream. 
+  :pr:`18370` by :user:`Trevor Waite <Trevor-Waite>`.
+
 :mod:`sklearn.neural_network`
 .............................
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -486,9 +486,8 @@ Changelog
   the data intrinsic dimensionality is too high for tree-based methods.
   :pr:`17148` by :user:`Geoffrey Bolmier <gbolmier>`.
 
-- |Fix| :class:`neighbors.NearestCentroid` calling ``fit`` method on an ``X`` 
-  vector with all features having zero variance will raise ``ValueError`` 
-  preventing divde by zero error downstream. 
+- |Fix| :class:`neighbors.NearestCentroid` with a numerical `shrink_threshold`
+  will raise a `ValueError` when fitting on data with all constant features.
   :pr:`18370` by :user:`Trevor Waite <Trevor-Waite>`.
 
 :mod:`sklearn.neural_network`

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -154,7 +154,7 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
                 self.centroids_[cur_class] = X[center_mask].mean(axis=0)
 
         if self.shrink_threshold:
-            if np.ptp(X).sum() == 0:
+            if np.ptp(X, axis=0).sum() == 0:
                 raise ValueError("All features have zero variance. "
                                  "Division by zero.")
             dataset_centroid_ = np.mean(X, axis=0)

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -146,7 +146,6 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
                 else:
                     self.centroids_[cur_class] = csc_median_axis_0(X[center_mask])
             else:
-                \]
                 if self.metric != 'euclidean':
                     warnings.warn("Averaging for metrics other than "
                                   "euclidean and manhattan not supported. "

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -146,6 +146,7 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
                 else:
                     self.centroids_[cur_class] = csc_median_axis_0(X[center_mask])
             else:
+                \]
                 if self.metric != 'euclidean':
                     warnings.warn("Averaging for metrics other than "
                                   "euclidean and manhattan not supported. "
@@ -161,6 +162,9 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
             # Calculate deviation using the standard deviation of centroids.
             variance = (X - self.centroids_[y_ind]) ** 2
             variance = variance.sum(axis=0)
+            if np.sum(variance) == 0:
+                raise ValueError("All features have zero variance. "
+                                 "Division by zero.")
             s = np.sqrt(variance / (n_samples - n_classes))
             s += np.median(s)  # To deter outliers from affecting the results.
             mm = m.reshape(len(m), 1)  # Reshape to allow broadcasting.

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -154,7 +154,7 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
                 self.centroids_[cur_class] = X[center_mask].mean(axis=0)
 
         if self.shrink_threshold:
-            if np.ptp(X, axis=0).sum() == 0:
+            if np.all(np.ptp(X, axis=0) == 0):
                 raise ValueError("All features have zero variance. "
                                  "Division by zero.")
             dataset_centroid_ = np.mean(X, axis=0)

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -154,6 +154,9 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
                 self.centroids_[cur_class] = X[center_mask].mean(axis=0)
 
         if self.shrink_threshold:
+            if np.ptp(X).sum() == 0:
+                raise ValueError("All features have zero variance. "
+                                 "Division by zero.")
             dataset_centroid_ = np.mean(X, axis=0)
 
             # m parameter for determining deviation
@@ -161,9 +164,6 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
             # Calculate deviation using the standard deviation of centroids.
             variance = (X - self.centroids_[y_ind]) ** 2
             variance = variance.sum(axis=0)
-            if np.sum(variance) == 0:
-                raise ValueError("All features have zero variance. "
-                                 "Division by zero.")
             s = np.sqrt(variance / (n_samples - n_classes))
             s += np.median(s)  # To deter outliers from affecting the results.
             mm = m.reshape(len(m), 1)  # Reshape to allow broadcasting.

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -146,3 +146,12 @@ def test_manhattan_metric():
     clf.fit(X_csr, y)
     assert_array_equal(clf.centroids_, dense_centroid)
     assert_array_equal(dense_centroid, [[-1, -1], [1, 1]])
+
+def test_features_zero_var():
+    # Test that features with 0 variance throw error
+
+    X = np.array([[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]])
+    y = np.array([1, 0, 0, 1, 0])
+    clf = NearestCentroid(shrink_threshold=0.1)
+    with assert_raises(ValueError):
+        clf.fit(X, y)

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -155,3 +155,4 @@ def test_features_zero_var():
     clf = NearestCentroid(shrink_threshold=0.1)
     with assert_raises(ValueError):
         clf.fit(X, y)
+        

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -147,6 +147,7 @@ def test_manhattan_metric():
     assert_array_equal(clf.centroids_, dense_centroid)
     assert_array_equal(dense_centroid, [[-1, -1], [1, 1]])
 
+
 def test_features_zero_var():
     # Test that features with 0 variance throw error
 
@@ -155,4 +156,3 @@ def test_features_zero_var():
     clf = NearestCentroid(shrink_threshold=0.1)
     with assert_raises(ValueError):
         clf.fit(X, y)
-        

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -151,8 +151,9 @@ def test_manhattan_metric():
 def test_features_zero_var():
     # Test that features with 0 variance throw error
 
-    X = np.array([[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]])
-    y = np.array([1, 0, 0, 1, 0])
+    X = np.empty((10, 2))
+    X[:, 0] = -0.13725701
+    X[:, 1] = -0.9853293
     clf = NearestCentroid(shrink_threshold=0.1)
     with assert_raises(ValueError):
         clf.fit(X, y)

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -154,6 +154,9 @@ def test_features_zero_var():
     X = np.empty((10, 2))
     X[:, 0] = -0.13725701
     X[:, 1] = -0.9853293
+    y = np.zeros((10))
+    y[0] = 1
+
     clf = NearestCentroid(shrink_threshold=0.1)
     with assert_raises(ValueError):
         clf.fit(X, y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
#18324



#### What does this implement/fix? Explain your changes.
Checks to see if X features are all 0 variance. If so, raises value error and will avoid divide by 0. 

#### Any other comments?
Not sure if this is desired behavior but seems like best way to handle, let me know if the error message is specific enough. 