### PR TITLE
DOC Fix parameter order in model_evaluation.rst

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -197,7 +197,7 @@ Here is an example of building custom scorers, and of using the
     >>> from sklearn.dummy import DummyClassifier
     >>> clf = DummyClassifier(strategy='most_frequent', random_state=0)
     >>> clf = clf.fit(X, y)
-    >>> my_custom_loss_func(clf.predict(X), y)
+    >>> my_custom_loss_func(y, clf.predict(X))
     0.69...
     >>> score(clf, X, y)
     -0.69...


### PR DESCRIPTION
Fixed docs.

#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

Fixes the parameter order in the example for make_scorer. The `clf.predict` should be second according to the `my_custom_loss_func` function. This fixes that.

#### Any other comments?

N/A
