### PR TITLE
DOC install everything from conda-forge when using conda-forge compilers

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -240,8 +240,8 @@ First install the macOS command line tools::
 It is recommended to use a dedicated `conda environment`_ to build
 scikit-learn from source::
 
-    conda create -n sklearn-dev python numpy scipy cython joblib pytest \
-        "conda-forge::compilers>=1.0.4,!=1.1.0" conda-forge::llvm-openmp
+    conda create -n sklearn-dev -c conda-forge python numpy scipy cython \
+        joblib threadpoolctl pytest "compilers>=1.0.4,!=1.1.0" llvm-openmp
     conda activate sklearn-dev
     make clean
     pip install --verbose --no-build-isolation --editable .
@@ -353,7 +353,8 @@ Linux compilers from conda-forge
 Alternatively, install a recent version of the GNU C Compiler toolchain (GCC)
 in the user folder using conda::
 
-    conda create -n sklearn-dev numpy scipy joblib cython conda-forge::compilers
+    conda create -n sklearn-dev -c conda-forge python numpy scipy cython \
+        joblib threadpoolctl pytest compilers
     conda activate sklearn-dev
     pip install --verbose --no-build-isolation --editable .
 


### PR DESCRIPTION
This is a companion PR to #18672 to update the documentation of the build instructions to be consistent with what we test on the CI.

The motivation is that conda has often trouble solving dependencies when we mix packages from the default channel with packages from conda-forge. In particular it will get stuck on python 3.7.