### PR TITLE
DOC Update documentation for LinearSVC loss with l1 penalty

### DIFF
--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -36,7 +36,7 @@ class LinearSVC(LinearClassifierMixin,
         Specifies the loss function. 'hinge' is the standard SVM loss
         (used e.g. by the SVC class) while 'squared_hinge' is the
         square of the hinge loss. The combination of ``penalty='l1'``
-        and ``loss='hinge'`` is not supported
+        and ``loss='hinge'`` is not supported.
 
     dual : bool, default=True
         Select the algorithm to either solve the dual or primal

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -35,7 +35,8 @@ class LinearSVC(LinearClassifierMixin,
     loss : {'hinge', 'squared_hinge'}, default='squared_hinge'
         Specifies the loss function. 'hinge' is the standard SVM loss
         (used e.g. by the SVC class) while 'squared_hinge' is the
-        square of the hinge loss.
+        square of the hinge loss. The combination of ``penalty='l1'``
+        and ``loss='hinge'`` is not supported
 
     dual : bool, default=True
         Select the algorithm to either solve the dual or primal


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #18320


#### What does this implement/fix? Explain your changes.

1. Update [svm documentation](https://scikit-learn.org/stable/modules/svm.html) because it has a deprecated statement as `loss='l2'` of `LinearSVC`
2. Add a description that the combination of penalty='l1' and loss='hinge' is not supported to [LinearSVC documentation](https://scikit-learn.org/stable/modules/generated/sklearn.svm.LinearSVC.html) 