### PR TITLE
[MRG] Skip loading_other_datasets doctest if pandas is not installed.

### DIFF
--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -43,6 +43,14 @@ def setup_working_with_text_data():
         raise SkipTest("Skipping dataset loading doctests")
 
 
+def setup_loading_other_datasets():
+    try:
+        import pandas  # noqa
+    except ImportError:
+        raise SkipTest("Skipping loading_other_datasets.rst, "
+                       "pandas not installed")
+
+
 def setup_compose():
     try:
         import pandas  # noqa
@@ -91,6 +99,8 @@ def pytest_runtest_setup(item):
         setup_compose()
     elif IS_PYPY and fname.endswith('modules/feature_extraction.rst'):
         raise SkipTest('FeatureHasher is not compatible with PyPy')
+    elif fname.endswith('datasets/loading_other_datasets.rst'):
+        setup_impute()
     elif fname.endswith('modules/impute.rst'):
         setup_impute()
     elif fname.endswith('modules/grid_search.rst'):

--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -100,7 +100,7 @@ def pytest_runtest_setup(item):
     elif IS_PYPY and fname.endswith('modules/feature_extraction.rst'):
         raise SkipTest('FeatureHasher is not compatible with PyPy')
     elif fname.endswith('datasets/loading_other_datasets.rst'):
-        setup_impute()
+        setup_loading_other_datasets()
     elif fname.endswith('modules/impute.rst'):
         setup_impute()
     elif fname.endswith('modules/grid_search.rst'):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Add directives to skip doctest on `loading_other_datasets.rst` when pandas is not installed.

#### Any other comments?
The test is failing without pandas installed because `fetch_openml` starting from 0.24 has `as_frame` set to auto at this line
https://github.com/scikit-learn/scikit-learn/blob/dccaf4c867c5ba254b1bd576101d30df40c00760/doc/datasets/loading_other_datasets.rst#L102