### PR TITLE
MNT use conda-forge for the pypy build on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,8 @@ jobs:
       - checkout
       - run: cd $HOME && wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
       - run: $HOME/bin/micromamba shell init -s bash -p $HOME/micromamba
-      - run: ./build_tools/circle/build_test_pypy.sh
+      - run: source ~/.bashrc
+      - run: bash ./build_tools/circle/build_test_pypy.sh
       - save_cache:
           key: pypy3-ccache-{{ .Branch }}-{{ .BuildNum }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,17 +103,16 @@ jobs:
 
   pypy3:
     docker:
-      - image: circleci/python
+      - image: condaforge/miniforge3
     steps:
       - restore_cache:
           keys:
             - pypy3-ccache-{{ .Branch }}
             - pypy3-ccache
       - checkout
-      - run: cd $HOME && wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-      - run: $HOME/bin/micromamba shell init -s bash -p $HOME/micromamba
-      - run: source ~/.bashrc
-      - run: bash ./build_tools/circle/build_test_pypy.sh
+      - run: conda init bash
+      - run: conda install -y mamba
+      - run: ./build_tools/circle/build_test_pypy.sh
       - save_cache:
           key: pypy3-ccache-{{ .Branch }}-{{ .BuildNum }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
             - pypy3-ccache-{{ .Branch }}
             - pypy3-ccache
       - checkout
-      - run: conda install -y mamba
+      - run: conda init bash && source ~/.bashrc
       - run: ./build_tools/circle/build_test_pypy.sh
       - save_cache:
           key: pypy3-ccache-{{ .Branch }}-{{ .BuildNum }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,6 @@ jobs:
             - pypy3-ccache-{{ .Branch }}
             - pypy3-ccache
       - checkout
-      - run: conda init bash
       - run: conda install -y mamba
       - run: ./build_tools/circle/build_test_pypy.sh
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
 
   pypy3:
     docker:
-      - image: buster-slim
+      - image: circleci/python:3.7.3-stretch
     steps:
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,8 @@ jobs:
             - pypy3-ccache-{{ .Branch }}
             - pypy3-ccache
       - checkout
+      - run: cd $HOME && wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+      - run: $HOME/bin/micromamba shell init -s bash -p $HOME/micromamba
       - run: ./build_tools/circle/build_test_pypy.sh
       - save_cache:
           key: pypy3-ccache-{{ .Branch }}-{{ .BuildNum }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
 
   pypy3:
     docker:
-      - image: pypy:3.6-7.2.0
+      - image: buster-slim
     steps:
       - restore_cache:
           keys:
@@ -154,12 +154,12 @@ workflows:
           requires:
             - doc
   pypy:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - master
     jobs:
       - pypy3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
 
   pypy3:
     docker:
-      - image: circleci/python:3.7.3-stretch
+      - image: circleci/python
     steps:
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,12 +155,12 @@ workflows:
           requires:
             - doc
   pypy:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - master
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - pypy3

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -8,8 +8,8 @@ sudo apt-get -yq install wget bzip2 build-essential ccache
 
 # Init micromamba, a fast and lightweight alternative to conda for CI.
 rm -rf ~/micromamba
-wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-./bin/micromamba shell init -s bash -p $HOME/micromamba
+wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj $HOME/bin/micromamba
+$HOME/bin/micromamba shell init -s bash -p $HOME/micromamba
 source ~/.bashrc
 micromamba activate
 

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -9,7 +9,9 @@ sudo apt-get -yq install wget bzip2 build-essential ccache
 # Init micromamba, a fast and lightweight alternative to conda for CI.
 rm -rf ~/micromamba
 mkdir -p $HOME/bin
-wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj $HOME/bin/micromamba
+pushd $HOME
+wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+popd
 $HOME/bin/micromamba shell init -s bash -p $HOME/micromamba
 source ~/.bashrc
 micromamba activate

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -3,17 +3,14 @@ set -x
 set -e
 
 # System build tools
-sudo apt-get -yq update
-sudo apt-get -yq install wget bzip2 build-essential ccache
+apt-get -yq update
+apt-get -yq install wget bzip2 build-essential ccache
 
-# Activate the base micromamba env
-export PATH="$HOME/bin:$PATH"
-micromamba activate
-
+conda activate
 # Install pypy and all the scikit-learn dependencies from conda-forge. In
 # particular, we want to install pypy compatible binary packages for numpy and
 # scipy as it would be to costly to build those from source.
-micromamba install -y -c conda-forge \
+mamba install -y \
     pypy numpy scipy cython \
     joblib threadpoolctl pillow pytest \
     sphinx numpydoc docutils

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -9,10 +9,14 @@ apt-get -yq install wget bzip2 build-essential ccache
 # Install pypy and all the scikit-learn dependencies from conda-forge. In
 # particular, we want to install pypy compatible binary packages for numpy and
 # scipy as it would be to costly to build those from source.
-mamba install -y \
+conda install -y mamba
+mamba create -n pypy -y \
     pypy numpy scipy cython \
     joblib threadpoolctl pillow pytest \
     sphinx numpydoc docutils
+
+eval "$(conda shell.bash hook)"
+conda activate pypy
 
 # Check that we are running PyPy instead of CPython in this environment.
 python --version

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -3,8 +3,8 @@ set -x
 set -e
 
 # System build tools
-apt-get -yq update
-apt-get -yq install wget bzip2 build-essential ccache
+sudo apt-get -yq update
+sudo apt-get -yq install wget bzip2 build-essential ccache
 
 # Init micromamba, a fast and lightweight alternative to conda for CI.
 rm -rf ~/micromamba

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -6,15 +6,8 @@ set -e
 sudo apt-get -yq update
 sudo apt-get -yq install wget bzip2 build-essential ccache
 
-# Init micromamba, a fast and lightweight alternative to conda for CI.
-rm -rf ~/micromamba
-mkdir -p $HOME/bin
-pushd $HOME
-wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-popd
+# Activate the base micromamba env
 export PATH="$HOME/bin:$PATH"
-micromamba shell init -s bash -p $HOME/micromamba
-source ~/.bashrc
 micromamba activate
 
 # Install pypy and all the scikit-learn dependencies from conda-forge. In

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -12,7 +12,8 @@ mkdir -p $HOME/bin
 pushd $HOME
 wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
 popd
-$HOME/bin/micromamba shell init -s bash -p $HOME/micromamba
+export PATH="$HOME/bin:$PATH"
+micromamba shell init -s bash -p $HOME/micromamba
 source ~/.bashrc
 micromamba activate
 

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -9,7 +9,7 @@ apt-get -yq install wget bzip2 build-essential ccache
 # Init micromamba, a fast and lightweight alternative to conda for CI.
 rm -rf ~/micromamba
 wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-./bin/micromamba shell init -s bash -p /home/$USER/micromamba
+./bin/micromamba shell init -s bash -p $HOME/micromamba
 source ~/.bashrc
 micromamba activate
 

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -6,7 +6,6 @@ set -e
 apt-get -yq update
 apt-get -yq install wget bzip2 build-essential ccache
 
-conda activate
 # Install pypy and all the scikit-learn dependencies from conda-forge. In
 # particular, we want to install pypy compatible binary packages for numpy and
 # scipy as it would be to costly to build those from source.

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -8,6 +8,7 @@ sudo apt-get -yq install wget bzip2 build-essential ccache
 
 # Init micromamba, a fast and lightweight alternative to conda for CI.
 rm -rf ~/micromamba
+mkdir -p $HOME/bin
 wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj $HOME/bin/micromamba
 $HOME/bin/micromamba shell init -s bash -p $HOME/micromamba
 source ~/.bashrc


### PR DESCRIPTION
Fixes: #18624

A patch for the upstream bug has been released on conda-forge but not yet an official release of PyPy on docker.