### PR TITLE
DOC Minor docstring update

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -653,7 +653,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
         True targets of binary classification.
 
     y_score : ndarray of shape (n_samples,)
-        Estimated probabilities or decision function.
+        Estimated probabilities or output of a decision function.
 
     pos_label : int or str, default=None
         The label of the positive class.
@@ -772,7 +772,7 @@ def precision_recall_curve(y_true, probas_pred, *, pos_label=None,
         pos_label should be explicitly given.
 
     probas_pred : ndarray of shape (n_samples,)
-        Estimated probabilities or decision function.
+        Estimated probabilities or output of a decision function.
 
     pos_label : int or str, default=None
         The label of the positive class.


### PR DESCRIPTION
fix doc_string for precision_recall_curve and _binary_clf_curve 

As the parameter gives Estimator probabilities or output of a decision function.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs  #18398
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


