### PR TITLE
Fix DeprecationWarning for np.bool type.

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -820,7 +820,7 @@ def test_unknown_categories_nan(insert_missing, Est,
         categorical_features = [1]
 
     if insert_missing:
-        mask = rng.binomial(1, 0.01, size=X.shape).astype(np.bool)
+        mask = rng.binomial(1, 0.01, size=X.shape).astype(np.bool_)
         assert mask.sum() > 0
         X[mask] = np.nan
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -820,7 +820,7 @@ def test_unknown_categories_nan(insert_missing, Est,
         categorical_features = [1]
 
     if insert_missing:
-        mask = rng.binomial(1, 0.01, size=X.shape).astype(np.bool_)
+        mask = rng.binomial(1, 0.01, size=X.shape).astype(bool)
         assert mask.sum() > 0
         X[mask] = np.nan
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Change `np.bool` to `np.bool_` to avoid numpy DeprecationWarning in nightly build with last versions of numpy.
See the [build](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=24450&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081).