### PR TITLE
DOC improve n_jobs docs in CalibratedClassifierCV

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -118,11 +118,11 @@ class CalibratedClassifierCV(ClassifierMixin,
 
     n_jobs : int, default=None
         Pool size for multiprocessing / multithreading, passed to
-		``joblib.Parallel`` for use in :meth:`fit`. Ignored if
+        ``joblib.Parallel`` for use in :meth:`fit`. Ignored if
         ``cv == "prefit"``.
 
         For every cross-validation split specified by ``cv``, a calibrated
-		classifier is fitted using the cloned base estimator, parallelized by
+        classifier is fitted using the cloned base estimator, parallelized by
         ``joblib.Parallel``.
 
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -117,13 +117,14 @@ class CalibratedClassifierCV(ClassifierMixin,
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Pool size for multiprocessing / multithreading, passed to
+		joblib.Parallel() for use in :meth:`fit`. Ignored if ``cv == "prefit"``.
+
+        For every cross-validation split specified by ``cv``, a calibrated
+		classifier is fitted using the cloned base estimator.
+
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors.
-
-        Base estimator clones are fitted in parallel across cross-validation
-        iterations. Therefore parallelism happens only when cv != "prefit".
-
+        ``-1`` means use all available processes / threads.
         See :term:`Glossary <n_jobs>` for more details.
 
         .. versionadded:: 0.24

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -118,7 +118,7 @@ class CalibratedClassifierCV(ClassifierMixin,
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. For every cross-validation split
-        specified by ``cv``, a calibrated classifier is fitted using the cloned
+        specified by ``cv``, a classifier is fitted using the cloned
         base estimator in :meth:`fit`. Ignored if ``cv == "prefit"``.
 
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -118,10 +118,12 @@ class CalibratedClassifierCV(ClassifierMixin,
 
     n_jobs : int, default=None
         Pool size for multiprocessing / multithreading, passed to
-		joblib.Parallel() for use in :meth:`fit`. Ignored if ``cv == "prefit"``.
+		``joblib.Parallel`` for use in :meth:`fit`. Ignored if
+        ``cv == "prefit"``.
 
         For every cross-validation split specified by ``cv``, a calibrated
-		classifier is fitted using the cloned base estimator.
+		classifier is fitted using the cloned base estimator, parallelized by
+        ``joblib.Parallel``.
 
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means use all available processes / threads.

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -117,13 +117,9 @@ class CalibratedClassifierCV(ClassifierMixin,
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
     n_jobs : int, default=None
-        Pool size for multiprocessing / multithreading, passed to
-        ``joblib.Parallel`` for use in :meth:`fit`. Ignored if
-        ``cv == "prefit"``.
-
-        For every cross-validation split specified by ``cv``, a calibrated
-        classifier is fitted using the cloned base estimator, parallelized by
-        ``joblib.Parallel``.
+        The number of jobs to run in parallel. For every cross-validation split
+        specified by ``cv``, a calibrated classifier is fitted using the cloned base
+        estimator in :meth:`fit`. Ignored if ``cv == "prefit"``.
 
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means use all available processes / threads.

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -118,8 +118,8 @@ class CalibratedClassifierCV(ClassifierMixin,
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. For every cross-validation split
-        specified by ``cv``, a calibrated classifier is fitted using the cloned base
-        estimator in :meth:`fit`. Ignored if ``cv == "prefit"``.
+        specified by ``cv``, a calibrated classifier is fitted using the cloned
+        base estimator in :meth:`fit`. Ignored if ``cv == "prefit"``.
 
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means use all available processes / threads.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses part of #14228

#### What does this implement/fix? Explain your changes.
Updated docs to reflect meaning and usage of `n_jobs` in `CalibratedClassifierCV`

#### Any other comments?
#14228 is opened to improve / clarify the docs for `n_jobs` in the sklearn code base. This PR focuses is tailored to address `sklearn/calibration.py`, where the only function that contains `n_jobs` is `CalibratedClassifierCV`. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
