### PR TITLE
TST Makes sure name is correct for fetch_* functions

### DIFF
--- a/sklearn/datasets/tests/conftest.py
+++ b/sklearn/datasets/tests/conftest.py
@@ -1,6 +1,7 @@
 """ Network tests are only run, if data is already locally available,
 or if download is specifically requested by environment variable."""
 import builtins
+from functools import wraps
 from os import environ
 import pytest
 from sklearn.datasets import fetch_20newsgroups
@@ -16,6 +17,7 @@ def _wrapped_fetch(f, dataset_name):
     """ Fetch dataset (download if missing and requested by environment) """
     download_if_missing = environ.get('SKLEARN_SKIP_NETWORK_TESTS', '1') == '0'
 
+    @wraps(f)
     def wrapped(*args, **kwargs):
         kwargs['download_if_missing'] = download_if_missing
         try:


### PR DESCRIPTION
This is needed because `check_pandas_dependency_message` uses `__name__` to check the error message:

https://github.com/scikit-learn/scikit-learn/blob/21121f50997dba43fffbfecb2f672431cf708363/sklearn/datasets/tests/test_common.py#L40-L47

and

https://github.com/scikit-learn/scikit-learn/blob/21121f50997dba43fffbfecb2f672431cf708363/sklearn/datasets/tests/test_kddcup99.py#L59-L60

now uses the fixture as an input to the function.