### PR TITLE
DOC Fix doc for return shape for linear model

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -232,7 +232,7 @@ class LinearModel(BaseEstimator, metaclass=ABCMeta):
 
         Returns
         -------
-        C : array, shape (n_samples,)
+        C : array, shape (n_samples,) or (n_samples, n_outputs)
             Returns predicted values.
         """
         return self._decision_function(X)
@@ -303,7 +303,7 @@ class LinearClassifierMixin(ClassifierMixin):
 
         Returns
         -------
-        C : array, shape [n_samples]
+        C : array, shape (n_samples,)
             Predicted class label per sample.
         """
         scores = self.decision_function(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Regression models like LinearRegression, Ridge, and Lasso support fitting with label as shape (n_samples, n_targets).
For this case, the return shape for predict will be (n_samples, n_outputs), where n_outputs=n_targets.
I follow the score function to use the name "n_outputs" instead of "n_targets", as it seems more suitable when you are not fitting the model.




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
