### PR TITLE
Improve multiclass calibration example

### DIFF
--- a/examples/calibration/plot_calibration_multiclass.py
+++ b/examples/calibration/plot_calibration_multiclass.py
@@ -4,66 +4,79 @@ Probability Calibration for 3-class classification
 ==================================================
 
 This example illustrates how sigmoid calibration changes predicted
-probabilities for a 3-class classification problem. Illustrated is the
-standard 2-simplex, where the three corners correspond to the three classes.
-Arrows point from the probability vectors predicted by an uncalibrated
-classifier to the probability vectors predicted by the same classifier after
-sigmoid calibration on a hold-out validation set. Colors indicate the true
-class of an instance (red: class 1, green: class 2, blue: class 3).
+probabilities for a 3-class classification problem. Illustrated is the standard
+2-simplex, where the three corners correspond to the three classes. Arrows
+point from the probability vectors predicted by an uncalibrated classifier to
+the probability vectors predicted by the same classifier after sigmoid
+calibration on a hold-out validation set. Colors indicate the true class of an
+instance (red: class 1, green: class 2, blue: class 3).
 
 The base classifier is a random forest classifier with 25 base estimators
-(trees). If this classifier is trained on all 800 training datapoints, it is
+(trees). If this classifier is trained on all 1000 training datapoints, it is
 overly confident in its predictions and thus incurs a large log-loss.
+
 Calibrating an identical classifier, which was trained on 600 datapoints, with
-method='sigmoid' on the remaining 200 datapoints reduces the confidence of the
+method='sigmoid' on the remaining 400 datapoints reduces the confidence of the
 predictions, i.e., moves the probability vectors from the edges of the simplex
 towards the center. This calibration results in a lower log-loss. Note that an
 alternative would have been to increase the number of base estimators which
 would have resulted in a similar decrease in log-loss.
