### PR TITLE
[MRG] Set check_finite=True only for callable metric in kernel_approximation.py

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -772,13 +772,16 @@ class Nystroem(TransformerMixin, BaseEstimator):
         basis_inds = inds[:n_components]
         basis = X[basis_inds]
 
-        basis_kernel = pairwise_kernels(basis, metric=self.kernel,
+        metric = self.kernel
+        basis_kernel = pairwise_kernels(basis, metric=metric,
                                         filter_params=True,
                                         n_jobs=self.n_jobs,
                                         **self._get_kernel_params())
 
+        # If metric is a callable it may return non finite values
+        check_finite = callable(metric)
         # sqrt of kernel matrix on basis vectors
-        U, S, V = svd(basis_kernel)
+        U, S, V = svd(basis_kernel, check_finite=check_finite)
         S = np.maximum(S, 1e-12)
         self.normalization_ = np.dot(U / np.sqrt(S), V)
         self.components_ = basis


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Work for #18837 on `sklearn.kernel_approximation` module

#### What does this implement/fix? Explain your changes.
As suggested in #18837 we use check_finite=False when using methods from linalg on data that we have already validated.
Here we call `svd` on the `basis_kernel` matrix that may contain non finite values depending on the `metric` we use.

#### Any other comments?
I assumed that metrics that can be specified by a string never return non finite values (and never will).
If we want to protect against this, we may always use check_finite=True.
What do you think ?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
