### PR TITLE
Display absolute numbers in confusion matrix while using normalize option

### DIFF
--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -67,8 +67,8 @@ class ConfusionMatrixDisplay:
     >>> disp.plot() # doctest: +SKIP
     """
     @_deprecate_positional_args
-    def __init__(self, confusion_matrix, *, display_labels=None, 
-        confusion_matrix_absolute=None):
+    def __init__(self, confusion_matrix, *, display_labels=None,
+                 confusion_matrix_absolute=None):
         self.confusion_matrix = confusion_matrix
         self.display_labels = display_labels
         self.confusion_matrix_absolute = confusion_matrix_absolute
@@ -277,8 +277,9 @@ def plot_confusion_matrix(estimator, X, y_true, *, labels=None,
     # retrieve absolute sample numbers
     cm_absolute = None
     if normalize and display_absolute:
-        cm_absolute = confusion_matrix(y_true, y_pred, sample_weight=sample_weight,
-                          labels=labels)
+        cm_absolute = confusion_matrix(y_true, y_pred,
+                                       sample_weight=sample_weight,
+                                       labels=labels)
 
     if display_labels is None:
         if labels is None:

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -140,7 +140,7 @@ class ConfusionMatrixDisplay:
                 else:
                     text_cm = format(cm[i, j], values_format)
 
-                if cm_absolute:
+                if isinstance(cm_absolute, np.ndarray):
                     text_cm_abs = format(cm_absolute[i, j], '.2g')
                     text_d = format(cm_absolute[i, j], 'd')
                     if len(text_d) < len(text_cm):

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -155,7 +155,7 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
         fmt = '.2g'
         if display_absolute:
             expected_text = np.array(
-                ["%s\n%s" % (format(v_rel, fmt), format(v_rel, fmt))
+                ["%s\n(%s)" % (format(v_rel, fmt), format(v_rel, fmt))
                     for v_rel, v_abs in zip(
                             cm.ravel(order="C"),
                             cm_abs.ravel(order="C")

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -153,7 +153,7 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
     if include_values:
         assert disp.text_.shape == (n_classes, n_classes)
         fmt = '.2g'
-        if display_absolute:
+        if display_absolute and normalize:
             expected_text = np.array(
                 ["%s\n(%s)" % (format(v_rel, fmt), format(v_rel, fmt))
                     for v_rel, v_abs in zip(

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -107,7 +107,7 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
     X, y = data
     ax = pyplot.gca()
     cmap = 'plasma'
-    cm = confusion_matrix(y, y_pred)
+    cm_abs = confusion_matrix(y, y_pred)
     disp = plot_confusion_matrix(fitted_clf, X, y,
                                  normalize=normalize,
                                  cmap=cmap, ax=ax,
@@ -117,11 +117,11 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
     assert disp.ax_ == ax
 
     if normalize == 'true':
-        cm = cm / cm.sum(axis=1, keepdims=True)
+        cm = cm_abs / cm.sum(axis=1, keepdims=True)
     elif normalize == 'pred':
-        cm = cm / cm.sum(axis=0, keepdims=True)
+        cm = cm_abs / cm.sum(axis=0, keepdims=True)
     elif normalize == 'all':
-        cm = cm / cm.sum()
+        cm = cm_abs / cm.sum()
 
     assert_allclose(disp.confusion_matrix, cm)
     import matplotlib as mpl
@@ -151,7 +151,18 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
     if include_values:
         assert disp.text_.shape == (n_classes, n_classes)
         fmt = '.2g'
-        expected_text = np.array([format(v, fmt) for v in cm.ravel(order="C")])
+        if display_absolute:
+            expected_text = np.array(
+                ["%s\n%s" % (format(v_rel, fmt), format(v_rel, fmt))
+                    for v_rel, v_abs in zip(
+                            cm.ravel(order="C"),
+                            cm_abs.ravel(order="C")
+                        )
+                 ]
+            )
+        else:
+            expected_text = np.array([format(v, fmt)
+                                      for v in cm.ravel(order="C")])
         text_text = np.array([
             t.get_text() for t in disp.text_.ravel(order="C")])
         assert_array_equal(expected_text, text_text)

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -155,7 +155,7 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
         fmt = '.2g'
         if display_absolute and normalize:
             expected_text = np.array(
-                ["%s\n(%s)" % (format(v_rel, fmt), format(v_rel, fmt))
+                ["%s\n(%s)" % (format(v_rel, fmt), format(v_abs, fmt))
                     for v_rel, v_abs in zip(
                             cm.ravel(order="C"),
                             cm_abs.ravel(order="C")

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -98,7 +98,6 @@ def test_plot_confusion_matrix_custom_labels(pyplot, data, y_pred, fitted_clf,
     assert_array_equal(y_ticks, expected_display_labels_str)
 
 
-
 @pytest.mark.parametrize("display_absolute", [False, True])
 @pytest.mark.parametrize("normalize", ['true', 'pred', 'all', None])
 @pytest.mark.parametrize("include_values", [True, False])

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -117,11 +117,11 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
     assert disp.ax_ == ax
 
     if normalize == 'true':
-        cm = cm_abs / cm.sum(axis=1, keepdims=True)
+        cm = cm_abs / cm_abs.sum(axis=1, keepdims=True)
     elif normalize == 'pred':
-        cm = cm_abs / cm.sum(axis=0, keepdims=True)
+        cm = cm_abs / cm_abs.sum(axis=0, keepdims=True)
     elif normalize == 'all':
-        cm = cm_abs / cm.sum()
+        cm = cm_abs / cm_abs.sum()
     else:
         cm = cm_abs
 

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -98,10 +98,12 @@ def test_plot_confusion_matrix_custom_labels(pyplot, data, y_pred, fitted_clf,
     assert_array_equal(y_ticks, expected_display_labels_str)
 
 
+
+@pytest.mark.parametrize("display_absolute", [False, True])
 @pytest.mark.parametrize("normalize", ['true', 'pred', 'all', None])
 @pytest.mark.parametrize("include_values", [True, False])
 def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
-                               normalize, include_values):
+                               normalize, include_values, display_absolute):
     X, y = data
     ax = pyplot.gca()
     cmap = 'plasma'
@@ -109,7 +111,8 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
     disp = plot_confusion_matrix(fitted_clf, X, y,
                                  normalize=normalize,
                                  cmap=cmap, ax=ax,
-                                 include_values=include_values)
+                                 include_values=include_values,
+                                 display_absolute=display_absolute)
 
     assert disp.ax_ == ax
 

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -122,6 +122,8 @@ def test_plot_confusion_matrix(pyplot, data, y_pred, n_classes, fitted_clf,
         cm = cm_abs / cm.sum(axis=0, keepdims=True)
     elif normalize == 'all':
         cm = cm_abs / cm.sum()
+    else:
+        cm = cm_abs
 
     assert_allclose(disp.confusion_matrix, cm)
     import matplotlib as mpl


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Often while using `normalize` in [plot_confusion_matrix](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.plot_confusion_matrix.html?highlight=plot_confusion#sklearn.metrics.plot_confusion_matrix) it is helpful to see the absolute number of samples right next to the percentual number. For example this functionality would solve issues like #16880.


#### What does this implement/fix? Explain your changes.

Implement a `display_absolute` option which adds an absolute sample count below the percentual value, i.e.

```python
plot_confusion_matrix(fitted_clf, X, y, normalize='true', display_absolute=True)
```

![image](https://user-images.githubusercontent.com/12762439/97618019-ca482980-1a1e-11eb-9e70-2ec0403b4f7e.png)

This option is only applied when `normalize` is set.
