### PR TITLE
[WIP] check_finite=False in sklearn.cluster

### DIFF
--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -60,9 +60,9 @@ def _bistochastic_normalize(X, max_iter=1000, tol=1e-5):
     for _ in range(max_iter):
         X_new, _, _ = _scale_normalize(X_scaled)
         if issparse(X):
-            dist = norm(X_scaled.data - X.data)
+            dist = norm(X_scaled.data - X.data, check_finite=False)
         else:
-            dist = norm(X_scaled - X_new)
+            dist = norm(X_scaled - X_new, check_finite=False)
         X_scaled = X_new
         if dist is not None and dist < tol:
             break
@@ -534,7 +534,10 @@ class SpectralBiclustering(BaseSpectral):
             return centroid[labels].ravel()
         piecewise_vectors = np.apply_along_axis(make_piecewise,
                                                 axis=1, arr=vectors)
-        dists = np.apply_along_axis(norm, axis=1,
+
+        def norm_without_check_finite(v):
+            return norm(v, check_finite=False)
+        dists = np.apply_along_axis(norm_without_check_finite, axis=1,
                                     arr=(vectors - piecewise_vectors))
         result = vectors[np.argsort(dists)[:n_best]]
         return result

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -88,6 +88,13 @@ def test_spectral_coclustering():
             _test_shape_indices(model)
 
 
+def test_print_scipy_version():
+    # TODO(Mathschy) remove this after seeing what is the version
+    #  of scipy in CI.
+    from scipy import __version__
+    assert False, "we are using scipy version: %s" % __version__
+
+
 def test_spectral_biclustering():
     # Test Kluger methods on a checkerboard dataset.
     S, rows, cols = make_checkerboard((30, 30), 3, noise=0.5,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Work for #18837 

#### What does this implement/fix? Explain your changes.
We set check_finite=False when computing norm in `_bistochastic_normalize`, because this function is called when X has already been validated (in `fit`).

We do the same in `_fit_best_piecewise` because the vectors have already been validated in `_svd`.
#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
