### PR TITLE
CI Avoid that "Assign" workflow is run on each issue comment

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -7,12 +7,12 @@ on:
 jobs:
   one:
     runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == 'take' ||
+       github.event.comment.body == 'Take')
+      && !github.event.issue.assignee
     steps:
-    - if: >-
-        (github.event.comment.body == 'take' || github.event.comment.body == 'Take')
-        && !github.event.issue.assignee
-      name:
-      run: |
-        echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
-        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
-        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/help%20wanted
+      - run: |
+          echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/help%20wanted


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I have noticed that whenever an issue comment is created, the `Assign` workflow runs the `one` job and skips or runs the `run` step according with the conditional statement.

However, we could save a little bit of computational resources moving the conditional statement at job-level instead of step-level.

#### Any other comments?

We could do the same for the `Unassign` workflow.

CC @thomasjpfan.