### PR TITLE
CI Publish to Pypi workflow for aarch64 wheels

### DIFF
--- a/build_tools/github/check_wheels.py
+++ b/build_tools/github/check_wheels.py
@@ -11,11 +11,11 @@ with gh_wheel_path.open('r') as f:
 build_matrix = wheel_config['jobs']['build_wheels']['strategy']['matrix']
 n_python_versions = len(build_matrix['python'])
 
-# For each python version we have: 6 wheels
+# For each python version we have: 5 wheels
 # 1 osx wheel (x86_64)
-# 3 linux wheel (i686 + x86_64 + arm64)
+# 2 linux wheel (i686 + x86_64)
 # 2 windows wheel (win32 + wind_amd64)
-n_wheels = 6 * n_python_versions
+n_wheels = 5 * n_python_versions
 
 # plus one more for the sdist
 n_wheels += 1

--- a/build_tools/github/check_wheels.py
+++ b/build_tools/github/check_wheels.py
@@ -20,6 +20,16 @@ n_wheels = 5 * n_python_versions
 # plus one more for the sdist
 n_wheels += 1
 
+# aarch64 builds from travis
+travis_config_path = Path.cwd() / ".travis.yml"
+with travis_config_path.open('r') as f:
+    travis_config = yaml.safe_load(f)
+
+jobs = travis_config['jobs']['include']
+travis_builds = [j for j in jobs
+                 if any("CIBW_BUILD" in env for env in j["env"])]
+n_wheels += len(travis_builds)
+
 dist_files = list(Path("dist").glob('**/*'))
 n_dist_files = len(dist_files)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/pull/19058

#### What does this implement/fix? Explain your changes.
Updates the "Publish to Pypi" workflow so that it counts the aarch64 builds from the travis config.

This only needs to be merged with master. Then we can trigger the workflow to upload to `testpypi` and then `pypi`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
