### PR TITLE
Updating svm.rst to include 'm_arcsinh' kernel

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -550,6 +550,31 @@ instance that will use that kernel::
 
  * :ref:`sphx_glr_auto_examples_svm_plot_custom_kernel.py`.
 
+A further example of a custom kernel (modified arcsinh or 'm-arcsinh') is provided below:
+
+def m_arcsinh(data, Y):
+    """Compute a modified arcsinh (m-arcsinh) hyperbolic function 
+	in place.
+
+    Further details on this function are available at:  
+    https://arxiv.org/abs/2009.07530 
+    (Parisi, L., 2020; License: http://creativecommons.org/licenses/by/4.0/). 
+    If you are using this function, please cite this paper as follows: 
+    arXiv:2009.07530 [cs.LG].
+
+    Parameters
+    ----------
+    data: {ndarray, dataframe} of shape (n_samples, n_features)
+    The data matrix. If as_frame=True, data will be a pandas DataFrame 
+    (see https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_iris.html).
+
+    y: {ndarray, Series} of shape (n_samples,)
+    The classification target. If as_frame=True, target will be a pandas Series
+    (see https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_iris.html).
+    """
+    return np.dot((1/3*np.arcsinh(data))*(1/4*np.sqrt(np.abs(data))), (1/3*np.arcsinh(Y.T))*(1/4*np.sqrt(np.abs(Y.T))))
+
+
 Using the Gram matrix
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Updating svm.rst to include 'm_arcsinh' kernel as a further and slightly more complex example of a custom kernel in SVM.
