### PR TITLE
[MRG]Adding an argument to make it easy to change font size of values in plot_confusion_matrix (Fixes  #19051)

### DIFF
--- a/examples/model_selection/plot_confusion_matrix.py
+++ b/examples/model_selection/plot_confusion_matrix.py
@@ -55,7 +55,8 @@ for title, normalize in titles_options:
     disp = plot_confusion_matrix(classifier, X_test, y_test,
                                  display_labels=class_names,
                                  cmap=plt.cm.Blues,
-                                 normalize=normalize)
+                                 normalize=normalize,
+                                 values_size=16)
     disp.ax_.set_title(title)
 
     print(title)

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -74,7 +74,7 @@ class ConfusionMatrixDisplay:
     @_deprecate_positional_args
     def plot(self, *, include_values=True, cmap='viridis',
              xticks_rotation='horizontal', values_format=None,
-             ax=None, colorbar=True):
+             values_size=None, ax=None, colorbar=True):
         """Plot visualization.
 
         Parameters
@@ -92,6 +92,10 @@ class ConfusionMatrixDisplay:
         values_format : str, default=None
             Format specification for values in confusion matrix. If `None`,
             the format specification is 'd' or '.2g' whichever is shorter.
+
+        values_size : int, default=None
+            Font size of the values in the confusion matrix. If `None`,
+            `plt.rcParams["font-size"]` will be used.
 
         ax : matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is
@@ -139,7 +143,7 @@ class ConfusionMatrixDisplay:
                 self.text_[i, j] = ax.text(
                     j, i, text_cm,
                     ha="center", va="center",
-                    color=color)
+                    color=color, fontsize=values_size)
 
         if self.display_labels is None:
             display_labels = np.arange(n_classes)
@@ -167,7 +171,7 @@ def plot_confusion_matrix(estimator, X, y_true, *, labels=None,
                           sample_weight=None, normalize=None,
                           display_labels=None, include_values=True,
                           xticks_rotation='horizontal',
-                          values_format=None,
+                          values_format=None, values_size=None,
                           cmap='viridis', ax=None, colorbar=True):
     """Plot Confusion Matrix.
 
@@ -213,6 +217,10 @@ def plot_confusion_matrix(estimator, X, y_true, *, labels=None,
     values_format : str, default=None
         Format specification for values in confusion matrix. If `None`,
         the format specification is 'd' or '.2g' whichever is shorter.
+
+    values_size : int, default=None
+        Font size of the values in the confusion matrix. If `None`,
+        `plt.rcParams["font-size"]` will be used.
 
     cmap : str or matplotlib Colormap, default='viridis'
         Colormap recognized by matplotlib.
@@ -271,4 +279,5 @@ def plot_confusion_matrix(estimator, X, y_true, *, labels=None,
                                   display_labels=display_labels)
     return disp.plot(include_values=include_values,
                      cmap=cmap, ax=ax, xticks_rotation=xticks_rotation,
-                     values_format=values_format, colorbar=colorbar)
+                     values_format=values_format, values_size=values_size,
+                     colorbar=colorbar)

--- a/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
+++ b/sklearn/metrics/_plot/tests/test_plot_confusion_matrix.py
@@ -282,6 +282,22 @@ def test_confusion_matrix_text_format(pyplot, data, y_pred, n_classes,
     assert_array_equal(expected_text, text_text)
 
 
+@pytest.mark.parametrize("values_size", [4, 16, 42])
+def test_confusion_matrix_text_size(pyplot, data, y_pred, n_classes,
+                                    fitted_clf, values_size):
+    # Make sure plot text is formatted with 'values_format'.
+    X, y = data
+    disp = plot_confusion_matrix(fitted_clf, X, y,
+                                 include_values=True,
+                                 values_size=values_size)
+
+    assert disp.text_.shape == (n_classes, n_classes)
+
+    sizes = np.array([text.get_fontsize() for text in disp.text_.ravel()])
+
+    assert np.all(sizes == values_size)
+
+
 def test_confusion_matrix_standard_format(pyplot):
     cm = np.array([[10000000, 0], [123456, 12345678]])
     plotted_text = ConfusionMatrixDisplay(


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes   #19051

#### What does this implement/fix? Explain your changes.

Adding an optional argument to the sklearn.metrics.plot_confusion_matrix method to make it easy to change the font size.

#### Any other comments?

This still need to be debated, it might not be worth adding another argument to this function.
