### PR TITLE
MAINT flake8: move E402 ignore rule to setup.cfg for examples folder

### DIFF
--- a/examples/.flake8
+++ b/examples/.flake8
@@ -1,5 +1,0 @@
-# Examples specific flake8 configuration
-
-[flake8]
-# Same ignore as project-wide plus E402 (imports not at top of file)
-ignore=E121,E123,E126,E24,E226,E704,W503,W504,E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,10 @@ artifact_indexes=
 [flake8]
 # Default flake8 3.5 ignored flags
 ignore=E121,E123,E126,E226,E24,E704,W503,W504
+# It's fine not to put the import at the top of the file in the examples
+# folder.
+per-file-ignores =
+    examples/*: E402
 
 [mypy]
 ignore_missing_imports = True


### PR DESCRIPTION
I noticed the flake8 E402 ignore rule for the example folder (import lines not at the top of the file) would not be taken into account when you run the flake8 command from the top level folder. In particular this would cause some dev environments such as VS Code to display the lint markers for those import lines.

Using the `per-file-ignores` directive in the top level `setup.cfg` file makes this configuration work, wherever the flake8 command is run from.

I will merge merge if CI stays green.