### PR TITLE
DOC Add enable_successive_halving module to the API Reference

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -457,6 +457,7 @@ Samples generator
 
    experimental.enable_hist_gradient_boosting
    experimental.enable_iterative_imputer
+   experimental.enable_successive_halving
 
 
 .. _feature_extraction_ref:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR adds the `sklearn.experimental.enable_successive_halving` module to the API Reference.