### PR TITLE
MNT Catches scipy 1.3.0 for using deprecated tostring method

### DIFF
--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -1,5 +1,6 @@
 """Testing for the VotingClassifier and VotingRegressor"""
 
+import warnings
 import pytest
 import re
 import numpy as np
@@ -370,7 +371,11 @@ def test_set_estimator_drop():
                                          ('nb', clf3)],
                              voting='hard', weights=[1, 1, 0.5])
     with pytest.warns(None) as record:
-        eclf2.set_params(rf='drop').fit(X, y)
+        with warnings.catch_warnings():
+            # scipy 1.3.0 uses tostring which is deprecated in numpy
+            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
+            eclf2.set_params(rf='drop').fit(X, y)
+
     assert not record
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
 
@@ -382,7 +387,11 @@ def test_set_estimator_drop():
 
     eclf1.set_params(voting='soft').fit(X, y)
     with pytest.warns(None) as record:
-        eclf2.set_params(voting='soft').fit(X, y)
+        with warnings.catch_warnings():
+            # scipy 1.3.0 uses tostring which is deprecated in numpy
+            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
+            eclf2.set_params(voting='soft').fit(X, y)
+
     assert not record
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
     assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
@@ -404,7 +413,6 @@ def test_set_estimator_drop():
                              flatten_transform=False)
     with pytest.warns(None) as record:
         eclf2.set_params(rf='drop').fit(X1, y1)
-    assert not record
     assert_array_almost_equal(eclf1.transform(X1),
                               np.array([[[0.7, 0.3], [0.3, 0.7]],
                                         [[1., 0.], [0., 1.]]]))

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -412,7 +412,11 @@ def test_set_estimator_drop():
                              voting='soft', weights=[1, 0.5],
                              flatten_transform=False)
     with pytest.warns(None) as record:
-        eclf2.set_params(rf='drop').fit(X1, y1)
+        with warnings.catch_warnings():
+            # scipy 1.3.0 uses tostring which is deprecated in numpy
+            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
+            eclf2.set_params(rf='drop').fit(X1, y1)
+    assert not record
     assert_array_almost_equal(eclf1.transform(X1),
                               np.array([[[0.7, 0.3], [0.3, 0.7]],
                                         [[1., 0.], [0., 1.]]]))

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -203,6 +203,8 @@ def test_warning_bounds():
     with pytest.warns(None) as record:
         gpc_sum.fit(X, y)
 
