### PR TITLE
[MRG] SimpleImputer: Handle string features where all values are missing

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -232,7 +232,8 @@ class SimpleImputer(_BaseImputer):
             # with strategy='most_frequent' or 'constant'
             # because the list is converted to Unicode numpy array
             if isinstance(X, list) and \
-               any(isinstance(elem, str) for row in X for elem in row):
+               (isinstance(self.fill_value, str) or
+                any(isinstance(elem, str) for row in X for elem in row)):
                 dtype = object
             else:
                 dtype = None

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -232,8 +232,8 @@ class SimpleImputer(_BaseImputer):
             # with strategy='most_frequent' or 'constant'
             # because the list is converted to Unicode numpy array
             if isinstance(X, list) and \
-               (isinstance(self.fill_value, str) or
-                any(isinstance(elem, str) for row in X for elem in row)):
+                (isinstance(self.fill_value, str)
+                 or any(isinstance(elem, str) for row in X for elem in row)):
                 dtype = object
             else:
                 dtype = None

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1475,6 +1475,7 @@ def test_simple_imputation_inverse_transform_exceptions(missing_value):
                        match=f"Got 'add_indicator={imputer.add_indicator}'"):
         imputer.inverse_transform(X_1_trans)
 
+
 def test_simple_imputation_string_column_all_missing():
     X_1 = [
         ['Lion'],

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1474,3 +1474,32 @@ def test_simple_imputation_inverse_transform_exceptions(missing_value):
     with pytest.raises(ValueError,
                        match=f"Got 'add_indicator={imputer.add_indicator}'"):
         imputer.inverse_transform(X_1_trans)
+
+def test_simple_imputation_string_column_all_missing():
+    X_1 = [
+        ['Lion'],
+        ['Tiger'],
+        ['Bear'],
+        [np.nan],
+    ]
+
+    imputer = SimpleImputer(strategy='constant', fill_value='UNKNOWN')
+    X_1_trans = imputer.fit_transform(X_1)
+    assert all(a == b for a, b in zip(X_1_trans, [
+        ['Lion'],
+        ['Tiger'],
+        ['Bear'],
+        ['UNKNOWN'],
+    ]))
+
+    X_2 = [
+        [np.nan],
+        [np.nan],
+        [np.nan],
+    ]
+    X_2_trans = imputer.transform(X_2)
+    assert all(a == b for a, b in zip(X_2_trans, [
+        ['UNKNOWN'],
+        ['UNKNOWN'],
+        ['UNKNOWN'],
+    ]))


### PR DESCRIPTION
#### Reference Issues/PRs

#17526 - This is relevant, as I don't think it was possible to run into this issue before.

#### What does this implement/fix? Explain your changes.

When dealing with a sparse string feature, it's not unlikely that a particular CV split has all missing values for said feature. In cases like this, `SimpleImputer` appears to break. I believe this is because [`_validate_input` currently looks for a `str` value to determine `dtype`](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/impute/_base.py#L234-L236).

To me, it seems that if a user specifies a string for `fill_value`, that's another good indicator that `dtype` should be `object`.

#### Any other comments?

Thanks for your time and consideration!