### PR TITLE
FIX Incorrect warning when clustering boolean data

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -70,6 +70,10 @@ Changelog
   in multicore settings. :pr:`19052` by
   :user:`Yusuke Nagasaka <YusukeNagasaka>`.
 
+- |Fix| Fixes incorrect multiple data-conversion warnings when clustering
+  boolean data. :pr:`19046` by :user:`Surya Prakash <jdsurya>` and
+  :user:`Nicolas Hug <NicolasHug>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -71,8 +71,7 @@ Changelog
   :user:`Yusuke Nagasaka <YusukeNagasaka>`.
 
 - |Fix| Fixes incorrect multiple data-conversion warnings when clustering
-  boolean data. :pr:`19046` by :user:`Surya Prakash <jdsurya>` and
-  :user:`Nicolas Hug <NicolasHug>`.
+  boolean data. :pr:`19046` by :user:`Surya Prakash <jdsurya>`.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/examples/model_selection/plot_randomized_search.py
+++ b/examples/model_selection/plot_randomized_search.py
@@ -12,7 +12,7 @@ The randomized search and the grid search explore exactly the same space of
 parameters. The result in parameter settings is quite similar, while the run
 time for randomized search is drastically lower.
 
-The performance may be slightly worse for the randomized search, and is likely
+The performance is may slightly worse for the randomized search, and is likely
 due to a noise effect and would not carry over to a held-out test set.
 
 Note that in practice, one would not search over this many different parameters

--- a/examples/model_selection/plot_randomized_search.py
+++ b/examples/model_selection/plot_randomized_search.py
@@ -12,7 +12,7 @@ The randomized search and the grid search explore exactly the same space of
 parameters. The result in parameter settings is quite similar, while the run
 time for randomized search is drastically lower.
 
-The performance is may slightly worse for the randomized search, and is likely
+The performance may be slightly worse for the randomized search, and is likely
 due to a noise effect and would not carry over to a held-out test set.
 
 Note that in practice, one would not search over this many different parameters

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -248,9 +248,9 @@ class OPTICS(ClusterMixin, BaseEstimator):
 
         dtype = bool if self.metric in PAIRWISE_BOOLEAN_FUNCTIONS else float
         if dtype == bool and X.dtype != bool:
-            msg = f"Data will be converted to boolean for" \
-                  f" metric {self.metric}, to avoid this warning," \
-                  f" you may convert the data prior to calling fit."
+            msg = (f"Data will be converted to boolean for"
+                   f" metric {self.metric}, to avoid this warning,"
+                   f" you may convert the data prior to calling fit.")
             warnings.warn(msg, DataConversionWarning)
 
         X = self._validate_data(X, dtype=dtype)

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -248,7 +248,7 @@ class OPTICS(ClusterMixin, BaseEstimator):
 
         dtype = bool if self.metric in PAIRWISE_BOOLEAN_FUNCTIONS else float
         if dtype == bool and X.dtype != bool:
-            msg = "Data was converted to boolean for metric %s" % self.metric
+            msg = "Data will be converted to boolean for metric %s" % self.metric
             warnings.warn(msg, DataConversionWarning)
 
         X = self._validate_data(X, dtype=dtype)

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -14,6 +14,8 @@ License: BSD 3 clause
 import warnings
 import numpy as np
 
+from ..exceptions import DataConversionWarning
+from ..metrics.pairwise import PAIRWISE_BOOLEAN_FUNCTIONS
 from ..utils import gen_batches, get_chunk_n_rows
 from ..utils.validation import _deprecate_positional_args
 from ..neighbors import NearestNeighbors
@@ -243,7 +245,13 @@ class OPTICS(ClusterMixin, BaseEstimator):
         self : instance of OPTICS
             The instance.
         """
-        X = self._validate_data(X, dtype=float)
+
+        dtype = bool if self.metric in PAIRWISE_BOOLEAN_FUNCTIONS else float
+        if dtype == bool and X.dtype != bool:
+            msg = "Data was converted to boolean for metric %s" % self.metric
+            warnings.warn(msg, DataConversionWarning)
+
+        X = self._validate_data(X, dtype=dtype)
 
         if self.cluster_method not in ['dbscan', 'xi']:
             raise ValueError("cluster_method should be one of"

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -248,8 +248,9 @@ class OPTICS(ClusterMixin, BaseEstimator):
 
         dtype = bool if self.metric in PAIRWISE_BOOLEAN_FUNCTIONS else float
         if dtype == bool and X.dtype != bool:
-            msg = f"Data will be converted to boolean for metric {self.metric}," \
-                  f" to avoid this warning, you may convert the data prior to calling fit."
+            msg = f"Data will be converted to boolean for" \
+                  f" metric {self.metric}, to avoid this warning," \
+                  f" you may convert the data prior to calling fit."
             warnings.warn(msg, DataConversionWarning)
 
         X = self._validate_data(X, dtype=dtype)

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -248,7 +248,8 @@ class OPTICS(ClusterMixin, BaseEstimator):
 
         dtype = bool if self.metric in PAIRWISE_BOOLEAN_FUNCTIONS else float
         if dtype == bool and X.dtype != bool:
-            msg = "Data will be converted to boolean for metric %s" % self.metric
+            msg = f"Data will be converted to boolean for metric {self.metric}," \
+                  f" to avoid this warning, you may convert the data prior to calling fit."
             warnings.warn(msg, DataConversionWarning)
 
         X = self._validate_data(X, dtype=dtype)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -222,8 +222,9 @@ def test_nowarn_if_metric_bool_data_bool():
 def test_warn_if_metric_bool_data_no_bool():
     pairwise_metric = 'rogerstanimoto'
     X = np.random.randint(2, size=(5, 2), dtype=np.int)
-    msg = f"Data will be converted to boolean for metric {pairwise_metric}," \
-          " to avoid this warning, you may convert the data prior to calling fit."
+    msg = f"Data will be converted to boolean for" \
+          f" metric {pairwise_metric}, to avoid this warning" \
+          f", you may convert the data prior to calling fit."
 
     with pytest.warns(DataConversionWarning, match=msg) as warn_record:
         OPTICS(metric=pairwise_metric).fit(X)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -211,6 +211,8 @@ def test_bad_reachability():
 
 
 def test_nowarn_if_metric_bool_data_bool():
+    # make sure no warning is raised if metric and data are both boolean
+    # non-regression test for https://github.com/scikit-learn/scikit-learn/issues/18996
     pairwise_metric = 'rogerstanimoto'
     X = np.random.randint(2, size=(5, 2), dtype=np.bool)
 

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -222,14 +222,12 @@ def test_nowarn_if_metric_bool_data_bool():
 
 
 def test_warn_if_metric_bool_data_no_bool():
-	# make sure a *single* conversion warning is raised if metric is boolean
-	# but data isn't
-	# non regression test for https://github.com/scikit-learn/scikit-learn/issues/18996
+    # make sure a *single* conversion warning is raised if metric is boolean
+    # but data isn't
+    # non regression test for https://github.com/scikit-learn/scikit-learn/issues/18996
     pairwise_metric = 'rogerstanimoto'
     X = np.random.randint(2, size=(5, 2), dtype=np.int)
-    msg = f"Data will be converted to boolean for" \
-          f" metric {pairwise_metric}, to avoid this warning" \
-          f", you may convert the data prior to calling fit."
+    msg = f"Data will be converted to boolean for metric {pairwise_metric}"
 
     with pytest.warns(DataConversionWarning, match=msg) as warn_record:
         OPTICS(metric=pairwise_metric).fit(X)
@@ -237,8 +235,8 @@ def test_warn_if_metric_bool_data_no_bool():
 
 
 def test_nowarn_if_metric_no_bool():
-	# make sure no conversion warning is raised if 
-	# metric isn't boolean, no matter what the data type is
+    # make sure no conversion warning is raised if
+    # metric isn't boolean, no matter what the data type is
     pairwise_metric = 'minkowski'
     X_bool = np.random.randint(2, size=(5, 2), dtype=np.bool)
     X_num = np.random.randint(2, size=(5, 2), dtype=np.int)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -232,6 +232,8 @@ def test_warn_if_metric_bool_data_no_bool():
 
 
 def test_nowarn_if_metric_no_bool():
+	# make sure no conversion warning is raised if 
+	# metric isn't boolean, no matter what the data type is
     pairwise_metric = 'minkowski'
     X_bool = np.random.randint(2, size=(5, 2), dtype=np.bool)
     X_num = np.random.randint(2, size=(5, 2), dtype=np.int)

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -212,7 +212,9 @@ def test_bad_reachability():
 
 def test_nowarn_if_metric_bool_data_bool():
     # make sure no warning is raised if metric and data are both boolean
-    # non-regression test for https://github.com/scikit-learn/scikit-learn/issues/18996
+    # non-regression test for
+    # https://github.com/scikit-learn/scikit-learn/issues/18996
+
     pairwise_metric = 'rogerstanimoto'
     X = np.random.randint(2, size=(5, 2), dtype=np.bool)
 
@@ -224,7 +226,9 @@ def test_nowarn_if_metric_bool_data_bool():
 def test_warn_if_metric_bool_data_no_bool():
     # make sure a *single* conversion warning is raised if metric is boolean
     # but data isn't
-    # non regression test for https://github.com/scikit-learn/scikit-learn/issues/18996
+    # non-regression test for
+    # https://github.com/scikit-learn/scikit-learn/issues/18996
+
     pairwise_metric = 'rogerstanimoto'
     X = np.random.randint(2, size=(5, 2), dtype=np.int)
     msg = f"Data will be converted to boolean for metric {pairwise_metric}"

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -220,6 +220,9 @@ def test_nowarn_if_metric_bool_data_bool():
 
 
 def test_warn_if_metric_bool_data_no_bool():
+	# make sure a *single* conversion warning is raised if metric is boolean
+	# but data isn't
+	# non regression test for https://github.com/scikit-learn/scikit-learn/issues/18996
     pairwise_metric = 'rogerstanimoto'
     X = np.random.randint(2, size=(5, 2), dtype=np.int)
     msg = f"Data will be converted to boolean for" \


### PR DESCRIPTION
Fixes #18996

Input X was being converted to float at the beginning of fit() method. However when a pairwise boolean metric was requested, X was again converted to boolean with multiple warning.

This caused were two issues:
1. The data, if it was already of boolean type, was first converted to float and later to boolean
2. The low level utility function printed the warning multiple times

As a FIX, a check has been put in place in the fit() method itself to let boolean data pass as such. However, when the data needs to be converted to boolean, it is done at this level only with the same warning that was printed earlier, but only once.