### PR TITLE
MNT Remove unnecessary assignments from LogisticRegression.fit

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1388,9 +1388,6 @@ class LogisticRegression(LinearClassifierMixin,
                                         self.intercept_[:, np.newaxis],
                                         axis=1)
 
-        self.coef_ = list()
-        self.intercept_ = np.zeros(n_classes)
-
         # Hack so that we iterate only once for the multinomial case.
         if multi_class == 'multinomial':
             classes_ = [None]
@@ -1432,6 +1429,8 @@ class LogisticRegression(LinearClassifierMixin,
         if self.fit_intercept:
             self.intercept_ = self.coef_[:, -1]
             self.coef_ = self.coef_[:, :-1]
+        else:
+            self.intercept_ = np.zeros(n_classes)
 
         return self
 


### PR DESCRIPTION
This is a little simpler and avoids allocating memory that is just going to be released a few lines later without ever being used.