### PR TITLE
DOC Behavior with duplicates for SimpleImputer(strategy=most_frequent)

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -140,6 +140,7 @@ class SimpleImputer(_BaseImputer):
           each column. Can only be used with numeric data.
         - If "most_frequent", then replace missing using the most frequent
           value along each column. Can be used with strings or numeric data.
+          If there is more than one such value, only the smallest is returned.
         - If "constant", then replace missing values with fill_value. Can be
           used with strings or numeric data.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The behaviour of `SimpleImputer(strategy=most_frequent)` may not be obvious in case of duplicates. The line added is taken from https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mode.html, which is the function used internally.
