### PR TITLE
DOC moved from rackspace to anaconda.org

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -563,11 +563,8 @@ budget of the project [#f1]_.
 Infrastructure support
 ----------------------
 
-- We would like to thank `Anaconda <https://www.anaconda.com>`_ for providing
-  us with a free `Anaconda Cloud <https://www.anaconda.org/>`_ account
-  to upload our staging and nightly builds.
-
 - We would also like to thank `Microsoft Azure
   <https://azure.microsoft.com/en-us/>`_, `Travis Cl <https://travis-ci.org/>`_,
   `CircleCl <https://circleci.com/>`_ for free CPU time on their Continuous
-  Integration servers.
+  Integration servers, And `Anaconda Inc. <https://www.anaconda.com>`_ for the
+  storage they provide for our staging and nightly builds.

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -563,11 +563,9 @@ budget of the project [#f1]_.
 Infrastructure support
 ----------------------
 
-- We would like to thank `Rackspace <https://www.rackspace.com>`_ for providing
-  us with a free `Rackspace Cloud <https://www.rackspace.com/cloud/>`_ account
-  to automatically build the documentation and the example gallery from for the
-  development version of scikit-learn using `this tool
-  <https://github.com/scikit-learn/sklearn-docbuilder>`_.
+- We would like to thank `Anaconda <https://www.anaconda.com>`_ for providing
+  us with a free `Anaconda Cloud <https://www.anaconda.org/>`_ account
+  to upload our staging and nightly builds.
 
 - We would also like to thank `Microsoft Azure
   <https://azure.microsoft.com/en-us/>`_, `Travis Cl <https://travis-ci.org/>`_,

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -566,5 +566,5 @@ Infrastructure support
 - We would also like to thank `Microsoft Azure
   <https://azure.microsoft.com/en-us/>`_, `Travis Cl <https://travis-ci.org/>`_,
   `CircleCl <https://circleci.com/>`_ for free CPU time on their Continuous
-  Integration servers, And `Anaconda Inc. <https://www.anaconda.com>`_ for the
+  Integration servers, and `Anaconda Inc. <https://www.anaconda.com>`_ for the
   storage they provide for our staging and nightly builds.


### PR DESCRIPTION
We have moved from rackspace to anaconda.org to store our staging and nightly builds.

cc: @ogrisel 