### PR TITLE
FIX Trigger CD build on master branch

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,6 +7,7 @@ on:
     - cron: "42 3 */1 * *"
   push:
     branches:
+      - master
       # Release branches
       - "[0-9]+.[0-9]+.X"
   pull_request:

--- a/build_tools/github/check_build_trigger.sh
+++ b/build_tools/github/check_build_trigger.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 COMMIT_MSG=$(git log --no-merges -1 --oneline)
-BRANCH_NAME=$(echo "${GITHUB_BRANCH##*/}")
+BRANCH_NAME=$(echo "${GITHUB_REF##*/}")
 
 # The commit marker "[cd build]" will trigger the build when required
 if [[ "$GITHUB_EVENT_NAME" == push && "$BRANCH_NAME" != master ||

--- a/build_tools/github/check_build_trigger.sh
+++ b/build_tools/github/check_build_trigger.sh
@@ -4,11 +4,9 @@ set -e
 set -x
 
 COMMIT_MSG=$(git log --no-merges -1 --oneline)
-BRANCH_NAME=$(echo "${GITHUB_REF##*/}")
 
 # The commit marker "[cd build]" will trigger the build when required
-if [[ "$GITHUB_EVENT_NAME" == push && "$BRANCH_NAME" != master ||
-      "$GITHUB_EVENT_NAME" == schedule ||
+if [[ "$GITHUB_EVENT_NAME" == schedule ||
       "$COMMIT_MSG" =~ \[cd\ build\] ]]; then
     echo "::set-output name=build::true"
 fi

--- a/build_tools/github/check_build_trigger.sh
+++ b/build_tools/github/check_build_trigger.sh
@@ -4,9 +4,10 @@ set -e
 set -x
 
 COMMIT_MSG=$(git log --no-merges -1 --oneline)
+BRANCH_NAME=$(echo "${GITHUB_BRANCH##*/}")
 
 # The commit marker "[cd build]" will trigger the build when required
-if [[ "$GITHUB_EVENT_NAME" == push ||
+if [[ "$GITHUB_EVENT_NAME" == push && "$BRANCH_NAME" != master ||
       "$GITHUB_EVENT_NAME" == schedule ||
       "$COMMIT_MSG" =~ \[cd\ build\] ]]; then
     echo "::set-output name=build::true"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This should trigger a build on push to release branches (regardless of whether the `[cd build]` commit trigger is present) and on PRs and push to master branch only if the `[cd build]` commit trigger is found.

Quick review @ogrisel @thomasjpfan?