### PR TITLE
ADD: krippendorff alpha score

### DIFF
--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -34,6 +34,7 @@ from ._classification import recall_score
 from ._classification import zero_one_loss
 from ._classification import brier_score_loss
 from ._classification import multilabel_confusion_matrix
+from ._classification import krippendorff_alpha_score
 
 from . import cluster
 from .cluster import adjusted_mutual_info_score
@@ -163,4 +164,5 @@ __all__ = [
     'v_measure_score',
     'zero_one_loss',
     'brier_score_loss',
+    'krippendorff_alpha_score',
 ]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This is my first PR in this project. I'm trying to add a function to calculate Inter-Rater Reliability (IRR). I realize IRR calculation provided by sklearn/metrics/_classification.py (_Cohen kappa score_) only able explain agreement between 2 Raters.

After looking for some other methods, I found that _Krippendorff's alpha_ is more suitable method to calculate agreement multiple Raters (more than 2) base on level of measurement (nominal, interval, ordinal or ratio data). This method also able to explain inverse agreement between Raters and make calculation even there are some missing values in given data.

#### Any other comments?

I try to implement the algorithm base on formulas in ["Computing Krippendorff's Alpha-Reliability"](https://repository.upenn.edu/asc_papers/43/). I've tested the result in my local using the examples in ["Calculating inter-coder reliability in media content analysisusing Krippendorff’s Alpha"](https://www.polcomm.org/wp-content/uploads/ICR01022012.pdf) and some other example, than compare the result with the output using library [krippendorff](https://pypi.org/project/krippendorff/) as baseline. The result between these 2 algorithm almost always the same, at least until 5 number behind comma. 
I've also run stress test by given the input data consist 10000 Raters and 10000 units labels (random int 0 to 10) for each Rater (10000x10000 matrix). Stress test result showed that this algorithm have much faster execution time compare to the baseline algorithm in my local (on average 10s compare to baseline 120s).

Please give me a feedback if there is something I can improve or change, thank you before.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
