### PR TITLE
[MRG] removed boston dataset

### DIFF
--- a/doc/datasets/toy_dataset.rst
+++ b/doc/datasets/toy_dataset.rst
@@ -16,7 +16,6 @@ They can be loaded using the following functions:
 
 .. autosummary::
 
-   load_boston
    load_iris
    load_diabetes
    load_digits
@@ -27,8 +26,6 @@ They can be loaded using the following functions:
 These datasets are useful to quickly illustrate the behavior of the
 various algorithms implemented in scikit-learn. They are however often too
 small to be representative of real world machine learning tasks.
-
-.. include:: ../../sklearn/datasets/descr/boston_house_prices.rst
 
 .. include:: ../../sklearn/datasets/descr/iris.rst
 

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -248,7 +248,6 @@ Loaders
    datasets.fetch_rcv1
    datasets.fetch_species_distributions
    datasets.get_data_home
-   datasets.load_boston
    datasets.load_breast_cancer
    datasets.load_diabetes
    datasets.load_digits


### PR DESCRIPTION
towards: #16155
Removing all the references to the boston dataset from the docs

#### Reference Issues/PRs
Removing all the references to the boston dataset from the docs


#### What does this implement/fix? Explain your changes.


#### Any other comments?
Closes #17351

worked on by @ezebunandu and @amy12xx