### PR TITLE
Add resample to AdaBoostClassifier in _weight_boosting.py

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -411,8 +411,8 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
                  n_estimators=50,
                  learning_rate=1.,
                  algorithm='SAMME.R',
-                 n_samples = None,
-                 replace = True,
+                 n_samples=None,
+                 replace=True,
                  random_state=None):
 
         super().__init__(
@@ -523,7 +523,10 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
 
         # pick random sample stack of size n_samples
         if self.n_samples is not None and self.n_samples < len(y):
-            X_fit, y_fit, sample_weight_fit = resample(X, y, sample_weight, n_samples=self.n_samples, replace=self.replace, random_state=random_state)
+            X_fit, y_fit, sample_weight_fit = resample(X, y, sample_weight, 
+                                                       n_samples=self.n_samples, 
+                                                       replace=self.replace, 
+                                                       random_state=random_state)
         else:
             X_fit = X
             y_fit = y
@@ -586,9 +589,12 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         """Implement a single boost using the SAMME discrete algorithm."""
         estimator = self._make_estimator(random_state=random_state)
 
-         # pick random sample stack of size n_samples
+        # pick random sample stack of size n_samples
         if self.n_samples is not None and self.n_samples < len(y):
-            X_fit, y_fit, sample_weight_fit = resample(X, y, sample_weight, n_samples=self.n_samples, replace=self.replace, random_state=random_state)
+            X_fit, y_fit, sample_weight_fit = resample(X, y, sample_weight, 
+                                                       n_samples=self.n_samples, 
+                                                       replace=self.replace, 
+                                                       random_state=random_state)
         else:
             X_fit = X
             y_fit = y

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -523,10 +523,11 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
 
         # pick random sample stack of size n_samples
         if self.n_samples is not None and self.n_samples < len(y):
-            X_fit, y_fit, sample_weight_fit = resample(X, y, sample_weight, 
-                                                       n_samples=self.n_samples, 
-                                                       replace=self.replace, 
-                                                       random_state=random_state)
+            (X_fit, y_fit,
+             sample_weight_fit) = resample(X, y, sample_weight,
+                                           n_samples=self.n_samples,
+                                           replace=self.replace,
+                                           random_state=random_state)
         else:
             X_fit = X
             y_fit = y
@@ -591,10 +592,11 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
 
         # pick random sample stack of size n_samples
         if self.n_samples is not None and self.n_samples < len(y):
-            X_fit, y_fit, sample_weight_fit = resample(X, y, sample_weight, 
-                                                       n_samples=self.n_samples, 
-                                                       replace=self.replace, 
-                                                       random_state=random_state)
+            (X_fit, y_fit,
+             sample_weight_fit) = resample(X, y, sample_weight,
+                                           n_samples=self.n_samples,
+                                           replace=self.replace,
+                                           random_state=random_state)
         else:
             X_fit = X
             y_fit = y

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -522,7 +522,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         estimator = self._make_estimator(random_state=random_state)
 
         # pick random sample stack of size n_samples
-        if self.n_samples != None and self.n_samples < len(y):
+        if self.n_samples is not None and self.n_samples < len(y):
             X_fit, y_fit, sample_weight_fit = resample(X, y, sample_weight, n_samples=self.n_samples, replace=self.replace, random_state=random_state)
         else:
             X_fit = X
@@ -587,7 +587,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
         estimator = self._make_estimator(random_state=random_state)
 
          # pick random sample stack of size n_samples
-        if self.n_samples != None and self.n_samples < len(y):
+        if self.n_samples is not None and self.n_samples < len(y):
             X_fit, y_fit, sample_weight_fit = resample(X, y, sample_weight, n_samples=self.n_samples, replace=self.replace, random_state=random_state)
         else:
             X_fit = X


### PR DESCRIPTION
My idea: 
Add the feature of resample (like in Bagging Classifier) to AdaBoost. In the literature this is quite common.
In every iteration of the n_estimators Boosting n_samples will be randomly picked and used for the training of the base estimator but the error score evaluation will be performed on the whole data set. 
This way overfitting is largely reduced. I use this modification myself.
