### PR TITLE
Implement binary/multiclass classification metric - Spherical Payoff

### DIFF
--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -35,6 +35,7 @@ from ._classification import recall_score
 from ._classification import zero_one_loss
 from ._classification import brier_score_loss
 from ._classification import multilabel_confusion_matrix
+from ._classification import spherical_payoff_score
 
 from . import cluster
 from .cluster import adjusted_mutual_info_score

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2567,7 +2567,7 @@ def spherical_payoff_score(y_true, y_prob, *, sample_weight=None):
         y_true[y_true==category] = idx    
     
     # Spherical Payoff
-    correct_prob = y_prob[np.arange(y_prob.shape[0]), y_test]
+    correct_prob = y_prob[np.arange(y_prob.shape[0]), y_true]
     sqrt_all_prob = np.sqrt(np.power(y_prob, 2).sum(axis=1))
     
     return np.average(correct_prob/sqrt_all_prob, weights=sample_weight)


### PR DESCRIPTION
#### What does this implement? Explain your changes.
This PR implements spherical payoff score for binary/multiclass classification.

This metric is most used in ecological modelling for Decision Making models such as Bayesian Networks, where you want to maximize the correct predicted classes and the model's confidence in that output.

 It's measures the model's confidence, through the probability, to predict the correct category and have a defined interval: [0, 1]. Best possible score is 1.0, and the worst is 0.0. It's calculated as the average over all samples.

The benefits to use this score:
- See if your model have confidence in predicted answers
- Support other useful metrics such as Confusion Matrix related, given the fact that measures the output probabilities
- The other metrics equivalents (scoring rules metrics, read more [here](https://en.wikipedia.org/wiki/Scoring_rule#:~:text=In%20decision%20theory%2C%20a%20score,set%20of%20mutually%20exclusive%20outcomes.)) as brier score or log loss it's only available for binary problems.  This metric doesn't have this issue.

#### Any other comments?
The equation was implemented based on this [2007 paper reference](https://www.fs.fed.us/pnw/pubs/journals/pnw_2006_marcot001.pdf):
![equation](https://user-images.githubusercontent.com/32513366/101266922-2dba2b00-3732-11eb-908a-d8a293a2780b.png)


Other point is the fact that **was not implemented yet for open source community**, the only reference that I found was in a paid program call [Netica in this tutorial](https://www.norsys.com/tutorials/netica/secD/tut_D2.htm).

Abs,
