### PR TITLE
MNT fix MacOS failure with more stable estimator_checks

### DIFF
--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -713,13 +713,11 @@ class KNeighborsMixin:
                     parse_version(joblib.__version__) < parse_version('0.12'))
             if old_joblib:
                 # Deal with change of API in joblib
-                delayed_query = delayed(_tree_query_parallel_helper)
                 parallel_kwargs = {"backend": "threading"}
             else:
-                delayed_query = delayed(_tree_query_parallel_helper)
                 parallel_kwargs = {"prefer": "threads"}
             chunked_results = Parallel(n_jobs, **parallel_kwargs)(
-                delayed_query(
+                delayed(_tree_query_parallel_helper)(
                     self._tree, X[s], n_neighbors, return_distance)
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )
@@ -1038,13 +1036,11 @@ class RadiusNeighborsMixin:
                     "or set algorithm='brute'" % self._fit_method)
 
             n_jobs = effective_n_jobs(self.n_jobs)
+            delayed_query = delayed(_tree_query_radius_parallel_helper)
             if parse_version(joblib.__version__) < parse_version('0.12'):
                 # Deal with change of API in joblib
-                delayed_query = delayed(_tree_query_radius_parallel_helper,
-                                        check_pickle=False)
                 parallel_kwargs = {"backend": "threading"}
             else:
-                delayed_query = delayed(_tree_query_radius_parallel_helper)
                 parallel_kwargs = {"prefer": "threads"}
 
             chunked_results = Parallel(n_jobs, **parallel_kwargs)(

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -346,7 +346,7 @@ def _construct_instance(Estimator):
             if issubclass(Estimator, RegressorMixin):
                 estimator = Estimator(Ridge())
             else:
-                estimator = Estimator(LinearDiscriminantAnalysis())
+                estimator = Estimator(LogisticRegression(C=1))
         elif required_parameters in (['estimators'],):
             # Heterogeneous ensemble classes (i.e. stacking, voting)
             if issubclass(Estimator, RegressorMixin):
@@ -1479,7 +1479,14 @@ def check_estimators_dtypes(name, estimator_orig, strict_mode=True):
     X_train_64 = X_train_32.astype(np.float64)
     X_train_int_64 = X_train_32.astype(np.int64)
     X_train_int_32 = X_train_32.astype(np.int32)
-    y = X_train_int_64[:, 0]
+
+    # Approximately balanced binary classification problem related to the first
+    # feature of X. Using a binary classification problem is preferable to a
+    # multiclass problem because there are few samples in the dataset and some
+    # meta-estimators perform internal cross-validation which further reduces
+    # the size of the inner training sets which can become degenerate with very
+    # few samples per target class leading to hard to debug edge cases.
+    y = X_train_int_64[:, 0] >= np.median(X_train_int_64[:, 0])
     y = _enforce_estimator_tags_y(estimator_orig, y)
 
     methods = ["predict", "transform", "decision_function", "predict_proba"]

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1478,14 +1478,7 @@ def check_estimators_dtypes(name, estimator_orig, strict_mode=True):
     X_train_64 = X_train_32.astype(np.float64)
     X_train_int_64 = X_train_32.astype(np.int64)
     X_train_int_32 = X_train_32.astype(np.int32)
-
-    # Approximately balanced binary classification problem related to the first
-    # feature of X. Using a binary classification problem is preferable to a
-    # multiclass problem because there are few samples in the dataset and some
-    # meta-estimators perform internal cross-validation which further reduces
-    # the size of the inner training sets which can become degenerate with very
-    # few samples per target class leading to hard to debug edge cases.
-    y = X_train_int_64[:, 0] >= np.median(X_train_int_64[:, 0])
+    y = X_train_int_64[:, 0]
     y = _enforce_estimator_tags_y(estimator_orig, y)
 
     methods = ["predict", "transform", "decision_function", "predict_proba"]

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -26,7 +26,6 @@ from ._testing import create_memmap_backed_data
 from ._testing import raises
 from . import is_scalar_nan
 
-from ..discriminant_analysis import LinearDiscriminantAnalysis
 from ..linear_model import LogisticRegression
 from ..linear_model import Ridge
 


### PR DESCRIPTION
This is a fix for the random macOS failure observed on the CI of various pull request investigated in: https://github.com/scikit-learn/scikit-learn/pull/18643

The failure is that `check_estimators_dtypes` would crash or fail with the `SequentialFeatureSelection` meta estimator. On the macOS CI this will trigger a hard crash because of https://github.com/conda-forge/scipy-feedstock/issues/144 but this is another problem).

I propose two changes:

- Use `LogisticRegression` instead of `LinearDiscriminantAnalysis` as the default base estimator for meta estimators as the latter can be numerically undefined on degenerate datasets (e.g. `LinearDiscriminantAnalysis().fit([[0], [1], [1]], [0, 1, 1])`).

- <del>Change the dataset of `check_estimators_dtypes` to avoid generating degenerate sub-problems when checking meta-estimators with nested cross-validation as is the case for `SequentialFeatureSelection`.</del> This does not work because it breaks `RANSACRegressor`.

Either of those two change is enough to avoid trigger the above failure but I think we should do both to make the estimator checks as stable as possible.

I will also open an issue for `LinearDiscriminantAnalysis().fit([[0], [1], [1]], [0, 1, 1]))` but I am not sure what should be done for this.