### PR TITLE
FIX solved legend issue in PDP

### DIFF
--- a/examples/calibration/plot_calibration_multiclass.py
+++ b/examples/calibration/plot_calibration_multiclass.py
@@ -141,7 +141,7 @@ p = p[p[:, 2] >= 0]
 calibrated_classifier = sig_clf.calibrated_classifiers_[0]
 prediction = np.vstack([calibrator.predict(this_p)
                         for calibrator, this_p in
-                        zip(calibrated_classifier.calibrators_, p.T)]).T
+                        zip(calibrated_classifier.calibrators, p.T)]).T
 prediction /= prediction.sum(axis=1)[:, None]
 
 # Plot modifications of calibrator

--- a/examples/calibration/plot_calibration_multiclass.py
+++ b/examples/calibration/plot_calibration_multiclass.py
@@ -141,7 +141,7 @@ p = p[p[:, 2] >= 0]
 calibrated_classifier = sig_clf.calibrated_classifiers_[0]
 prediction = np.vstack([calibrator.predict(this_p)
                         for calibrator, this_p in
-                        zip(calibrated_classifier.calibrators, p.T)]).T
+                        zip(calibrated_classifier.calibrators_, p.T)]).T
 prediction /= prediction.sum(axis=1)[:, None]
 
 # Plot modifications of calibrator

--- a/examples/ensemble/plot_monotonic_constraints.py
+++ b/examples/ensemble/plot_monotonic_constraints.py
@@ -45,23 +45,33 @@ fig, ax = plt.subplots()
 gbdt = HistGradientBoostingRegressor()
 gbdt.fit(X, y)
 disp = plot_partial_dependence(
-    gbdt, X, features=[0, 1],
-    line_kw={'linewidth': 4, 'label': 'unconstrained'},
-    ax=ax)
+    gbdt,
+    X,
+    features=[0, 1],
+    line_kw={"linewidth": 4, "label": "unconstrained", "color": "tab:blue"},
+    ax=ax,
+)
 
 # With positive and negative constraints
 gbdt = HistGradientBoostingRegressor(monotonic_cst=[1, -1])
 gbdt.fit(X, y)
 
 plot_partial_dependence(
-    gbdt, X, features=[0, 1],
-    feature_names=('First feature\nPositive constraint',
-                   'Second feature\nNegtive constraint'),
-    line_kw={'linewidth': 4, 'label': 'constrained'},
-    ax=disp.axes_)
+    gbdt,
+    X,
+    features=[0, 1],
+    feature_names=(
+        "First feature\nPositive constraint",
+        "Second feature\nNegtive constraint",
+    ),
+    line_kw={"linewidth": 4, "label": "constrained", "color": "tab:orange"},
+    ax=disp.axes_,
+)
 
 for f_idx in (0, 1):
-    disp.axes_[0, f_idx].plot(X[:, f_idx], y, 'o', alpha=.3, zorder=-1)
+    disp.axes_[0, f_idx].plot(
+        X[:, f_idx], y, "o", alpha=0.3, zorder=-1, color="tab:green"
+    )
     disp.axes_[0, f_idx].set_ylim(-6, 6)
 
 plt.legend()

--- a/examples/release_highlights/plot_release_highlights_0_23_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_23_0.py
@@ -138,10 +138,13 @@ gbdt_cst = HistGradientBoostingRegressor(monotonic_cst=[1, 0]).fit(X, y)
 
 disp = plot_partial_dependence(
     gbdt_no_cst, X, features=[0], feature_names=['feature 0'],
-    line_kw={'linewidth': 4, 'label': 'unconstrained'})
+    line_kw={'linewidth': 4, 'label': 'unconstrained', "color": "tab:blue"})
 plot_partial_dependence(gbdt_cst, X, features=[0],
-    line_kw={'linewidth': 4, 'label': 'constrained'}, ax=disp.axes_)
-disp.axes_[0, 0].plot(X[:, 0], y, 'o', alpha=.5, zorder=-1, label='samples')
+    line_kw={'linewidth': 4, 'label': 'constrained', "color": "tab:orange"},
+    ax=disp.axes_)
+disp.axes_[0, 0].plot(
+    X[:, 0], y, 'o', alpha=.5, zorder=-1, label='samples', color="tab:green"
+)
 disp.axes_[0, 0].set_ylim(-3, 3); disp.axes_[0, 0].set_xlim(-1, 1)
 plt.legend()
 plt.show()

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -1,5 +1,4 @@
 import numbers
