### PR TITLE
MNT Deprecate coef_ and intercept_ in OVR

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -443,7 +443,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
     def n_classes_(self):
         return len(self.classes_)
 
-    # TODO: Remove in 0.26 when the intercept_ attribute is deprecated
+    # TODO: Remove in 0.26 when the coef_ attribute is deprecated
     # mypy error: Decorated property not supported
     @deprecated("Attribute coef_ was deprecated in "  # type: ignore
                 "version 0.24 and will be removed in 0.26. "

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -184,7 +184,11 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
         exists only if the ``estimators_`` defines ``coef_``.
 
         .. deprecated:: 0.24
-            This attribute is deprecated in 0.24 and will be removed in 0.26.
+            This attribute is deprecated in 0.24 and will
+            be removed in 0.26. If you use this attribute
+            in :class:`~sklearn.feature_selection.RFE` or
+            :class:`~sklearn.feature_selection.SelectFromModel`,
+            change by the importance_getter parameter instead.
 
     intercept_ : ndarray of shape (1, 1) or (n_classes, 1)
         If ``y`` is binary, the shape is ``(1, 1)`` else ``(n_classes, 1)``
@@ -192,7 +196,11 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
         ``intercept_``.
 
         .. deprecated:: 0.24
-            This attribute is deprecated in 0.24 and will be removed in 0.26.
+            This attribute is deprecated in 0.24 and will
+            be removed in 0.26. If you use this attribute
+            in :class:`~sklearn.feature_selection.RFE` or
+            :class:`~sklearn.feature_selection.SelectFromModel`,
+            change by the importance_getter parameter instead.
 
     classes_ : array, shape = [`n_classes`]
         Class labels.
@@ -447,7 +455,9 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
     # mypy error: Decorated property not supported
     @deprecated("Attribute coef_ was deprecated in "  # type: ignore
                 "version 0.24 and will be removed in 0.26. "
-                "Use the importance_getter parameter instead.")
+                "If you observe this warning while using RFE "
+                "or SelectFromModel, use the importance_getter "
+                "parameter instead.")
     @property
     def coef_(self):
         check_is_fitted(self)
@@ -463,7 +473,9 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
     # mypy error: Decorated property not supported
     @deprecated("Attribute intercept_ was deprecated in "  # type: ignore
                 "version 0.24 and will be removed in 0.26. "
-                "Use the importance_getter parameter instead.")
+                "If you observe this warning while using RFE "
+                "or SelectFromModel, use the importance_getter "
+                "parameter instead.")
     @property
     def intercept_(self):
         check_is_fitted(self)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -437,6 +437,11 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
     def n_classes_(self):
         return len(self.classes_)
 
+    # TODO: Remove in 0.26 when the intercept_ attribute is deprecated
+    # mypy error: Decorated property not supported
+    @deprecated("Attribute coef_ was deprecated in "  # type: ignore
+                "version 0.24 and will be removed in 0.26. "
+                "Use the importance_getter parameter instead.")
     @property
     def coef_(self):
         check_is_fitted(self)
@@ -448,6 +453,11 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
             return sp.vstack(coefs)
         return np.vstack(coefs)
 
+    # TODO: Remove in 0.26 when the intercept_ attribute is deprecated
+    # mypy error: Decorated property not supported
+    @deprecated("Attribute intercept_ was deprecated in "  # type: ignore
+                "version 0.24 and will be removed in 0.26. "
+                "Use the importance_getter parameter instead.")
     @property
     def intercept_(self):
         check_is_fitted(self)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -451,7 +451,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
     def n_classes_(self):
         return len(self.classes_)
 
