### PR TITLE
Add numpy to pip install list in documentation

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -60,7 +60,7 @@ feature, code or documentation improvement).
 
 #. Install Cython_ and build the project with pip in :ref:`editable_mode`::
 
-        pip install cython
+        pip install cython numpy
         pip install --verbose --no-build-isolation --editable .
 
 #. Check that the installed scikit-learn has a version number ending with
@@ -327,7 +327,7 @@ Ubuntu::
 
 then proceed as usual::
 
-    pip3 install cython
+    pip3 install cython numpy
     pip3 install --verbose --editable .
 
 Cython and the pre-compiled wheels for the runtime dependencies (numpy, scipy

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -223,7 +223,7 @@ how to set up your git repository:
 
 4. Install the development dependencies::
 
-       $ pip install cython pytest pytest-cov flake8 mypy
+       $ pip install cython pytest pytest-cov flake8 mypy numpy
 
 5. Install scikit-learn in editable mode::
 


### PR DESCRIPTION
numpy is required to build scikit-learn.
It is imported by _build_utils/pre_build_helpers.py
	which is imported by _build_utils/__init__.py
	which is needed to import _build_utils.min_dependencies in setup.py

However, the documentation does not mention installing numpy before building.

The documentation and the code in setup.py suggest that the intention was to make it possible to build without installing numpy beforehand, but it seems this is no longer the case. If you'd prefer, I could look into reorganizing the build script to make that possible, rather than changing the docs to ask people to install it first.