### PR TITLE
MNT change 0.25 to 1.0 and 0.26 to 1.1 in deprecation messages

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -228,8 +228,8 @@ to slice rows and columns.
 
 .. deprecated:: 0.24
 
-    The _pairwise attribute is deprecated in 0.24. From 1.1 onward,
-    the `pairwise` estimator tag should be used instead.
+    The _pairwise attribute is deprecated in 0.24. From 1.1 (renaming of 0.26)
+    onward, the `pairwise` estimator tag should be used instead.
 
 Universal attributes
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -228,8 +228,8 @@ to slice rows and columns.
 
 .. deprecated:: 0.24
 
-    The _pairwise attribute is deprecated in 0.24. From 1.1 (renaming of 0.26)
-    onward, the `pairwise` estimator tag should be used instead.
+    The _pairwise attribute is deprecated in 0.24. From 1.1 onward
+    (renaming of 0.26), the `pairwise` estimator tag should be used instead.
 
 Universal attributes
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -228,8 +228,8 @@ to slice rows and columns.
 
 .. deprecated:: 0.24
 
-    The _pairwise attribute is deprecated in 0.24. From 1.1 onward
-    (renaming of 0.26), the `pairwise` estimator tag should be used instead.
+    The _pairwise attribute is deprecated in 0.24. From 1.1 (renaming of 0.26)
+    onward, the `pairwise` estimator tag should be used instead.
 
 Universal attributes
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -228,7 +228,7 @@ to slice rows and columns.
 
 .. deprecated:: 0.24
 
-    The _pairwise attribute is deprecated in 0.24. From 0.26 onward,
+    The _pairwise attribute is deprecated in 0.24. From 1.1 onward,
     the `pairwise` estimator tag should be used instead.
 
 Universal attributes

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -390,8 +390,8 @@ General Concepts
                 .. deprecated:: 0.24
 
                     The _pairwise attribute is deprecated in 0.24. From 1.1
-                    onward, the `pairwise` estimator tag should be used
-                    instead.
+                    (renaming of 0.26) onward, the `pairwise` estimator tag
+                    should be used instead.
 
         For more detailed info, see :ref:`estimator_tags`.
 

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -389,7 +389,7 @@ General Concepts
 
                 .. deprecated:: 0.24
 
-                    The _pairwise attribute is deprecated in 0.24. From 0.26
+                    The _pairwise attribute is deprecated in 0.24. From 1.1
                     onward, the `pairwise` estimator tag should be used
                     instead.
 

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1637,5 +1637,5 @@ Utilities from joblib:
 Recently deprecated
 ===================
 
-To be removed in 1.0
---------------------
+To be removed in 1.0 (renaming of 0.25)
+---------------------------------------

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1637,5 +1637,5 @@ Utilities from joblib:
 Recently deprecated
 ===================
 
-To be removed in 0.25
----------------------
+To be removed in 1.0
+--------------------

--- a/doc/whats_new/v0.23.rst
+++ b/doc/whats_new/v0.23.rst
@@ -166,8 +166,8 @@ In an effort to promote clear and non-ambiguous use of the library, most
 constructor and function parameters are now expected to be passed as keyword
 arguments (i.e. using the `param=value` syntax) instead of positional. To
 ease the transition, a `FutureWarning` is raised if a keyword-only parameter
-is used as positional. In version 0.25, these parameters will be strictly
-keyword-only, and a `TypeError` will be raised.
+is used as positional. In version 1.0 (renaming of 0.25), these parameters
+will be strictly keyword-only, and a `TypeError` will be raised.
 :issue:`15005` by `Joel Nothman`_, `Adrin Jalali`_, `Thomas Fan`_, and
 `Nicolas Hug`_. See `SLEP009
 <https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep009/proposal.html>`_

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -104,7 +104,7 @@ Changelog
   initial cluster centroids. :pr:`17937` by :user:`g-walsh`
 
 - |API| :class:`cluster.MiniBatchKMeans` attributes, `counts_` and
-  `init_size_`, are deprecated and will be removed in 0.26. :pr:`17864` by
+  `init_size_`, are deprecated and will be removed in 1.1. :pr:`17864` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.compose`
@@ -128,7 +128,7 @@ Changelog
 - |API| Deprecates `cv_alphas_` in favor of `cv_results_['alphas']` and
   `grid_scores_` in favor of split scores in `cv_results_` in
   :class:`covariance.GraphicalLassoCV`. `cv_alphas_` and `grid_scores_` will be
-  removed in version 0.26. :pr:`16392` by `Thomas Fan`_.
+  removed in version 1.1. :pr:`16392` by `Thomas Fan`_.
 
 :mod:`sklearn.cross_decomposition`
 ..................................
@@ -149,7 +149,7 @@ Changelog
 - |API| For :class:`cross_decomposition.NMF`,
   the `init` value, when 'init=None' and
   n_components <= min(n_samples, n_features) will be changed from
-  `'nndsvd'` to `'nndsvda'` in 0.26.
+  `'nndsvd'` to `'nndsvda'` in 1.1.
   :pr:`18525` by :user:`Chiara Marmo <cmarmo>`.
 
 - |API| The bounds of the `n_components` parameter is now restricted:
@@ -159,12 +159,12 @@ Changelog
     and :class:`cross_decomposition.PLSCanonical`.
   - into `[1, n_features]` or :class:`cross_decomposition.PLSRegression`.
 
-  An error will be raised in 0.26. :pr:`17095` by `Nicolas Hug`_.
+  An error will be raised in 1.1. :pr:`17095` by `Nicolas Hug`_.
 
 - |API| For :class:`cross_decomposition.PLSSVD`,
   :class:`cross_decomposition.CCA`, and
   :class:`cross_decomposition.PLSCanonical`, the `x_scores_` and `y_scores_`
-  attributes were deprecated and will be removed in 0.26. They can be
+  attributes were deprecated and will be removed in 1.1. They can be
   retrieved by calling `transform` on the training data. The `norm_y_weights`
   attribute will also be removed. :pr:`17095` by `Nicolas Hug`_.
 
@@ -172,7 +172,7 @@ Changelog
   :class:`cross_decomposition.PLSCanonical`,
   :class:`cross_decomposition.CCA`, and
   :class:`cross_decomposition.PLSSVD`, the `x_mean_`, `y_mean_`, `x_std_`, and
-  `y_std_` attributes were deprecated and will be removed in 0.26.
+  `y_std_` attributes were deprecated and will be removed in 1.1.
   :pr:`18768` by :user:`Maren Westermann <marenwestermann>`.
 
 - |Fix| :class:`decomposition.TruncatedSVD` becomes deterministic by using the
@@ -240,7 +240,7 @@ Changelog
 
 - |Fix| Fix :class:`decomposition.SparseCoder` such that it follows
   scikit-learn API and support cloning. The attribute `components_` is
-  deprecated in 0.24 and will be removed in 0.26. This attribute was
+  deprecated in 0.24 and will be removed in 1.1. This attribute was
   redundant with the `dictionary` attribute and constructor parameter.
   :pr:`17679` by :user:`Xavier Dupré <sdpython>`.
 
@@ -302,7 +302,7 @@ Changelog
 
 - |API| :class:`exceptions.ChangedBehaviorWarning` and
   :class:`exceptions.NonBLASDotWarning` are deprecated and will be removed in
-  v0.26, :pr:`17804` by `Adrin Jalali`_.
+  v1.1, :pr:`17804` by `Adrin Jalali`_.
 
 :mod:`sklearn.feature_extraction`
 .................................
@@ -390,7 +390,7 @@ Changelog
   :user:`Roei Kahny <RoeiKa>`.
 
 - |API| Positional arguments are deprecated in
-  :meth:`inspection.PartialDependenceDisplay.plot` and will error in 0.26.
+  :meth:`inspection.PartialDependenceDisplay.plot` and will error in 1.1.
   :pr:`18293` by `Thomas Fan`_.
 
 :mod:`sklearn.isotonic`
@@ -458,7 +458,7 @@ Changelog
 
 - |Enhancement| Add `square_distances` parameter to :class:`manifold.TSNE`,
   which provides backward compatibility during deprecation of legacy squaring
-  behavior. Distances will be squared by default in 0.26, and this parameter
+  behavior. Distances will be squared by default in 1.1, and this parameter
   will be removed in 0.28. :pr:`17662` by
   :user:`Joshua Newton <joshuacwnewton>`.
 
@@ -645,7 +645,7 @@ Changelog
 - |API| The attributes ``coef_`` and ``intercept_`` are now deprecated in
   :class:`naive_bayes.MultinomialNB`, :class:`naive_bayes.ComplementNB`,
   :class:`naive_bayes.BernoulliNB` and :class:`naive_bayes.CategoricalNB`,
-  and will be removed in v0.26. :pr:`17427` by
+  and will be removed in v1.1. :pr:`17427` by
   :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
 
 :mod:`sklearn.neighbors`

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -104,8 +104,8 @@ Changelog
   initial cluster centroids. :pr:`17937` by :user:`g-walsh`
 
 - |API| :class:`cluster.MiniBatchKMeans` attributes, `counts_` and
-  `init_size_`, are deprecated and will be removed in 1.1. :pr:`17864` by
-  :user:`Jérémie du Boisberranger <jeremiedbb>`.
+  `init_size_`, are deprecated and will be removed in 1.1 (renaming of 0.26).
+  :pr:`17864` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.compose`
 ......................
@@ -128,7 +128,8 @@ Changelog
 - |API| Deprecates `cv_alphas_` in favor of `cv_results_['alphas']` and
   `grid_scores_` in favor of split scores in `cv_results_` in
   :class:`covariance.GraphicalLassoCV`. `cv_alphas_` and `grid_scores_` will be
-  removed in version 1.1. :pr:`16392` by `Thomas Fan`_.
+  removed in version 1.1 (renaming of 0.26).
+  :pr:`16392` by `Thomas Fan`_.
 
 :mod:`sklearn.cross_decomposition`
 ..................................
@@ -149,7 +150,7 @@ Changelog
 - |API| For :class:`cross_decomposition.NMF`,
   the `init` value, when 'init=None' and
   n_components <= min(n_samples, n_features) will be changed from
-  `'nndsvd'` to `'nndsvda'` in 1.1.
+  `'nndsvd'` to `'nndsvda'` in 1.1 (renaming of 0.26).
   :pr:`18525` by :user:`Chiara Marmo <cmarmo>`.
 
 - |API| The bounds of the `n_components` parameter is now restricted:
@@ -159,20 +160,23 @@ Changelog
     and :class:`cross_decomposition.PLSCanonical`.
   - into `[1, n_features]` or :class:`cross_decomposition.PLSRegression`.
 
-  An error will be raised in 1.1. :pr:`17095` by `Nicolas Hug`_.
+  An error will be raised in 1.1 (renaming of 0.26).
+  :pr:`17095` by `Nicolas Hug`_.
 
 - |API| For :class:`cross_decomposition.PLSSVD`,
   :class:`cross_decomposition.CCA`, and
   :class:`cross_decomposition.PLSCanonical`, the `x_scores_` and `y_scores_`
-  attributes were deprecated and will be removed in 1.1. They can be
-  retrieved by calling `transform` on the training data. The `norm_y_weights`
-  attribute will also be removed. :pr:`17095` by `Nicolas Hug`_.
+  attributes were deprecated and will be removed in 1.1 (renaming of 0.26).
+  They can be retrieved by calling `transform` on the training data.
+  The `norm_y_weights` attribute will also be removed.
+  :pr:`17095` by `Nicolas Hug`_.
 
 - |API| For :class:`cross_decomposition.PLSRegression`,
   :class:`cross_decomposition.PLSCanonical`,
   :class:`cross_decomposition.CCA`, and
   :class:`cross_decomposition.PLSSVD`, the `x_mean_`, `y_mean_`, `x_std_`, and
-  `y_std_` attributes were deprecated and will be removed in 1.1.
+  `y_std_` attributes were deprecated and will be removed in 1.1
+  (renaming of 0.26).
   :pr:`18768` by :user:`Maren Westermann <marenwestermann>`.
 
 - |Fix| :class:`decomposition.TruncatedSVD` becomes deterministic by using the
@@ -240,8 +244,9 @@ Changelog
 
 - |Fix| Fix :class:`decomposition.SparseCoder` such that it follows
   scikit-learn API and support cloning. The attribute `components_` is
-  deprecated in 0.24 and will be removed in 1.1. This attribute was
-  redundant with the `dictionary` attribute and constructor parameter.
+  deprecated in 0.24 and will be removed in 1.1 (renaming of 0.26).
+  This attribute was redundant with the `dictionary` attribute and constructor
+  parameter.
   :pr:`17679` by :user:`Xavier Dupré <sdpython>`.
 
 - |Fix| :meth:`TruncatedSVD.fit_transform` consistently returns the same
@@ -302,7 +307,8 @@ Changelog
 
 - |API| :class:`exceptions.ChangedBehaviorWarning` and
   :class:`exceptions.NonBLASDotWarning` are deprecated and will be removed in
-  v1.1, :pr:`17804` by `Adrin Jalali`_.
+  1.1 (renaming of 0.26).
+  :pr:`17804` by `Adrin Jalali`_.
 
 :mod:`sklearn.feature_extraction`
 .................................
@@ -390,7 +396,8 @@ Changelog
   :user:`Roei Kahny <RoeiKa>`.
 
 - |API| Positional arguments are deprecated in
-  :meth:`inspection.PartialDependenceDisplay.plot` and will error in 1.1.
+  :meth:`inspection.PartialDependenceDisplay.plot` and will error in 1.1
+  (renaming of 0.26).
   :pr:`18293` by `Thomas Fan`_.
 
 :mod:`sklearn.isotonic`
@@ -458,8 +465,8 @@ Changelog
 
 - |Enhancement| Add `square_distances` parameter to :class:`manifold.TSNE`,
   which provides backward compatibility during deprecation of legacy squaring
-  behavior. Distances will be squared by default in 1.1, and this parameter
-  will be removed in 0.28. :pr:`17662` by
+  behavior. Distances will be squared by default in 1.1 (renaming of 0.26),
+  and this parameter will be removed in 1.3. :pr:`17662` by
   :user:`Joshua Newton <joshuacwnewton>`.
 
 - |Fix| :class:`manifold.MDS` now correctly sets its `_pairwise` attribute.
@@ -645,8 +652,8 @@ Changelog
 - |API| The attributes ``coef_`` and ``intercept_`` are now deprecated in
   :class:`naive_bayes.MultinomialNB`, :class:`naive_bayes.ComplementNB`,
   :class:`naive_bayes.BernoulliNB` and :class:`naive_bayes.CategoricalNB`,
-  and will be removed in v1.1. :pr:`17427` by
-  :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
+  and will be removed in v1.1 (renaming of 0.26).
+  :pr:`17427` by :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
 
 :mod:`sklearn.neighbors`
 ........................

--- a/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
+++ b/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
@@ -101,7 +101,7 @@ plt.title("Feature Selection")
 plt.subplot(1, 3, 3)
 plt.imshow(coef_agglomeration_, interpolation="nearest", cmap=plt.cm.RdBu_r)
 plt.title("Feature Agglomeration")
-plt.subplots_adjust(0.04, 0.0, 0.98, 0.94, 0.16, 0.26)
+plt.subplots_adjust(0.04, 0.0, 0.98, 0.94, 0.16, 1.1)
 plt.show()
 
 # Attempt to remove the temporary cachedir, but don't worry if it fails

--- a/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
+++ b/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
@@ -101,7 +101,7 @@ plt.title("Feature Selection")
 plt.subplot(1, 3, 3)
 plt.imshow(coef_agglomeration_, interpolation="nearest", cmap=plt.cm.RdBu_r)
 plt.title("Feature Agglomeration")
-plt.subplots_adjust(0.04, 0.0, 0.98, 0.94, 0.16, 1.1)
+plt.subplots_adjust(0.04, 0.0, 0.98, 0.94, 0.16, 0.26)
 plt.show()
 
 # Attempt to remove the temporary cachedir, but don't worry if it fails

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -101,5 +101,5 @@ plt.subplot(2, 2, 4)
 plot_samples(S_ica_ / np.std(S_ica_))
 plt.title('ICA recovered signals')
 
-plt.subplots_adjust(0.09, 0.04, 0.94, 0.94, 1.1, 0.36)
+plt.subplots_adjust(0.09, 0.04, 0.94, 0.94, 0.26, 0.36)
 plt.show()

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -101,5 +101,5 @@ plt.subplot(2, 2, 4)
 plot_samples(S_ica_ / np.std(S_ica_))
 plt.title('ICA recovered signals')
 
-plt.subplots_adjust(0.09, 0.04, 0.94, 0.94, 0.26, 0.36)
+plt.subplots_adjust(0.09, 0.04, 0.94, 0.94, 1.1, 0.36)
 plt.show()

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -845,9 +845,12 @@ def _is_pairwise(estimator):
 
     if has_pairwise_attribute:
         if pairwise_attribute != pairwise_tag:
-            warnings.warn("_pairwise was deprecated in 0.24 and will be "
-                          "removed in 1.1. Set the estimator tags of your "
-                          "estimator instead", FutureWarning)
+            warnings.warn(
+                "_pairwise was deprecated in 0.24 and will be removed in 1.1 "
+                "(renaming of 0.26). Set the estimator tags of your estimator "
+                "instead",
+                FutureWarning
+            )
         return pairwise_attribute
 
     # use pairwise tag when the attribute is not present

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -846,7 +846,7 @@ def _is_pairwise(estimator):
     if has_pairwise_attribute:
         if pairwise_attribute != pairwise_tag:
             warnings.warn("_pairwise was deprecated in 0.24 and will be "
-                          "removed in 0.26. Set the estimator tags of your "
+                          "removed in 1.1. Set the estimator tags of your "
                           "estimator instead", FutureWarning)
         return pairwise_attribute
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -599,7 +599,7 @@ class _CalibratedClassifier:
 
         .. deprecated:: 0.24
            `calibrators_` is deprecated from 0.24 and will be removed in
