### PR TITLE
DOC Refer to the new numpy intersphinx inventory.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -268,7 +268,7 @@ trim_doctests_flags = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{.major}'.format(
         sys.version_info), None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://numpy.org/doc/stable/objects.inv', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -268,7 +268,7 @@ trim_doctests_flags = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{.major}'.format(
         sys.version_info), None),
-    'numpy': ('https://numpy.org/doc/stable/objects.inv', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
intersphinx inventory has moved: https://docs.scipy.org/doc/numpy/objects.inv -> https://numpy.org/doc/stable/objects.inv