### PR TITLE
[MRG] Added option to return raw predictions from cross_validate

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -156,8 +156,10 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
         .. versionadded:: 0.20
 
     return_predictions : {'predict_proba', 'predict'}, default=None
-        Return cross-validation predictions for the dataset. 'predict' returns
-        the predictions whereas 'predict_proba' returns class probabilities.
+        What predictions to return. If 'predict', return output of
+        :term:`predict` and if 'predict_proba', return output of
+        :term:`predict_proba`.
+        If None, do not return predictions.
 
         .. versionadded:: 0.24
 
@@ -546,8 +548,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         Whether to return the fitted estimator.
 
     return_predictions : {'predict_proba', 'predict'}, default=None
-        Return cross-validation predictions for the dataset. 'predict' returns
-        the predictions whereas 'predict_proba' returns class probabilities.
+        What predictions to return. If 'predict', return output of
+        :term:`predict` and if 'predict_proba', return output of
+        :term:`predict_proba`. The test set indices are also returned under a
+        separate dict key.
+        If None, do not return predictions or test data indices.
 
     Returns
     -------
@@ -569,11 +574,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
             The fitted estimator.
         fit_failed : bool
             The estimator failed to fit.
-        test_indices : int
-            Indices of cv split test set
+        test_indices : array-like of shape (n_test_samples,)
+            Indices of test samples.
         predictions : float
             Predicted class or predicted class probability of
-            cv split test set
+            test samples.
     """
     progress_msg = ""
     if verbose > 2:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -41,7 +41,8 @@ __all__ = ['cross_validate', 'cross_val_score', 'cross_val_predict',
 def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
                    n_jobs=None, verbose=0, fit_params=None,
                    pre_dispatch='2*n_jobs', return_train_score=False,
-                   return_estimator=False, error_score=np.nan):
+                   return_estimator=False, error_score=np.nan,
+                   return_predictions=None):
     """Evaluate metric(s) by cross-validation and also record fit/score times.
 
     Read more in the :ref:`User Guide <multimetric_cross_validation>`.
@@ -154,6 +155,12 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
 
         .. versionadded:: 0.20
 
+    return_predictions : {'predict_proba', 'predict'}, default=None
+        Return cross-validation predictions for the dataset. 'predict' returns
+        the predictions whereas 'predict_proba' returns class probabilities.
+
+        .. versionadded:: 0.24
+
     Returns
     -------
     scores : dict of float arrays of shape (n_splits,)
@@ -185,6 +192,10 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
                 The estimator objects for each cv split.
                 This is available only if ``return_estimator`` parameter
                 is set to ``True``.
+            ``predictions``
+                Cross-validation predictions for the dataset.
+                This is available only if ``return_predictions`` parameter
+                is set to ``predict`` or ``predict_proba``.
 
     Examples
     --------
@@ -228,6 +239,12 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
         loss function.
 
     """
+    if (return_predictions is not None) and \
+            (not isinstance(return_predictions, str)
+             or return_predictions not in ["predict", "predict_proba"]):
+        raise ValueError("return_predictions must either be 'predict' "
+                         "or 'predict_proba'")
+
     X, y, groups = indexable(X, y, groups)
 
     cv = check_cv(cv, y, classifier=is_classifier(estimator))
@@ -248,10 +265,10 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
             clone(estimator), X, y, scorers, train, test, verbose, None,
             fit_params, return_train_score=return_train_score,
             return_times=True, return_estimator=return_estimator,
-            error_score=error_score)
+            error_score=error_score, return_predictions=return_predictions)
         for train, test in cv.split(X, y, groups))
 
-    # For callabe scoring, the return type is only know after calling. If the
+    # For callable scoring, the return type is only know after calling. If the
     # return type is a dictionary, the error scores can now be inserted with
     # the correct key.
     if callable(scoring):
@@ -275,6 +292,14 @@ def cross_validate(estimator, X, y=None, *, groups=None, scoring=None, cv=None,
         if return_train_score:
             key = 'train_%s' % name
             ret[key] = train_scores_dict[name]
+
+    if return_predictions:
+        if return_predictions == "predict":
+            predictions = np.hstack(results["predictions"])
+        else:
+            predictions = np.vstack(results["predictions"])
+        test_indices = np.hstack(results["test_indices"])
+        ret['predictions'] = predictions[test_indices]
 
     return ret
 
@@ -452,8 +477,7 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    return_parameters=False, return_n_test_samples=False,
                    return_times=False, return_estimator=False,
                    split_progress=None, candidate_progress=None,
-                   error_score=np.nan):
-
+                   error_score=np.nan, return_predictions=None):
     """Fit estimator and compute scores for a given dataset split.
 
     Parameters
