### PR TITLE
DOC add attribute documentation to PLSRegression

### DIFF
--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -482,6 +482,20 @@ class PLSRegression(_PLS):
 
     Attributes
     ----------
+    x_mean_ : ndarray of shape (n_features,)
+        Centered X with mean of zero.
+
+    y_mean_ : ndarray of shape (n_targets,)
+        Centered Y with mean of zero.
+
+    x_std_ : ndarray of shape (n_features,)
+        Standard deviations of X per feature. If scale is False, the standard
+        deviations are set to one.
+
+    y_std_ : ndarray of shape (n_targets,)
+        Standard deviations of Y per target vector. If scale is False, the
+        standard deviations are set to one.
+
     x_weights_ : ndarray of shape (n_features, n_components)
         The left singular vectors of the cross-covariance matrices of each
         iteration.


### PR DESCRIPTION
#### Reference Issues/PRs
References #14312 


#### What does this implement/fix? Explain your changes.
Documents the attributes x_mean_, y_mean_, x_std_, y_std_ in class PLSRegression

#### Any other comments? 
