### PR TITLE
DOC Fix docs for Drawbarcks of Davies-Bouldin index

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1793,7 +1793,7 @@ Advantages
 Drawbacks
 ~~~~~~~~~
 
-- The Davies-Boulding index is generally higher for convex clusters than other
+- The Davies-Boulding index is generally lower for convex clusters than other
   concepts of clusters, such as density based clusters like those obtained from
   DBSCAN.
 - The usage of centroid distance limits the distance metric to Euclidean space.


### PR DESCRIPTION
The Drawbarcks of Davies-Bouldin index are similar to those of Calinski-Harabasz Index and Silhouette Coefficient. The larger the latter two, the better the clustering effect, but contrary to Davies-Bouldin index, the smaller the better clustering effect. So this place should be changed to lower.