### PR TITLE
API Warn upon removal of NaN columns

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -272,6 +272,12 @@ Changelog
   :pr:`17169` by `Dmytro Lituiev <DSLituiev>`
   and `Julien Jerphanion <jjerphan>`.
 
+:mod:`sklearn.impute`
+................................
+- |API| The `verbose` parameter was deprecated for :class:`impute.SimpleImputer`.
+  A warning will always be raised upon the removal of empty columns.
+  :pr:`18467` by :user:`Oleh Kozynets <OlehKSS>`.
+
 :mod:`sklearn.inspection`
 .........................
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -158,6 +158,11 @@ class SimpleImputer(_BaseImputer):
     verbose : integer, default=0
         Controls the verbosity of the imputer.
 
+        .. deprecated:: 1.0
+           The 'verbose' parameter was deprecated in version 1.0 and will be
+           removed in 1.2. A warning will always be raised upon the removal of
+           empty columns in the future version.
+
     copy : boolean, default=True
         If True, a copy of X will be created. If False, imputation will
         be done in-place whenever possible. Note that, in the following cases,
@@ -211,7 +216,8 @@ class SimpleImputer(_BaseImputer):
 
     """
     def __init__(self, *, missing_values=np.nan, strategy="mean",
-                 fill_value=None, verbose=0, copy=True, add_indicator=False):
+                 fill_value=None, verbose=None, copy=True,
+                 add_indicator=False):
         super().__init__(
             missing_values=missing_values,
             add_indicator=add_indicator
@@ -283,6 +289,12 @@ class SimpleImputer(_BaseImputer):
         -------
         self : SimpleImputer
         """
+        if self.verbose is not None:
+            warnings.warn("The 'verbose' parameter was deprecated in version "
+                          "1.0 and will be removed in 1.2. A warning will "
+                          "always be raised upon the removal of empty columns "
+                          "in the future version.", FutureWarning)
+
         X = self._validate_input(X, in_fit=True)
 
         # default fill_value is 0 for numerical input and "missing_value"

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -216,7 +216,7 @@ class SimpleImputer(_BaseImputer):
 
     """
     def __init__(self, *, missing_values=np.nan, strategy="mean",
-                 fill_value=None, verbose=None, copy=True,
+                 fill_value=None, verbose="deprecated", copy=True,
                  add_indicator=False):
         super().__init__(
             missing_values=missing_values,
@@ -289,7 +289,7 @@ class SimpleImputer(_BaseImputer):
         -------
         self : SimpleImputer
         """
-        if self.verbose is not None:
+        if self.verbose != "deprecated":
             warnings.warn("The 'verbose' parameter was deprecated in version "
                           "1.0 and will be removed in 1.2. A warning will "
                           "always be raised upon the removal of empty columns "
@@ -468,7 +468,7 @@ class SimpleImputer(_BaseImputer):
 
             if invalid_mask.any():
                 missing = np.arange(X.shape[1])[invalid_mask]
-                if self.verbose:
+                if self.verbose != "deprecated" and self.verbose:
                     warnings.warn("Deleting features without "
                                   "observed values: %s" % missing)
                 X = X[:, valid_statistics_indexes]

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -100,10 +100,13 @@ def test_imputation_error_invalid_strategy(strategy):
 def test_imputation_deletion_warning(strategy):
     X = np.ones((3, 5))
     X[:, 0] = np.nan
+    imputer = SimpleImputer(strategy=strategy, verbose=1)
+
+    with pytest.warns(FutureWarning, match="The 'verbose' parameter"):
+        imputer.fit(X)
 
     with pytest.warns(UserWarning, match="Deleting"):
-        imputer = SimpleImputer(strategy=strategy, verbose=True)
-        imputer.fit_transform(X)
+        imputer.transform(X)
 
 
 @pytest.mark.parametrize("strategy", ["mean", "median",

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -102,6 +102,7 @@ def test_imputation_deletion_warning(strategy):
     X[:, 0] = np.nan
     imputer = SimpleImputer(strategy=strategy, verbose=1)
 
+    # TODO: Remove in 1.2
     with pytest.warns(FutureWarning, match="The 'verbose' parameter"):
         imputer.fit(X)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #8781

#### What does this implement/fix? Explain your changes.
`SimpleImputer` issues a warning when columns that are completely NAN are removed during imputation by default.
