### PR TITLE
MNT Parallel platforms for cibuildwheel [cd build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,18 +47,27 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python: [36, 37, 38, 39]
+        bitness: [32, 64]
         include:
           # Run 32 and 64 bit version in parallel for Linux and Windows
           - os: windows-latest
+            bitness: 64
             platform-id: win_amd64
           - os: windows-latest
+            bitness: 32
             platform-id: win32
           - os: ubuntu-latest
+            bitness: 64
             platform-id: manylinux_x86_64
           - os: ubuntu-latest
+            bitness: 32
             platform-id: manylinux_i686
           - os: macos-latest
+            bitness: 64
             platform-id: macosx_x86_64
+        exclude:
+          - os: macos-latest
+          - bitness: 32
 
     steps:
       - name: Checkout scikit-learn

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,11 +48,11 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python: [36, 37, 38, 39]
         include:
-          os: windows-latest
+          - os: windows-latest
             platform-id: [win_amd64, win32]
-          os: ubuntu-latest
+          - os: ubuntu-latest
             platform-id: [manylinux_x86_64, manylinux_i686]
-          os: macos-latest
+          - os: macos-latest
             platform-id: macosx_x86_64
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,10 +48,15 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python: [36, 37, 38, 39]
         include:
+          # Run 32 and 64 bit version in parallel for Linux and Windows
           - os: windows-latest
-            platform-id: [win_amd64, win32]
+            platform-id: win_amd64
+          - os: windows-latest
+            platform-id: win32
           - os: ubuntu-latest
-            platform-id: [manylinux_x86_64, manylinux_i686]
+            platform-id: manylinux_x86_64
+          - os: ubuntu-latest
+            platform-id: manylinux_i686
           - os: macos-latest
             platform-id: macosx_x86_64
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,7 @@ jobs:
 
   # Build the wheels for Linux, Windows and macOS for Python 3.6 and newer
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} for Py ${{ matrix.python }} ({{ matrix.bitness }} bit)
+    name: Build wheels on ${{ matrix.os }} for Py${{ matrix.python }} ({{ matrix.bitness }} bit)
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build
@@ -46,25 +46,25 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python: [36, 37, 38, 39]
         bitness: [32, 64]
+        python: [36, 37, 38, 39]
         include:
           # Run 32 and 64 bit version in parallel for Linux and Windows
           - os: windows-latest
             bitness: 64
-            platform-id: win_amd64
+            platform_id: win_amd64
           - os: windows-latest
             bitness: 32
-            platform-id: win32
+            platform_id: win32
           - os: ubuntu-latest
             bitness: 64
-            platform-id: manylinux_x86_64
+            platform_id: manylinux_x86_64
           - os: ubuntu-latest
             bitness: 32
-            platform-id: manylinux_i686
+            platform_id: manylinux_i686
           - os: macos-latest
             bitness: 64
-            platform-id: macosx_x86_64
+            platform_id: macosx_x86_64
         exclude:
           - os: macos-latest
           - bitness: 32
@@ -80,7 +80,7 @@ jobs:
         env:
           # Set the directory where the wheel is unpacked
           CIBW_ENVIRONMENT: "WHEEL_DIRNAME=scikit_learn-$SCIKIT_LEARN_VERSION"
-          CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform-id }}
+          CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl
           # Test that there are no links to system libraries
           CIBW_TEST_COMMAND: pytest --pyargs sklearn &&

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,6 +47,13 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python: [36, 37, 38, 39]
+        include:
+          os: windows-latest
+            platform-id: [win_amd64, win32]
+          os: ubuntu-latest
+            platform-id: [manylinux_x86_64, manylinux_i686]
+          os: macos-latest
+            platform-id: macosx_x86_64
 
     steps:
       - name: Checkout scikit-learn
@@ -59,7 +66,7 @@ jobs:
         env:
           # Set the directory where the wheel is unpacked
           CIBW_ENVIRONMENT: "WHEEL_DIRNAME=scikit_learn-$SCIKIT_LEARN_VERSION"
-          CIBW_BUILD: cp${{ matrix.python }}-*
+          CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform-id }}
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl
           # Test that there are no links to system libraries
           CIBW_TEST_COMMAND: pytest --pyargs sklearn &&

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,7 @@ jobs:
 
   # Build the wheels for Linux, Windows and macOS for Python 3.6 and newer
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} for Py${{ matrix.python }} ({{ matrix.bitness }} bit)
+    name: Build wheels on ${{ matrix.os }} for Py${{ matrix.python }} (${{ matrix.bitness }} bit)
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,8 +45,8 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
         bitness: [32, 64]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         python: [36, 37, 38, 39]
         include:
           # Run 32 and 64 bit version in parallel for Linux and Windows

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,7 @@ jobs:
 
   # Build the wheels for Linux, Windows and macOS for Python 3.6 and newer
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} for Python ${{ matrix.python }}
+    name: Build wheels on ${{ matrix.os }} for Py ${{ matrix.python }} ({{ matrix.bitness }} bit)
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,7 @@ jobs:
 
   # Build the wheels for Linux, Windows and macOS for Python 3.6 and newer
   build_wheels:
-    name: Build wheels cp${{ matrix.python }}-${{ matrix.platform_id }}
+    name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform_id }}
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,7 @@ jobs:
 
   # Build the wheels for Linux, Windows and macOS for Python 3.6 and newer
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} for Py${{ matrix.python }} (${{ matrix.bitness }} bit)
+    name: Build wheels cp${{ matrix.python }}-${{ matrix.platform_id }}
     runs-on: ${{ matrix.os }}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,9 +45,9 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        bitness: [32, 64]
         os: [windows-latest, ubuntu-latest, macos-latest]
         python: [36, 37, 38, 39]
+        bitness: [32, 64]
         include:
           # Run 32 and 64 bit version in parallel for Linux and Windows
           - os: windows-latest
@@ -67,7 +67,7 @@ jobs:
             platform_id: macosx_x86_64
         exclude:
           - os: macos-latest
-          - bitness: 32
+            bitness: 32
 
     steps:
       - name: Checkout scikit-learn


### PR DESCRIPTION
The 32bit + 64bit sequential builds for Linux and Windows lasts for more than 40 min. The goal of this PR is to try to parallelize them by adjusting the github actions build matrix.