### PR TITLE
Corrected docstring for balanced_accuracy_score

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1787,7 +1787,7 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None,
     deal with imbalanced datasets. It is defined as the average of recall
     obtained on each class.
 
-    The best value is 1 and the worst value is 0 when ``adjusted=False``.
+    The best value is 1 and the worst value is 0 when ``adjusted=True``.
 
     Read more in the :ref:`User Guide <balanced_accuracy_score>`.
 


### PR DESCRIPTION
Corrected the docstring for balanced_accuracy_score

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #19003


#### What does this implement/fix? Explain your changes.
This corrects the documentation regarding the range of balanced_accuracy_score when using the adjusted parameter.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
