### PR TITLE
[MRG] Fix exception when MultinomialNB is given data with only one class 

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -782,6 +782,8 @@ class MultinomialNB(_BaseDiscreteNB):
 
     def _joint_log_likelihood(self, X):
         """Calculate the posterior log probability of the samples X"""
+        if self.classes_.size == 1:
+            return np.full((X.shape[0], 1), np.inf)
         return (safe_sparse_dot(X, self.feature_log_prob_.T) +
                 self.class_log_prior_)
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -530,6 +530,19 @@ def test_mnb_sample_weight():
                               [1 / 3., 2 / 3.])
 
 
+def test_mnb_one_class():
+    # Test when a MultinomialNB is given data with only one class observed
+    X = [
+        (0.072777, 0.334995),
+        (0.857577, 0.977991),
+        (0.310364, 0.230206)
+    ]
+    y = [0, 0, 0]
+    clf = MultinomialNB(fit_prior=False)
+    clf.fit(X, y)
+    assert_array_equal(clf.predict(X), y)
+
+
 def test_bnb():
     # Tests that BernoulliNB when alpha=1.0 gives the same values as
     # those given for the toy example in Manning, Raghavan, and


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #17926 

#### What does this implement/fix? Explain your changes.
The following snippet raises an exception:
```python
import sklearn
from sklearn.naive_bayes import MultinomialNB

X = [(0.072777, 0.334995),
     (0.857577, 0.977991),
     (0.310364, 0.230206),
     (0.75821 , 0.600593),
     (0.883202, 0.066408)]

y = [0, 0, 0, 0, 0]

clf = MultinomialNB(fit_prior=False)
clf.fit(X, y)
clf.predict(X)
```

`IndexError: index 1 is out of bounds for axis 0 with size 1`

This happens because `_joint_log_likelihood()` outputs a `(n_examples,  2)` matrix, even though there is only one class.
The correct size should be `(n_examples, 1)` with `+inf` values.

#### Any other comments?
There is a lot of weird behaviors when a MNB is given data with only one class, depending on the `fit_prior` argument.
Example:

```python
X = [(0.072777, 0.334995),
     (0.857577, 0.977991),
     (0.310364, 0.230206),
     (0.75821 , 0.600593),
     (0.883202, 0.066408)]

y = [2, 2, 2, 2, 2]

clf = MultinomialNB(fit_prior=False)
clf.fit(X, y)

print(clf.class_count_)
print(clf.class_log_prior_)
print(clf.classes_)
```
Outputs:
```
[5. 0.]
[-0.]
[2]
```

Whereas
```python
clf = MultinomialNB(fit_prior=True)
clf.fit(X, y)
print(clf.class_count_)
print(clf.class_log_prior_)
print(clf.classes_)
```

Outputs:
```
[5. 0.]
[  0. -inf]
[2]
```