-           1.1. Use `calibrators` instead.
+           1.1 (renaming of 0.26). Use `calibrators` instead.
     """
     def __init__(self, base_estimator, calibrators, *, classes,
                  method='sigmoid'):
@@ -611,8 +611,8 @@ class _CalibratedClassifier:
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "calibrators_ is deprecated in 0.24 and will be removed in 1.1. "
-        "Use calibrators instead."
+        "calibrators_ is deprecated in 0.24 and will be removed in 1.1"
+        "(renaming of 0.26). Use calibrators instead."
     )
     @property
     def calibrators_(self):

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -599,7 +599,7 @@ class _CalibratedClassifier:
 
         .. deprecated:: 0.24
            `calibrators_` is deprecated from 0.24 and will be removed in
-           0.26. Use `calibrators` instead.
+           1.1. Use `calibrators` instead.
     """
     def __init__(self, base_estimator, calibrators, *, classes,
                  method='sigmoid'):
@@ -608,10 +608,10 @@ class _CalibratedClassifier:
         self.classes = classes
         self.method = method
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "calibrators_ is deprecated in 0.24 and will be removed in 0.26. "
+        "calibrators_ is deprecated in 0.24 and will be removed in 1.1. "
         "Use calibrators instead."
     )
     @property

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -146,7 +146,7 @@ def affinity_propagation(S, *, preference=None, convergence_iter=15,
 
     if random_state == 'warn':
         warnings.warn(("'random_state' has been introduced in 0.23. "
-                       "It will be set to None starting from 0.25 which "
+                       "It will be set to None starting from 1.0 which "
                        "means that results will differ at every function "
                        "call. Set 'random_state' to None to silence this "
                        "warning, or to 0 to keep the behavior of versions "

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -379,7 +379,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         return self.affinity == "precomputed"

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -145,13 +145,14 @@ def affinity_propagation(S, *, preference=None, convergence_iter=15,
                     else (np.array([0]), np.array([0] * n_samples)))
 
     if random_state == 'warn':
-        warnings.warn(("'random_state' has been introduced in 0.23. "
-                       "It will be set to None starting from 1.0 which "
-                       "means that results will differ at every function "
-                       "call. Set 'random_state' to None to silence this "
-                       "warning, or to 0 to keep the behavior of versions "
-                       "<0.23."),
-                      FutureWarning)
+        warnings.warn(
+            "'random_state' has been introduced in 0.23. It will be set to "
+            "None starting from 1.0 (renaming of 0.25) which means that "
+            "results will differ at every function call. Set 'random_state' "
+            "to None to silence this warning, or to 0 to keep the behavior of "
+            "versions <0.23.",
+            FutureWarning
+        )
         random_state = 0
     random_state = check_random_state(random_state)
 

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -375,10 +375,10 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
         self.affinity = affinity
         self.random_state = random_state
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         return self.affinity == "precomputed"

--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -118,7 +118,7 @@ class BaseSpectral(BiclusterMixin, BaseEstimator, metaclass=ABCMeta):
         """
         if self.n_jobs != 'deprecated':
             warnings.warn("'n_jobs' was deprecated in version 0.23 and will be"
-                          " removed in 1.0.", FutureWarning)
+                          " removed in 1.0 (renaming of 0.25).", FutureWarning)
 
         X = self._validate_data(X, accept_sparse='csr', dtype=np.float64)
         self._check_parameters()

--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -118,7 +118,7 @@ class BaseSpectral(BiclusterMixin, BaseEstimator, metaclass=ABCMeta):
         """
         if self.n_jobs != 'deprecated':
             warnings.warn("'n_jobs' was deprecated in version 0.23 and will be"
-                          " removed in 0.25.", FutureWarning)
+                          " removed in 1.0.", FutureWarning)
 
         X = self._validate_data(X, accept_sparse='csr', dtype=np.float64)
         self._check_parameters()
@@ -240,7 +240,7 @@ class SpectralCoclustering(BaseSpectral):
 
         .. deprecated:: 0.23
             ``n_jobs`` was deprecated in version 0.23 and will be removed in
-            0.25.
+            1.0.
 
     random_state : int, RandomState instance, default=None
         Used for randomizing the singular value decomposition and the k-means
@@ -392,7 +392,7 @@ class SpectralBiclustering(BaseSpectral):
 
         .. deprecated:: 0.23
             ``n_jobs`` was deprecated in version 0.23 and will be removed in
-            0.25.
+            1.0.
 
     random_state : int, RandomState instance, default=None
         Used for randomizing the singular value decomposition and the k-means

--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -240,7 +240,7 @@ class SpectralCoclustering(BaseSpectral):
 
         .. deprecated:: 0.23
             ``n_jobs`` was deprecated in version 0.23 and will be removed in
-            1.0.
+            1.0 (renaming of 0.25).
 
     random_state : int, RandomState instance, default=None
         Used for randomizing the singular value decomposition and the k-means
@@ -392,7 +392,7 @@ class SpectralBiclustering(BaseSpectral):
 
         .. deprecated:: 0.23
             ``n_jobs`` was deprecated in version 0.23 and will be removed in
-            1.0.
+            1.0 (renaming of 0.25).
 
     random_state : int, RandomState instance, default=None
         Used for randomizing the singular value decomposition and the k-means

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -212,7 +212,7 @@ def k_means(X, n_clusters, *, sample_weight=None, init='k-means++',
 
         .. deprecated:: 0.23
             'precompute_distances' was deprecated in version 0.23 and will be
-            removed in 0.25. It has no effect.
+            removed in 1.0. It has no effect.
 
     n_init : int, default=10
         Number of time the k-means algorithm will be run with different
@@ -254,7 +254,7 @@ def k_means(X, n_clusters, *, sample_weight=None, init='k-means++',
 
         .. deprecated:: 0.23
             ``n_jobs`` was deprecated in version 0.23 and will be removed in
-            0.25.
+            1.0.
 
     algorithm : {"auto", "full", "elkan"}, default="auto"
         K-means algorithm to use. The classical EM-style algorithm is "full".
@@ -657,7 +657,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         .. deprecated:: 0.23
             'precompute_distances' was deprecated in version 0.22 and will be
-            removed in 0.25. It has no effect.
+            removed in 1.0. It has no effect.
 
     verbose : int, default=0
         Verbosity mode.
@@ -686,7 +686,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         .. deprecated:: 0.23
             ``n_jobs`` was deprecated in version 0.23 and will be removed in
-            0.25.
+            1.0.
 
     algorithm : {"auto", "full", "elkan"}, default="auto"
         K-means algorithm to use. The classical EM-style algorithm is "full".
@@ -784,13 +784,13 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         # precompute_distances
         if self.precompute_distances != 'deprecated':
             warnings.warn("'precompute_distances' was deprecated in version "
-                          "0.23 and will be removed in 0.25. It has no "
+                          "0.23 and will be removed in 1.0. It has no "
                           "effect", FutureWarning)
 
         # n_jobs
         if self.n_jobs != 'deprecated':
             warnings.warn("'n_jobs' was deprecated in version 0.23 and will be"
-                          " removed in 0.25.", FutureWarning)
+                          " removed in 1.0.", FutureWarning)
             self._n_threads = self.n_jobs
         else:
             self._n_threads = None

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -212,7 +212,7 @@ def k_means(X, n_clusters, *, sample_weight=None, init='k-means++',
 
         .. deprecated:: 0.23
             'precompute_distances' was deprecated in version 0.23 and will be
-            removed in 1.0. It has no effect.
+            removed in 1.0 (renaming of 0.25). It has no effect.
 
     n_init : int, default=10
         Number of time the k-means algorithm will be run with different
@@ -254,7 +254,7 @@ def k_means(X, n_clusters, *, sample_weight=None, init='k-means++',
 
         .. deprecated:: 0.23
             ``n_jobs`` was deprecated in version 0.23 and will be removed in
-            1.0.
+            1.0 (renaming of 0.25).
 
     algorithm : {"auto", "full", "elkan"}, default="auto"
         K-means algorithm to use. The classical EM-style algorithm is "full".
@@ -657,7 +657,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         .. deprecated:: 0.23
             'precompute_distances' was deprecated in version 0.22 and will be
-            removed in 1.0. It has no effect.
+            removed in 1.0 (renaming of 0.25). It has no effect.
 
     verbose : int, default=0
         Verbosity mode.
@@ -686,7 +686,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         .. deprecated:: 0.23
             ``n_jobs`` was deprecated in version 0.23 and will be removed in
-            1.0.
+            1.0 (renaming of 0.25).
 
     algorithm : {"auto", "full", "elkan"}, default="auto"
         K-means algorithm to use. The classical EM-style algorithm is "full".
@@ -1512,13 +1512,15 @@ class MiniBatchKMeans(KMeans):
         Weigth sum of each cluster.
 
         .. deprecated:: 0.24
-           This attribute is deprecated in 0.24 and will be removed in 1.1.
+           This attribute is deprecated in 0.24 and will be removed in
+           1.1 (renaming of 0.26).
 
     init_size_ : int
         The effective number of samples used for the initialization.
 
         .. deprecated:: 0.24
-           This attribute is deprecated in 0.24 and will be removed in 1.1.
+           This attribute is deprecated in 0.24 and will be removed in
+           1.1 (renaming of 0.26).
 
     See Also
     --------
@@ -1577,19 +1579,19 @@ class MiniBatchKMeans(KMeans):
         self.reassignment_ratio = reassignment_ratio
 
     @deprecated("The attribute 'counts_' is deprecated in 0.24"  # type: ignore
-                " and will be removed in 1.1.")
+                " and will be removed in 1.1 (renaming of 0.26).")
     @property
     def counts_(self):
         return self._counts
 
     @deprecated("The attribute 'init_size_' is deprecated in "  # type: ignore
-                "0.24 and will be removed in 1.1.")
+                "0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def init_size_(self):
         return self._init_size
 
     @deprecated("The attribute 'random_state_' is deprecated "  # type: ignore
-                "in 0.24 and will be removed in 1.1.")
+                "in 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def random_state_(self):
         return getattr(self, "_random_state", None)

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -784,13 +784,13 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         # precompute_distances
         if self.precompute_distances != 'deprecated':
             warnings.warn("'precompute_distances' was deprecated in version "
-                          "0.23 and will be removed in 1.0. It has no "
-                          "effect", FutureWarning)
+                          "0.23 and will be removed in 1.0 (renaming of 0.25)"
+                          ". It has no effect", FutureWarning)
 
         # n_jobs
         if self.n_jobs != 'deprecated':
             warnings.warn("'n_jobs' was deprecated in version 0.23 and will be"
-                          " removed in 1.0.", FutureWarning)
+                          " removed in 1.0 (renaming of 0.25).", FutureWarning)
             self._n_threads = self.n_jobs
         else:
             self._n_threads = None

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1512,13 +1512,13 @@ class MiniBatchKMeans(KMeans):
         Weigth sum of each cluster.
 
         .. deprecated:: 0.24
-           This attribute is deprecated in 0.24 and will be removed in 0.26.
+           This attribute is deprecated in 0.24 and will be removed in 1.1.
 
     init_size_ : int
         The effective number of samples used for the initialization.
 
         .. deprecated:: 0.24
-           This attribute is deprecated in 0.24 and will be removed in 0.26.
+           This attribute is deprecated in 0.24 and will be removed in 1.1.
 
     See Also
     --------
@@ -1577,19 +1577,19 @@ class MiniBatchKMeans(KMeans):
         self.reassignment_ratio = reassignment_ratio
 
     @deprecated("The attribute 'counts_' is deprecated in 0.24"  # type: ignore
-                " and will be removed in 0.26.")
+                " and will be removed in 1.1.")
     @property
     def counts_(self):
         return self._counts
 
     @deprecated("The attribute 'init_size_' is deprecated in "  # type: ignore
-                "0.24 and will be removed in 0.26.")
+                "0.24 and will be removed in 1.1.")
     @property
     def init_size_(self):
         return self._init_size
 
     @deprecated("The attribute 'random_state_' is deprecated "  # type: ignore
-                "in 0.24 and will be removed in 0.26.")
+                "in 0.24 and will be removed in 1.1.")
     @property
     def random_state_(self):
         return getattr(self, "_random_state", None)

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -571,10 +571,10 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
         return {'pairwise': self.affinity in ["precomputed",
                                               "precomputed_nearest_neighbors"]}
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         return self.affinity in ["precomputed",

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -574,7 +574,7 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         return self.affinity in ["precomputed",

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -204,12 +204,12 @@ def test_affinity_propagation_random_state():
     assert np.mean((centers0 - centers76) ** 2) > 1
 
 
-# FIXME: to be removed in 0.25
+# FIXME: to be removed in 1.0
 def test_affinity_propagation_random_state_warning():
     # test that a warning is raised when random_state is not defined.
     X = np.array([[0, 0], [1, 1], [-2, -2]])
     match = ("'random_state' has been introduced in 0.23. "
-             "It will be set to None starting from 0.25 which "
+             "It will be set to None starting from 1.0 which "
              "means that results will differ at every function "
              "call. Set 'random_state' to None to silence this "
              "warning, or to 0 to keep the behavior of versions "

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -208,12 +208,7 @@ def test_affinity_propagation_random_state():
 def test_affinity_propagation_random_state_warning():
     # test that a warning is raised when random_state is not defined.
     X = np.array([[0, 0], [1, 1], [-2, -2]])
-    match = ("'random_state' has been introduced in 0.23. "
-             "It will be set to None starting from 1.0 which "
-             "means that results will differ at every function "
-             "call. Set 'random_state' to None to silence this "
-             "warning, or to 0 to keep the behavior of versions "
-             "<0.23.")
+    match = "'random_state' has been introduced in 0.23."
     with pytest.warns(FutureWarning, match=match):
         AffinityPropagation().fit(X)
 

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -246,7 +246,7 @@ def test_affinity_propagation_float32():
     assert_array_equal(afp.labels_, expected)
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 def test_affinity_propagation_pairwise_is_deprecated():
     afp = AffinityPropagation(affinity='precomputed')
     msg = r"Attribute _pairwise was deprecated in version 0\.24"

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -269,7 +269,7 @@ def test_n_features_in_(est):
 def test_n_jobs_deprecated(klass, n_jobs):
     # FIXME: remove in 1.0
     depr_msg = ("'n_jobs' was deprecated in version 0.23 and will be removed "
-                "in 1.0.")
+                "in 1.0")
     S, _, _ = make_biclusters((30, 30), 3, noise=0.5, random_state=0)
     est = klass(random_state=0, n_jobs=n_jobs)
 

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -267,9 +267,9 @@ def test_n_features_in_(est):
 @pytest.mark.parametrize("klass", [SpectralBiclustering, SpectralCoclustering])
 @pytest.mark.parametrize("n_jobs", [None, 1])
 def test_n_jobs_deprecated(klass, n_jobs):
-    # FIXME: remove in 0.25
+    # FIXME: remove in 1.0
     depr_msg = ("'n_jobs' was deprecated in version 0.23 and will be removed "
-                "in 0.25.")
+                "in 1.0.")
     S, _, _ = make_biclusters((30, 30), 3, noise=0.5, random_state=0)
     est = klass(random_state=0, n_jobs=n_jobs)
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -856,7 +856,7 @@ def test_result_of_kmeans_equal_in_diff_n_threads():
 def test_precompute_distance_deprecated(precompute_distances):
     # FIXME: remove in 1.0
     depr_msg = ("'precompute_distances' was deprecated in version 0.23 and "
-                "will be removed in 1.0.")
+                "will be removed in 1.0")
     X, _ = make_blobs(n_samples=10, n_features=2, centers=2, random_state=0)
     kmeans = KMeans(n_clusters=2, n_init=1, init='random', random_state=0,
                     precompute_distances=precompute_distances)
@@ -869,7 +869,7 @@ def test_precompute_distance_deprecated(precompute_distances):
 def test_n_jobs_deprecated(n_jobs):
     # FIXME: remove in 1.0
     depr_msg = ("'n_jobs' was deprecated in version 0.23 and will be removed "
-                "in 1.0.")
+                "in 1.0")
     X, _ = make_blobs(n_samples=10, n_features=2, centers=2, random_state=0)
     kmeans = KMeans(n_clusters=2, n_init=1, init='random', random_state=0,
                     n_jobs=n_jobs)
@@ -883,7 +883,7 @@ def test_minibatch_kmeans_deprecated_attributes(attr):
     # check that we raise a deprecation warning when accessing `init_size_`
     # FIXME: remove in 1.1
     depr_msg = (f"The attribute '{attr}' is deprecated in 0.24 and will be "
-                f"removed in 1.1.")
+                f"removed in 1.1")
     km = MiniBatchKMeans(n_clusters=2, n_init=1, init='random', random_state=0)
     km.fit(X)
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -854,9 +854,9 @@ def test_result_of_kmeans_equal_in_diff_n_threads():
 
 @pytest.mark.parametrize("precompute_distances", ["auto", False, True])
 def test_precompute_distance_deprecated(precompute_distances):
-    # FIXME: remove in 0.25
+    # FIXME: remove in 1.0
     depr_msg = ("'precompute_distances' was deprecated in version 0.23 and "
-                "will be removed in 0.25.")
+                "will be removed in 1.0.")
     X, _ = make_blobs(n_samples=10, n_features=2, centers=2, random_state=0)
     kmeans = KMeans(n_clusters=2, n_init=1, init='random', random_state=0,
                     precompute_distances=precompute_distances)
