### PR TITLE
BLD Adds max numpy version for python=3.6

### DIFF
--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -53,6 +53,12 @@ for package, (min_version, extras) in dependent_packages.items():
     for extra in extras.split(', '):
         tag_to_packages[extra].append("{}>={}".format(package, min_version))
 
+# extra dependencies
+extra_dependencies = {'numpy': 'numpy<1.20; python_version == "3.6"'}
+for package, extra_dep in extra_dependencies.items():
+    extras = dependent_packages[package][1]
+    for extra in extras.split(', '):
+        tag_to_packages[extra].append(extra_dep)
 
 # Used by CI to get the min dependencies
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Address one of the items in https://github.com/scikit-learn/scikit-learn/issues/18977


#### What does this implement/fix? Explain your changes.
This PR adds a max numpy version for python==3.6.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