@@ -521,6 +545,10 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     return_estimator : bool, default=False
         Whether to return the fitted estimator.
 
+    return_predictions : {'predict_proba', 'predict'}, default=None
+        Return cross-validation predictions for the dataset. 'predict' returns
+        the predictions whereas 'predict_proba' returns class probabilities.
+
     Returns
     -------
     result : dict with the following attributes
@@ -541,6 +569,11 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
             The fitted estimator.
         fit_failed : bool
             The estimator failed to fit.
+        test_indices : int
+            Indices of cv split test set
+        predictions : float
+            Predicted class or predicted class probability of
+            cv split test set
     """
     progress_msg = ""
     if verbose > 2:
@@ -651,6 +684,12 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
         result["parameters"] = parameters
     if return_estimator:
         result["estimator"] = estimator
+    if return_predictions:
+        result["test_indices"] = test
+        if return_predictions == "predict":
+            result["predictions"] = estimator.predict(X_test)
+        if return_predictions == "predict_proba":
+            result["predictions"] = estimator.predict_proba(X_test)
     return result
 
 

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1782,3 +1782,36 @@ def test_callable_multimetric_confusion_matrix_cross_validate():
     score_names = ['tn', 'fp', 'fn', 'tp']
     for name in score_names:
         assert "test_{}".format(name) in cv_results
+
+
+def test_cross_validate_return_predict():
+    clf = MockClassifier()
+    X = np.random.rand(1000, 10)
+    y = np.random.choice([0, 1], size=(1000,), p=[0.5, 0.5])
+    ret = cross_validate(clf, X, y, cv=3, return_train_score=False,
+                         return_estimator=True, return_predictions='predict')
+    assert np.all(ret['predictions'] == clf.predict(X))
+
+
+def test_cross_validate_return_predict_proba_shape():
+    n_samples = 10000
+    n_classes = 2
+    clf = LogisticRegression(random_state=0)
+    X, y = make_classification(n_samples=n_samples, random_state=0,
+                               n_classes=n_classes)
+
+    ret = cross_validate(clf, X, y, return_train_score=False,
+                         return_estimator=True,
+                         return_predictions='predict_proba')
+    assert ret['predictions'].shape == (n_samples, n_classes)
+
+
+def test_cross_validate_return_predictions_value_error():
+    error_message = "return_predictions must either be 'predict' " \
+                    "or 'predict_proba'"
+    clf = MockClassifier()
+    X = np.random.rand(10, 2)
+    y = np.random.choice([0, 1], size=(10,), p=[0.5, 0.5])
+
+    assert_raise_message(ValueError, error_message, cross_validate,
+                         clf, X, y, return_predictions="wrong_value")


### PR DESCRIPTION
Fix for #13478
Created new PR #15907 due to merge conflict.

This allows the user to extract predictions or prediction probabilities using 'return_predictions' argument for cross_validate. The argument takes 'predict_proba' or 'predict' as a string to return the predictions.

The approach has been to have `_fit_and_score` run inference on the cross-validation split and return it with the indices. Once all the indices and predictions have been returned to the `cross_validate` function, they are ordered according to the dataset and returned.

```
from sklearn.linear_model import LogisticRegression
from sklearn.model_selection import cross_validate
from sklearn.datasets._samples_generator import make_classification

n_samples = 25
n_classes = 2
clf = LogisticRegression(random_state=0)
X, y = make_classification(n_samples=n_samples, n_classes=n_classes)

ret = cross_validate(clf, X, y, return_train_score=False,
                     return_estimator=True, return_predictions='predict')
ret['predictions']
>>> array([0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1,
       0, 1, 1])
```

@cmarmo could you take a look please?