### PR TITLE
Duplicate check_finite when calling scipy.linalg functions on sklearn.covariance

### DIFF
--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -167,7 +167,7 @@ class EmpiricalCovariance(BaseEstimator):
         self.covariance_ = covariance
         # set precision
         if self.store_precision:
-            self.precision_ = linalg.pinvh(covariance,check_finite=False)
+            self.precision_ = linalg.pinvh(covariance, check_finite=False)
         else:
             self.precision_ = None
 
@@ -182,7 +182,7 @@ class EmpiricalCovariance(BaseEstimator):
         if self.store_precision:
             precision = self.precision_
         else:
-            precision = linalg.pinvh(self.covariance_,check_finite=False)
+            precision = linalg.pinvh(self.covariance_, check_finite=False)
         return precision
 
     def fit(self, X, y=None):

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -279,8 +279,7 @@ class EmpiricalCovariance(BaseEstimator):
         if norm == "frobenius":
             squared_norm = np.sum(error ** 2)
         elif norm == "spectral":
-            squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error),
-                                                  check_finite=False,))
+            squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error),))
         else:
             raise NotImplementedError(
                 "Only spectral and frobenius norms are implemented")

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -167,7 +167,7 @@ class EmpiricalCovariance(BaseEstimator):
         self.covariance_ = covariance
         # set precision
         if self.store_precision:
-            self.precision_ = linalg.pinvh(covariance,check_finite=False)
+            self.precision_ = linalg.pinvh(covariance, check_finite=False)
         else:
             self.precision_ = None
 
@@ -182,7 +182,7 @@ class EmpiricalCovariance(BaseEstimator):
         if self.store_precision:
             precision = self.precision_
         else:
-            precision = linalg.pinvh(self.covariance_,check_finite=False)
+            precision = linalg.pinvh(self.covariance_, check_finite=False)
         return precision
 
     def fit(self, X, y=None):
@@ -279,7 +279,7 @@ class EmpiricalCovariance(BaseEstimator):
         if norm == "frobenius":
             squared_norm = np.sum(error ** 2)
         elif norm == "spectral":
-            squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error)))
+            squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error), check_finite=False))
         else:
             raise NotImplementedError(
                 "Only spectral and frobenius norms are implemented")

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -279,7 +279,7 @@ class EmpiricalCovariance(BaseEstimator):
         if norm == "frobenius":
             squared_norm = np.sum(error ** 2)
         elif norm == "spectral":
-            squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error),))
+            squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error)))
         else:
             raise NotImplementedError(
                 "Only spectral and frobenius norms are implemented")

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -167,7 +167,7 @@ class EmpiricalCovariance(BaseEstimator):
         self.covariance_ = covariance
         # set precision
         if self.store_precision:
-            self.precision_ = linalg.pinvh(covariance)
+            self.precision_ = linalg.pinvh(covariance,check_finite=False)
         else:
             self.precision_ = None
 
@@ -182,7 +182,7 @@ class EmpiricalCovariance(BaseEstimator):
         if self.store_precision:
             precision = self.precision_
         else:
-            precision = linalg.pinvh(self.covariance_)
+            precision = linalg.pinvh(self.covariance_,check_finite=False)
         return precision
 
     def fit(self, X, y=None):

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -279,7 +279,8 @@ class EmpiricalCovariance(BaseEstimator):
         if norm == "frobenius":
             squared_norm = np.sum(error ** 2)
         elif norm == "spectral":
-            squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error), check_finite=False))
+            squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error),
+                                                  check_finite=False,))
         else:
             raise NotImplementedError(
                 "Only spectral and frobenius norms are implemented")

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -643,7 +643,7 @@ class MinCovDet(EmpiricalCovariance):
         random_state = check_random_state(self.random_state)
         n_samples, n_features = X.shape
         # check that the empirical covariance is full rank
