### PR TITLE
FIX add attributes X_offset_ and X_scale_ in ARDRegression needed in predict

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -350,6 +350,11 @@ Changelog
   `predict` and `score` would fail when `fit_intercept=False` and there was
   one feature during fitting. :pr:`18121` by `Thomas Fan`_.
 
+- |Fix| Fixes bug in :class:`linear_model.ARDRegression` where `predict`
+  was raising an error when `normalize=True` and `return_std=True` because
+  `X_offset_` and `X_scale_` were undefined.
+  :pr:`18607` by :user:`fhaselbeck <fhaselbeck>`.
+
 :mod:`sklearn.manifold`
 .......................
 

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -536,6 +536,9 @@ class ARDRegression(RegressorMixin, LinearModel):
         X, y, X_offset_, y_offset_, X_scale_ = self._preprocess_data(
             X, y, self.fit_intercept, self.normalize, self.copy_X)
 
+        self.X_offset_ = X_offset_
+        self.X_scale_ = X_scale_
+
         # Launch the convergence loop
         keep_lambda = np.ones(n_features, dtype=bool)
 

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -119,6 +119,12 @@ class BayesianRidge(RegressorMixin, LinearModel):
     n_iter_ : int
         The actual number of iterations to reach the stopping criterion.
 
+    X_offset_ : float
+        if normalized, offset subtracted for centering data to mean zero
+
+    X_scale_ : float
+        if normalized, scaling parameter for division
+    
     Examples
     --------
     >>> from sklearn import linear_model
@@ -464,6 +470,12 @@ class ARDRegression(RegressorMixin, LinearModel):
         Independent term in decision function. Set to 0.0 if
         ``fit_intercept = False``.
 
+    X_offset_ : float
+        if normalized, offset subtracted for centering data to mean zero
+
+    X_scale_ : float
+        if normalized, scaling parameter for division
+    
     Examples
     --------
     >>> from sklearn import linear_model

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -120,11 +120,13 @@ class BayesianRidge(RegressorMixin, LinearModel):
         The actual number of iterations to reach the stopping criterion.
 
     X_offset_ : float
-        if normalized, offset subtracted for centering data to mean zero
+        If `normalize=True`, offset subtracted for centering data to a
+        zero mean.
 
     X_scale_ : float
-        if normalized, scaling parameter for division
-    
+        If `normalize=True`, parameter used to scale data to a unit
+        standard deviation.
+
     Examples
     --------
     >>> from sklearn import linear_model
@@ -471,11 +473,13 @@ class ARDRegression(RegressorMixin, LinearModel):
         ``fit_intercept = False``.
 
     X_offset_ : float
-        if normalized, offset subtracted for centering data to mean zero
+        If `normalize=True`, offset subtracted for centering data to a
+        zero mean.
 
     X_scale_ : float
-        if normalized, scaling parameter for division
-    
+        If `normalize=True`, parameter used to scale data to a unit
+        standard deviation.
+
     Examples
     --------
     >>> from sklearn import linear_model

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -272,3 +272,13 @@ def test_update_sigma(seed):
     sigma_woodbury = reg._update_sigma_woodbury(X, alpha, lmbda, keep_lambda)
 
     np.testing.assert_allclose(sigma, sigma_woodbury)
+
+
+def test_ard_regression_predict_normalize_true():
+    """Check that we can predict with `normalize=True` and `return_std=True`.
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/18605
+    """
+    clf = ARDRegression(normalize=True)
+    clf.fit([[0, 0], [1, 1], [2, 2]], [0, 1, 2])
+    clf.predict([[1, 1]], return_std=True)

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -240,7 +240,7 @@ def test_fit_docstring_attributes(name, Estimator):
         with ignore_warnings(category=FutureWarning):
             assert hasattr(est, attr.name)
 
-    IGNORED = {'BayesianRidge', 'Birch', 'CCA',
+    IGNORED = {'Birch', 'CCA',
                'LarsCV', 'Lasso',
                'OrthogonalMatchingPursuit',
                'PLSCanonical', 'PLSSVD'}


### PR DESCRIPTION
Fixes #18605 

ARDRegression is crashing during prediction when normalize is set true as in `predict` `self.X_offset_` and `self.X_scale_` are used to transform but are not set in fit method (in contrast to BayesianRidge).

Added this part to fit just like in `BayesianRidge`:
```python
self.X_offset_ = X_offset_
self.X_scale_ = X_scale_
```

