### PR TITLE
Adds giotto-tda to "Related projects"

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -234,13 +234,13 @@ and tasks.
 **Topological Data Analysis**
 
 - `giotto-tda <https://github.com/giotto-ai/giotto-tda>`_ A library collecting
-  state-of-the-art implementations of several algorithms in Topological Data Analysis.
-  It offers a scikit-learn–compatible API, a suite of tools to transform various kinds
-  of data inputs (point clouds, graphs, time-series, images, etc.) into forms suitable
-  for computations of topological features, and components dedicated to extracting
-  rich sets of scalar features of topological origin, which can be used alongside other
-  feature extraction methods in scikit-learn and/or in the context of complex
-  scikit-learn pipelines.
+  state-of-the-art implementations of several algorithms in `Topological Data Analysis
+  <https://en.wikipedia.org/wiki/Topological_data_analysis>`_. It offers a
+  scikit-learn–compatible API, a suite of tools to transform various kinds of data
+  inputs (point clouds, graphs, time-series, images, etc.) into forms suitable for
+  computations of topological features, and components dedicated to extracting rich 
+  ets of scalar features of topological origin, which can be used alongside other feature
+  extraction methods in scikit-learn and/or in the context of complex scikit-learn pipelines.
 
 Statistical learning with Python
 --------------------------------

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -233,12 +233,14 @@ and tasks.
 
 **Topological Data Analysis**
 
-- `giotto-tda <https://github.com/giotto-ai/giotto-tda>`_ A library for `Topological Data Analysis
-  <https://en.wikipedia.org/wiki/Topological_data_analysis>`_ aiming to provide a
-  scikit-learn compatible API. It offers tools to transform data inputs (point clouds,
-  graphs, time series, images) into forms suitable for computations of topological summaries,
-  and components dedicated to extracting sets of scalar features of topological origin,
-  which can be used alongside other feature extraction methods in scikit-learn.
+- `giotto-tda <https://github.com/giotto-ai/giotto-tda>`_ A library for
+  `Topological Data Analysis
+  <https://en.wikipedia.org/wiki/Topological_data_analysis>`_ aiming to
+  provide a scikit-learn compatible API. It offers tools to transform data
+  inputs (point clouds, graphs, time series, images) into forms suitable for
+  computations of topological summaries, and components dedicated to
+  extracting sets of scalar features of topological origin, which can be used
+  alongside other feature extraction methods in scikit-learn.
 
 Statistical learning with Python
 --------------------------------

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -238,8 +238,8 @@ and tasks.
   <https://en.wikipedia.org/wiki/Topological_data_analysis>`_. It offers a
   scikit-learn–compatible API, a suite of tools to transform various kinds of data
   inputs (point clouds, graphs, time-series, images, etc.) into forms suitable for
-  computations of topological features, and components dedicated to extracting rich 
-  ets of scalar features of topological origin, which can be used alongside other feature
+  computations of topological summaries, and components dedicated to extracting rich 
+  sets of scalar features of topological origin, which can be used alongside other feature
   extraction methods in scikit-learn and/or in the context of complex scikit-learn pipelines.
 
 Statistical learning with Python

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -233,14 +233,13 @@ and tasks.
 
 **Topological Data Analysis**
 
-- `giotto-tda <https://github.com/giotto-ai/giotto-tda>`_ A library collecting
-  state-of-the-art implementations of several algorithms in `Topological Data Analysis
-  <https://en.wikipedia.org/wiki/Topological_data_analysis>`_. It offers a
-  scikit-learn–compatible API, a suite of tools to transform various kinds of data
-  inputs (point clouds, graphs, time-series, images, etc.) into forms suitable for
-  computations of topological summaries, and components dedicated to extracting rich 
+- `giotto-tda <https://github.com/giotto-ai/giotto-tda>`_ A library for `Topological Data Analysis
+  <https://en.wikipedia.org/wiki/Topological_data_analysis>`_ aiming to provide a
+  scikit-learn compatible API. It offers tools to transform data
+  inputs (point clouds, graphs, time-series, images) into forms suitable for
+  computations of topological summaries, and components dedicated to extracting
   sets of scalar features of topological origin, which can be used alongside other feature
-  extraction methods in scikit-learn and/or in the context of complex scikit-learn pipelines.
+  extraction methods in scikit-learn.
 
 Statistical learning with Python
 --------------------------------

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -235,11 +235,10 @@ and tasks.
 
 - `giotto-tda <https://github.com/giotto-ai/giotto-tda>`_ A library for `Topological Data Analysis
   <https://en.wikipedia.org/wiki/Topological_data_analysis>`_ aiming to provide a
-  scikit-learn compatible API. It offers tools to transform data
-  inputs (point clouds, graphs, time-series, images) into forms suitable for
-  computations of topological summaries, and components dedicated to extracting
-  sets of scalar features of topological origin, which can be used alongside other feature
-  extraction methods in scikit-learn.
+  scikit-learn compatible API. It offers tools to transform data inputs (point clouds,
+  graphs, time series, images) into forms suitable for computations of topological summaries,
+  and components dedicated to extracting sets of scalar features of topological origin,
+  which can be used alongside other feature extraction methods in scikit-learn.
 
 Statistical learning with Python
 --------------------------------

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -231,6 +231,17 @@ and tasks.
   Feature-engine allows the application of preprocessing steps to selected groups
   of variables and it is fully compatible with the Scikit-learn Pipeline.
 
+**Topological Data Analysis**
+
+- `giotto-tda <https://github.com/giotto-ai/giotto-tda>`_ A library collecting
+  state-of-the-art implementations of several algorithms in Topological Data Analysis.
+  It offers a scikit-learn–compatible API, a suite of tools to transform various kinds
+  of data inputs (point clouds, graphs, time-series, images, etc.) into forms suitable
+  for computations of topological features, and components dedicated to extracting
+  rich sets of scalar features of topological origin, which can be used alongside other
+  feature extraction methods in scikit-learn and/or in the context of complex
+  scikit-learn pipelines.
+
 Statistical learning with Python
 --------------------------------
 Other packages useful for data analysis and machine learning.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Adds a Topological Data Analysis section in "Other estimators and tasks" and populates it with the `giotto-tda` library ([source](https://github.com/giotto-ai/giotto-tda), [docs](https://giotto-ai.github.io/gtda-docs/latest/library.html)).

A great deal of effort has been put into making `giotto-tda` compatible with `scikit-learn` in the strongest possible sense, despite the fact that, by necessity, it deviates from the `scikit-learn` model in some ways (chiefly, by accepting higher than 2-dimensional input in some cases). A research paper (currently under review) can be found at https://arxiv.org/abs/2004.02551.

Disclaimer: I am a maintainer of `giotto-tda`.