### PR TITLE
[MRG] Change nu default value in OneClassSVM

### DIFF
--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -148,6 +148,13 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         If X is a dense array, then the other methods will not support sparse
         matrices as input.
         """
+        # changing default value of nu in OneClassSVM, remove in 0.26
+        if self.nu == 'warn':
+            warnings.warn('The default value of nu will change from 0.5 to 0.1'
+                          ' in version 0.26.', FutureWarning)
+            self._nu = 0.5
+        else:
+            self._nu = self.nu
 
         rnd = check_random_state(self.random_state)
 
@@ -278,7 +285,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                 X, y,
                 svm_type=solver_type, sample_weight=sample_weight,
                 class_weight=self.class_weight_, kernel=kernel, C=self.C,
-                nu=self.nu, probability=self.probability, degree=self.degree,
+                nu=self._nu, probability=self.probability, degree=self.degree,
                 shrinking=self.shrinking, tol=self.tol,
                 cache_size=self.cache_size, coef0=self.coef0,
                 gamma=self._gamma, epsilon=self.epsilon,
@@ -302,7 +309,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                 X.shape[1], X.data, X.indices, X.indptr, y, solver_type,
                 kernel_type, self.degree, self._gamma, self.coef0, self.tol,
                 self.C, self.class_weight_,
-                sample_weight, self.nu, self.cache_size, self.epsilon,
+                sample_weight, self._nu, self.cache_size, self.epsilon,
                 int(self.shrinking), int(self.probability), self.max_iter,
                 random_seed)
 
@@ -384,7 +391,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             LIBSVM_IMPL.index(self._impl), kernel_type,
             self.degree, self._gamma, self.coef0, self.tol,
             C, self.class_weight_,
-            self.nu, self.epsilon, self.shrinking,
+            self._nu, self.epsilon, self.shrinking,
             self.probability, self._n_support,
             self._probA, self._probB)
 
@@ -463,7 +470,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             LIBSVM_IMPL.index(self._impl), kernel_type,
             self.degree, self._gamma, self.coef0, self.tol,
             self.C, self.class_weight_,
-            self.nu, self.epsilon, self.shrinking,
+            self._nu, self.epsilon, self.shrinking,
             self.probability, self._n_support,
             self._probA, self._probB)
 
@@ -744,7 +751,7 @@ class BaseSVC(ClassifierMixin, BaseLibSVM, metaclass=ABCMeta):
             LIBSVM_IMPL.index(self._impl), kernel_type,
             self.degree, self._gamma, self.coef0, self.tol,
             self.C, self.class_weight_,
-            self.nu, self.epsilon, self.shrinking,
+            self._nu, self.epsilon, self.shrinking,
             self.probability, self._n_support,
             self._probA, self._probB)
 

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -1268,6 +1268,9 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
         vectors. Should be in the interval (0, 1]. By default 0.5
         will be taken.
 
+        .. versionchanged:: 0.26
+           The default value of ``nu`` will change to 0.1 in version 0.26.
+
     shrinking : bool, default=True
         Whether to use the shrinking heuristic.
         See the :ref:`User Guide <shrinking_svm>`.
@@ -1329,19 +1332,19 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
     --------
     >>> from sklearn.svm import OneClassSVM
     >>> X = [[0], [0.44], [0.45], [0.46], [1]]
-    >>> clf = OneClassSVM(gamma='auto').fit(X)
+    >>> clf = OneClassSVM(gamma='auto', nu=0.1).fit(X)
     >>> clf.predict(X)
     array([-1,  1,  1,  1, -1])
     >>> clf.score_samples(X)
-    array([1.7798..., 2.0547..., 2.0556..., 2.0561..., 1.7332...])
+    array([0.3419..., 0.3886..., 0.3889..., 0.3890..., 0.3419...])
     """
 
     _impl = 'one_class'
 
     @_deprecate_positional_args
     def __init__(self, *, kernel='rbf', degree=3, gamma='scale',
-                 coef0=0.0, tol=1e-3, nu=0.5, shrinking=True, cache_size=200,
-                 verbose=False, max_iter=-1):
+                 coef0=0.0, tol=1e-3, nu='warn', shrinking=True,
+                 cache_size=200, verbose=False, max_iter=-1):
 
         super().__init__(
             kernel, degree, gamma, coef0, tol, 0., nu, 0.,

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -281,6 +281,7 @@ def test_sparse_liblinear_intercept_handling():
     test_svm.test_dense_liblinear_intercept_handling(svm.LinearSVC)
 
 
+@pytest.mark.filterwarnings('ignore:The default value of nu')
 @pytest.mark.parametrize("datasets_index", range(4))
 @pytest.mark.parametrize("kernel", ["linear", "poly", "rbf", "sigmoid"])
 @skip_if_32bit

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -246,7 +246,7 @@ def test_svr_errors():
 
 def test_oneclass():
     # Test OneClassSVM
-    clf = svm.OneClassSVM()
+    clf = svm.OneClassSVM(nu=0.5)
     clf.fit(X)
     pred = clf.predict(T)
 
@@ -262,7 +262,6 @@ def test_oneclass():
 
 def test_oneclass_decision_function():
     # Test OneClassSVM decision function
-    clf = svm.OneClassSVM()
     rnd = check_random_state(2)
 
     # Generate train data
@@ -290,6 +289,7 @@ def test_oneclass_decision_function():
     assert_array_equal((dec_func_outliers > 0).ravel(), y_pred_outliers == 1)
 
 
+@pytest.mark.filterwarnings('ignore:The default value of nu')
 def test_oneclass_score_samples():
     X_train = [[1, 1], [1, 2], [2, 1]]
     clf = svm.OneClassSVM(gamma=1).fit(X_train)
@@ -499,6 +499,7 @@ def test_svm_equivalence_sample_weight_C():
     assert_allclose(dual_coef_no_weight, clf.dual_coef_)
 
 
+@pytest.mark.filterwarnings('ignore:The default value of nu')
 @pytest.mark.parametrize(
     "Estimator, err_msg",
     [(svm.SVC,
@@ -661,6 +662,7 @@ def test_bad_input():
         clf.predict(Xt)
 
 
+@pytest.mark.filterwarnings('ignore:The default value of nu')
 @pytest.mark.parametrize(
     'Estimator, data',
     [(svm.SVC, datasets.load_iris(return_X_y=True)),
@@ -912,6 +914,7 @@ def test_liblinear_set_coef():
     assert_array_equal(values, values2)
 
 
+@pytest.mark.filterwarnings('ignore:The default value of nu')
 def test_immutable_coef_property():
     # Check that primal coef modification are not silently ignored
     svms = [
@@ -1216,6 +1219,7 @@ def test_linearsvm_liblinear_sample_weight(SVM, params):
             assert_allclose(X_est_no_weight, X_est_with_weight)
 
 
+@pytest.mark.filterwarnings('ignore:The default value of nu')
 def test_n_support_oneclass_svr():
     # Make n_support is correct for oneclass and SVR (used to be
     # non-initialized)
@@ -1236,6 +1240,7 @@ def test_n_support_oneclass_svr():
 
 
 # TODO: Remove in 0.25 when probA_ and probB_ are deprecated
+@pytest.mark.filterwarnings('ignore:The default value of nu')
 @pytest.mark.parametrize("SVMClass, data", [
     (svm.OneClassSVM, (X, )),
     (svm.SVR, (X, Y))
@@ -1288,3 +1293,12 @@ def test_custom_kernel_not_array_input(Estimator):
     else:  # regressor
         assert_allclose(svc1.predict(data), svc2.predict(X))
         assert_allclose(svc1.predict(data), svc3.predict(K))
+
+
+def test_warning_oneclasssvm_nu_default_value():
+    # remove test in 0.26 when removing FutureWarning
+    clf = svm.OneClassSVM()
+    warn_msg = ('The default value of nu will change from 0.5 to 0.1 in '
+                'version 0.26.')
+    with pytest.warns(FutureWarning, match=warn_msg):
+        clf.fit(X)

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -174,6 +174,7 @@ def _construct_searchcv_instance(SearchCV):
     return SearchCV(LogisticRegression(), {"C": [0.1, 1]})
 
 
+@pytest.mark.filterwarnings('ignore:The default value of nu')
 @pytest.mark.parametrize('name, Estimator',
                          all_estimators())
 def test_fit_docstring_attributes(name, Estimator):


### PR DESCRIPTION
Fixes #12249

Change the default value of nu in OneClassSVM from 0.5 to 0.1 which makes more sense for outlier/novelty detection and is more consistent with the other outlier detectors (`IsolationForest`, `LocalOutlierFacotr`, `EllipticEnvelope`) which use a default contamination of 0.1 