### PR TITLE
[MRG] Prevent division-by-0 error in GPR

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -196,6 +196,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
         if self.normalize_y:
             self._y_train_mean = np.mean(y, axis=0)
             self._y_train_std = np.std(y, axis=0)
+            self._y_train_std = self._y_train_std if self._y_train_std else 1
 
             # Remove mean and make unit variance
             y = (y - self._y_train_mean) / self._y_train_std


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### What does this implement/fix? Explain your changes.

Fixes division by zero error that may happen in GaussianProcessRegressor during normalization if the data passed is completely uniform (thus standard deviation is 0). This will cause the array to become all NaNs, causing an exception further down the line.