### PR TITLE
FIX handle VisibleDeprecationWarning in type_of_target and is_multilabel

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -8,6 +8,7 @@ Multi-class / multi-label utility function
 """
 from collections.abc import Sequence
 from itertools import chain
+import warnings
 
 from scipy.sparse import issparse
 from scipy.sparse.base import spmatrix
@@ -137,11 +138,9 @@ def is_multilabel(y):
     >>> is_multilabel(np.array([[1, 0, 0]]))
     True
     """
-    import warnings
-
     if hasattr(y, '__array__') or isinstance(y, Sequence):
-        # TODO: Replace the warning context manager with a try-except statement
         # DeprecationWarning will be replaced by ValueError, see NEP 34
+        # https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
         with warnings.catch_warnings():
             warnings.simplefilter('error', np.VisibleDeprecationWarning)
             try:
@@ -248,8 +247,6 @@ def type_of_target(y):
     >>> type_of_target(np.array([[0, 1], [1, 1]]))
     'multilabel-indicator'
     """
-    import warnings
-
     valid = ((isinstance(y, (Sequence, spmatrix)) or hasattr(y, '__array__'))
              and not isinstance(y, str))
 
@@ -264,8 +261,8 @@ def type_of_target(y):
     if is_multilabel(y):
         return 'multilabel-indicator'
 
-    # TODO: Replace the warning context manager with a try-except statement
     # DeprecationWarning will be replaced by ValueError, see NEP 34
+    # https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
     with warnings.catch_warnings():
         warnings.simplefilter('error', np.VisibleDeprecationWarning)
         try:

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -137,8 +137,16 @@ def is_multilabel(y):
     >>> is_multilabel(np.array([[1, 0, 0]]))
     True
     """
+    import warnings
+
     if hasattr(y, '__array__') or isinstance(y, Sequence):
-        y = np.asarray(y)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', np.VisibleDeprecationWarning)
+            try:
+                y = np.asarray(y)
+            except np.VisibleDeprecationWarning:
+                y = np.array(y, dtype=object)
+
     if not (hasattr(y, "shape") and y.ndim == 2 and y.shape[1] > 1):
         return False
 
@@ -236,6 +244,8 @@ def type_of_target(y):
     >>> type_of_target(np.array([[0, 1], [1, 1]]))
     'multilabel-indicator'
     """
+    import warnings
+
     valid = ((isinstance(y, (Sequence, spmatrix)) or hasattr(y, '__array__'))
              and not isinstance(y, str))
 
@@ -250,7 +260,12 @@ def type_of_target(y):
     if is_multilabel(y):
         return 'multilabel-indicator'
 
-    y = np.asarray(y)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', np.VisibleDeprecationWarning)
+        try:
+            y = np.asarray(y)
+        except np.VisibleDeprecationWarning:
+            y = np.asarray(y, dtype=object)
 
     # The old sequence of sequences format
     try:

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -140,11 +140,15 @@ def is_multilabel(y):
     import warnings
 
     if hasattr(y, '__array__') or isinstance(y, Sequence):
+        # TODO: Replace the warning context manager with a try-except statement
+        # DeprecationWarning will be replaced by ValueError, see NEP 34
         with warnings.catch_warnings():
             warnings.simplefilter('error', np.VisibleDeprecationWarning)
             try:
                 y = np.asarray(y)
             except np.VisibleDeprecationWarning:
+                # dtype=object should be provided explicitly for ragged arrays,
+                # see NEP 34
                 y = np.array(y, dtype=object)
 
     if not (hasattr(y, "shape") and y.ndim == 2 and y.shape[1] > 1):
@@ -260,11 +264,15 @@ def type_of_target(y):
     if is_multilabel(y):
         return 'multilabel-indicator'
 
+    # TODO: Replace the warning context manager with a try-except statement
+    # DeprecationWarning will be replaced by ValueError, see NEP 34
     with warnings.catch_warnings():
         warnings.simplefilter('error', np.VisibleDeprecationWarning)
         try:
             y = np.asarray(y)
         except np.VisibleDeprecationWarning:
+            # dtype=object should be provided explicitly for ragged arrays,
+            # see NEP 34
             y = np.asarray(y, dtype=object)
 
     # The old sequence of sequences format


### PR DESCRIPTION
#### Reference Issues/PRs
Fix #18367 

#### What does this implement/fix? Explain your changes.
Fix `numpy.VisibleDeprecationWarning` in `type_of_target`, `is_multilabel`.
This warning was issued by `numpy.asarray` because of ragged/jagged sequences that were provided to this function. It was spotted in the following unit tests:
 
* test_raise_value_error_multilabel_sequences:
* test__check_targets
* test_unique_labels_non_specific
* test_is_multilabel
* test_check_classification_targets
* test_type_of_target



#### Any other comments?
As far as I see, there are several ways to solve it:

1. Not provide ragged/jagged sequences failing unit tests, use `numpy.array` instead. In that case, only users will see this warning
2. Treat any input sequence as ragged/jagged, i.e. always call `numpy.asarray(, dtype=object)`
3. Test where an input sequence is ragged/jagged and then call `numpy.asarray` correctly.

I decided to it as in the 3rd list item. Here, I assumed that it'd better let NumPy do this test and then catch that warning as an exception. Not sure whether it is the optimal way to do it. What do you think?
