### PR TITLE
DOC Clarify sentence in learning curve user guide

### DIFF
--- a/doc/modules/learning_curve.rst
+++ b/doc/modules/learning_curve.rst
@@ -94,9 +94,9 @@ The function :func:`validation_curve` can help in this case::
 If the training score and the validation score are both low, the estimator will
 be underfitting. If the training score is high and the validation score is low,
 the estimator is overfitting and otherwise it is working very well. A low
-training score and a high validation score is usually not possible. All three
-cases can be found in the plot below where we vary the parameter
-:math:`\gamma` of an SVM on the digits dataset.
+training score and a high validation score is usually not possible. Underfitting, 
+overfitting, and a working model are shown in the in the plot below where we vary 
+the parameter :math:`\gamma` of an SVM on the digits dataset.
 
 .. figure:: ../auto_examples/model_selection/images/sphx_glr_plot_validation_curve_001.png
    :target: ../auto_examples/model_selection/plot_validation_curve.html


### PR DESCRIPTION
There were four cases described and then it said "all three cases..."  

this makes what three appear in the plot more explicit. 