### PR TITLE
CI Update PR labeler to support pull_request_target

### DIFF
--- a/.github/workflows/labeler-module.yml
+++ b/.github/workflows/labeler-module.yml
@@ -5,7 +5,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.4.6
+    - uses: thomasjpfan/labeler@v2.5.0
       continue-on-error: true
       if: github.repository == 'scikit-learn/scikit-learn'
       with:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Continues https://github.com/scikit-learn/scikit-learn/pull/18489


#### What does this implement/fix? Explain your changes.
Previously, the labeler scans through every PR to find PRs that needed to be labeled. This was done with a cron job because the `pull_request` event did not give access to `secrets.GITHUB_TOKEN` which was needed to add labels.

This updated labeler takes advantage of the `pull_request_target` event to add labels in response to this event, without needing to scan through every PR. This works because `pull_request_target` event has access to the secret.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
