### PR TITLE
CI Prevent wheel builder jobs from failing if upload artifact step fails

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,6 +96,9 @@ jobs:
 
       - name: Store artifacts
         uses: actions/upload-artifact@v2
+        # Prevent the job from failing when the upload artifact step
+        # fails (the network infrastructure is not very reliable yet)
+        continue-on-error: true
         with:
           path: wheelhouse/*.whl
 
@@ -127,6 +130,9 @@ jobs:
 
       - name: Store artifacts
         uses: actions/upload-artifact@v2
+        # Prevent the job from failing when the upload artifact step
+        # fails (the network infrastructure is not very reliable yet)
+        continue-on-error: true
         with:
           path: dist/*.tar.gz
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -94,7 +94,7 @@ jobs:
 
         run: bash build_tools/github/build_wheels.sh
 
-      - name: Store artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v2
         # Prevent the job from failing when the upload artifact step
         # fails (the network infrastructure is not very reliable yet)
@@ -128,7 +128,7 @@ jobs:
           OPENBLAS_NUM_THREADS: 2
           SKLEARN_SKIP_NETWORK_TESTS: 1
 
-      - name: Store artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v2
         # Prevent the job from failing when the upload artifact step
         # fails (the network infrastructure is not very reliable yet)


### PR DESCRIPTION
#### Reference Issues/PRs

See https://github.com/scikit-learn/scikit-learn/pull/18877#issuecomment-731292081.

#### What does this implement/fix? Explain your changes.

This PR prevents that a wheel builder job fails if the upload artifact step fails. In the time being, the network infrastructure is not very reliable.

#### Any other comments?

CC @ogrisel and @thomasjpfan.