-        if (linalg.svdvals(np.dot(X.T, X), 
+        if (linalg.svdvals(np.dot(X.T, X), \
                            check_finite=False) > 1e-8).sum() != n_features:
             warnings.warn("The covariance matrix associated to your dataset "
                           "is not full rank")

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -643,8 +643,8 @@ class MinCovDet(EmpiricalCovariance):
         random_state = check_random_state(self.random_state)
         n_samples, n_features = X.shape
         # check that the empirical covariance is full rank
-        if (linalg.svdvals(np.dot(X.T, X),check_finite=False) > 1e-8)
-                          .sum() != n_features:
+        if (linalg.svdvals(np.dot(X.T, X), check_finite=False) > 1e-8)
+                .sum() != n_features:
             warnings.warn("The covariance matrix associated to your dataset "
                           "is not full rank")
         # compute and store raw estimates

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -643,8 +643,8 @@ class MinCovDet(EmpiricalCovariance):
         random_state = check_random_state(self.random_state)
         n_samples, n_features = X.shape
         # check that the empirical covariance is full rank
-        if (linalg.svdvals(np.dot(X.T, X), \
-                           check_finite=False) > 1e-8).sum() != n_features:
+        if (linalg.svdvals(np.dot(X.T, X),check_finite=False) > 1e-8)
+                          .sum() != n_features:
             warnings.warn("The covariance matrix associated to your dataset "
                           "is not full rank")
         # compute and store raw estimates

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -643,8 +643,7 @@ class MinCovDet(EmpiricalCovariance):
         random_state = check_random_state(self.random_state)
         n_samples, n_features = X.shape
         # check that the empirical covariance is full rank
-        if (linalg.svdvals(np.dot(X.T, X),
-                           check_finite=False) > 1e-8).sum() != n_features:
+        if (linalg.svdvals(np.dot(X.T, X)) > 1e-8).sum() != n_features:
             warnings.warn("The covariance matrix associated to your dataset "
                           "is not full rank")
         # compute and store raw estimates

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -643,7 +643,8 @@ class MinCovDet(EmpiricalCovariance):
         random_state = check_random_state(self.random_state)
         n_samples, n_features = X.shape
         # check that the empirical covariance is full rank
-        if (linalg.svdvals(np.dot(X.T, X), check_finite=False) > 1e-8).sum() != n_features:
+        if (linalg.svdvals(np.dot(X.T, X), 
+                           check_finite=False) > 1e-8).sum() != n_features:
             warnings.warn("The covariance matrix associated to your dataset "
                           "is not full rank")
         # compute and store raw estimates

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -55,7 +55,7 @@ def c_step(X, n_support, remaining_iterations=30, initial_estimates=None,
         - initial_estimates[0]: an initial location estimate
         - initial_estimates[1]: an initial covariance estimate
 
-    verbose : bool, defaut=False
+    verbose : bool, default=False
         Verbose mode.
 
     cov_computation_method : callable, \
@@ -228,7 +228,7 @@ def select_candidates(X, n_support, n_trials, select=1, n_iter=30,
         (2 is enough to be close to the final solution. "Never" exceeds 20).
         This parameter must be a strictly positive integer.
 
-    verbose : bool, default False
+    verbose : bool, default=False
         Control the output verbosity.
 
     cov_computation_method : callable, \
@@ -643,7 +643,7 @@ class MinCovDet(EmpiricalCovariance):
         random_state = check_random_state(self.random_state)
         n_samples, n_features = X.shape
         # check that the empirical covariance is full rank
-        if (linalg.svdvals(np.dot(X.T, X)) > 1e-8).sum() != n_features:
+        if (linalg.svdvals(np.dot(X.T, X), check_finite=False) > 1e-8).sum() != n_features:
             warnings.warn("The covariance matrix associated to your dataset "
                           "is not full rank")
         # compute and store raw estimates

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -643,8 +643,8 @@ class MinCovDet(EmpiricalCovariance):
         random_state = check_random_state(self.random_state)
         n_samples, n_features = X.shape
         # check that the empirical covariance is full rank
-        if (linalg.svdvals(np.dot(X.T, X), check_finite=False) > 1e-8)
-                .sum() != n_features:
+        if (linalg.svdvals(np.dot(X.T, X),
+                           check_finite=False) > 1e-8).sum() != n_features:
             warnings.warn("The covariance matrix associated to your dataset "
                           "is not full rank")
         # compute and store raw estimates

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -176,7 +176,7 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
         If False, data will be centered before computation.
 
     block_size : int, default=1000
-        Size of the blocks into which the covariance matrix will be split.
+        Size of blocks into which the covariance matrix will be split.
 
     Returns
     -------
@@ -271,7 +271,7 @@ def ledoit_wolf(X, *, assume_centered=False, block_size=1000):
         If False, data will be centered before computation.
 
     block_size : int, default=1000
-        Size of the blocks into which the covariance matrix will be split.
+        Size of blocks into which the covariance matrix will be split.
         This is purely a memory optimization and does not affect results.
 
     Returns
@@ -339,7 +339,7 @@ class LedoitWolf(EmpiricalCovariance):
         If False (default), data will be centered before computation.
 
     block_size : int, default=1000
-        Size of the blocks into which the covariance matrix will be split
+        Size of blocks into which the covariance matrix will be split
         during its Ledoit-Wolf estimation. This is purely a memory
         optimization and does not affect results.
 


### PR DESCRIPTION
 ## Reference Issues/PRs
Fixes this issue #18837


#### What does this implement/fix? Explain your changes.
the input covariance matrix has already checked by the `check_array` function.
