### PR TITLE
DOC fix typo in _bayesian_mixture.py

### DIFF
--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -712,7 +712,7 @@ class BayesianGaussianMixture(BaseMixture):
         """Estimate the lower bound of the model.
 
         The lower bound on the likelihood (of the training data with respect to
-        the model) is used to detect the convergence and has to decrease at
+        the model) is used to detect the convergence and has to increase at
         each iteration.
 
         Parameters


### PR DESCRIPTION
The evidence lower bound on the likelihood **increase** instead of **decrease** during variational expectation maximisation for Bayesian Gaussian mixture model.