-from copy import deepcopy
 from itertools import chain
 from math import ceil
 
@@ -614,7 +613,12 @@ class PartialDependenceDisplay:
             )[0]
 
     def _plot_average_dependence(
-        self, avg_preds, feature_values, ax, pd_line_idx, label, line_kw,
+        self,
+        avg_preds,
+        feature_values,
+        ax,
+        pd_line_idx,
+        line_kw,
     ):
         """Plot the average partial dependence.
 
@@ -630,8 +634,6 @@ class PartialDependenceDisplay:
         pd_line_idx : int
             The sequential index of the plot. It will be unraveled to find the
             matching 2D position in the grid layout.
-        label : str or None
-            The label to add to the legend plot.
         line_kw : dict
             Dict with keywords passed when plotting the PD plot.
         """
@@ -639,7 +641,6 @@ class PartialDependenceDisplay:
         self.lines_[line_idx] = ax.plot(
             feature_values,
             avg_preds,
-            label=label,
             **line_kw,
         )[0]
 
@@ -689,7 +690,6 @@ class PartialDependenceDisplay:
             Dict with keywords passed when plotting the PD plot.
         """
         from matplotlib import transforms  # noqa
-        show_legend = False
 
         if self.kind in ("individual", "both"):
             self._plot_ice_lines(
@@ -703,25 +703,18 @@ class PartialDependenceDisplay:
             )
 
         if self.kind in ("average", "both"):
-            # do not modify the `line_kw` in place since it might be reuse for
-            # each feature for which the partial dependence is requested
-            line_kw = deepcopy(line_kw)
             # the average is stored as the last line
             if self.kind == "average":
-                label = line_kw.pop("label", None)
                 pd_line_idx = pd_plot_idx
             else:
-                label = line_kw.pop("label", "average")
                 pd_line_idx = pd_plot_idx * n_lines + n_ice_lines
             self._plot_average_dependence(
                 avg_preds[self.target_idx].ravel(),
                 feature_values,
                 ax,
                 pd_line_idx,
-                label,
                 line_kw,
             )
-            show_legend = label is not None
 
         trans = transforms.blended_transform_factory(
             ax.transData, ax.transAxes
@@ -748,7 +741,7 @@ class PartialDependenceDisplay:
         else:
             ax.set_yticklabels([])
 
-        if show_legend:
+        if line_kw.get("label", None):
             ax.legend()
 
     def _plot_two_way_partial_dependence(
@@ -871,7 +864,10 @@ class PartialDependenceDisplay:
         default_contour_kws = {"alpha": 0.75}
         contour_kw = {**default_contour_kws, **contour_kw}
 
-        default_line_kws = {'color': 'C0'}
+        default_line_kws = {
+            "color": "C0",
+            "label": None if self.kind == "average" else "average",
+        }
         line_kw = {**default_line_kws, **line_kw}
         individual_line_kw = line_kw.copy()
 

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -689,6 +689,7 @@ class PartialDependenceDisplay:
             Dict with keywords passed when plotting the PD plot.
         """
         from matplotlib import transforms  # noqa
+        show_legend = False
 
         if self.kind in ("individual", "both"):
             self._plot_ice_lines(
@@ -702,16 +703,15 @@ class PartialDependenceDisplay:
             )
 
         if self.kind in ("average", "both"):
+            # do not modify the `line_kw` in place since it might be reuse for
+            # each feature for which the partial dependence is requested
+            line_kw = deepcopy(line_kw)
             # the average is stored as the last line
             if self.kind == "average":
