### PR TITLE
DOC don't suggest contributors to add type annotations

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -448,11 +448,7 @@ You can check for common programming errors with the following tools:
 
   see also :ref:`testing_coverage`
 
-* A moderate use of type annotations is encouraged but is not mandatory. See
-  `mypy quickstart <https://mypy.readthedocs.io/en/latest/getting_started.html>`_
-  for an introduction, as well as `pandas contributing documentation
-  <https://pandas.pydata.org/pandas-docs/stable/development/contributing.html#type-hints>`_
-  for style guidelines. Whether you add type annotation or not::
+* Run static analysis with `mypy`::
 
     mypy sklearn
 


### PR DESCRIPTION
The current contributing guidelines suggest to "moderately" introduce type annotations in PRs.

I think that  type annotations is something we need to discuss in more depth  before we suggest contributors to add some (see https://github.com/scikit-learn/scikit-learn/issues/16705#issuecomment-683477933 and subsequent comments for discussions and current limitations/complications).

(I also feel like we should either go all in or not at all when it comes to introducing new standards in PRs.)

CC @rth ;)