### PR TITLE
[MRG] Use check_finite=False in sklearn.mixture

### DIFF
--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -325,8 +325,7 @@ def _compute_precision_cholesky(covariances, covariance_type):
         _, n_features = covariances.shape
         try:
             cov_chol = linalg.cholesky(covariances,
-                                       lower=True,
-                                       check_finite=False)
+                                       lower=True)
         except linalg.LinAlgError:
             raise ValueError(estimate_precision_error_message)
         precisions_chol = linalg.solve_triangular(cov_chol,

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -671,11 +671,12 @@ class GaussianMixture(BaseMixture):
                 covariances, self.covariance_type)
         elif self.covariance_type == 'full':
             self.precisions_cholesky_ = np.array(
-                [linalg.cholesky(prec_init, lower=True)
+                [linalg.cholesky(prec_init, lower=True, check_finite=False)
                  for prec_init in self.precisions_init])
         elif self.covariance_type == 'tied':
             self.precisions_cholesky_ = linalg.cholesky(self.precisions_init,
-                                                        lower=True)
+                                                        lower=True,
+                                                        check_finite=False)
         else:
             self.precisions_cholesky_ = self.precisions_init
 

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -83,7 +83,7 @@ def _check_precision_positivity(precision, covariance_type):
 def _check_precision_matrix(precision, covariance_type):
     """Check a precision matrix is symmetric and positive-definite."""
     if not (np.allclose(precision, precision.T) and
-            np.all(linalg.eigvalsh(precision) > 0.)):
+            np.all(linalg.eigvalsh(precision, check_finite=False) > 0.)):
         raise ValueError("'%s precision' should be symmetric, "
                          "positive-definite" % covariance_type)
 

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -314,20 +314,27 @@ def _compute_precision_cholesky(covariances, covariance_type):
         precisions_chol = np.empty((n_components, n_features, n_features))
         for k, covariance in enumerate(covariances):
             try:
-                cov_chol = linalg.cholesky(covariance, lower=True)
+                cov_chol = linalg.cholesky(covariance,
+                                           lower=True,
+                                           check_finite=False)
             except linalg.LinAlgError:
                 raise ValueError(estimate_precision_error_message)
             precisions_chol[k] = linalg.solve_triangular(cov_chol,
                                                          np.eye(n_features),
-                                                         lower=True).T
+                                                         lower=True,
+                                                         check_finite=False).T
     elif covariance_type == 'tied':
         _, n_features = covariances.shape
         try:
-            cov_chol = linalg.cholesky(covariances, lower=True)
+            cov_chol = linalg.cholesky(covariances,
+                                       lower=True,
+                                       check_finite=False)
         except linalg.LinAlgError:
             raise ValueError(estimate_precision_error_message)
-        precisions_chol = linalg.solve_triangular(cov_chol, np.eye(n_features),
-                                                  lower=True).T
+        precisions_chol = linalg.solve_triangular(cov_chol,
+                                                  np.eye(n_features),
+                                                  lower=True,
+                                                  check_finite=False).T
     else:
         if np.any(np.less_equal(covariances, 0.0)):
             raise ValueError(estimate_precision_error_message)

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -319,8 +319,7 @@ def _compute_precision_cholesky(covariances, covariance_type):
                 raise ValueError(estimate_precision_error_message)
             precisions_chol[k] = linalg.solve_triangular(cov_chol,
                                                          np.eye(n_features),
-                                                         lower=True,
-                                                         check_finite=False).T
+                                                         lower=True).T
     elif covariance_type == 'tied':
         _, n_features = covariances.shape
         try:
@@ -330,8 +329,7 @@ def _compute_precision_cholesky(covariances, covariance_type):
             raise ValueError(estimate_precision_error_message)
         precisions_chol = linalg.solve_triangular(cov_chol,
                                                   np.eye(n_features),
-                                                  lower=True,
-                                                  check_finite=False).T
+                                                  lower=True).T
     else:
         if np.any(np.less_equal(covariances, 0.0)):
             raise ValueError(estimate_precision_error_message)

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -83,7 +83,7 @@ def _check_precision_positivity(precision, covariance_type):
 def _check_precision_matrix(precision, covariance_type):
     """Check a precision matrix is symmetric and positive-definite."""
     if not (np.allclose(precision, precision.T) and
-            np.all(linalg.eigvalsh(precision, check_finite=False) > 0.)):
+            np.all(linalg.eigvalsh(precision) > 0.)):
         raise ValueError("'%s precision' should be symmetric, "
                          "positive-definite" % covariance_type)
 
