### PR TITLE
[MRG] Adding n_jobs to kernel_approximation.Nystroem

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -326,6 +326,9 @@ Changelog
   map approximation.
   :pr:`13003` by :user:`Daniel López Sánchez <lopeLH>`.
 
+- |Efficiency| :class:`kernel_approximation.Nystroem` now supports
+  parallelization via `joblib.Parallel` using argument `n_jobs`.
+  :pr:`18545` by :user:`Laurenz Reitsam <LaurenzReitsam>`.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -670,6 +670,11 @@ class Nystroem(TransformerMixin, BaseEstimator):
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
+    n_jobs : int, default=None
+        The number of jobs to use for the computation. This works by breaking
+        down the kernel matrix into n_jobs even slices and computing them in
+        parallel.
+
     Attributes
     ----------
     components_ : ndarray of shape (n_components, n_features)

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -675,9 +675,6 @@ class Nystroem(TransformerMixin, BaseEstimator):
     components_ : ndarray of shape (n_components, n_features)
         Subset of training points used to construct the feature map.
 
-    component_indices_ : ndarray of shape (n_components)
-        Indices of ``components_`` in the training set.
-
     normalization_ : ndarray of shape (n_components, n_components)
         Normalization matrix needed for embedding.
         Square root of the kernel matrix on ``components_``.
@@ -767,7 +764,6 @@ class Nystroem(TransformerMixin, BaseEstimator):
         S = np.maximum(S, 1e-12)
         self.normalization_ = np.dot(U / np.sqrt(S), V)
         self.components_ = basis
-        self.component_indices_ = inds
         return self
 
     def transform(self, X):

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -675,6 +675,12 @@ class Nystroem(TransformerMixin, BaseEstimator):
         down the kernel matrix into n_jobs even slices and computing them in
         parallel.
 
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+
+        .. versionadded:: 0.24
+
     Attributes
     ----------
     components_ : ndarray of shape (n_components, n_features)

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -680,6 +680,9 @@ class Nystroem(TransformerMixin, BaseEstimator):
     components_ : ndarray of shape (n_components, n_features)
         Subset of training points used to construct the feature map.
 
+    component_indices_ : ndarray of shape (n_components)
+        Indices of ``components_`` in the training set.
+
     normalization_ : ndarray of shape (n_components, n_components)
         Normalization matrix needed for embedding.
         Square root of the kernel matrix on ``components_``.
@@ -773,6 +776,7 @@ class Nystroem(TransformerMixin, BaseEstimator):
         S = np.maximum(S, 1e-12)
         self.normalization_ = np.dot(U / np.sqrt(S), V)
         self.components_ = basis
+        self.component_indices_ = inds
         return self
 
     def transform(self, X):

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -716,7 +716,9 @@ class Nystroem(TransformerMixin, BaseEstimator):
     """
     @_deprecate_positional_args
     def __init__(self, kernel="rbf", *, gamma=None, coef0=None, degree=None,
-                 kernel_params=None, n_components=100, random_state=None):
+                 kernel_params=None, n_components=100, random_state=None,
+                 n_jobs=None):
+
         self.kernel = kernel
         self.gamma = gamma
         self.coef0 = coef0
@@ -724,6 +726,7 @@ class Nystroem(TransformerMixin, BaseEstimator):
         self.kernel_params = kernel_params
         self.n_components = n_components
         self.random_state = random_state
+        self.n_jobs = n_jobs
 
     def fit(self, X, y=None):
         """Fit estimator to data.
@@ -757,6 +760,7 @@ class Nystroem(TransformerMixin, BaseEstimator):
 
         basis_kernel = pairwise_kernels(basis, metric=self.kernel,
                                         filter_params=True,
+                                        n_jobs=self.n_jobs,
                                         **self._get_kernel_params())
 
         # sqrt of kernel matrix on basis vectors
@@ -789,6 +793,7 @@ class Nystroem(TransformerMixin, BaseEstimator):
         embedded = pairwise_kernels(X, self.components_,
                                     metric=self.kernel,
                                     filter_params=True,
+                                    n_jobs=self.n_jobs,
                                     **kernel_params)
         return np.dot(embedded, self.normalization_.T)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
- Adding n_jobs for parallel calculation of kernel matrix to Nystroem class.
- Removing unnecessary attribute component_indices_ from Nystroem class 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
