### PR TITLE
[MRG] Use check_finite=False in sklearn.cluster

### DIFF
--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -60,9 +60,9 @@ def _bistochastic_normalize(X, max_iter=1000, tol=1e-5):
     for _ in range(max_iter):
         X_new, _, _ = _scale_normalize(X_scaled)
         if issparse(X):
-            dist = norm(X_scaled.data - X.data)
+            dist = norm(X_scaled.data - X.data, check_finite=False)
         else:
-            dist = norm(X_scaled - X_new)
+            dist = norm(X_scaled - X_new, check_finite=False)
         X_scaled = X_new
         if dist is not None and dist < tol:
             break


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs

Work for #18837 on module sklearn.cluster.



#### What does this implement/fix? Explain your changes.

As suggested in #18837 we add `check_finite=False` when using methods from `linalg`.
These methods are called on synthetic data in this module, so we should not need to check for infinite and nan on our end.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
