### PR TITLE
DOC RidgeCV cv_values_ documentation when scoring is not None 

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1753,13 +1753,14 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     Attributes
     ----------
-    cv_values_ : ndarray of shape (n_samples, n_alphas) or \
+    cv_values_ : ndarray of shape (n_samples, n_alphas) or
         shape (n_samples, n_targets, n_alphas), optional
         Cross-validation values for each alpha (only available if
         ``store_cv_values=True`` and ``cv=None``). After ``fit()`` has been
         called, this attribute will contain the mean squared errors
-        (by default) or the values of the ``{loss,score}_func`` function
-        (if provided in the constructor).
+        (by default, ``scoring=None``) otherwise if scoring argument
+        provided, attribute will contain standardized per point
+        prediction values.
 
     coef_ : ndarray of shape (n_features) or (n_targets, n_features)
         Weight vector(s).
@@ -1863,9 +1864,10 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     cv_values_ : ndarray of shape (n_samples, n_targets, n_alphas), optional
         Cross-validation values for each alpha (if ``store_cv_values=True`` and
         ``cv=None``). After ``fit()`` has been called, this attribute will
-        contain the mean squared errors (by default) or the values of the
-        ``{loss,score}_func`` function (if provided in the constructor). This
-        attribute exists only when ``store_cv_values`` is True.
+        contain the mean squared errors (by default, ``scoring=None``)
+        otherwise if scoring argument provided, attribute will contain
+        standardized per point prediction values. This attribute exists only
+        when ``store_cv_values`` is True.
 
     coef_ : ndarray of shape (1, n_features) or (n_targets, n_features)
         Coefficient of the features in the decision function.


### PR DESCRIPTION
… reflect actual behaviour

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
 RidgeCV cv_values_ documentation when scoring is not None #18364.

#### What does this implement/fix? Explain your changes.
Changed documentation to reflect actual behavior of `cv_values_` attribute storing point predictions when scoring not None. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
