### PR TITLE
MNT Support and test Python 3.9

### DIFF
--- a/.github/workflows/check-manifest.yml
+++ b/.github/workflows/check-manifest.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install dependencies
         # scipy and cython are required to build sdist
         run: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.8'
+        versionSpec: '3.9'
     - bash: |
         pip install flake8 mypy==0.782
       displayName: Install linters
@@ -129,7 +129,7 @@ jobs:
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:
         DISTRIB: 'conda-pip-latest'
-        PYTHON_VERSION: '3.8'
+        PYTHON_VERSION: '3.9'
         PANDAS_VERSION: 'none'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -84,7 +84,10 @@ elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     setup_ccache
     python -m pip install -U pip
 
-    python -m pip install pandas matplotlib pyamg scikit-image
+    # optionally install scikit-image
+    python -m pip install --only-binary :all: sckit-image || true
+
+    python -m pip install pandas matplotlib pyamg
     # do not install dependencies for lightgbm since it requires scikit-learn
     # and install a version less than 3.0.0 until the issue #18316 is solved.
     python -m pip install "lightgbm<3.0.0" --no-deps

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -85,7 +85,7 @@ elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     python -m pip install -U pip
 
     # optionally install scikit-image
-    python -m pip install --only-binary :all: sckit-image || true
+    python -m pip install --only-binary :all: scikit-image || true
 
     python -m pip install pandas matplotlib pyamg
     # do not install dependencies for lightgbm since it requires scikit-learn

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -84,7 +84,7 @@ elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     setup_ccache
     python -m pip install -U pip
 
-    # optionally install scikit-image
+    # Do not build scikit-image from source because it is an optional dependency
     python -m pip install --only-binary :all: scikit-image || true
 
     python -m pip install pandas matplotlib pyamg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,27 @@ requires = [
     "setuptools",
     "wheel",
     "Cython>=0.28.5",
-    "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX' and platform_python_implementation == 'CPython'",
-    "numpy==1.14.0; python_version=='3.6' and platform_system!='AIX' and platform_python_implementation != 'CPython'",
-    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
-    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
+
+    # PyPy needs numpy >= 1.14.0
+    # platform_python_implementation!='CPython' not needed >= Python 3.7 which is numpy 1.14.5
+    "numpy==1.13.3; python_version=='3.6' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation=='CPython'",
+    "numpy==1.14.0; python_version=='3.6' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation!='CPython'",
+
+    # AIX needs numpy >= 1.16.0
+    # platform_system!='AIX' not needed >= Python 3.8 which is numpy 1.17.3
+    "numpy==1.16.0; python_version=='3.6' and platform_machine!='aarch64' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.7' and platform_machine!='aarch64' and platform_system=='AIX'",
+
+    # ARM needs numpy >= 1.19.0
+    # platform_machine!='aarch64' not needed >= Python 3.9 which is numpy 1.19.3
+    "numpy==1.19.0; python_version=='3.6' and platform_machine=='aarch64'",
+    "numpy==1.19.0; python_version=='3.7' and platform_machine=='aarch64'",
+    "numpy==1.19.0; python_version=='3.8' and platform_machine=='aarch64'",
+
+    # default numpy requirements
+    "numpy==1.14.5; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64'",
+    "numpy==1.19.3; python_version=='3.9'",
+
     "scipy>=0.19.1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -240,6 +240,7 @@ def setup_package():
                                  'Programming Language :: Python :: 3.6',
                                  'Programming Language :: Python :: 3.7',
                                  'Programming Language :: Python :: 3.8',
+                                 'Programming Language :: Python :: 3.9',
                                  ('Programming Language :: Python :: '
                                   'Implementation :: CPython'),
                                  ('Programming Language :: Python :: '


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Updates Python 3.8 to Python 3.9 in latest tests, and updates trove classifiers to mention Python 3.9 support. I'm not sure what else is needed to build the Python 3.9 wheels since I didn't see anything obvious in this repo that should be changed.