### PR TITLE
CI Fixes scipy-dev build instance

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -96,7 +96,11 @@ elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     python -m pip install -U pip
     echo "Installing numpy and scipy master wheels"
     dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
-    pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
+    pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy pandas
+
+    # issue with metadata in scipy builds https://github.com/scipy/scipy/issues/13196
+    # --use-deprecated=legacy-resolver needs to be included
+    pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url scipy --use-deprecated=legacy-resolver
     pip install --pre cython
     setup_ccache
     echo "Installing joblib master"

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -98,7 +98,7 @@ elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
     dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
     pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy pandas
 
-    # issue with metadata in scipy builds https://github.com/scipy/scipy/issues/13196
+    # issue with metadata in scipy dev builds https://github.com/scipy/scipy/issues/13196
     # --use-deprecated=legacy-resolver needs to be included
     pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url scipy --use-deprecated=legacy-resolver
     pip install --pre cython


### PR DESCRIPTION
The nightly CI was failing to install scipy [here](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=24930&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=eb5122d5-ab7e-5479-a8ce-245b4d64938b)

The issue is related to https://github.com/scipy/scipy/issues/13196