### PR TITLE
[MRG] MNT put back original anchor to avoid breaking links

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -480,7 +480,7 @@ Example of Leave-2-Out on a dataset with 4 samples::
   [0 1] [2 3]
 
 
-.. _shuffle_split:
+.. _ShuffleSplit:
 
 Random permutations cross-validation a.k.a. Shuffle & Split
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/whats_new/older_versions.rst
+++ b/doc/whats_new/older_versions.rst
@@ -760,7 +760,7 @@ Changelog
 
 - Faster mean shift by Conrad Lee
 
-- New ``Bootstrap``, :ref:`shuffle_split` and various other
+- New ``Bootstrap``, :ref:`ShuffleSplit` and various other
   improvements in cross validation schemes by `Olivier Grisel`_ and
   `Gael Varoquaux`_
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1425,7 +1425,7 @@ class ShuffleSplit(BaseShuffleSplit):
     do not guarantee that all folds will be different, although this is
     still very likely for sizeable datasets.
 
-    Read more in the :ref:`User Guide <shuffle_split>`.
+    Read more in the :ref:`User Guide <ShuffleSplit>`.
 
     Parameters
     ----------


### PR DESCRIPTION
Put back original `ShuffleSplit` anchor instead of `shuffle_split` to avoid breaking URLs:

- stable: https://scikit-learn.org/stable/modules/cross_validation.html#shufflesplit
- dev: https://scikit-learn.org/dev/modules/cross_validation.html#shufflesplit  <--- broken

The changes reverted here were introduced in https://github.com/scikit-learn/scikit-learn/pull/18379 and in https://github.com/scikit-learn/scikit-learn/pull/18544

CC @thomasjpfan @cmarmo 