### PR TITLE
Fixed typo in Iterative Imputer doc

### DIFF
--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -68,7 +68,7 @@ class IterativeImputer(_BaseImputer):
         Maximum number of imputation rounds to perform before returning the
         imputations computed during the final round. A round is a single
         imputation of each feature with missing values. The stopping criterion
-        is met once `abs(max(X_t - X_{t-1}))/abs(max(X[known_vals]))` < tol,
+        is met once `max(abs(X_t - X_{t-1}))/max(abs(X[known_vals]))` < tol,
         where `X_t` is `X` at iteration `t. Note that early stopping is only
         applied if ``sample_posterior=False``.
 


### PR DESCRIPTION
Switched positions of `abs` and `max` in both numerator and denominator of the `max_iter` parameter of Iterative Imputer

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

We're essentially first noting the absolute values of the elements in the _difference matrix_ generated by subtracting the feature matrices at the two latest iterations, then figuring out the `max` of those values and then finally proceeding with the calculations. Fixed this typo


#### Any other comments?

It would be better if we could be a little bit more verbose about what _X[known_vals]_ actually is.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
