### PR TITLE
[MRG] Avoid nonlinear complexity for repr of nested estimators when print_c…

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -598,6 +598,13 @@ Changelog
   with different endianness.
   :pr:`17644` by :user:`Qi Zhang <qzhang90>`.
 
+Miscellaneous
+.............
+
+- |Enhancement| Calls to ``repr`` are now faster
+  when `print_changed_only=True`, especially with meta-estimators.
+  :pr:`18508` by :user:`Nathan C. <Xethan>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -99,10 +99,11 @@ def _changed_params(estimator):
             return True
         if init_params[k] == inspect._empty:  # k has no default value
             return True
-        # avoid `repr` on nested estimators, it causes nonlinear complexity
+        # try to avoid calling repr on nested estimators
         if (isinstance(v, BaseEstimator) and
            v.__class__ != init_params[k].__class__):
             return True
+        # Use repr as a last resort. It may be expensive.
         if (repr(v) != repr(init_params[k]) and
            not (is_scalar_nan(init_params[k]) and is_scalar_nan(v))):
             return True

--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -96,8 +96,11 @@ def _changed_params(estimator):
     init_params = {name: param.default for name, param in init_params.items()}
 
     for k, v in params.items():
-        if (k not in init_params or (  # happens if k is part of a **kwargs
-                repr(v) != repr(init_params[k]) and
+        if (k not in init_params or  # happens if k is part of a **kwargs
+            # avoid `repr` if possible, it can be costly for nested estimators
+            (isinstance(v, BaseEstimator) and
+                v.__class__ != init_params[k].__class__) or
+            (repr(v) != repr(init_params[k]) and
                 not (is_scalar_nan(init_params[k]) and is_scalar_nan(v)))):
             filtered_params[k] = v
     return filtered_params

--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -63,7 +63,7 @@ BaseEstimator.__repr__ for pretty-printing estimators"""
 # - long sequences (lists, tuples, dict items) with more than N elements are
 #   shortened using ellipsis (', ...') at the end.
 
-from inspect import signature, _empty
+import inspect
 import pprint
 from collections import OrderedDict
 
@@ -89,22 +89,26 @@ def _changed_params(estimator):
     estimator with non-default values."""
 
     params = estimator.get_params(deep=False)
-    filtered_params = {}
     init_func = getattr(estimator.__init__, 'deprecated_original',
                         estimator.__init__)
-    init_params = signature(init_func).parameters
+    init_params = inspect.signature(init_func).parameters
     init_params = {name: param.default for name, param in init_params.items()}
 
-    for k, v in params.items():
-        if (k not in init_params or  # happens if k is part of a **kwargs
-            init_params[k] == _empty or  # k has no default value
-            # don't `repr` nested estimators, it causes nonlinear complexity
-            (isinstance(v, BaseEstimator) and
-                v.__class__ != init_params[k].__class__) or
-            (repr(v) != repr(init_params[k]) and
-                not (is_scalar_nan(init_params[k]) and is_scalar_nan(v)))):
-            filtered_params[k] = v
-    return filtered_params
+    def has_changed(k, v):
+        if k not in init_params:  # happens if k is part of a **kwargs
+            return True
+        if init_params[k] == inspect._empty:  # k has no default value
+            return True
+        # avoid `repr` on nested estimators, it causes nonlinear complexity
+        if (isinstance(v, BaseEstimator) and
+           v.__class__ != init_params[k].__class__):
+            return True
+        if (repr(v) != repr(init_params[k]) and
+           not (is_scalar_nan(init_params[k]) and is_scalar_nan(v))):
+            return True
+        return False
+
+    return {k: v for k, v in params.items() if has_changed(k, v)}
 
 
 class _EstimatorPrettyPrinter(pprint.PrettyPrinter):

--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -63,7 +63,7 @@ BaseEstimator.__repr__ for pretty-printing estimators"""
 # - long sequences (lists, tuples, dict items) with more than N elements are
 #   shortened using ellipsis (', ...') at the end.
 
-from inspect import signature
+from inspect import signature, _empty
 import pprint
 from collections import OrderedDict
 
@@ -97,7 +97,8 @@ def _changed_params(estimator):
 
     for k, v in params.items():
         if (k not in init_params or  # happens if k is part of a **kwargs
-            # avoid `repr` if possible, it can be costly for nested estimators
+            init_params[k] == _empty or  # k has no default value
+            # don't `repr` nested estimators, it causes nonlinear complexity
             (isinstance(v, BaseEstimator) and
                 v.__class__ != init_params[k].__class__) or
             (repr(v) != repr(init_params[k]) and


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #18490


#### What does this implement/fix? Explain your changes.
When `print_changed_only` is `True` and `repr` is called on an estimator, parameters are checked to see if they are different from the default value using `repr`. This causes a complexity issue for nested estimators because it will recursively call `repr` on the attributes that are estimators and so on, so we first check if the parameter is an estimator with a type different than the default value (often the parameter will have no default value) and exit the `if` early.

I tested it on the case that caused me trouble and it went from 30+ minutes to roughly 1 minute.

#### Any other comments?
I don't know if it is possible to do a non-regression test as functionality is unchanged. I don't know how to use asv benchmarks and I would need to reproduce the issue with base estimators first.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
