### PR TITLE
ENH parallelized predict_proba in MultiOutputClassifier

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -393,8 +393,10 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
         return self._predict_proba
 
     def _predict_proba(self, X):
-        results = [estimator.predict_proba(X) for estimator in
-                   self.estimators_]
+        results = Parallel(n_jobs=self.n_jobs)(
+            delayed(e.predict_proba)(X)
+            for e in self.estimators_)
+
         return results
 
     def score(self, X, y):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Resolves #18635

#### What does this implement/fix? Explain your changes.
Replaces existing list comprehension to run `predict_proba` in MultiOutputClassifier with same `joblib` parallelization used in its other methods (`fit`, `predict`, `partial_fit`)

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
