### PR TITLE
[MRG] Correct handling of missing_values and NaN in SimpleImputer for object arrays (closes #19071)

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -371,19 +371,23 @@ class SimpleImputer(_BaseImputer):
 
     @staticmethod
     def _prepare_dtype_object(masked_X, missing_mask, missing_values):
-        """Try to convert object array into float64 to prepare for mean/median calculation."""
+        """Try to convert object array into float64.
+         to prepare for mean/median calculation."""
         if masked_X.data.dtype.kind == "O":
             result = masked_X
-            result.data[missing_mask] = np.nan  # this can be converted converted safely
-            result = result.astype(np.float64)  # conversion is necessary to calculate mean/median
-            ind_notmasked_nan = np.isnan(result.data[~missing_mask])  # in the not-masked part non-numeric can remain
-            X_notmasked_nan = masked_X.data[~missing_mask][ind_notmasked_nan]  # here we have their original values
-            num_notmasked_nan = len(X_notmasked_nan)  # we want error message to be informative
+            result.data[missing_mask] = np.nan
+            result = result.astype(np.float64)
+            # we want error message to be informative
+            ind_notmasked_nan = np.isnan(result.data[~missing_mask])
+            X_notmasked_nan = masked_X.data[~missing_mask][ind_notmasked_nan]
+            num_notmasked_nan = len(X_notmasked_nan)
             num_show = min(num_notmasked_nan, 3)
             if num_notmasked_nan > 0:
+                examples = X_notmasked_nan[:num_show]
                 msg = (
-                    f"Non-numeric values other than missing_values={missing_values}, "
-                    f"showing {num_show}/{num_notmasked_nan}: {X_notmasked_nan[:num_show]}"
+                    f"Non-numeric values other than "
+                    f"missing_values={missing_values}, "
+                    f"showing {num_show}/{num_notmasked_nan}: {examples}"
                 )
                 raise ValueError(msg)
         else:
@@ -399,7 +403,8 @@ class SimpleImputer(_BaseImputer):
 
         # Mean
         if strategy == "mean":
-            masked_X = self._prepare_dtype_object(masked_X, missing_mask, missing_values)
+            masked_X = self._prepare_dtype_object(
+                masked_X, missing_mask, missing_values)
             mean_masked = np.ma.mean(masked_X, axis=0)
             # Avoid the warning "Warning: converting a masked element to nan."
             mean = np.ma.getdata(mean_masked)
@@ -409,7 +414,8 @@ class SimpleImputer(_BaseImputer):
 
         # Median
         elif strategy == "median":
-            masked_X = self._prepare_dtype_object(masked_X, missing_mask, missing_values)
+            masked_X = self._prepare_dtype_object(
+                masked_X, missing_mask, missing_values)
             median_masked = np.ma.median(masked_X, axis=0)
             # Avoid the warning "Warning: converting a masked element to nan."
             median = np.ma.getdata(median_masked)

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -241,7 +241,10 @@ class SimpleImputer(_BaseImputer):
             else:
                 dtype = None
         else:
-            dtype = FLOAT_DTYPES
+            if isinstance(X, np.ndarray) and X.dtype.kind == "O":
+                dtype = object
+            else:
+                dtype = FLOAT_DTYPES
 
         if not is_scalar_nan(self.missing_values):
             force_all_finite = True
@@ -366,6 +369,27 @@ class SimpleImputer(_BaseImputer):
 
         return statistics
 
+    @staticmethod
+    def _prepare_dtype_object(masked_X, missing_mask, missing_values):
+        """Try to convert object array into float64 to prepare for mean/median calculation."""
+        if masked_X.data.dtype.kind == "O":
+            result = masked_X
+            result.data[missing_mask] = np.nan  # this can be converted converted safely
+            result = result.astype(np.float64)  # conversion is necessary to calculate mean/median
+            ind_notmasked_nan = np.isnan(result.data[~missing_mask])  # in the not-masked part non-numeric can remain
+            X_notmasked_nan = masked_X.data[~missing_mask][ind_notmasked_nan]  # here we have their original values
+            num_notmasked_nan = len(X_notmasked_nan)  # we want error message to be informative
+            num_show = min(num_notmasked_nan, 3)
+            if num_notmasked_nan > 0:
+                msg = (
+                    f"Non-numeric values other than missing_values={missing_values}, "
+                    f"showing {num_show}/{num_notmasked_nan}: {X_notmasked_nan[:num_show]}"
+                )
+                raise ValueError(msg)
+        else:
+            result = masked_X
+        return result
+
     def _dense_fit(self, X, strategy, missing_values, fill_value):
         """Fit the transformer on dense data."""
         missing_mask = _get_mask(X, missing_values)
@@ -375,6 +399,7 @@ class SimpleImputer(_BaseImputer):
 
         # Mean
         if strategy == "mean":
+            masked_X = self._prepare_dtype_object(masked_X, missing_mask, missing_values)
             mean_masked = np.ma.mean(masked_X, axis=0)
             # Avoid the warning "Warning: converting a masked element to nan."
             mean = np.ma.getdata(mean_masked)
@@ -384,6 +409,7 @@ class SimpleImputer(_BaseImputer):
 
         # Median
         elif strategy == "median":
+            masked_X = self._prepare_dtype_object(masked_X, missing_mask, missing_values)
             median_masked = np.ma.median(masked_X, axis=0)
             # Avoid the warning "Warning: converting a masked element to nan."
             median = np.ma.getdata(median_masked)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -704,7 +704,7 @@ def test_iterative_imputer_clip():
     n = 100
     d = 10
     X = _sparse_random_matrix(n, d, density=0.10,
-                             random_state=rng).toarray()
+                              random_state=rng).toarray()
 
     imputer = IterativeImputer(missing_values=0,
                                max_iter=1,
@@ -808,7 +808,7 @@ def test_iterative_imputer_transform_stochasticity():
     n = 100
     d = 10
     X = _sparse_random_matrix(n, d, density=0.10,
-                             random_state=rng1).toarray()
+                              random_state=rng1).toarray()
 
     # when sample_posterior=True, two transforms shouldn't be equal
     imputer = IterativeImputer(missing_values=0,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #19071.
In `SimpleImputer` strategies mean/median you can use input arrays with dtype is `object`. Imagine numeric data in the input array, except for missing values. In object arrays, you have a lot of flexibility on how to encode missing values. You can use `np.nan`, `None`, a string constant or anything else. There are two scenarios which are described in the issue #19071:

1.  There is more than one type of missing value in the input object array, one of them is specified as the `missing_values` parameter of the `SimpleImputer`. In this case the mean/median imputation should fail, because there are still non-numeric values in the input array other than `missing_values` which is masked. See #19071 for an example of not failing.
2. There is just one type of missing value in the input object array and that is specified as the `missing_values` parameter of the `SimpleImputer`. In this case the mean/median imputation must not fail and should calculate mean/median from the remaining values of the input array. See #19071 for an example of this failing with `missing_values=None`.

#### What does this implement/fix? Explain your changes.

In the `_validate_input` method, I keep the dtype as object.
In the `_dense_fit` method I try to convert the object array into float64 to prepare for mean/median calculation. If the not-masked values still contain some non-numeric values (scenario 1), ValueError is raised with the following informative error message:
```
Non-numeric values other than missing_values={missing_values}, showing {num_show}/{num_notmasked_nan}: {examples}
```
where the number of examples is limited to three.

#### Any other comments?

A comprehensive set of unit tests is added, which covers both scenarios.