@@ -314,9 +314,7 @@ def _compute_precision_cholesky(covariances, covariance_type):
         precisions_chol = np.empty((n_components, n_features, n_features))
         for k, covariance in enumerate(covariances):
             try:
-                cov_chol = linalg.cholesky(covariance,
-                                           lower=True,
-                                           check_finite=False)
+                cov_chol = linalg.cholesky(covariance, lower=True)
             except linalg.LinAlgError:
                 raise ValueError(estimate_precision_error_message)
             precisions_chol[k] = linalg.solve_triangular(cov_chol,
@@ -671,12 +669,11 @@ class GaussianMixture(BaseMixture):
                 covariances, self.covariance_type)
         elif self.covariance_type == 'full':
             self.precisions_cholesky_ = np.array(
-                [linalg.cholesky(prec_init, lower=True, check_finite=False)
+                [linalg.cholesky(prec_init, lower=True)
                  for prec_init in self.precisions_init])
         elif self.covariance_type == 'tied':
             self.precisions_cholesky_ = linalg.cholesky(self.precisions_init,
-                                                        lower=True,
-                                                        check_finite=False)
+                                                        lower=True)
         else:
             self.precisions_cholesky_ = self.precisions_init
 

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -86,8 +86,8 @@ class RandomData:
         self.precisions = {
             'spherical': 1. / self.covariances['spherical'],
             'diag': 1. / self.covariances['diag'],
-            'tied': linalg.inv(self.covariances['tied']),
-            'full': np.array([linalg.inv(covariance)
+            'tied': linalg.inv(self.covariances['tied'], check_finite=False),
+            'full': np.array([linalg.inv(covariance, check_finite=False)
                              for covariance in self.covariances['full']])}
 
         self.X = dict(zip(COVARIANCE_TYPE, [generate_data(

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -342,7 +342,8 @@ def test_suffstat_sk_full():
     # check the precision computation
     precs_chol_pred = _compute_precision_cholesky(covars_pred, 'full')
     precs_pred = np.array([np.dot(prec, prec.T) for prec in precs_chol_pred])
-    precs_est = np.array([linalg.inv(cov) for cov in covars_pred])
+    precs_est = np.array([linalg.inv(cov, check_finite=False)
+                          for cov in covars_pred])
     assert_array_almost_equal(precs_est, precs_pred)
 
     # special case 2, assuming resp are all ones
@@ -358,7 +359,8 @@ def test_suffstat_sk_full():
     # check the precision computation
     precs_chol_pred = _compute_precision_cholesky(covars_pred, 'full')
     precs_pred = np.array([np.dot(prec, prec.T) for prec in precs_chol_pred])
-    precs_est = np.array([linalg.inv(cov) for cov in covars_pred])
+    precs_est = np.array([linalg.inv(cov, check_finite=False)
+                          for cov in covars_pred])
     assert_array_almost_equal(precs_est, precs_pred)
 
 

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -449,9 +449,10 @@ def test_compute_log_det_cholesky():
         covariance = rand_data.covariances[covar_type]
 
         if covar_type == 'full':
-            predected_det = np.array([linalg.det(cov) for cov in covariance])
+            predected_det = np.array([linalg.det(cov, check_finite=False)
+                                      for cov in covariance])
         elif covar_type == 'tied':
-            predected_det = linalg.det(covariance)
+            predected_det = linalg.det(covariance, check_finite=False)
         elif covar_type == 'diag':
             predected_det = np.array([np.prod(cov) for cov in covariance])
         elif covar_type == 'spherical':
@@ -965,9 +966,11 @@ def test_property():
         if covar_type == 'full':
             for prec, covar in zip(gmm.precisions_, gmm.covariances_):
 
-                assert_array_almost_equal(linalg.inv(prec), covar)
+                assert_array_almost_equal(linalg.inv(prec, check_finite=False),
+                                          covar)
         elif covar_type == 'tied':
-            assert_array_almost_equal(linalg.inv(gmm.precisions_),
+            assert_array_almost_equal(linalg.inv(gmm.precisions_,
+                                                 check_finite=False),
                                       gmm.covariances_)
         else:
             assert_array_almost_equal(gmm.precisions_, 1. / gmm.covariances_)

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -389,7 +389,7 @@ def test_suffstat_sk_tied():
     # check the precision computation
     precs_chol_pred = _compute_precision_cholesky(covars_pred_tied, 'tied')
     precs_pred = np.dot(precs_chol_pred, precs_chol_pred.T)
-    precs_est = linalg.inv(covars_pred_tied)
+    precs_est = linalg.inv(covars_pred_tied, check_finite=False)
     assert_array_almost_equal(precs_est, precs_pred)
 
 

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -963,8 +963,7 @@ def test_property():
         if covar_type == 'full':
             for prec, covar in zip(gmm.precisions_, gmm.covariances_):
 
-                assert_array_almost_equal(linalg.inv(prec),
-                                          covar)
+                assert_array_almost_equal(linalg.inv(prec), covar)
         elif covar_type == 'tied':
             assert_array_almost_equal(linalg.inv(gmm.precisions_),
                                       gmm.covariances_)

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -86,8 +86,8 @@ class RandomData:
         self.precisions = {
             'spherical': 1. / self.covariances['spherical'],
             'diag': 1. / self.covariances['diag'],
-            'tied': linalg.inv(self.covariances['tied'], check_finite=False),
-            'full': np.array([linalg.inv(covariance, check_finite=False)
+            'tied': linalg.inv(self.covariances['tied']),
+            'full': np.array([linalg.inv(covariance)
                              for covariance in self.covariances['full']])}
 
         self.X = dict(zip(COVARIANCE_TYPE, [generate_data(
@@ -342,8 +342,7 @@ def test_suffstat_sk_full():
     # check the precision computation
     precs_chol_pred = _compute_precision_cholesky(covars_pred, 'full')
     precs_pred = np.array([np.dot(prec, prec.T) for prec in precs_chol_pred])
-    precs_est = np.array([linalg.inv(cov, check_finite=False)
-                          for cov in covars_pred])
+    precs_est = np.array([linalg.inv(cov) for cov in covars_pred])
     assert_array_almost_equal(precs_est, precs_pred)
 
     # special case 2, assuming resp are all ones
@@ -359,8 +358,7 @@ def test_suffstat_sk_full():
     # check the precision computation
     precs_chol_pred = _compute_precision_cholesky(covars_pred, 'full')
     precs_pred = np.array([np.dot(prec, prec.T) for prec in precs_chol_pred])
-    precs_est = np.array([linalg.inv(cov, check_finite=False)
-                          for cov in covars_pred])
+    precs_est = np.array([linalg.inv(cov) for cov in covars_pred])
     assert_array_almost_equal(precs_est, precs_pred)
 
 
@@ -389,7 +387,7 @@ def test_suffstat_sk_tied():
     # check the precision computation
     precs_chol_pred = _compute_precision_cholesky(covars_pred_tied, 'tied')
     precs_pred = np.dot(precs_chol_pred, precs_chol_pred.T)
-    precs_est = linalg.inv(covars_pred_tied, check_finite=False)
+    precs_est = linalg.inv(covars_pred_tied)
     assert_array_almost_equal(precs_est, precs_pred)
 
 
@@ -449,10 +447,9 @@ def test_compute_log_det_cholesky():
         covariance = rand_data.covariances[covar_type]
 
         if covar_type == 'full':
-            predected_det = np.array([linalg.det(cov, check_finite=False)
-                                      for cov in covariance])
+            predected_det = np.array([linalg.det(cov) for cov in covariance])
         elif covar_type == 'tied':
-            predected_det = linalg.det(covariance, check_finite=False)
+            predected_det = linalg.det(covariance)
         elif covar_type == 'diag':
             predected_det = np.array([np.prod(cov) for cov in covariance])
         elif covar_type == 'spherical':
@@ -966,11 +963,10 @@ def test_property():
         if covar_type == 'full':
             for prec, covar in zip(gmm.precisions_, gmm.covariances_):
 
-                assert_array_almost_equal(linalg.inv(prec, check_finite=False),
+                assert_array_almost_equal(linalg.inv(prec),
                                           covar)
         elif covar_type == 'tied':
-            assert_array_almost_equal(linalg.inv(gmm.precisions_,
-                                                 check_finite=False),
+            assert_array_almost_equal(linalg.inv(gmm.precisions_),
                                       gmm.covariances_)
         else:
             assert_array_almost_equal(gmm.precisions_, 1. / gmm.covariances_)


### PR DESCRIPTION
**Reference Issues/PRs**

Treats  #18837 for `sklearn.mixture`.

**What does this implement/fix? Explain your changes.**

It removes the check for non-finite values on `scipy.linalg` functions when previous checks exist in the `sklearn.mixture` module.

**Any other comments?**

I need confirmation for some commits (see their message).

Thank you for review! :slightly_smiling_face: 