### PR TITLE
MNT set OMP_NUM_THREADS=2 for cibuildwheel [cd build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -86,10 +86,7 @@ jobs:
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl
           # Test that there are no links to system libraries
-          CIBW_TEST_COMMAND: python -c "import os; print('OMP_NUM_THREADS=', os.getenv('OMP_NUM_THREADS'))" &&
-                             python -c "import os; print('OPENBLAS_NUM_THREADS=', os.getenv('OPENBLAS_NUM_THREADS'))" &&
-                             python -c "import os; print('SKLEARN_SKIP_NETWORK_TESTS=', os.getenv('SKLEARN_SKIP_NETWORK_TESTS'))" &&
-                             pytest --pyargs sklearn &&
+          CIBW_TEST_COMMAND: pytest --pyargs sklearn &&
                              python -m threadpoolctl -i sklearn
           # By default, the Windows wheels are not repaired.
           # In this case, we need to vendor the vcomp140.dll

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,7 +57,6 @@ jobs:
 
       - name: Build and test wheels
         env:
-          CIBW_BUILD_VERBOSITY: 1
           # Set the directory where the wheel is unpacked
           CIBW_ENVIRONMENT: WHEEL_DIRNAME=scikit_learn-$SCIKIT_LEARN_VERSION
                             OMP_NUM_THREADS=2
@@ -66,8 +65,9 @@ jobs:
           CIBW_BUILD: cp${{ matrix.python }}-*
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl
           # Test that there are no links to system libraries
-          CIBW_TEST_COMMAND: echo $OMP_NUM_THREADS &&
-                             echo $SKLEARN_SKIP_NETWORK_TESTS &&
+          CIBW_TEST_COMMAND: echo OMP_NUM_THREADS=$OMP_NUM_THREADS &&
+                             echo OPENBLAS_NUM_THREADS=$OPENBLAS_NUM_THREADS &&
+                             echo SKLEARN_SKIP_NETWORK_TESTS=$SKLEARN_SKIP_NETWORK_TESTS &&
                              pytest --pyargs sklearn &&
                              python -m threadpoolctl -i sklearn
           # By default, the Windows wheels are not repaired.

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,12 +57,18 @@ jobs:
 
       - name: Build and test wheels
         env:
+          CIBW_BUILD_VERBOSITY: 1
           # Set the directory where the wheel is unpacked
-          CIBW_ENVIRONMENT: "WHEEL_DIRNAME=scikit_learn-$SCIKIT_LEARN_VERSION"
+          CIBW_ENVIRONMENT: WHEEL_DIRNAME=scikit_learn-$SCIKIT_LEARN_VERSION
+                            OMP_NUM_THREADS=2
+                            OPENBLAS_NUM_THREADS=2
+                            SKLEARN_SKIP_NETWORK_TESTS=1
           CIBW_BUILD: cp${{ matrix.python }}-*
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl
           # Test that there are no links to system libraries
-          CIBW_TEST_COMMAND: pytest --pyargs sklearn &&
+          CIBW_TEST_COMMAND: echo $OMP_NUM_THREADS &&
+                             echo $SKLEARN_SKIP_NETWORK_TESTS &&
+                             pytest --pyargs sklearn &&
                              python -m threadpoolctl -i sklearn
           # By default, the Windows wheels are not repaired.
           # In this case, we need to vendor the vcomp140.dll


### PR DESCRIPTION
Let's check if it's possible to set the usual CI env variables to avoid network connections and oversubscription during the tests run by cibuildwheel.