### PR TITLE
DOC Remove U+30DE unicode characters

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -887,4 +887,4 @@ Timo Kaufmann, tnwei, Tom Dupré la Tour, Trevor Waite, ufmayer, Umberto Lupo,
 Venkatachalam N, Vikas Pandey, Vinicius Rios Fuck, Violeta, watchtheblur, Wenbo
 Zhao, willpeppo, xavier dupré, Xethan, Xue Qianming, xun-tang, yagi-3, Yakov
 Pchelintsev, Yashika Sharma, Yi-Yan Ge, Yue Wu, Yutaro Ikeda, Zaccharie Ramzi,
-zoj613, マーティン, 赵丰 (Zhao Feng).
+zoj613, Zhao Feng.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR removes the U+30DE unicode characters from `doc/whats_new/v0.24.rst` (since they are not supported by LaTeX) to fix the documentation failures.