### PR TITLE
CI Add workflow_dispatch event to manually trigger wheel builder

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,6 +14,8 @@ on:
     branches:
       - master
       - "[0-9]+.[0-9]+.X"
+  # Manual run
+  workflow_dispatch:
 
 env:
   SCIKIT_LEARN_VERSION: 0.24.dev0


### PR DESCRIPTION
#### Reference Issues/PRs

See https://github.com/scikit-learn/scikit-learn/pull/18774#issuecomment-723435615.

#### What does this implement/fix? Explain your changes.

This PR adds the `workflow_dispatch` event so that we can manually trigger the `Wheel builder` workflow when needed. Thus, I think that we do not need the `[cd build]` commit trigger anymore.

CC @rth, @ogrisel and @thomasjpfan.