### PR TITLE
MRG Sample weight for StandardScaler

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -575,7 +575,7 @@ Changelog
   :class:`preprocessing.StandardScaler` for when X is dense. Allows setting
   individual weights for each sample. :pr:`18510` and
   :pr:`18447` and :pr:`16066` by :user:`Maria Telenczuk <maikia>` and
-  `Albert Villanova:user:<albertvillanova>` and :user:`<panpiort8>`
+  :user:`Albert Villanova <albertvillanova>` and :user:`<panpiort8>`
 
 :mod:`sklearn.svm`
 ..................

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -571,6 +571,12 @@ Changelog
   :class:`preprocessing.KBinsDiscretizer`.
   :pr:`16335` by :user:`Arthur Imbert <Henley13>`.
 
+- |Feature| Add ``sample_weight`` parameter to
+  :class:`preprocessing.StandardScaler` for when X is dense. Allows setting
+  individual weights for each sample. :pr:`18510` and
+  :pr:`18447` and :pr:`16066` by :user:`Maria Telenczuk <maikia>` and
+  `Albert Villanova:user:<albertvillanova>` and :user:`<panpiort8>`
+
 :mod:`sklearn.svm`
 ..................
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -749,6 +749,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
 
         sample_weight : array-like of shape (n_samples,), default=None
             Individual weights for each sample
+            sample_weight only works if X is sparse and it will through
+            `NotImplementedError` if X is sparse.
 
             .. versionadded:: 0.24
                parameter *sample_weight* support to StandardScaler.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -710,7 +710,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
 
         sample_weight : array-like of shape (n_samples,), default=None
             Individual weights for each sample. Works only if X is dense. It
-            will throw an `NotImplemented Error` if passed with sparse X
+            will raise a `NotImplementedError` if called with sparse X
 
             .. versionadded:: 0.24
                parameter *sample_weight* support to StandardScaler.
@@ -749,7 +749,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
 
         sample_weight : array-like of shape (n_samples,), default=None
             Individual weights for each sample. Works only if X is dense. It
-            will throw an `NotImplemented Error` if passed with sparse X
+            will raise a `NotImplementedError` if called with sparse X
 
             .. versionadded:: 0.24
                parameter *sample_weight* support to StandardScaler.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -804,6 +804,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
 
             if not hasattr(self, 'n_samples_seen_'):
                 if sample_weight is not None:
+
                     self.n_samples_seen_ = (
                        sample_weight.sum() - counts_nan).astype(np.int64,
                                                                 copy=False)
@@ -823,6 +824,7 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                         # Vol. 37, No. 3,
                         # pp. 242-247
                         # TODO take care of NANS in Sparse
+
                         new_sum = safe_sparse_dot(sample_weight, X)
                         new_sample_count = np.sum(sample_weight)
                         T = new_sum / new_sample_count

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -709,7 +709,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
             Ignored.
 
         sample_weight : array-like of shape (n_samples,), default=None
-            Individual weights for each sample
+            Individual weights for each sample. Works only if X is dense. It
+            will throw an `NotImplemented Error` if passed with sparse X
 
             .. versionadded:: 0.24
                parameter *sample_weight* support to StandardScaler.
@@ -747,9 +748,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
             Ignored.
 
         sample_weight : array-like of shape (n_samples,), default=None