+    # Only checks ConvergenceWarnings
+    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 2
     assert record[0].message.args[0] == ("The optimal value found for "
                                          "dimension 0 of parameter "
@@ -226,6 +228,8 @@ def test_warning_bounds():
     with pytest.warns(None) as record:
         gpc_dims.fit(X_tile, y)
 
+    # Only checks ConvergenceWarnings
+    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 2
     assert record[0].message.args[0] == ("The optimal value found for "
                                          "dimension 0 of parameter "

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -3,6 +3,7 @@
 # Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
 # License: BSD 3 clause
 
+import warnings
 import numpy as np
 
 from scipy.optimize import approx_fprime
@@ -201,10 +202,11 @@ def test_warning_bounds():
                   RBF(length_scale_bounds=[1e3, 1e5]))
     gpc_sum = GaussianProcessClassifier(kernel=kernel_sum)
     with pytest.warns(None) as record:
-        gpc_sum.fit(X, y)
+        with warnings.catch_warnings():
+            # scipy 1.3.0 uses tostring which is deprecated in numpy
+            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
+            gpc_sum.fit(X, y)
 
-    # Only checks ConvergenceWarnings
-    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 2
     assert record[0].message.args[0] == ("The optimal value found for "
                                          "dimension 0 of parameter "
@@ -226,10 +228,11 @@ def test_warning_bounds():
     gpc_dims = GaussianProcessClassifier(kernel=kernel_dims)
 
     with pytest.warns(None) as record:
-        gpc_dims.fit(X_tile, y)
+        with warnings.catch_warnings():
+            # scipy 1.3.0 uses tostring which is deprecated in numpy
+            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
+            gpc_dims.fit(X_tile, y)
 
-    # Only checks ConvergenceWarnings
-    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 2
     assert record[0].message.args[0] == ("The optimal value found for "
                                          "dimension 0 of parameter "

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -6,6 +6,7 @@
 
 import sys
 import numpy as np
+import warnings
 
 from scipy.optimize import approx_fprime
 
@@ -486,10 +487,11 @@ def test_warning_bounds():
                   RBF(length_scale_bounds=[1e3, 1e5]))
     gpr_sum = GaussianProcessRegressor(kernel=kernel_sum)
     with pytest.warns(None) as record:
-        gpr_sum.fit(X, y)
+        with warnings.catch_warnings():
+            # scipy 1.3.0 uses tostring which is deprecated in numpy
+            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
+            gpr_sum.fit(X, y)
 
-    # Only checks ConvergenceWarnings
-    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 2
     assert record[0].message.args[0] == ("The optimal value found for "
                                          "dimension 0 of parameter "
@@ -511,10 +513,11 @@ def test_warning_bounds():
     gpr_dims = GaussianProcessRegressor(kernel=kernel_dims)
 
     with pytest.warns(None) as record:
-        gpr_dims.fit(X_tile, y)
+        with warnings.catch_warnings():
+            # scipy 1.3.0 uses tostring which is deprecated in numpy
+            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
+            gpr_dims.fit(X_tile, y)
 
-    # Only checks ConvergenceWarnings
-    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 2
     assert record[0].message.args[0] == ("The optimal value found for "
                                          "dimension 0 of parameter "

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -488,6 +488,8 @@ def test_warning_bounds():
     with pytest.warns(None) as record:
         gpr_sum.fit(X, y)
 
+    # Only checks ConvergenceWarnings
+    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 2
     assert record[0].message.args[0] == ("The optimal value found for "
                                          "dimension 0 of parameter "
@@ -511,6 +513,8 @@ def test_warning_bounds():
     with pytest.warns(None) as record:
         gpr_dims.fit(X_tile, y)
 
+    # Only checks ConvergenceWarnings
+    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 2
     assert record[0].message.args[0] == ("The optimal value found for "
                                          "dimension 0 of parameter "

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -394,6 +394,8 @@ def test_logistic_regression_path_convergence_fail():
         _logistic_regression_path(
             X, y, Cs=Cs, tol=0., max_iter=1, random_state=0, verbose=0)
 
+    # Only check for ConvergenceWarnings
+    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 1
     warn_msg = record[0].message.args[0]
     assert "lbfgs failed to converge" in warn_msg

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 from numpy.testing import assert_array_almost_equal, assert_array_equal
@@ -391,11 +392,12 @@ def test_logistic_regression_path_convergence_fail():
     # advice (scaling the data) and to the logistic regression specific
     # documentation that includes hints on the solver configuration.
     with pytest.warns(ConvergenceWarning) as record:
-        _logistic_regression_path(
-            X, y, Cs=Cs, tol=0., max_iter=1, random_state=0, verbose=0)
+        with warnings.catch_warnings():
+            # scipy 1.3.0 uses tostring which is deprecated in numpy
+            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
+            _logistic_regression_path(
+                X, y, Cs=Cs, tol=0., max_iter=1, random_state=0, verbose=0)
 
-    # Only check for ConvergenceWarnings
-    record = [r for r in record if r.category == ConvergenceWarning]
     assert len(record) == 1
     warn_msg = record[0].message.args[0]
     assert "lbfgs failed to converge" in warn_msg


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Resolves https://github.com/scikit-learn/scikit-learn/issues/18752


#### What does this implement/fix? Explain your changes.
1. Catches warnings before the `pytest.warns` can catch them for `Voting*`
2. Filter out non convergence warnings for the rest.



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
