### PR TITLE
Add benchmark for HistGradientBoostingClassifier

### DIFF
--- a/asv_benchmarks/benchmarks/ensemble.py
+++ b/asv_benchmarks/benchmarks/ensemble.py
@@ -79,6 +79,11 @@ class GradientBoostingClassifierBenchmark(Predictor, Estimator, Benchmark):
                                                subsample=0.5,
                                                random_state=0)
 
+        return estimator
+
+    def make_scorers(self):
+        make_gen_classif_scorers(self)
+
 
 class HistGradientBoostingClassifierBenchmark(Predictor, Estimator, Benchmark):
     """

--- a/asv_benchmarks/benchmarks/ensemble.py
+++ b/asv_benchmarks/benchmarks/ensemble.py
@@ -1,8 +1,12 @@
-from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier
+from sklearn.experimental import enable_hist_gradient_boosting
+from sklearn.ensemble import (RandomForestClassifier,
+                              GradientBoostingClassifier,
+                              HistGradientBoostingClassifier)
 
 from .common import Benchmark, Estimator, Predictor
 from .datasets import (_20newsgroups_highdim_dataset,
-                       _20newsgroups_lowdim_dataset)
+                       _20newsgroups_lowdim_dataset,
+                       _synth_classification_dataset)
 from .utils import make_gen_classif_scorers
 
 
@@ -74,6 +78,31 @@ class GradientBoostingClassifierBenchmark(Predictor, Estimator, Benchmark):
                                                max_features='log2',
                                                subsample=0.5,
                                                random_state=0)
+
+
+class HistGradientBoostingClassifierBenchmark(Predictor, Estimator, Benchmark):
+    """
+    Benchmarks for HistGradientBoostingClassifier.
+    """
+
+    param_names = []
+    params = ()
+
+    def setup_cache(self):
+        super().setup_cache()
+
+    def make_data(self, params):
+        data = _synth_classification_dataset(n_samples=10000,
+                                             n_features=100,
+                                             n_classes=5)
+
+        return data
+
+    def make_estimator(self, params):
+        estimator = HistGradientBoostingClassifier(max_iter=100,
+                                                   max_leaf_nodes=15,
+                                                   early_stopping=False,
+                                                   random_state=0)
 
         return estimator
 

--- a/asv_benchmarks/benchmarks/ensemble.py
+++ b/asv_benchmarks/benchmarks/ensemble.py
@@ -1,4 +1,4 @@
-from sklearn.experimental import enable_hist_gradient_boosting
+from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import (RandomForestClassifier,
                               GradientBoostingClassifier,
                               HistGradientBoostingClassifier)


### PR DESCRIPTION
closes #18775 

here are the results on my laptop:
```
[ 16.67%] ··· Setting up ensemble:91                                                 ok
[ 16.67%] ··· ensemble.HistGradientBoostingClassifierBenchmark.peakmem_fit           87.5M
[ 33.33%] ··· ensemble.HistGradientBoostingClassifierBenchmark.peakmem_predict       75.3M
[ 50.00%] ··· ensemble.HistGradientBoostingClassifierBenchmark.time_fit              3.25±0.02s
[ 66.67%] ··· ensemble.HistGradientBoostingClassifierBenchmark.time_predict          143±2ms
[ 83.33%] ··· ensemble.HistGradientBoostingClassifierBenchmark.track_test_score      0.7230709112942986
[100.00%] ··· ensemble.HistGradientBoostingClassifierBenchmark.track_train_score     0.9812160155622751
 
```
