### PR TITLE
Parallelize init_bound_dense in Elkan algorithm

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -52,6 +52,10 @@ Changelog
   settings. :pr:`19002` by :user:`Jon Crall <Erotemic>` and
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |Efficiency| :class:`cluster.KMeans` with `algorithm='elkan'` is now faster
+  in multicore settings. :pr:`19052` by
+  :user:`Yusuke Nagasaka <YusukeNagasaka>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -159,7 +159,7 @@ def init_bounds_sparse(
 
         floating[::1] centers_squared_norms = row_norms(centers, squared=True)
 
-    for i in range(n_samples):
+    for i in prange(n_samples, schedule='static', nogil=True):
         best_cluster = 0
         min_dist = _euclidean_sparse_dense(
             X_data[X_indptr[i]: X_indptr[i + 1]],

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -83,7 +83,7 @@ def init_bounds_dense(
         floating min_dist, dist
         int best_cluster, i, j
 
-    for i in range(n_samples):
+    for i in prange(n_samples, schedule='static', nogil=True):
         best_cluster = 0
         min_dist = _euclidean_dense_dense(&X[i, 0], &centers[0, 0],
                                           n_features, False)


### PR DESCRIPTION
#### What does this implement/fix?
Parallelize init_bound_dense function. This is an initialization part in Elkan algorithm.

#### Any other comments?
This fix does not affect the quality of the clustering itself. This parallelization only reduces execution time of KMeans.fit on multi-core CPUs, even more beneficial on many-core CPUs.
For instance, I tested on a machine with 2 sockets of Intel Xeon CPUs (totally 40 cores). The table below is the time spent during KMeans.fit and init_bound_dense (the time in seconds). The data is generated uniformly at random with `n_samples=1M, n_features=100`. The parameters of KMeans are `n_clusters=1000, init='random', algorithm='elkan', max_iter=1000`.

|                  | master | PR|
| --- | --- | --- |
| total time | 751 | 692 |
| init_bound_dense | 66 | 2 | 



