### PR TITLE
DOC Removes double space in precision_recall_curve docs

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -747,7 +747,7 @@ def precision_recall_curve(y_true, probas_pred, *, pos_label=None,
     intuitively the ability of the classifier to find all the positive samples.
 
     The last precision and recall values are 1. and 0. respectively and do not
-    have a corresponding threshold.  This ensures that the graph starts on the
+    have a corresponding threshold. This ensures that the graph starts on the
     y axis.
 
     Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.


### PR DESCRIPTION
#### Reference Issues/PRs
None as far as I'm aware

#### What does this implement/fix? Explain your changes.
Accidentaly double space in documentation for precision_recall_curve

#### Any other comments?
