### PR TITLE
FIX: incr_mean_variance_axis when axis=1 and last_mean have shape of …

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -687,6 +687,11 @@ Changelog
   with different endianness.
   :pr:`17644` by :user:`Qi Zhang <qzhang90>`.
 
+- |Fix| Check that we raise proper error when axis=1 and the
+  dimensions do not match in :func:`utils.sparse_func.incr_mean_variance_axis`.
+  By :user:`Alex Gramfort <agramfort>`.
+
+
 Miscellaneous
 .............
 

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -131,15 +131,15 @@ def incr_mean_variance_axis(X, *, axis, last_mean, last_var, last_n):
 
     Returns
     -------
-    means : ndarray, shape (n_features,) or (n_samples,), dtype=floating
+    means : ndarray of shape (n_features,) or (n_samples,), dtype=floating
         Updated feature-wise means if axis = 0 or
         sample-wise means if axis = 1.
 
-    variances : ndarray, shape (n_features,) or (n_samples,), dtype=floating
+    variances : ndarray of shape (n_features,) or (n_samples,), dtype=floating
         Updated feature-wise variances if axis = 0 or
         sample-wise variances if axis = 1.
 
-    n : ndarray, shape (n_features,) or (n_samples,), dtype=integral
+    n : ndarray of shape (n_features,) or (n_samples,), dtype=integral
         Updated number of seen samples per feature if axis=0
         or number of seen features per sample if axis=1.
 

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -117,32 +117,29 @@ def incr_mean_variance_axis(X, *, axis, last_mean, last_var, last_n):
     axis : int (either 0 or 1)
         Axis along which the axis should be computed.
 
-    last_mean : ndarray, shape (n_features,) or (n_samples,)
+    last_mean : ndarray of shape (n_features,) or (n_samples,), dtype=floating
         Array of means to update with the new data X.
-        Should be of shape (n_features,) if axis=0 or
-        (n_samples,) if axis=1.
+        Should be of shape (n_features,) if axis=0 or (n_samples,) if axis=1.
 
-    last_var : ndarray, shape (n_features,) or (n_samples,)
+    last_var : ndarray of shape (n_features,) or (n_samples,), dtype=floating
         Array of variances to update with the new data X.
-        Should be of shape (n_features,) if axis=0 or
-        (n_samples,) if axis=1.
+        Should be of shape (n_features,) if axis=0 or (n_samples,) if axis=1.
 
-    last_n : ndarray, shape (n_features,) or (n_samples,)
+    last_n : ndarray of shape (n_features,) or (n_samples,), dtype=integral
         Sum of the weights seen so far, excluding the current weights
-        Should be of shape (n_samples,) if axis=0 or
-        (n_features,) if axis=1.
+        Should be of shape (n_samples,) if axis=0 or (n_features,) if axis=1.
 
     Returns
     -------
-    means : ndarray, shape (n_features,) or (n_samples,)
+    means : ndarray, shape (n_features,) or (n_samples,), dtype=floating
         Updated feature-wise means if axis = 0 or
         sample-wise means if axis = 1.
 
-    variances : ndarray, shape (n_features,) or (n_samples,)
+    variances : ndarray, shape (n_features,) or (n_samples,), dtype=floating
         Updated feature-wise variances if axis = 0 or
         sample-wise variances if axis = 1.
 
-    n : ndarray, shape (n_features,) or (n_samples,)
+    n : ndarray, shape (n_features,) or (n_samples,), dtype=integral
         Updated number of seen samples per feature if axis=0
         or number of seen features per sample if axis=1.
 

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -154,19 +154,22 @@ def incr_mean_variance_axis(X, *, axis, last_mean, last_var, last_n):
         _raise_typeerror(X)
 
     if not (np.size(last_mean) == np.size(last_var) == np.size(last_n)):
-        raise ValueError("last_mean, last_var, last_n do not have the "
-                         "same shapes.")
+        raise ValueError(
+            "last_mean, last_var, last_n do not have the same shapes."
+        )
 
     if axis == 1:
         if np.size(last_mean) != X.shape[0]:
