### PR TITLE
DOC mean_precision_prior attribute documentation of class BayesianGaussianMixture

### DIFF
--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -259,6 +259,13 @@ class BayesianGaussianMixture(BaseMixture):
         The dirichlet concentration of each component on the weight
         distribution (Dirichlet).
 
+    mean_precision_prior : float | None, default=None.
+        The precision prior on the mean distribution (Gaussian).
+        Controls the extent of where means can be placed. Larger
+        values concentrate the cluster means around `mean_prior`.
+        The value of this attribute must be greater than 0.
+        If it is None, it is set to 1.
+
     mean_precision_prior_ : float
         The precision prior on the mean distribution (Gaussian).
         Controls the extent of where means can be placed.


### PR DESCRIPTION
#### Reference Issues/PRs
References #14312


#### What does this implement/fix? Explain your changes.
Documents the attribute mean_precision_prior in class BayesianGaussianMixture


#### Any other comments?
I copied the documentation with minor changes from the mean_precision_prior parameter documentation as this parameter is assigned to the mean_precision_prior attribute without introducing changes.
