### PR TITLE
FIX Explicit int cast in NN binary trees

### DIFF
--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -1074,7 +1074,8 @@ cdef class BinaryTree:
         # determine number of levels in the tree, and from this
         # the number of nodes in the tree.  This results in leaf nodes
         # with numbers of points between leaf_size and 2 * leaf_size
-        self.n_levels = np.log2(fmax(1, (n_samples - 1) / self.leaf_size)) + 1
+        self.n_levels = int(
+            np.log2(fmax(1, (n_samples - 1) / self.leaf_size)) + 1)
         self.n_nodes = (2 ** self.n_levels) - 1
 
         # allocate arrays for storage


### PR DESCRIPTION
Using latest NumPy and scikit-learn master and Cython , I get:
```
  File "/home/larsoner/python/mne-python/mne/surface.py", line 522, in __init__
    self.query = partial(_safe_query, func=BallTree(xhs).query,
  File "sklearn/neighbors/_binary_tree.pxi", line 1077, in sklearn.neighbors._ball_tree.BinaryTree.__init__
TypeError: 'numpy.float64' object cannot be interpreted as an integer
```
I assume this has to do with more strict type checking somewhere, so this just uses an explicit cast.

I'm not 100% sure this is the right fix, but things at least seem to work with it in place.