### PR TITLE
CI Use macos-10.13 compatible libomp when building the wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -86,6 +86,7 @@ jobs:
                             OPENBLAS_NUM_THREADS=2
                             SKLEARN_SKIP_NETWORK_TESTS=1
                             SKLEARN_BUILD_PARALLEL=3
+                            MACOSX_DEPLOYMENT_TARGET=10.13
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: bash build_tools/github/repair_windows_wheels.sh {wheel} {dest_dir} ${{ matrix.bitness }}
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }} ${{ matrix.bitness }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -66,11 +66,11 @@ jobs:
           - os: ubuntu-latest
             bitness: 32
             platform_id: manylinux_i686
-          - os: macos-latest
+          - os: macos-10.13
             bitness: 64
             platform_id: macosx_x86_64
         exclude:
-          - os: macos-latest
+          - os: macos-10.13
             bitness: 32
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,7 +47,9 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        # Use the oldest supported version of macos to avoid having the
+        # vendored libomp depend on too recent system libs.
+        os: [windows-latest, ubuntu-latest, macos-10.13]
         python: [36, 37, 38, 39]
         bitness: [32, 64]
         include:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,9 +47,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        # Use the oldest supported version of macos to avoid having the
-        # vendored libomp depend on too recent system libs.
-        os: [windows-latest, ubuntu-latest, macos-10.13]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         python: [36, 37, 38, 39]
         bitness: [32, 64]
         include:
@@ -66,11 +64,11 @@ jobs:
           - os: ubuntu-latest
             bitness: 32
             platform_id: manylinux_i686
-          - os: macos-10.13
+          - os: macos-latest
             bitness: 64
             platform_id: macosx_x86_64
         exclude:
-          - os: macos-10.13
+          - os: macos-latest
             bitness: 32
 
     steps:

--- a/build_tools/github/build_wheels.sh
+++ b/build_tools/github/build_wheels.sh
@@ -5,8 +5,9 @@ set -x
 
 # OpenMP is not present on macOS by default
 if [[ "$RUNNER_OS" == "macOS" ]]; then
-    # Use the oldest support version of macos SDK as libomp will be vendored
-    # into the scikit-learn wheels on macos.
+    # Make sure to a libomp version binary compatible with the oldest supported
+    # version of the macos SDK as libomp will be vendored into the scikit-learn
+    # wheels for macos.
     wget https://homebrew.bintray.com/bottles/libomp-11.0.0.high_sierra.bottle.tar.gz
     brew install libomp-11.0.0.high_sierra.bottle.tar.gz
     export CC=/usr/bin/clang

--- a/build_tools/github/build_wheels.sh
+++ b/build_tools/github/build_wheels.sh
@@ -7,7 +7,11 @@ set -x
 if [[ "$RUNNER_OS" == "macOS" ]]; then
     # Make sure to use a libomp version binary compatible with the oldest
     # supported version of the macos SDK as libomp will be vendored into the
-    # scikit-learn wheels for macos.
+    # scikit-learn wheels for macos. The list of bottles can be found at:
+    # https://formulae.brew.sh/api/formula/libomp.json. Currently, the oldest
+    # supported macos version is: High Sierra / 10.13. When upgrading this, be
+    # sure to update the MACOSX_DEPLOYMENT_TARGET environment variable in
+    # wheels.yml accordingly.
     wget https://homebrew.bintray.com/bottles/libomp-11.0.0.high_sierra.bottle.tar.gz
     brew install libomp-11.0.0.high_sierra.bottle.tar.gz
     export CC=/usr/bin/clang

--- a/build_tools/github/build_wheels.sh
+++ b/build_tools/github/build_wheels.sh
@@ -5,7 +5,10 @@ set -x
 
 # OpenMP is not present on macOS by default
 if [[ "$RUNNER_OS" == "macOS" ]]; then
-    brew install libomp
+    # Use the oldest support version of macos SDK as libomp will be vendored
+    # into the scikit-learn wheels on macos.
+    wget https://homebrew.bintray.com/bottles/libomp-11.0.0.high_sierra.bottle.tar.gz
+    brew install libomp-11.0.0.high_sierra.bottle.tar.gz
     export CC=/usr/bin/clang
     export CXX=/usr/bin/clang++
     export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"

--- a/build_tools/github/build_wheels.sh
+++ b/build_tools/github/build_wheels.sh
@@ -5,9 +5,9 @@ set -x
 
 # OpenMP is not present on macOS by default
 if [[ "$RUNNER_OS" == "macOS" ]]; then
-    # Make sure to a libomp version binary compatible with the oldest supported
-    # version of the macos SDK as libomp will be vendored into the scikit-learn
-    # wheels for macos.
+    # Make sure to use a libomp version binary compatible with the oldest
+    # supported version of the macos SDK as libomp will be vendored into the
+    # scikit-learn wheels for macos.
     wget https://homebrew.bintray.com/bottles/libomp-11.0.0.high_sierra.bottle.tar.gz
     brew install libomp-11.0.0.high_sierra.bottle.tar.gz
     export CC=/usr/bin/clang


### PR DESCRIPTION
Tentative fix for #19063.

macos-10.13 is still referenced here: https://github.com/actions/virtual-environments/tree/main/images/macos

but not referenced there anymore: https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-software