### PR TITLE
DOC fix docstring for monotonic constraing in hist-GBDT

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -851,7 +851,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         is always reserved for missing values. Must be no larger than 255.
     monotonic_cst : array-like of int of shape (n_features), default=None
         Indicates the monotonic constraint to enforce on each feature. -1, 1
-        and 0 respectively correspond to a positive constraint, negative
+        and 0 respectively correspond to a negative constraint, positive
         constraint and no constraint. Read more in the :ref:`User Guide
         <monotonic_cst_gbdt>`.
 
@@ -1082,7 +1082,7 @@ class HistGradientBoostingClassifier(ClassifierMixin,
         is always reserved for missing values. Must be no larger than 255.
     monotonic_cst : array-like of int of shape (n_features), default=None
         Indicates the monotonic constraint to enforce on each feature. -1, 1
-        and 0 respectively correspond to a positive constraint, negative
+        and 0 respectively correspond to a negative constraint, positive
         constraint and no constraint. Read more in the :ref:`User Guide
         <monotonic_cst_gbdt>`.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #18565 

#### What does this implement/fix? Explain your changes.
-1 and 1 were incorrectly classified as positive and negative constraints, So I interchanged them
#### Any other comments?
Done for both HistGradientBoostingClassifier and HistGradientBoostingRegressor as requested by @thomasjpfan 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
