### PR TITLE
added ValueError for improperly shaped Y when doing a multilabel fit

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -468,6 +468,9 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
         self : object
         """
         X, Y = self._validate_data(X, Y, multi_output=True, accept_sparse=True)
+        if Y.ndim == 1:
+            raise ValueError("invalid Y for multi-label fit. "
+                             "Y must be of shape (n_samples, n_classes)")
 
         random_state = check_random_state(self.random_state)
         check_array(X, accept_sparse=True)

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 import scipy.sparse as sp
 from joblib import cpu_count
+import re
 
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_raises
@@ -21,6 +22,7 @@ from sklearn.linear_model import OrthogonalMatchingPursuit
 from sklearn.linear_model import Ridge
 from sklearn.linear_model import SGDClassifier
 from sklearn.linear_model import SGDRegressor
+from sklearn.linear_model import LinearRegression
 from sklearn.metrics import jaccard_score, mean_squared_error
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.multioutput import ClassifierChain, RegressorChain
@@ -647,4 +649,32 @@ def test_classifier_chain_tuple_invalid_order():
     chain = ClassifierChain(RandomForestClassifier(), order=order)
 
     with pytest.raises(ValueError, match='invalid order'):
+        chain.fit(X, y)
+
+
+def test_multi_label_y():
+    err_msg = "invalid Y for multi-label fit. " \
+        "Y must be of shape (n_samples, n_classes)"
+
+    X, y = datasets.make_classification(
+        n_samples=100,
+        n_features=4,
+        n_classes=1,
+        n_informative=1,
+        random_state=0)
+    base_clf = RandomForestClassifier()
+    chain = ClassifierChain(
+        base_clf,
+        order='random',
+        random_state=0)
+    with pytest.raises(ValueError, match=re.escape(err_msg)):
+        chain.fit(X, y)
+
+    X, y = datasets.make_regression(n_samples=100, n_targets=1, random_state=0)
+    base_reg = LinearRegression()
+    chain = RegressorChain(
+        base_reg,
+        order='random',
+        random_state=0)
+    with pytest.raises(ValueError, match=re.escape(err_msg)):
         chain.fit(X, y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See also #18947 for related conversation. These changes were initially on that PR
but should have been on their own.


#### What does this implement/fix? Explain your changes.
Adds a raise ValueError check for multi-label fits where Y is not truly multi-labeled.
Passing a 1-dimensional Y fails since it isn't multi-labeled, so this change enforces
the correct dimensions of Y and adds a more helpful error message.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