-            Individual weights for each sample
-            sample_weight only works if X is sparse and it will through
-            `NotImplementedError` if X is sparse.
+            Individual weights for each sample. Works only if X is dense. It
+            will throw an `NotImplemented Error` if passed with sparse X
 
             .. versionadded:: 0.24
                parameter *sample_weight* support to StandardScaler.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -781,7 +781,6 @@ class StandardScaler(TransformerMixin, BaseEstimator):
             X = safe_sparse_dot(sw_matrix, X)
             '''
 
-
         # Even in the case of `with_mean=False`, we update the mean anyway
         # This is needed for the incremental computation of the var
         # See incr_mean_variance_axis and _incremental_mean_variance_axis
@@ -844,15 +843,10 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                 self.var_ = None
                 self.n_samples_seen_ += X.shape[0] - np.isnan(X).sum(axis=0)
             else:
-                if sample_weight is not None:
-                    X = X * sample_weight[:,None]
-
                 self.mean_, self.var_, self.n_samples_seen_ = \
                     _incremental_mean_and_var(X, self.mean_, self.var_,
-                                              self.n_samples_seen_)
-
-                if sample_weight is not None:
-                    self.mean_ /= np.mean(sample_weight)
+                                              self.n_samples_seen_,
+                                              sample_weight=sample_weight)
 
         # for backward-compatibility, reduce n_samples_seen_ to an integer
         # if the number of samples is the same for each feature (i.e. no

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -176,7 +176,6 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
     else:
         X = np.asarray(X)
         if with_mean:
-
             mean_ = np.nanmean(X, axis)
         if with_std:
             scale_ = np.nanstd(X, axis)

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -791,12 +791,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                     (np.isnan(X.data), X.indices, X.indptr),
                     shape=X.shape,
                     dtype=sample_weight.dtype)
-                if counts_nan.format == 'csr':
-                    counts_nan.data *= sample_weight.repeat(
-                        np.diff(counts_nan.indptr))
-                elif counts_nan.format == 'csc':
-                    counts_nan.data *= sample_weight[counts_nan.row]
-                counts_nan = counts_nan.sum(axis=0).A.ravel()
+                nan_weights = nan_values.multiply(sample_weight[:, np.newaxis])
+                counts_nan = nan_weights.sum(axis=0).A.ravel()
             else:
                 counts_nan = sparse_constructor(
                         (np.isnan(X.data), X.indices, X.indptr),
@@ -824,6 +820,12 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                         # Vol. 37, No. 3,
                         # pp. 242-247
                         # TODO take care of NANS in Sparse
+                        X.data
+                        nans_place = sparse_constructor((np.isnan(X.data), X.indices, X.indptr),shape=X.shape,dtype=sample_weight.dtype)
+                        notnans_place = nans_place
+                        nans_place.multiply(X)
+                        X_not_nan = X.copy()
+                        X_not_nan.data[int(nans_place.data*(-1)+1)]
 
                         new_sum = safe_sparse_dot(sample_weight, X)
                         new_sample_count = np.sum(sample_weight)

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -22,7 +22,8 @@ from scipy.special import boxcox
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array
 from ..utils.extmath import row_norms
-from ..utils.extmath import _incremental_mean_and_var
+from ..utils.extmath import (_incremental_mean_and_var,
+                             _incremental_weighted_mean_and_var)
 from ..utils.sparsefuncs_fast import (inplace_csr_row_normalize_l1,
                                       inplace_csr_row_normalize_l2)
 from ..utils.sparsefuncs import (inplace_column_scale,
@@ -828,11 +829,17 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                 self.mean_ = None
                 self.var_ = None
                 self.n_samples_seen_ += X.shape[0] - np.isnan(X).sum(axis=0)
+
+            elif sample_weight is not None:
+                self.mean_, self.var_, self.n_samples_seen_ = \
+                    _incremental_weighted_mean_and_var(X, sample_weight,
+                                                   self.mean_,
+                                                   self.var_,
+                                                   self.n_samples_seen_)
             else:
                 self.mean_, self.var_, self.n_samples_seen_ = \
                     _incremental_mean_and_var(X, self.mean_, self.var_,
-                                              self.n_samples_seen_,
-                                              sample_weight=sample_weight)
+                                              self.n_samples_seen_)
 
         # for backward-compatibility, reduce n_samples_seen_ to an integer
         # if the number of samples is the same for each feature (i.e. no

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -791,7 +791,6 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                     (np.isnan(X.data), X.indices, X.indptr),
                     shape=X.shape,
                     dtype=sample_weight.dtype)
-                # for CSR
                 if counts_nan.format == 'csr':
                     counts_nan.data *= sample_weight.repeat(
                         np.diff(counts_nan.indptr))
@@ -806,7 +805,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
             if not hasattr(self, 'n_samples_seen_'):
                 if sample_weight is not None:
                     self.n_samples_seen_ = (
-                        X.shape[0] - counts_nan).astype(np.int64, copy=False)
+                       sample_weight.sum() - counts_nan).astype(np.int64,
+                                                                copy=False)
                 else:
                     self.n_samples_seen_ = (
                         X.shape[0] - counts_nan).astype(np.int64, copy=False)

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -791,19 +791,17 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                     (np.isnan(X.data), X.indices, X.indptr),
                     shape=X.shape,
                     dtype=sample_weight.dtype)
-                counts_nan.data *= sample_weight.repeat(
-                    np.diff(counts_nan.indptr))
+                # for CSR
+                if counts_nan.format == 'csr':
+                    counts_nan.data *= sample_weight.repeat(
+                        np.diff(counts_nan.indptr))
+                elif counts_nan.format == 'csc':
+                    counts_nan.data *= sample_weight[counts_nan.row]
                 counts_nan = counts_nan.sum(axis=0).A.ravel()
             else:
-                # TODO: that is changing X to dense in X.data ???
                 counts_nan = sparse_constructor(
                         (np.isnan(X.data), X.indices, X.indptr),
                         shape=X.shape).sum(axis=0).A.ravel()
-            if sample_weight is not None:
-                 # _sample_weight_mean = np.mean(sample_weight)
-                 sample_weight = (sparse.csr_matrix(sample_weight)
-                                  if X.format == 'csr'
-                                 else sparse.csc_matrix(sample_weight))
 
             if not hasattr(self, 'n_samples_seen_'):
                 if sample_weight is not None:

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -766,21 +766,6 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                                                  dtype=X.dtype)
             sample_weight = np.asarray(sample_weight)
 
-            # TODO: scale X by weights (using )
-            '''
-            from ..utils.extmath import safe_sparse_dot
-            # (from _base)
-            n_samples = X.shape[0]
-            sample_weight = np.asarray(sample_weight)
-            if sample_weight.ndim == 0:
-                sample_weight = np.full(n_samples, sample_weight,
-                                        dtype=sample_weight.dtype)
-            # sample_weight = np.sqrt(sample_weight)
-            sw_matrix = sparse.dia_matrix((sample_weight, 0),
-                                  shape=(n_samples, n_samples))
-            X = safe_sparse_dot(sw_matrix, X)
-            '''
-
         # Even in the case of `with_mean=False`, we update the mean anyway
         # This is needed for the incremental computation of the var
         # See incr_mean_variance_axis and _incremental_mean_variance_axis
@@ -820,7 +805,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                         incr_mean_variance_axis(X, axis=0,
                                                 last_mean=self.mean_,
                                                 last_var=self.var_,
-                                                last_n=self.n_samples_seen_)
+                                                last_n=self.n_samples_seen_,
+                                                sample_weight=sample_weight)
             else:
                 self.mean_ = None
                 self.var_ = None

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -372,12 +372,17 @@ def test_standard_scaler_sparse_sample_weights(Xw, X, sample_weight):
     scaler.fit(X_sparse, y)
 
 
-def test_standard_scaler_1d():
+@pytest.mark.parametrize("add_sample_weight", [False, True])
+def test_standard_scaler_1d(add_sample_weight):
     # Test scaling of dataset along single axis
     for X in [X_1row, X_1col, X_list_1row, X_list_1row]:
-
+        if add_sample_weight:
+            sample_weight = np.ones(len(X))
+        else:
+            sample_weight = None
         scaler = StandardScaler()
-        X_scaled = scaler.fit(X).transform(X, copy=True)
+        X_scaled = scaler.fit(X, sample_weight=sample_weight).transform(
+            X, copy=True)
 
         if isinstance(X, list):
             X = np.array(X)  # cast only after scaling done

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -418,15 +418,21 @@ def test_standard_scaler_1d(add_sample_weight):
     assert scaler.n_samples_seen_ == X.shape[0]
 
 
-def test_standard_scaler_dtype():
+@pytest.mark.parametrize("add_sample_weight", [False, True])
+def test_standard_scaler_dtype(add_sample_weight):
     # Ensure scaling does not affect dtype
     rng = np.random.RandomState(0)
     n_samples = 10
     n_features = 3
+    if add_sample_weight:
+        sample_weight = np.ones(n_samples)
+    else:
+        sample_weight = None
+
     for dtype in [np.float16, np.float32, np.float64]:
         X = rng.randn(n_samples, n_features).astype(dtype)
         scaler = StandardScaler()
-        X_scaled = scaler.fit(X).transform(X)
+        X_scaled = scaler.fit(X, sample_weight=sample_weight).transform(X)
         assert X.dtype == X_scaled.dtype
         assert scaler.mean_.dtype == np.float64
         assert scaler.scale_.dtype == np.float64

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -92,48 +92,6 @@ def assert_correct_incr(i, batch_start, batch_stop, n, chunk_size,
                      n_samples_seen)
 
 
-def test_raises_value_error_if_sample_weights_greater_than_1d():
-    # Sample weights must be either scalar or 1D
-
-    n_sampless = [2, 3]
-    n_featuress = [3, 2]
-
-    for n_samples, n_features in zip(n_sampless, n_featuress):
-        X = rng.randn(n_samples, n_features)
-        y = rng.randn(n_samples)
-        sample_weights_OK = rng.randn(n_samples) ** 2 + 1
-        sample_weights_OK_1 = 1.
-        sample_weights_OK_2 = 2.
-
-        scaler = StandardScaler()
-
-        # make sure the "OK" sample weights actually work
-        scaler.fit(X, y, sample_weights_OK)
-        scaler.fit(X, y, sample_weights_OK_1)
-        scaler.fit(X, y, sample_weights_OK_2)
-
-
-def test_standard_scaler_sample_weights():
-    # weighted StandardScaler
-    Xw = [[1, 2, 3], [4, 5, 6]]
-    yw = [[3, 2], [2, 3]]
-    sample_weight = np.asarray([2., 1.])
-    scaler_w = StandardScaler()
-    scaler_w.fit(Xw, yw, sample_weight=sample_weight)
-
-    # unweighted, but with repeated samples
-    X = [[1, 2, 3], [1, 2, 3], [4, 5, 6]]
-    y = [[3, 2], [3, 2], [2, 3]]
-    scaler = StandardScaler()
-    scaler.fit(X, y)
-
-    X_test = [[1.5, 2.5, 3.5], [3.5, 4.5, 5.5]]
-    assert_almost_equal(scaler.mean_, scaler_w.mean_)
-    assert_almost_equal(scaler.var_, scaler_w.var_)
-
-    assert_almost_equal(scaler.transform(data), scaler_w.transform(data))
-
-
 def test_polynomial_features():
     # Test Polynomial Features
     X1 = np.arange(6)[:, np.newaxis]
@@ -328,6 +286,48 @@ def test_polynomial_features_csr_X_dim_edges(deg, dim, interaction_only):
     assert isinstance(Xt_csr, sparse.csr_matrix)
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
+
+
+def test_raises_value_error_if_sample_weights_greater_than_1d():
+    # Sample weights must be either scalar or 1D
+
+    n_sampless = [2, 3]
+    n_featuress = [3, 2]
+
+    for n_samples, n_features in zip(n_sampless, n_featuress):
+        X = rng.randn(n_samples, n_features)
+        y = rng.randn(n_samples)
+        sample_weights_OK = rng.randn(n_samples) ** 2 + 1
+        sample_weights_OK_1 = 1.
+        sample_weights_OK_2 = 2.
+
+        scaler = StandardScaler()
+
+        # make sure the "OK" sample weights actually work
+        scaler.fit(X, y, sample_weights_OK)
+        scaler.fit(X, y, sample_weights_OK_1)
+        scaler.fit(X, y, sample_weights_OK_2)
+
+
+def test_standard_scaler_sample_weights():
+    # weighted StandardScaler
+    Xw = [[1, 2, 3], [4, 5, 6]]
+    yw = [[3, 2], [2, 3]]
+    sample_weight = np.asarray([2., 1.])
+    scaler_w = StandardScaler()
+    scaler_w.fit(Xw, yw, sample_weight=sample_weight)
+
+    # unweighted, but with repeated samples
+    X = [[1, 2, 3], [1, 2, 3], [4, 5, 6]]
+    y = [[3, 2], [3, 2], [2, 3]]
+    scaler = StandardScaler()
+    scaler.fit(X, y)
+
+    X_test = [[1.5, 2.5, 3.5], [3.5, 4.5, 5.5]]
+
+    assert_almost_equal(scaler.mean_, scaler_w.mean_)
+    assert_almost_equal(scaler.var_, scaler_w.var_)
+    assert_almost_equal(scaler.transform(X_test), scaler_w.transform(X_test))
 
 
 def test_standard_scaler_1d():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -721,7 +721,7 @@ def test_standard_scaler_partial_fit_numerical_stability(add_sample_weight):
     scaler_incr = StandardScaler()
     for chunk in X:
         scaler_incr = scaler_incr.partial_fit(chunk.reshape(1, n_features),
-                                              sample_weight = [1])
+                                              sample_weight=[1])
 
     # Regardless of abs values, they must not be more diff 6 significant digits
     tol = 10 ** (-6)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -294,6 +294,7 @@ def test_raises_value_error_if_sample_weights_greater_than_1d():
     n_sampless = [2, 3]
     n_featuress = [3, 2]
 
+    warning_msg = 'Sample weights must be 1D array or scalar'
     for n_samples, n_features in zip(n_sampless, n_featuress):
         X = rng.randn(n_samples, n_features)
         y = rng.randn(n_samples)
@@ -307,6 +308,11 @@ def test_raises_value_error_if_sample_weights_greater_than_1d():
         scaler.fit(X, y, sample_weights_OK)
         scaler.fit(X, y, sample_weights_OK_1)
         scaler.fit(X, y, sample_weights_OK_2)
+
+        # make sure Error is raised the sample weights greater than 1d
+        sample_weight_notOK = sample_weights_OK[:, np.newaxis]
+        with pytest.raises(ValueError):
+            scaler.fit(X, y, sample_weight=sample_weight_notOK)
 
 
 def test_standard_scaler_sample_weights():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -92,6 +92,48 @@ def assert_correct_incr(i, batch_start, batch_stop, n, chunk_size,
                      n_samples_seen)
 
 
+def test_raises_value_error_if_sample_weights_greater_than_1d():
+    # Sample weights must be either scalar or 1D
+
+    n_sampless = [2, 3]
+    n_featuress = [3, 2]
+
+    for n_samples, n_features in zip(n_sampless, n_featuress):
+        X = rng.randn(n_samples, n_features)
+        y = rng.randn(n_samples)
+        sample_weights_OK = rng.randn(n_samples) ** 2 + 1
+        sample_weights_OK_1 = 1.
+        sample_weights_OK_2 = 2.
+
+        scaler = StandardScaler()
+
+        # make sure the "OK" sample weights actually work
+        scaler.fit(X, y, sample_weights_OK)
+        scaler.fit(X, y, sample_weights_OK_1)
+        scaler.fit(X, y, sample_weights_OK_2)
+
+
+def test_standard_scaler_sample_weights():
+    # weighted StandardScaler
+    Xw = [[1, 2, 3], [4, 5, 6]]
+    yw = [[3, 2], [2, 3]]
+    sample_weight = np.asarray([2., 1.])
+    scaler_w = StandardScaler()
+    scaler_w.fit(Xw, yw, sample_weight=sample_weight)
+
+    # unweighted, but with repeated samples
+    X = [[1, 2, 3], [1, 2, 3], [4, 5, 6]]
+    y = [[3, 2], [3, 2], [2, 3]]
+    scaler = StandardScaler()
+    scaler.fit(X, y)
+
+    X_test = [[1.5, 2.5, 3.5], [3.5, 4.5, 5.5]]
+    assert_almost_equal(scaler.mean_, scaler_w.mean_)
+    assert_almost_equal(scaler.var_, scaler_w.var_)
+
+    assert_almost_equal(scaler.transform(data), scaler_w.transform(data))
+
+
 def test_polynomial_features():
     # Test Polynomial Features
     X1 = np.arange(6)[:, np.newaxis]

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -395,7 +395,6 @@ def test_standard_scaler_1d():
 
     # Constant feature
     X = np.ones((5, 1))
-
     scaler = StandardScaler()
     X_scaled = scaler.fit(X).transform(X, copy=True)
     assert_almost_equal(scaler.mean_, 1.)
@@ -722,7 +721,6 @@ def test_standard_scaler_trasform_with_partial_fit():
     for i, batch in enumerate(gen_batches(X.shape[0], 1)):
 
         X_sofar = X[:(i + 1), :]
-
         chunks_copy = X_sofar.copy()
         scaled_batch = StandardScaler().fit_transform(X_sofar)
         scaler_incr = scaler_incr.partial_fit(X[batch])
@@ -1576,15 +1574,15 @@ def test_quantile_transform_bounds():
     transformer = QuantileTransformer()
     transformer.fit(X)
     assert (transformer.transform([[-10]]) ==
-                transformer.transform([[np.min(X)]]))
+                 transformer.transform([[np.min(X)]]))
     assert (transformer.transform([[10]]) ==
-                transformer.transform([[np.max(X)]]))
+                 transformer.transform([[np.max(X)]]))
     assert (transformer.inverse_transform([[-10]]) ==
-                transformer.inverse_transform(
-                    [[np.min(transformer.references_)]]))
+                 transformer.inverse_transform(
+                     [[np.min(transformer.references_)]]))
     assert (transformer.inverse_transform([[10]]) ==
-                transformer.inverse_transform(
-                    [[np.max(transformer.references_)]]))
+                 transformer.inverse_transform(
+                     [[np.max(transformer.references_)]]))
 
 
 def test_quantile_transform_and_inverse():
@@ -1889,9 +1887,9 @@ def test_maxabs_scaler_partial_fit():
                                   scaler_incr_csc.max_abs_)
         assert scaler_batch.n_samples_seen_ == scaler_incr.n_samples_seen_
         assert (scaler_batch.n_samples_seen_ ==
-                scaler_incr_csr.n_samples_seen_)
+                    scaler_incr_csr.n_samples_seen_)
         assert (scaler_batch.n_samples_seen_ ==
-                scaler_incr_csc.n_samples_seen_)
+                    scaler_incr_csc.n_samples_seen_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csc.scale_)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1887,9 +1887,9 @@ def test_maxabs_scaler_partial_fit():
                                   scaler_incr_csc.max_abs_)
         assert scaler_batch.n_samples_seen_ == scaler_incr.n_samples_seen_
         assert (scaler_batch.n_samples_seen_ ==
-                    scaler_incr_csr.n_samples_seen_)
+                     scaler_incr_csr.n_samples_seen_)
         assert (scaler_batch.n_samples_seen_ ==
-                    scaler_incr_csc.n_samples_seen_)
+                     scaler_incr_csc.n_samples_seen_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csc.scale_)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -334,67 +334,18 @@ def test_standard_scaler_sample_weights():
     assert_almost_equal(scaler.var_, scaler_w.var_)
     assert_almost_equal(scaler.transform(X_test), scaler_w.transform(X_test))
 
-# TODO
-def test_standard_scalers_sample_weight_with_nans():
-    pass
 
-# TODO
-def test_sample_weight_partial_fit():
-    pass
-
-
-# TODO
-def test_sample_weight_scalar_partial_fit():
-    pass
-
-# TODO: X being csc or csr or coo (?)
-# TODO: add parametrize
-def test_standard_scaler_sparse_sample_weights():
-    # weighted StandardScaler
-    Xw_dense = [[0, 0, 1, np.nan, 2, 0],[0, 3, np.nan, np.nan, np.nan, 2]]
-    # Xw_dense = [[1, 2, 3], [4, 5, 6]]
-    # np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])
-    Xw_sparse = sparse.csr_matrix(Xw_dense)
-    yw = [[3, 2], [2, 3]]  # [[3, 2], [2, 3], [4, 5]]
-    sample_weight = np.asarray([1., 2.])  # np.asarray([2., 1., 1.])
-    scaler_w = StandardScaler(with_mean=False)
-    scaler_w.fit(Xw_sparse, yw, sample_weight=sample_weight)
-
-    # X_dense = [[1, 2, 3], [1, 2, 3], [4, 5, 6]]
-    X_dense = [[0, 0, 1, np.nan, 2, 0],[0, 0, 1, np.nan, 2, 0], [0, 3, np.nan, np.nan, np.nan, 2]]
-    # np.array([[3.0, 0, 4.0], [3.0, 0, 4.0],
-    # [1.0, 0, 0.0], [2.0, 3.0, 0.0]])
-    X_sparse = sparse.csr_matrix(X_dense)
-    y = [[3, 2], [3, 2], [2, 3]]  # [[3, 2], [2, 3], [4, 5], [2, 3]]
-    scaler = StandardScaler(with_mean=False)
-    scaler.fit(X_sparse, y)
-
-    X_test = [[1.5, 2.5, 3.5], [3.5, 4.5, 5.5]]
-    # [[1.5, 2.5, 3.5], [3.5, 0.0, 5.5], [4.5, 0.0, 0.0]]
-    X_test_sparse = sparse.csr_matrix(X_test)
-
-    assert_almost_equal(scaler.mean_, scaler_w.mean_)
-    assert_almost_equal(scaler.var_, scaler_w.var_)
-
-    transformed = scaler.transform(X_test_sparse)
-    transformed_w = scaler_w.transform(X_test_sparse)
-    assert_array_almost_equal(transformed.toarray(),
-                              transformed_w.toarray())
-
-
-# TODO: X being csc or csr or coo (?)
-# TODO: add parametrize
 @pytest.mark.parametrize(['Xw', 'X', 'sample_weight'],
-                           [([[0, 0, 1, np.nan, 2, 0],
-                              [0, 3, np.nan, np.nan, np.nan, 2]],
-                             [[0, 0, 1, np.nan, 2, 0],
-                              [0, 0, 1, np.nan, 2, 0],
-                              [0, 3, np.nan, np.nan, np.nan, 2]],
-                             [1., 2.]),
-                            ([[1, 0, 1], [0, 0, 1]],
-                             [[1, 0, 1], [0, 0, 1], [0, 0, 1], [0, 0, 1]],
-                             np.array([1, 3]))
-                           ])
+                         [([[0, 0, 1, np.nan, 2, 0],
+                            [0, 3, np.nan, np.nan, np.nan, 2]],
+                           [[0, 0, 1, np.nan, 2, 0],
+                            [0, 0, 1, np.nan, 2, 0],
+                            [0, 3, np.nan, np.nan, np.nan, 2]],
+                           [1., 2.]),
+                          ([[1, 0, 1], [0, 0, 1]],
+                           [[1, 0, 1], [0, 0, 1], [0, 0, 1], [0, 0, 1]],
+                           np.array([1, 3]))
+                          ])
 def test_standard_scaler_sparse_sample_weights(Xw, X, sample_weight):
     # weighted StandardScaler throughs notImplementedError when run with
     # sample_weight

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -648,36 +648,31 @@ def test_standard_scaler_partial_fit(add_sample_weight):
     X = X_2d
     n = X.shape[0]
 
+    sample_weight_batch = None
+    sample_weight = None
     for chunk_size in [1, 2, 50, n, n + 42]:
         # Test mean at the end of the process
         if add_sample_weight:
-            sample_weight_batch = np.ones(len(X))
-            sample_weight_incr = np.ones(chunk_size)
-        else:
-            sample_weight_batch = None
-            sample_weight_incr = None
+            sample_weight = np.ones(len(X))
 
         scaler_batch = StandardScaler(with_std=False).fit(
-            X, sample_weight=sample_weight_batch)
+            X, sample_weight=sample_weight)
 
         scaler_incr = StandardScaler(with_std=False)
         for batch in gen_batches(n_samples, chunk_size):
-            try:
-                scaler_incr = scaler_incr.partial_fit(
-                  X[batch], sample_weight=sample_weight_incr)
-
-            except:
-                import pdb; pdb.set_trace()
-
+            if add_sample_weight:
+                sample_weight_batch = np.ones(min(n_samples, chunk_size))
+            scaler_incr = scaler_incr.partial_fit(
+                X[batch], sample_weight=sample_weight_batch)
         assert_array_almost_equal(scaler_batch.mean_, scaler_incr.mean_)
         assert scaler_batch.var_ == scaler_incr.var_  # Nones
         assert scaler_batch.n_samples_seen_ == scaler_incr.n_samples_seen_
 
         # Test std after 1 step
         batch0 = slice(0, chunk_size)
-
         scaler_incr = StandardScaler().partial_fit(
-            X[batch0], sample_weight=sample_weight_incr)
+            X[batch0], sample_weight=sample_weight_batch)
+
         if chunk_size == 1:
             assert_array_almost_equal(np.zeros(n_features, dtype=np.float64),
                                       scaler_incr.var_)
@@ -690,12 +685,14 @@ def test_standard_scaler_partial_fit(add_sample_weight):
                                       scaler_incr.scale_)  # no constants
 
         # Test std until the end of partial fits, and
-        scaler_batch = StandardScaler().fit(X,
-                                            sample_weight=sample_weight_batch)
+        scaler_batch = StandardScaler().fit(X, sample_weight=sample_weight)
         scaler_incr = StandardScaler()  # Clean estimator
+        sample_weight_batch = None
         for i, batch in enumerate(gen_batches(n_samples, chunk_size)):
+            if add_sample_weight:
+                sample_weight_batch = np.ones(min(n_samples, chunk_size))
             scaler_incr = scaler_incr.partial_fit(
-                X[batch], sample_weight=sample_weight_incr)
+                X[batch], sample_weight=sample_weight_batch)
             assert_correct_incr(i, batch_start=batch.start,
                                 batch_stop=batch.stop, n=n,
                                 chunk_size=chunk_size,

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -295,6 +295,7 @@ def test_raises_value_error_if_sample_weights_greater_than_1d():
     n_featuress = [3, 2]
 
     for n_samples, n_features in zip(n_sampless, n_featuress):
+
         X = rng.randn(n_samples, n_features)
         y = rng.randn(n_samples)
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -368,8 +368,7 @@ def test_standard_scaler_1d():
     # Test scaling of dataset along single axis
     for X in [X_1row, X_1col, X_list_1row, X_list_1row]:
         scaler = StandardScaler()
-        X_scaled = scaler.fit(X).transform(
-            X, copy=True)
+        X_scaled = scaler.fit(X).transform(X, copy=True)
 
         if isinstance(X, list):
             X = np.array(X)  # cast only after scaling done
@@ -398,8 +397,7 @@ def test_standard_scaler_1d():
     X = np.ones((5, 1))
 
     scaler = StandardScaler()
-    X_scaled = scaler.fit(X).transform(
-        X, copy=True)
+    X_scaled = scaler.fit(X).transform(X, copy=True)
     assert_almost_equal(scaler.mean_, 1.)
     assert_almost_equal(scaler.scale_, 1.)
     assert_array_almost_equal(X_scaled.mean(axis=0), .0)
@@ -617,8 +615,7 @@ def test_standard_scaler_partial_fit():
 
     for chunk_size in [1, 2, 50, n, n + 42]:
         # Test mean at the end of the process
-        scaler_batch = StandardScaler(with_std=False).fit(
-            X)
+        scaler_batch = StandardScaler(with_std=False).fit(X)
 
         scaler_incr = StandardScaler(with_std=False)
         for batch in gen_batches(n_samples, chunk_size):
@@ -731,6 +728,7 @@ def test_standard_scaler_trasform_with_partial_fit():
 
         scaler_incr = scaler_incr.partial_fit(X[batch])
         scaled_incr = scaler_incr.transform(X_sofar)
+
         assert_array_almost_equal(scaled_batch, scaled_incr)
         assert_array_almost_equal(X_sofar, chunks_copy)  # No change
         right_input = scaler_incr.inverse_transform(scaled_incr)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -314,17 +314,26 @@ def test_raises_value_error_if_sample_weights_greater_than_1d():
             scaler.fit(X, y, sample_weight=sample_weight_notOK)
 
 
-def test_standard_scaler_sample_weights():
+@pytest.mark.parametrize(['Xw', 'X', 'sample_weight'],
+                         [([[1, 2, 3], [4, 5, 6]],
+                           [[1, 2, 3], [1, 2, 3], [4, 5, 6]],
+                           [2., 1.]),
+                          ([[1, 0, 1], [0, 0, 1]],
+                           [[1, 0, 1], [0, 0, 1], [0, 0, 1], [0, 0, 1]],
+                           np.array([1, 3])),
+                          ([[1, np.nan, 1], [np.nan, np.nan, 1]],
+                           [[1, np.nan, 1], [np.nan, np.nan, 1],
+                            [np.nan, np.nan, 1], [np.nan, np.nan, 1]],
+                           np.array([1, 3])),
+                          ])
+def test_standard_scaler_sample_weight(Xw, X, sample_weight):
     # weighted StandardScaler
-    Xw = [[1, 2, 3], [4, 5, 6]]
-    yw = [[3, 2], [2, 3]]
-    sample_weight = np.asarray([2., 1.])
+    yw = np.ones(len(Xw))
     scaler_w = StandardScaler()
     scaler_w.fit(Xw, yw, sample_weight=sample_weight)
 
     # unweighted, but with repeated samples
-    X = [[1, 2, 3], [1, 2, 3], [4, 5, 6]]
-    y = [[3, 2], [3, 2], [2, 3]]
+    y = np.ones(len(X))
     scaler = StandardScaler()
     scaler.fit(X, y)
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -297,16 +297,8 @@ def test_raises_value_error_if_sample_weights_greater_than_1d():
     for n_samples, n_features in zip(n_sampless, n_featuress):
         X = rng.randn(n_samples, n_features)
         y = rng.randn(n_samples)
-        sample_weights_OK = rng.randn(n_samples) ** 2 + 1
-        sample_weights_OK_1 = 1.
-        sample_weights_OK_2 = 2.
 
         scaler = StandardScaler()
-
-        # make sure the "OK" sample weights actually work
-        scaler.fit(X, y, sample_weights_OK)
-        scaler.fit(X, y, sample_weights_OK_1)
-        scaler.fit(X, y, sample_weights_OK_2)
 
         # make sure Error is raised the sample weights greater than 1d
         sample_weight_notOK = sample_weights_OK[:, np.newaxis]
@@ -372,16 +364,11 @@ def test_standard_scaler_sparse_sample_weights(Xw, X, sample_weight):
     scaler.fit(X_sparse, y)
 
 
-@pytest.mark.parametrize("add_sample_weight", [False, True])
-def test_standard_scaler_1d(add_sample_weight):
+def test_standard_scaler_1d():
     # Test scaling of dataset along single axis
     for X in [X_1row, X_1col, X_list_1row, X_list_1row]:
-        if add_sample_weight:
-            sample_weight = np.ones(len(X))
-        else:
-            sample_weight = None
         scaler = StandardScaler()
-        X_scaled = scaler.fit(X, sample_weight=sample_weight).transform(
+        X_scaled = scaler.fit(X).transform(
             X, copy=True)
 
         if isinstance(X, list):
@@ -409,13 +396,9 @@ def test_standard_scaler_1d(add_sample_weight):
 
     # Constant feature
     X = np.ones((5, 1))
-    if add_sample_weight:
-        sample_weight = np.ones(len(X))
-    else:
-        sample_weight = None
 
     scaler = StandardScaler()
-    X_scaled = scaler.fit(X, sample_weight=sample_weight).transform(
+    X_scaled = scaler.fit(X).transform(
         X, copy=True)
     assert_almost_equal(scaler.mean_, 1.)
     assert_almost_equal(scaler.scale_, 1.)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -770,7 +770,8 @@ def test_partial_fit_sparse_input():
         assert_array_equal(X_orig.data, X.data)
 
 
-def test_standard_scaler_trasform_with_partial_fit():
+@pytest.mark.parametrize("add_sample_weight", [False, True])
+def test_standard_scaler_trasform_with_partial_fit(add_sample_weight):
     # Check some postconditions after applying partial_fit and transform
     X = X_2d[:100, :]
 
@@ -778,10 +779,17 @@ def test_standard_scaler_trasform_with_partial_fit():
     for i, batch in enumerate(gen_batches(X.shape[0], 1)):
 
         X_sofar = X[:(i + 1), :]
-        chunks_copy = X_sofar.copy()
-        scaled_batch = StandardScaler().fit_transform(X_sofar)
+        if add_sample_weight:
+            sample_weight = np.ones(len(X_sofar))
+        else:
+            sample_weight = None
 
-        scaler_incr = scaler_incr.partial_fit(X[batch])
+        chunks_copy = X_sofar.copy()
+        scaled_batch = StandardScaler().fit_transform(
+            X_sofar, sample_weight=sample_weight)
+
+        scaler_incr = scaler_incr.partial_fit(X[batch],
+                                              sample_weight=np.ones(1))
         scaled_incr = scaler_incr.transform(X_sofar)
 
         assert_array_almost_equal(scaled_batch, scaled_incr)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -725,7 +725,6 @@ def test_standard_scaler_trasform_with_partial_fit():
 
         chunks_copy = X_sofar.copy()
         scaled_batch = StandardScaler().fit_transform(X_sofar)
-
         scaler_incr = scaler_incr.partial_fit(X[batch])
         scaled_incr = scaler_incr.transform(X_sofar)
 
@@ -1577,15 +1576,15 @@ def test_quantile_transform_bounds():
     transformer = QuantileTransformer()
     transformer.fit(X)
     assert (transformer.transform([[-10]]) ==
-            transformer.transform([[np.min(X)]]))
+                transformer.transform([[np.min(X)]]))
     assert (transformer.transform([[10]]) ==
-            transformer.transform([[np.max(X)]]))
+                transformer.transform([[np.max(X)]]))
     assert (transformer.inverse_transform([[-10]]) ==
-            transformer.inverse_transform(
-                [[np.min(transformer.references_)]]))
+                transformer.inverse_transform(
+                    [[np.min(transformer.references_)]]))
     assert (transformer.inverse_transform([[10]]) ==
-            transformer.inverse_transform(
-                [[np.max(transformer.references_)]]))
+                transformer.inverse_transform(
+                    [[np.max(transformer.references_)]]))
 
 
 def test_quantile_transform_and_inverse():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -330,6 +330,31 @@ def test_standard_scaler_sample_weights():
     assert_almost_equal(scaler.transform(X_test), scaler_w.transform(X_test))
 
 
+def test_standard_scaler_sparse_sample_weights():
+    # weighted StandardScaler
+    Xw_dense = np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])
+    Xw_sparse = sparse.csr_matrix(Xw_dense)
+    yw = [[3, 2], [2, 3], [4, 5]]
+    sample_weight = np.asarray([2., 1., 1.])
+    scaler_w = StandardScaler(with_mean=False)
+    scaler_w.fit(Xw_sparse, yw, sample_weight=sample_weight)
+
+    X_dense = np.array([[3.0, 0, 4.0], [3.0, 0, 4.0],
+                        [1.0, 0, 0.0], [2.0, 3.0, 0.0]])
+    X_sparse = sparse.csr_matrix(Xw_dense)
+    y = [[3, 2], [2, 3], [4, 5], [2, 3]]
+    scaler = StandardScaler(with_mean=False)
+    scaler.fit(X_sparse, y)
+
+    X_test = [[1.5, 2.5, 3.5], [3.5, 0.0, 5.5], [4.5, 0.0, 0.0]]
+    X_test_sparse = sparse.csr_matrix(X_test)
+
+    assert_almost_equal(scaler.mean_, scaler_w.mean_)
+    assert_almost_equal(scaler.var_, scaler_w.var_)
+    assert_array_almost_equal(np.array(scaler.transform(X_test_sparse)),
+                              np.array(scaler_w.transform(X_test_sparse)))
+
+
 def test_standard_scaler_1d():
     # Test scaling of dataset along single axis
     for X in [X_1row, X_1col, X_list_1row, X_list_1row]:

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -294,7 +294,6 @@ def test_raises_value_error_if_sample_weights_greater_than_1d():
     n_sampless = [2, 3]
     n_featuress = [3, 2]
 
-    warning_msg = 'Sample weights must be 1D array or scalar'
     for n_samples, n_features in zip(n_sampless, n_featuress):
         X = rng.randn(n_samples, n_features)
         y = rng.randn(n_samples)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -334,6 +334,9 @@ def test_standard_scaler_sample_weights():
     assert_almost_equal(scaler.var_, scaler_w.var_)
     assert_almost_equal(scaler.transform(X_test), scaler_w.transform(X_test))
 
+# TODO
+def test_standard_scalers_sample_weight_with_nans():
+    pass
 
 # TODO
 def test_sample_weight_partial_fit():
@@ -344,19 +347,21 @@ def test_sample_weight_partial_fit():
 def test_sample_weight_scalar_partial_fit():
     pass
 
-
+# TODO: X being csc or csr or coo (?)
 # TODO: add parametrize
 def test_standard_scaler_sparse_sample_weights():
     # weighted StandardScaler
-    Xw_dense = [[1, 2, 3], [4, 5, 6]]
+    Xw_dense = [[0, 0, 1, np.nan, 2, 0],[0, 3, np.nan, np.nan, np.nan, 2]]
+    # Xw_dense = [[1, 2, 3], [4, 5, 6]]
     # np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])
     Xw_sparse = sparse.csr_matrix(Xw_dense)
     yw = [[3, 2], [2, 3]]  # [[3, 2], [2, 3], [4, 5]]
-    sample_weight = np.asarray([2., 1.])  # np.asarray([2., 1., 1.])
+    sample_weight = np.asarray([1., 2.])  # np.asarray([2., 1., 1.])
     scaler_w = StandardScaler(with_mean=False)
     scaler_w.fit(Xw_sparse, yw, sample_weight=sample_weight)
 
-    X_dense = [[1, 2, 3], [1, 2, 3], [4, 5, 6]]
+    # X_dense = [[1, 2, 3], [1, 2, 3], [4, 5, 6]]
+    X_dense = [[0, 0, 1, np.nan, 2, 0],[0, 0, 1, np.nan, 2, 0], [0, 3, np.nan, np.nan, np.nan, 2]]
     # np.array([[3.0, 0, 4.0], [3.0, 0, 4.0],
     # [1.0, 0, 0.0], [2.0, 3.0, 0.0]])
     X_sparse = sparse.csr_matrix(X_dense)
@@ -375,6 +380,36 @@ def test_standard_scaler_sparse_sample_weights():
     transformed_w = scaler_w.transform(X_test_sparse)
     assert_array_almost_equal(transformed.toarray(),
                               transformed_w.toarray())
+
+
+# TODO: X being csc or csr or coo (?)
+# TODO: add parametrize
+@pytest.mark.parametrize(['Xw', 'X', 'sample_weight'],
+                           [([[0, 0, 1, np.nan, 2, 0],
+                              [0, 3, np.nan, np.nan, np.nan, 2]],
+                             [[0, 0, 1, np.nan, 2, 0],
+                              [0, 0, 1, np.nan, 2, 0],
+                              [0, 3, np.nan, np.nan, np.nan, 2]],
+                             [1., 2.]),
+                            ([[1, 0, 1], [0, 0, 1]],
+                             [[1, 0, 1], [0, 0, 1], [0, 0, 1], [0, 0, 1]],
+                             np.array([1, 3]))
+                           ])
+def test_standard_scaler_sparse_sample_weights(Xw, X, sample_weight):
+    # weighted StandardScaler throughs notImplementedError when run with
+    # sample_weight
+    Xw_sparse = sparse.csr_matrix(Xw)
+    yw = np.ones(len(Xw))
+
+    scaler_w = StandardScaler(with_mean=False)
+    with pytest.raises(NotImplementedError):
+        scaler_w.fit(Xw_sparse, yw, sample_weight=sample_weight)
+
+    # but passes through when run without sample_weight
+    X_sparse = sparse.csr_matrix(X)
+    y = np.ones(len(X))
+    scaler = StandardScaler(with_mean=False)
+    scaler.fit(X_sparse, y)
 
 
 def test_standard_scaler_1d():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -89,7 +89,7 @@ def assert_correct_incr(i, batch_start, batch_stop, n, chunk_size,
         assert (i + 1) * chunk_size == n_samples_seen
     else:
         assert (i * chunk_size + (batch_stop - batch_start) ==
-                     n_samples_seen)
+                n_samples_seen)
 
 
 def test_polynomial_features():
@@ -331,6 +331,7 @@ def test_standard_scaler_sample_weights():
 
 
 def test_standard_scaler_sparse_sample_weights():
+    # TODO: still work needed
     # weighted StandardScaler
     Xw_dense = np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])
     Xw_sparse = sparse.csr_matrix(Xw_dense)
@@ -341,7 +342,7 @@ def test_standard_scaler_sparse_sample_weights():
 
     X_dense = np.array([[3.0, 0, 4.0], [3.0, 0, 4.0],
                         [1.0, 0, 0.0], [2.0, 3.0, 0.0]])
-    X_sparse = sparse.csr_matrix(Xw_dense)
+    X_sparse = sparse.csr_matrix(X_dense)
     y = [[3, 2], [2, 3], [4, 5], [2, 3]]
     scaler = StandardScaler(with_mean=False)
     scaler.fit(X_sparse, y)
@@ -1563,15 +1564,15 @@ def test_quantile_transform_bounds():
     transformer = QuantileTransformer()
     transformer.fit(X)
     assert (transformer.transform([[-10]]) ==
-                 transformer.transform([[np.min(X)]]))
+            transformer.transform([[np.min(X)]]))
     assert (transformer.transform([[10]]) ==
-                 transformer.transform([[np.max(X)]]))
+            transformer.transform([[np.max(X)]]))
     assert (transformer.inverse_transform([[-10]]) ==
-                 transformer.inverse_transform(
-                     [[np.min(transformer.references_)]]))
+            transformer.inverse_transform(
+                [[np.min(transformer.references_)]]))
     assert (transformer.inverse_transform([[10]]) ==
-                 transformer.inverse_transform(
-                     [[np.max(transformer.references_)]]))
+            transformer.inverse_transform(
+                [[np.max(transformer.references_)]]))
 
 
 def test_quantile_transform_and_inverse():
@@ -1876,9 +1877,9 @@ def test_maxabs_scaler_partial_fit():
                                   scaler_incr_csc.max_abs_)
         assert scaler_batch.n_samples_seen_ == scaler_incr.n_samples_seen_
         assert (scaler_batch.n_samples_seen_ ==
-                     scaler_incr_csr.n_samples_seen_)
+                scaler_incr_csr.n_samples_seen_)
         assert (scaler_batch.n_samples_seen_ ==
-                     scaler_incr_csc.n_samples_seen_)
+                scaler_incr_csc.n_samples_seen_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csr.scale_)
         assert_array_almost_equal(scaler_batch.scale_, scaler_incr_csc.scale_)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -335,30 +335,46 @@ def test_standard_scaler_sample_weights():
     assert_almost_equal(scaler.transform(X_test), scaler_w.transform(X_test))
 
 
+# TODO
+def test_sample_weight_partial_fit():
+    pass
+
+
+# TODO
+def test_sample_weight_scalar_partial_fit():
+    pass
+
+
+# TODO: add parametrize
 def test_standard_scaler_sparse_sample_weights():
-    # TODO: still work needed
     # weighted StandardScaler
-    Xw_dense = np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])
+    Xw_dense = [[1, 2, 3], [4, 5, 6]]
+    # np.array([[3.0, 0, 4.0], [1.0, 0.0, 0.0], [2.0, 3.0, 0.0]])
     Xw_sparse = sparse.csr_matrix(Xw_dense)
-    yw = [[3, 2], [2, 3], [4, 5]]
-    sample_weight = np.asarray([2., 1., 1.])
+    yw = [[3, 2], [2, 3]]  # [[3, 2], [2, 3], [4, 5]]
+    sample_weight = np.asarray([2., 1.])  # np.asarray([2., 1., 1.])
     scaler_w = StandardScaler(with_mean=False)
     scaler_w.fit(Xw_sparse, yw, sample_weight=sample_weight)
 
-    X_dense = np.array([[3.0, 0, 4.0], [3.0, 0, 4.0],
-                        [1.0, 0, 0.0], [2.0, 3.0, 0.0]])
+    X_dense = [[1, 2, 3], [1, 2, 3], [4, 5, 6]]
+    # np.array([[3.0, 0, 4.0], [3.0, 0, 4.0],
+    # [1.0, 0, 0.0], [2.0, 3.0, 0.0]])
     X_sparse = sparse.csr_matrix(X_dense)
-    y = [[3, 2], [2, 3], [4, 5], [2, 3]]
+    y = [[3, 2], [3, 2], [2, 3]]  # [[3, 2], [2, 3], [4, 5], [2, 3]]
     scaler = StandardScaler(with_mean=False)
     scaler.fit(X_sparse, y)
 
-    X_test = [[1.5, 2.5, 3.5], [3.5, 0.0, 5.5], [4.5, 0.0, 0.0]]
+    X_test = [[1.5, 2.5, 3.5], [3.5, 4.5, 5.5]]
+    # [[1.5, 2.5, 3.5], [3.5, 0.0, 5.5], [4.5, 0.0, 0.0]]
     X_test_sparse = sparse.csr_matrix(X_test)
 
     assert_almost_equal(scaler.mean_, scaler_w.mean_)
     assert_almost_equal(scaler.var_, scaler_w.var_)
-    assert_array_almost_equal(np.array(scaler.transform(X_test_sparse)),
-                              np.array(scaler_w.transform(X_test_sparse)))
+
+    transformed = scaler.transform(X_test_sparse)
+    transformed_w = scaler_w.transform(X_test_sparse)
+    assert_array_almost_equal(transformed.toarray(),
+                              transformed_w.toarray())
 
 
 def test_standard_scaler_1d():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -475,7 +475,6 @@ def test_standard_scaler_numerical_stability():
 
 def test_scaler_2d_arrays():
     # Test scaling of 2d array along first axis
-
     rng = np.random.RandomState(0)
     n_features = 5
     n_samples = 4
@@ -483,8 +482,7 @@ def test_scaler_2d_arrays():
     X[:, 0] = 0.0  # first feature is always of zero
 
     scaler = StandardScaler()
-    X_scaled = scaler.fit(X).transform(
-        X, copy=True)
+    X_scaled = scaler.fit(X).transform(X, copy=True)
     assert not np.any(np.isnan(X_scaled))
     assert scaler.n_samples_seen_ == n_samples
 
@@ -509,8 +507,7 @@ def test_scaler_2d_arrays():
     # Check that the data hasn't been modified
     assert X_scaled is not X
 
-    X_scaled = scaler.fit(X).transform(
-        X, copy=False)
+    X_scaled = scaler.fit(X).transform(X, copy=False)
     assert not np.any(np.isnan(X_scaled))
     assert_array_almost_equal(X_scaled.mean(axis=0), n_features * [0.0])
     assert_array_almost_equal(X_scaled.std(axis=0), [0., 1., 1., 1., 1.])
@@ -520,8 +517,7 @@ def test_scaler_2d_arrays():
     X = rng.randn(4, 5)
     X[:, 0] = 1.0  # first feature is a constant, non zero feature
     scaler = StandardScaler()
-    X_scaled = scaler.fit(X).transform(
-        X, copy=True)
+    X_scaled = scaler.fit(X).transform(X, copy=True)
     assert not np.any(np.isnan(X_scaled))
     assert_array_almost_equal(X_scaled.mean(axis=0), n_features * [0.0])
     assert_array_almost_equal(X_scaled.std(axis=0), [0., 1., 1., 1., 1.])
@@ -626,8 +622,7 @@ def test_standard_scaler_partial_fit():
 
         scaler_incr = StandardScaler(with_std=False)
         for batch in gen_batches(n_samples, chunk_size):
-            scaler_incr = scaler_incr.partial_fit(
-                X[batch])
+            scaler_incr = scaler_incr.partial_fit(X[batch])
         assert_array_almost_equal(scaler_batch.mean_, scaler_incr.mean_)
         assert scaler_batch.var_ == scaler_incr.var_  # Nones
         assert scaler_batch.n_samples_seen_ == scaler_incr.n_samples_seen_
@@ -635,7 +630,6 @@ def test_standard_scaler_partial_fit():
         # Test std after 1 step
         batch0 = slice(0, chunk_size)
         scaler_incr = StandardScaler().partial_fit(X[batch0])
-
         if chunk_size == 1:
             assert_array_almost_equal(np.zeros(n_features, dtype=np.float64),
                                       scaler_incr.var_)
@@ -651,7 +645,6 @@ def test_standard_scaler_partial_fit():
         scaler_batch = StandardScaler().fit(X)
         scaler_incr = StandardScaler()  # Clean estimator
         for i, batch in enumerate(gen_batches(n_samples, chunk_size)):
-
             scaler_incr = scaler_incr.partial_fit(X[batch])
             assert_correct_incr(i, batch_start=batch.start,
                                 batch_stop=batch.stop, n=n,
@@ -734,12 +727,10 @@ def test_standard_scaler_trasform_with_partial_fit():
         X_sofar = X[:(i + 1), :]
 
         chunks_copy = X_sofar.copy()
-        scaled_batch = StandardScaler().fit_transform(
-            X_sofar)
+        scaled_batch = StandardScaler().fit_transform(X_sofar)
 
         scaler_incr = scaler_incr.partial_fit(X[batch])
         scaled_incr = scaler_incr.transform(X_sofar)
-
         assert_array_almost_equal(scaled_batch, scaled_incr)
         assert_array_almost_equal(X_sofar, chunks_copy)  # No change
         right_input = scaler_incr.inverse_transform(scaled_incr)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -755,8 +755,8 @@ def _incremental_weighted_mean_and_var(X, sample_weight,
     nan_mask = np.isnan(X)
     sample_weight_T = np.reshape(sample_weight, (1, -1))
     # new_weight_sum with shape (n_features,)
-    new_weight_sum = \
-        _safe_accumulator_op(np.dot, sample_weight_T, ~nan_mask).ravel()
+    new_weight_sum = np.dot(sample_weight_T,
+                            ~nan_mask).ravel().astype(np.float64)
     total_weight_sum = _safe_accumulator_op(np.sum, sample_weight, axis=0)
 
     X_0 = np.where(nan_mask, 0, X)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -842,7 +842,6 @@ def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
 
     new_sum = _safe_accumulator_op(np.nansum, X, axis=0)
     new_sample_count = np.sum(~np.isnan(X), axis=0)
-
     updated_sample_count = last_sample_count + new_sample_count
 
     updated_mean = (last_sum + new_sum) / updated_sample_count
@@ -855,9 +854,7 @@ def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
         last_unnormalized_variance = last_variance * last_sample_count
 
         with np.errstate(divide='ignore', invalid='ignore'):
-
             last_over_new_count = last_sample_count / new_sample_count
-
             updated_unnormalized_variance = (
                 last_unnormalized_variance + new_unnormalized_variance +
                 last_over_new_count / updated_sample_count *

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -839,8 +839,8 @@ def _incremental_mean_and_var(X, last_mean, last_variance, last_sample_count):
     # new = the current increment
     # updated = the aggregated stats
     last_sum = last_mean * last_sample_count
-
     new_sum = _safe_accumulator_op(np.nansum, X, axis=0)
+
     new_sample_count = np.sum(~np.isnan(X), axis=0)
     updated_sample_count = last_sample_count + new_sample_count
 


### PR DESCRIPTION
towards  #15601
This PR adds a possibility of defining `sample_weight` for the StandardScaler (only for the dense X).

Right now  #3020 and #17743 are on hold because if we would like to substitute the use of normalize in linear models we need to assure that the suggested way of substitution will work in all cases (ie suggested way is using a Pipeline with a StandardScaler).

However, as pointed out in #18159 this would not work in the case if the linear model is using `sample_weight`. By adding possibility to add `sample_weight` to StandardScaler we are making the above substitution valid again.