### PR TITLE
FIX numerical rounding issue causing test_poisson_zero_nodes to fail at random

### DIFF
--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1440,15 +1440,15 @@ cdef class Poisson(RegressionCriterion):
         cdef SIZE_t n_outputs = self.n_outputs
 
         for k in range(n_outputs):
-            y_mean = y_sum[k] / weight_sum
-
-            if y_mean <= EPSILON:
-                # y_mean could be computed from the subtraction
+            if y_sum[k] <= EPSILON:
+                # y_sum could be computed from the subtraction
                 # sum_right = sum_total - sum_left leading to a potential
                 # floating point rounding error.
-                # Thus, we relax the comparison y_mean <= 0 to
-                # y_mean <= EPSILON.
+                # Thus, we relax the comparison y_sum <= 0 to
+                # y_sum <= EPSILON.
                 return INFINITY
+
+            y_mean = y_sum[k] / weight_sum
 
             for p in range(start, end):
                 i = self.samples[p]

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1385,7 +1385,8 @@ cdef class Poisson(RegressionCriterion):
         cdef double y_mean_right = 0.
 
         for k in range(self.n_outputs):
-            if (self.sum_left[k] <= EPSILON) or (self.sum_right[k] <= EPSILON):
+            if ((self.sum_left[k] <= 10 * EPSILON) or
+                    (self.sum_right[k] <= 10 * EPSILON)):
                 # Poisson loss does not allow non-positive predictions. We
                 # therefore forbid splits that have child nodes with
                 # sum(y_i) <= 0.
@@ -1440,7 +1441,7 @@ cdef class Poisson(RegressionCriterion):
         cdef SIZE_t n_outputs = self.n_outputs
 
         for k in range(n_outputs):
-            if y_sum[k] <= EPSILON:
+            if y_sum[k] <= 10 * EPSILON:
                 # y_sum could be computed from the subtraction
                 # sum_right = sum_total - sum_left leading to a potential
                 # floating point rounding error.

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1389,6 +1389,9 @@ cdef class Poisson(RegressionCriterion):
                 # Poisson loss does not allow non-positive predictions. We
                 # therefore forbid splits that have child nodes with
                 # sum(y_i) <= 0.
+                # Since sum_right = sum_total - sum_left, it can lead to
+                # floating point rounding error and will not give zero. Thus,
+                # we relax the above comparison to sum(y_i) <= EPSILON.
                 return -INFINITY
             else:
                 y_mean_left = self.sum_left[k] / self.weighted_n_left
@@ -1440,6 +1443,11 @@ cdef class Poisson(RegressionCriterion):
             y_mean = y_sum[k] / weight_sum
 
             if y_mean <= EPSILON:
+                # y_mean could be computed from the subtraction
+                # sum_right = sum_total - sum_left leading to a potential
+                # floating point rounding error.
+                # Thus, we relax the comparison y_mean <= 0 to
+                # y_mean <= EPSILON.
                 return INFINITY
 
             for p in range(start, end):

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -34,6 +34,7 @@ from ._utils cimport safe_realloc
 from ._utils cimport sizet_ptr_to_ndarray
 from ._utils cimport WeightedMedianCalculator
 
+cdef double EPSILON = np.finfo('double').eps
 
 cdef class Criterion:
     """Interface for impurity criteria.
@@ -1384,7 +1385,7 @@ cdef class Poisson(RegressionCriterion):
         cdef double y_mean_right = 0.
 
         for k in range(self.n_outputs):
-            if (self.sum_left[k] <= 0) or (self.sum_right[k] <= 0):
+            if (self.sum_left[k] <= EPSILON) or (self.sum_right[k] <= EPSILON):
                 # Poisson loss does not allow non-positive predictions. We
                 # therefore forbid splits that have child nodes with
                 # sum(y_i) <= 0.
@@ -1438,7 +1439,7 @@ cdef class Poisson(RegressionCriterion):
         for k in range(n_outputs):
             y_mean = y_sum[k] / weight_sum
 
-            if y_mean <= 0:
+            if y_mean <= EPSILON:
                 return INFINITY
 
             for p in range(start, end):

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -34,7 +34,8 @@ from ._utils cimport safe_realloc
 from ._utils cimport sizet_ptr_to_ndarray
 from ._utils cimport WeightedMedianCalculator
 
-cdef double EPSILON = np.finfo('double').eps
+# EPSILON is used in the Poisson criterion
+cdef double EPSILON = 10 * np.finfo('double').eps
 
 cdef class Criterion:
     """Interface for impurity criteria.
