### PR TITLE
ENH Use check_finite=False in sklearn.datasets

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1156,8 +1156,10 @@ def make_low_rank_matrix(n_samples=100, n_features=100, *, effective_rank=10,
     n = min(n_samples, n_features)
 
     # Random (ortho normal) vectors
-    u, _ = linalg.qr(generator.randn(n_samples, n), mode='economic')
-    v, _ = linalg.qr(generator.randn(n_features, n), mode='economic')
+    u, _ = linalg.qr(generator.randn(n_samples, n), mode='economic',
+                     check_finite=False)
+    v, _ = linalg.qr(generator.randn(n_features, n), mode='economic',
+                     check_finite=False)
 
     # Index of the singular values
     singular_ind = np.arange(n, dtype=np.float64)
@@ -1315,7 +1317,7 @@ def make_spd_matrix(n_dim, *, random_state=None):
     generator = check_random_state(random_state)
 
     A = generator.rand(n_dim, n_dim)
-    U, _, Vt = linalg.svd(np.dot(A.T, A))
+    U, _, Vt = linalg.svd(np.dot(A.T, A), check_finite=False)
     X = np.dot(np.dot(U, 1.0 + np.diag(generator.rand(n_dim))), Vt)
 
     return X


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Work for #18837 on module `sklearn.datasets`.

#### What does this implement/fix? Explain your changes.
As suggested in #18837 we add `check_finite=False` when using methods from `linalg`.
These methods are called on synthetic data in this module, so we should not need to check for infinite and nan on our end.

#### Any other comments?
Thank you for review!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