-    # TODO: Remove in 0.26 when the coef_ attribute is deprecated
+    # TODO: Remove coef_ attribute in 0.26
     # mypy error: Decorated property not supported
     @deprecated("Attribute coef_ was deprecated in "  # type: ignore
                 "version 0.24 and will be removed in 0.26. "
@@ -469,7 +469,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
             return sp.vstack(coefs)
         return np.vstack(coefs)
 
-    # TODO: Remove in 0.26 when the intercept_ attribute is deprecated
+    # TODO: Remove intercept_ attribute in 0.26
     # mypy error: Decorated property not supported
     @deprecated("Attribute intercept_ was deprecated in "  # type: ignore
                 "version 0.24 and will be removed in 0.26. "

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -188,7 +188,9 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
             be removed in 0.26. If you use this attribute
             in :class:`~sklearn.feature_selection.RFE` or
             :class:`~sklearn.feature_selection.SelectFromModel`,
-            change by the importance_getter parameter instead.
+            you may pass a callable to the `importance_getter`
+            parameter that extracts feature the importances
+            from `estimators_`.
 
     intercept_ : ndarray of shape (1, 1) or (n_classes, 1)
         If ``y`` is binary, the shape is ``(1, 1)`` else ``(n_classes, 1)``
@@ -200,7 +202,9 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
             be removed in 0.26. If you use this attribute
             in :class:`~sklearn.feature_selection.RFE` or
             :class:`~sklearn.feature_selection.SelectFromModel`,
-            change by the importance_getter parameter instead.
+            you may pass a callable to the `importance_getter`
+            parameter that extracts feature the importances
+            from `estimators_`.
 
     classes_ : array, shape = [`n_classes`]
         Class labels.

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -183,10 +183,16 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
         Coefficient of the features in the decision function. This attribute
         exists only if the ``estimators_`` defines ``coef_``.
 
+        .. deprecated:: 0.24
+            This attribute is deprecated in 0.24 and will be removed in 0.26.
+
     intercept_ : ndarray of shape (1, 1) or (n_classes, 1)
         If ``y`` is binary, the shape is ``(1, 1)`` else ``(n_classes, 1)``
         This attribute exists only if the ``estimators_`` defines
         ``intercept_``.
+
+        .. deprecated:: 0.24
+            This attribute is deprecated in 0.24 and will be removed in 0.26.
 
     classes_ : array, shape = [`n_classes`]
         Class labels.

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -832,11 +832,13 @@ def test_support_missing_values(MultiClassClassifier):
 # TODO: Remove this test in version 0.26 when
 # the coef_ and intercept_ attributes are removed
 def test_ovr_deprecated_coef_intercept():
-    ovr = OneVsRestClassifier(SVC(degree=2))
+    ovr = OneVsRestClassifier(SVC(kernel="linear"))
+    ovr = ovr.fit(iris.data, iris.target)
 
-    msg = ("Attribute {0} was deprecated in version "
-           "0.24 and will be removed in 0.26. Use the "
-           "importance_getter parameter instead.")
+    msg = ("Attribute {0} was deprecated in version 0.24 "
+           "and will be removed in 0.26. If you observe "
+           "this warning while using RFE or SelectFromModel, "
+           "use the importance_getter parameter instead.")
 
     for att in ["coef_", "intercept_"]:
         with pytest.warns(FutureWarning, match=msg.format(att)):

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -837,6 +837,7 @@ def test_support_missing_values(MultiClassClassifier):
     # the underlying pipeline or classifiers
     rng = np.random.RandomState(42)
     X, y = iris.data, iris.target
+    X = np.copy(X)  # Copy to avoid that the original data is modified
     mask = rng.choice([1, 0], X.shape, p=[.1, .9]).astype(bool)
     X[mask] = np.nan
     lr = make_pipeline(SimpleImputer(),

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -439,6 +439,8 @@ def test_ovr_pipeline():
     assert_array_equal(ovr.predict(iris.data), ovr_pipe.predict(iris.data))
 
 
+# TODO: Remove in 0.26 when the coef_ attribute is deprecated
+@ignore_warnings(category=FutureWarning)
 def test_ovr_coef_():
     for base_classifier in [SVC(kernel='linear', random_state=0),
                             LinearSVC(random_state=0)]:
@@ -456,6 +458,8 @@ def test_ovr_coef_():
                          sp.issparse(ovr.coef_))
 
 
+# TODO: Remove in 0.26 when the coef_ attribute is deprecated
+@ignore_warnings(category=FutureWarning)
 def test_ovr_coef_exceptions():
     # Not fitted exception!
     ovr = OneVsRestClassifier(LinearSVC(random_state=0))
@@ -821,3 +825,17 @@ def test_support_missing_values(MultiClassClassifier):
                        LogisticRegression(random_state=rng))
 
     MultiClassClassifier(lr).fit(X, y).score(X, y)
+
+
+# TODO: Remove in version 0.26 when the coef_
+# and intercept_ attributes are deprecated
+def test_ovr_deprecated_coef_intercept():
+    ovr = OneVsRestClassifier(SVC(degree=2))
+
+    msg = ("Attribute {0} was deprecated in version "
+           "0.24 and will be removed in 0.26. Use the "
+           "importance_getter parameter instead.")
+
+    for att in ["coef_", "intercept_"]:
+        with pytest.warns(FutureWarning, match=msg.format(att)):
+            hasattr(ovr, att)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -439,7 +439,8 @@ def test_ovr_pipeline():
     assert_array_equal(ovr.predict(iris.data), ovr_pipe.predict(iris.data))
 
 
-# TODO: Remove in 0.26 when the coef_ attribute is deprecated
+# TODO: Remove this test in version 0.26
+# when the coef_ attribute is removed
 @ignore_warnings(category=FutureWarning)
 def test_ovr_coef_():
     for base_classifier in [SVC(kernel='linear', random_state=0),
@@ -458,7 +459,8 @@ def test_ovr_coef_():
                          sp.issparse(ovr.coef_))
 
 
-# TODO: Remove in 0.26 when the coef_ attribute is deprecated
+# TODO: Remove this test in version 0.26
+# when the coef_ attribute is removed
 @ignore_warnings(category=FutureWarning)
 def test_ovr_coef_exceptions():
     # Not fitted exception!
@@ -827,8 +829,8 @@ def test_support_missing_values(MultiClassClassifier):
     MultiClassClassifier(lr).fit(X, y).score(X, y)
 
 
-# TODO: Remove in version 0.26 when the coef_
-# and intercept_ attributes are deprecated
+# TODO: Remove this test in version 0.26 when
+# the coef_ and intercept_ attributes are removed
 def test_ovr_deprecated_coef_intercept():
     ovr = OneVsRestClassifier(SVC(degree=2))
 
@@ -838,4 +840,4 @@ def test_ovr_deprecated_coef_intercept():
 
     for att in ["coef_", "intercept_"]:
         with pytest.warns(FutureWarning, match=msg.format(att)):
-            hasattr(ovr, att)
+            getattr(ovr, att)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -474,6 +474,22 @@ def test_ovr_coef_exceptions():
     assert_raises(AttributeError, lambda x: ovr.coef_, None)
 
 
+# TODO: Remove this test in version 0.26 when
+# the coef_ and intercept_ attributes are removed
+def test_ovr_deprecated_coef_intercept():
+    ovr = OneVsRestClassifier(SVC(kernel="linear"))
+    ovr = ovr.fit(iris.data, iris.target)
+
+    msg = ("Attribute {0} was deprecated in version 0.24 "
+           "and will be removed in 0.26. If you observe "
+           "this warning while using RFE or SelectFromModel, "
+           "use the importance_getter parameter instead.")
+
+    for att in ["coef_", "intercept_"]:
+        with pytest.warns(FutureWarning, match=msg.format(att)):
+            getattr(ovr, att)
+
+
 def test_ovo_exceptions():
     ovo = OneVsOneClassifier(LinearSVC(random_state=0))
     assert_raises(ValueError, ovo.predict, [])
@@ -827,19 +843,3 @@ def test_support_missing_values(MultiClassClassifier):
                        LogisticRegression(random_state=rng))
 
     MultiClassClassifier(lr).fit(X, y).score(X, y)
-
-
-# TODO: Remove this test in version 0.26 when
-# the coef_ and intercept_ attributes are removed
-def test_ovr_deprecated_coef_intercept():
-    ovr = OneVsRestClassifier(SVC(kernel="linear"))
-    ovr = ovr.fit(iris.data, iris.target)
-
-    msg = ("Attribute {0} was deprecated in version 0.24 "
-           "and will be removed in 0.26. If you observe "
-           "this warning while using RFE or SelectFromModel, "
-           "use the importance_getter parameter instead.")
-
-    for att in ["coef_", "intercept_"]:
-        with pytest.warns(FutureWarning, match=msg.format(att)):
-            getattr(ovr, att)


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #14816.

#### What does this implement/fix? Explain your changes.

This PR deprecates the `coef_` and `intercept_` attributes in the `sklearn.multiclass.OneVsRestClassifier` estimator.

#### Any other comments?

CC @NicolasHug.