### PR TITLE
BUG Fixes fetch_kddcup99 for return_X_y and as_frame

### DIFF
--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -199,14 +199,14 @@ def fetch_kddcup99(*, subset=None, data_home=None, shuffle=False,
     with open(join(module_path, 'descr', 'kddcup99.rst')) as rst_file:
         fdescr = rst_file.read()
 
-    if return_X_y:
-        return data, target
-
     frame = None
     if as_frame:
         frame, data, target = _convert_data_dataframe(
             "fetch_kddcup99", data, target, feature_names, target_names
         )
+
+    if return_X_y:
+        return data, target
 
     return Bunch(
         data=data,

--- a/sklearn/datasets/tests/test_common.py
+++ b/sklearn/datasets/tests/test_common.py
@@ -75,6 +75,14 @@ def check_as_frame(bunch, dataset_func,
     if expected_target_dtype is not None:
         assert np.all(frame_bunch.target.dtypes == expected_target_dtype)
 
+    # Test for return_X_y and as_frame=True
+    frame_X, frame_y = dataset_func(as_frame=True, return_X_y=True)
+    assert isinstance(frame_X, pd.DataFrame)
+    if frame_y.ndim > 1:
+        assert isinstance(frame_X, pd.DataFrame)
+    else:
+        assert isinstance(frame_y, pd.Series)
+
 
 def _skip_network_tests():
     return os.environ.get('SKLEARN_SKIP_NETWORK_TESTS', '1') == '1'


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/19010


#### What does this implement/fix? Explain your changes.
Adds test for `return_X_y=True` and `as_frame=True` into the common tests.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
