### PR TITLE
[MRG] DOC: Add display='diagram' guides to visualize estimators

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -123,6 +123,11 @@ the test data::
     Notebook, use ``set_config(display='diagram')`` and then call the pipeline
     object.
 
+    >>> from sklearn import set_config
+    >>> set_config(display='diagram')   # doctest: +SKIP
+    >>> # displays HTML representation in a jupyter context
+    >>> pipe  # doctest: +SKIP
+
 Model evaluation
 ----------------
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -123,10 +123,6 @@ the test data::
     Notebook, use ``set_config(display='diagram')`` and then call the pipeline
     object.
 
-    >>> with config_context(display='diagram'):
-    >>>    pipe
-    <diagram renders here>
-
 Model evaluation
 ----------------
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -117,6 +117,16 @@ the test data::
   >>> accuracy_score(pipe.predict(X_test), y_test)
   0.97...
 
+.. note:: Diagram rendering of estimators
+    The default configuration for displaying a pipeline is 'text':
+    ``set_config(display='text')``. To visualize the diagram in Jupyter
+    Notebook, use ``set_config(display='diagram')`` and then call the pipeline
+    object.
+
+    >>> with config_context(display='diagram'):
+    >>>    pipe
+    <diagram renders here>
+
 Model evaluation
 ----------------
 

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -539,7 +539,7 @@ many estimators. This visualization is activated by setting the
 
   >>> from sklearn import set_config
   >>> set_config(display='diagram')   # doctest: +SKIP
-  >>> # diplays HTML representation in a jupyter context
+  >>> # displays HTML representation in a jupyter context
   >>> column_trans  # doctest: +SKIP
 
 An example of the HTML output can be seen in the

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -91,7 +91,7 @@ clf.fit(X_train, y_train)
 print("model score: %.3f" % clf.score(X_test, y_test))
 
 # %%
-# HTML representation of ``Pipeline``
+# HTML representation of ``Pipeline`` (Display Diagram)
 ###############################################################################
 # When the ``Pipeline`` is printed out in a jupyter notebook an HTML
 # representation of the estimator is displayed as follows:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Closes #18305 . 


#### What does this implement/fix? Explain your changes.
- Add display='diagram' guides to Getting Started, as per comments on #18305,

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