@@ -867,9 +867,9 @@ def test_precompute_distance_deprecated(precompute_distances):
 
 @pytest.mark.parametrize("n_jobs", [None, 1])
 def test_n_jobs_deprecated(n_jobs):
-    # FIXME: remove in 0.25
+    # FIXME: remove in 1.0
     depr_msg = ("'n_jobs' was deprecated in version 0.23 and will be removed "
-                "in 0.25.")
+                "in 1.0.")
     X, _ = make_blobs(n_samples=10, n_features=2, centers=2, random_state=0)
     kmeans = KMeans(n_clusters=2, n_init=1, init='random', random_state=0,
                     n_jobs=n_jobs)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -881,9 +881,9 @@ def test_n_jobs_deprecated(n_jobs):
 @pytest.mark.parametrize("attr", ["counts_", "init_size_", "random_state_"])
 def test_minibatch_kmeans_deprecated_attributes(attr):
     # check that we raise a deprecation warning when accessing `init_size_`
-    # FIXME: remove in 0.26
+    # FIXME: remove in 1.1
     depr_msg = (f"The attribute '{attr}' is deprecated in 0.24 and will be "
-                f"removed in 0.26.")
+                f"removed in 1.1.")
     km = MiniBatchKMeans(n_clusters=2, n_init=1, init='random', random_state=0)
     km.fit(X)
 

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -268,7 +268,7 @@ def test_verbose(assign_labels, capsys):
         assert re.search(r"Iteration [0-9]+, inertia", captured.out)
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 @pytest.mark.parametrize("affinity", ["precomputed",
                                       "precomputed_nearest_neighbors"])
 def test_pairwise_is_deprecated(affinity):

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -607,14 +607,16 @@ class GraphicalLassoCV(GraphicalLasso):
 
         .. deprecated:: 0.24
             The `cv_alphas_` attribute is deprecated in version 0.24 in favor
-            of `cv_results_['alphas']` and will be removed in version 1.1.
+            of `cv_results_['alphas']` and will be removed in version
+            1.1 (renaming of 0.26).
 
     grid_scores_ : ndarray of shape (n_alphas, n_folds)
         Log-likelihood score on left-out data across folds.
 
         .. deprecated:: 0.24
             The `grid_scores_` attribute is deprecated in version 0.24 in favor
-            of `cv_results_` and will be removed in version 1.1.
+            of `cv_results_` and will be removed in version
+            1.1 (renaming of 0.26).
 
     cv_results_ : dict of ndarrays
         A dict with keys:
@@ -832,7 +834,7 @@ class GraphicalLassoCV(GraphicalLasso):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The grid_scores_ attribute is deprecated in version 0.24 in favor "
-        "of cv_results_ and will be removed in version 1.1"
+        "of cv_results_ and will be removed in version 1.1 (renaming of 0.26)."
     )
     @property
     def grid_scores_(self):
@@ -846,7 +848,8 @@ class GraphicalLassoCV(GraphicalLasso):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The cv_alphas_ attribute is deprecated in version 0.24 in favor "
-        "of cv_results_['alpha'] and will be removed in version 1.1"
+        "of cv_results_['alpha'] and will be removed in version 1.1 "
+        "(renaming of 0.26)."
     )
     @property
     def cv_alphas_(self):

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -607,14 +607,14 @@ class GraphicalLassoCV(GraphicalLasso):
 
         .. deprecated:: 0.24
             The `cv_alphas_` attribute is deprecated in version 0.24 in favor
-            of `cv_results_['alphas']` and will be removed in version 0.26.
+            of `cv_results_['alphas']` and will be removed in version 1.1.
 
     grid_scores_ : ndarray of shape (n_alphas, n_folds)
         Log-likelihood score on left-out data across folds.
 
         .. deprecated:: 0.24
             The `grid_scores_` attribute is deprecated in version 0.24 in favor
-            of `cv_results_` and will be removed in version 0.26.
+            of `cv_results_` and will be removed in version 1.1.
 
     cv_results_ : dict of ndarrays
         A dict with keys:
@@ -828,11 +828,11 @@ class GraphicalLassoCV(GraphicalLasso):
             verbose=inner_verbose, return_n_iter=True)
         return self
 
-    # TODO: Remove in 0.26 when grid_scores_ is deprecated
+    # TODO: Remove in 1.1 when grid_scores_ is deprecated
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The grid_scores_ attribute is deprecated in version 0.24 in favor "
-        "of cv_results_ and will be removed in version 0.26"
+        "of cv_results_ and will be removed in version 1.1"
     )
     @property
     def grid_scores_(self):
@@ -842,11 +842,11 @@ class GraphicalLassoCV(GraphicalLasso):
             [self.cv_results_["split{}_score".format(i)]
              for i in range(n_alphas)]).T
 
-    # TODO: Remove in 0.26 when cv_alphas_ is deprecated
+    # TODO: Remove in 1.1 when cv_alphas_ is deprecated
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The cv_alphas_ attribute is deprecated in version 0.24 in favor "
-        "of cv_results_['alpha'] and will be removed in version 0.26"
+        "of cv_results_['alpha'] and will be removed in version 1.1"
     )
     @property
     def cv_alphas_(self):

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -152,7 +152,7 @@ def test_graphical_lasso_cv(random_state=1):
     GraphicalLassoCV(alphas=[0.8, 0.5], tol=1e-1, n_jobs=1).fit(X)
 
 
-# TODO: Remove in 0.26 when grid_scores_ is deprecated
+# TODO: Remove in 1.1 when grid_scores_ is deprecated
 def test_graphical_lasso_cv_grid_scores_and_cv_alphas_deprecated():
     splits = 4
     n_alphas = 5

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -169,13 +169,13 @@ def test_graphical_lasso_cv_grid_scores_and_cv_alphas_deprecated():
     total_alphas = n_refinements * n_alphas + 1
     msg = (r"The grid_scores_ attribute is deprecated in version 0\.24 in "
            r"favor of cv_results_ and will be removed in version 1\.1 "
-           r"(renaming of 0\.25)")
+           r"\(renaming of 0\.26\).")
     with pytest.warns(FutureWarning, match=msg):
         assert cov.grid_scores_.shape == (total_alphas, splits)
 
     msg = (r"The cv_alphas_ attribute is deprecated in version 0\.24 in "
            r"favor of cv_results_\['alpha'\] and will be removed in version "
-           r"1\.1 (renaming of 0\.26)")
+           r"1\.1 \(renaming of 0\.26\)")
     with pytest.warns(FutureWarning, match=msg):
         assert len(cov.cv_alphas_) == total_alphas
 

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -168,13 +168,14 @@ def test_graphical_lasso_cv_grid_scores_and_cv_alphas_deprecated():
 
     total_alphas = n_refinements * n_alphas + 1
     msg = (r"The grid_scores_ attribute is deprecated in version 0\.24 in "
-           r"favor of cv_results_ and will be removed in version 1\.1")
+           r"favor of cv_results_ and will be removed in version 1\.1 "
+           r"(renaming of 0\.25)")
     with pytest.warns(FutureWarning, match=msg):
         assert cov.grid_scores_.shape == (total_alphas, splits)
 
     msg = (r"The cv_alphas_ attribute is deprecated in version 0\.24 in "
            r"favor of cv_results_\['alpha'\] and will be removed in version "
-           r"1\.1")
+           r"1\.1 (renaming of 0\.26)")
     with pytest.warns(FutureWarning, match=msg):
         assert len(cov.cv_alphas_) == total_alphas
 

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -168,13 +168,13 @@ def test_graphical_lasso_cv_grid_scores_and_cv_alphas_deprecated():
 
     total_alphas = n_refinements * n_alphas + 1
     msg = (r"The grid_scores_ attribute is deprecated in version 0\.24 in "
-           r"favor of cv_results_ and will be removed in version 0\.26")
+           r"favor of cv_results_ and will be removed in version 1\.1")
     with pytest.warns(FutureWarning, match=msg):
         assert cov.grid_scores_.shape == (total_alphas, splits)
 
     msg = (r"The cv_alphas_ attribute is deprecated in version 0\.24 in "
            r"favor of cv_results_\['alpha'\] and will be removed in version "
-           r"0\.26")
+           r"1\.1")
     with pytest.warns(FutureWarning, match=msg):
         assert len(cov.cv_alphas_) == total_alphas
 

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -408,35 +408,35 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute norm_y_weights was deprecated in version 0.24 and "
-        "will be removed in 1.1.")
+        "will be removed in 1.1 (renaming of 0.26).")
     @property
     def norm_y_weights(self):
         return self._norm_y_weights
 
     @deprecated(  # type: ignore
         "Attribute x_mean_ was deprecated in version 0.24 and "
-        "will be removed in 1.1.")
+        "will be removed in 1.1 (renaming of 0.26).")
     @property
     def x_mean_(self):
         return self._x_mean
 
     @deprecated(  # type: ignore
         "Attribute y_mean_ was deprecated in version 0.24 and "
-        "will be removed in 1.1.")
+        "will be removed in 1.1 (renaming of 0.26).")
     @property
     def y_mean_(self):
         return self._y_mean
 
     @deprecated(  # type: ignore
         "Attribute x_std_ was deprecated in version 0.24 and "
-        "will be removed in 1.1.")
+        "will be removed in 1.1 (renaming of 0.26).")
     @property
     def x_std_(self):
         return self._x_std
 
     @deprecated(  # type: ignore
         "Attribute y_std_ was deprecated in version 0.24 and "
-        "will be removed in 1.1.")
+        "will be removed in 1.1 (renaming of 0.26).")
     @property
     def y_std_(self):
         return self._y_std
@@ -627,15 +627,17 @@ class PLSCanonical(_PLS):
         The transformed training samples.
 
         .. deprecated:: 0.24
-           `x_scores_` is deprecated in 0.24 and will be removed in 1.1. You
-           can just call `transform` on the training data instead.
+           `x_scores_` is deprecated in 0.24 and will be removed in 1.1
+           (renaming of 0.26). You can just call `transform` on the training
+           data instead.
 
     y_scores_ : ndarray of shape (n_samples, n_components)
         The transformed training targets.
 
         .. deprecated:: 0.24
-           `y_scores_` is deprecated in 0.24 and will be removed in 1.1. You
-           can just call `transform` on the training data instead.
+           `y_scores_` is deprecated in 0.24 and will be removed in 1.1
+           (renaming of 0.26). You can just call `transform` on the training
+           data instead.
 
     x_rotations_ : ndarray of shape (n_features, n_components)
         The projection matrix used to transform `X`.
@@ -737,15 +739,17 @@ class CCA(_PLS):
         The transformed training samples.
 
         .. deprecated:: 0.24
-           `x_scores_` is deprecated in 0.24 and will be removed in 1.1. You
-           can just call `transform` on the training data instead.
+           `x_scores_` is deprecated in 0.24 and will be removed in 1.1
+           (renaming of 0.26). You can just call `transform` on the training
+           data instead.
 
     y_scores_ : ndarray of shape (n_samples, n_components)
         The transformed training targets.
 
         .. deprecated:: 0.24
-           `y_scores_` is deprecated in 0.24 and will be removed in 1.1. You
-           can just call `transform` on the training data instead.
+           `y_scores_` is deprecated in 0.24 and will be removed in 1.1
+           (renaming of 0.26). You can just call `transform` on the training
+           data instead.
 
     x_rotations_ : ndarray of shape (n_features, n_components)
         The projection matrix used to transform `X`.
@@ -826,15 +830,17 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         The transformed training samples.
 
         .. deprecated:: 0.24
-           `x_scores_` is deprecated in 0.24 and will be removed in 1.1. You
-           can just call `transform` on the training data instead.
+           `x_scores_` is deprecated in 0.24 and will be removed in 1.1
+           (renaming of 0.26). You can just call `transform` on the training
+           data instead.
 
     y_scores_ : ndarray of shape (n_samples, n_components)
         The transformed training targets.
 
         .. deprecated:: 0.24
-           `y_scores_` is deprecated in 0.24 and will be removed in 1.1. You
-           can just call `transform` on the training data instead.
+           `y_scores_` is deprecated in 0.24 and will be removed in 1.1
+           (renaming of 0.26). You can just call `transform` on the training
+           data instead.
 
     Examples
     --------
@@ -919,8 +925,9 @@ class PLSSVD(TransformerMixin, BaseEstimator):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute x_scores_ was deprecated in version 0.24 and "
-        "will be removed in 1.1. Use est.transform(X) on the "
-        "training data instead.")
+        "will be removed in 1.1 (renaming of 0.26). Use est.transform(X) on "
+        "the training data instead."
+    )
     @property
     def x_scores_(self):
         return self._x_scores
@@ -928,36 +935,37 @@ class PLSSVD(TransformerMixin, BaseEstimator):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute y_scores_ was deprecated in version 0.24 and "
-        "will be removed in 1.1. Use est.transform(X, Y) on the "
-        "training data instead.")
+        "will be removed in 1.1 (renaming of 0.26). Use est.transform(X, Y) "
+        "on the training data instead."
+    )
     @property
     def y_scores_(self):
         return self._y_scores
 
     @deprecated(  # type: ignore
         "Attribute x_mean_ was deprecated in version 0.24 and "
-        "will be removed in 1.1.")
+        "will be removed in 1.1 (renaming of 0.26).")
     @property
     def x_mean_(self):
         return self._x_mean
 
     @deprecated(  # type: ignore
         "Attribute y_mean_ was deprecated in version 0.24 and "
-        "will be removed in 1.1.")
+        "will be removed in 1.1 (renaming of 0.26).")
     @property
     def y_mean_(self):
         return self._y_mean
 
     @deprecated(  # type: ignore
         "Attribute x_std_ was deprecated in version 0.24 and "
-        "will be removed in 1.1.")
+        "will be removed in 1.1 (renaming of 0.26).")
     @property
     def x_std_(self):
         return self._x_std
 
     @deprecated(  # type: ignore
         "Attribute y_std_ was deprecated in version 0.24 and "
-        "will be removed in 1.1.")
+        "will be removed in 1.1 (renaming of 0.26).")
     @property
     def y_std_(self):
         return self._y_std

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -181,12 +181,12 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
             # see Wegelin page 25
             rank_upper_bound = p
             if not 1 <= n_components <= rank_upper_bound:
-                # TODO: raise an error in 0.26
+                # TODO: raise an error in 1.1
                 warnings.warn(
                     f"As of version 0.24, n_components({n_components}) should "
                     f"be in [1, n_features]."
                     f"n_components={rank_upper_bound} will be used instead. "
-                    f"In version 0.26, an error will be raised.",
+                    f"In version 1.1, an error will be raised.",
                     FutureWarning
                 )
                 n_components = rank_upper_bound
@@ -195,13 +195,13 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
             # X and the rank of Y: see Wegelin page 12
             rank_upper_bound = min(n, p, q)
             if not 1 <= self.n_components <= rank_upper_bound:
-                # TODO: raise an error in 0.26
+                # TODO: raise an error in 1.1
                 warnings.warn(
                     f"As of version 0.24, n_components({n_components}) should "
                     f"be in [1, min(n_features, n_samples, n_targets)] = "
                     f"[1, {rank_upper_bound}]. "
                     f"n_components={rank_upper_bound} will be used instead. "
-                    f"In version 0.26, an error will be raised.",
+                    f"In version 1.1, an error will be raised.",
                     FutureWarning
                 )
                 n_components = rank_upper_bound
@@ -210,7 +210,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
             raise ValueError("algorithm should be 'svd' or 'nipals', got "
                              f"{self.algorithm}.")
 
-        self._norm_y_weights = (self.deflation_mode == 'canonical')  # 0.26
+        self._norm_y_weights = (self.deflation_mode == 'canonical')  # 1.1
         norm_y_weights = self._norm_y_weights
 
         # Scale (in place)
@@ -406,47 +406,47 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute norm_y_weights was deprecated in version 0.24 and "
-        "will be removed in 0.26.")
+        "will be removed in 1.1.")
     @property
     def norm_y_weights(self):
         return self._norm_y_weights
 
     @deprecated(  # type: ignore
         "Attribute x_mean_ was deprecated in version 0.24 and "
-        "will be removed in 0.26.")
+        "will be removed in 1.1.")
     @property
     def x_mean_(self):
         return self._x_mean
 
     @deprecated(  # type: ignore
         "Attribute y_mean_ was deprecated in version 0.24 and "
-        "will be removed in 0.26.")
+        "will be removed in 1.1.")
     @property
     def y_mean_(self):
         return self._y_mean
 
     @deprecated(  # type: ignore
         "Attribute x_std_ was deprecated in version 0.24 and "
-        "will be removed in 0.26.")
+        "will be removed in 1.1.")
     @property
     def x_std_(self):
         return self._x_std
 
     @deprecated(  # type: ignore
         "Attribute y_std_ was deprecated in version 0.24 and "
-        "will be removed in 0.26.")
+        "will be removed in 1.1.")
     @property
     def y_std_(self):
         return self._y_std
 
     @property
     def x_scores_(self):
-        # TODO: raise error in 0.26 instead
+        # TODO: raise error in 1.1 instead
         if not isinstance(self, PLSRegression):
             pass
             warnings.warn(
                 "Attribute x_scores_ was deprecated in version 0.24 and "
-                "will be removed in 0.26. Use est.transform(X) on the "
+                "will be removed in 1.1. Use est.transform(X) on the "
                 "training data instead.",
                 FutureWarning
             )
