### PR TITLE
[MRG] Fix randomized_svd random_state default in documentation

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -296,7 +296,7 @@ def randomized_svd(M, n_components, *, n_oversamples=10, n_iter='auto',
         set to `True`, the sign ambiguity is resolved by making the largest
         loadings for each component in the left singular vectors positive.
 
-    random_state : int, RandomState instance or None, default=None
+    random_state : int, RandomState instance or None, default=0
         The seed of the pseudo random number generator to use when shuffling
         the data, i.e. getting the random vectors to initialize the algorithm.
         Pass an int for reproducible results across multiple function calls.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #18554.

#### What does this implement/fix? Explain your changes.
The documentation for the
`utils.extmath.randomized_svd` function lists
`None` as the default value for the `random_state`
parameter. However, the implementation has `0` as
the default value. This PR modifies the function's
documentation to reflect the default value in the
implementation.

#### Any other comments?
Changing the default value of the `random_state`
parameter to `None` in a future PR should be
considered, as this would align with the guidelines
given in the scikit-learn glossary and standard
usecases.