### PR TITLE
[WIP] CI Add workflow to unlabel reviewed pull requests

### DIFF
--- a/.github/workflows/unlabel-review.yml
+++ b/.github/workflows/unlabel-review.yml
@@ -13,4 +13,4 @@ jobs:
         if: github.event.pull_request.state == 'open'
         run: |
           echo "Marking pull request ${{ github.event.pull_request.number }} as reviewed"
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["Waiting for Reviewer"]}' https://api.github.com/repos/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/labels
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["Waiting for Reviewer"]}' https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/labels

--- a/.github/workflows/unlabel-review.yml
+++ b/.github/workflows/unlabel-review.yml
@@ -1,6 +1,7 @@
 
 name: Reviewed
-# Runs when a core-dev review a PR and remove the "Waiting for Reviewer" label
+# Runs when a review is submitted to a PR and
+# remove the "Waiting for Reviewer" label
 on:
   pull_request_review:
     types: submitted
@@ -13,4 +14,4 @@ jobs:
         if: github.event.pull_request.state == 'open'
         run: |
           echo "Marking pull request ${{ github.event.pull_request.number }} as reviewed"
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/labels/Waiting%20for%20Reviewer
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/Waiting%20for%20Reviewer

--- a/.github/workflows/unlabel-review.yml
+++ b/.github/workflows/unlabel-review.yml
@@ -1,0 +1,16 @@
+
+name: Reviewed
+#Runs when a core-dev review a PR and remove the 'waiting for review' label
+on:
+  pull_request_review:
+    types: submitted
+
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    steps:
+      - name:
+        if: github.event.pull_request.state == 'open'
+        run: |
+          echo "Marking pull request ${{ github.event.pull_request.number }} as reviewed"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["Waiting for Reviewer"]}' https://api.github.com/repos/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/labels

--- a/.github/workflows/unlabel-review.yml
+++ b/.github/workflows/unlabel-review.yml
@@ -13,4 +13,4 @@ jobs:
         if: github.event.pull_request.state == 'open'
         run: |
           echo "Marking pull request ${{ github.event.pull_request.number }} as reviewed"
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["Waiting for Reviewer"]}' https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/labels
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" '{"labels": ["Waiting for Reviewer"]}' https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/labels

--- a/.github/workflows/unlabel-review.yml
+++ b/.github/workflows/unlabel-review.yml
@@ -10,8 +10,15 @@ jobs:
   one:
     runs-on: ubuntu-latest
     steps:
-      - name:
-        if: github.event.pull_request.state == 'open'
+      - name: Set variables
         run: |
-          echo "Marking pull request ${{ github.event.pull_request.number }} as reviewed"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/scikit-learn/teams/core-devs/members >> $CORE_DEV_ENV
+          echo "${{ CORE_DEV_ENV.*.login }}"
+      - name: Relabeling
+        if: github.event.pull_request.state == 'open'
+            && contains(${{ CORE_DEV_ENV.*.login }}, github.event.pull_request_review.sender)
+        run: |
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/scikit-learn/teams/core-devs/members >> $CORE_DEV_ENV
+          if
+          echo "Marking pull request ${{ github.event.pull_request.number }} as reviewed by"
           curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/Waiting%20for%20Reviewer

--- a/.github/workflows/unlabel-review.yml
+++ b/.github/workflows/unlabel-review.yml
@@ -13,4 +13,4 @@ jobs:
         if: github.event.pull_request.state == 'open'
         run: |
           echo "Marking pull request ${{ github.event.pull_request.number }} as reviewed"
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" '{"labels": ["Waiting for Reviewer"]}' https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/labels
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/labels/Waiting%20for%20Reviewer

--- a/.github/workflows/unlabel-review.yml
+++ b/.github/workflows/unlabel-review.yml
@@ -16,9 +16,7 @@ jobs:
           echo "${{ CORE_DEV_ENV.*.login }}"
       - name: Relabeling
         if: github.event.pull_request.state == 'open'
-            && contains(${{ CORE_DEV_ENV.*.login }}, github.event.pull_request_review.sender)
+            && contains(env.CORE_DEV_ENV.*.login, github.event.pull_request_review.sender)
         run: |
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/scikit-learn/teams/core-devs/members >> $CORE_DEV_ENV
-          if
           echo "Marking pull request ${{ github.event.pull_request.number }} as reviewed by"
           curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/Waiting%20for%20Reviewer

--- a/.github/workflows/unlabel-review.yml
+++ b/.github/workflows/unlabel-review.yml
@@ -1,6 +1,6 @@
 
 name: Reviewed
-#Runs when a core-dev review a PR and remove the 'waiting for review' label
+# Runs when a core-dev review a PR and remove the "Waiting for Reviewer" label
 on:
   pull_request_review:
     types: submitted


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Remove the "Waiting for Reviewer" label from pull requests when a review is  submitted.
Use the [pull_request_review](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_review) event (type submitted).

#### Any other comments?
I've tried to test this action on my fork, but github doesn't allow me to review my own pull request... so I'm not sure it works: in particular I don't know if the system makes a difference between core-devs and contributors.
Please consider this as a RFC.