@@ -454,11 +454,11 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
 
     @property
     def y_scores_(self):
-        # TODO: raise error in 0.26 instead
+        # TODO: raise error in 1.1 instead
         if not isinstance(self, PLSRegression):
             warnings.warn(
                 "Attribute y_scores_ was deprecated in version 0.24 and "
-                "will be removed in 0.26. Use est.transform(X) on the "
+                "will be removed in 1.1. Use est.transform(X) on the "
                 "training data instead.",
                 FutureWarning
             )
@@ -625,14 +625,14 @@ class PLSCanonical(_PLS):
         The transformed training samples.
 
         .. deprecated:: 0.24
-           `x_scores_` is deprecated in 0.24 and will be removed in 0.26. You
+           `x_scores_` is deprecated in 0.24 and will be removed in 1.1. You
            can just call `transform` on the training data instead.
 
     y_scores_ : ndarray of shape (n_samples, n_components)
         The transformed training targets.
 
         .. deprecated:: 0.24
-           `y_scores_` is deprecated in 0.24 and will be removed in 0.26. You
+           `y_scores_` is deprecated in 0.24 and will be removed in 1.1. You
            can just call `transform` on the training data instead.
 
     x_rotations_ : ndarray of shape (n_features, n_components)
@@ -735,14 +735,14 @@ class CCA(_PLS):
         The transformed training samples.
 
         .. deprecated:: 0.24
-           `x_scores_` is deprecated in 0.24 and will be removed in 0.26. You
+           `x_scores_` is deprecated in 0.24 and will be removed in 1.1. You
            can just call `transform` on the training data instead.
 
     y_scores_ : ndarray of shape (n_samples, n_components)
         The transformed training targets.
 
         .. deprecated:: 0.24
-           `y_scores_` is deprecated in 0.24 and will be removed in 0.26. You
+           `y_scores_` is deprecated in 0.24 and will be removed in 1.1. You
            can just call `transform` on the training data instead.
 
     x_rotations_ : ndarray of shape (n_features, n_components)
@@ -824,14 +824,14 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         The transformed training samples.
 
         .. deprecated:: 0.24
-           `x_scores_` is deprecated in 0.24 and will be removed in 0.26. You
+           `x_scores_` is deprecated in 0.24 and will be removed in 1.1. You
            can just call `transform` on the training data instead.
 
     y_scores_ : ndarray of shape (n_samples, n_components)
         The transformed training targets.
 
         .. deprecated:: 0.24
-           `y_scores_` is deprecated in 0.24 and will be removed in 0.26. You
+           `y_scores_` is deprecated in 0.24 and will be removed in 1.1. You
            can just call `transform` on the training data instead.
 
     Examples
@@ -886,13 +886,13 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         n_components = self.n_components
         rank_upper_bound = min(X.shape[0], X.shape[1], Y.shape[1])
         if not 1 <= n_components <= rank_upper_bound:
-            # TODO: raise an error in 0.26
+            # TODO: raise an error in 1.1
             warnings.warn(
                 f"As of version 0.24, n_components({n_components}) should be "
                 f"in [1, min(n_features, n_samples, n_targets)] = "
                 f"[1, {rank_upper_bound}]. "
                 f"n_components={rank_upper_bound} will be used instead. "
-                f"In version 0.26, an error will be raised.",
+                f"In version 1.1, an error will be raised.",
                 FutureWarning
             )
             n_components = rank_upper_bound
@@ -908,8 +908,8 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         U, Vt = svd_flip(U, Vt)
         V = Vt.T
 
-        self._x_scores = np.dot(X, U)  # TODO: remove in 0.26
-        self._y_scores = np.dot(Y, V)  # TODO: remove in 0.26
+        self._x_scores = np.dot(X, U)  # TODO: remove in 1.1
+        self._y_scores = np.dot(Y, V)  # TODO: remove in 1.1
         self.x_weights_ = U
         self.y_weights_ = V
         return self
@@ -917,7 +917,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute x_scores_ was deprecated in version 0.24 and "
-        "will be removed in 0.26. Use est.transform(X) on the "
+        "will be removed in 1.1. Use est.transform(X) on the "
         "training data instead.")
     @property
     def x_scores_(self):
@@ -926,7 +926,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute y_scores_ was deprecated in version 0.24 and "
-        "will be removed in 0.26. Use est.transform(X, Y) on the "
+        "will be removed in 1.1. Use est.transform(X, Y) on the "
         "training data instead.")
     @property
     def y_scores_(self):
@@ -934,28 +934,28 @@ class PLSSVD(TransformerMixin, BaseEstimator):
 
     @deprecated(  # type: ignore
         "Attribute x_mean_ was deprecated in version 0.24 and "
-        "will be removed in 0.26.")
+        "will be removed in 1.1.")
     @property
     def x_mean_(self):
         return self._x_mean
 
     @deprecated(  # type: ignore
         "Attribute y_mean_ was deprecated in version 0.24 and "
-        "will be removed in 0.26.")
+        "will be removed in 1.1.")
     @property
     def y_mean_(self):
         return self._y_mean
 
     @deprecated(  # type: ignore
         "Attribute x_std_ was deprecated in version 0.24 and "
-        "will be removed in 0.26.")
+        "will be removed in 1.1.")
     @property
     def x_std_(self):
         return self._x_std
 
     @deprecated(  # type: ignore
         "Attribute y_std_ was deprecated in version 0.24 and "
-        "will be removed in 0.26.")
+        "will be removed in 1.1.")
     @property
     def y_std_(self):
         return self._y_std

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -186,7 +186,8 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
                     f"As of version 0.24, n_components({n_components}) should "
                     f"be in [1, n_features]."
                     f"n_components={rank_upper_bound} will be used instead. "
-                    f"In version 1.1, an error will be raised.",
+                    f"In version 1.1 (renaming of 0.26), an error will be "
+                    f"raised.",
                     FutureWarning
                 )
                 n_components = rank_upper_bound
@@ -201,7 +202,8 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
                     f"be in [1, min(n_features, n_samples, n_targets)] = "
                     f"[1, {rank_upper_bound}]. "
                     f"n_components={rank_upper_bound} will be used instead. "
-                    f"In version 1.1, an error will be raised.",
+                    f"In version 1.1 (renaming of 0.26), an error will be "
+                    f"raised.",
                     FutureWarning
                 )
                 n_components = rank_upper_bound
@@ -446,8 +448,8 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
             pass
             warnings.warn(
                 "Attribute x_scores_ was deprecated in version 0.24 and "
-                "will be removed in 1.1. Use est.transform(X) on the "
-                "training data instead.",
+                "will be removed in 1.1 (renaming of 0.26). Use "
+                "est.transform(X) on the training data instead.",
                 FutureWarning
             )
         return self._x_scores
@@ -458,8 +460,8 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
         if not isinstance(self, PLSRegression):
             warnings.warn(
                 "Attribute y_scores_ was deprecated in version 0.24 and "
-                "will be removed in 1.1. Use est.transform(X) on the "
-                "training data instead.",
+                "will be removed in 1.1 (renaming of 0.26). Use "
+                "est.transform(X) on the training data instead.",
                 FutureWarning
             )
         return self._y_scores
@@ -892,7 +894,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
                 f"in [1, min(n_features, n_samples, n_targets)] = "
                 f"[1, {rank_upper_bound}]. "
                 f"n_components={rank_upper_bound} will be used instead. "
-                f"In version 1.1, an error will be raised.",
+                f"In version 1.1 (renaming of 0.26), an error will be raised.",
                 FutureWarning
             )
             n_components = rank_upper_bound

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -315,7 +315,7 @@ def test_convergence_fail():
         pls_nipals.fit(X, Y)
 
 
-@pytest.mark.filterwarnings('ignore:.*scores_ was deprecated')  # 0.26
+@pytest.mark.filterwarnings('ignore:.*scores_ was deprecated')  # 1.1
 @pytest.mark.parametrize('Est', (PLSSVD, PLSRegression, PLSCanonical))
 def test_attibutes_shapes(Est):
     # Make sure attributes are of the correct shape depending on n_components
@@ -439,7 +439,7 @@ def test_scale_and_stability(Est, X, Y):
 @pytest.mark.parametrize('n_components', (0, 4))
 def test_n_components_bounds(Est, n_components):
     # n_components should be in [1, min(n_samples, n_features, n_targets)]
-    # TODO: catch error instead of warning in 0.26
+    # TODO: catch error instead of warning in 1.1
     rng = np.random.RandomState(0)
     X = rng.randn(10, 5)
     Y = rng.randn(10, 3)
@@ -454,7 +454,7 @@ def test_n_components_bounds(Est, n_components):
 @pytest.mark.parametrize('n_components', (0, 6))
 def test_n_components_bounds_pls_regression(n_components):
     # For PLSRegression, the upper bound for n_components is n_features
-    # TODO: catch error instead of warning in 0.26
+    # TODO: catch error instead of warning in 1.1
     rng = np.random.RandomState(0)
     X = rng.randn(10, 5)
     Y = rng.randn(10, 3)
@@ -471,7 +471,7 @@ def test_scores_deprecations(Est):
     # Make sure x_scores_ and y_scores_ are deprecated.
     # It's not deprecated for PLSRegression because y_score_ is different from
     # transform(Y_train)
-    # TODO: remove attributes and test in 0.26
+    # TODO: remove attributes and test in 1.1
     rng = np.random.RandomState(0)
     X = rng.randn(10, 5)
     Y = rng.randn(10, 3)
@@ -492,7 +492,7 @@ def test_norm_y_weights_deprecation(Est):
         est.norm_y_weights
 
 
-# TODO: Remove test in 0.26
+# TODO: Remove test in 1.1
 @pytest.mark.parametrize('Estimator',
                          (PLSRegression, PLSCanonical, CCA, PLSSVD))
 @pytest.mark.parametrize('attribute',

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1024,7 +1024,7 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
         The unchanged dictionary atoms.
 
         .. deprecated:: 0.24
-           This attribute is deprecated in 0.24 and will be removed in 0.26.
+           This attribute is deprecated in 0.24 and will be removed in 1.1.
            Use `dictionary` instead.
 
     Examples
@@ -1089,7 +1089,7 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
         return self
 
     @deprecated("The attribute 'components_' is deprecated "  # type: ignore
-                "in 0.24 and will be removed in 0.26. Use the "
+                "in 0.24 and will be removed in 1.1. Use the "
                 "'dictionary' instead.")
     @property
     def components_(self):

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1024,8 +1024,8 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
         The unchanged dictionary atoms.
 
         .. deprecated:: 0.24
-           This attribute is deprecated in 0.24 and will be removed in 1.1.
-           Use `dictionary` instead.
+           This attribute is deprecated in 0.24 and will be removed in
+           1.1 (renaming of 0.26). Use `dictionary` instead.
 
     Examples
     --------
@@ -1089,8 +1089,8 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
         return self
 
     @deprecated("The attribute 'components_' is deprecated "  # type: ignore
-                "in 0.24 and will be removed in 1.1. Use the "
-                "'dictionary' instead.")
+                "in 0.24 and will be removed in 1.1 (renaming of 0.26). Use "
+                "the 'dictionary' instead.")
     @property
     def components_(self):
         return self.dictionary

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -167,10 +167,10 @@ class KernelPCA(TransformerMixin, BaseEstimator):
         self.n_jobs = n_jobs
         self.copy_X = copy_X
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         return self.kernel == "precomputed"

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -170,7 +170,7 @@ class KernelPCA(TransformerMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         return self.kernel == "precomputed"

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -312,7 +312,7 @@ def _initialize_nmf(X, n_components, init='warn', eps=1e-6,
         warnings.warn(("The 'init' value, when 'init=None' and "
                        "n_components is less than n_samples and "
                        "n_features, will be changed from 'nndsvd' to "
-                       "'nndsvda' in 1.1."), FutureWarning)
+                       "'nndsvda' in 1.1 (renaming of 0.26)."), FutureWarning)
         init = None
 
     check_non_negative(X, "NMF initialization")

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -312,7 +312,7 @@ def _initialize_nmf(X, n_components, init='warn', eps=1e-6,
         warnings.warn(("The 'init' value, when 'init=None' and "
                        "n_components is less than n_samples and "
                        "n_features, will be changed from 'nndsvd' to "
-                       "'nndsvda' in 0.26."), FutureWarning)
+                       "'nndsvda' in 1.1."), FutureWarning)
         init = None
 
     check_non_negative(X, "NMF initialization")

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -557,7 +557,7 @@ def test_sparse_coder_common_transformer():
     check_transformers_unfitted(sc.__class__.__name__, sc)
 
 
-# TODO: remove in 0.26
+# TODO: remove in 1.1
 def test_sparse_coder_deprecation():
     # check that we raise a deprecation warning when accessing `components_`
     rng = np.random.RandomState(777)

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -316,7 +316,7 @@ def test_32_64_decomposition_shape():
             kpca.fit_transform(X.astype(np.float32)).shape)
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 def test_kernel_pcc_pairwise_is_deprecated():
     kp = KernelPCA(kernel='precomputed')
     msg = r"Attribute _pairwise was deprecated in version 0\.24"

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -42,7 +42,7 @@ def test_initialize_nn_output():
 def test_parameter_checking():
     A = np.ones((2, 2))
     name = 'spam'
-    # FIXME : should be removed in 0.26
+    # FIXME : should be removed in 1.1
     init = 'nndsvda'
     msg = "Invalid solver parameter: got 'spam' instead of one of"
     assert_raise_message(ValueError, msg, NMF(solver=name, init=init).fit, A)
@@ -179,7 +179,7 @@ def test_n_components_greater_n_features():
     # Smoke test for the case of more components than features.
     rng = np.random.mtrand.RandomState(42)
     A = np.abs(rng.randn(30, 10))
-    # FIXME : should be removed in 0.26
+    # FIXME : should be removed in 1.1
     init = 'random'
     NMF(n_components=15, random_state=0, tol=1e-2, init=init).fit(A)
 
@@ -441,7 +441,7 @@ def test_nmf_regularization():
     rng = np.random.mtrand.RandomState(42)
     X = np.abs(rng.randn(n_samples, n_features))
 
-    # FIXME : should be removed in 0.26
+    # FIXME : should be removed in 1.1
     init = 'nndsvda'
     # L1 regularization should increase the number of zeros
     l1_ratio = 1.
@@ -552,7 +552,7 @@ def test_nmf_dtype_match(dtype_in, dtype_out, solver, regularization):
     # Check that NMF preserves dtype (float32 and float64)
     X = np.random.RandomState(0).randn(20, 15).astype(dtype_in, copy=False)
     np.abs(X, out=X)
-    # FIXME : should be removed in 0.26
+    # FIXME : should be removed in 1.1
     init = 'nndsvda'
     nmf = NMF(solver=solver, regularization=regularization, init=init)
 
@@ -568,7 +568,7 @@ def test_nmf_float32_float64_consistency(solver, regularization):
     # Check that the result of NMF is the same between float32 and float64
     X = np.random.RandomState(0).randn(50, 7)
     np.abs(X, out=X)
-    # FIXME : should be removed in 0.26
+    # FIXME : should be removed in 1.1
     init = 'nndsvda'
     nmf32 = NMF(solver=solver, regularization=regularization, random_state=0,
                 init=init)
@@ -595,13 +595,13 @@ def test_nmf_custom_init_dtype_error():
         non_negative_factorization(X, H=H, update_H=False)
 
 
-# FIXME : should be removed in 0.26
+# FIXME : should be removed in 1.1
 def test_init_default_deprecation():
     # Test FutureWarning on init default
     msg = ("The 'init' value, when 'init=None' and "
            "n_components is less than n_samples and "
            "n_features, will be changed from 'nndsvd' to "
-           "'nndsvda' in 0.26.")
+           "'nndsvda' in 1.1.")
     rng = np.random.mtrand.RandomState(42)
     A = np.abs(rng.randn(6, 5))
     with pytest.warns(FutureWarning, match=msg):

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -601,7 +601,7 @@ def test_init_default_deprecation():
     msg = ("The 'init' value, when 'init=None' and "
            "n_components is less than n_samples and "
            "n_features, will be changed from 'nndsvd' to "
-           "'nndsvda' in 1.1.")
+           "'nndsvda' in 1.1 (renaming of 0.26).")
     rng = np.random.mtrand.RandomState(42)
     A = np.abs(rng.randn(6, 5))
     with pytest.warns(FutureWarning, match=msg):

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -598,10 +598,10 @@ def test_nmf_custom_init_dtype_error():
 # FIXME : should be removed in 1.1
 def test_init_default_deprecation():
     # Test FutureWarning on init default
-    msg = ("The 'init' value, when 'init=None' and "
-           "n_components is less than n_samples and "
-           "n_features, will be changed from 'nndsvd' to "
-           "'nndsvda' in 1.1 (renaming of 0.26).")
+    msg = (r"The 'init' value, when 'init=None' and "
+           r"n_components is less than n_samples and "
+           r"n_features, will be changed from 'nndsvd' to "
+           r"'nndsvda' in 1.1 \(renaming of 0.26\).")
     rng = np.random.mtrand.RandomState(42)
     A = np.abs(rng.randn(6, 5))
     with pytest.warns(FutureWarning, match=msg):

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -991,8 +991,8 @@ class RandomForestClassifier(ForestClassifier):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
-
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     bootstrap : bool, default=True
         Whether bootstrap samples are used when building trees. If False, the
@@ -1314,7 +1314,8 @@ class RandomForestRegressor(ForestRegressor):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     bootstrap : bool, default=True
         Whether bootstrap samples are used when building trees. If False, the