-            raise ValueError("If axis=1, then last_mean, last_n, last_var "
-                             "should be of size n_samples %d (Got %d)." %
-                             (X.shape[0], np.size(last_mean)))
+            raise ValueError(
+                f"If axis=1, then last_mean, last_n, last_var should be of "
+                f"size n_samples {X.shape[0]} (Got {np.size(last_mean)})."
+            )
     else:  # axis == 0
         if np.size(last_mean) != X.shape[1]:
-            raise ValueError("If axis=0, then last_mean, last_n, last_var "
-                             "should be of size n_features %d (Got %d)." %
-                             (X.shape[1], np.size(last_mean)))
+            raise ValueError(
+                f"If axis=0, then last_mean, last_n, last_var should be of "
+                f"size n_features {X.shape[1]} (Got {np.size(last_mean)})."
+            )
 
     if isinstance(X, sp.csr_matrix):
         if axis == 0:

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -117,26 +117,34 @@ def incr_mean_variance_axis(X, *, axis, last_mean, last_var, last_n):
     axis : int (either 0 or 1)
         Axis along which the axis should be computed.
 
-    last_mean : float array with shape (n_features,)
-        Array of feature-wise means to update with the new data X.
+    last_mean : ndarray, shape (n_features,) or (n_samples,)
+        Array of means to update with the new data X.
+        Should be of shape (n_features,) if axis=0 or
+        (n_samples,) if axis=1.
 
-    last_var : float array with shape (n_features,)
-        Array of feature-wise var to update with the new data X.
+    last_var : ndarray, shape (n_features,) or (n_samples,)
+        Array of variances to update with the new data X.
+        Should be of shape (n_features,) if axis=0 or
+        (n_samples,) if axis=1.
 
-    last_n : int with shape (n_features,)
-        Number of samples seen so far, excluded X.
+    last_n : ndarray, shape (n_features,) or (n_samples,)
+        Sum of the weights seen so far, excluding the current weights
+        Should be of shape (n_samples,) if axis=0 or
+        (n_features,) if axis=1.
 
     Returns
     -------
+    means : ndarray, shape (n_features,) or (n_samples,)
+        Updated feature-wise means if axis = 0 or
+        sample-wise means if axis = 1.
 
-    means : float array with shape (n_features,)
-        Updated feature-wise means.
+    variances : ndarray, shape (n_features,) or (n_samples,)
+        Updated feature-wise variances if axis = 0 or
+        sample-wise variances if axis = 1.
 
-    variances : float array with shape (n_features,)
-        Updated feature-wise variances.
-
-    n : int with shape (n_features,)
-        Updated number of seen samples.
+    n : ndarray, shape (n_features,) or (n_samples,)
+        Updated number of seen samples per feature if axis=0
+        or number of seen features per sample if axis=1.
 
     Notes
     -----