+
 """
 print(__doc__)
 
 # Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
 # License: BSD Style.
 
-
-import matplotlib.pyplot as plt
-
+# %%
 import numpy as np
-
 from sklearn.datasets import make_blobs
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.calibration import CalibratedClassifierCV
-from sklearn.metrics import log_loss
 
 np.random.seed(0)
 
 # Generate data
-X, y = make_blobs(n_samples=1000, random_state=42, cluster_std=5.0)
+X, y = make_blobs(n_samples=2000, random_state=42, cluster_std=5.0)
 X_train, y_train = X[:600], y[:600]
-X_valid, y_valid = X[600:800], y[600:800]
-X_train_valid, y_train_valid = X[:800], y[:800]
-X_test, y_test = X[800:], y[800:]
+X_valid, y_valid = X[600:1000], y[600:1000]
+X_train_valid, y_train_valid = X[:1000], y[:1000]
+X_test, y_test = X[1000:], y[1000:]
 
-# Train uncalibrated random forest classifier on whole train and validation
-# data and evaluate on test data
+# %%
+# Train uncalibrated random forest classifier on the concatenated train plus
+# validation data.
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.metrics import log_loss
+
 clf = RandomForestClassifier(n_estimators=25)
 clf.fit(X_train_valid, y_train_valid)
+
+# %%
+# Train a random forest classifier and calibrate on validation data in a
+# 2-stage process:
+clf = RandomForestClassifier(n_estimators=25)
+clf.fit(X_train, y_train)
+sig_clf = CalibratedClassifierCV(clf, method="sigmoid", cv="prefit")
+sig_clf.fit(X_valid, y_valid)
+
+# %%
+# Compare the calibration of the predictions 1000 held-out test samples.
 clf_probs = clf.predict_proba(X_test)
 score = log_loss(y_test, clf_probs)
 
-# Train random forest classifier, calibrate on validation data and evaluate
-# on test data
-clf = RandomForestClassifier(n_estimators=25)
-clf.fit(X_train, y_train)
-clf_probs = clf.predict_proba(X_test)
-sig_clf = CalibratedClassifierCV(clf, method="sigmoid", cv="prefit")
-sig_clf.fit(X_valid, y_valid)
 sig_clf_probs = sig_clf.predict_proba(X_test)
 sig_score = log_loss(y_test, sig_clf_probs)
 
-# Plot changes in predicted probabilities via arrows
-plt.figure()
+print("Log-loss of")
+print(f" * uncalibrated classifier: {score:.3f}")
+print(f" * calibrated classifier: {sig_score:.3f}")
+
+# %%
+# Plot changes in predicted probabilities on test samples using
+# arrows with the color of the true class.
+import matplotlib.pyplot as plt
+
+plt.figure(figsize=(10, 10))
 colors = ["r", "g", "b"]
 for i in range(clf_probs.shape[0]):
     plt.arrow(clf_probs[i, 0], clf_probs[i, 1],
@@ -116,40 +129,41 @@ for x in [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]:
     plt.plot([0, 0 + (1-x)/2], [x, x + (1-x)/2], 'k', alpha=0.2)
     plt.plot([x, x + (1-x)/2], [0, 0 + (1-x)/2], 'k', alpha=0.2)
 
-plt.title("Change of predicted probabilities after sigmoid calibration")
+plt.title("Change of predicted probabilities on test samples "
+          "after sigmoid calibration")
 plt.xlabel("Probability class 1")
 plt.ylabel("Probability class 2")
 plt.xlim(-0.05, 1.05)
 plt.ylim(-0.05, 1.05)
-plt.legend(loc="best")
+_ = plt.legend(loc="best")
 
-print("Log-loss of")
-print(" * uncalibrated classifier trained on 800 datapoints: %.3f "
-      % score)
-print(" * classifier trained on 600 datapoints and calibrated on "
-      "200 datapoint: %.3f" % sig_score)
-
-# Illustrate calibrator
-plt.figure()
-# generate grid over 2-simplex
+# %%
+# Generate a grid over the 2-simplex to plot the learned calibration map:
+plt.figure(figsize=(10, 10))
 p1d = np.linspace(0, 1, 20)
 p0, p1 = np.meshgrid(p1d, p1d)
 p2 = 1 - p0 - p1
 p = np.c_[p0.ravel(), p1.ravel(), p2.ravel()]
 p = p[p[:, 2] >= 0]
 
+# Use the class-wise calibrators to compute where those points are mapped.
 calibrated_classifier = sig_clf.calibrated_classifiers_[0]
 prediction = np.vstack([calibrator.predict(this_p)
                         for calibrator, this_p in
                         zip(calibrated_classifier.calibrators, p.T)]).T
+
+# Re-normalize the calibrated predictions to make sure they stay inside the
+# simplex. This same renormalization step is performed internally by the
+# predict method of CalibratedClassifierCV on multiclass problems.
 prediction /= prediction.sum(axis=1)[:, None]
 
-# Plot modifications of calibrator
+# Plot changes in predicted probabilities induced by the calibrators
 for i in range(prediction.shape[0]):
     plt.arrow(p[i, 0], p[i, 1],
               prediction[i, 0] - p[i, 0], prediction[i, 1] - p[i, 1],
               head_width=1e-2, color=colors[np.argmax(p[i])])
-# Plot boundaries of unit simplex
+
+# Plot the boundaries of the unit simplex
 plt.plot([0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], 'k', label="Simplex")
 
 plt.grid(False)
@@ -158,7 +172,7 @@ for x in [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]:
     plt.plot([0, 0 + (1-x)/2], [x, x + (1-x)/2], 'k', alpha=0.2)
     plt.plot([x, x + (1-x)/2], [0, 0 + (1-x)/2], 'k', alpha=0.2)
 
-plt.title("Illustration of sigmoid calibrator")
+plt.title("Learned sigmoid calibration map")
 plt.xlabel("Probability class 1")
 plt.ylabel("Probability class 2")
 plt.xlim(-0.05, 1.05)


### PR DESCRIPTION
This PR improves the multiclass calibration example to make it easier to follow:

- Change the titles of the figures to make them more descriptive and accurate;
- Use notebook cells to split the examples in smaller code snippets that are easier to digest (with better inline comments);
- Use a larger test set to get more arrows on the first figure.