@@ -1596,7 +1597,8 @@ class ExtraTreesClassifier(ForestClassifier):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     bootstrap : bool, default=False
         Whether bootstrap samples are used when building trees. If False, the
@@ -1914,7 +1916,8 @@ class ExtraTreesRegressor(ForestRegressor):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     bootstrap : bool, default=False
         Whether bootstrap samples are used when building trees. If False, the
@@ -2173,7 +2176,8 @@ class RandomTreesEmbedding(BaseForest):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     sparse_output : bool, default=True
         Whether or not to return a sparse CSR matrix, as default behavior,

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -991,7 +991,7 @@ class RandomForestClassifier(ForestClassifier):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
 
     bootstrap : bool, default=True
@@ -1314,7 +1314,7 @@ class RandomForestRegressor(ForestRegressor):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     bootstrap : bool, default=True
         Whether bootstrap samples are used when building trees. If False, the
@@ -1596,7 +1596,7 @@ class ExtraTreesClassifier(ForestClassifier):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     bootstrap : bool, default=False
         Whether bootstrap samples are used when building trees. If False, the
@@ -1914,7 +1914,7 @@ class ExtraTreesRegressor(ForestRegressor):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     bootstrap : bool, default=False
         Whether bootstrap samples are used when building trees. If False, the
@@ -2173,7 +2173,7 @@ class RandomTreesEmbedding(BaseForest):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     sparse_output : bool, default=True
         Whether or not to return a sparse CSR matrix, as default behavior,

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -398,7 +398,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         self : object
         """
         if self.criterion == 'mae':
-            # TODO: This should raise an error from 0.26
+            # TODO: This should raise an error from 1.1
             self._warn_mae_for_criterion()
 
         # if not warmstart - clear the estimator state
@@ -812,7 +812,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         .. versionadded:: 0.18
         .. deprecated:: 0.24
             `criterion='mae'` is deprecated and will be removed in version
-            0.26. Use `criterion='friedman_mse'` or `'mse'` instead, as trees
+            1.1. Use `criterion='friedman_mse'` or `'mse'` instead, as trees
             should use a least-square criterion in Gradient Boosting.
 
     min_samples_split : int or float, default=2
@@ -1112,9 +1112,9 @@ shape (n_estimators, ``loss_.K``)
         return y
 
     def _warn_mae_for_criterion(self):
-        # TODO: This should raise an error from 0.26
+        # TODO: This should raise an error from 1.1
         warnings.warn("criterion='mae' was deprecated in version 0.24 and "
-                      "will be removed in version 0.26. Use "
+                      "will be removed in version 1.1. Use "
                       "criterion='friedman_mse' or 'mse' instead, as trees "
                       "should use a least-square criterion in Gradient "
                       "Boosting.", FutureWarning)
@@ -1339,7 +1339,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         .. versionadded:: 0.18
         .. deprecated:: 0.24
             `criterion='mae'` is deprecated and will be removed in version
-            0.26. The correct way of minimizing the absolute error is to use
+            1.1. The correct way of minimizing the absolute error is to use
             `loss='lad'` instead.
 
     min_samples_split : int or float, default=2
@@ -1535,7 +1535,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
 
         .. deprecated:: 0.24
             Attribute ``n_classes_`` was deprecated in version 0.24 and
-            will be removed in 0.26.
+            will be removed in 1.1.
 
     n_estimators_ : int
         The number of estimators as selected by early stopping (if
@@ -1623,9 +1623,9 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         return y
 
     def _warn_mae_for_criterion(self):
-        # TODO: This should raise an error from 0.26
+        # TODO: This should raise an error from 1.1
         warnings.warn("criterion='mae' was deprecated in version 0.24 and "
-                      "will be removed in version 0.26. The correct way of "
+                      "will be removed in version 1.1. The correct way of "
                       "minimizing the absolute error is to use loss='lad' "
                       "instead.", FutureWarning)
 
@@ -1692,10 +1692,10 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         leaves = leaves.reshape(X.shape[0], self.estimators_.shape[0])
         return leaves
 
-    # FIXME: to be removed in 0.26
+    # FIXME: to be removed in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute n_classes_ was deprecated "  # type: ignore
-                "in version 0.24 and will be removed in 0.26.")
+                "in version 0.24 and will be removed in 1.1.")
     @property
     def n_classes_(self):
         try:

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1114,7 +1114,7 @@ shape (n_estimators, ``loss_.K``)
     def _warn_mae_for_criterion(self):
         # TODO: This should raise an error from 1.1
         warnings.warn("criterion='mae' was deprecated in version 0.24 and "
-                      "will be removed in version 1.1. Use "
+                      "will be removed in version 1.1 (renaming of 0.26). Use "
                       "criterion='friedman_mse' or 'mse' instead, as trees "
                       "should use a least-square criterion in Gradient "
                       "Boosting.", FutureWarning)
@@ -1625,9 +1625,9 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     def _warn_mae_for_criterion(self):
         # TODO: This should raise an error from 1.1
         warnings.warn("criterion='mae' was deprecated in version 0.24 and "
-                      "will be removed in version 1.1. The correct way of "
-                      "minimizing the absolute error is to use loss='lad' "
-                      "instead.", FutureWarning)
+                      "will be removed in version 1.1 (renaming of 0.26). The "
+                      "correct way of minimizing the absolute error is to use "
+                      " loss='lad' instead.", FutureWarning)
 
     def predict(self, X):
         """Predict regression target for X.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -878,7 +878,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     init : estimator or 'zero', default=None
         An estimator object that is used to compute the initial predictions.
@@ -1405,7 +1405,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     init : estimator or 'zero', default=None
         An estimator object that is used to compute the initial predictions.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -812,8 +812,9 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         .. versionadded:: 0.18
         .. deprecated:: 0.24
             `criterion='mae'` is deprecated and will be removed in version
-            1.1. Use `criterion='friedman_mse'` or `'mse'` instead, as trees
-            should use a least-square criterion in Gradient Boosting.
+            1.1 (renaming of 0.26). Use `criterion='friedman_mse'` or `'mse'`
+            instead, as trees should use a least-square criterion in
+            Gradient Boosting.
 
     min_samples_split : int or float, default=2
         The minimum number of samples required to split an internal node:
@@ -878,7 +879,8 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     init : estimator or 'zero', default=None
         An estimator object that is used to compute the initial predictions.
@@ -1339,8 +1341,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         .. versionadded:: 0.18
         .. deprecated:: 0.24
             `criterion='mae'` is deprecated and will be removed in version
-            1.1. The correct way of minimizing the absolute error is to use
-            `loss='lad'` instead.
+            1.1 (renaming of 0.26). The correct way of minimizing the absolute
+            error is to use `loss='lad'` instead.
 
     min_samples_split : int or float, default=2
         The minimum number of samples required to split an internal node:
@@ -1405,7 +1407,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     init : estimator or 'zero', default=None
         An estimator object that is used to compute the initial predictions.
@@ -1535,7 +1538,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
 
         .. deprecated:: 0.24
             Attribute ``n_classes_`` was deprecated in version 0.24 and
-            will be removed in 1.1.
+            will be removed in 1.1 (renaming of 0.26).
 
     n_estimators_ : int
         The number of estimators as selected by early stopping (if
@@ -1695,7 +1698,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     # FIXME: to be removed in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute n_classes_ was deprecated "  # type: ignore
-                "in version 0.24 and will be removed in 1.1.")
+                "in version 0.24 and will be removed in 1.1 "
+                "(renaming of 0.26).")
     @property
     def n_classes_(self):
         try:

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1344,6 +1344,6 @@ def test_criterion_mae_deprecation(estimator):
     # checks whether a deprecation warning is issues when criterion='mae'
     # is used.
     msg = ("criterion='mae' was deprecated in version 0.24 and "
-           "will be removed in version 1.1.")
+           "will be removed in version 1.1")
     with pytest.warns(FutureWarning, match=msg):
         estimator.fit(X, y)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1308,7 +1308,7 @@ def test_gbr_degenerate_feature_importances():
                        np.zeros(10, dtype=np.float64))
 
 
-# TODO: Remove in 0.26 when `n_classes_` is deprecated
+# TODO: Remove in 1.1 when `n_classes_` is deprecated
 def test_gbr_deprecated_attr():
     # check that accessing n_classes_ in GradientBoostingRegressor raises
     # a deprecation warning
@@ -1320,7 +1320,7 @@ def test_gbr_deprecated_attr():
         gbr.n_classes_
 
 
-# TODO: Remove in 0.26 when `n_classes_` is deprecated
+# TODO: Remove in 1.1 when `n_classes_` is deprecated
 @pytest.mark.filterwarnings("ignore:Attribute n_classes_ was deprecated")
 def test_attr_error_raised_if_not_fitted():
     # check that accessing n_classes_ in not fitted GradientBoostingRegressor
@@ -1335,7 +1335,7 @@ def test_attr_error_raised_if_not_fitted():
         gbr.n_classes_
 
 
