### PR TITLE
FIX avoid spurious warning in IncrementalPCA due to n_samples == n_components_

### DIFF
--- a/sklearn/decomposition/_incremental_pca.py
+++ b/sklearn/decomposition/_incremental_pca.py
@@ -311,7 +311,7 @@ class IncrementalPCA(_BasePCA):
         self.explained_variance_ = explained_variance[:self.n_components_]
         self.explained_variance_ratio_ = \
             explained_variance_ratio[:self.n_components_]
-        if self.n_components_ < n_features:
+        if self.n_components_ not in (n_samples, n_features):
             self.noise_variance_ = \
                 explained_variance[self.n_components_:].mean()
         else:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes  #19050. 


#### What does this implement/fix? Explain your changes.
Added conditon
```python
if self.n_components_ not in (n_samples, n_features):
```
in sklearn/decompostion/_incremental_pca.py

No longer throws warning message when n_conditions are equal to n_samples.

#### Any other comments?
Non-regression tests:
```python 
import sklearn.decomposition as skdecomp
ipca=skdecomp.IncrementalPCA(n_components=5)
ipca.partial_fit(np.random.randn(5,7))
```

```python
import sklearn.decomposition as skdecomp
ipca=skdecomp.IncrementalPCA(n_components=5)
ipca.fit(np.random.randn(5,7))
```
Resulted in no warnings.