### PR TITLE
FIX VisibleDeprecationWarning in unit tests and docstrings

### DIFF
--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -449,7 +449,7 @@ def test_multilabel_binarizer_non_integer_labels():
         assert_array_equal(mlb.fit_transform(inp), indicator_mat)
         assert_array_equal(mlb.classes_, classes)
         indicator_mat_inv = np.array(mlb.inverse_transform(indicator_mat),
-            dtype=object)
+                                     dtype=object)
         assert_array_equal(indicator_mat_inv, inp)
 
         # fit().transform()
@@ -457,7 +457,7 @@ def test_multilabel_binarizer_non_integer_labels():
         assert_array_equal(mlb.fit(inp).transform(inp), indicator_mat)
         assert_array_equal(mlb.classes_, classes)
         indicator_mat_inv = np.array(mlb.inverse_transform(indicator_mat),
-            dtype=object)
+                                     dtype=object)
         assert_array_equal(indicator_mat_inv, inp)
 
     mlb = MultiLabelBinarizer()

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -445,15 +445,20 @@ def test_multilabel_binarizer_non_integer_labels():
     for inp, classes in inputs:
         # fit_transform()
         mlb = MultiLabelBinarizer()
+        inp = np.array(inp, dtype=object)
         assert_array_equal(mlb.fit_transform(inp), indicator_mat)
         assert_array_equal(mlb.classes_, classes)
-        assert_array_equal(mlb.inverse_transform(indicator_mat), inp)
+        indicator_mat_inv = np.array(mlb.inverse_transform(indicator_mat),
+            dtype=object)
+        assert_array_equal(indicator_mat_inv, inp)
 
         # fit().transform()
         mlb = MultiLabelBinarizer()
         assert_array_equal(mlb.fit(inp).transform(inp), indicator_mat)
         assert_array_equal(mlb.classes_, classes)
-        assert_array_equal(mlb.inverse_transform(indicator_mat), inp)
+        indicator_mat_inv = np.array(mlb.inverse_transform(indicator_mat),
+            dtype=object)
+        assert_array_equal(indicator_mat_inv, inp)
 
     mlb = MultiLabelBinarizer()
     with pytest.raises(TypeError):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -813,10 +813,7 @@ def _to_object_array(sequence):
     array([array([0]), array([1])], dtype=object)
     >>> _to_object_array([np.array([0]), np.array([1, 2])])
     array([array([0]), array([1, 2])], dtype=object)
-    >>> np.array([np.array([0]), np.array([1])])
-    array([[0],
-       [1]])
-    >>> np.array([np.array([0]), np.array([1, 2])])
+    >>> _to_object_array([np.array([0]), np.array([1, 2])])
     array([array([0]), array([1, 2])], dtype=object)
     """
     out = np.empty(len(sequence), dtype=object)


### PR DESCRIPTION
#### Reference Issues/PRs
Related to #18367 

#### What does this implement/fix? Explain your changes.
Fix `numpy.VisibleDeprecationWarning` in `test_multilabel_binarizer_non_integer_labels`, caused by an implicit conversion of a ragged nested sequence to `numpy.ndarray`.

Numpy's message:
*numpy.VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray*

Also, fix `numpy.VisibleDeprecationWarning` in the _to_object_array docstring tests.