-# TODO: Update in 0.26 to check for the error raised
+# TODO: Update in 1.1 to check for the error raised
 @pytest.mark.parametrize('estimator', [
     GradientBoostingClassifier(criterion='mae'),
     GradientBoostingRegressor(criterion='mae')
@@ -1344,6 +1344,6 @@ def test_criterion_mae_deprecation(estimator):
     # checks whether a deprecation warning is issues when criterion='mae'
     # is used.
     msg = ("criterion='mae' was deprecated in version 0.24 and "
-           "will be removed in version 0.26.")
+           "will be removed in version 1.1.")
     with pytest.warns(FutureWarning, match=msg):
         estimator.fit(X, y)

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -41,7 +41,7 @@ class NotFittedError(ValueError, AttributeError):
 
 
 @deprecated("ChangedBehaviorWarning is deprecated in 0.24 and will be removed "
-            "in 0.26")
+            "in 1.1")
 class ChangedBehaviorWarning(UserWarning):
     """Warning class used to notify the user of any change in the behavior.
 
@@ -114,7 +114,7 @@ class FitFailedWarning(RuntimeWarning):
 
 
 @deprecated("NonBLASDotWarning is deprecated in 0.24 and will be removed in "
-            "0.26")
+            "1.1")
 class NonBLASDotWarning(EfficiencyWarning):
     """Warning used when the dot operation does not use BLAS.
 

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -504,9 +504,9 @@ def partial_dependence(estimator, X, features, *, response_method='auto',
     if kind == 'legacy':
         warnings.warn(
             "A Bunch will be returned in place of 'predictions' from version"
-            " 1.1 with partial dependence results accessible via the "
-            "'average' key. In the meantime, pass kind='average' to get the "
-            "future behaviour.",
+            " 1.1 (renaming of 0.26) with partial dependence results "
+            "accessible via the 'average' key. In the meantime, pass "
+            "kind='average' to get the future behaviour.",
             FutureWarning
         )
         # TODO 1.1: Remove kind == 'legacy' section

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -307,7 +307,7 @@ def partial_dependence(estimator, X, features, *, response_method='auto',
 
         .. versionadded:: 0.24
         .. deprecated:: 0.24
-            `kind='legacy'` is deprecated and will be removed in version 0.26.
+            `kind='legacy'` is deprecated and will be removed in version 1.1.
             `kind='average'` will be the new default. It is intended to migrate
             from the ndarray output to :class:`~sklearn.utils.Bunch` output.
 
@@ -504,12 +504,12 @@ def partial_dependence(estimator, X, features, *, response_method='auto',
     if kind == 'legacy':
         warnings.warn(
             "A Bunch will be returned in place of 'predictions' from version"
-            " 0.26 with partial dependence results accessible via the "
+            " 1.1 with partial dependence results accessible via the "
             "'average' key. In the meantime, pass kind='average' to get the "
             "future behaviour.",
             FutureWarning
         )
-        # TODO 0.26: Remove kind == 'legacy' section
+        # TODO 1.1: Remove kind == 'legacy' section
         return averaged_predictions, values
     elif kind == 'average':
         return Bunch(average=averaged_predictions, values=values)

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -817,7 +817,7 @@ class PartialDependenceDisplay:
             ax.set_xlabel(self.feature_names[feature_idx[0]])
         ax.set_ylabel(self.feature_names[feature_idx[1]])
 
-    @_deprecate_positional_args(version="0.26")
+    @_deprecate_positional_args(version="1.1")
     def plot(self, *, ax=None, n_cols=3, line_kw=None, contour_kw=None):
         """Plot partial dependence plots.
 

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -100,7 +100,7 @@ def test_output_shape(Estimator, method, data, grid_resolution,
         est, X=X, features=features, method=method, kind=kind,
         grid_resolution=grid_resolution
     )
-    # FIXME: Remove 'legacy' support in 0.26
+    # FIXME: Remove 'legacy' support in 1.1
     pdp, axes = result if kind == 'legacy' else (result, result["values"])
 
     expected_pdp_shape = (n_targets,
@@ -711,7 +711,7 @@ def test_warning_for_kind_legacy():
     est.fit(X, y)
 
     err_msg = ("A Bunch will be returned in place of 'predictions' from "
-               "version 0.26")
+               "version 1.1")
     with pytest.warns(FutureWarning, match=err_msg):
         partial_dependence(est, X=X, features=[1, 2])
 

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -139,7 +139,7 @@ class KernelRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         return self.kernel == "precomputed"

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -136,10 +136,10 @@ class KernelRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
     def _more_tags(self):
         return {'pairwise': self.kernel == 'precomputed'}
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         return self.kernel == "precomputed"

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -291,7 +291,7 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute standard_coef_ was deprecated "  # type: ignore
-                "in version 0.23 and will be removed in 0.25.")
+                "in version 0.23 and will be removed in 1.0.")
     @property
     def standard_coef_(self):
         return self._standard_coef
@@ -299,7 +299,7 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute standard_intercept_ was deprecated "
-        "in version 0.23 and will be removed in 0.25."
+        "in version 0.23 and will be removed in 1.0."
     )
     @property
     def standard_intercept_(self):
@@ -307,14 +307,14 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute average_coef_ was deprecated "  # type: ignore
-                "in version 0.23 and will be removed in 0.25.")
+                "in version 0.23 and will be removed in 1.0.")
     @property
     def average_coef_(self):
         return self._average_coef
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute average_intercept_ was deprecated "  # type: ignore
-                "in version 0.23 and will be removed in 0.25.")
+                "in version 0.23 and will be removed in 1.0.")
     @property
     def average_intercept_(self):
         return self._average_intercept
@@ -1531,14 +1531,14 @@ class SGDRegressor(BaseSGDRegressor):
 
         .. deprecated:: 0.23
             Attribute ``average_coef_`` was deprecated
-            in version 0.23 and will be removed in 0.25.
+            in version 0.23 and will be removed in 1.0.
 
     average_intercept_ : ndarray of shape (1,)
         The averaged intercept term. Only available if ``average=True``.
 
         .. deprecated:: 0.23
             Attribute ``average_intercept_`` was deprecated
-            in version 0.23 and will be removed in 0.25.
+            in version 0.23 and will be removed in 1.0.
 
     n_iter_ : int
         The actual number of iterations before reaching the stopping criterion.

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -291,7 +291,8 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute standard_coef_ was deprecated "  # type: ignore
-                "in version 0.23 and will be removed in 1.0.")
+                "in version 0.23 and will be removed in 1.0 "
+                "(renaming of 0.25).")
     @property
     def standard_coef_(self):
         return self._standard_coef
@@ -299,7 +300,7 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute standard_intercept_ was deprecated "
-        "in version 0.23 and will be removed in 1.0."
+        "in version 0.23 and will be removed in 1.0 (renaming of 0.25)."
     )
     @property
     def standard_intercept_(self):
@@ -307,14 +308,16 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute average_coef_ was deprecated "  # type: ignore
-                "in version 0.23 and will be removed in 1.0.")
+                "in version 0.23 and will be removed in 1.0 "
+                "(renaming of 0.25).")
     @property
     def average_coef_(self):
         return self._average_coef
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute average_intercept_ was deprecated "  # type: ignore
-                "in version 0.23 and will be removed in 1.0.")
+                "in version 0.23 and will be removed in 1.0 "
+                "(renaming of 0.25).")
     @property
     def average_intercept_(self):
         return self._average_intercept
@@ -1531,14 +1534,14 @@ class SGDRegressor(BaseSGDRegressor):
 
         .. deprecated:: 0.23
             Attribute ``average_coef_`` was deprecated
-            in version 0.23 and will be removed in 1.0.
+            in version 0.23 and will be removed in 1.0 (renaming of 0.25).
 
     average_intercept_ : ndarray of shape (1,)
         The averaged intercept term. Only available if ``average=True``.
 
         .. deprecated:: 0.23
             Attribute ``average_intercept_`` was deprecated
-            in version 0.23 and will be removed in 1.0.
+            in version 0.23 and will be removed in 1.0 (renaming of 0.25).
 
     n_iter_ : int
         The actual number of iterations before reaching the stopping criterion.

--- a/sklearn/linear_model/tests/test_passive_aggressive.py
+++ b/sklearn/linear_model/tests/test_passive_aggressive.py
@@ -267,7 +267,7 @@ def test_regressor_undefined_methods():
     for meth in ("transform",):
         assert_raises(AttributeError, lambda x: getattr(reg, x), meth)
 
-# TODO: remove in 0.25
+# TODO: remove in 1.0
 @pytest.mark.parametrize('klass', [PassiveAggressiveClassifier,
                                    PassiveAggressiveRegressor])
 def test_passive_aggressive_deprecated_attr(klass):

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -269,7 +269,7 @@ def test_plain_has_no_average_attr(klass):
     assert not hasattr(clf, '_standard_coef')
 
 
-# TODO: remove in 0.25
+# TODO: remove in 1.0
 @pytest.mark.parametrize('klass', [SGDClassifier, SGDRegressor])
 def test_sgd_deprecated_attr(klass):
     est = klass(average=True, eta0=.01)

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -389,10 +389,10 @@ class MDS(BaseEstimator):
     def _more_tags(self):
         return {'pairwise': self.dissimilarity == 'precomputed'}
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         return self.dissimilarity == "precomputed"

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -392,7 +392,7 @@ class MDS(BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         return self.dissimilarity == "precomputed"

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -475,7 +475,7 @@ class SpectralEmbedding(BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         return self.affinity in ["precomputed",

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -472,10 +472,10 @@ class SpectralEmbedding(BaseEstimator):
         return {'pairwise': self.affinity in ["precomputed",
                                               "precomputed_nearest_neighbors"]}
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         return self.affinity in ["precomputed",

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -611,8 +611,8 @@ class TSNE(BaseEstimator):
            legacy squaring behavior.
         .. deprecated:: 0.24
            Legacy squaring behavior was deprecated in 0.24. The ``'legacy'``
-           value will be removed in 1.1, at which point the default value will
-           change to ``True``.
+           value will be removed in 1.1 (renaming of 0.26), at which point the
+           default value will change to ``True``.
 
     Attributes
     ----------
@@ -675,7 +675,7 @@ class TSNE(BaseEstimator):
         self.method = method
         self.angle = angle
         self.n_jobs = n_jobs
-        # TODO Revisit deprecation of square_distances for 1.1-0.28 (#12401)
+        # TODO Revisit deprecation of square_distances for 1.1-1.3 (#12401)
         self.square_distances = square_distances
 
     def _fit(self, X, skip_num_points=0):

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -688,14 +688,16 @@ class TSNE(BaseEstimator):
         if self.square_distances not in [True, 'legacy']:
             raise ValueError("'square_distances' must be True or 'legacy'.")
         if self.metric != "euclidean" and self.square_distances is not True:
-            warnings.warn(("'square_distances' has been introduced in 0.24"
-                           "to help phase out legacy squaring behavior. The "
-                           "'legacy' setting will be removed in 1.1, and the "
-                           "default setting will be changed to True. In 0.28, "
-                           "'square_distances' will be removed altogether,"
-                           "and distances will be squared by default. Set "
-                           "'square_distances'=True to silence this warning."),
-                          FutureWarning)
+            warnings.warn(
+                "'square_distances' has been introduced in 0.24 to help phase "
+                "out legacy squaring behavior. The 'legacy' setting will be "
+                "removed in 1.1 (renaming of 0.26), and the default setting "
+                "will be changed to True. In 1.3, 'square_distances' will be "
+                "removed altogether, and distances will be squared by "
+                "default. Set 'square_distances'=True to silence this "
+                "warning.",
+                FutureWarning
+            )
         if self.method == 'barnes_hut':
             X = self._validate_data(X, accept_sparse=['csr'],
                                     ensure_min_samples=2,

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -611,7 +611,7 @@ class TSNE(BaseEstimator):
            legacy squaring behavior.
         .. deprecated:: 0.24
            Legacy squaring behavior was deprecated in 0.24. The ``'legacy'``
-           value will be removed in 0.26, at which point the default value will
+           value will be removed in 1.1, at which point the default value will
            change to ``True``.
 
     Attributes
@@ -675,7 +675,7 @@ class TSNE(BaseEstimator):
         self.method = method
         self.angle = angle
         self.n_jobs = n_jobs
-        # TODO Revisit deprecation of square_distances for 0.26-0.28 (#12401)
+        # TODO Revisit deprecation of square_distances for 1.1-0.28 (#12401)
         self.square_distances = square_distances
 
     def _fit(self, X, skip_num_points=0):
@@ -690,7 +690,7 @@ class TSNE(BaseEstimator):
         if self.metric != "euclidean" and self.square_distances is not True:
             warnings.warn(("'square_distances' has been introduced in 0.24"
                            "to help phase out legacy squaring behavior. The "
-                           "'legacy' setting will be removed in 0.26, and the "
+                           "'legacy' setting will be removed in 1.1, and the "
                            "default setting will be changed to True. In 0.28, "
                            "'square_distances' will be removed altogether,"
                            "and distances will be squared by default. Set "

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -65,7 +65,7 @@ def test_MDS():
     mds_clf.fit(sim)
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 def test_MDS_pairwise_deprecated():
     mds_clf = mds.MDS(metric='precomputed')
     msg = r"Attribute _pairwise was deprecated in version 0\.24"
@@ -73,7 +73,7 @@ def test_MDS_pairwise_deprecated():
         mds_clf._pairwise
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 @ignore_warnings(category=FutureWarning)
 @pytest.mark.parametrize("dissimilarity, expected_pairwise", [
    ("precomputed", True),

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -347,7 +347,7 @@ def test_spectral_embedding_first_eigen_vector():
         assert np.std(embedding[:, 1]) > 1e-3
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 @pytest.mark.parametrize("affinity", ["precomputed",
                                       "precomputed_nearest_neighbors"])
 def test_spectral_embedding_pairwise_deprecated(affinity):

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -898,7 +898,7 @@ def test_tsne_with_different_distance_metrics():
 @ignore_warnings(category=FutureWarning)
 def test_tsne_different_square_distances(method, metric, square_distances):
     # Make sure that TSNE works for different square_distances settings
-    # FIXME remove test when square_distances=True becomes the default in 0.26
+    # FIXME remove test when square_distances=True becomes the default in 1.1
     random_state = check_random_state(0)
     n_components_original = 3
     n_components_embedding = 2

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1447,7 +1447,7 @@ def _precompute_metric_params(X, Y, metric=None, **kwds):
         if X is Y:
             V = np.var(X, axis=0, ddof=1, dtype=dtype)
         else:
-            warnings.warn("from version 0.25, pairwise_distances for "
+            warnings.warn("from version 1.0, pairwise_distances for "
                           "metric='seuclidean' will require V to be "
                           "specified if Y is passed.", FutureWarning)
             V = np.var(np.vstack([X, Y]), axis=0, ddof=1, dtype=dtype)
@@ -1456,7 +1456,7 @@ def _precompute_metric_params(X, Y, metric=None, **kwds):
         if X is Y:
             VI = np.linalg.inv(np.cov(X.T)).T
         else:
-            warnings.warn("from version 0.25, pairwise_distances for "
+            warnings.warn("from version 1.0, pairwise_distances for "
                           "metric='mahalanobis' will require VI to be "
                           "specified if Y is passed.", FutureWarning)
             VI = np.linalg.inv(np.cov(np.vstack([X, Y]).T)).T

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1447,18 +1447,24 @@ def _precompute_metric_params(X, Y, metric=None, **kwds):
         if X is Y:
             V = np.var(X, axis=0, ddof=1, dtype=dtype)
         else:
-            warnings.warn("from version 1.0, pairwise_distances for "
-                          "metric='seuclidean' will require V to be "
-                          "specified if Y is passed.", FutureWarning)
+            warnings.warn(
+                "from version 1.0 (renaming of 0.25), pairwise_distances for "
+                "metric='seuclidean' will require V to be specified if Y is "
+                "passed.",
+                FutureWarning
+            )
             V = np.var(np.vstack([X, Y]), axis=0, ddof=1, dtype=dtype)
         return {'V': V}
     if metric == "mahalanobis" and 'VI' not in kwds:
         if X is Y:
             VI = np.linalg.inv(np.cov(X.T)).T
         else:
-            warnings.warn("from version 1.0, pairwise_distances for "
-                          "metric='mahalanobis' will require VI to be "
-                          "specified if Y is passed.", FutureWarning)
+            warnings.warn(
+                "from version 1.0 (renaming of 0.25), pairwise_distances for "
+                "metric='mahalanobis' will require VI to be specified if Y "
+                "is passed.",
+                FutureWarning
+            )
             VI = np.linalg.inv(np.cov(np.vstack([X, Y]).T)).T
         return {'VI': VI}
     return {}

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -1281,7 +1281,7 @@ def test_pairwise_distances_data_derived_params(n_jobs, metric, dist_function,
                 params = {'VI': np.linalg.inv(np.cov(np.vstack([X, Y]).T)).T}
 
         expected_dist_explicit_params = cdist(X, Y, metric=metric, **params)
-        # TODO: Remove warn_checker in 0.25
+        # TODO: Remove warn_checker in 1.0
         if y_is_x:
             warn_checker = pytest.warns(None)
         else:

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -440,10 +440,10 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                               "DataConversionWarning not caught"},
         }
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         # allows cross-validation to see 'precomputed' metrics

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -317,7 +317,7 @@ class ParameterSampler:
 # FIXME Remove fit_grid_point in 1.0
 @deprecated(
     "fit_grid_point is deprecated in version 0.23 "
-    "and will be removed in version 1.0"
+    "and will be removed in version 1.0 (renaming of 0.25)"
 )
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
                    verbose, error_score=np.nan, **fit_params):
@@ -443,7 +443,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         # allows cross-validation to see 'precomputed' metrics

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -314,10 +314,10 @@ class ParameterSampler:
             return self.n_iter
 
 
-# FIXME Remove fit_grid_point in 0.25
+# FIXME Remove fit_grid_point in 1.0
 @deprecated(
     "fit_grid_point is deprecated in version 0.23 "
-    "and will be removed in version 0.25"
+    "and will be removed in version 1.0"
 )
 def fit_grid_point(X, y, estimator, parameters, train, test, scorer,
                    verbose, error_score=np.nan, **fit_params):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1266,7 +1266,7 @@ def test_grid_search_correct_score_results():
                 assert_almost_equal(correct_score, cv_scores[i])
 
 
-# FIXME remove test_fit_grid_point as the function will be removed on 0.25
+# FIXME remove test_fit_grid_point as the function will be removed on 1.0
 @ignore_warnings(category=FutureWarning)
 def test_fit_grid_point():
     X, y = make_classification(random_state=0)
@@ -1297,13 +1297,13 @@ def test_fit_grid_point():
 
 
 # FIXME remove test_fit_grid_point_deprecated as
-# fit_grid_point will be removed on 0.25
+# fit_grid_point will be removed on 1.0
 def test_fit_grid_point_deprecated():
     X, y = make_classification(random_state=0)
     svc = LinearSVC(random_state=0)
     scorer = make_scorer(accuracy_score)
     msg = ("fit_grid_point is deprecated in version 0.23 "
-           "and will be removed in version 0.25")
+           "and will be removed in version 1.0")
     params = {'C': 0.1}
     train, test = next(StratifiedKFold().split(X, y))
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1963,7 +1963,7 @@ def test_search_cv_pairwise_property_delegated_to_base_estimator(pairwise):
     assert pairwise == cv._get_tags()['pairwise'], attr_message
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 @ignore_warnings(category=FutureWarning)
 def test_search_cv__pairwise_property_delegated_to_base_estimator():
     """

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1962,7 +1962,7 @@ def test_callable_multimetric_confusion_matrix_cross_validate():
         assert "test_{}".format(name) in cv_results
 
 
-# TODO: Remove in 0.26 when the _pairwise attribute is removed
+# TODO: Remove in 1.1 when the _pairwise attribute is removed
 def test_validation_pairwise():
     # checks the interactions between the pairwise estimator tag
     # and the _pairwise attribute
@@ -1981,7 +1981,7 @@ def test_validation_pairwise():
             return {'pairwise': False}
 
     svm = IncorrectTagSVM(kernel='precomputed')
-    msg = ("_pairwise was deprecated in 0.24 and will be removed in 0.26. "
+    msg = ("_pairwise was deprecated in 0.24 and will be removed in 1.1. "
            "Set the estimator tags of your estimator instead")
     with pytest.warns(FutureWarning, match=msg):
         cross_validate(svm, linear_kernel, y, cv=2)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1981,7 +1981,6 @@ def test_validation_pairwise():
             return {'pairwise': False}
 
     svm = IncorrectTagSVM(kernel='precomputed')
-    msg = ("_pairwise was deprecated in 0.24 and will be removed in 1.1. "
-           "Set the estimator tags of your estimator instead")
+    msg = "_pairwise was deprecated in 0.24 and will be removed in 1.1"
     with pytest.warns(FutureWarning, match=msg):
         cross_validate(svm, linear_kernel, y, cv=2)

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -186,7 +186,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
 
         .. deprecated:: 0.24
             This attribute is deprecated in 0.24 and will
-            be removed in 0.26. If you use this attribute
+            be removed in 1.1. If you use this attribute
             in :class:`~sklearn.feature_selection.RFE` or
             :class:`~sklearn.feature_selection.SelectFromModel`,
             you may pass a callable to the `importance_getter`
@@ -200,7 +200,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
 
         .. deprecated:: 0.24
             This attribute is deprecated in 0.24 and will
-            be removed in 0.26. If you use this attribute
+            be removed in 1.1. If you use this attribute
             in :class:`~sklearn.feature_selection.RFE` or
             :class:`~sklearn.feature_selection.SelectFromModel`,
             you may pass a callable to the `importance_getter`
@@ -456,10 +456,10 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
     def n_classes_(self):
         return len(self.classes_)
 
-    # TODO: Remove coef_ attribute in 0.26
+    # TODO: Remove coef_ attribute in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute coef_ was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26. "
+                "version 0.24 and will be removed in 1.1. "
                 "If you observe this warning while using RFE "
                 "or SelectFromModel, use the importance_getter "
                 "parameter instead.")
@@ -474,10 +474,10 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
             return sp.vstack(coefs)
         return np.vstack(coefs)
 
-    # TODO: Remove intercept_ attribute in 0.26
+    # TODO: Remove intercept_ attribute in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute intercept_ was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26. "
+                "version 0.24 and will be removed in 1.1. "
                 "If you observe this warning while using RFE "
                 "or SelectFromModel, use the importance_getter "
                 "parameter instead.")
@@ -489,10 +489,10 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
                 "Base estimator doesn't have an intercept_ attribute.")
         return np.array([e.intercept_.ravel() for e in self.estimators_])
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         """Indicate if wrapped estimator is using a precomputed Gram matrix"""
@@ -591,7 +591,7 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
 
         .. deprecated:: 0.24
 
-            The _pairwise attribute is deprecated in 0.24. From 0.26 and
+            The _pairwise attribute is deprecated in 0.24. From 1.1 and
             onward, `pairwise_indices_` will use the pairwise estimator tag
             instead.
 
@@ -769,10 +769,10 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
     def n_classes_(self):
         return len(self.classes_)
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         """Indicate if wrapped estimator is using a precomputed Gram matrix"""

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -186,7 +186,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
 
         .. deprecated:: 0.24
             This attribute is deprecated in 0.24 and will
-            be removed in 1.1. If you use this attribute
+            be removed in 1.1 (renaming of 0.26). If you use this attribute
             in :class:`~sklearn.feature_selection.RFE` or
             :class:`~sklearn.feature_selection.SelectFromModel`,
             you may pass a callable to the `importance_getter`
@@ -200,7 +200,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
 
         .. deprecated:: 0.24
             This attribute is deprecated in 0.24 and will
-            be removed in 1.1. If you use this attribute
+            be removed in 1.1 (renaming of 0.26). If you use this attribute
             in :class:`~sklearn.feature_selection.RFE` or
             :class:`~sklearn.feature_selection.SelectFromModel`,
             you may pass a callable to the `importance_getter`
@@ -459,7 +459,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
     # TODO: Remove coef_ attribute in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute coef_ was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1. "
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26). "
                 "If you observe this warning while using RFE "
                 "or SelectFromModel, use the importance_getter "
                 "parameter instead.")
@@ -477,7 +477,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
     # TODO: Remove intercept_ attribute in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute intercept_ was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1. "
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26). "
                 "If you observe this warning while using RFE "
                 "or SelectFromModel, use the importance_getter "
                 "parameter instead.")
