### PR TITLE
CI Uses "ci sync" label to sync pull request

### DIFF
--- a/.github/workflows/sync_pull_request.yml
+++ b/.github/workflows/sync_pull_request.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Remove label
         run: |
           # The label is always removed so that this action can be triggered
-          # again by adding the label even if the merge fails
+          # again by adding the label even if the sync fails.
 
           curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ci%20sync
       - uses: actions/checkout@v2

--- a/.github/workflows/sync_pull_request.yml
+++ b/.github/workflows/sync_pull_request.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: '0'
       - name: Sync with master
         run: |
-          set -x
+          set -xe
           git remote add pr_remote ${{ github.event.pull_request.head.repo.html_url }}
           git fetch pr_remote ${{ github.event.pull_request.head.ref }}
           git checkout pr_remote/${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/sync_pull_request.yml
+++ b/.github/workflows/sync_pull_request.yml
@@ -1,0 +1,29 @@
+name: Sync Pull Request
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  sync_pull_request:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ci sync')
+    steps:
+      - name: Remove label
+        run: |
+          # The label is always removed so that this action can be triggered
+          # again by adding the label even if the merge fails
+
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ci%20sync
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Sync with master
+        run: |
+          set -x
+          git remote add pr_remote ${{ github.event.pull_request.head.repo.html_url }}
+          git fetch pr_remote ${{ github.event.pull_request.head.ref }}
+          git checkout pr_remote/${{ github.event.pull_request.head.ref }}
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git merge origin/master
+          git push pr_remote HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
This PR adds a new GitHub action where we can add a "ci sync" label to a PR to sync the PR up with the master branch. You can see it in [action here](https://github.com/thomasjpfan/scikit-learn/pull/59) where azure runs on the merge commit.

Note that when this gets merged the commit message will have the following by default:

```
Co-authored-by: github-actions <github-actions@github.com>
```

CC @adrinjalali 