@@ -1385,8 +1386,7 @@ cdef class Poisson(RegressionCriterion):
         cdef double y_mean_right = 0.
 
         for k in range(self.n_outputs):
-            if ((self.sum_left[k] <= 10 * EPSILON) or
-                    (self.sum_right[k] <= 10 * EPSILON)):
+            if (self.sum_left[k] <= EPSILON) or (self.sum_right[k] <= EPSILON):
                 # Poisson loss does not allow non-positive predictions. We
                 # therefore forbid splits that have child nodes with
                 # sum(y_i) <= 0.
@@ -1441,7 +1441,7 @@ cdef class Poisson(RegressionCriterion):
         cdef SIZE_t n_outputs = self.n_outputs
 
         for k in range(n_outputs):
-            if y_sum[k] <= 10 * EPSILON:
+            if y_sum[k] <= EPSILON:
                 # y_sum could be computed from the subtraction
                 # sum_right = sum_total - sum_left leading to a potential
                 # floating point rounding error.

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1987,7 +1987,7 @@ def test_balance_property(criterion, Tree):
     assert np.sum(reg.predict(X)) == pytest.approx(np.sum(y))
 
 
-@pytest.mark.parametrize("seed", range(100))
+@pytest.mark.parametrize("seed", range(10000))
 def test_poisson_zero_nodes(seed):
     # Test that sum(y)=0 and therefore y_pred=0 is forbidden on nodes.
     X = [[0, 0], [0, 1], [0, 2], [0, 3],

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1987,7 +1987,7 @@ def test_balance_property(criterion, Tree):
     assert np.sum(reg.predict(X)) == pytest.approx(np.sum(y))
 
 
-@pytest.mark.parametrize("seed", range(1000))
+@pytest.mark.parametrize("seed", range(3))
 def test_poisson_zero_nodes(seed):
     # Test that sum(y)=0 and therefore y_pred=0 is forbidden on nodes.
     X = [[0, 0], [0, 1], [0, 2], [0, 3],

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1987,7 +1987,7 @@ def test_balance_property(criterion, Tree):
     assert np.sum(reg.predict(X)) == pytest.approx(np.sum(y))
 
 
-@pytest.mark.parametrize("seed", range(10000))
+@pytest.mark.parametrize("seed", range(1000))
 def test_poisson_zero_nodes(seed):
     # Test that sum(y)=0 and therefore y_pred=0 is forbidden on nodes.
     X = [[0, 0], [0, 1], [0, 2], [0, 3],

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1988,17 +1988,18 @@ def test_balance_property(criterion, Tree):
 
 
 def test_poisson_zero_nodes():
+    seed = 42
     # Test that sum(y)=0 and therefore y_pred=0 is forbidden on nodes.
     X = [[0, 0], [0, 1], [0, 2], [0, 3],
          [1, 0], [1, 2], [1, 2], [1, 3]]
     y = [0, 0, 0, 0, 1, 2, 3, 4]
     # Note that X[:, 0] == 0 is a 100% indicator for y == 0. The tree can
     # easily learn that:
-    reg = DecisionTreeRegressor(criterion="mse", random_state=1)
+    reg = DecisionTreeRegressor(criterion="mse", random_state=seed)
     reg.fit(X, y)
     assert np.amin(reg.predict(X)) == 0
     # whereas Poisson must predict strictly positive numbers
-    reg = DecisionTreeRegressor(criterion="poisson", random_state=1)
+    reg = DecisionTreeRegressor(criterion="poisson", random_state=seed)
     reg.fit(X, y)
     assert np.all(reg.predict(X) > 0)
 
@@ -2009,12 +2010,13 @@ def test_poisson_zero_nodes():
         n_samples=1_000,
         n_features=n_features,
         n_informative=n_features * 2 // 3,
+        random_state=seed,
     )
     # some excess zeros
     y[(-1 < y) & (y < 0)] = 0
     # make sure the target is positive
     y = np.abs(y)
-    reg = DecisionTreeRegressor(criterion='poisson', random_state=42)
+    reg = DecisionTreeRegressor(criterion='poisson', random_state=seed)
     reg.fit(X, y)
     assert np.all(reg.predict(X) > 0)
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1987,8 +1987,8 @@ def test_balance_property(criterion, Tree):
     assert np.sum(reg.predict(X)) == pytest.approx(np.sum(y))
 
 
-def test_poisson_zero_nodes():
-    seed = 42
+@pytest.mark.parametrize("seed", range(100))
+def test_poisson_zero_nodes(seed):
     # Test that sum(y)=0 and therefore y_pred=0 is forbidden on nodes.
     X = [[0, 0], [0, 1], [0, 2], [0, 3],
          [1, 0], [1, 2], [1, 2], [1, 3]]


### PR DESCRIPTION
`test_poisson_zero_nodes` is failing at random on test data more complex than usual.

Here is an example of the original failure observed in #18727:

```
2020-11-02T17:46:34.7932442Z ___________________________ test_poisson_zero_nodes ___________________________
2020-11-02T17:46:34.7932888Z [gw0] win32 -- Python 3.7.9 c:\miniconda\envs\testvenv\python.exe
2020-11-02T17:46:34.7933220Z 
2020-11-02T17:46:34.7933464Z     def test_poisson_zero_nodes():
2020-11-02T17:46:34.7933881Z         # Test that sum(y)=0 and therefore y_pred=0 is forbidden on nodes.
2020-11-02T17:46:34.7934298Z         X = [[0, 0], [0, 1], [0, 2], [0, 3],
2020-11-02T17:46:34.7934611Z              [1, 0], [1, 2], [1, 2], [1, 3]]
2020-11-02T17:46:34.7934969Z         y = [0, 0, 0, 0, 1, 2, 3, 4]
2020-11-02T17:46:34.7935489Z         # Note that X[:, 0] == 0 is a 100% indicator for y == 0. The tree can
2020-11-02T17:46:34.7935835Z         # easily learn that:
2020-11-02T17:46:34.7936209Z         reg = DecisionTreeRegressor(criterion="mse", random_state=1)
2020-11-02T17:46:34.7936520Z         reg.fit(X, y)
2020-11-02T17:46:34.7936870Z         assert np.amin(reg.predict(X)) == 0
2020-11-02T17:46:34.7937250Z         # whereas Poisson must predict strictly positive numbers
2020-11-02T17:46:34.7937669Z         reg = DecisionTreeRegressor(criterion="poisson", random_state=1)
2020-11-02T17:46:34.7937979Z         reg.fit(X, y)
2020-11-02T17:46:34.7938282Z         assert np.all(reg.predict(X) > 0)
2020-11-02T17:46:34.7938635Z     
2020-11-02T17:46:34.7938968Z         # Test additional dataset where something could go wrong.
2020-11-02T17:46:34.7939317Z         n_features = 10
2020-11-02T17:46:34.7939587Z         X, y = datasets.make_regression(
2020-11-02T17:46:34.7939973Z             effective_rank=n_features * 2 // 3, tail_strength=0.6,
2020-11-02T17:46:34.7940279Z             n_samples=1_000,
2020-11-02T17:46:34.7940586Z             n_features=n_features,
2020-11-02T17:46:34.7940918Z             n_informative=n_features * 2 // 3,
2020-11-02T17:46:34.7941596Z         )
2020-11-02T17:46:34.7941874Z         # some excess zeros
2020-11-02T17:46:34.7942137Z         y[(-1 < y) & (y < 0)] = 0
2020-11-02T17:46:34.7942470Z         # make sure the target is positive
2020-11-02T17:46:34.7942786Z         y = np.abs(y)
2020-11-02T17:46:34.7943105Z         reg = DecisionTreeRegressor(criterion='poisson', random_state=42)
2020-11-02T17:46:34.7943477Z         reg.fit(X, y)
2020-11-02T17:46:34.7943785Z >       assert np.all(reg.predict(X) > 0)
2020-11-02T17:46:34.7944091Z E       AssertionError: assert False
2020-11-02T17:46:34.7944894Z E        +  where False = <function all at 0x000002B7FC7ADDC8>(array([2.10771821e+00, 1.65428151e+00, 5.98524378e+00, 3.19025199e+00,\n       4.95470497e+00, 1.16949401e-01, 2.291628...2.90288054e+00, 4.19665946e+00, 3.03705704e+00,\n       2.05303557e+00, 1.43979061e+00, 6.61262364e+00, 6.29637090e-01]) > 0)
2020-11-02T17:46:34.7945967Z E        +    where <function all at 0x000002B7FC7ADDC8> = np.all
2020-11-02T17:46:34.7947272Z E        +    and   array([2.10771821e+00, 1.65428151e+00, 5.98524378e+00, 3.19025199e+00,\n       4.95470497e+00, 1.16949401e-01, 2.291628...2.90288054e+00, 4.19665946e+00, 3.03705704e+00,\n       2.05303557e+00, 1.43979061e+00, 6.61262364e+00, 6.29637090e-01]) = <bound method BaseDecisionTree.predict of DecisionTreeRegressor(criterion='poisson', random_state=42)>(array([[-0.01698191,  0.02468876,  0.00559544, ...,  0.00576349,\n         0.00226511, -0.0235138 ],\n       [ 0.0054320...711, -0.01739591],\n       [-0.02495476, -0.01743518,  0.00785444, ..., -0.00650216,\n         0.02237994,  0.00958636]]))
2020-11-02T17:46:34.7948882Z E        +      where <bound method BaseDecisionTree.predict of DecisionTreeRegressor(criterion='poisson', random_state=42)> = DecisionTreeRegressor(criterion='poisson', random_state=42).predict
2020-11-02T17:46:34.7949395Z 
2020-11-02T17:46:34.7949734Z X          = array([[-0.01698191,  0.02468876,  0.00559544, ...,  0.00576349,
2020-11-02T17:46:34.7951425Z          0.00226511, -0.0235138 ],
2020-11-02T17:46:34.7951887Z        [ 0.0054320...711, -0.01739591],
2020-11-02T17:46:34.7952430Z        [-0.02495476, -0.01743518,  0.00785444, ..., -0.00650216,
2020-11-02T17:46:34.7952797Z          0.02237994,  0.00958636]])
2020-11-02T17:46:34.7953123Z n_features = 10
2020-11-02T17:46:34.7953434Z reg        = DecisionTreeRegressor(criterion='poisson', random_state=42)
2020-11-02T17:46:34.7953910Z y          = array([2.10771821e+00, 1.65428151e+00, 5.98524378e+00, 3.19025199e+00,
2020-11-02T17:46:34.7954426Z        4.95470497e+00, 0.00000000e+00, 2.291628...2.90288054e+00, 4.19665946e+00, 3.03705704e+00,
2020-11-02T17:46:34.7954873Z        2.05303557e+00, 1.43979061e+00, 6.61262364e+00, 0.00000000e+00])
```