### PR TITLE
CI Fixes CI sync

### DIFF
--- a/.github/workflows/sync_pull_request.yml
+++ b/.github/workflows/sync_pull_request.yml
@@ -22,7 +22,7 @@ jobs:
           set -xe
           git remote add pr_remote ${{ github.event.pull_request.head.repo.html_url }}
           git fetch pr_remote ${{ github.event.pull_request.head.ref }}
-          git checkout pr_remote/${{ github.event.pull_request.head.ref }}
+          git checkout -b pr_branch pr_remote/${{ github.event.pull_request.head.ref }}
           git config user.name github-actions
           git config user.email github-actions@github.com
           git merge origin/master


### PR DESCRIPTION
This should fix the ci sync label issue seen in https://github.com/scikit-learn/scikit-learn/pull/18652

( think it is the detached head that does not allow for the merge.)

> Also, it seems the git fetch command fetches way too much, it could just fetch the master branch and only shallow.

@adrinjalali I couldn't think of a way to use https://github.com/actions/checkout#usage to fetch "just enough" such that `git merge` can find the common ancestor.