### PR TITLE
CI Use Travis secret tokens to upload the ARM64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ env:
                         OPENBLAS_NUM_THREADS=2
                         SKLEARN_BUILD_PARALLEL=8
                         SKLEARN_SKIP_NETWORK_TESTS=1"
-    # Nightly upload token and staging upload token are set in Travis settings
-    - SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN=__token__
-    - SCIKIT_LEARN_STAGING_UPLOAD_TOKEN=__token__
 
 jobs:
   include:

--- a/build_tools/travis/after_success.sh
+++ b/build_tools/travis/after_success.sh
@@ -8,7 +8,8 @@ set -e
 
 # The wheels cannot be uploaded on PRs
 if [[ $BUILD_WHEEL == true && $TRAVIS_EVENT_TYPE != pull_request ]]; then
-    # The tokens are set from Travis (originally generated at Anaconda cloud)
+    # Nightly upload token and staging upload token are set in
+    # Travis settings (originally generated at Anaconda cloud)
     if [ $TRAVIS_EVENT_TYPE == cron ]; then
         ANACONDA_ORG="scipy-wheels-nightly"
         ANACONDA_TOKEN="$SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN"

--- a/build_tools/travis/after_success.sh
+++ b/build_tools/travis/after_success.sh
@@ -10,7 +10,7 @@ set -e
 if [[ $BUILD_WHEEL == true && $TRAVIS_EVENT_TYPE != pull_request ]]; then
     # Nightly upload token and staging upload token are set in
     # Travis settings (originally generated at Anaconda cloud)
-    if [ $TRAVIS_EVENT_TYPE == cron ]; then
+    if [[ $TRAVIS_EVENT_TYPE == cron ]]; then
         ANACONDA_ORG="scipy-wheels-nightly"
         ANACONDA_TOKEN="$SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN"
     else

--- a/build_tools/travis/after_success.sh
+++ b/build_tools/travis/after_success.sh
@@ -8,6 +8,7 @@ set -e
 
 # The wheels cannot be uploaded on PRs
 if [[ $BUILD_WHEEL == true && $TRAVIS_EVENT_TYPE != pull_request ]]; then
+    # The tokens are set from Travis (originally generated at Anaconda cloud)
     if [ $TRAVIS_EVENT_TYPE == cron ]; then
         ANACONDA_ORG="scipy-wheels-nightly"
         ANACONDA_TOKEN="$SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN"


### PR DESCRIPTION
#### Reference Issues/PRs

See https://github.com/scikit-learn/scikit-learn/pull/18782#discussion_r544205098.

#### What does this implement/fix? Explain your changes.

This PR uses the `Travis` secret tokens to upload the ARM64 wheels to Anaconda cloud.

#### Any other comments?

I have used the same approach that the [`numpy` wheel builder](https://github.com/MacPython/numpy-wheels/blob/32a382e5b41290eeaf61cc413185fbbf6e631747/.travis.yml#L68-L87).

CC @thomasjpfan and @ogrisel.