### PR TITLE
FIX Fix scikit-image substitution in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ scikit-learn 0.23 and later require Python 3.6 or newer.
 Scikit-learn plotting capabilities (i.e., functions start with ``plot_`` and
 classes end with "Display") require Matplotlib (>= |MatplotlibMinVersion|).
 For running the examples Matplotlib >= |MatplotlibMinVersion| is required.
-A few examples require scikit-image >= |ScikitImageMinVersion|, a few examples
+A few examples require scikit-image >= |Scikit-ImageMinVersion|, a few examples
 require pandas >= |PandasMinVersion|, some examples require seaborn >=
 |SeabornMinVersion|.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR fixes the `scikit-image` substitution in the `README.rst` file.

#### Any other comments?

Sorry for not noticing this in the original PR 😢. Now [renders fine](https://github.com/scikit-learn/scikit-learn/blob/0dd896792f8b94ad7fdd54ed6ac80c7750913e88/README.rst).

Quick review @rth.