### PR TITLE
Partial Dependence Plot (ICE): do not plot the legend when kind==individual.

### DIFF
--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -866,7 +866,7 @@ class PartialDependenceDisplay:
 
         default_line_kws = {
             "color": "C0",
-            "label": None if self.kind == "average" else "average",
+            "label": "average" if self.kind == "both" else None,
         }
         line_kw = {**default_line_kws, **line_kw}
 

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -741,7 +741,7 @@ class PartialDependenceDisplay:
         else:
             ax.set_yticklabels([])
 
-        if line_kw.get("label", None):
+        if line_kw.get("label", None) and self.kind != 'individual':
             ax.legend()
 
     def _plot_two_way_partial_dependence(

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -554,6 +554,8 @@ def test_plot_partial_dependence_subsampling(
 @pytest.mark.parametrize(
     "kind, line_kw, label",
     [
+        ("individual", {}, None),
+        ("individual", {"label": "xxx"}, None),
         ("average", {}, None),
         ("average", {"label": "xxx"}, "xxx"),
         ("both", {}, "average"),


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
When using `kind='individual'` in `partial_dependence_plot` an empty legend is added to the plot and the following warning is thrown:
```
No handles with labels found to put in legend.
No handles with labels found to put in legend.
No handles with labels found to put in legend.
No handles with labels found to put in legend.
```
This pull request remove the legend when `kind='individual'`.

#### Any other comments?
The code to reproduce the issue
```
from sklearn.linear_model import BayesianRidge
from sklearn.datasets import fetch_california_housing
from sklearn.inspection import plot_partial_dependence

X, y = fetch_california_housing(return_X_y=True, as_frame=True)
print('Computing partial dependence plots...')
features = ['MedInc', 'AveOccup', 'HouseAge', 'AveRooms']
est = BayesianRidge()
est.fit(X, y)
display = plot_partial_dependence(
       est, X, features, kind="individual", subsample=50,
       n_jobs=3, grid_resolution=20, random_state=0
)
```

An example of the [rendering](https://125566-843222-gh.circle-artifacts.com/0/doc/auto_examples/release_highlights/plot_release_highlights_0_24_0.html#individual-conditional-expectation).

cc @glemaitre 