-                # do not modify the `line_kw` in place since it might be reuse
-                # for each feature for which the partial dependence is
-                # requested
-                line_kw = deepcopy(line_kw)
-                label = line_kw.pop("label", "average")
+                label = line_kw.pop("label", None)
                 pd_line_idx = pd_plot_idx
             else:
-                label = None
+                label = line_kw.pop("label", "average")
                 pd_line_idx = pd_plot_idx * n_lines + n_ice_lines
             self._plot_average_dependence(
                 avg_preds[self.target_idx].ravel(),
@@ -721,6 +721,7 @@ class PartialDependenceDisplay:
                 label,
                 line_kw,
             )
+            show_legend = label is not None
 
         trans = transforms.blended_transform_factory(
             ax.transData, ax.transAxes
@@ -746,6 +747,9 @@ class PartialDependenceDisplay:
                 ax.set_ylabel('Partial dependence')
         else:
             ax.set_yticklabels([])
+
+        if show_legend:
+            ax.legend()
 
     def _plot_two_way_partial_dependence(
         self,

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -701,11 +701,12 @@ class PartialDependenceDisplay:
             )
 
         if self.kind in ("average", "both"):
-            label = None if self.kind == "average" else "average"
             # the average is stored as the last line
             if self.kind == "average":
+                label = line_kw.pop("label", "average")
                 pd_line_idx = pd_plot_idx
             else:
+                label = None
                 pd_line_idx = pd_plot_idx * n_lines + n_ice_lines
             self._plot_average_dependence(
                 avg_preds[self.target_idx].ravel(),

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -1,4 +1,5 @@
 import numbers
+from copy import deepcopy
 from itertools import chain
 from math import ceil
 
@@ -703,6 +704,10 @@ class PartialDependenceDisplay:
         if self.kind in ("average", "both"):
             # the average is stored as the last line
             if self.kind == "average":
+                # do not modify the `line_kw` in place since it might be reuse
+                # for each feature for which the partial dependence is
+                # requested
+                line_kw = deepcopy(line_kw)
                 label = line_kw.pop("label", "average")
                 pd_line_idx = pd_plot_idx
             else:

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -549,3 +549,38 @@ def test_plot_partial_dependence_subsampling(
             for line in disp1.lines_.ravel()
         ]
     )
+
+
+@pytest.mark.parametrize(
+    "kind, line_kw, label",
+    [
+        ("average", {}, None),
+        ("average", {"label": "xxx"}, "xxx"),
+        ("both", {}, "average"),
+        ("both", {"label": "xxx"}, "xxx"),
+    ],
+)
+def test_partial_dependence_overwrite_labels(
+    pyplot,
+    clf_diabetes,
+    diabetes,
+    kind,
+    line_kw,
+    label,
+):
+    """Test that make sure that we can overwrite the label of the PDP plot"""
+    disp = plot_partial_dependence(
+        clf_diabetes,
+        diabetes.data,
+        [0, 2],
+        grid_resolution=25,
+        feature_names=diabetes.feature_names,
+        kind=kind,
+        line_kw=line_kw,
+    )
+
+    for ax in disp.axes_.ravel():
+        if label is None:
+            assert ax.get_legend() is None
+        else:
+            assert ax.get_legend().get_texts()[0].get_text() == label


### PR DESCRIPTION
Fixing master
closes #18712

I am not sure why we did not catch these errors before merging:

## PDP:

`label` could not be overwritten en plotting the PDP

- [x]  Add regression tests
- [x] Check the rendering of all examples

## `CalibratedClassifierCV`

**This will be addressed in a separate pull-request**

* The example uses some private attributes.

```pytb
Unexpected failing examples:
/home/circleci/project/examples/calibration/plot_calibration_multiclass.py failed leaving traceback:
Traceback (most recent call last):
  File "/home/circleci/project/examples/calibration/plot_calibration_multiclass.py", line 144, in <module>
    zip(calibrated_classifier.calibrators_, p.T)]).T
AttributeError: '_CalibratedClassifier' object has no attribute 'calibrators_'
```