@@ -492,7 +492,7 @@ class OneVsRestClassifier(MultiOutputMixin, ClassifierMixin,
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         """Indicate if wrapped estimator is using a precomputed Gram matrix"""
@@ -591,9 +591,9 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
 
         .. deprecated:: 0.24
 
-            The _pairwise attribute is deprecated in 0.24. From 1.1 and
-            onward, `pairwise_indices_` will use the pairwise estimator tag
-            instead.
+            The _pairwise attribute is deprecated in 0.24. From 1.1
+            (renaming of 0.25) and onward, `pairwise_indices_` will use the
+            pairwise estimator tag instead.
 
     Examples
     --------
@@ -772,7 +772,7 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         """Indicate if wrapped estimator is using a precomputed Gram matrix"""

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -648,7 +648,7 @@ class _BaseDiscreteNB(_BaseNB):
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute coef_ was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def coef_(self):
         return (self.feature_log_prob_[1:]
@@ -656,7 +656,7 @@ class _BaseDiscreteNB(_BaseNB):
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute intercept_ was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def intercept_(self):
         return (self.class_log_prior_[1:]
@@ -708,7 +708,8 @@ class MultinomialNB(_BaseDiscreteNB):
         as a linear model.
 
         .. deprecated:: 0.24
-            ``coef_`` is deprecated in 0.24 and will be removed in 1.1.
+            ``coef_`` is deprecated in 0.24 and will be removed in 1.1
+            (renaming of 0.26).
 
     feature_count_ : ndarray of shape (n_classes, n_features)
         Number of samples encountered for each (class, feature)
@@ -724,7 +725,8 @@ class MultinomialNB(_BaseDiscreteNB):
         as a linear model.
 
         .. deprecated:: 0.24
-            ``intercept_`` is deprecated in 0.24 and will be removed in 1.1.
+            ``intercept_`` is deprecated in 0.24 and will be removed in 1.1
+            (renaming of 0.26).
 
     n_features_ : int
         Number of features of each sample.
@@ -830,7 +832,8 @@ class ComplementNB(_BaseDiscreteNB):
         as a linear model.
 
         .. deprecated:: 0.24
-            ``coef_`` is deprecated in 0.24 and will be removed in 1.1.
+            ``coef_`` is deprecated in 0.24 and will be removed in 1.1
+            (renaming of 0.26).
 
     feature_all_ : ndarray of shape (n_features,)
         Number of samples encountered for each feature during fitting. This
@@ -848,7 +851,8 @@ class ComplementNB(_BaseDiscreteNB):
         as a linear model.
 
         .. deprecated:: 0.24
-            ``coef_`` is deprecated in 0.24 and will be removed in 1.1.
+            ``coef_`` is deprecated in 0.24 and will be removed in 1.1
+            (renaming of 0.26).
 
     n_features_ : int
         Number of features of each sample.

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -648,7 +648,7 @@ class _BaseDiscreteNB(_BaseNB):
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute coef_ was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def coef_(self):
         return (self.feature_log_prob_[1:]
@@ -656,7 +656,7 @@ class _BaseDiscreteNB(_BaseNB):
 
     # mypy error: Decorated property not supported
     @deprecated("Attribute intercept_ was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def intercept_(self):
         return (self.class_log_prior_[1:]
@@ -708,7 +708,7 @@ class MultinomialNB(_BaseDiscreteNB):
         as a linear model.
 
         .. deprecated:: 0.24
-            ``coef_`` is deprecated in 0.24 and will be removed in 0.26.
+            ``coef_`` is deprecated in 0.24 and will be removed in 1.1.
 
     feature_count_ : ndarray of shape (n_classes, n_features)
         Number of samples encountered for each (class, feature)
@@ -724,7 +724,7 @@ class MultinomialNB(_BaseDiscreteNB):
         as a linear model.
 
         .. deprecated:: 0.24
-            ``intercept_`` is deprecated in 0.24 and will be removed in 0.26.
+            ``intercept_`` is deprecated in 0.24 and will be removed in 1.1.
 
     n_features_ : int
         Number of features of each sample.
@@ -830,7 +830,7 @@ class ComplementNB(_BaseDiscreteNB):
         as a linear model.
 
         .. deprecated:: 0.24
-            ``coef_`` is deprecated in 0.24 and will be removed in 0.26.
+            ``coef_`` is deprecated in 0.24 and will be removed in 1.1.
 
     feature_all_ : ndarray of shape (n_features,)
         Number of samples encountered for each feature during fitting. This
@@ -848,7 +848,7 @@ class ComplementNB(_BaseDiscreteNB):
         as a linear model.
 
         .. deprecated:: 0.24
-            ``coef_`` is deprecated in 0.24 and will be removed in 0.26.
+            ``coef_`` is deprecated in 0.24 and will be removed in 1.1.
 
     n_features_ : int
         Number of features of each sample.

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -528,10 +528,10 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         # For cross-validation routines to split data correctly
         return {'pairwise': self.metric == 'precomputed'}
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         # For cross-validation routines to split data correctly

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -531,7 +531,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         # For cross-validation routines to split data correctly

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -163,7 +163,7 @@ class KNeighborsRegressor(KNeighborsMixin,
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         # For cross-validation routines to split data correctly

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -160,10 +160,10 @@ class KNeighborsRegressor(KNeighborsMixin,
         # For cross-validation routines to split data correctly
         return {'pairwise': self.metric == 'precomputed'}
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         # For cross-validation routines to split data correctly

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1733,7 +1733,7 @@ def test_auto_algorithm(X, metric, metric_params, expected_algo):
     assert model._fit_method == expected_algo
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 @pytest.mark.parametrize("NearestNeighbors", [neighbors.KNeighborsClassifier,
                                               neighbors.KNeighborsRegressor,
                                               neighbors.NearestNeighbors])

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -629,10 +629,10 @@ class Pipeline(_BaseComposition):
         # check if first estimator expects pairwise input
         return {'pairwise': _safe_tags(self.steps[0][1], "pairwise")}
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         # check if first estimator expects pairwise input

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -632,7 +632,7 @@ class Pipeline(_BaseComposition):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         # check if first estimator expects pairwise input

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2312,10 +2312,10 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
     def _more_tags(self):
         return {'pairwise': True}
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         return True

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2246,7 +2246,7 @@ def test_cv_pipeline_precomputed():
     # did the pipeline set the pairwise attribute?
     assert pipeline._get_tags()['pairwise']
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     msg = r"Attribute _pairwise was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         assert pipeline._pairwise
@@ -2258,7 +2258,7 @@ def test_cv_pipeline_precomputed():
     assert_array_almost_equal(y_true, y_pred)
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 def test_pairwise_deprecated():
     kcent = KernelCenterer()
     msg = r"Attribute _pairwise was deprecated in version 0\.24"

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -107,10 +107,10 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         # Used by cross_val_score.
         return {'pairwise': self.kernel == 'precomputed'}
 
-    # TODO: Remove in 0.26
+    # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 0.26.")
+                "version 0.24 and will be removed in 1.1.")
     @property
     def _pairwise(self):
         # Used by cross_val_score.

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -110,7 +110,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated("Attribute _pairwise was deprecated in "  # type: ignore
-                "version 0.24 and will be removed in 1.1.")
+                "version 0.24 and will be removed in 1.1 (renaming of 0.26).")
     @property
     def _pairwise(self):
         # Used by cross_val_score.

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -1048,7 +1048,7 @@ class SVR(RegressorMixin, BaseLibSVM):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The probA_ attribute is deprecated in version 0.23 and will be "
-        "removed in version 0.25.")
+        "removed in version 1.0.")
     @property
     def probA_(self):
         return self._probA
@@ -1056,7 +1056,7 @@ class SVR(RegressorMixin, BaseLibSVM):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The probB_ attribute is deprecated in version 0.23 and will be "
-        "removed in version 0.25.")
+        "removed in version 1.0.")
     @property
     def probB_(self):
         return self._probB
@@ -1434,7 +1434,7 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The probA_ attribute is deprecated in version 0.23 and will be "
-        "removed in version 0.25.")
+        "removed in version 1.0.")
     @property
     def probA_(self):
         return self._probA
@@ -1442,7 +1442,7 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The probB_ attribute is deprecated in version 0.23 and will be "
-        "removed in version 0.25.")
+        "removed in version 1.0.")
     @property
     def probB_(self):
         return self._probB

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -1048,7 +1048,7 @@ class SVR(RegressorMixin, BaseLibSVM):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The probA_ attribute is deprecated in version 0.23 and will be "
-        "removed in version 1.0.")
+        "removed in version 1.0 (renaming of 0.25).")
     @property
     def probA_(self):
         return self._probA
@@ -1056,7 +1056,7 @@ class SVR(RegressorMixin, BaseLibSVM):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "The probB_ attribute is deprecated in version 0.23 and will be "
-        "removed in version 1.0.")
+        "removed in version 1.0 (renaming of 0.25).")
     @property
     def probB_(self):
         return self._probB

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1245,7 +1245,7 @@ def test_svm_probA_proB_deprecated(SVMClass, data, deprecated_prob):
     clf = SVMClass().fit(*data)
 
     msg = ("The {} attribute is deprecated in version 0.23 and will be "
-           "removed in version 1.0.").format(deprecated_prob)
+           "removed in version 1.0").format(deprecated_prob)
     with pytest.warns(FutureWarning, match=msg):
         getattr(clf, deprecated_prob)
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1235,7 +1235,7 @@ def test_n_support_oneclass_svr():
     assert reg.n_support_ == 4
 
 
-# TODO: Remove in 0.25 when probA_ and probB_ are deprecated
+# TODO: Remove in 1.0 when probA_ and probB_ are deprecated
 @pytest.mark.parametrize("SVMClass, data", [
     (svm.OneClassSVM, (X, )),
     (svm.SVR, (X, Y))
@@ -1245,7 +1245,7 @@ def test_svm_probA_proB_deprecated(SVMClass, data, deprecated_prob):
     clf = SVMClass().fit(*data)
 
     msg = ("The {} attribute is deprecated in version 0.23 and will be "
-           "removed in version 0.25.").format(deprecated_prob)
+           "removed in version 1.0.").format(deprecated_prob)
     with pytest.warns(FutureWarning, match=msg):
         getattr(clf, deprecated_prob)
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -540,7 +540,7 @@ def test_repr_html_wraps():
         assert "<style>" in output
 
 
-# TODO: Remove in 0.26 when the _pairwise attribute is removed
+# TODO: Remove in 1.1 when the _pairwise attribute is removed
 def test_is_pairwise():
     # simple checks for _is_pairwise
     pca = KernelPCA(kernel='precomputed')
@@ -553,7 +553,7 @@ def test_is_pairwise():
         _pairwise = False
 
     pca = IncorrectTagPCA(kernel='precomputed')
-    msg = ("_pairwise was deprecated in 0.24 and will be removed in 0.26. "
+    msg = ("_pairwise was deprecated in 0.24 and will be removed in 1.1. "
            "Set the estimator tags of your estimator instead")
     with pytest.warns(FutureWarning, match=msg):
         assert not _is_pairwise(pca)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -553,8 +553,7 @@ def test_is_pairwise():
         _pairwise = False
 
     pca = IncorrectTagPCA(kernel='precomputed')
-    msg = ("_pairwise was deprecated in 0.24 and will be removed in 1.1. "
-           "Set the estimator tags of your estimator instead")
+    msg = "_pairwise was deprecated in 0.24 and will be removed in 1.1"
     with pytest.warns(FutureWarning, match=msg):
         assert not _is_pairwise(pca)
 

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -544,7 +544,7 @@ def test_calibration_attributes(clf, cv):
         assert calib_clf.n_features_in_ == X.shape[1]
 
 
-# FIXME: remove in 0.26
+# FIXME: remove in 1.1
 def test_calibrated_classifier_cv_deprecation(data):
     # Check that we raise the proper deprecation warning if accessing
     # `calibrators_` from the `_CalibratedClassifier`.

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -212,11 +212,11 @@ def test_fit_docstring_attributes(name, Estimator):
     if 'PLS' in Estimator.__name__ or 'CCA' in Estimator.__name__:
         est.n_components = 1  # default = 2 is invalid for single target.
 
-    # TO BE REMOVED for v0.25 (avoid FutureWarning)
+    # FIXME: TO BE REMOVED for 1.0 (avoid FutureWarning)
     if Estimator.__name__ == 'AffinityPropagation':
         est.random_state = 63
 
-    # TO BE REMOVED for v0.26 (avoid FutureWarning)
+    # FIXME: TO BE REMOVED for 1.1 (avoid FutureWarning)
     if Estimator.__name__ == 'NMF':
         est.init = 'nndsvda'
 

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -235,8 +235,8 @@ def test_fit_docstring_attributes(name, Estimator):
         est.fit(X, y)
 
     skipped_attributes = {'n_features_in_',
-                          'x_scores_',  # For PLS, TODO remove in 0.26
-                          'y_scores_'}  # For PLS, TODO remove in 0.26
+                          'x_scores_',  # For PLS, TODO remove in 1.1
+                          'y_scores_'}  # For PLS, TODO remove in 1.1
 
     for attr in attributes:
         if attr.name in skipped_attributes:

--- a/sklearn/tests/test_kernel_ridge.py
+++ b/sklearn/tests/test_kernel_ridge.py
@@ -87,7 +87,7 @@ def test_kernel_ridge_multi_output():
     assert_array_almost_equal(pred2, pred3)
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 def test_kernel_ridge_pairwise_is_deprecated():
     k_ridge = KernelRidge(kernel='precomputed')
     msg = r"Attribute _pairwise was deprecated in version 0\.24"

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -482,10 +482,10 @@ def test_ovr_deprecated_coef_intercept():
     ovr = OneVsRestClassifier(SVC(kernel="linear"))
     ovr = ovr.fit(iris.data, iris.target)
 
-    msg = ("Attribute {0} was deprecated in version 0.24 "
-           "and will be removed in 1.1 (renaming of 0.26). If you observe "
-           "this warning while using RFE or SelectFromModel, "
-           "use the importance_getter parameter instead.")
+    msg = (r"Attribute {0} was deprecated in version 0.24 "
+           r"and will be removed in 1.1 \(renaming of 0.26\). If you observe "
+           r"this warning while using RFE or SelectFromModel, "
+           r"use the importance_getter parameter instead.")
 
     for att in ["coef_", "intercept_"]:
         with pytest.warns(FutureWarning, match=msg.format(att)):

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -483,7 +483,7 @@ def test_ovr_deprecated_coef_intercept():
     ovr = ovr.fit(iris.data, iris.target)
 
     msg = ("Attribute {0} was deprecated in version 0.24 "
-           "and will be removed in 1.1. If you observe "
+           "and will be removed in 1.1 (renaming of 0.26). If you observe "
            "this warning while using RFE or SelectFromModel, "
            "use the importance_getter parameter instead.")
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -441,7 +441,7 @@ def test_ovr_pipeline():
     assert_array_equal(ovr.predict(iris.data), ovr_pipe.predict(iris.data))
 
 
-# TODO: Remove this test in version 0.26
+# TODO: Remove this test in version 1.1
 # when the coef_ attribute is removed
 @ignore_warnings(category=FutureWarning)
 def test_ovr_coef_():
@@ -461,7 +461,7 @@ def test_ovr_coef_():
                          sp.issparse(ovr.coef_))
 
 
-# TODO: Remove this test in version 0.26
+# TODO: Remove this test in version 1.1
 # when the coef_ attribute is removed
 @ignore_warnings(category=FutureWarning)
 def test_ovr_coef_exceptions():
@@ -476,14 +476,14 @@ def test_ovr_coef_exceptions():
     assert_raises(AttributeError, lambda x: ovr.coef_, None)
 
 
-# TODO: Remove this test in version 0.26 when
+# TODO: Remove this test in version 1.1 when
 # the coef_ and intercept_ attributes are removed
 def test_ovr_deprecated_coef_intercept():
     ovr = OneVsRestClassifier(SVC(kernel="linear"))
     ovr = ovr.fit(iris.data, iris.target)
 
     msg = ("Attribute {0} was deprecated in version 0.24 "
-           "and will be removed in 0.26. If you observe "
+           "and will be removed in 1.1. If you observe "
            "this warning while using RFE or SelectFromModel, "
            "use the importance_getter parameter instead.")
 
@@ -802,7 +802,7 @@ def test_pairwise_tag(MultiClassClassifier):
     assert ovr_true._get_tags()["pairwise"]
 
 
-# TODO: Remove in 0.26
+# TODO: Remove in 1.1
 @pytest.mark.parametrize("MultiClassClassifier", [OneVsRestClassifier,
                                                   OneVsOneClassifier])
 def test_pairwise_deprecated(MultiClassClassifier):

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -194,7 +194,7 @@ def test_gnb_naive_bayes_scale_invariance():
     assert_array_equal(labels[1], labels[2])
 
 
-# TODO: Remove in version 0.26
+# TODO: Remove in version 1.1
 @pytest.mark.parametrize("cls", [MultinomialNB, ComplementNB, BernoulliNB,
                                  CategoricalNB])
 def test_discretenb_deprecated_coef_intercept(cls):
@@ -319,7 +319,7 @@ def test_discretenb_input_check_partial_fit(cls):
     assert_raises(ValueError, clf.predict, X2[:, :-1])
 
 
-# TODO: Remove in version 0.26
+# TODO: Remove in version 1.1
 @ignore_warnings(category=FutureWarning)
 def test_discretenb_predict_proba():
     # Test discrete NB classes' probability scores
@@ -423,7 +423,7 @@ def test_discretenb_sample_weight_multiclass(cls):
     assert_array_equal(clf.predict(X), [0, 1, 1, 2])
 
 
-# TODO: Remove in version 0.26
+# TODO: Remove in version 1.1
 @ignore_warnings(category=FutureWarning)
 @pytest.mark.parametrize('cls', [BernoulliNB, MultinomialNB])
 def test_discretenb_coef_intercept_shape(cls):
@@ -517,7 +517,7 @@ def test_mnb_prior_unobserved_targets():
     assert clf.predict([[1, 1]]) == 2
 
 
-# TODO: Remove in version 0.26
+# TODO: Remove in version 1.1
 @ignore_warnings(category=FutureWarning)
 def test_mnb_sample_weight():
     clf = MultinomialNB()

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -312,11 +312,13 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
         min_impurity_split = self.min_impurity_split
         if min_impurity_split is not None:
-            warnings.warn("The min_impurity_split parameter is deprecated. "
-                          "Its default value has changed from 1e-7 to 0 in "
-                          "version 0.23, and it will be removed in 1.0. "
-                          "Use the min_impurity_decrease parameter instead.",
-                          FutureWarning)
+            warnings.warn(
+                "The min_impurity_split parameter is deprecated. Its default "
+                "value has changed from 1e-7 to 0 in version 0.23, and it "
+                "will be removed in 1.0 (renaming of 0.25). Use the "
+                "min_impurity_decrease parameter instead.",
+                FutureWarning
+            )
 
             if min_impurity_split < 0.:
                 raise ValueError("min_impurity_split must be greater than "
@@ -328,12 +330,15 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             raise ValueError("min_impurity_decrease must be greater than "
                              "or equal to 0")
 
-        # TODO: Remove in v1.1
+        # TODO: Remove in 1.1
         if X_idx_sorted != "deprecated":
-            warnings.warn("The parameter 'X_idx_sorted' is deprecated and has "
-                          "no effect. It will be removed in v1.1. You can "
-                          "suppress this warning by not passing any value to "
-                          "the 'X_idx_sorted' parameter.", FutureWarning)
+            warnings.warn(
+                "The parameter 'X_idx_sorted' is deprecated and has no "
+                "effect. It will be removed in 1.1 (renaming of 0.26). You "
+                "can suppress this warning by not passing any value to the "
+                "'X_idx_sorted' parameter.",
+                FutureWarning
+            )
 
         # Build tree
         criterion = self.criterion

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -314,7 +314,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         if min_impurity_split is not None:
             warnings.warn("The min_impurity_split parameter is deprecated. "
                           "Its default value has changed from 1e-7 to 0 in "
-                          "version 0.23, and it will be removed in 0.25. "
+                          "version 0.23, and it will be removed in 1.0. "
                           "Use the min_impurity_decrease parameter instead.",
                           FutureWarning)
 
@@ -710,7 +710,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     class_weight : dict, list of dict or "balanced", default=None
         Weights associated with classes in the form ``{class_label: weight}``.
@@ -1096,7 +1096,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     ccp_alpha : non-negative float, default=0.0
         Complexity parameter used for Minimal Cost-Complexity Pruning. The
@@ -1382,7 +1382,7 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     class_weight : dict, list of dict or "balanced", default=None
         Weights associated with classes in the form ``{class_label: weight}``.
@@ -1631,7 +1631,7 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 0.25. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
 
     max_leaf_nodes : int, default=None
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -328,10 +328,10 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             raise ValueError("min_impurity_decrease must be greater than "
                              "or equal to 0")
 
-        # TODO: Remove in v0.26
+        # TODO: Remove in v1.1
         if X_idx_sorted != "deprecated":
             warnings.warn("The parameter 'X_idx_sorted' is deprecated and has "
-                          "no effect. It will be removed in v0.26. You can "
+                          "no effect. It will be removed in v1.1. You can "
                           "suppress this warning by not passing any value to "
                           "the 'X_idx_sorted' parameter.", FutureWarning)
 
@@ -879,7 +879,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
 
         X_idx_sorted : deprecated, default="deprecated"
             This parameter is deprecated and has no effect.
-            It will be removed in v0.26.
+            It will be removed in v1.1.
 
             .. deprecated :: 0.24
 
@@ -1227,7 +1227,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
 
         X_idx_sorted : deprecated, default="deprecated"
             This parameter is deprecated and has no effect.
-            It will be removed in v0.26.
+            It will be removed in v1.1.
 
             .. deprecated :: 0.24
 

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -715,7 +715,8 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     class_weight : dict, list of dict or "balanced", default=None
         Weights associated with classes in the form ``{class_label: weight}``.
@@ -884,7 +885,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
 
         X_idx_sorted : deprecated, default="deprecated"
             This parameter is deprecated and has no effect.
-            It will be removed in v1.1.
+            It will be removed in 1.1 (renaming of 0.26).
 
             .. deprecated :: 0.24
 
@@ -1101,7 +1102,8 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     ccp_alpha : non-negative float, default=0.0
         Complexity parameter used for Minimal Cost-Complexity Pruning. The
@@ -1232,7 +1234,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
 
         X_idx_sorted : deprecated, default="deprecated"
             This parameter is deprecated and has no effect.
-            It will be removed in v1.1.
+            It will be removed in 1.1 (renaming of 0.26).
 
             .. deprecated :: 0.24
 
@@ -1387,7 +1389,8 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     class_weight : dict, list of dict or "balanced", default=None
         Weights associated with classes in the form ``{class_label: weight}``.
@@ -1636,7 +1639,8 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
            ``min_impurity_split`` has been deprecated in favor of
            ``min_impurity_decrease`` in 0.19. The default value of
            ``min_impurity_split`` has changed from 1e-7 to 0 in 0.23 and it
-           will be removed in 1.0. Use ``min_impurity_decrease`` instead.
+           will be removed in 1.0 (renaming of 0.25).
+           Use ``min_impurity_decrease`` instead.
 
     max_leaf_nodes : int, default=None
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1344,7 +1344,7 @@ cdef class Poisson(RegressionCriterion):
     implemented impurity:
         1/n * sum(y_true * log(y_true/y_pred)
     """
-    # FIXME in 0.25:
+    # FIXME in 1.0:
     # min_impurity_split with default = 0 forces us to use a non-negative
     # impurity like the Poisson deviance. Without this restriction, one could
     # throw away the 'constant' term sum(y_true * log(y_true)) and just use

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -140,7 +140,7 @@ def plot_tree(decision_tree, *, max_depth=None, feature_names=None,
         it is kept here for backward compatibility.
 
         .. deprecated:: 0.23
-           ``rotate`` is deprecated in 0.23 and will be removed in 0.25.
+           ``rotate`` is deprecated in 0.23 and will be removed in 1.0.
 
 
     rounded : bool, default=False
@@ -182,7 +182,7 @@ def plot_tree(decision_tree, *, max_depth=None, feature_names=None,
 
     if rotate != 'deprecated':
         warnings.warn(("'rotate' has no effect and is deprecated in 0.23. "
-                       "It will be removed in 0.25."),
+                       "It will be removed in 1.0."),
                       FutureWarning)
 
     exporter = _MPLTreeExporter(

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -182,7 +182,7 @@ def plot_tree(decision_tree, *, max_depth=None, feature_names=None,
 
     if rotate != 'deprecated':
         warnings.warn(("'rotate' has no effect and is deprecated in 0.23. "
-                       "It will be removed in 1.0."),
+                       "It will be removed in 1.0 (renaming of 0.25)."),
                       FutureWarning)
 
     exporter = _MPLTreeExporter(

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -140,8 +140,8 @@ def plot_tree(decision_tree, *, max_depth=None, feature_names=None,
         it is kept here for backward compatibility.
 
         .. deprecated:: 0.23
-           ``rotate`` is deprecated in 0.23 and will be removed in 1.0.
-
+           ``rotate`` is deprecated in 0.23 and will be removed in 1.0
+           (renaming of 0.25).
 
     rounded : bool, default=False
         When set to ``True``, draw node boxes with rounded corners and use

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -455,8 +455,8 @@ def test_plot_tree_rotate_deprecation(pyplot):
     tree = DecisionTreeClassifier()
     tree.fit(X, y)
     # test that a warning is raised when rotate is used.
-    match = ("'rotate' has no effect and is deprecated in 0.23. "
-             "It will be removed in 1.0 (renaming of 0.25).")
+    match = (r"'rotate' has no effect and is deprecated in 0.23. "
+             r"It will be removed in 1.0 \(renaming of 0.25\).")
     with pytest.warns(FutureWarning, match=match):
         plot_tree(tree, rotate=True)
 

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -456,7 +456,7 @@ def test_plot_tree_rotate_deprecation(pyplot):
     tree.fit(X, y)
     # test that a warning is raised when rotate is used.
     match = ("'rotate' has no effect and is deprecated in 0.23. "
-             "It will be removed in 1.0.")
+             "It will be removed in 1.0 (renaming of 0.25).")
     with pytest.warns(FutureWarning, match=match):
         plot_tree(tree, rotate=True)
 

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -450,13 +450,13 @@ def test_plot_tree_gini(pyplot):
     assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"
 
 
-# FIXME: to be removed in 0.25
+# FIXME: to be removed in 1.0
 def test_plot_tree_rotate_deprecation(pyplot):
     tree = DecisionTreeClassifier()
     tree.fit(X, y)
     # test that a warning is raised when rotate is used.
     match = ("'rotate' has no effect and is deprecated in 0.23. "
-             "It will be removed in 0.25.")
+             "It will be removed in 1.0.")
     with pytest.warns(FutureWarning, match=match):
         plot_tree(tree, rotate=True)
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2103,7 +2103,7 @@ def test_decision_tree_regressor_sample_weight_consistentcy(
     assert_allclose(tree1.predict(X), tree2.predict(X))
 
 
-# TODO: Remove in v0.26
+# TODO: Remove in v1.1
 @pytest.mark.parametrize("TreeEstimator", [DecisionTreeClassifier,
                                            DecisionTreeRegressor])
 def test_X_idx_sorted_deprecated(TreeEstimator):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3065,7 +3065,7 @@ def check_n_features_in(name, estimator_orig):
             "n_features_in_ attribute, unless the 'no_validation' tag is "
             "True. This attribute should be equal to the number of features "
             "passed to the fit method. "
-            "An error will be raised from version 0.25 when calling "
+            "An error will be raised from version 1.0 when calling "
             "check_estimator(). "
             "See SLEP010: "
             "https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep010/proposal.html",  # noqa
@@ -3089,7 +3089,7 @@ def check_requires_y_none(name, estimator_orig):
     warning_msg = ("As of scikit-learn 0.23, estimators should have a "
                    "'requires_y' tag set to the appropriate value. "
                    "The default value of the tag is False. "
-                   "An error will be raised from version 0.25 when calling "
+                   "An error will be raised from version 1.0 when calling "
                    "check_estimator() if the tag isn't properly set.")
 
     expected_err_msgs = (

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -578,7 +578,7 @@ def _set_checking_parameters(estimator):
             estimator.set_params(max_iter=20)
         # NMF
         if estimator.__class__.__name__ == 'NMF':
-            # FIXME : init should be removed in 0.26
+            # FIXME : init should be removed in 1.1
             estimator.set_params(max_iter=500, init='nndsvda')
         # MLP
         if estimator.__class__.__name__ in ['MLPClassifier', 'MLPRegressor']:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3065,8 +3065,8 @@ def check_n_features_in(name, estimator_orig):
             "n_features_in_ attribute, unless the 'no_validation' tag is "
             "True. This attribute should be equal to the number of features "
             "passed to the fit method. "
-            "An error will be raised from version 1.0 when calling "
-            "check_estimator(). "
+            "An error will be raised from version 1.0 (renaming of 0.25) "
+            "when calling check_estimator(). "
             "See SLEP010: "
             "https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep010/proposal.html",  # noqa
             FutureWarning

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -19,7 +19,7 @@ import scipy.sparse as sp
 import scipy
 import scipy.stats
 from scipy.sparse.linalg import lsqr as sparse_lsqr  # noqa
-from numpy.ma import MaskedArray as _MaskedArray  # TODO: remove in 0.25
+from numpy.ma import MaskedArray as _MaskedArray  # TODO: remove in 1.0
 from .._config import config_context, get_config
 
 from .deprecation import deprecated
@@ -159,10 +159,10 @@ class loguniform(scipy.stats.reciprocal):
 
 @deprecated(
     'MaskedArray is deprecated in version 0.23 and will be removed in version '
-    '0.25. Use numpy.ma.MaskedArray instead.'
+    '1.0. Use numpy.ma.MaskedArray instead.'
 )
 class MaskedArray(_MaskedArray):
-    pass  # TODO: remove in 0.25
+    pass  # TODO: remove in 1.0
 
 
 def _take_along_axis(arr, indices, axis):

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -159,7 +159,7 @@ class loguniform(scipy.stats.reciprocal):
 
 @deprecated(
     'MaskedArray is deprecated in version 0.23 and will be removed in version '
-    '1.0. Use numpy.ma.MaskedArray instead.'
+    '1.0 (renaming of 0.25). Use numpy.ma.MaskedArray instead.'
 )
 class MaskedArray(_MaskedArray):
     pass  # TODO: remove in 1.0

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -159,8 +159,9 @@ def _safe_split(estimator, X, y, indices, train_indices=None):
 
     .. deprecated:: 0.24
 
-        The _pairwise attribute is deprecated in 0.24. From 1.1 and onward,
-        this function will check for the pairwise estimator tag.
+        The _pairwise attribute is deprecated in 0.24. From 1.1
+        (renaming of 0.26) and onward, this function will check for the
+        pairwise estimator tag.
 
     Labels y will always be indexed only along the first axis.
 

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -159,7 +159,7 @@ def _safe_split(estimator, X, y, indices, train_indices=None):
 
     .. deprecated:: 0.24
 
-        The _pairwise attribute is deprecated in 0.24. From 0.26 and onward,
+        The _pairwise attribute is deprecated in 0.24. From 1.1 and onward,
         this function will check for the pairwise estimator tag.
 
     Labels y will always be indexed only along the first axis.

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -86,6 +86,6 @@ def test_loguniform(low, high, base):
     )
 
 
-def test_masked_array_deprecated():  # TODO: remove in 0.25
+def test_masked_array_deprecated():  # TODO: remove in 1.0
     with pytest.warns(FutureWarning, match='is deprecated'):
         MaskedArray()

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -338,7 +338,7 @@ def test_check_array():
     assert isinstance(result, np.ndarray)
 
 
-# TODO: Check for error in 0.26 when implicit conversation is removed
+# TODO: Check for error in 1.1 when implicit conversation is removed
 @pytest.mark.parametrize("X", [
    [['1', '2'], ['3', '4']],
    np.array([['1', '2'], ['3', '4']], dtype='U'),
@@ -350,12 +350,12 @@ def test_check_array_numeric_warns(X):
     """Test that check_array warns when it converts a bytes/string into a
     float."""
     expected_msg = (r"Arrays of bytes/strings is being converted to decimal .*"
-                    r"deprecated in 0.24 and will be removed in 0.26")
+                    r"deprecated in 0.24 and will be removed in 1.1")
     with pytest.warns(FutureWarning, match=expected_msg):
         check_array(X, dtype="numeric")
 
 
-# TODO: remove in 0.26
+# TODO: remove in 1.1
 @ignore_warnings(category=FutureWarning)
 @pytest.mark.parametrize("X", [
    [['11', '12'], ['13', 'xx']],
@@ -405,7 +405,7 @@ def test_check_array_pandas_na_support(pd_dtype, dtype, expected_dtype):
         check_array(X, force_all_finite=True)
 
 
-# TODO: remove test in 0.26 once this behavior is deprecated
+# TODO: remove test in 1.1 once this behavior is deprecated
 def test_check_array_pandas_dtype_object_conversion():
     # test that data-frame like objects with dtype object
     # get converted
@@ -1169,12 +1169,12 @@ def test_deprecate_positional_args_warns_for_function():
 
 
 def test_deprecate_positional_args_warns_for_function_version():
-    @_deprecate_positional_args(version="0.26")
+    @_deprecate_positional_args(version="1.1")
     def f1(a, *, b):
         pass
 
     with pytest.warns(FutureWarning,
-                      match=r"From version 0.26 passing these as positional"):
+                      match=r"From version 1.1 passing these as positional"):
         f1(1, 2)
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -42,7 +42,7 @@ def _deprecate_positional_args(func=None, *, version="1.0 (renaming of 0.25)"):
     ----------
     func : callable, default=None
         Function to check arguments on.
-    version : callable, default="1.0"
+    version : callable, default="1.0 (renaming of 0.25)"
         The version when positional arguments will result in error.
     """
     def _inner_deprecate_positional_args(f):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -32,7 +32,7 @@ from ..exceptions import DataConversionWarning
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
 
 
-def _deprecate_positional_args(func=None, *, version="1.0"):
+def _deprecate_positional_args(func=None, *, version="1.0 (renaming of 0.25)"):
     """Decorator for methods that issues warnings for positional arguments.
 
     Using the keyword-only argument syntax in pep 3102, arguments after the
@@ -642,12 +642,13 @@ def check_array(array, accept_sparse=False, *, accept_large_sparse=True,
 
         # make sure we actually converted to numeric:
         if dtype_numeric and array.dtype.kind in "OUSV":
-            warnings.warn("Arrays of bytes/strings is being converted to "
-                          "decimal numbers if dtype='numeric'. This behavior "
-                          "is deprecated in 0.24 and will be removed in 1.1 "
-                          "Please convert your data to numeric values "
-                          "explicitly instead.",
-                          FutureWarning, stacklevel=2)
+            warnings.warn(
+                "Arrays of bytes/strings is being converted to decimal "
+                "numbers if dtype='numeric'. This behavior is deprecated in "
+                "0.24 and will be removed in 1.1 (renaming of 0.26). Please "
+                "convert your data to numeric values explicitly instead.",
+                FutureWarning, stacklevel=2
+            )
             try:
                 array = array.astype(np.float64)
             except ValueError as e:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -644,7 +644,7 @@ def check_array(array, accept_sparse=False, *, accept_large_sparse=True,
         if dtype_numeric and array.dtype.kind in "OUSV":
             warnings.warn("Arrays of bytes/strings is being converted to "
                           "decimal numbers if dtype='numeric'. This behavior "
-                          "is deprecated in 0.24 and will be removed in 0.26 "
+                          "is deprecated in 0.24 and will be removed in 1.1 "
                           "Please convert your data to numeric values "
                           "explicitly instead.",
                           FutureWarning, stacklevel=2)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -32,7 +32,7 @@ from ..exceptions import DataConversionWarning
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
 
 
-def _deprecate_positional_args(func=None, *, version="0.25"):
+def _deprecate_positional_args(func=None, *, version="1.0"):
     """Decorator for methods that issues warnings for positional arguments.
 
     Using the keyword-only argument syntax in pep 3102, arguments after the
@@ -42,7 +42,7 @@ def _deprecate_positional_args(func=None, *, version="0.25"):
     ----------
     func : callable, default=None
         Function to check arguments on.
-    version : callable, default="0.25"
+    version : callable, default="1.0"
         The version when positional arguments will result in error.
     """
     def _inner_deprecate_positional_args(f):


### PR DESCRIPTION
Change the version in `FutureWarning` after making the choice of releasing a major upcoming release (1.0)