### PR TITLE
BLD Uses cython master [scipy-dev]

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -89,7 +89,7 @@ elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     echo "Installing numpy and scipy master wheels"
     dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
     pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-    pip install --pre cython
+    pip install https://github.com/cython/cython
     setup_ccache
     echo "Installing joblib master"
     pip install https://github.com/joblib/joblib/archive/master.zip

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -89,7 +89,7 @@ elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     echo "Installing numpy and scipy master wheels"
     dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
     pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-    pip install https://github.com/cython/cython
+    pip install https://github.com/cython/cython/archive/master.zip
     setup_ccache
     echo "Installing joblib master"
     pip install https://github.com/joblib/joblib/archive/master.zip

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -64,7 +64,7 @@ if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then
     echo "Installing numpy and scipy master wheels"
     dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
     pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-    pip install https://github.com/cython/cython
+    pip install https://github.com/cython/cython/archive/master.zip
     echo "Installing joblib master"
     pip install https://github.com/joblib/joblib/archive/master.zip
     echo "Installing pillow master"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -64,7 +64,7 @@ if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then
     echo "Installing numpy and scipy master wheels"
     dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
     pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-    pip install --pre cython
+    pip install https://github.com/cython/cython
     echo "Installing joblib master"
     pip install https://github.com/joblib/joblib/archive/master.zip
     echo "Installing pillow master"


### PR DESCRIPTION
The nightly build is failing tests and some of it is fixed by using the master version of cython.