### PR TITLE
DOC Revises a sentence in the description of RFE

### DIFF
--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -119,12 +119,12 @@ Recursive feature elimination
 =============================
 
 Given an external estimator that assigns weights to features (e.g., the
-coefficients of a linear model), recursive feature elimination (:class:`RFE`)
+coefficients of a linear model), the goal of recursive feature elimination (:class:`RFE`)
 is to select features by recursively considering smaller and smaller sets of
 features. First, the estimator is trained on the initial set of features and
 the importance of each feature is obtained either through any specific attribute
 (such as ``coef_``, ``feature_importances_``) or callable. Then, the least important
-features are pruned from current set of features.That procedure is recursively
+features are pruned from current set of features. That procedure is recursively
 repeated on the pruned set until the desired number of features to select is
 eventually reached.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This pull request revises a sentence in the description of RFE in accordance with the description in the main link. It also adds a white space before the last line in the description.