### PR TITLE
DOC Fix docs for default values in sklearn.utils.sparsefuncs

### DIFF
--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -416,7 +416,7 @@ def min_max_axis(X, axis, ignore_nan=False):
     axis : int (either 0 or 1)
         Axis along which the axis should be computed.
 
-    ignore_nan : bool, default is False
+    ignore_nan : bool, default=False
         Ignore or passing through NaN values.
 
         .. versionadded:: 0.20


### PR DESCRIPTION
#### Reference Issues/PRs

Partially addresses #15761


#### What does this implement/fix? Explain your changes.
fixed default value of "ignore_nan" to standard writing
