### PR TITLE
ENH preserves dtypes for GenericUnivariateSelect class

### DIFF
--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -458,6 +458,10 @@ Changelog
 - |API| Adds :class:`feature_selection.SelectorMixin` back to public API.
   :pr:`16132` by :user:`trimeta`.
 
+- |Enhancement| : class:`feature_selection.GenericUnivariateSelect` preserves
+  float32 dtype. :pr:`18482` by :user:`Thierry Gameiro <titigmr>`
+  and :user:`Daniel Kharsa <aflatoune>`.
+
 :mod:`sklearn.gaussian_process`
 ...............................
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -262,6 +262,9 @@ Changelog
   :class:`neighbors.KDTree` for counting nearest neighbors. :pr:`17878` by
   :user:`Noel Rogers <noelano>`.
 
+- |Enhancement| : class:`feature_selection.GenericUnivariateSelect` preserves
+  float32 dtype. :pr:`18482` by :user:`Thierry Gameiro <titigmr>`.
+
 :mod:`sklearn.gaussian_process`
 ...............................
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -263,7 +263,8 @@ Changelog
   :user:`Noel Rogers <noelano>`.
 
 - |Enhancement| : class:`feature_selection.GenericUnivariateSelect` preserves
-  float32 dtype. :pr:`18482` by :user:`Thierry Gameiro <titigmr>`.
+  float32 dtype. :pr:`18482` by :user:`Thierry Gameiro <titigmr>`
+  and :user:`Daniel Kharsa <aflatoune>`.
 
 :mod:`sklearn.gaussian_process`
 ...............................

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -82,7 +82,7 @@ class SelectorMixin(TransformerMixin, metaclass=ABCMeta):
             warn("No features were selected: either the data is"
                  " too noisy or the selection test too strict.",
                  UserWarning)
-            return np.empty(0).reshape((X.shape[0], 0))
+            return np.empty(0, dtype=X.dtype).reshape((X.shape[0], 0))
         if len(mask) != X.shape[1]:
             raise ValueError("X has a different shape than during fitting.")
         return X[:, safe_mask(X, mask)]

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -822,6 +822,9 @@ class GenericUnivariateSelect(_BaseFilter):
 
         return selector
 
+    def _more_tags(self):
+        return {'preserves_dtype': [np.float64, np.float32]}
+
     def _check_params(self, X, y):
         if self.mode not in self._selection_modes:
             raise ValueError("The mode passed should be one of %s, %r,"

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -667,3 +667,16 @@ def test_mutual_info_regression():
     gtruth = np.zeros(10)
     gtruth[:2] = 1
     assert_array_equal(support, gtruth)
+
+
+def test_generic_univariate_selection_empty_selection():
+    # check that the empy array generated is the same dtype of the X array
+    # when no features selected
+    X, y = make_regression(
+        n_samples=200, n_features=20, n_informative=5, shuffle=False,
+        random_state=0
+    )
+    X = X.astype('float32')
+    select = GenericUnivariateSelect(score_func=f_classif)
+    X_trans = select.fit_transform(X, y)
+    assert X_trans.dtype == np.float32

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -667,16 +667,3 @@ def test_mutual_info_regression():
     gtruth = np.zeros(10)
     gtruth[:2] = 1
     assert_array_equal(support, gtruth)
-
-
-def test_generic_univariate_selection_empty_selection():
-    # check that the empy array generated is the same dtype of the X array
-    # when no features selected
-    X, y = make_regression(
-        n_samples=200, n_features=20, n_informative=5, shuffle=False,
-        random_state=0
-    )
-    X = X.astype('float32')
-    select = GenericUnivariateSelect(score_func=f_classif)
-    X_trans = select.fit_transform(X, y)
-    assert X_trans.dtype == np.float32

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -42,7 +42,7 @@ from ..base import (
 
 from ..metrics import accuracy_score, adjusted_rand_score, f1_score
 from ..random_projection import BaseRandomProjection
-from ..feature_selection import SelectKBest
+from ..feature_selection import SelectKBest, f_regression
 from ..pipeline import make_pipeline
 from ..exceptions import DataConversionWarning
 from ..exceptions import NotFittedError
@@ -664,6 +664,9 @@ def _set_checking_parameters(estimator):
 
     if name == 'OneHotEncoder':
         estimator.set_params(handle_unknown='ignore')
+
+    if name == 'GenericUnivariateSelect':
+        estimator.set_params(score_func=f_regression)
 
 
 class _NotAnArray:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Refer to #11000

#### What does this implement/fix? Explain your changes.

This PR preserves dtypes for GenericUnivariateSelect class.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
