### PR TITLE
FIX An overflow issue in HashingVectorizer

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -44,7 +44,6 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
-
 :mod:`sklearn.feature_extraction`
 .................................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -48,8 +48,9 @@ Changelog
 :mod:`sklearn.feature_extraction`
 .................................
 
-- |Fix| :there will be a negative in indices of class:`feature_extraction.HashingVectorizer`
-  result when mumurhash function return -2**31. :pr:`19035` by :user:`Liu Yu <ly648499246>`.
+- |Fix| Fixed a bug in class:`feature_extraction.HashingVectorizer` where some
+  input strings would result in negative indices in the transformed data.
+  :pr:`19035` by :user:`Liu Yu <ly648499246>`.
 
 :mod:`sklearn.cluster`
 ......................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -69,7 +69,6 @@ Changelog
 - |Fix| :meth:`ElasticNet.fit` no longer modifies `sample_weight` in place.
   :pr:`19055` by `Thomas Fan`_.
 
-
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -59,7 +59,6 @@ Changelog
   settings. :pr:`19002` by :user:`Jon Crall <Erotemic>` and
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
-
 - |Efficiency| :class:`cluster.KMeans` with `algorithm='elkan'` is now faster
   in multicore settings. :pr:`19052` by
   :user:`Yusuke Nagasaka <YusukeNagasaka>`.

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -44,7 +44,11 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.feature_extraction`
+.................................
 
+- |Fix| :there will be a negative in indices of class:`feature_extraction.HashingVectorizer`
+    result when mumurhash function return -2**31. :pr:`19035` by :user:`Liu Yu <ly648499246>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/sklearn/feature_extraction/_hashing_fast.pyx
+++ b/sklearn/feature_extraction/_hashing_fast.pyx
@@ -68,7 +68,7 @@ def transform(raw_X, Py_ssize_t n_features, dtype,
             h = murmurhash3_bytes_s32(<bytes>f, seed)
 
             array.resize_smart(indices, len(indices) + 1)
-            indices[len(indices) - 1] = abs(h) % n_features
+            indices[len(indices) - 1] = abs(h % n_features)
             # improve inner product preservation in the hashed space
             if alternate_sign:
                 value *= (h >= 0) * 2 - 1

--- a/sklearn/feature_extraction/_hashing_fast.pyx
+++ b/sklearn/feature_extraction/_hashing_fast.pyx
@@ -69,7 +69,8 @@ def transform(raw_X, Py_ssize_t n_features, dtype,
 
             array.resize_smart(indices, len(indices) + 1)
             if h == - 2147483648:
-                # abs(-2**31) is undefined behavior
+                # abs(-2**31) is undefined behavior because h is a `np.int32`
+                # The following is defined such that it is equal to: abs(-2**31) % n_features
                 indices[len(indices) - 1] = (2147483647 - (n_features - 1)) % n_features
             else:
                 indices[len(indices) - 1] = abs(h) % n_features

--- a/sklearn/feature_extraction/_hashing_fast.pyx
+++ b/sklearn/feature_extraction/_hashing_fast.pyx
@@ -68,7 +68,11 @@ def transform(raw_X, Py_ssize_t n_features, dtype,
             h = murmurhash3_bytes_s32(<bytes>f, seed)
 
             array.resize_smart(indices, len(indices) + 1)
-            indices[len(indices) - 1] = abs(h % n_features)
+            if h == - 2147483648:
+                # abs(-2**31) is undefined behavior
+                indices[len(indices) - 1] = (2147483647 - (n_features - 1)) % n_features
+            else:
+                indices[len(indices) - 1] = abs(h) % n_features
             # improve inner product preservation in the hashed space
             if alternate_sign:
                 value *= (h >= 0) * 2 - 1

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1387,7 +1387,7 @@ def test_tie_breaking_sample_order_invariance():
     assert vocab1 == vocab2
 
 # add test for pr 19035
-def test_nonnegative_hashing_vectorizer_result_indeices():
+def test_nonnegative_hashing_vectorizer_result_indices():
     hashing = HashingVectorizer(n_features=1000000, ngram_range=(2, 3))
     indices = hashing.transform(['22pcs efuture']).indices
     assert indices[0] >= 0

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1385,3 +1385,8 @@ def test_tie_breaking_sample_order_invariance():
     vocab1 = vec.fit(['hello', 'world']).vocabulary_
     vocab2 = vec.fit(['world', 'hello']).vocabulary_
     assert vocab1 == vocab2
+
+def test_nonnegative_hashing_vectorizer_result_indeices():
+    hashing = HashingVectorizer(n_features=1000000, ngram_range=(2,3))
+    indices = hashing.transform(['22pcs efuture']).indices
+    assert indices[0] >= 0

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1388,6 +1388,6 @@ def test_tie_breaking_sample_order_invariance():
 
 # add test for pr 19035
 def test_nonnegative_hashing_vectorizer_result_indeices():
-    hashing = HashingVectorizer(n_features=1000000, ngram_range=(2,3))
+    hashing = HashingVectorizer(n_features=1000000, ngram_range=(2, 3))
     indices = hashing.transform(['22pcs efuture']).indices
     assert indices[0] >= 0

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1386,6 +1386,7 @@ def test_tie_breaking_sample_order_invariance():
     vocab2 = vec.fit(['world', 'hello']).vocabulary_
     assert vocab1 == vocab2
 
+# add test for pr 19035
 def test_nonnegative_hashing_vectorizer_result_indeices():
     hashing = HashingVectorizer(n_features=1000000, ngram_range=(2,3))
     indices = hashing.transform(['22pcs efuture']).indices

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1387,8 +1387,8 @@ def test_tie_breaking_sample_order_invariance():
     assert vocab1 == vocab2
 
 
-# add test for pr 19035
 def test_nonnegative_hashing_vectorizer_result_indices():
+    # add test for pr 19035
     hashing = HashingVectorizer(n_features=1000000, ngram_range=(2, 3))
     indices = hashing.transform(['22pcs efuture']).indices
     assert indices[0] >= 0

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1386,6 +1386,7 @@ def test_tie_breaking_sample_order_invariance():
     vocab2 = vec.fit(['world', 'hello']).vocabulary_
     assert vocab1 == vocab2
 
+
 # add test for pr 19035
 def test_nonnegative_hashing_vectorizer_result_indices():
     hashing = HashingVectorizer(n_features=1000000, ngram_range=(2, 3))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #19034 

#### What does this implement/fix? Explain your changes.
There is an overflow issue in _hashing_fast.pyx

In this code, when h == -2147483648 (-2^31), result of abs(h) is still -2147483648, and result of abs(h) % n_features is a negative.

After this change, when h != -2147483648, result of  abs(h) % n_features is same with before change, and when h == -2147483648, it can return a correct result.

#### Any other comments?
This issue truly happened in my job, hope it can be resolved.
Thanks for your attention!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
