### PR TITLE
MAINT Build fixes for pyodide

### DIFF
--- a/sklearn/_build_utils/openmp_helpers.py
+++ b/sklearn/_build_utils/openmp_helpers.py
@@ -46,6 +46,9 @@ def get_openmp_flag(compiler):
 
 def check_openmp_support():
     """Check whether OpenMP test code can be compiled and run"""
+    if "PYODIDE_PACKAGE_ABI" in os.environ:
+        # Pyodide doesn't support OpenMP
+        return False
     code = textwrap.dedent(
         """\
         #include <omp.h>

--- a/sklearn/_build_utils/pre_build_helpers.py
+++ b/sklearn/_build_utils/pre_build_helpers.py
@@ -87,6 +87,9 @@ def compile_test_program(code, extra_preargs=[], extra_postargs=[]):
 
 def basic_check_build():
     """Check basic compilation and linking of C code"""
+    if "PYODIDE_PACKAGE_ABI" in os.environ:
+        # The following check won't work in pyodide
+        return
     code = textwrap.dedent(
         """\
         #include <stdio.h>


### PR DESCRIPTION
This adds a few minor fixes for building with pydodide, which would avoid [patching scikit-learn there](https://github.com/iodide-project/pyodide/blob/master/packages/scikit-learn/patches/disable-openmp.patch). The `basic_check_build` and `check_openmp_support` are not really working in the case of pyodide, but they are not necessary anyway to build scikit-learn.

See [detecting Pyodide at build time](https://pyodide.readthedocs.io/en/latest/faq.html#how-to-detect-that-code-is-run-with-pyodide) for more information.