### PR TITLE
CI Enable parallel build on CI via an env variable

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -83,6 +83,7 @@ jobs:
                             OMP_NUM_THREADS=2
                             OPENBLAS_NUM_THREADS=2
                             SKLEARN_SKIP_NETWORK_TESTS=1
+                            SKLEARN_BUILD_PARALLEL=auto
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl
           # Test that there are no links to system libraries

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -83,7 +83,7 @@ jobs:
                             OMP_NUM_THREADS=2
                             OPENBLAS_NUM_THREADS=2
                             SKLEARN_SKIP_NETWORK_TESTS=1
-                            SKLEARN_BUILD_PARALLEL=auto
+                            SKLEARN_BUILD_PARALLEL=3
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl
           # Test that there are no links to system libraries

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -133,10 +133,9 @@ try:
 except ImportError:
     print('pandas not installed')
 "
-# Automatically use as many cores as possible to speed-up scikit-learn
-# build.
-pip install loky
-export SKLEARN_BUILD_PARALLEL="auto"
+# Set parallelism to 3 to overlap IO bound tasks with CPU bound tasks on CI
+# workers with 2 cores when building the compiled extensions of scikit-learn.
+export SKLEARN_BUILD_PARALLEL=3
 
 python -m pip list
 if [[ "$DISTRIB" == "conda-pip-latest" ]]; then

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -140,8 +140,9 @@ export SKLEARN_BUILD_PARALLEL="auto"
 
 python -m pip list
 if [[ "$DISTRIB" == "conda-pip-latest" ]]; then
-    # Check that pip can automatically install missing build dependencies from
-    # pyproject.toml.
+    # Check that pip can automatically build scikit-learn with the build
+    # dependencies specified in pyproject.toml using an isolated build
+    # environment:
     pip install --verbose --editable .
 else
     # Use the pre-installed build dependencies and build directly in the

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -139,5 +139,13 @@ pip install loky
 export SKLEARN_BUILD_PARALLEL="auto"
 
 python -m pip list
-python setup.py develop
+if [[ "$DISTRIB" == "conda-pip-latest" ]]; then
+    # Check that pip can automatically install missing build dependencies from
+    # pyproject.toml.
+    pip install --verbose --editable .
+else
+    # Use the pre-installed build dependencies and build directly in the
+    # current environment.
+    python setup.py develop
+fi
 ccache -s

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -133,19 +133,11 @@ try:
 except ImportError:
     print('pandas not installed')
 "
+# Automatically use as many cores as possible to speed-up scikit-learn
+# build.
+pip install loky
+export SKLEARN_BUILD_PARALLEL="auto"
+
 python -m pip list
-
-if [[ "$DISTRIB" == "conda-pip-latest" ]]; then
-    # Check that pip can automatically install the build dependencies from
-    # pyproject.toml using an isolated build environment:
-    pip install --verbose --editable .
-else
-    # Use the pre-installed build dependencies and build directly in the
-    # current environment.
-    # Use setup.py instead of `pip install -e .` to be able to pass the -j flag
-    # to speed-up the building multicore CI machines.
-    python setup.py build_ext --inplace -j 3
-    python setup.py develop
-fi
-
+python setup.py develop
 ccache -s

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -182,10 +182,10 @@ conda create -n $CONDA_ENV_NAME --yes --quiet \
 source activate testenv
 pip install sphinx-gallery
 pip install numpydoc
-pip install loky
 
-# Build and install scikit-learn in dev mode
-export SKLEARN_BUILD_PARALLEL="auto"
+# Set parallelism to 3 to overlap IO bound tasks with CPU bound tasks on CI
+# workers with 2 cores when building the compiled extensions of scikit-learn.
+export SKLEARN_BUILD_PARALLEL=3
 python setup.py develop
 
 export OMP_NUM_THREADS=1

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -182,9 +182,10 @@ conda create -n $CONDA_ENV_NAME --yes --quiet \
 source activate testenv
 pip install sphinx-gallery
 pip install numpydoc
+pip install loky
 
 # Build and install scikit-learn in dev mode
-python setup.py build_ext --inplace -j 3
+export SKLEARN_BUILD_PARALLEL="auto"
 python setup.py develop
 
 export OMP_NUM_THREADS=1

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -25,14 +25,16 @@ pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux20
 
 # Install Cython directly
 pip install https://antocuni.github.io/pypy-wheels/ubuntu/Cython/Cython-0.29.14-py3-none-any.whl
-pip install sphinx numpydoc docutils joblib pillow pytest loky
+pip install sphinx numpydoc docutils joblib pillow pytest
 
 ccache -M 512M
 export CCACHE_COMPRESS=1
 export PATH=/usr/lib/ccache:$PATH
 export LOKY_MAX_CPU_COUNT="2"
 export OMP_NUM_THREADS="1"
-export SKLEARN_BUILD_PARALLEL="auto"
+# Set parallelism to 3 to overlap IO bound tasks with CPU bound tasks on CI
+# workers with 2 cores when building the compiled extensions of scikit-learn.
+export SKLEARN_BUILD_PARALLEL=3
 
 # Build and install scikit-learn in dev mode
 pip install --no-build-isolation -e .

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -25,15 +25,16 @@ pip install --extra-index-url https://antocuni.github.io/pypy-wheels/manylinux20
 
 # Install Cython directly
 pip install https://antocuni.github.io/pypy-wheels/ubuntu/Cython/Cython-0.29.14-py3-none-any.whl
