### PR TITLE
DOC Temporarily remove prompt from 2 command lines

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -210,8 +210,8 @@ For 64-bit Python, configure the build environment with:
 
     ::
 
-      SET DISTUTILS_USE_SDK=1
-      "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
+      $ SET DISTUTILS_USE_SDK=1
+      $ "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 Replace ``x64`` by ``x86`` to build for 32-bit Python.
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -208,10 +208,10 @@ console:
 
 For 64-bit Python, configure the build environment with:
 
-.. prompt:: bash $
+    ::
 
-    SET DISTUTILS_USE_SDK=1
-    "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
+      SET DISTUTILS_USE_SDK=1
+      "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 Replace ``x64`` by ``x86`` to build for 32-bit Python.
 

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -114,9 +114,9 @@ Making a release
    - Edit the doc/whats_new.rst file to add release title and commit
      statistics. You can retrieve commit statistics with:
 
-     .. prompt:: bash $
+     ::
 
-        git shortlog -s 0.99.33.. | cut -f2- | sort --ignore-case | tr '\n' ';' | sed 's/;/, /g;s/, $//'
+       $ git shortlog -s 0.99.33.. | cut -f2- | sort --ignore-case | tr '\n' ';' | sed 's/;/, /g;s/, $//'
 
    - Update the release date in ``whats_new.rst``
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fix #18918

#### What does this implement/fix? Explain your changes.
This pull request remove the sphinx prompt directive from 2 commands containing backslashes. 

#### Any other comments?
The latex rendering is different with and without sphinx prompt directive. A better fix will be to propose a different implementation in the sphinx-prompt code. This is just a temporarily fix in order to move forward with 0.24 release.