### PR TITLE
[WIP] PERF compute float32 grad and hess in HGBT

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -91,14 +91,14 @@ def test_derivatives(loss, x0, y_true):
         return get_hessians(y_true, x)
 
     optimum = newton(func, x0=x0, fprime=fprime, fprime2=fprime2,
-                     maxiter=70, tol=2e-8)
+                     maxiter=70, tol=5e-6)
 
     # Need to ravel arrays because assert_allclose requires matching dimensions
     y_true = y_true.ravel()
     optimum = optimum.ravel()
-    assert_allclose(loss.inverse_link_function(optimum), y_true)
-    assert_allclose(func(optimum), 0, atol=1e-14)
-    assert_allclose(get_gradients(y_true, optimum), 0, atol=1e-7)
+    assert_allclose(loss.inverse_link_function(optimum), y_true, atol=2e-5)
+    assert_allclose(func(optimum), 0, atol=2e-11)
+    assert_allclose(get_gradients(y_true, optimum), 0, atol=2e-5)
 
 
 @pytest.mark.parametrize('loss, n_classes, prediction_dim', [

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_loss.py
@@ -91,14 +91,14 @@ def test_derivatives(loss, x0, y_true):
         return get_hessians(y_true, x)
 
     optimum = newton(func, x0=x0, fprime=fprime, fprime2=fprime2,
-                     maxiter=70, tol=5e-6)
+                     maxiter=70, tol=5e-7)
 
     # Need to ravel arrays because assert_allclose requires matching dimensions
     y_true = y_true.ravel()
     optimum = optimum.ravel()
-    assert_allclose(loss.inverse_link_function(optimum), y_true, atol=2e-5)
-    assert_allclose(func(optimum), 0, atol=2e-11)
-    assert_allclose(get_gradients(y_true, optimum), 0, atol=2e-5)
+    assert_allclose(loss.inverse_link_function(optimum), y_true, atol=5e-7)
+    assert_allclose(func(optimum), 0, atol=1e-13)
+    assert_allclose(get_gradients(y_true, optimum), 0, atol=5e-7)
 
 
 @pytest.mark.parametrize('loss, n_classes, prediction_dim', [


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The `BaseHistGradientBoosting` is using float32 for storing gradiends and hessians. Nevertheless, the computations are done using full float64 and only at the end are they converted to float32.
One can gain some perfomance, i.e. less fit time, by doing expensive calculations of exp in float32, too.

This PR basically replaces some Cython calls to `double exp(double)` by `float expf(float)`.

#### Any other comments?
Some test accuracies must be lowered, too.