### PR TITLE
MNT install git and ssh on miniconda docker image for PyPy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,12 +156,12 @@ workflows:
           requires:
             - doc
   pypy:
-    # triggers:
-    #   - schedule:
-    #       cron: "0 0 * * *"
-    #       filters:
-    #         branches:
-    #           only:
-    #             - master
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - pypy3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
           keys:
             - pypy3-ccache-{{ .Branch }}
             - pypy3-ccache
+      - run: apt-get -yq update && apt-get -yq install git ssh
       - checkout
       - run: conda init bash && source ~/.bashrc
       - run: ./build_tools/circle/build_test_pypy.sh
@@ -155,12 +156,12 @@ workflows:
           requires:
             - doc
   pypy:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    # triggers:
+    #   - schedule:
+    #       cron: "0 0 * * *"
+    #       filters:
+    #         branches:
+    #           only:
+    #             - master
     jobs:
       - pypy3


### PR DESCRIPTION
Followup for #18867: the scheduled PyPy run failed with:

```
Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.

ssh: no key found
```

https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn/9723/workflows/19d7c789-25c3-4fea-aec1-2f505ab4ebc0/jobs/126178