### PR TITLE
Don't divide by zero in _gpr.py

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -201,8 +201,11 @@ class GaussianProcessRegressor(MultiOutputMixin,
             self._y_train_std = np.std(y, axis=0)
 
             # Remove mean and make unit variance
-            y = (y - self._y_train_mean) / self._y_train_std
-
+            if self._y_train_std:
+                # Don't divide by 0
+                y = (y - self._y_train_mean) / self._y_train_std
+            else:
+                y = (y - self._y_train_mean)
         else:
             self._y_train_mean = np.zeros(1)
             self._y_train_std = 1


### PR DESCRIPTION
Bug was introduced here: https://github.com/scikit-learn/scikit-learn/commit/4c29be44fa

Possible test:
```
kernel = RBF()
gpr = GaussianProcessRegressor(kernel=kernel, normalize_y=True)
gpr.fit([[1, 1], [2, 2]], [0, 0])
```