### PR TITLE
train_test_split documentation: add example for `stratify` param

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -518,6 +518,8 @@ Here is a visualization of the cross-validation behavior. Note that
 validation that allows a finer control on the number of iterations and
 the proportion of samples on each side of the train / test split.
 
+.. _stratification:
+
 Cross-validation iterators with stratification based on class labels.
 ---------------------------------------------------------------------
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -570,8 +570,8 @@ class StratifiedKFold(_BaseKFold):
     This cross-validation object is a variation of KFold that returns
     stratified folds. The folds are made by preserving the percentage of
     samples for each class.
-    
-    Read more in the :ref:`User Guide <stratified_k_fold>`. 
+
+    Read more in the :ref:`User Guide <stratified_k_fold>`.
 
     Parameters
     ----------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -571,8 +571,6 @@ class StratifiedKFold(_BaseKFold):
     stratified folds. The folds are made by preserving the percentage of
     samples for each class.
 
-    Read more about stratification in the :ref:`User Guide <stratification>`.
-
     Parameters
     ----------
     n_splits : int, default=5
@@ -2119,7 +2117,8 @@ def train_test_split(*arrays,
 
     stratify : array-like, default=None
         If not None, data is split in a stratified fashion, using this as
-        the class labels. aaaaaaaaaa
+        the class labels. 
+        Read more about stratification in the :ref:`User Guide <stratification>`.
 
     Returns
     -------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -571,7 +571,7 @@ class StratifiedKFold(_BaseKFold):
     stratified folds. The folds are made by preserving the percentage of
     samples for each class.
 
-    Read more in the :ref:`User Guide <stratified_k_fold>`.
+    Read more about stratification in the :ref:`User Guide <stratification>`.
 
     Parameters
     ----------
@@ -2119,13 +2119,7 @@ def train_test_split(*arrays,
 
     stratify : array-like, default=None
         If not None, data is split in a stratified fashion, using this as
-        the class labels. 
-        The `stratify` parameter makes a split in such a way that the 
-        proportion of values in the sample produced shall be the 
-        same as the proportion of values in the array provided as value to 
-        the parameter. For example, specifying `stratify=[1, 0, 1, 1]` 
-        will make sure that every sample in your split has 25% of 0's 
-        and 75% of 1's.
+        the class labels. aaaaaaaaaa
 
     Returns
     -------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2120,7 +2120,7 @@ def train_test_split(*arrays,
     stratify : array-like, default=None
         If not None, data is split in a stratified fashion, using this as
         the class labels. 
-        Read more about stratification in the :ref:`User Guide <stratification>`.
+        Read more in the :ref:`User Guide <stratification>`.
 
     Returns
     -------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -570,6 +570,8 @@ class StratifiedKFold(_BaseKFold):
     This cross-validation object is a variation of KFold that returns
     stratified folds. The folds are made by preserving the percentage of
     samples for each class.
+    
+    Read more in the :ref:`User Guide <stratified_k_fold>`. 
 
     Parameters
     ----------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2119,7 +2119,7 @@ def train_test_split(*arrays,
 
     stratify : array-like, default=None
         If not None, data is split in a stratified fashion, using this as
-        the class labels. 
+        the class labels.
         Read more in the :ref:`User Guide <stratification>`.
 
     Returns

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2119,7 +2119,13 @@ def train_test_split(*arrays,
 
     stratify : array-like, default=None
         If not None, data is split in a stratified fashion, using this as
-        the class labels.
+        the class labels. 
+        The `stratify` parameter makes a split in such a way that the 
+        proportion of values in the sample produced shall be the 
+        same as the proportion of values in the array provided as value to 
+        the parameter. For example, specifying `stratify=[1, 0, 1, 1]` 
+        will make sure that every sample in your split has 25% of 0's 
+        and 75% of 1's.
 
     Returns
     -------


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
Provided an understandable example to the `train_test_split` function documentation, namely concerning the `stratify` parameter. Inspired by [this reply](https://stackoverflow.com/a/38889389/4883320) on StackOverflow.