### PR TITLE
MNT Put back positional args in KBinsDiscretizer

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -126,7 +126,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
     """
 
     @_deprecate_positional_args
-    def __init__(self, n_bins=5, encode='onehot', strategy='quantile',
+    def __init__(self, n_bins=5, *, encode='onehot', strategy='quantile',
                  dtype=None):
         self.n_bins = n_bins
         self.encode = encode


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR adds the `*` argument to denote keyword only arguments in `sklearn.preprocessing.KBinsDiscretizer`.