### PR TITLE
MNT simplify pyproject.toml by using oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,26 +5,11 @@ requires = [
     "wheel",
     "Cython>=0.28.5",
 
-    # PyPy needs numpy >= 1.14.0
-    # platform_python_implementation!='CPython' not needed >= Python 3.7 which is numpy 1.14.5
-    "numpy==1.13.3; python_version=='3.6' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation=='CPython'",
-    "numpy==1.14.0; python_version=='3.6' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation!='CPython'",
-
-    # AIX needs numpy >= 1.16.0
-    # platform_system!='AIX' not needed >= Python 3.8 which is numpy 1.17.3
-    "numpy==1.16.0; python_version=='3.6' and platform_machine!='aarch64' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.7' and platform_machine!='aarch64' and platform_system=='AIX'",
-
-    # ARM needs numpy >= 1.19.0
-    # platform_machine!='aarch64' not needed >= Python 3.9 which is numpy 1.19.3
-    "numpy==1.19.0; python_version=='3.6' and platform_machine=='aarch64'",
-    "numpy==1.19.0; python_version=='3.7' and platform_machine=='aarch64'",
-    "numpy==1.19.0; python_version=='3.8' and platform_machine=='aarch64'",
-
-    # default numpy requirements
-    "numpy==1.14.5; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX'",
-    "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64'",
-    "numpy==1.19.3; python_version=='3.9'",
+    # use oldest-supported-numpy which provides the oldest numpy version with
+    # wheels on PyPI
+    #
+    # see: https://github.com/scipy/oldest-supported-numpy/blob/master/setup.cfg
+    "oldest-supported-numpy",
 
     "scipy>=0.19.1",
 ]

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -6,7 +6,7 @@ import argparse
 # numpy scipy and cython should by in sync with pyproject.toml
 if platform.python_implementation() == 'PyPy':
     SCIPY_MIN_VERSION = '1.1.0'
-    NUMPY_MIN_VERSION = '1.14.0'
+    NUMPY_MIN_VERSION = '1.19.0'
 else:
     SCIPY_MIN_VERSION = '0.19.1'
     NUMPY_MIN_VERSION = '1.13.3'


### PR DESCRIPTION
#### Reference Issues/PRs

Follows up on comment by @alfaro96  https://github.com/scikit-learn/scikit-learn/pull/18761#discussion_r520632307

#### What does this implement/fix? Explain your changes.

Uses `oldest-supported-numpy` as it now matches the versions specified in `pyproject.toml` (`@master` but not released, see: scipy/oldest-supported-numpy#13)

On the comment https://github.com/scikit-learn/scikit-learn/pull/18761#discussion_r520632307 we resolved we may not be able to upstream the PyPy requirements, but I realized we could constrain `oldest-supported-numpy` to only be used when **not** matching PyPy.

#### Any other comments?

This should be merged only pending a new release of `oldest-supported-numpy`. I'm asking about the release schedule now.