### PR TITLE
FIX Improved the error message from check_classification_targets function when label is invalid

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -182,8 +182,9 @@ def check_classification_targets(y):
     if y_type not in ['binary', 'multiclass', 'multiclass-multioutput',
                       'multilabel-indicator', 'multilabel-sequences']:
         raise ValueError("Unknown label type: %r. Expected 'binary', "
-                         "'multiclass', 'multiclass-multioutput', 'multilabel-indicator', "
-                         "'multilabel-sequences'." % y_type)
+                         "'multiclass', 'multiclass-multioutput', "
+                         "'multilabel-indicator', 'multilabel-sequences'."
+                         % y_type)
 
 
 def type_of_target(y):

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -95,7 +95,7 @@ def unique_labels(*ys):
     # Get the unique set of labels
     _unique_labels = _FN_UNIQUE_LABELS.get(label_type, None)
     if not _unique_labels:
-        raise ValueError("Unknown label type: %s" % repr(ys))
+        raise ValueError("Unknown label type: %s. Expected 'binary', 'multiclass', 'multilabel'." % repr(ys))
 
     ys_labels = set(chain.from_iterable(_unique_labels(y) for y in ys))
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -95,7 +95,8 @@ def unique_labels(*ys):
     # Get the unique set of labels
     _unique_labels = _FN_UNIQUE_LABELS.get(label_type, None)
     if not _unique_labels:
-        raise ValueError("Unknown label type: %s. Expected 'binary', 'multiclass', 'multilabel'." % repr(ys))
+        raise ValueError("Unknown label type: %s. Expected 'binary', "
+                         "'multiclass', 'multilabel'." % repr(ys))
 
     ys_labels = set(chain.from_iterable(_unique_labels(y) for y in ys))
 
@@ -180,8 +181,9 @@ def check_classification_targets(y):
     y_type = type_of_target(y)
     if y_type not in ['binary', 'multiclass', 'multiclass-multioutput',
                       'multilabel-indicator', 'multilabel-sequences']:
-        raise ValueError("Unknown label type: %r.Expected 'binary', 'multiclass', 'multiclass-multioutput',
-                         'multilabel-indicator', 'multilabel-sequences'." % y_type)
+        raise ValueError("Unknown label type: %r. Expected 'binary', 'multiclass', "
+                         "'multiclass-multioutput', 'multilabel-indicator', "
+                         "'multilabel-sequences'." % y_type)
 
 
 def type_of_target(y):

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -180,7 +180,8 @@ def check_classification_targets(y):
     y_type = type_of_target(y)
     if y_type not in ['binary', 'multiclass', 'multiclass-multioutput',
                       'multilabel-indicator', 'multilabel-sequences']:
-        raise ValueError("Unknown label type: %r" % y_type)
+        raise ValueError("Unknown label type: %r.Expected 'binary', 'multiclass', 'multiclass-multioutput',
+                         'multilabel-indicator', 'multilabel-sequences'." % y_type)
 
 
 def type_of_target(y):

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -181,8 +181,8 @@ def check_classification_targets(y):
     y_type = type_of_target(y)
     if y_type not in ['binary', 'multiclass', 'multiclass-multioutput',
                       'multilabel-indicator', 'multilabel-sequences']:
-        raise ValueError("Unknown label type: %r. Expected 'binary', 'multiclass', "
-                         "'multiclass-multioutput', 'multilabel-indicator', "
+        raise ValueError("Unknown label type: %r. Expected 'binary', "
+                         "'multiclass', 'multiclass-multioutput', 'multilabel-indicator', "
                          "'multilabel-sequences'." % y_type)
 
 


### PR DESCRIPTION
When invalid types of labels are used, the error `Unknown label type` is raised.
 This pull request explicitly added the expected label types to the error message, which should provide more actionable information (especially for novices).

**Expected error message:**
`"Unknown label type: %r. Expected label types include 'binary', 'multiclass', 'multiclass-multioutput', 'multilabel-indicator', 'multilabel-sequences' % y_type"`

`"Unknown label type: %s. Expected 'binary', 'multiclass', 'multilabel'" % repr(ys)`

