### PR TITLE
MAINT Use conda-forge channel for macOS pylatest_conda_forge_mkl on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,9 +160,10 @@ jobs:
     dependsOn: [linting]
     condition: and(ne(variables['Build.Reason'], 'Schedule'), succeeded('linting'))
     matrix:
-      pylatest_conda_mkl:
+      pylatest_conda_forge_mkl:
         DISTRIB: 'conda'
         BLAS: 'mkl'
+        CONDA_CHANNEL: 'conda-forge'
       pylatest_conda_mkl_no_openmp:
         DISTRIB: 'conda'
         BLAS: 'mkl'

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -27,7 +27,13 @@ source build_tools/shared.sh
 
 if [[ "$DISTRIB" == "conda" ]]; then
 
-    TO_INSTALL="python=$PYTHON_VERSION ccache pip blas[build=$BLAS]"
+    if [[ "CONDA_CHANNEL" != "" ]]; then
+        TO_INSTALL="-c $CONDA_CHANNEL"
+    else
+        TO_INSTALL=""
+    fi
+
+    TO_INSTALL="$TO_INSTALL python=$PYTHON_VERSION ccache pip blas[build=$BLAS]"
 
     TO_INSTALL="$TO_INSTALL $(get_dep numpy $NUMPY_VERSION)"
     TO_INSTALL="$TO_INSTALL $(get_dep scipy $SCIPY_VERSION)"

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -27,7 +27,7 @@ source build_tools/shared.sh
 
 if [[ "$DISTRIB" == "conda" ]]; then
 
-    if [[ "CONDA_CHANNEL" != "" ]]; then
+    if [[ "$CONDA_CHANNEL" != "" ]]; then
         TO_INSTALL="-c $CONDA_CHANNEL"
     else
         TO_INSTALL=""

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -50,8 +50,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
             # TODO: Remove !=1.1.0 when the following is fixed:
             # sklearn/svm/_libsvm.cpython-38-darwin.so,
             # 2): Symbol not found: _svm_check_parameter error
-            TO_INSTALL="$TO_INSTALL conda-forge::compilers>=1.0.4,!=1.1.0 \
-                        conda-forge::llvm-openmp"
+            TO_INSTALL="$TO_INSTALL compilers>=1.0.4,!=1.1.0 llvm-openmp"
         fi
     fi
 	make_conda $TO_INSTALL


### PR DESCRIPTION
This is a follow-up PR for #18667.

Install everything from conda-forge when compiler with the OpenMP enabled compilers from conda-forge on macOS.

I noticed when working on #18667 that conda deps can be overly constrained when mixing packages from the default channel and the conda-forge channel. In particular, priori to this PR this would select Python 3.7 instead of more recent Python 3.8 or 3.9 versions which is weird for a CI build entry that has "pylatest" in its name.