### PR TITLE
DOC Fix links to navigate to correct pages as in link text

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -53,8 +53,8 @@
           <p class="card-text"><strong>Applications:</strong> Drug response, Stock prices.</br>
           <strong>Algorithms:</strong>
           <a href="modules/svm.html#svm-regression">SVR</a>,
-          <a href="modules/linear_model.html#ridge-regression">nearest neighbors</a>,
-          <a href="modules/linear_model.html#lasso">random forest</a>,
+          <a href="modules/neighbors.html#regression">nearest neighbors</a>,
+          <a href="modules/ensemble.html#forest">random forest</a>,
           and <a href="supervised_learning.html#supervised-learning">more...</a></p>
         </div>
         <div class="overflow-hidden mx-2 text-center flex-fill">


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None

#### What does this implement/fix? Explain your changes.
The links in the home page are navigating to different pages unlike mentioned in the link text.
Refer the regression card in the [home page](https://scikit-learn.org/stable/) the links with texts *nearest neighbors* and *random forest* are not navigating to knn regression page or the random forest section in ensemble page, so I have changed the `href` attributes in `index.html`.

#### Any other comments?
Possibly we could change the link text to ridge and lasso regression, If that is the correct solution.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
