### PR TITLE
DOC: Specify Units for Mutual Information Metrics #18288

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -749,7 +749,8 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     Returns
     -------
     mi : float
-       Mutual information, a non-negative value, measured in nats using the natural logarithm
+       Mutual information, a non-negative value, measured in nats using the
+       natural logarithm
 
     Notes
     -----
@@ -960,7 +961,7 @@ def normalized_mutual_info_score(labels_true, labels_pred, *,
     Returns
     -------
     nmi : float
-       score between 0.0 and 1.0 in normalized nats (based on the natural 
+       score between 0.0 and 1.0 in normalized nats (based on the natural
        logarithm). 1.0 stands for perfectly complete labeling.
 
     See Also

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -710,7 +710,7 @@ def v_measure_score(labels_true, labels_pred, *, beta=1.0):
 def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     """Mutual Information between two clusterings.
 
-    The Mutual Information is a measure of the similarity between two labels 
+    The Mutual Information is a measure of the similarity between two labels
     of the same data. Where :math:`|U_i|` is the number of the samples
     in cluster :math:`U_i` and :math:`|V_j|` is the number of the
     samples in cluster :math:`V_j`, the Mutual Information

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -735,10 +735,10 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets (U).
+        A clustering of the data into disjoint subsets, called $U$ in the above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets (V).
+        A clustering of the data into disjoint subsets, called $V$ in the above formula.
 
     contingency : {ndarray, sparse matrix} of shape \
             (n_classes_true, n_classes_pred), default=None
@@ -824,10 +824,10 @@ def adjusted_mutual_info_score(labels_true, labels_pred, *,
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets (U).
+        A clustering of the data into disjoint subsets, called $U$ in the above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets (V).
+        A clustering of the data into disjoint subsets, called $V$ in the above formula.
 
     average_method : str, default='arithmetic'
         How to compute the normalizer in the denominator. Possible options
@@ -961,7 +961,7 @@ def normalized_mutual_info_score(labels_true, labels_pred, *,
     Returns
     -------
     nmi : float
-       score between 0.0 and 1.0 in normalized nats (based on the natural
+       Score between 0.0 and 1.0 in normalized nats (based on the natural
        logarithm). 1.0 stands for perfectly complete labeling.
 
     See Also

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -710,8 +710,8 @@ def v_measure_score(labels_true, labels_pred, *, beta=1.0):
 def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     """Mutual Information between two clusterings.
 
-    The Mutual Information is a measure of the similarity between two labels of
-    the same data. Where :math:`|U_i|` is the number of the samples
+    The Mutual Information is a measure of the similarity between two labels 
+    of the same data. Where :math:`|U_i|` is the number of the samples
     in cluster :math:`U_i` and :math:`|V_j|` is the number of the
     samples in cluster :math:`V_j`, the Mutual Information
     between clusterings :math:`U` and :math:`V` is given as:

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -735,10 +735,10 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets.
+        A clustering of the data into disjoint subsets (U).
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets.
+        A clustering of the data into disjoint subsets (V).
 
     contingency : {ndarray, sparse matrix} of shape \
             (n_classes_true, n_classes_pred), default=None
@@ -749,7 +749,7 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     Returns
     -------
     mi : float
-       Mutual information, a non-negative value
+       Mutual information, a non-negative value, measured in nats using the natural logarithm
 
     Notes
     -----
@@ -823,10 +823,10 @@ def adjusted_mutual_info_score(labels_true, labels_pred, *,
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets.
+        A clustering of the data into disjoint subsets (U).
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets.
+        A clustering of the data into disjoint subsets (V).
 
     average_method : str, default='arithmetic'
         How to compute the normalizer in the denominator. Possible options
@@ -843,7 +843,8 @@ def adjusted_mutual_info_score(labels_true, labels_pred, *,
     ami: float (upperlimited by 1.0)
        The AMI returns a value of 1 when the two partitions are identical
        (ie perfectly matched). Random partitions (independent labellings) have
-       an expected AMI around 0 on average hence can be negative.
+       an expected AMI around 0 on average hence can be negative. The value is
+       in adjusted nats (based on the natural logarithm).
 
     See Also
     --------
@@ -959,7 +960,8 @@ def normalized_mutual_info_score(labels_true, labels_pred, *,
     Returns
     -------
     nmi : float
-       score between 0.0 and 1.0. 1.0 stands for perfectly complete labeling
+       score between 0.0 and 1.0 in normalized nats (based on the natural 
+       logarithm). 1.0 stands for perfectly complete labeling.
 
     See Also
     --------

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -750,7 +750,7 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     -------
     mi : float
        Mutual information, a non-negative value, measured in nats using the
-       natural logarithm
+       natural logarithm.
 
     Notes
     -----

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -736,12 +736,12 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets, called :math:`U` in the
-        above formula.
+        A clustering of the data into disjoint subsets, called :math:`U` in 
+        the above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets, called :math:`V` in the
-        above formula.
+        A clustering of the data into disjoint subsets, called :math:`V` in 
+        the above formula.
 
     contingency : {ndarray, sparse matrix} of shape \
             (n_classes_true, n_classes_pred), default=None
@@ -827,12 +827,12 @@ def adjusted_mutual_info_score(labels_true, labels_pred, *,
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets, called :math:`U` in the
-        above formula.
+        A clustering of the data into disjoint subsets, called :math:`U` in 
+        the above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets, called :math:`V` in the
-        above formula.
+        A clustering of the data into disjoint subsets, called :math:`V` in 
+        the above formula.
 
     average_method : str, default='arithmetic'
         How to compute the normalizer in the denominator. Possible options

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -725,10 +725,10 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     a permutation of the class or cluster label values won't change the
     score value in any way.
 
-    This metric is furthermore symmetric: switching :math:`U` (i.e 
-    ``label_true``) with :math:`V` (i.e. ``label_pred``) will return the 
-    same score value. This can be useful to measure the agreement of two 
-    independent label assignments strategies on the same dataset when the 
+    This metric is furthermore symmetric: switching :math:`U` (i.e
+    ``label_true``) with :math:`V` (i.e. ``label_pred``) will return the
+    same score value. This can be useful to measure the agreement of two
+    independent label assignments strategies on the same dataset when the
     real ground truth is not known.
 
     Read more in the :ref:`User Guide <mutual_info_score>`.
@@ -736,11 +736,11 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets, called :math:`U` in 
+        A clustering of the data into disjoint subsets, called :math:`U` in
         the above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets, called :math:`V` in 
+        A clustering of the data into disjoint subsets, called :math:`V` in
         the above formula.
 
     contingency : {ndarray, sparse matrix} of shape \
@@ -814,9 +814,9 @@ def adjusted_mutual_info_score(labels_true, labels_pred, *,
     a permutation of the class or cluster label values won't change the
     score value in any way.
 
-    This metric is furthermore symmetric: switching :math:`U` (``label_true``) 
-    with :math:`V` (``labels_pred``) will return the same score value. This can 
-    be useful to measure the agreement of two independent label assignments 
+    This metric is furthermore symmetric: switching :math:`U` (``label_true``)
+    with :math:`V` (``labels_pred``) will return the same score value. This can
+    be useful to measure the agreement of two independent label assignments
     strategies on the same dataset when the real ground truth is not known.
 
     Be mindful that this function is an order of magnitude slower than other
@@ -827,11 +827,11 @@ def adjusted_mutual_info_score(labels_true, labels_pred, *,
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets, called :math:`U` in 
+        A clustering of the data into disjoint subsets, called :math:`U` in
         the above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets, called :math:`V` in 
+        A clustering of the data into disjoint subsets, called :math:`V` in
         the above formula.
 
     average_method : str, default='arithmetic'

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -735,10 +735,12 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets, called $U$ in the above formula.
+        A clustering of the data into disjoint subsets, called $U$ in the
+        above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets, called $V$ in the above formula.
+        A clustering of the data into disjoint subsets, called $V$ in the
+        above formula.
 
     contingency : {ndarray, sparse matrix} of shape \
             (n_classes_true, n_classes_pred), default=None
@@ -824,10 +826,12 @@ def adjusted_mutual_info_score(labels_true, labels_pred, *,
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets, called $U$ in the above formula.
+        A clustering of the data into disjoint subsets, called $U$ in the
+        above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets, called $V$ in the above formula.
+        A clustering of the data into disjoint subsets, called $V$ in the
+        above formula.
 
     average_method : str, default='arithmetic'
         How to compute the normalizer in the denominator. Possible options

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -725,21 +725,22 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     a permutation of the class or cluster label values won't change the
     score value in any way.
 
-    This metric is furthermore symmetric: switching ``label_true`` with
-    ``label_pred`` will return the same score value. This can be useful to
-    measure the agreement of two independent label assignments strategies
-    on the same dataset when the real ground truth is not known.
+    This metric is furthermore symmetric: switching :math:`U` (i.e 
+    ``label_true``) with :math:`V` (i.e. ``label_pred``) will return the 
+    same score value. This can be useful to measure the agreement of two 
+    independent label assignments strategies on the same dataset when the 
+    real ground truth is not known.
 
     Read more in the :ref:`User Guide <mutual_info_score>`.
 
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets, called $U$ in the
+        A clustering of the data into disjoint subsets, called :math:`U` in the
         above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets, called $V$ in the
+        A clustering of the data into disjoint subsets, called :math:`V` in the
         above formula.
 
     contingency : {ndarray, sparse matrix} of shape \
@@ -813,10 +814,10 @@ def adjusted_mutual_info_score(labels_true, labels_pred, *,
     a permutation of the class or cluster label values won't change the
     score value in any way.
 
-    This metric is furthermore symmetric: switching ``label_true`` with
-    ``label_pred`` will return the same score value. This can be useful to
-    measure the agreement of two independent label assignments strategies
-    on the same dataset when the real ground truth is not known.
+    This metric is furthermore symmetric: switching :math:`U` (``label_true``) 
+    with :math:`V` (``labels_pred``) will return the same score value. This can 
+    be useful to measure the agreement of two independent label assignments 
+    strategies on the same dataset when the real ground truth is not known.
 
     Be mindful that this function is an order of magnitude slower than other
     metrics, such as the Adjusted Rand Index.
@@ -826,11 +827,11 @@ def adjusted_mutual_info_score(labels_true, labels_pred, *,
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        A clustering of the data into disjoint subsets, called $U$ in the
+        A clustering of the data into disjoint subsets, called :math:`U` in the
         above formula.
 
     labels_pred : int array-like of shape (n_samples,)
-        A clustering of the data into disjoint subsets, called $V$ in the
+        A clustering of the data into disjoint subsets, called :math:`V` in the
         above formula.
 
     average_method : str, default='arithmetic'


### PR DESCRIPTION
Fixes scikit-learn#18288

This PR adds documentation to the return values of the mutual-information-score functions to make it clear that the units are based on the natural logarithm. It also indicates how the parameters are related to the mathematical representations.