### PR TITLE
ENH allows checks generator to be pluggable

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -800,5 +800,5 @@ purpose. This parameter is a generator that yield callables such as::
         yield check_estimator_has_fit
 
 .. warning::
-   The API of the checks function is experimental and the expected signature
-   can change without notice.
+   This feature is experimental. The signature of the `check` functions can
+   change without any deprecation cycle.

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -777,3 +777,28 @@ The reason for this setup is reproducibility:
 when an estimator is ``fit`` twice to the same data,
 it should produce an identical model both times,
 hence the validation in ``fit``, not ``__init__``.
+
+Reuse the testing infrastructure from scikit-learn
+--------------------------------------------------
+
+Scikit-learn provides two utilities:
+:func:`~sklearn.utils.estimator_checks.check_estimator` and
+:func:`~sklearn.utils.estimator_checks.parametrize_with_checks`. These
+utilities tests if a custom estimator is compatible with the different tools
+available in scikit-learn. It is common for a third-party library to extend
+the test suite with its own estimator checks.
+
+Both functions accept a parameter `checks_generator` which can be used for this
+purpose. This parameter is a generator that yield callables such as::
+
+
+    def check_estimator_has_fit(name, instance, strict_mode=True):
+        assert hasattr(instance, "fit"), f"{name} does not implement fit"
+
+
+    def checks_generator(estimator):
+        yield check_estimator_has_fit
+
+.. warning::
+   The API of the checks function is experimental and the expected signature
+   can change without notice.

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -776,7 +776,7 @@ Changelog
   :func:`~sklearn.utils.estimator_checks.parametrize_with_checks`. Note that
   this feature is experimental in such way that the expected signature of the
   `check` functions can change without deprecation cycle.
-  :pr:`18750` by :user:`Guillaume Lemaitre`_.
+  :pr:`18750` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Miscellaneous
 .............

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -770,6 +770,13 @@ Changelog
   :func:`utils.sparse_func.incr_mean_variance_axis`.
   By :user:`Maria Telenczuk <maikia>` and :user:`Alex Gramfort <agramfort>`.
 
+- |Enhancement| Allows to pass a custom checks generator using the parameter
+  `checks_generator` in
+  :func:`~sklearn.utils.estimator_checks.check_estimator` and
+  :func:`~sklearn.utils.estimator_checks.parametrize_with_checks`. Note that
+  this feature is experimental in such way that the expected signature of the
+  `check` functions can change without deprecation cycle.
+  :pr:`18750` by :user:`Guillaume Lemaitre`_.
 
 Miscellaneous
 .............

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -470,7 +470,7 @@ def parametrize_with_checks(
         The generator yielding checks for the estimators. By default, the
         common checks from scikit-learn will be yielded.
 
-        .. versionadded::0.24
+        .. versionadded:: 0.24
 
     Returns
     -------
@@ -568,7 +568,7 @@ def check_estimator(
         The generator yielding checks for the estimators. By default, the
         common checks from scikit-learn will be yielded.
 
-        .. versionadded::0.24
+        .. versionadded:: 0.24
 
     Returns
     -------

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -26,7 +26,6 @@ from sklearn.utils.estimator_checks import check_fit_score_takes_y
 from sklearn.utils.estimator_checks import check_no_attributes_set_in_init
 from sklearn.utils.estimator_checks import check_classifier_data_not_an_array
 from sklearn.utils.estimator_checks import check_regressor_data_not_an_array
-from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.estimator_checks import parametrize_with_checks
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.estimator_checks import check_outlier_corruption

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -1,5 +1,6 @@
 import unittest
 import sys
+import warnings
 
 import numpy as np
 import scipy.sparse as sp
@@ -7,10 +8,14 @@ import joblib
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils import deprecated
-from sklearn.utils._testing import (assert_raises_regex,
-                                    ignore_warnings,
-                                    assert_warns, assert_raises,
-                                    SkipTest)
+from sklearn.utils._testing import (
+    assert_raises_regex,
+    ignore_warnings,
+    assert_warns,
+    assert_warns_message,
+    assert_raises,
+    SkipTest,
+)
 from sklearn.utils.estimator_checks import check_estimator, _NotAnArray
 from sklearn.utils.estimator_checks \
     import check_class_weight_balanced_linear_classifier
@@ -21,6 +26,8 @@ from sklearn.utils.estimator_checks import check_fit_score_takes_y
 from sklearn.utils.estimator_checks import check_no_attributes_set_in_init
 from sklearn.utils.estimator_checks import check_classifier_data_not_an_array
 from sklearn.utils.estimator_checks import check_regressor_data_not_an_array
+from sklearn.utils.estimator_checks import check_estimator
+from sklearn.utils.estimator_checks import parametrize_with_checks
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.estimator_checks import check_outlier_corruption
 from sklearn.utils.fixes import np_version, parse_version
@@ -677,3 +684,44 @@ def test_xfail_ignored_in_check_estimator():
     # Make sure checks marked as xfail are just ignored and not run by
     # check_estimator(), but still raise a warning.
     assert_warns(SkipTestWarning, check_estimator, NuSVC())
+
+
+def my_own_check(name, instance, strict_mode=True):
+    warnings.warn("my_own_check was executed", UserWarning)
+
+
+def my_own_generator(estimator):
+    yield my_own_check
+
+
+def test_check_estimator_checks_generator():
+    # Check that we can pass a custom checks generator in `check_estimator`
+    assert_warns_message(
+        UserWarning,
+        "my_own_check was executed",
+        check_estimator,
+        BaseEstimator(),
+        checks_generator=my_own_generator,
+    )
+
+
+def test_parametrize_with_checks_checks_generator():
+    # Check that we can pass a custom checks generator in
+    # `parametrize_with_checks`
+    decorator = parametrize_with_checks(
+        [BaseEstimator()], checks_generator=my_own_generator
+    )
+
+    def test_estimator(estimator, check):
+        check(estimator)
+
+    test_estimator = decorator(test_estimator)
+    for _mark in test_estimator.pytestmark:
+        for estimator, check in _mark.args[1]:
+            assert_warns_message(
+                UserWarning,
+                "my_own_check was executed",
+                test_estimator,
+                estimator,
+                check,
+            )


### PR DESCRIPTION
This PR allows passing a third-party generator that yields custom checks.

In imbalanced-learn, we reimplement the infrastructure developed in scikit-learn just to overwrite `_yield_all_checks` with our own generator. It would be more friendly to allow plugging any generator.

However, we should mention that the signature of the `check` functions can be changed at any time.