### PR TITLE
DOC Forces word-break of code blocks to not break

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -37,6 +37,7 @@ code {
   background-color: #ecf0f3;
   border-radius: 0.2rem;
   padding: 0.15rem;
+  word-break: normal;
 }
 
 nav {


### PR DESCRIPTION
Current the docs table in [multiclass and multilabel classification](https://scikit-learn.org/dev/modules/model_evaluation.html#multiclass-and-multilabel-classification) looks like:

<img width="271" alt="Screen Shot 2020-11-20 at 3 36 56 PM" src="https://user-images.githubusercontent.com/5402633/99847604-52b17a00-2b46-11eb-8f98-a561301da6eb.png">

This PR fixes this to look like:

<img width="322" alt="Screen Shot 2020-11-20 at 3 38 19 PM" src="https://user-images.githubusercontent.com/5402633/99847682-7248a280-2b46-11eb-91d6-6ee8cc346863.png">
