### PR TITLE
DOC Fix step 5 under "Contributing Code" to include build tools installation

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -229,7 +229,7 @@ how to set up your git repository:
 
        $ pip install --no-build-isolation --editable .
 
-   If you receive errors in building scikit-learn, follow steps 2-5 in the
+   If you receive errors in building scikit-learn, see the
    :ref:`install_bleeding_edge` section.
 
 .. _upstream:

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -206,6 +206,8 @@ then submit a "pull request" (PR).
 In the first few steps, we explain how to locally install scikit-learn, and
 how to set up your git repository:
 
+0.  build me
+
 1. `Create an account <https://github.com/join>`_ on
    GitHub if you do not already have one.
 
@@ -229,7 +231,7 @@ how to set up your git repository:
 
        $ pip install --no-build-isolation --editable .
 
-   for more details about advanced installation, see the
+   If you receive errors in building scikit-learn, follow steps 2-5 in the
    :ref:`install_bleeding_edge` section.
 
 .. _upstream:

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -206,8 +206,6 @@ then submit a "pull request" (PR).
 In the first few steps, we explain how to locally install scikit-learn, and
 how to set up your git repository:
 
-0.  build me
-
 1. `Create an account <https://github.com/join>`_ on
    GitHub if you do not already have one.
 


### PR DESCRIPTION
#### Reference Issues/PRs
Trying to resolve issue fixes #18416 

#### What does this implement/fix? Explain your changes.
Build tools may be mandatory to contribute to code changes.  I've changed step 5 under Contributing Code to reflect this possible change.

#### Any other comments?
In some OSs, build tools aren't included by default.  That makes the advanced installation [Building from source](https://scikit-learn.org/stable/developers/advanced_installation.html#install-bleeding-edge) possibly mandatory.