### PR TITLE
DOC Clarify GaussianProcessRegressor default kernel behavior

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -45,8 +45,10 @@ class GaussianProcessRegressor(MultiOutputMixin,
     ----------
     kernel : kernel instance, default=None
         The kernel specifying the covariance function of the GP. If None is
-        passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
-        the kernel's hyperparameters are optimized during fitting.
+        passed, the kernel "ConstantKernel(1.0, constant_value_bounds="fixed"
+        * RBF(1.0, length_scale_bounds="fixed")" is used as default. Note that
+        the kernel hyperparameters are optimized during fitting unless the
+        bounds are marked as "fixed".
 
     alpha : float or ndarray of shape (n_samples,), default=1e-10
         Value added to the diagonal of the kernel matrix during fitting.

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -45,8 +45,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
     ----------
     kernel : kernel instance, default=None
         The kernel specifying the covariance function of the GP. If None is
-        passed, the kernel "ConstantKernel(1.0, constant_value_bounds="fixed"
-        * RBF(1.0, length_scale_bounds="fixed")" is used as default. Note that
+        passed, the kernel ``ConstantKernel(1.0, constant_value_bounds="fixed"
+        * RBF(1.0, length_scale_bounds="fixed")`` is used as default. Note that
         the kernel hyperparameters are optimized during fitting unless the
         bounds are marked as "fixed".
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #17871 and #12444


#### What does this implement/fix? Explain your changes.

I ran into this confusion a while ago and after digging through some issues, it looks like I wasn't the only one who was confused as to why the default behavior of the `GaussianProcessRegressor` didn't tune the hyperparameters.

I was very confused when this snippet of code:

```python
gp = GaussianProcessRegressor(n_restarts_optimizer=10)
gp.fit(X, y)

print(gp.kernel_)         # 1**2 * RBF(length_scale=1)       <--- nothing changed?
```

behaves differently than this code:

```python
kernel = C(1.0) * RBF(1.0)
gp = GaussianProcessRegressor(kernel=kernel, n_restarts_optimizer=10)
gp.fit(X, y)

print(gp.kernel_)         # 124**2 * RBF(length_scale=129)  <-- hyp changed even though i used same default kernel? (not quite true) 
```


Hopefully, this update to the docs helps to clarify this (even printing `gp.kernel_` doesn't let you know the bounds).

#### Any other comments?

I think an alternative would be to change the default kernel to:

```python
kernel = ConstantKernel(1.0) * RBF(1.0)
```

I feel like this is the behavior I _expected_ from reading the docs. But this would require changing the default behavior.

Thanks for your consideration!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
