### PR TITLE
DOC Fix docstring RST formatting in TimeSeriesSplit

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -817,7 +817,7 @@ class TimeSeriesSplit(_BaseKFold):
     Notes
     -----
     The training set has size ``i * n_samples // (n_splits + 1)
-    + n_samples % (n_splits + 1)`` in the ``i``th split,
+    + n_samples % (n_splits + 1)`` in the ``i`` th split,
     with a test set of size ``n_samples//(n_splits + 1)`` by default,
     where ``n_samples`` is the number of samples.
     """


### PR DESCRIPTION
This PR fixes the current formatting issue with the TimeSeriesSplit docstring:
![Screenshot 2020-11-12 at 02 07 30](https://user-images.githubusercontent.com/852409/98882183-03a37f00-248c-11eb-800c-06a078ac5423.png)
