### PR TITLE
Restore previous sample_weight validation behaviour in BaseWeightBoosting

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -110,9 +110,10 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
 
         sample_weight = _check_sample_weight(sample_weight, X, np.float64)
         sample_weight /= sample_weight.sum()
-        if np.any(sample_weight < 0):
-            raise ValueError("sample_weight cannot contain negative weights")
-
+        if sample_weight.sum() <= 0:
+            raise ValueError(
+                    "Attempting to fit with a non-positive "
+                    "weighted number of samples.")
         # Check parameters
         self._validate_estimator()
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #18934 


#### What does this implement/fix? Explain your changes.
Described in #18934 

Support (or rather don't explicitly disallow) negative sample weights as long as their sum is not negative.

#### Any other comments?
I opened this PR in case this proposed trivial change is enough (i.e. restoring previous behaviour) to close the above issue.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

Thank you all for this library, it's really neat.