### PR TITLE
MNT Disable test coverage report in ci

### DIFF
--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -24,8 +24,13 @@ pip list
 TEST_CMD="python -m pytest --showlocals --durations=20 --junitxml=$JUNITXML"
 
 if [[ "$COVERAGE" == "true" ]]; then
+    # Note: --cov-report= is used to disable to long text output report in the
+    # CI logs. The coverage data is consolidated by codecov to get an online
+    # web report across all the platforms so there is no need for this text
+    # report that otherwise hides the test failures and forces long scrolls in
+    # the CI logs.
     export COVERAGE_PROCESS_START="$BUILD_SOURCESDIRECTORY/.coveragerc"
-    TEST_CMD="$TEST_CMD --cov-config=$COVERAGE_PROCESS_START --cov sklearn"
+    TEST_CMD="$TEST_CMD --cov-config=$COVERAGE_PROCESS_START --cov sklearn --cov-report="
 fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -45,10 +45,6 @@ run_tests() {
         export SKLEARN_SKIP_NETWORK_TESTS=0
     fi
 
-    if [[ "$COVERAGE" == "true" ]]; then
-        TEST_CMD="$TEST_CMD --cov sklearn"
-    fi
-
     if [[ -n "$CHECK_WARNINGS" ]]; then
         TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning"
     fi


### PR DESCRIPTION
I find it really annoying to have to scroll up several pages in the CI logs to find the interesting pytest error messages. The coverage reports are better consolidated by codecov anyways. So let's disable the text report which is tedious to parse anyway.

Related to #18833.