### PR TITLE
[MRG] Forbid splitters that yield different splits in SequentialFeatureSelection

### DIFF
--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -173,7 +173,8 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin,
                 f"Got {self.direction}."
             )
 
-        # We need score of candidate features to be compared on the same splits
+        # We need the scores of the candidate features to be compared on the
+        # same splits
         if not _yields_constant_splits(self.cv):
             raise ValueError(
                 "The cv parameter must yield consistent folds across "

--- a/sklearn/feature_selection/tests/test_sequential.py
+++ b/sklearn/feature_selection/tests/test_sequential.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from sklearn.preprocessing import StandardScaler
+from sklearn.model_selection import KFold
 from sklearn.pipeline import make_pipeline
 from sklearn.feature_selection import SequentialFeatureSelector
 from sklearn.datasets import make_regression
@@ -132,3 +133,14 @@ def test_pipeline_support():
     pipe = make_pipeline(StandardScaler(), sfs)
     pipe.fit(X, y)
     pipe.transform(X)
+
+
+@pytest.mark.parametrize('random_state', (None, np.random.RandomState(0)))
+def test_cv_same_splits(random_state):
+    # Make sure that cvs that yield different splits are not allowed
+
+    cv = KFold(shuffle=True, random_state=random_state)
+
+    X, y = make_regression()
+    with pytest.raises(ValueError, match='must yield consistent folds'):
+        SequentialFeatureSelector(LinearRegression(), cv=cv).fit(X, y)

--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -435,7 +435,8 @@ class HalvingGridSearchCV(BaseSuccessiveHalving):
             the same across multiple calls to `cv.split()`. For
             built-in `scikit-learn` iterators, this can be achieved by
             deactivating shuffling (`shuffle=False`), or by setting the
-            `cv`'s `random_state` parameter to an integer.
+            `cv`'s `random_state` parameter to an integer. If you pass an
+            iterable, this is up to you to enforce.
 
     scoring : string, callable, or None, default=None
         A single string (see :ref:`scoring_parameter`) or a callable

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2239,6 +2239,13 @@ def _build_repr(self):
 
 def _yields_constant_splits(cv):
     # Return True if calling cv.split() always returns the same splits
+    if isinstance(cv, numbers.Integral):
+        return True
+    if isinstance(cv, Iterable):
+        # This will be up to users to enforce.
+        return True
+
+    # We got an instance
     # We assume that if a cv doesn't have a shuffle parameter, it shuffles by
     # default (e.g. ShuffleSplit). If it actually doesn't shuffle (e.g.
     # LeaveOneOut), then it won't have a random_state parameter anyway, in

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1638,6 +1638,8 @@ def test_random_state_shuffle_false(Klass):
     (LeaveOneGroupOut(), True),
     (LeavePGroupsOut(n_groups=2), True),
     (LeavePOut(p=2), True),
+    (5, True),
+    ([], True),  # some iterable
 
     (KFold(shuffle=True, random_state=None), False),
     (KFold(shuffle=True, random_state=None), False),


### PR DESCRIPTION
This would lead to comparing scores that are evaluated on different splits. We have no guarantee that the number of folds is large enough or that the data is large enough either for the average scores to be reliable.

Note that we do the same thing in `SuccessiveHalving`