### PR TITLE
DOC update shape of returned array in BinaryTree.query

### DIFF
--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -1323,11 +1323,11 @@ cdef class BinaryTree:
         i    : if return_distance == False
         (d,i) : if return_distance == True
 
-        d : ndarray of shape X.shape[:-1] + k, dtype=double
+        d : ndarray of shape X.shape[:-1] + (k,), dtype=double
             Each entry gives the list of distances to the neighbors of the
             corresponding point.
 
-        i : ndarray of shape X.shape[:-1] + k, dtype=int
+        i : ndarray of shape X.shape[:-1] + (k,), dtype=int
             Each entry gives the list of indices of neighbors of the
             corresponding point.
         """


### PR DESCRIPTION
Method ```query``` returns the values which have the shape X.shape[:-1] + (k,).
But docstring seems to be tuple + integer.

#### What does this implement/fix? Explain your changes.
Clarify the return value's shape.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
