### PR TITLE
DOC min_sample_split does not take sample_weight into account

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -363,7 +363,7 @@ Tips on practical use
     classification with few classes, ``min_samples_leaf=1`` is often the best
     choice.
 
-  * Note that ``min_samples_split`` considers samples directly and independent of
+    Note that ``min_samples_split`` considers samples directly and independent of
     ``sample_weight``, if provided (e.g. a node with m weighted samples is still
     treated as having exactly m samples). Consider ``min_weight_fraction_leaf`` or
     ``min_impurity_decrease`` if accounting for sample weights is required at splits.

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -363,6 +363,11 @@ Tips on practical use
     classification with few classes, ``min_samples_leaf=1`` is often the best
     choice.
 
+  * Note that ``min_samples_split`` considers samples directly and independent of
+    ``sample_weight``, if provided (e.g. a node with m weighted samples is still
+    treated as having exactly m samples). Consider ``min_weight_fraction_leaf`` or
+    ``min_impurity_decrease`` if accounting for sample weights is required at splits.
+
   * Balance your dataset before training to prevent the tree from being biased
     toward the classes that are dominant. Class balancing can be done by
     sampling an equal number of samples from each class, or preferably by


### PR DESCRIPTION
… when splitting a tree node.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Resolves #18153


#### What does this implement/fix? Explain your changes.
Documentation added to explain that min_samples_split does not account for sample_weight.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
