### PR TITLE
[WIP] 'most_frequent' drop method for OneHotEncoder

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -80,13 +80,19 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                                  " it has to be of shape (n_features,).")
 
         self.categories_ = []
+        self.categories_count_ = []
 
         for i in range(n_features):
             Xi = X_list[i]
             if self.categories == 'auto':
-                cats = _unique(Xi)
+                cats, cats_count = _unique(Xi, return_counts=True)
             else:
                 cats = np.array(self.categories[i], dtype=Xi.dtype)
+                cats_, cats_count = _unique(Xi, return_counts=True)
+                missing = np.setdiff1d(cats, cats_, assume_unique=True)
+                cats_count = np.append(cats_count, np.zeros(missing.shape[0]))
+                idx = np.argsort(cats)
+                cats_count = cats_count[idx]
                 if Xi.dtype != object:
                     if not np.all(np.sort(cats) == cats):
                         raise ValueError("Unsorted categories are not "
@@ -97,6 +103,7 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                         msg = ("Found unknown categories {0} in column {1}"
                                " during fit".format(diff, i))
                         raise ValueError(msg)
+            self.categories_count_.append(cats_count)
             self.categories_.append(cats)
 
     def _transform(self, X, handle_unknown='error'):
@@ -205,6 +212,8 @@ class OneHotEncoder(_BaseEncoder):
         - 'if_binary' : drop the first category in each feature with two
           categories. Features with 1 or more than 2 categories are
           left intact.
+        - 'most_frequent' : drop the most frequent category in each feature.
+          If all categories frequency are equal, first category is dropped.
         - array : ``drop[i]`` is the category in feature ``X[:, i]`` that
           should be dropped.
 
@@ -226,6 +235,13 @@ class OneHotEncoder(_BaseEncoder):
     ----------
     categories_ : list of arrays
         The categories of each feature determined during fitting
+        (in order of the features in X and corresponding with the output
+        of ``transform``). This includes the category specified in ``drop``
+        (if any).
+
+    categories_count_ : list of arrays
+        The frequency count of each category within each feature determined
+        during fitting.
         (in order of the features in X and corresponding with the output
         of ``transform``). This includes the category specified in ``drop``
         (if any).
@@ -327,10 +343,15 @@ class OneHotEncoder(_BaseEncoder):
             elif self.drop == 'if_binary':
                 return np.array([0 if len(cats) == 2 else None
                                 for cats in self.categories_], dtype=object)
+            elif self.drop == 'most_frequent':
+                return np.array([np.argmax(cats_count)
+                                for cats_count in self.categories_count_],
+                                dtype=object)
             else:
                 msg = (
                     "Wrong input for parameter `drop`. Expected "
-                    "'first', 'if_binary', None or array of objects, got {}"
+                    "'first', 'if_binary', 'most_frequent', None "
+                    "or array of objects, got {}"
                     )
                 raise ValueError(msg.format(type(self.drop)))
 
@@ -341,7 +362,8 @@ class OneHotEncoder(_BaseEncoder):
             except (ValueError, TypeError):
                 msg = (
                     "Wrong input for parameter `drop`. Expected "
-                    "'first', 'if_binary', None or array of objects, got {}"
+                    "'first', 'if_binary', 'most_frequent', None "
+                    "or array of objects, got {}"
                     )
                 raise ValueError(msg.format(type(self.drop)))
             if droplen != len(self.categories_):

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -757,3 +757,16 @@ def test_encoders_does_not_support_none_values(Encoder):
     with pytest.raises(TypeError, match="Encoders require their input to be "
                                         "uniformly strings or numbers."):
         Encoder().fit(values)
+
+
+def test_drop_most_frequent():
+    X = [['abc', 12, 2, 55],
+         ['def', 12, 1, 55],
+         ['def', 12, 3, 56]]
+    exp = [[1, 1, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 1, 1]]
+    ohe = OneHotEncoder(drop='most_frequent')
+    trans = ohe.fit_transform(X).toarray()
+    assert_array_equal(trans, exp)
+    assert_array_equal(ohe.inverse_transform(trans), np.array(X, dtype=object))


### PR DESCRIPTION
…tribute

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
#18553
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Added 'most frequent' option to drop argument. This will drop most frequent category in each feature. If all categories at an equal count, first category will be dropped. Added new `categories_count` attribute to help accomplish this.

#### Any other comments?
In original issues, it was mentioned that a `dropped_levels_` would be helpful. Let me know if you would also like this added. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
