### PR TITLE
DOC Fix ref to MultiTaskElasticNetCV in MultiTaskElasticNet doc

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1861,7 +1861,7 @@ class MultiTaskElasticNet(Lasso):
 
     See Also
     --------
-    MultiTaskElasticNet : Multi-task L1/L2 ElasticNet with built-in
+    MultiTaskElasticNetCV : Multi-task L1/L2 ElasticNet with built-in
         cross-validation.
     ElasticNet
     MultiTaskLasso


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #18813

#### What does this implement/fix? Explain your changes.
Fixes a reference in the documentation to MultiTaskElasticNet that should have been MultiTaskElasticNetCV