### PR TITLE
Increase coverage of covtype dataset

### DIFF
--- a/sklearn/datasets/tests/test_covtype.py
+++ b/sklearn/datasets/tests/test_covtype.py
@@ -59,6 +59,15 @@ def test_pandas_dependency_message(fetch_covtype_fxt,
 @patch('sklearn.datasets._covtype.GzipFile', Mock())
 @patch('sklearn.datasets._covtype.remove', Mock())
 def test_fetch_with_download(exists, genfromtext):
+    """
+        This test covers the fetch of the dataset from the network
+        and the operations that are mandatory when you dont have the dataset locally
+        - create the folder
+        - gzip it
+        - cast the numpy result
+        - remove the file
+        - dump in joblib
+    """
     genfromtext.return_value = np.array([
         [2.596e+03, 5.100e+01, 3.000e+00, 2.580e+02, 0.000e+00, 5.100e+02,
          2.210e+02, 2.320e+02, 1.480e+02, 6.279e+03, 1.000e+00, 0.000e+00,

--- a/sklearn/datasets/tests/test_covtype.py
+++ b/sklearn/datasets/tests/test_covtype.py
@@ -52,6 +52,7 @@ def test_pandas_dependency_message(fetch_covtype_fxt,
     with pytest.raises(ImportError, match=expected_msg):
         fetch_covtype_fxt(as_frame=True)
 
+
 @patch('sklearn.datasets._covtype.np.genfromtxt')
 @patch('sklearn.datasets._covtype.exists', return_value=False)
 @patch('sklearn.datasets._covtype.makedirs', Mock())

--- a/sklearn/datasets/tests/test_covtype.py
+++ b/sklearn/datasets/tests/test_covtype.py
@@ -4,6 +4,9 @@ or if specifically requested via environment variable
 from functools import partial
 import pytest
 from sklearn.datasets.tests.test_common import check_return_X_y
+from sklearn.datasets._covtype import fetch_covtype
+from unittest.mock import Mock, patch
+import numpy as np
 
 
 def test_fetch(fetch_covtype_fxt):
@@ -48,3 +51,36 @@ def test_pandas_dependency_message(fetch_covtype_fxt,
                     ' requires pandas')
     with pytest.raises(ImportError, match=expected_msg):
         fetch_covtype_fxt(as_frame=True)
+
+@patch('sklearn.datasets._covtype.np.genfromtxt')
+@patch('sklearn.datasets._covtype.exists', return_value=False)
+@patch('sklearn.datasets._covtype.makedirs', Mock())
+@patch('sklearn.datasets._covtype._fetch_remote', Mock())
+@patch('sklearn.datasets._covtype.GzipFile', Mock())
+@patch('sklearn.datasets._covtype.remove', Mock())
+def test_fetch_with_download(exists, genfromtext):
+    genfromtext.return_value = np.array([
+        [2.596e+03, 5.100e+01, 3.000e+00, 2.580e+02, 0.000e+00, 5.100e+02,
+         2.210e+02, 2.320e+02, 1.480e+02, 6.279e+03, 1.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         1.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         5.000e+00],
+
+        [2.590e+03, 5.600e+01, 2.000e+00, 2.120e+02, -6.000e+00,
+         3.900e+02, 2.200e+02, 2.350e+02, 1.510e+02, 6.225e+03,
+         1.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 1.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00,
+         0.000e+00, 0.000e+00, 0.000e+00, 0.000e+00, 5.000e+00]
+        ])
+    fetch_covtype(download_if_missing=True)

--- a/sklearn/datasets/tests/test_covtype.py
+++ b/sklearn/datasets/tests/test_covtype.py
@@ -61,7 +61,8 @@ def test_pandas_dependency_message(fetch_covtype_fxt,
 def test_fetch_with_download(exists, genfromtext):
     """
         This test covers the fetch of the dataset from the network
-        and the operations that are mandatory when you dont have the dataset locally
+        and the operations that are mandatory when we dont have
+        the dataset locally
         - create the folder
         - gzip it
         - cast the numpy result


### PR DESCRIPTION
My first PR to scikit-learn \0/, created as a draft as I would like to get feedback on the overall direction before proceeding.
I looked for low coverage and seems that the dataset folder is the worst offender so I'm starting there. The covtype dataset [does not cover the crucial code to get the dataset](https://codecov.io/gh/scikit-learn/scikit-learn/src/master/sklearn/datasets/_covtype.py), this PR is an attempt to change that.

Theres a lot of patching so maybe an approach to fake the downloaded file is better, but I want to hear your opinion first.

Before creating the final PR I'll squash the commits.