@@ -144,6 +152,24 @@ def incr_mean_variance_axis(X, *, axis, last_mean, last_var, last_n):
 
     """
     _raise_error_wrong_axis(axis)
+
+    if not isinstance(X, (sp.csr_matrix, sp.csc_matrix)):
+        _raise_typeerror(X)
+
+    if not (np.size(last_mean) == np.size(last_var) == np.size(last_n)):
+        raise ValueError("last_mean, last_var, last_n do not have the "
+                         "same shapes.")
+
+    if axis == 1:
+        if np.size(last_mean) != X.shape[0]:
+            raise ValueError("If axis=1, then last_mean, last_n, last_var "
+                             "should be of size n_samples %d (Got %d)." %
+                             (X.shape[0], np.size(last_mean)))
+    else:  # axis == 0
+        if np.size(last_mean) != X.shape[1]:
+            raise ValueError("If axis=0, then last_mean, last_n, last_var "
+                             "should be of size n_features %d (Got %d)." %
+                             (X.shape[1], np.size(last_mean)))
 
     if isinstance(X, sp.csr_matrix):
         if axis == 0:
@@ -159,8 +185,6 @@ def incr_mean_variance_axis(X, *, axis, last_mean, last_var, last_n):
         else:
             return _incr_mean_var_axis0(X.T, last_mean=last_mean,
                                         last_var=last_var, last_n=last_n)
-    else:
-        _raise_typeerror(X)
 
 
 def inplace_column_scale(X, scale):

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -180,14 +180,12 @@ def test_incr_mean_variance_axis_dim_mismatch():
 
     # test ValueError if axis=1 and last_mean.size == n_features
     with pytest.raises(ValueError):
-        mean1, var1, _ = incr_mean_variance_axis(X, axis=1, **kwargs)
-        assert_array_almost_equal(np.mean(X.toarray(), axis=1), mean1)
-        assert_array_almost_equal(np.var(X.toarray(), axis=1), var1)
+        incr_mean_variance_axis(X, axis=1, **kwargs)
 
     # test inconsistent shapes of last_mean, last_var, last_n
     kwargs = dict(last_mean=last_mean[:-1], last_var=last_var, last_n=last_n)
     with pytest.raises(ValueError):
-        mean0, var0, _ = incr_mean_variance_axis(X, axis=0, **kwargs)
+        incr_mean_variance_axis(X, axis=0, **kwargs)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -90,17 +90,23 @@ def test_incr_mean_variance_axis():
         rng = np.random.RandomState(0)
         n_features = 50
         n_samples = 10
-        data_chunks = [rng.randint(0, 2, size=n_features)
-                       for i in range(n_samples)]
+        if axis == 0:
+            data_chunks = [rng.randint(0, 2, size=n_features)
+                           for i in range(n_samples)]
+        else:
+            data_chunks = [rng.randint(0, 2, size=n_samples)
+                           for i in range(n_features)]
 
         # default params for incr_mean_variance
-        last_mean = np.zeros(n_features)
+        last_mean = np.zeros(n_features) if axis == 0 else np.zeros(n_samples)
         last_var = np.zeros_like(last_mean)
         last_n = np.zeros_like(last_mean, dtype=np.int64)
 
         # Test errors
         X = np.array(data_chunks[0])
         X = np.atleast_2d(X)
+        if axis == 1:
+            X = X.T
         X_lil = sp.lil_matrix(X)
         X_csr = sp.csr_matrix(X_lil)
 
@@ -129,6 +135,8 @@ def test_incr_mean_variance_axis():
 
         # Test _incremental_mean_and_var with whole data
         X = np.vstack(data_chunks)
+        if axis == 1:
+            X = X.T
         X_lil = sp.lil_matrix(X)
         X_csr = sp.csr_matrix(X_lil)
         X_csc = sp.csc_matrix(X_lil)
@@ -154,6 +162,32 @@ def test_incr_mean_variance_axis():
                 assert_array_almost_equal(X_means, X_means_incr)
                 assert_array_almost_equal(X_vars, X_vars_incr)
                 assert_array_equal(X.shape[axis], n_incr)
+
+
+def test_incr_mean_variance_axis_dim_mismatch():
+    n_samples, n_features = 60, 4
+    rng = np.random.RandomState(42)
+    X = sp.csc_matrix(rng.rand(n_samples, n_features))
+
+    last_mean = np.zeros(n_features)
+    last_var = np.zeros_like(last_mean)
+    last_n = np.zeros(last_mean.shape, dtype=np.int64)
+
+    kwargs = dict(last_mean=last_mean, last_var=last_var, last_n=last_n)
+    mean0, var0, _ = incr_mean_variance_axis(X, axis=0, **kwargs)
+    assert_array_almost_equal(np.mean(X.toarray(), axis=0), mean0)
+    assert_array_almost_equal(np.var(X.toarray(), axis=0), var0)
+
+    # test ValueError if axis=1 and last_mean.size == n_features
+    with pytest.raises(ValueError):
+        mean1, var1, _ = incr_mean_variance_axis(X, axis=1, **kwargs)
+        assert_array_almost_equal(np.mean(X.toarray(), axis=1), mean1)
+        assert_array_almost_equal(np.var(X.toarray(), axis=1), var1)
+
+    # test inconsistent shapes of last_mean, last_var, last_n
+    kwargs = dict(last_mean=last_mean[:-1], last_var=last_var, last_n=last_n)
+    with pytest.raises(ValueError):
+        mean0, var0, _ = incr_mean_variance_axis(X, axis=0, **kwargs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
the added test would segfault in master and it would not check that last_mean has the correct size.

if I now check the shape is valid for last_mean the old test `test_incr_mean_variance_axis` would break so I had to fix it.

cc @ogrisel @glemaitre 