### PR TITLE
Prevent division by zero in GPR when y_train is constant

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -198,7 +198,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
             self._y_train_std = np.std(y, axis=0)
 
             # Remove mean and make unit variance
-            # Moreover, add a very small number to the y_train.std to avoid a divide by zero error.
+            # Moreover, add a very small number to the y_train.std to
+            # avoid a divide by zero error.
             y = (y - self._y_train_mean) / (self._y_train_std + 1E-19)
 
         else:

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -200,7 +200,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
             # Remove mean and make unit variance
             # Moreover, add a very small number to the y_train.std to
             # avoid a divide by zero error.
-            if self._y_train_std == 0:
+            if self._y_train_std.all() == 0:
                 y = (y - self._y_train_mean) / (self._y_train_std + 1E-19)
             else:
                 y = (y - self._y_train_mean) / self._y_train_std

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -196,14 +196,13 @@ class GaussianProcessRegressor(MultiOutputMixin,
         if self.normalize_y:
             self._y_train_mean = np.mean(y, axis=0)
             self._y_train_std = np.std(y, axis=0)
-            # assign _y_train.std to 1 when _y_train.std is zero
-            # to avoid divide by zero error
+            # Assign a standard deviation of one to constant
+            # targets for avoiding division by zero errors
             if np.iterable(self._y_train_std):
-                self._y_train_std = np.asarray(
-                        [std if std else 1 for std in self._y_train_std])
+                self._y_train_std[self._y_train_std == 0] = 1
             else:
-                self._y_train_std = \
-                    self._y_train_std if self._y_train_std else 1
+                self._y_train_std = (
+                    self._y_train_std if self._y_train_std!=0 else 1)
             # Remove mean and make unit variance
             y = (y - self._y_train_mean) / self._y_train_std
         else:

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -196,14 +196,16 @@ class GaussianProcessRegressor(MultiOutputMixin,
         if self.normalize_y:
             self._y_train_mean = np.mean(y, axis=0)
             self._y_train_std = np.std(y, axis=0)
-
-            # Remove mean and make unit variance
-            # Moreover, add a very small number to the y_train.std to
-            # avoid a divide by zero error.
-            if self._y_train_std.all() == 0:
-                y = (y - self._y_train_mean) / (self._y_train_std + 1E-19)
+            # assign _y_train.std to 1 when _y_train.std is zero
+            # to avoid divide by zero error
+            if np.iterable(self._y_train_std):
+                self._y_train_std = np.asarray(
+                        [std if std else 1 for std in self._y_train_std])
             else:
-                y = (y - self._y_train_mean) / self._y_train_std
+                self._y_train_std = \
+                    self._y_train_std if self._y_train_std else 1
+            # Remove mean and make unit variance
+            y = (y - self._y_train_mean) / self._y_train_std
         else:
             self._y_train_mean = np.zeros(1)
             self._y_train_std = 1

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -202,7 +202,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 self._y_train_std[self._y_train_std == 0] = 1
             else:
                 self._y_train_std = (
-                    self._y_train_std if self._y_train_std!=0 else 1)
+                    self._y_train_std if self._y_train_std != 0 else 1)
             # Remove mean and make unit variance
             y = (y - self._y_train_mean) / self._y_train_std
         else:

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -200,8 +200,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
             # Remove mean and make unit variance
             # Moreover, add a very small number to the y_train.std to
             # avoid a divide by zero error.
-            y = (y - self._y_train_mean) / (self._y_train_std + 1E-19)
-
+            if self._y_train_std == 0:
+                y = (y - self._y_train_mean) / (self._y_train_std + 1E-19)
+            else:
+                y = (y - self._y_train_mean) / self._y_train_std
         else:
             self._y_train_mean = np.zeros(1)
             self._y_train_std = 1

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -198,7 +198,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
             self._y_train_std = np.std(y, axis=0)
 
             # Remove mean and make unit variance
-            y = (y - self._y_train_mean) / self._y_train_std
+            # Moreover, add a very small number to the y_train.std to avoid a divide by zero error.
+            y = (y - self._y_train_mean) / (self._y_train_std + 1E-19)
 
         else:
             self._y_train_mean = np.zeros(1)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -536,3 +536,16 @@ def test_bound_check_fixed_hyperparameter():
                         periodicity_bounds="fixed")  # seasonal component
     kernel = k1 + k2
     GaussianProcessRegressor(kernel=kernel).fit(X, y)
+
+@pytest.mark.parametrize('kernel', kernels)
+def test_constant_target(kernel):
+    # Test for constant target(s), the private _y_train_std attribute has
+    # a standard deviation of 1 instead of 0
+    gpr = GaussianProcessRegressor(kernel=kernel, normalize_y=True)
+    #create a constant targets of 2
+    y = np.full((1,X.shape[0]),2).ravel()
+    expected_std = np.full((1,X.shape[0]),1).ravel()
+    gpr.fit(X, y)
+    _y_train_std = gpr._y_train_std
+
+    assert_array_equal(_y_train_std,expected_std)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -537,15 +537,16 @@ def test_bound_check_fixed_hyperparameter():
     kernel = k1 + k2
     GaussianProcessRegressor(kernel=kernel).fit(X, y)
 
+
 @pytest.mark.parametrize('kernel', kernels)
 def test_constant_target(kernel):
     # Test for constant target(s), the private _y_train_std attribute has
     # a standard deviation of 1 instead of 0
     gpr = GaussianProcessRegressor(kernel=kernel, normalize_y=True)
-    #create a constant targets of 2
-    y = np.full((1,X.shape[0]),2).ravel()
-    expected_std = np.full((1,X.shape[0]),1).ravel()
+    # create a constant targets of 2
+    y = np.full((1, X.shape[0]), 2).ravel()
+    expected_std = np.full((1, X.shape[0]), 1).ravel()
     gpr.fit(X, y)
     _y_train_std = gpr._y_train_std
 
-    assert_array_equal(_y_train_std,expected_std)
+    assert_array_equal(_y_train_std, expected_std)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #18318
Regression in GP standard deviation where y_train.std() == 0
The normalize_y=True option which is used now divides out the standard deviation of the y data, not just subtracting the mean. When there is just one data point, this results in a NaN

#### What does this implement/fix? Explain your changes.
Add a very small number to the y_train.std to avoid a divide by zero error.

#### Any other comments?


