### PR TITLE
MAINT fix fetch_kddcup99_fxt fixture

### DIFF
--- a/sklearn/datasets/tests/conftest.py
+++ b/sklearn/datasets/tests/conftest.py
@@ -22,6 +22,10 @@ def _wrapped_fetch(f, dataset_name):
             return f(*args, **kwargs)
         except IOError:
             pytest.skip("Download {} to run this test".format(dataset_name))
+
+    # Necessary to display the expected error message when pandas is not
+    # installed.
+    wrapped.__name__ = f.__name__
     return wrapped
 
 


### PR DESCRIPTION
`test_pandas_dependency_message` would previously fail when run
locally because the fake `fetch_kddcup99_fxt` dataset loading
function would fail to expose the right function name used
to build the expected error message.

Note that this problem is not visible on the CI because we set
`SKLEARN_SKIP_NETWORK_TESTS=1` in our CI settings to limit bandwidth
usage.