-pip install sphinx numpydoc docutils joblib pillow pytest
+pip install sphinx numpydoc docutils joblib pillow pytest loky
 
 ccache -M 512M
 export CCACHE_COMPRESS=1
 export PATH=/usr/lib/ccache:$PATH
 export LOKY_MAX_CPU_COUNT="2"
 export OMP_NUM_THREADS="1"
+export SKLEARN_BUILD_PARALLEL="auto"
 
-python setup.py build_ext --inplace -j 3
+# Build and install scikit-learn in dev mode
 pip install --no-build-isolation -e .
 
 # Check that Python implementation is PyPy

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -439,3 +439,17 @@ Before using ICC, you need to set up environment variables::
 Finally, you can build scikit-learn. For example on Linux x86_64::
 
     python setup.py build_ext --compiler=intelem -i build_clib --compiler=intelem
+
+Parallel builds
+===============
+
+It is possible to build scikit-learn compiled extensions in parallel by setting
+and environment variable as follows before calling the ``pip install`` or
+``python setup.py build_ext`` commands::
+
+    export SKLEARN_BUILD_PARALLEL=3
+    pip install --verbose --no-build-isolation --editable .
+
+On a machine with 2 CPU cores, it has been empirically shown beneficial to use
+a parallelism level of 3 to overlap IO bound tasks (reading and writing files
+on disk) with CPU bound tasks (actually compiling).

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -450,6 +450,6 @@ and environment variable as follows before calling the ``pip install`` or
     export SKLEARN_BUILD_PARALLEL=3
     pip install --verbose --no-build-isolation --editable .
 
-On a machine with 2 CPU cores, it has been empirically shown beneficial to use
-a parallelism level of 3 to overlap IO bound tasks (reading and writing files
-on disk) with CPU bound tasks (actually compiling).
+On a machine with 2 CPU cores, it can be beneficial to use a parallelism level
+of 3 to overlap IO bound tasks (reading and writing files on disk) with CPU
+bound tasks (actually compiling).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,6 @@ requires = [
     "setuptools",
     "wheel",
     "Cython>=0.28.5",
-    # loky is used for automated detection of useable CPU cores for
-    # parallel builds on cloud platforms that can use linux container
-    # CPU usage quotas (see the custom build_ext command in setup.py)
-    # for more details.
-    "loky",
 
     # PyPy needs numpy >= 1.14.0
     # platform_python_implementation!='CPython' not needed >= Python 3.7 which is numpy 1.14.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,11 @@ requires = [
     "setuptools",
     "wheel",
     "Cython>=0.28.5",
+    # loky is used for automated detection of useable CPU cores for
+    # parallel builds on cloud platforms that can use linux container
+    # CPU usage quotas (see the custom build_ext command in setup.py)
+    # for more details.
+    "loky",
 
     # PyPy needs numpy >= 1.14.0
     # platform_python_implementation!='CPython' not needed >= Python 3.7 which is numpy 1.14.5

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ try:
     class build_ext_subclass(build_ext):
 
         def finalize_options(self):
-            build_ext.finalize_options(self)
+            super().finalize_options()
             if self.parallel is None:
                 # Do not override self.parallel if already defined by
                 # command-line flag (--parallel or -j)

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ from pkg_resources import parse_version
 import traceback
 import importlib
 try:
-    import loky
-except ImportError:
-    loky = None
-try:
     import builtins
 except ImportError:
     # Python 2 compat: just to be able to declare that Python >=3.6 is needed.
@@ -112,8 +108,9 @@ class CleanCommand(Clean):
 
 cmdclass = {'clean': CleanCommand, 'sdist': sdist}
 
-# custom build_ext command to set OpenMP compile flags depending on os and
-# compiler
+# Custom build_ext command to set OpenMP compile flags depending on os and
+# compiler. Also makes it possible to set the parallelism level via
+# and environment variable (useful for the wheel building CI).
 # build_ext has to be imported after setuptools
 try:
     from numpy.distutils.command.build_ext import build_ext  # noqa
@@ -127,17 +124,7 @@ try:
                 # command-line flag (--parallel or -j)
 
                 parallel = os.environ.get("SKLEARN_BUILD_PARALLEL")
-                if parallel == "auto":
-                    if loky is not None:
-                        # loky can automatically detect the useable number of
-                        # cores taking any CPU usage quota into account.
-                        self.parallel = loky.cpu_count()
-                    else:
-                        # Fall-back to to non CPU quota aware, yet affinity
-                        # aware detection of useable CPUs
-                        self.parallel = len(os.sched_getaffinity())
-                elif parallel:
-                    # Assume a fixed number.
+                if parallel:
                     self.parallel = int(parallel)
             if self.parallel:
                 print("setting parallel=%d " % self.parallel)


### PR DESCRIPTION
On the wheel build, it's not easy to do the usual `python setup.py build_ext -j 3` because cibuildwheel does not allow to customize the build command and it uses pip wheel that does the build in an isolated environment (which is otherwise nice to make sure we respect the pinned versions of the build dependencies from pyproject.toml).

Furthermore, I expect that on some future ARM builds we will get many more cores than on x86 hosts but we need to be able to automatically defect the number of usable cores for optimal performance and avoiding over-subscription caused by docker CPU quotas for instance.

So here is a tentative update of our custom `build_ext` command <del>to automatically use as many core as possible by setting `SKLEARN_BUILD_PARALLEL=auto`</del> to use 3 parallel tasks by setting `SKLEARN_BUILD_PARALLEL=3` in the various CI environments.

Edit: use a static level of parallel build task to allow for overlapping IO and CPU bound tasks.