### PR TITLE
[MRG] Common Private Loss Module

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1647,3 +1647,27 @@ Recently deprecated
 
 To be removed in 1.0 (renaming of 0.25)
 ---------------------------------------
+
+.. _loss_function_ref:
+
+:mod:`sklearn._loss`: Non-public Loss Function Classes
+===========================================================
+
+.. automodule:: sklearn._loss
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: sklearn
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   _loss.HalfSquaredError
+   _loss.AbsoluteError
+   _loss.PinballLoss
+   _loss.HalfPoissonLoss
+   _loss.HalfGammaLoss
+   _loss.HalfTweedieLoss
+   _loss.BinaryCrossEntropy
+   _loss.CategoricalCrossEntropy

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1650,7 +1650,7 @@ To be removed in 1.0 (renaming of 0.25)
 
 .. _loss_function_ref:
 
-:mod:`sklearn._loss`: Non-public Loss Function Classes
+:mod:`sklearn._loss`: Private Loss Function Classes
 ===========================================================
 
 .. automodule:: sklearn._loss

--- a/sklearn/_loss/__init__.py
+++ b/sklearn/_loss/__init__.py
@@ -2,3 +2,26 @@
 The :mod:`sklearn._loss` module includes loss function classes suitable for
 fitting classification and regression tasks.
 """
+
+from ._loss import (
+    HalfSquaredError,
+    AbsoluteError,
+    PinballLoss,
+    HalfPoissonLoss,
+    HalfGammaLoss,
+    HalfTweedieLoss,
+    BinaryCrossEntropy,
+    CategoricalCrossEntropy,
+)
+
+
+__all__ = [
+    "HalfSquaredError",
+    "AbsoluteError",
+    "PinballLoss",
+    "HalfPoissonLoss",
+    "HalfGammaLoss",
+    "HalfTweedieLoss",
+    "BinaryCrossEntropy",
+    "CategoricalCrossEntropy",
+]

--- a/sklearn/_loss/__init__.py
+++ b/sklearn/_loss/__init__.py
@@ -3,7 +3,7 @@ The :mod:`sklearn._loss` module includes loss function classes suitable for
 fitting classification and regression tasks.
 """
 
-from ._loss import (
+from .loss import (
     HalfSquaredError,
     AbsoluteError,
     PinballLoss,

--- a/sklearn/_loss/__init__.py
+++ b/sklearn/_loss/__init__.py
@@ -1,0 +1,4 @@
+"""
+The :mod:`sklearn._loss` module includes loss function classes suitable for
+fitting classification and regression tasks.
+"""

--- a/sklearn/_loss/_loss.pxd
+++ b/sklearn/_loss/_loss.pxd
@@ -1,0 +1,75 @@
+# cython: language_level=3
+
+import numpy as np
+cimport numpy as np
+
+np.import_array()
+
+
+# Fused types for y_true, y_pred, raw_prediction
+ctypedef fused Y_DTYPE_C:
+    np.npy_float64
+    np.npy_float32
+
+
+# Fused types for gradient and hessian
+ctypedef fused G_DTYPE_C:
+    np.npy_float64
+    np.npy_float32
+
+
+# Struct to return 2 doubles
+ctypedef struct double2:
+   double val1
+   double val2
+
+
+# C base class for loss functions
+cdef class cLossFunction:
+    cdef double closs(self, double y_true, double raw_prediction) nogil
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+
+
+cdef class cHalfSquaredError(cLossFunction):
+    cdef double closs(self, double y_true, double raw_prediction) nogil
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+
+
+cdef class cAbsoluteError(cLossFunction):
+    cdef double closs(self, double y_true, double raw_prediction) nogil
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+
+
+cdef class cPinballLoss(cLossFunction):
+    cdef readonly double quantile  # readonly makes it inherited by children
+    cdef double closs(self, double y_true, double raw_prediction) nogil
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+
+
+cdef class cHalfPoissonLoss(cLossFunction):
+    cdef double closs(self, double y_true, double raw_prediction) nogil
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+
+
+cdef class cHalfGammaLoss(cLossFunction):
+    cdef double closs(self, double y_true, double raw_prediction) nogil
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+
+
+cdef class cHalfTweedieLoss(cLossFunction):
+    cdef readonly double power  # readonly makes it inherited by children
+    cdef double closs(self, double y_true, double raw_prediction) nogil
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+
+
+cdef class cBinaryCrossEntropy(cLossFunction):
+    cdef double closs(self, double y_true, double raw_prediction) nogil
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil

--- a/sklearn/_loss/_loss.pxd
+++ b/sklearn/_loss/_loss.pxd
@@ -19,7 +19,7 @@ ctypedef fused G_DTYPE_C:
 
 
 # Struct to return 2 doubles
-ctypedef struct double2:
+ctypedef struct double_pair:
    double val1
    double val2
 
@@ -28,48 +28,48 @@ ctypedef struct double2:
 cdef class cLossFunction:
     cdef double closs(self, double y_true, double raw_prediction) nogil
     cdef double cgradient(self, double y_true, double raw_prediction) nogil
-    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+    cdef double_pair cgrad_hess(self, double y_true, double raw_prediction) nogil
 
 
 cdef class cHalfSquaredError(cLossFunction):
     cdef double closs(self, double y_true, double raw_prediction) nogil
     cdef double cgradient(self, double y_true, double raw_prediction) nogil
-    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+    cdef double_pair cgrad_hess(self, double y_true, double raw_prediction) nogil
 
 
 cdef class cAbsoluteError(cLossFunction):
     cdef double closs(self, double y_true, double raw_prediction) nogil
     cdef double cgradient(self, double y_true, double raw_prediction) nogil
-    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+    cdef double_pair cgrad_hess(self, double y_true, double raw_prediction) nogil
 
 
 cdef class cPinballLoss(cLossFunction):
     cdef readonly double quantile  # readonly makes it inherited by children
     cdef double closs(self, double y_true, double raw_prediction) nogil
     cdef double cgradient(self, double y_true, double raw_prediction) nogil
-    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+    cdef double_pair cgrad_hess(self, double y_true, double raw_prediction) nogil
 
 
 cdef class cHalfPoissonLoss(cLossFunction):
     cdef double closs(self, double y_true, double raw_prediction) nogil
     cdef double cgradient(self, double y_true, double raw_prediction) nogil
-    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+    cdef double_pair cgrad_hess(self, double y_true, double raw_prediction) nogil
 
 
 cdef class cHalfGammaLoss(cLossFunction):
     cdef double closs(self, double y_true, double raw_prediction) nogil
     cdef double cgradient(self, double y_true, double raw_prediction) nogil
-    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+    cdef double_pair cgrad_hess(self, double y_true, double raw_prediction) nogil
 
 
 cdef class cHalfTweedieLoss(cLossFunction):
     cdef readonly double power  # readonly makes it inherited by children
     cdef double closs(self, double y_true, double raw_prediction) nogil
     cdef double cgradient(self, double y_true, double raw_prediction) nogil
-    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+    cdef double_pair cgrad_hess(self, double y_true, double raw_prediction) nogil
 
 
 cdef class cBinaryCrossEntropy(cLossFunction):
     cdef double closs(self, double y_true, double raw_prediction) nogil
     cdef double cgradient(self, double y_true, double raw_prediction) nogil
-    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil
+    cdef double_pair cgrad_hess(self, double y_true, double raw_prediction) nogil

--- a/sklearn/_loss/_loss.pyx
+++ b/sklearn/_loss/_loss.pyx
@@ -1601,7 +1601,6 @@ cdef class cCategoricalCrossEntropy(cLossFunction):
 
                 for i in prange(n_samples, schedule='static'):
                     sum_exp_minus_max(i, raw_prediction, p)
-                    max_value = raw_prediction[i, 0]
                     max_value = p[n_classes]     # p[-2]
                     sum_exps = p[n_classes + 1]  # p[-1]
                     loss[i] = log(sum_exps) + max_value

--- a/sklearn/_loss/_loss.pyx
+++ b/sklearn/_loss/_loss.pyx
@@ -358,7 +358,7 @@ cdef inline double cgradient_binary_crossentropy(
     #         return ((1 - y_true) - y_true * exp_tmp) / (1 + exp_tmp)
     # Note that optimal speed would be achieved, at the cost of precision, by
     #     return expit(raw_prediction) - y_true
-    # i.e. no if else, and an own inline implemention of expit instead of
+    # i.e. no "if else" and an own inline implemention of expit instead of
     #     from scipy.special.cython_special cimport expit
     # The case distinction raw_prediction < 0 in the stable implementation
     # does not provide significant better precision. Therefore we go without
@@ -465,7 +465,7 @@ cdef class cLossFunction:
 
         Returns
         -------
-        grad_hess_pair
+        double2
             Gradient and hessian of the loss function w.r.t. `raw_prediction`.
         """
         pass
@@ -495,7 +495,7 @@ cdef class cLossFunction:
         loss : array of shape (n_samples,)
             A location into which the result is stored.
         n_threads : int
-            Might use openmp thread parallelism.
+            Number of threads used by OpenMP (if any).
 
         Returns
         -------
@@ -525,7 +525,7 @@ cdef class cLossFunction:
         gradient : array of shape (n_samples,)
             A location into which the result is stored.
         n_threads : int
-            Might use openmp thread parallelism.
+            Number of threads used by OpenMP (if any).
 
         Returns
         -------
@@ -558,7 +558,7 @@ cdef class cLossFunction:
         gradient : array of shape (n_samples,)
             A location into which the gradient is stored.
         n_threads : int
-            Might use openmp thread parallelism.
+            Number of threads used by OpenMP (if any).
 
         Returns
         -------
@@ -598,7 +598,7 @@ cdef class cLossFunction:
         hessian : array of shape (n_samples,)
             A location into which the hessian is stored.
         n_threads : int
-            Might use openmp thread parallelism.
+            Number of threads used by OpenMP (if any).
 
         Returns
         -------

--- a/sklearn/_loss/_loss.pyx
+++ b/sklearn/_loss/_loss.pyx
@@ -1,0 +1,1780 @@
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+
+# Design:
+# See https://github.com/scikit-learn/scikit-learn/issues/15123 for reasons.
+# a) Merge link functions into loss functions for speed and numerical
+#    stability, i.e. use raw_prediction instead of y_pred in signature.
+# b) Pure C functions (nogil) calculate single points (single sample)
+# c) Wrap C functions in a loop to get Python functions operating on ndarrays.
+#   - Write loops manually.
+#     Reason: There is still some performance overhead when using a wrapper
+#     function "wrap" that carries out the loop and gets as argument a function
+#     pointer to one of the C functions from b), e.g.
+#     wrap(closs_half_poisson, y_true, ...)
+#   - Pass n_threads as argument to prange and propagate option to all callers.
+# d) Provide classes (Cython extension types) per loss in order to have
+#    semantical structured objects.
+#    - Member function for single points just call the C function from b).
+#      These are used e.g. in SGD `_plain_sgd`.
+#    - Member functions operating on ndarrays looping, see c), over calls to C
+#      functions from b).
+# e) Provide convenience Python classes that inherit from these extension types
+#    elsewhere (see loss.py)
+#    - Example: loss.gradient calls extension_type._gradient but does some
+#      input checking like None -> np.empty().
+#
+# Note: We require 1-dim ndarrays to be contiguous.
+# TODO: Use const memoryviews with Cython 3.0 where appropriate (# IN)
+
+cimport cython
+from cython.parallel import parallel, prange
+import numpy as np
+cimport numpy as np
+
+from libc.math cimport exp, fabs, log, log1p
+from libc.stdlib cimport malloc, free
+
+np.import_array()
+
+
+# -------------------------------------
+# Helper functions
+# -------------------------------------
+# Numerically stable version of log(1 + exp(x)) for double precision
+# See https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
+cdef inline double log1pexp(double x) nogil:
+    if x <= -37:
+        return exp(x)
+    elif x <= 18:
+        return log1p(exp(x))
+    elif x <= 33.3:
+        return x + exp(-x)
+    else:
+        return x
+
+
+cdef inline void sum_exp_minus_max(
+    const int i, Y_DTYPE_C[:, :] raw_prediction,  # IN
+    Y_DTYPE_C *p                                  # OUT
+) nogil:
+    # Store p[k] = exp(raw_prediction_i_k - max_value) for k = 0 to n_classes-1
+    #       p[-2] = max(raw_prediction_i_k, k = 0 to n_classes-1)
+    #       p[-1] = sum(p[k], k = 0 to n_classes-1) = sum of exponentials
+    # len(p) must be n_classes + 2
+    # Notes:
+    # - Using "by reference" arguments doesn't work well, therefore we use a
+    #   longer p, see https://github.com/cython/cython/issues/1863
+    # - i needs to be passed (and stays constant) because otherwise Cython does
+    #   not generate optimal code, see
+    #   https://github.com/scikit-learn/scikit-learn/issues/17299
+    # - We do not calculate p[k] = p[k] / sum_exps to save one loop over k.
+    cdef:
+        int k
+        int n_classes = raw_prediction.shape[1]
+        double max_value = raw_prediction[i, 0]
+        double sum_exps = 0
+    for k in range(1, n_classes):
+        # Compute max value of array for numerical stability
+        if max_value < raw_prediction[i, k]:
+            max_value = raw_prediction[i, k]
+
+    for k in range(n_classes):
+        p[k] = exp(raw_prediction[i, k] - max_value)
+        sum_exps += p[k]
+
+    p[n_classes] = max_value     # same as p[-2]
+    p[n_classes + 1] = sum_exps  # same as p[-1]
+
+
+# -------------------------------------
+# Single point inline C functions
+# -------------------------------------
+# Half Squared Error
+cdef inline double closs_half_squared_error(double y_true, double raw_prediction) nogil:
+    return 0.5 * (raw_prediction - y_true) * (raw_prediction - y_true)
+
+
+cdef inline double cgradient_half_squared_error(
+    double y_true, double raw_prediction
+) nogil:
+    return raw_prediction - y_true
+
+
+cdef inline double2 cgrad_hess_half_squared_error(
+    double y_true, double raw_prediction
+) nogil:
+    cdef double2 gh
+    gh.val1 = raw_prediction - y_true  # gradient
+    gh.val2 = 1.                       # hessian
+    return gh
+
+
+# Absolute Error
+cdef inline double closs_absolute_error(double y_true, double raw_prediction) nogil:
+    return fabs(raw_prediction - y_true)
+
+
+cdef inline double cgradient_absolute_error(double y_true, double raw_prediction) nogil:
+    return 1. if raw_prediction > y_true else -1.
+
+
+cdef inline double2 cgrad_hess_absolute_error(
+    double y_true, double raw_prediction
+) nogil:
+    cdef double2 gh
+    # Note that exact hessian = 0 almost everywhere. Optimization routines like
+    # in HGBT, however, need a hessian > 0. Therefore, we assign 1.
+    gh.val1 = 1. if raw_prediction > y_true else -1.  # gradient
+    gh.val2 = 1.                                      # hessian
+    return gh
+
+
+# Quantile Loss / Pinball Loss
+cdef inline double closs_pinball_loss(
+    double y_true, double raw_prediction, double quantile
+) nogil:
+    return (quantile * (y_true - raw_prediction) if y_true >= raw_prediction
+            else (1. - quantile) * (raw_prediction - y_true))
+
+
+cdef inline double cgradient_pinball_loss(
+    double y_true, double raw_prediction, double quantile
+) nogil:
+    return -quantile if y_true >=raw_prediction else 1. - quantile
+
+
+cdef inline double2 cgrad_hess_pinball_loss(
+    double y_true, double raw_prediction, double quantile
+) nogil:
+    cdef double2 gh
+    # Note that exact hessian = 0 almost everywhere. Optimization routines like
+    # in HGBT, however, need a hessian > 0. Therefore, we assign 1.
+    gh.val1 = -quantile if y_true >=raw_prediction else 1. - quantile  # gradient
+    gh.val2 = 1.                                                       # hessian
+    return gh
+
+
+# Half Poisson Deviance with Log-Link, dropping constant terms
+cdef inline double closs_half_poisson(double y_true, double raw_prediction) nogil:
+    return exp(raw_prediction) - y_true * raw_prediction
+
+
+cdef inline double cgradient_half_poisson(double y_true, double raw_prediction) nogil:
+    # y_pred - y_true
+    return exp(raw_prediction) - y_true
+
+
+cdef inline double2 closs_grad_half_poisson(double y_true, double raw_prediction) nogil:
+    cdef double2 lg
+    lg.val2 = exp(raw_prediction)
+    lg.val1 = lg.val2 - y_true * raw_prediction  # loss
+    lg.val2 -= y_true                            # gradient
+    return lg
+
+
+cdef inline double2 cgrad_hess_half_poisson(double y_true, double raw_prediction) nogil:
+    cdef double2 gh
+    gh.val2 = exp(raw_prediction)  # hessian
+    gh.val1 = gh.val2 - y_true     # gradient
+    return gh
+
+
+# Half Gamma Deviance with Log-Link, dropping constant terms
+cdef inline double closs_half_gamma(double y_true, double raw_prediction) nogil:
+    return raw_prediction + y_true * exp(-raw_prediction)
+
+
+cdef inline double cgradient_half_gamma(double y_true, double raw_prediction) nogil:
+    return 1. - y_true * exp(-raw_prediction)
+
+
+cdef inline double2 closs_grad_half_gamma(double y_true, double raw_prediction) nogil:
+    cdef double2 lg
+    lg.val2 = exp(-raw_prediction)
+    lg.val1 = raw_prediction + y_true * lg.val2  # loss
+    lg.val2 = 1. - y_true * lg.val2              # gradient
+    return lg
+
+
+cdef inline double2 cgrad_hess_half_gamma(double y_true, double raw_prediction) nogil:
+    cdef double2 gh
+    gh.val2 = exp(-raw_prediction)
+    gh.val1 = 1. - y_true * gh.val2  # gradient
+    gh.val2 *= y_true                # hessian
+    return gh
+
+
+# Half Tweedie Deviance with Log-Link, dropping constant terms
+# Note that by dropping constants this is no longer smooth in parameter power.
+cdef inline double closs_half_tweedie(
+    double y_true, double raw_prediction, double power
+) nogil:
+    if power == 0.:
+        return closs_half_squared_error(y_true, exp(raw_prediction))
+    elif power == 1.:
+        return closs_half_poisson(y_true, raw_prediction)
+    elif power == 2.:
+        return closs_half_gamma(y_true, raw_prediction)
+    else:
+        return (exp((2. - power) * raw_prediction) / (2. - power)
+                - y_true * exp((1. - power) * raw_prediction) / (1. - power))
+
+
+cdef inline double cgradient_half_tweedie(
+    double y_true, double raw_prediction, double power
+) nogil:
+    cdef double exp1
+    if power == 0.:
+        exp1 = exp(raw_prediction)
+        return exp1 * (exp1 - y_true)
+    elif power == 1.:
+        return cgradient_half_poisson(y_true, raw_prediction)
+    elif power == 2.:
+        return cgradient_half_gamma(y_true, raw_prediction)
+    else:
+        return (exp((2. - power) * raw_prediction)
+                - y_true * exp((1. - power) * raw_prediction))
+
+
+cdef inline double2 closs_grad_half_tweedie(
+    double y_true, double raw_prediction, double power
+) nogil:
+    cdef double2 lg
+    cdef double exp1, exp2
+    if power == 0.:
+        exp1 = exp(raw_prediction)
+        lg.val1 = closs_half_squared_error(y_true, exp1)  # loss
+        lg.val2 = exp1 * (exp1 - y_true)                  # gradient
+    elif power == 1.:
+        return closs_grad_half_poisson(y_true, raw_prediction)
+    elif power == 2.:
+        return closs_grad_half_gamma(y_true, raw_prediction)
+    else:
+        exp1 = exp((1. - power) * raw_prediction)
+        exp2 = exp((2. - power) * raw_prediction)
+        lg.val1 = exp2 / (2. - power) - y_true * exp1 / (1. - power)  # loss
+        lg.val2 = exp2 - y_true * exp1                                # gradient
+    return lg
+
+
+cdef inline double2 cgrad_hess_half_tweedie(
+    double y_true, double raw_prediction, double power
+) nogil:
+    cdef double2 gh
+    cdef double exp1, exp2
+    if power == 0.:
+        exp1 = exp(raw_prediction)
+        gh.val1 = exp1 * (exp1 - y_true)      # gradient
+        gh.val2 = exp1 * (2 * exp1 - y_true)  # hessian
+    elif power == 1.:
+        return cgrad_hess_half_poisson(y_true, raw_prediction)
+    elif power == 2.:
+        return cgrad_hess_half_gamma(y_true, raw_prediction)
+    else:
+        exp1 = exp((1. - power) * raw_prediction)
+        exp2 = exp((2. - power) * raw_prediction)
+        gh.val1 = exp2 - y_true * exp1                                # gradient
+        gh.val2 = (2. - power) * exp2 - (1. - power) * y_true * exp1  # hessian
+    return gh
+
+
+# Binary cross entropy aka log-loss
+cdef inline double closs_binary_crossentropy(
+    double y_true, double raw_prediction
+) nogil:
+    # log1p(exp(raw_prediction)) - y_true * raw_prediction
+    return log1pexp(raw_prediction) - y_true * raw_prediction
+
+
+cdef inline double cgradient_binary_crossentropy(
+    double y_true, double raw_prediction
+) nogil:
+    # y_pred - y_true = expit(raw_prediction) - y_true
+    # Numerically more stable, see
+    # http://fa.bianp.net/blog/2019/evaluate_logistic/
+    #     if raw_prediction < 0:
+    #         exp_tmp = exp(raw_prediction)
+    #         return ((1 - y_true) * exp_tmp - y_true) / (1 + exp_tmp)
+    #     else:
+    #         exp_tmp = exp(-raw_prediction)
+    #         return ((1 - y_true) - y_true * exp_tmp) / (1 + exp_tmp)
+    # Note that optimal speed would be achieved, at the cost of precision, by
+    #     return expit(raw_prediction) - y_true
+    # i.e. no if else, and an own inline implemention of expit instead of
+    #     from scipy.special.cython_special cimport expit
+    # The case distinction raw_prediction < 0 in the stable implementation
+    # does not provide significant better precision. Therefore we go without
+    # it.
+    cdef double exp_tmp
+    exp_tmp = exp(-raw_prediction)
+    return ((1 - y_true) - y_true * exp_tmp) / (1 + exp_tmp)
+
+
+cdef inline double2 closs_grad_binary_crossentropy(
+    double y_true, double raw_prediction
+) nogil:
+    cdef double2 lg
+    if raw_prediction <= 0:
+        lg.val2 = exp(raw_prediction)
+        if raw_prediction <= -37:
+            lg.val1 = lg.val2 - y_true * raw_prediction              # loss
+        else:
+            lg.val1 = log1p(lg.val2) - y_true * raw_prediction       # loss
+        lg.val2 = ((1 - y_true) * lg.val2 - y_true) / (1 + lg.val2)  # gradient
+    else:
+        lg.val2 = exp(-raw_prediction)
+        if raw_prediction <= 18:
+            # log1p(exp(x)) = log(1 + exp(x)) = x + log1p(exp(-x))
+            lg.val1 = log1p(lg.val2) + (1 - y_true) * raw_prediction  # loss
+        else:
+            lg.val1 = lg.val2 + (1 - y_true) * raw_prediction         # loss
+        lg.val2 = ((1 - y_true) - y_true * lg.val2) / (1 + lg.val2)   # gradient
+    return lg
+
+
+cdef inline double2 cgrad_hess_binary_crossentropy(
+    double y_true, double raw_prediction
+) nogil:
+    # with y_pred = expit(raw)
+    # hessian = y_pred * (1 - y_pred) = exp(raw) / (1 + exp(raw))**2
+    #                                 = exp(-raw) / (1 + exp(-raw))**2
+    cdef double2 gh
+    gh.val2 = exp(-raw_prediction)
+    gh.val1 = ((1 - y_true) - y_true * gh.val2) / (1 + gh.val2)  # gradient
+    gh.val2 = gh.val2 / (1 + gh.val2)**2                         # hessian
+    return gh
+
+
+# ---------------------------------------------------
+# Extension Types for Loss Functions of 1-dim targets
+# ---------------------------------------------------
+cdef class cLossFunction:
+    """Base class for convex loss functions."""
+
+    cdef double closs(self, double y_true, double raw_prediction) nogil:
+        """Compute the loss for a single sample.
+
+        Parameters
+        ----------
+        y_true : double
+            Observed, true target value.
+        raw_prediction : double
+            Raw prediction value (in link space).
+
+        Returns
+        -------
+        double
+            The loss evaluated at `y_true` and `raw_prediction`.
+        """
+        pass
+
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil:
+        """Compute gradient of loss w.r.t. raw_prediction for a single sample.
+
+        Parameters
+        ----------
+        y_true : double
+            Observed, true target value.
+        raw_prediction : double
+            Raw prediction value (in link space).
+
+        Returns
+        -------
+        double
+            The derivative of the loss function w.r.t. `raw_prediction`.
+        """
+        pass
+
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil:
+        """Compute gradient and hessian.
+
+        Gradient and hessian of loss w.r.t. raw_prediction for a single sample.
+
+        This is usually diagonal in raw_prediction_i and raw_prediction_j.
+        Therefore, we return the diagonal element i=j.
+
+        For a loss with a non-canonical link, this might implement the diagonal
+        of the Fisher matrix (=expected hessian) instead of the hessian.
+
+        Parameters
+        ----------
+        y_true : double
+            Observed, true target value.
+        raw_prediction : double
+            Raw prediction value (in link space).
+
+        Returns
+        -------
+        grad_hess_pair
+            Gradient and hessian of the loss function w.r.t. `raw_prediction`.
+        """
+        pass
+
+    # Note: With Cython 3.0, fused types can be used together with const:
+    #       const Y_DTYPE_C double[::1] y_true
+    # See release notes 3.0.0 alpha1
+    # https://cython.readthedocs.io/en/latest/src/changes.html#alpha-1-2020-04-12
+    def _loss(
+        self,
+        Y_DTYPE_C[::1] y_true,          # IN
+        Y_DTYPE_C[::1] raw_prediction,  # IN
+        Y_DTYPE_C[::1] sample_weight,   # IN
+        G_DTYPE_C[::1] loss,            # OUT
+        int n_threads=1
+    ):
+        """Compute the pointwise loss value for each input.
+
+        Parameters
+        ----------
+        y_true : array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : array of shape (n_samples,)
+            Raw prediction values (in link space).
+        sample_weight : array of shape (n_samples,) or None
+            Sample weights.
+        loss : array of shape (n_samples,)
+            A location into which the result is stored.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        loss : array of shape (n_samples,)
+            Element-wise loss function.
+        """
+        pass
+
+    def _gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,          # IN
+        Y_DTYPE_C[::1] raw_prediction,  # IN
+        Y_DTYPE_C[::1] sample_weight,   # IN
+        G_DTYPE_C[::1] gradient,        # OUT
+        int n_threads=1
+    ):
+        """Compute gradient of loss w.r.t raw_prediction for each input.
+
+        Parameters
+        ----------
+        y_true : array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : array of shape (n_samples,)
+            Raw prediction values (in link space).
+        sample_weight : array of shape (n_samples,) or None
+            Sample weights.
+        gradient : array of shape (n_samples,)
+            A location into which the result is stored.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        gradient : array of shape (n_samples,)
+            Element-wise gradients.
+        """
+        pass
+
+    def _loss_gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,          # IN
+        Y_DTYPE_C[::1] raw_prediction,  # IN
+        Y_DTYPE_C[::1] sample_weight,   # IN
+        G_DTYPE_C[::1] loss,            # OUT
+        G_DTYPE_C[::1] gradient,        # OUT
+        int n_threads=1
+    ):
+        """Compute loss and gradient of loss w.r.t raw_prediction.
+
+        Parameters
+        ----------
+        y_true : array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : array of shape (n_samples,)
+            Raw prediction values (in link space).
+        sample_weight : array of shape (n_samples,) or None
+            Sample weights.
+        loss : array of shape (n_samples,) or None
+            A location into which the element-wise loss is stored.
+        gradient : array of shape (n_samples,)
+            A location into which the gradient is stored.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        loss : array of shape (n_samples,)
+            Element-wise loss function.
+
+        gradient : array of shape (n_samples,)
+            Element-wise gradients.
+        """
+        self._loss(y_true, raw_prediction, sample_weight, loss,
+                            n_threads)
+        self._gradient(y_true, raw_prediction, sample_weight, gradient,
+                      n_threads)
+        return np.asarray(loss), np.asarray(gradient)
+
+    def _gradient_hessian(
+        self,
+        Y_DTYPE_C[::1] y_true,          # IN
+        Y_DTYPE_C[::1] raw_prediction,  # IN
+        Y_DTYPE_C[::1] sample_weight,   # IN
+        G_DTYPE_C[::1] gradient,        # OUT
+        G_DTYPE_C[::1] hessian,         # OUT
+        int n_threads=1
+    ):
+        """Compute gradient and hessian of loss w.r.t raw_prediction.
+
+        Parameters
+        ----------
+        y_true : array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : array of shape (n_samples,)
+            Raw prediction values (in link space).
+        sample_weight : array of shape (n_samples,) or None
+            Sample weights.
+        gradient : array of shape (n_samples,)
+            A location into which the gradient is stored.
+        hessian : array of shape (n_samples,)
+            A location into which the hessian is stored.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        gradient : array of shape (n_samples,)
+            Element-wise gradients.
+
+        hessian : array of shape (n_samples,)
+            Element-wise hessians.
+        """
+        pass
+
+
+cdef class cHalfSquaredError(cLossFunction):
+    """Half Squared Error with identity link.
+
+    Domain:
+    y_true and y_pred all real numbers
+
+    Link:
+    y_pred = raw_prediction
+    """
+
+    cdef double closs(self, double y_true, double raw_prediction) nogil:
+        return closs_half_squared_error(y_true, raw_prediction)
+
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil:
+        return cgradient_half_squared_error(y_true, raw_prediction)
+
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil:
+        return cgrad_hess_half_squared_error(y_true, raw_prediction)
+
+    def _loss(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = closs_half_squared_error(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = (
+                    sample_weight[i]
+                    * closs_half_squared_error(y_true[i], raw_prediction[i])
+                )
+
+        return np.asarray(loss)
+
+    def _gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = cgradient_half_squared_error(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = (
+                    sample_weight[i]
+                    * cgradient_half_squared_error(y_true[i], raw_prediction[i])
+                )
+
+        return np.asarray(gradient)
+
+
+    def _gradient_hessian(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        G_DTYPE_C[::1] hessian,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_half_squared_error(y_true[i], raw_prediction[i])
+                gradient[i] = dbl2.val1
+                hessian[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_half_squared_error(y_true[i], raw_prediction[i])
+                gradient[i] = sample_weight[i] * dbl2.val1
+                hessian[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(gradient), np.asarray(hessian)
+
+
+cdef class cAbsoluteError(cLossFunction):
+    """Absolute Error with identity link.
+
+    Domain:
+    y_true and y_pred all real numbers
+
+    Link:
+    y_pred = raw_prediction
+    """
+
+    cdef double closs(self, double y_true, double raw_prediction) nogil:
+        return closs_absolute_error(y_true, raw_prediction)
+
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil:
+        return cgradient_absolute_error(y_true, raw_prediction)
+
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil:
+        return cgrad_hess_absolute_error(y_true, raw_prediction)
+
+    def _loss(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = closs_absolute_error(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = (sample_weight[i]
+                    * closs_absolute_error(y_true[i], raw_prediction[i]))
+
+        return np.asarray(loss)
+
+    def _gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = cgradient_absolute_error(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = (
+                    sample_weight[i]
+                    * cgradient_absolute_error(y_true[i], raw_prediction[i])
+                )
+
+        return np.asarray(gradient)
+
+    def _gradient_hessian(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        G_DTYPE_C[::1] hessian,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_absolute_error(y_true[i], raw_prediction[i])
+                gradient[i] = dbl2.val1
+                hessian[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_absolute_error(y_true[i], raw_prediction[i])
+                gradient[i] = sample_weight[i] * dbl2.val1
+                hessian[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(gradient), np.asarray(hessian)
+
+
+cdef class cPinballLoss(cLossFunction):
+    """Quantile Loss aka Pinball Loss with identity link.
+
+    Domain:
+    y_true and y_pred all real numbers
+    quantile in (0, 1)
+
+    Link:
+    y_pred = raw_prediction
+
+    Note: 2 * cPinballLoss(quantile=0.5) equals cAbsoluteError()
+    """
+
+    def __init__(self, quantile):
+        self.quantile = quantile
+
+    cdef double closs(self, double y_true, double raw_prediction) nogil:
+        return closs_pinball_loss(y_true, raw_prediction, self.quantile)
+
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil:
+        return cgradient_pinball_loss(y_true, raw_prediction, self.quantile)
+
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil:
+        return cgrad_hess_pinball_loss(y_true, raw_prediction, self.quantile)
+
+    def _loss(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = closs_pinball_loss(y_true[i], raw_prediction[i], self.quantile)
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = (
+                    sample_weight[i]
+                    * closs_pinball_loss(y_true[i], raw_prediction[i], self.quantile)
+                )
+
+        return np.asarray(loss)
+
+    def _gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = cgradient_pinball_loss(
+                    y_true[i], raw_prediction[i], self.quantile
+                )
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = (
+                    sample_weight[i]
+                    * cgradient_pinball_loss(y_true[i], raw_prediction[i], self.quantile)
+                )
+
+        return np.asarray(gradient)
+
+    def _gradient_hessian(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        G_DTYPE_C[::1] hessian,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_pinball_loss(
+                    y_true[i], raw_prediction[i], self.quantile
+                )
+                gradient[i] = dbl2.val1
+                hessian[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_pinball_loss(
+                    y_true[i], raw_prediction[i], self.quantile
+                )
+                gradient[i] = sample_weight[i] * dbl2.val1
+                hessian[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(gradient), np.asarray(hessian)
+
+
+cdef class cHalfPoissonLoss(cLossFunction):
+    """Half Poisson deviance loss with log-link.
+
+    Domain:
+    y_true in non-negative real numbers
+    y_pred in positive real numbers
+
+    Link:
+    y_pred = exp(raw_prediction)
+
+    Half Poisson deviance with log-link is
+        y_true * log(y_true/y_pred) + y_pred - y_true
+        = y_true * log(y_true) - y_true * raw_prediction
+          + exp(raw_prediction) - y_true
+
+    Dropping constant terms, this gives:
+        exp(raw_prediction) - y_true * raw_prediction
+    """
+
+    cdef double closs(self, double y_true, double raw_prediction) nogil:
+        return closs_half_poisson(y_true, raw_prediction)
+
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil:
+        return cgradient_half_poisson(y_true, raw_prediction)
+
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil:
+        return cgrad_hess_half_poisson(y_true, raw_prediction)
+
+    def _loss(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = closs_half_poisson(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = (
+                    sample_weight[i]
+                    * closs_half_poisson(y_true[i], raw_prediction[i])
+                )
+
+        return np.asarray(loss)
+
+    def _loss_gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = closs_grad_half_poisson(y_true[i], raw_prediction[i])
+                loss[i] = dbl2.val1
+                gradient[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = closs_grad_half_poisson(y_true[i], raw_prediction[i])
+                loss[i] = sample_weight[i] * dbl2.val1
+                gradient[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(loss), np.asarray(gradient)
+
+    def _gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = cgradient_half_poisson(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = (
+                    sample_weight[i]
+                    * cgradient_half_poisson(y_true[i], raw_prediction[i])
+                )
+
+        return np.asarray(gradient)
+
+    def _gradient_hessian(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        G_DTYPE_C[::1] hessian,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_half_poisson(y_true[i], raw_prediction[i])
+                gradient[i] = dbl2.val1
+                hessian[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_half_poisson(y_true[i], raw_prediction[i])
+                gradient[i] = sample_weight[i] * dbl2.val1
+                hessian[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(gradient), np.asarray(hessian)
+
+
+cdef class cHalfGammaLoss(cLossFunction):
+    """Half Gamma deviance loss with log-link.
+
+    Domain:
+    y_true and y_pred in positive real numbers
+
+    Link:
+    y_pred = exp(raw_prediction)
+
+    Half Gamma deviance with log-link is
+        log(y_pred/y_true) + y_true/y_pred - 1
+        = raw_prediction - log(y_true) + y_true * exp(-raw_prediction) - 1
+
+    Dropping constant terms, this gives:
+        raw_prediction + y_true * exp(-raw_prediction)
+    """
+
+    cdef double closs(self, double y_true, double raw_prediction) nogil:
+        return closs_half_gamma(y_true, raw_prediction)
+
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil:
+        return cgradient_half_gamma(y_true, raw_prediction)
+
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil:
+        return cgrad_hess_half_gamma(y_true, raw_prediction)
+
+    def _loss(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = closs_half_gamma(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = (
+                    sample_weight[i]
+                    * closs_half_gamma(y_true[i], raw_prediction[i])
+                )
+
+        return np.asarray(loss)
+
+    def _loss_gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = closs_grad_half_gamma(y_true[i], raw_prediction[i])
+                loss[i] = dbl2.val1
+                gradient[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = closs_grad_half_gamma(y_true[i], raw_prediction[i])
+                loss[i] = sample_weight[i] * dbl2.val1
+                gradient[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(loss), np.asarray(gradient)
+
+    def _gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = cgradient_half_gamma(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = (
+                    sample_weight[i]
+                    * cgradient_half_gamma(y_true[i], raw_prediction[i])
+                )
+
+        return np.asarray(gradient)
+
+    def _gradient_hessian(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        G_DTYPE_C[::1] hessian,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_half_gamma(y_true[i], raw_prediction[i])
+                gradient[i] = dbl2.val1
+                hessian[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_half_gamma(y_true[i], raw_prediction[i])
+                gradient[i] = sample_weight[i] * dbl2.val1
+                hessian[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(gradient), np.asarray(hessian)
+
+
+cdef class cHalfTweedieLoss(cLossFunction):
+    """Half Tweedie deviance loss with log-link.
+
+    Domain:
+    y_true in real numbers if p <= 0
+    y_true in non-negative real numbers if 0 < p < 2
+    y_true in positive real numbers if p >= 2
+    y_pred and power in positive real numbers
+
+    Link:
+    y_pred = exp(raw_prediction)
+
+    Half Tweedie deviance with log-link and p=power is
+        max(y_true, 0)**(2-p) / (1-p) / (2-p)
+        - y_true * y_pred**(1-p) / (1-p)
+        + y_pred**(2-p) / (2-p)
+        = max(y_true, 0)**(2-p) / (1-p) / (2-p)
+        - y_true * exp((1-p) * raw_prediction) / (1-p)
+        + exp((2-p) * raw_prediction) / (2-p)
+
+    Dropping constant terms, this gives:
+        exp((2-p) * raw_prediction) / (2-p)
+        - y_true * exp((1-p) * raw_prediction) / (1-p)
+
+    Notes:
+    - Poisson with p=1 and and Gamma with p=2 have different terms dropped such
+      that cHalfTweedieLoss is not continuous in p=power at p=1 and p=2.
+    - While the Tweedie distribution only exists for p<=0 or p>=1, the range
+      0<p<1 still gives a strictly consistent scoring function for the
+      expectation.
+    """
+
+    def __init__(self, power):
+        self.power = power
+
+    cdef double closs(self, double y_true, double raw_prediction) nogil:
+        return closs_half_tweedie(y_true, raw_prediction, self.power)
+
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil:
+        return cgradient_half_tweedie(y_true, raw_prediction, self.power)
+
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil:
+        return cgrad_hess_half_tweedie(y_true, raw_prediction, self.power)
+
+    def _loss(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = closs_half_tweedie(y_true[i], raw_prediction[i], self.power)
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = (
+                    sample_weight[i]
+                    * closs_half_tweedie(y_true[i], raw_prediction[i], self.power)
+                )
+
+        return np.asarray(loss)
+
+    def _loss_gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = closs_grad_half_tweedie(y_true[i], raw_prediction[i], self.power)
+                loss[i] = dbl2.val1
+                gradient[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = closs_grad_half_tweedie(y_true[i], raw_prediction[i], self.power)
+                loss[i] = sample_weight[i] * dbl2.val1
+                gradient[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(loss), np.asarray(gradient)
+
+    def _gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = cgradient_half_tweedie(
+                    y_true[i], raw_prediction[i], self.power
+                )
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = (
+                    sample_weight[i]
+                    * cgradient_half_tweedie(y_true[i], raw_prediction[i], self.power)
+                )
+
+        return np.asarray(gradient)
+
+    def _gradient_hessian(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        G_DTYPE_C[::1] hessian,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_half_tweedie(y_true[i], raw_prediction[i], self.power)
+                gradient[i] = dbl2.val1
+                hessian[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_half_tweedie(y_true[i], raw_prediction[i], self.power)
+                gradient[i] = sample_weight[i] * dbl2.val1
+                hessian[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(gradient), np.asarray(hessian)
+
+
+cdef class cBinaryCrossEntropy(cLossFunction):
+    """BinaryCrossEntropy with logit link.
+
+    Domain:
+    y_true in [0, 1]
+    y_pred in (0, 1), i.e. boundaries excluded
+
+    Link:
+    y_pred = expit(raw_prediction)
+    """
+
+    cdef double closs(self, double y_true, double raw_prediction) nogil:
+        return closs_binary_crossentropy(y_true, raw_prediction)
+
+    cdef double cgradient(self, double y_true, double raw_prediction) nogil:
+        return cgradient_binary_crossentropy(y_true, raw_prediction)
+
+    cdef double2 cgrad_hess(self, double y_true, double raw_prediction) nogil:
+        return cgrad_hess_binary_crossentropy(y_true, raw_prediction)
+
+    def _loss(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = closs_binary_crossentropy(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                loss[i] = (
+                    sample_weight[i]
+                    * closs_binary_crossentropy(y_true[i], raw_prediction[i])
+                )
+
+        return np.asarray(loss)
+
+    def _loss_gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = closs_grad_binary_crossentropy(y_true[i], raw_prediction[i])
+                loss[i] = dbl2.val1
+                gradient[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = closs_grad_binary_crossentropy(y_true[i], raw_prediction[i])
+                loss[i] = sample_weight[i] * dbl2.val1
+                gradient[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(loss), np.asarray(gradient)
+
+    def _gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = cgradient_binary_crossentropy(y_true[i], raw_prediction[i])
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                gradient[i] = (
+                    sample_weight[i]
+                    * cgradient_binary_crossentropy(y_true[i], raw_prediction[i])
+                )
+
+        return np.asarray(gradient)
+
+    def _gradient_hessian(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[::1] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] gradient,
+        G_DTYPE_C[::1] hessian,
+        int n_threads=1
+    ):
+        cdef:
+            int i
+            int n_samples = y_true.shape[0]
+            double2 dbl2
+
+        if sample_weight is None:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_binary_crossentropy(y_true[i], raw_prediction[i])
+                gradient[i] = dbl2.val1
+                hessian[i] = dbl2.val2
+        else:
+            for i in prange(
+                n_samples, schedule='static', nogil=True, num_threads=n_threads
+            ):
+                dbl2 = cgrad_hess_binary_crossentropy(y_true[i], raw_prediction[i])
+                gradient[i] = sample_weight[i] * dbl2.val1
+                hessian[i] = sample_weight[i] * dbl2.val2
+
+        return np.asarray(gradient), np.asarray(hessian)
+
+
+cdef class cCategoricalCrossEntropy(cLossFunction):
+    """CategoricalCrossEntropy with multinomial logit link.
+
+    Domain:
+    y_true in {0, 1, 2, 3, .., n_classes - 1}
+    y_pred in (0, 1)**n_classes, i.e. interval with boundaries excluded
+
+    Link:
+    y_pred = softmax(raw_prediction)
+
+    Note: Label encoding is built-in, i.e. {0, 1, 2, 3, .., n_classes - 1} is
+    mapped to (y_true == k) for k = 0 .. n_classes - 1 which is either 0 or 1.
+    """
+
+    # Note that we do not assume memory alignement/contiguity of 2d arrays.
+    # There seems to be little benefit in doing so. Benchmarks proofing the
+    # opposite are welcome.
+    def _loss(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[:, :] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        int n_threads=1
+    ):
+        cdef:
+            int i, k
+            int n_samples = y_true.shape[0]
+            int n_classes = raw_prediction.shape[1]
+            Y_DTYPE_C max_value, sum_exps
+            Y_DTYPE_C*  p  # temporary buffer
+
+        # We assume n_samples > n_classes. In this case having the inner loop
+        # over n_classes is a good default.
+        # TODO: If every memoryview is contiguous and raw_preduction is
+        #       f-contiguous, can we write a better algo (loops) to improve
+        #       performance?
+        if sample_weight is None:
+            # inner loop over n_classes
+            with nogil, parallel(num_threads=n_threads):
+                # Define private buffer variables as each thread might use its
+                # own.
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    max_value = p[n_classes]     # p[-2]
+                    sum_exps = p[n_classes + 1]  # p[-1]
+                    loss[i] = log(sum_exps) + max_value
+
+                    for k in range(n_classes):
+                        # label decode y_true
+                        if y_true[i] == k:
+                            loss[i] -= raw_prediction[i, k]
+
+                free(p)
+        else:
+            with nogil, parallel(num_threads=n_threads):
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    max_value = raw_prediction[i, 0]
+                    max_value = p[n_classes]     # p[-2]
+                    sum_exps = p[n_classes + 1]  # p[-1]
+                    loss[i] = log(sum_exps) + max_value
+
+                    for k in range(n_classes):
+                        # label decode y_true
+                        if y_true[i] == k:
+                            loss[i] -= raw_prediction[i, k]
+
+                    loss[i] *= sample_weight[i]
+
+                free(p)
+
+        return np.asarray(loss)
+
+    def _loss_gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[:, :] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[::1] loss,
+        G_DTYPE_C[:, :] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i, k
+            int n_samples = y_true.shape[0]
+            int n_classes = raw_prediction.shape[1]
+            Y_DTYPE_C max_value, sum_exps
+            Y_DTYPE_C*  p  # temporary buffer
+
+        if sample_weight is None:
+            # inner loop over n_classes
+            with nogil, parallel(num_threads=n_threads):
+                # Define private buffer variables as each thread might use its
+                # own.
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    max_value = p[n_classes]  # p[-2]
+                    sum_exps = p[n_classes + 1]  # p[-1]
+                    loss[i] = log(sum_exps) + max_value
+
+                    for k in range(n_classes):
+                        # label decode y_true
+                        if y_true [i] == k:
+                            loss[i] -= raw_prediction[i, k]
+                        p[k] /= sum_exps  # p_k = y_pred_k = prob of class k
+                        # gradient_k = p_k - (y_true == k)
+                        gradient[i, k] = p[k] - (y_true[i] == k)
+
+                free(p)
+        else:
+            with nogil, parallel(num_threads=n_threads):
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    max_value = p[n_classes]  # p[-2]
+                    sum_exps = p[n_classes + 1]  # p[-1]
+                    loss[i] = log(sum_exps) + max_value
+
+                    for k in range(n_classes):
+                        # label decode y_true
+                        if y_true [i] == k:
+                            loss[i] -= raw_prediction[i, k]
+                        p[k] /= sum_exps  # p_k = y_pred_k = prob of class k
+                        # gradient_k = (p_k - (y_true == k)) * sw
+                        gradient[i, k] = (p[k] - (y_true[i] == k)) * sample_weight[i]
+
+                    loss[i] *= sample_weight[i]
+
+                free(p)
+
+        return np.asarray(loss), np.asarray(gradient)
+
+    def _gradient(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[:, :] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[:, :] gradient,
+        int n_threads=1
+    ):
+        cdef:
+            int i, k
+            int n_samples = y_true.shape[0]
+            int n_classes = raw_prediction.shape[1]
+            Y_DTYPE_C sum_exps
+            Y_DTYPE_C*  p  # temporary buffer
+
+        if sample_weight is None:
+            # inner loop over n_classes
+            with nogil, parallel(num_threads=n_threads):
+                # Define private buffer variables as each thread might use its
+                # own.
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    sum_exps = p[n_classes + 1]  # p[-1]
+
+                    for k in range(n_classes):
+                        p[k] /= sum_exps  # p_k = y_pred_k = prob of class k
+                        # gradient_k = y_pred_k - (y_true == k)
+                        gradient[i, k] = p[k] - (y_true[i] == k)
+
+                free(p)
+        else:
+            with nogil, parallel(num_threads=n_threads):
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    sum_exps = p[n_classes + 1]  # p[-1]
+
+                    for k in range(n_classes):
+                        p[k] /= sum_exps  # p_k = y_pred_k = prob of class k
+                        # gradient_k = (p_k - (y_true == k)) * sw
+                        gradient[i, k] = (p[k] - (y_true[i] == k)) * sample_weight[i]
+
+                free(p)
+
+        return np.asarray(gradient)
+
+    def _gradient_hessian(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[:, :] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[:, :] gradient,
+        G_DTYPE_C[:, :] hessian,
+        int n_threads=1
+    ):
+        cdef:
+            int i, k
+            int n_samples = y_true.shape[0]
+            int n_classes = raw_prediction.shape[1]
+            Y_DTYPE_C sum_exps
+            Y_DTYPE_C* p  # temporary buffer
+
+        if sample_weight is None:
+            # inner loop over n_classes
+            with nogil, parallel(num_threads=n_threads):
+                # Define private buffer variables as each thread might use its
+                # own.
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    sum_exps = p[n_classes + 1]  # p[-1]
+
+                    for k in range(n_classes):
+                        p[k] /= sum_exps  # p_k = y_pred_k = prob of class k
+                        # hessian_k = p_k * (1 - p_k)
+                        # gradient_k = p_k - (y_true == k)
+                        gradient[i, k] = p[k] - (y_true[i] == k)
+                        hessian[i, k] = p[k] * (1. - p[k])
+
+                free(p)
+        else:
+            with nogil, parallel(num_threads=n_threads):
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    sum_exps = p[n_classes + 1]  # p[-1]
+
+                    for k in range(n_classes):
+                        p[k] /= sum_exps  # p_k = y_pred_k = prob of class k
+                        # gradient_k = (p_k - (y_true == k)) * sw
+                        # hessian_k = p_k * (1 - p_k) * sw
+                        gradient[i, k] = (p[k] - (y_true[i] == k)) * sample_weight[i]
+                        hessian[i, k] = (p[k] * (1. - p[k])) * sample_weight[i]
+
+                free(p)
+
+        return np.asarray(gradient), np.asarray(hessian)
+
+
+    # This method simplifies the implementation of hessp in linear models,
+    # i.e. the matrix-vector product of the full hessian, not only of the
+    # diagonal (in the classes) approximation as implemented above.
+    def _gradient_proba(
+        self,
+        Y_DTYPE_C[::1] y_true,
+        Y_DTYPE_C[:, :] raw_prediction,
+        Y_DTYPE_C[::1] sample_weight,
+        G_DTYPE_C[:, :] gradient,
+        G_DTYPE_C[:, :] proba,
+        int n_threads=1
+    ):
+        cdef:
+            int i, k
+            int n_samples = y_true.shape[0]
+            int n_classes = raw_prediction.shape[1]
+            Y_DTYPE_C sum_exps
+            Y_DTYPE_C*  p  # temporary buffer
+
+        if sample_weight is None:
+            # inner loop over n_classes
+            with nogil, parallel(num_threads=n_threads):
+                # Define private buffer variables as each thread might use its
+                # own.
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    sum_exps = p[n_classes + 1]  # p[-1]
+
+                    for k in range(n_classes):
+                        proba[i, k] = p[k] / sum_exps  # y_pred_k = prob of class k
+                        # gradient_k = y_pred_k - (y_true == k)
+                        gradient[i, k] = proba[i, k] - (y_true[i] == k)
+
+                free(p)
+        else:
+            with nogil, parallel(num_threads=n_threads):
+                p = <Y_DTYPE_C *> malloc(sizeof(Y_DTYPE_C) * (n_classes + 2))
+
+                for i in prange(n_samples, schedule='static'):
+                    sum_exp_minus_max(i, raw_prediction, p)
+                    sum_exps = p[n_classes + 1]  # p[-1]
+
+                    for k in range(n_classes):
+                        proba[i, k] = p[k] / sum_exps  # y_pred_k = prob of class k
+                        # gradient_k = (p_k - (y_true == k)) * sw
+                        gradient[i, k] = (proba[i, k] - (y_true[i] == k)) * sample_weight[i]
+
+                free(p)
+
+        return np.asarray(gradient), np.asarray(proba)

--- a/sklearn/_loss/link.py
+++ b/sklearn/_loss/link.py
@@ -12,9 +12,7 @@ from scipy.stats import gmean
 from ..utils.extmath import softmax
 
 
-Interval = namedtuple(
-    "Interval", ("low", "high", "low_inclusive", "high_inclusive")
-)
+Interval = namedtuple("Interval", ("low", "high", "low_inclusive", "high_inclusive"))
 
 
 def is_in_interval_range(x, interval):

--- a/sklearn/_loss/link.py
+++ b/sklearn/_loss/link.py
@@ -1,0 +1,246 @@
+"""
+Module contains classes for invertible (and differentiable) link functions.
+"""
+# Author: Christian Lorentzen <lorentzen.ch@googlemail.com>
+
+from abc import ABC, abstractmethod
+from collections import namedtuple
+
+import numpy as np
+from scipy.special import expit, logit
+from scipy.stats import gmean
+from ..utils.extmath import softmax
+
+
+Interval = namedtuple(
+    "Interval", ("low", "high", "low_inclusive", "high_inclusive")
+)
+
+
+def is_in_interval_range(x, interval):
+    """Test whether values of x are in interval range from Interval.
+
+    Parameters
+    ----------
+    x : ndarray
+        Array whose elements are tested to be in interval range.
+    interval: Interval
+        An Interval range.
+    """
+    if interval.low_inclusive:
+        low = np.greater_equal(x, interval.low)
+    else:
+        low = np.greater(x, interval.low)
+
+    if not np.all(low):
+        return False
+
+    if interval.high_inclusive:
+        high = np.less_equal(x, interval.high)
+    else:
+        high = np.less(x, interval.high)
+
+    # Note: np.all returns numpy.bool_
+    if np.all(high):
+        return True
+    else:
+        return False
+
+
+def _inclusive_low_high(interval, dtype=float):
+    """Generate values low and high to be within the interval range."""
+    eps = 10 * np.finfo(dtype).eps
+    if interval.low == -np.inf:
+        low = -1e10
+    elif interval.low < 0:
+        low = interval.low * (1 - eps) + eps
+    else:
+        low = interval.low * (1 + eps) + eps
+
+    if interval.high == np.inf:
+        high = 1e10
+    elif interval.high < 0:
+        high = interval.high * (1 + eps) - eps
+    else:
+        high = interval.high * (1 - eps) - eps
+
+    return low, high
+
+
+class BaseLink(ABC):
+    """Abstract base class for differentiable, invertible link functions.
+
+    Convention:
+        - link function g: raw_prediction = g(y_pred)
+        - inverse link h: y_pred = h(raw_prediction)
+
+    For (generalized) linear models, `raw_prediction = X @ coef` is the so
+    called linear predictor, and `y_pred = h(raw_prediction)` is the predicted
+    conditional (on X) expected value of the target `y_true`.
+
+    In case a link function needs parameters, the methods are not implemented
+    as staticmethods.
+    """
+
+    multiclass = False
+
+    # Usually, raw_prediction may be any real number and y_pred is an open
+    # interval.
+    interval_raw_prediction = Interval(-np.inf, np.inf, False, False)
+    interval_y_pred = Interval(-np.inf, np.inf, False, False)
+
+    @abstractmethod
+    def link(self, y_pred, out=None):
+        """Compute the link function g(y_pred).
+
+        The link function maps (predicted) target values to raw predictions,
+        i.e. `g(y_pred) = raw_prediction`.
+
+        Parameters
+        ----------
+        y_pred : array
+            Predicted target values.
+        out : array
+            A location into which the result is stored. If provided, it must
+            have a shape that the inputs broadcast to. If not provided or None,
+            a freshly-allocated array is returned.
+
+        Returns
+        -------
+        out : array
+            Output array, element-wise link function.
+        """
+
+    @abstractmethod
+    def inverse(self, raw_prediction, out=None):
+        """Compute the inverse link function h(raw_prediction).
+
+        The inverse link function maps raw predictions to predicted target
+        values, i.e. `h(raw_prediction) = y_pred`.
+
+        Parameters
+        ----------
+        raw_prediction : array
+            Raw prediction values (in link space).
+        out : array
+            A location into which the result is stored. If provided, it must
+            have a shape that the inputs broadcast to. If not provided or None,
+            a freshly-allocated array is returned.
+
+        Returns
+        -------
+        out : array
+            Output array, element-wise inverse link function.
+        """
+
+
+class IdentityLink(BaseLink):
+    """The identity link function g(x)=x."""
+
+    def link(self, y_pred, out=None):
+        if out is not None:
+            np.copyto(out, y_pred)
+            return out
+        else:
+            return y_pred
+
+    inverse = link
+
+
+class LogLink(BaseLink):
+    """The log link function g(x)=log(x)."""
+
+    interval_y_pred = Interval(0, np.inf, False, False)
+
+    def link(self, y_pred, out=None):
+        return np.log(y_pred, out=out)
+
+    def inverse(self, raw_prediction, out=None):
+        return np.exp(raw_prediction, out=out)
+
+
+class LogitLink(BaseLink):
+    """The logit link function g(x)=logit(x)."""
+
+    interval_y_pred = Interval(0, 1, False, False)
+
+    def link(self, y_pred, out=None):
+        return logit(y_pred, out=out)
+
+    def inverse(self, raw_prediction, out=None):
+        return expit(raw_prediction, out=out)
+
+
+class MultinomialLogit(BaseLink):
+    """The symmetric multinomial logit function.
+
+    Convention:
+        - y_pred.shape = raw_prediction.shape = (n_samples, n_classes)
+
+    Notes:
+        - The inverse link h is the softmax function.
+        - The sum is over the second axis, i.e. axis=1 (n_classes).
+
+    We have to choose additional contraints in order to make
+
+        y_pred_k = exp(raw_pred_k) / sum(exp(raw_pred_k), k=0..n_classes-1)
+
+    for n_classes classes identifiable and invertible.
+    We choose the symmetric side contraint where the geometric mean response
+    is set as reference category, see [2]:
+
+    The symmetric multinomial logit link function for a single data point is
+    then defined as
+
+        raw_prediction[k] = g(y_pred[k]) = log(y_pred[k]/gmean(y_pred))
+        = log(y_pred[k]) - mean(log(y_pred)).
+
+    Note that this is equivalent to the definition in [1] and implies mean
+    centered raw predictions:
+
+        sum(raw_prediction[k], k=0..n_classes-1) = 0.
+
+    For linear models with raw_prediction = X @ coef, this corresponds to
+    sum(coef[k], k=0..n_classes-1) = 0, i.e. the sum over classes for every
+    feature is zero.
+
+    Reference
+    ---------
+    .. [1] Friedman, Jerome; Hastie, Trevor; Tibshirani, Robert. "Additive
+        logistic regression: a statistical view of boosting" Ann. Statist.
+        28 (2000), no. 2, 337--407. doi:10.1214/aos/1016218223.
+        https://projecteuclid.org/euclid.aos/1016218223
+
+    .. [2] Zahid, Faisal Maqbool and Gerhard Tutz. "Ridge estimation for
+        multinomial logit models with symmetric side constraints."
+        Computational Statistics 28 (2013): 1017-1034.
+        http://epub.ub.uni-muenchen.de/11001/1/tr067.pdf
+    """
+
+    multiclass = True
+    interval_y_pred = Interval(0, 1, False, False)
+
+    def symmetrize_raw_prediction(self, raw_prediction):
+        return raw_prediction - np.mean(raw_prediction, axis=1)[:, np.newaxis]
+
+    def link(self, y_pred, out=None):
+        # geometric mean as reference category
+        gm = gmean(y_pred, axis=1)
+        out = np.log(y_pred / gm[:, np.newaxis], out=out)
+        return out
+
+    def inverse(self, raw_prediction, out=None):
+        if out is None:
+            return softmax(raw_prediction, copy=True)
+        else:
+            np.copyto(out, raw_prediction)
+            softmax(out, copy=False)
+            return out
+
+
+_LINKS = {
+    "identity": IdentityLink,
+    "log": LogLink,
+    "logit": LogitLink,
+    "multinomial_logit": MultinomialLogit,
+}

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -1,0 +1,910 @@
+"""
+This module contains loss classes suitable for fitting.
+
+It is not part of the public API.
+Specific losses are used for regression, binary classification or multiclass
+classification.
+"""
+# Goals:
+# - Provide a common private module for loss functions/classes.
+# - Replace losses for:
+#   - LogisticRegression
+#   - PoissonRegressor, GammaRegressor, TweedieRegressor
+#   - HistGradientBoostingRegressor, HistGradientBoostingClassifier
+#   - GradientBoostingRegressor, GradientBoostingClassifier
+#   - SGDRegressor, SGDClassifier
+# - Replace link module of GLMs.
+
+import numpy as np
+from scipy.special import xlogy
+from ._loss import (
+    cLossFunction,
+    cHalfSquaredError,
+    cAbsoluteError,
+    cPinballLoss,
+    cHalfPoissonLoss,
+    cHalfGammaLoss,
+    cHalfTweedieLoss,
+    cBinaryCrossEntropy,
+    cCategoricalCrossEntropy,
+)
+from .link import (
+    Interval,
+    is_in_interval_range,
+    BaseLink,
+    IdentityLink,
+    LogLink,
+    LogitLink,
+    MultinomialLogit,
+)
+from ..utils.stats import _weighted_percentile
+
+
+# Note: The shape of raw_prediction for multiclass classifications are
+# - GradientBoostingClassifier: (n_samples, n_classes)
+# - HistGradientBoostingClassifier: (n_classes, n_samples)
+class BaseLoss(BaseLink, cLossFunction):
+    """Base class for a loss function of 1-dimensional targets.
+
+    Conventions:
+
+        - y_true.shape = sample_weight.shape = (n_samples,)
+        - y_pred.shape = raw_prediction.shape = (n_samples,)
+        - If n_classes >= 3 (multiclass classification), then
+          y_pred.shape = raw_prediction.shape = (n_samples, n_classes)
+          Note that this corresponds to the return value of decision_function.
+
+    y_true, y_pred, sample_weight and raw_prediction must either be all float64
+    or all float32.
+    gradient and hessian must be either both float64 or both float32.
+
+    Note that y_pred = link.inverse(raw_prediction).
+
+    Specific loss classes can inherit specific link classes to satisfy
+    BaseLink's abstractmethods.
+
+    Parameters
+    ----------
+    sample_weight : {None, ndarray}
+        If sample_weight is None, the hessian might be constant.
+    n_classes : {None, int}
+        The number of classes for classification, else None.
+
+    Attributes
+    ----------
+    interval_y_true: Interval
+        Valid interval for y_true
+    interval_y_pred: Interval
+        Valid Interval for y_pred
+    differentiable: bool
+        Indicates whether or not loss function is differentiable in
+        raw_prediction everywhere.
+    need_update_leaves_values: bool
+        Indicates whether decision trees in gradient boosting need to uptade
+        leave values after having been fit to the (negative) gradients.
+    approx_hessian : bool
+        Indicates whether the hessian is approximated or exact. If,
+        approximated, it should be larger or equal to the exact one.
+    constant_hessian : bool
+        Indicates whether the hessian is one for this loss.
+    """
+
+    # Inherited methods from BaseLink:
+    # - link
+    # - inverse
+    #
+    # Inherited methods from cLossFunction:
+    # - _loss, _loss_gradient, _gradient, _gradient_hessian
+
+    # For decision trees:
+    # This variable indicates whether the loss requires the leaves values to
+    # be updated once the tree has been trained. The trees are trained to
+    # predict a Newton-Raphson step (see grower._finalize_leaf()). But for
+    # some losses (e.g. least absolute deviation) we need to adjust the tree
+    # values to account for the "line search" of the gradient descent
+    # procedure. See the original paper Greedy Function Approximation: A
+    # Gradient Boosting Machine by Friedman
+    # (https://statweb.stanford.edu/~jhf/ftp/trebst.pdf) for the theory.
+    need_update_leaves_values = False
+    differentiable = True
+
+    def __init__(self, n_classes=1):
+        self.approx_hessian = False
+        self.constant_hessian = False
+        self.n_classes = n_classes
+        self.interval_y_true = Interval(-np.inf, np.inf, False, False)
+        self.interval_y_pred = Interval(-np.inf, np.inf, False, False)
+
+    def in_y_true_range(self, y):
+        """Return True if y is in the valid range of y_true.
+
+        Parameters
+        ----------
+        y : ndarray
+        """
+        return is_in_interval_range(y, self.interval_y_true)
+
+    def in_y_pred_range(self, y):
+        """Return True if y is in the valid range of y_pred.
+
+        Parameters
+        ----------
+        y : ndarray
+        """
+        return is_in_interval_range(y, self.interval_y_pred)
+
+    def loss(
+        self,
+        y_true,
+        raw_prediction,
+        sample_weight=None,
+        loss=None,
+        n_threads=1,
+    ):
+        """Compute the pointwise loss value for each input.
+
+        Parameters
+        ----------
+        y_true : C-contiguous array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : C-contiguous array of shape (n_samples,) or array of \
+            shape (n_samples, n_classes)
+            Raw prediction values (in link space).
+        sample_weight : None or C-contiguous array of shape (n_samples,)
+            Sample weights.
+        loss : None or C-contiguous array of shape (n_samples,)
+            A location into which the result is stored. If None, a new array
+            might be created.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        loss : array of shape (n_samples,)
+            Element-wise loss function.
+        """
+        if loss is None:
+            loss = np.empty_like(y_true)
+        # Be graceful to shape (n_samples, 1) -> (n_samples,)
+        if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
+            raw_prediction = raw_prediction.squeeze(1)
+        return self._loss(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            loss=loss,
+            n_threads=n_threads,
+        )
+
+    def loss_gradient(
+        self,
+        y_true,
+        raw_prediction,
+        sample_weight=None,
+        loss=None,
+        gradient=None,
+        n_threads=1,
+    ):
+        """Compute loss and gradient w.r.t. raw_prediction for each input.
+
+        Parameters
+        ----------
+        y_true : C-contiguous array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : C-contiguous array of shape (n_samples,) or array of \
+            shape (n_samples, n_classes)
+            Raw prediction values (in link space).
+        sample_weight : None or C-contiguous array of shape (n_samples,)
+            Sample weights.
+        loss : None or C-contiguous array of shape (n_samples,)
+            A location into which the loss is stored. If None, a new array
+            might be created.
+        gradient : None or C-contiguous array of shape (n_samples,) or array \
+            of shape (n_samples, n_classes)
+            A location into which the gradient is stored. If None, a new array
+            might be created.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        loss : array of shape (n_samples,)
+            Element-wise loss function.
+
+        gradient : array of shape (n_samples,) or (n_samples, n_classes)
+            Element-wise gradients.
+        """
+        if loss is None:
+            if gradient is None:
+                loss = np.empty_like(y_true)
+                gradient = np.empty_like(raw_prediction)
+            else:
+                loss = np.empty_like(y_true, dtype=gradient.dtype)
+        elif gradient is None:
+            gradient = np.empty_like(raw_prediction, dtype=loss.dtype)
+
+        # Be graceful to shape (n_samples, 1) -> (n_samples,)
+        if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
+            raw_prediction = raw_prediction.squeeze(1)
+        if gradient.ndim == 2 and gradient.shape[1] == 1:
+            gradient = gradient.squeeze(1)
+
+        return self._loss_gradient(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            loss=loss,
+            gradient=gradient,
+            n_threads=n_threads,
+        )
+
+    def gradient(
+        self,
+        y_true,
+        raw_prediction,
+        sample_weight=None,
+        gradient=None,
+        n_threads=1,
+    ):
+        """Compute gradient of loss w.r.t raw_prediction for each input.
+
+        Parameters
+        ----------
+        y_true : C-contiguous array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : C-contiguous array of shape (n_samples,) or array of \
+            shape (n_samples, n_classes)
+            Raw prediction values (in link space).
+        sample_weight : None or C-contiguous array of shape (n_samples,)
+            Sample weights.
+        gradient : None or C-contiguous array of shape (n_samples,) or array \
+            of shape (n_samples, n_classes)
+            A location into which the result is stored. If None, a new array
+            might be created.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        gradient : array of shape (n_samples,) or (n_samples, n_classes)
+            Element-wise gradients.
+        """
+        if gradient is None:
+            gradient = np.empty_like(raw_prediction)
+
+        # Be graceful to shape (n_samples, 1) -> (n_samples,)
+        if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
+            raw_prediction = raw_prediction.squeeze(1)
+        if gradient.ndim == 2 and gradient.shape[1] == 1:
+            gradient = gradient.squeeze(1)
+
+        return self._gradient(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            gradient=gradient,
+            n_threads=n_threads,
+        )
+
+    def gradient_hessian(
+        self,
+        y_true,
+        raw_prediction,
+        sample_weight=None,
+        gradient=None,
+        hessian=None,
+        n_threads=1,
+    ):
+        """Compute gradient and hessian of loss w.r.t raw_prediction.
+
+        Parameters
+        ----------
+        y_true : C-contiguous array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : C-contiguous array of shape (n_samples,) or array of \
+            shape (n_samples, n_classes)
+            Raw prediction values (in link space).
+        sample_weight : None or C-contiguous array of shape (n_samples,)
+            Sample weights.
+        gradient : None or C-contiguous array of shape (n_samples,) or array \
+            of shape (n_samples, n_classes)
+            A location into which the gradient is stored. If None, a new array
+            might be created.
+        hessian : None or C-contiguous array of shape (n_samples,) or array \
+            of shape (n_samples, n_classes)
+            A location into which the hessian is stored. If None, a new array
+            might be created.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        gradient : arrays of shape (n_samples,) or (n_samples, n_classes)
+            Element-wise gradients.
+
+        hessian : arrays of shape (n_samples,) or (n_samples, n_classes)
+            Element-wise hessians.
+        """
+        if gradient is None:
+            if hessian is None:
+                gradient = np.empty_like(raw_prediction)
+                hessian = np.empty_like(raw_prediction)
+            else:
+                gradient = np.empty_like(hessian)
+        elif hessian is None:
+            hessian = np.empty_like(gradient)
+
+        # Be graceful to shape (n_samples, 1) -> (n_samples,)
+        if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
+            raw_prediction = raw_prediction.squeeze(1)
+        if gradient.ndim == 2 and gradient.shape[1] == 1:
+            gradient = gradient.squeeze(1)
+        if hessian.ndim == 2 and hessian.shape[1] == 1:
+            hessian = hessian.squeeze(1)
+
+        return self._gradient_hessian(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            gradient=gradient,
+            hessian=hessian,
+            n_threads=n_threads,
+        )
+
+    def __call__(
+        self, y_true, raw_prediction, sample_weight=None, n_threads=1
+    ):
+        """Compute the weighted average loss.
+
+        Parameters
+        ----------
+        y_true : C-contiguous array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : C-contiguous array of shape (n_samples,) or array of \
+            shape (n_samples, n_classes)
+            Raw prediction values (in link space).
+        sample_weight : None or C-contiguous array of shape (n_samples,)
+            Sample weights.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        loss : float
+            Mean or averaged loss function.
+        """
+        return np.average(
+            self.loss(
+                y_true=y_true,
+                raw_prediction=raw_prediction,
+                sample_weight=None,
+                loss=None,
+                n_threads=n_threads,
+            ),
+            weights=sample_weight,
+        )
+
+    def fit_intercept_only(self, y_true, sample_weight=None):
+        """Compute raw_prediction of an intercept-only model.
+
+        This can be used as initial estimates of predictions, i.e. before the
+        first iteration in fit.
+
+        Parameters
+        ----------
+        y_true : array-like of shape (n_samples,)
+            Observed, true target values.
+        sample_weight : None or array of shape (n_samples,)
+            Sample weights.
+
+        Returns
+        -------
+        raw_prediction : float or (n_classes,)
+            Raw predictions of an intercept-only model.
+        """
+        # As default, take weighted average of the target over the samples
+        # axis=0 and then transform into link-scale (raw_prediction).
+        y_pred = np.average(y_true, weights=sample_weight, axis=0)
+        eps = 10 * np.finfo(y_pred.dtype).eps
+
+        if self.interval_y_pred.low == -np.inf:
+            a_min = None
+        elif self.interval_y_pred.low_inclusive:
+            a_min = self.interval_y_pred.low
+        else:
+            a_min = self.interval_y_pred.low + eps
+
+        if self.interval_y_pred.high == np.inf:
+            a_max = None
+        elif self.interval_y_pred.high_inclusive:
+            a_max = self.interval_y_pred.high
+        else:
+            a_max = self.interval_y_pred.high - eps
+
+        if a_min is None and a_max is None:
+            return self.link(y_pred)
+        else:
+            return self.link(np.clip(y_pred, a_min, a_max))
+
+    def constant_to_optimal_zero(self, y_true, sample_weight=None):
+        """Calculate term dropped in loss.
+
+        With this term added, the loss of perfect predictions is zero.
+        """
+        return np.zeros_like(y_true)
+
+
+class HalfSquaredError(IdentityLink, BaseLoss, cHalfSquaredError):
+    """Half Squared Error with identity link, for regression.
+
+    Domain:
+    y_true and y_pred all real numbers
+
+    Link:
+    y_pred = raw_prediction
+
+    For a given sample x_i, half squares error is defined as::
+
+        loss(x_i) = 0.5 * (y_true_i - raw_prediction_i)**2
+
+    The factor of 0.5 simplifies the computation of gradients and results in a
+    unit hessian (and be consistent with what is done in LightGBM).
+    """
+
+    def __init__(self, sample_weight=None):
+        super().__init__()
+        if sample_weight is None:
+            self.constant_hessian = True
+        else:
+            self.constant_hessian = False
+
+    def gradient(
+        self,
+        y_true,
+        raw_prediction,
+        sample_weight=None,
+        gradient=None,
+        n_threads=1,
+    ):
+        # easier in numpy
+        # gradient = raw_prediction - y_true is easier in numpy
+
+        # Be graceful to shape (n_samples, 1) -> (n_samples,)
+        if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
+            raw_prediction = raw_prediction.squeeze(1)
+        if (
+            gradient is not None
+            and gradient.ndim == 2
+            and gradient.shape[1] == 1
+        ):
+            gradient = gradient.squeeze(1)
+
+        gradient = np.subtract(raw_prediction, y_true, out=gradient)
+        if sample_weight is None:
+            return gradient
+        else:
+            return np.multiply(sample_weight, gradient, out=gradient)
+
+    def gradient_hessian(
+        self,
+        y_true,
+        raw_prediction,
+        sample_weight=None,
+        gradient=None,
+        hessian=None,
+        n_threads=1,
+    ):
+        # easier in numpy
+        gradient = self.gradient(
+            y_true, raw_prediction, sample_weight, gradient, hessian
+        )
+        if hessian is None:
+            hessian = np.empty_like(gradient)
+        elif hessian.ndim == 2 and hessian.shape[1] == 1:
+            # Be graceful to shape (n_samples, 1) -> (n_samples,)
+            hessian = hessian.squeeze(1)
+        if sample_weight is None:
+            hessian.fill(1)
+        else:
+            np.copyto(hessian, sample_weight)
+        return gradient, hessian
+
+
+class AbsoluteError(IdentityLink, BaseLoss, cAbsoluteError):
+    """Least absolute error, for regression.
+
+    Domain:
+    y_true and y_pred all real numbers
+
+    Link:
+    y_pred = raw_prediction
+
+    For a given sample x_i, the absolute error is defined as::
+
+        loss(x_i) = |y_true_i - raw_prediction_i|
+    """
+
+    differentiable = False
+    need_update_leaves_values = True
+
+    def __init__(self, sample_weight=None):
+        super().__init__()
+        self.approx_hessian = True
+        if sample_weight is None:
+            self.constant_hessian = True
+        else:
+            self.constant_hessian = False
+
+    def fit_intercept_only(self, y_true, sample_weight=None):
+        """Compute raw_prediction of an intercept-only model.
+
+        This is the weighted median of the target, i.e. over the samples
+        axis=0.
+        """
+        if sample_weight is None:
+            return np.median(y_true, axis=0)
+        else:
+            return _weighted_percentile(y_true, sample_weight, 50)
+
+
+class PinballLoss(IdentityLink, BaseLoss, cPinballLoss):
+    """Quantile Loss aka Pinball Loss, for regression.
+
+    Domain:
+    y_true and y_pred all real numbers
+    quantile in (0, 1)
+
+    Link:
+    y_pred = raw_prediction
+
+    For a given sample x_i, the pinball loss loss is defined as::
+
+        loss(x_i) = rho_{quantile}(y_true_i - raw_prediction_i)
+
+        rho_{quantile}(u) = u * (quantile - 1_{u<0})
+                          = -u (1 - quantile)  if u < 0
+                            u * quantile       if u >= 0
+
+    Note: 2 * PinballLoss(quantile=0.5) equals AbsoluteError().
+
+    Additional Attributes
+    ---------------------
+    quantile : float
+        The quantile to be estimated. Must be in range (0, 1).
+    """
+
+    differentiable = False
+    need_update_leaves_values = True
+
+    def __init__(self, sample_weight=None, quantile=0.5):
+        BaseLoss.__init__(self)
+        cPinballLoss.__init__(self, quantile=float(quantile))
+        self.approx_hessian = True
+        if sample_weight is None:
+            self.constant_hessian = True
+        else:
+            self.constant_hessian = False
+        if quantile <= 0 or quantile >= 1:
+            raise ValueError(
+                f"PinballLoss aka quantile loss only accepts "
+                f"0 < quantile < 1; {quantile} was given."
+            )
+
+    def fit_intercept_only(self, y_true, sample_weight=None):
+        """Compute raw_prediction of an intercept-only model.
+
+        This is the weighted median of the target, i.e. over the samples
+        axis=0.
+        """
+        if sample_weight is None:
+            return np.percentile(y_true, 100 * self.quantile, axis=0)
+        else:
+            return _weighted_percentile(
+                y_true, sample_weight, 100 * self.quantile
+            )
+
+
+class HalfPoissonLoss(LogLink, BaseLoss, cHalfPoissonLoss):
+    """Poisson deviance loss with log-link, for regression.
+
+    Domain:
+    y_true in non-negative real numbers
+    y_pred in positive real numbers
+
+    Link:
+    y_pred = exp(raw_prediction)
+
+    For a given sample x_i, half the Poisson deviance is defined as::
+
+        loss(x_i) = y_true_i * log(y_true_i/exp(raw_prediction_i))
+                    - y_true_i + exp(raw_prediction_i)
+
+    Half the Poisson deviance is actually the negative log likelihood up to
+    constant terms (not involving raw_prediction) and simplifies the
+    computation of the gradients.
+    We also skip the constant term `y_true_i * log(y_true_i) - y_true_i`.
+    """
+
+    def __init__(self, sample_weight=None):
+        super().__init__()
+        self.interval_y_true = Interval(0, np.inf, True, False)
+        self.interval_y_pred = Interval(0, np.inf, False, False)
+
+    def constant_to_optimal_zero(self, y_true, sample_weight=None):
+        term = xlogy(y_true, y_true) - y_true
+        if sample_weight is not None:
+            term *= sample_weight
+        return term
+
+
+class HalfGammaLoss(LogLink, BaseLoss, cHalfGammaLoss):
+    """Gamma deviance loss with log-link, for regression.
+
+    Domain:
+    y_true and y_pred in positive real numbers
+
+    Link:
+    y_pred = exp(raw_prediction)
+
+    For a given sample x_i, half Gamma deviance loss is defined as::
+
+        loss(x_i) = log(exp(raw_prediction_i)/y_true_i)
+                    + y_true/exp(raw_prediction_i) - 1
+
+    Half the Gamma deviance is actually proportional the negative log
+    likelihood up constant terms (not involving raw_prediction) and simplifies
+    the computation of the gradients.
+    We also skip the constant term `-log(y_true_i) - 1`.
+    """
+
+    def __init__(self, sample_weight=None):
+        super().__init__()
+        self.interval_y_true = Interval(0, np.inf, False, False)
+        self.interval_y_pred = Interval(0, np.inf, False, False)
+
+    def constant_to_optimal_zero(self, y_true, sample_weight=None):
+        term = -np.log(y_true) - 1
+        if sample_weight is not None:
+            term *= sample_weight
+        return term
+
+
+class HalfTweedieLoss(LogLink, BaseLoss, cHalfTweedieLoss):
+    """Tweedie deviance loss with log-link, for regression.
+
+    Domain:
+    y_true in real numbers for power <= 0
+    y_true in non-negative real numbers for 0 < power < 2
+    y_true in positive real numbers for 2 <= power
+    y_pred in positive real numbers
+    power in real numbers
+
+    Link:
+    y_pred = exp(raw_prediction)
+
+    For a given sample x_i, half Tweedie deviance loss with p=power is defined
+    as::
+
+        loss(x_i) = max(y_true_i, 0)**(2-p) / (1-p) / (2-p)
+                    - y_true_i * exp(raw_prediction_i)**(1-p) / (1-p)
+                    + exp(raw_prediction_i)**(2-p) / (2-p)
+
+    Taking the limits for p=0, 1, 2 gives HalfSquaredError with a log link,
+    HalfPoissonLoss and HalfGammaLoss.
+
+    We also skip constant terms, but those are different for p=0, 1, 2.
+    Therefore, the loss is not continuous in `power`.
+
+    Note furthermore that although no Tweedie distribution exists for
+    0 < power < 1, it still gives a strictly consistent scoring function for
+    the expectation.
+    """
+
+    def __init__(self, sample_weight=None, power=1.5):
+        BaseLoss.__init__(self)
+        cHalfTweedieLoss.__init__(self, power=power)
+        self.interval_y_pred = Interval(0, np.inf, False, False)
+        if self.power <= 0:
+            self.interval_y_true = Interval(-np.inf, np.inf, False, False)
+        elif self.power < 2:
+            self.interval_y_true = Interval(0, np.inf, True, False)
+        else:
+            self.interval_y_true = Interval(0, np.inf, False, False)
+
+    def constant_to_optimal_zero(self, y_true, sample_weight=None):
+        if self.power == 0:
+            return HalfSquaredError().constant_to_optimal_zero(
+                y_true=y_true, sample_weight=sample_weight
+            )
+        elif self.power == 1:
+            return HalfPoissonLoss().constant_to_optimal_zero(
+                y_true=y_true, sample_weight=sample_weight
+            )
+        elif self.power == 2:
+            return HalfGammaLoss().constant_to_optimal_zero(
+                y_true=y_true, sample_weight=sample_weight
+            )
+        else:
+            p = self.power
+            term = np.power(np.maximum(y_true, 0), 2 - p) / (1 - p) / (2 - p)
+            if sample_weight is not None:
+                term *= sample_weight
+            return term
+
+
+class BinaryCrossEntropy(LogitLink, BaseLoss, cBinaryCrossEntropy):
+    """Binary cross entropy loss for binary classification.
+
+    Domain:
+    y_true in [0, 1]
+    y_pred in (0, 1), i.e. boundaries excluded
+
+    Link:
+    y_pred = expit(raw_prediction)
+
+    For a given sample x_i, the binary cross-entropy, aka log loss, is defined
+    as the negative log-likelihood of the Bernoulli distributions and can be
+    expressed as::
+
+        loss(x_i) = log(1 + exp(raw_pred_i)) - y_true_i * raw_pred_i
+
+    See The Elements of Statistical Learning, by Hastie, Tibshirani, Friedman,
+    section 4.4.1 (about logistic regression).
+    """
+
+    def __init__(self, sample_weight=None):
+        super().__init__(n_classes=2)
+        self.interval_y_true = Interval(0, 1, True, True)
+        self.interval_y_pred = Interval(0, 1, False, False)
+
+    def constant_to_optimal_zero(self, y_true, sample_weight=None):
+        # This is non-zero only if y_true is neither 0 nor 1.
+        term = xlogy(y_true, y_true) + xlogy(1 - y_true, 1 - y_true)
+        if sample_weight is not None:
+            term *= sample_weight
+        return term
+
+    def predict_proba(self, raw_prediction):
+        # Be graceful to shape (n_samples, 1) -> (n_samples,)
+        if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
+            raw_prediction = raw_prediction.squeeze(1)
+        proba = np.empty(
+            (raw_prediction.shape[0], 2), dtype=raw_prediction.dtype
+        )
+        proba[:, 1] = self.inverse(raw_prediction)
+        proba[:, 0] = 1 - proba[:, 1]
+        return proba
+
+
+class CategoricalCrossEntropy(
+    MultinomialLogit, BaseLoss, cCategoricalCrossEntropy
+):
+    """Categorical cross-entropy loss for multiclass classification.
+
+    Domain:
+    y_true in {0, 1, 2, 3, .., n_classes - 1}
+    y_pred a n_classes array, each element in (0, 1)
+
+    Link:
+    y_pred = softmax(raw_prediction)
+
+    Note: We assume y_true to be already label encoded.
+
+    For a given sample x_i, the categorical cross-entropy loss is defined as
+    the negative log-likelihood of the multinomial distribution, it generalizes
+    the binary cross-entropy to more than 2 classes::
+
+        loss_i = log(sum(exp(raw_pred_{i, k}), k=0..n_classes-1))
+                - sum(y_true_{i, k} * raw_pred_{i, k}, k=0..n_classes-1)
+
+    See [1].
+
+    Note that for the hessian, we calculate only the diagonal part in the
+    classes: If the full hessian for classes k and l and sample i is H_i_k_l,
+    we calculate H_i_k_k, i.e. k=l.
+
+    Reference
+    ---------
+    .. [1] Simon, Noah, J. Friedman and T. Hastie.
+        "A Blockwise Descent Algorithm for Group-penalized Multiresponse and
+        Multinomial Regression."
+        https://arxiv.org/pdf/1311.6529.pdf
+    """
+
+    def __init__(self, sample_weight=None, n_classes=3):
+        super().__init__(n_classes=n_classes)
+        self.interval_y_true = Interval(0, np.inf, True, False)
+        self.interval_y_pred = Interval(0, 1, False, False)
+
+    def in_y_true_range(self, y):
+        """Return True if y is in the valid range of y_true.
+
+        Parameters
+        ----------
+        y : ndarray
+        """
+        return is_in_interval_range(y, self.interval_y_true) and np.all(
+            y.astype(np.int) == y
+        )
+
+    def fit_intercept_only(self, y_true, sample_weight=None):
+        """Compute raw_prediction of an intercept-only model.
+
+        This is the softmax of the weighted average of the target, i.e. over
+        the samples axis=0.
+        """
+        out = np.zeros(self.n_classes, dtype=y_true.dtype)
+        eps = np.finfo(y_true.dtype).eps
+        for k in range(self.n_classes):
+            out[k] = np.average(y_true == k, weights=sample_weight, axis=0)
+            out[k] = np.clip(out[k], eps, 1 - eps)
+        return self.link(out[None, :]).reshape(-1)
+
+    def predict_proba(self, raw_prediction):
+        return self.inverse(raw_prediction)
+
+    def gradient_proba(
+        self,
+        y_true,
+        raw_prediction,
+        sample_weight=None,
+        gradient=None,
+        proba=None,
+        n_threads=1,
+    ):
+        """Compute gradient and probabilities of loss w.r.t raw_prediction.
+
+        Parameters
+        ----------
+        y_true : C-contiguous array of shape (n_samples,)
+            Observed, true target values.
+        raw_prediction : array of shape (n_samples, n_classes)
+            Raw prediction values (in link space).
+        sample_weight : None or C-contiguous array of shape (n_samples,)
+            Sample weights.
+        gradient : None or array of shape (n_samples, n_classes)
+            A location into which the gradient is stored. If None, a new array
+            might be created.
+        proba : None or array of shape (n_samples, n_classes)
+            A location into which the class probabilities are stored. If None,
+            a new array might be created.
+        n_threads : int
+            Might use openmp thread parallelism.
+
+        Returns
+        -------
+        gradient, proba : array of shape (n_samples, n_classes)
+            Element-wise gradients.
+
+        proba : array of shape (n_samples, n_classes)
+            Element-wise class probabilites.
+        """
+        if gradient is None:
+            if proba is None:
+                gradient = np.empty_like(raw_prediction)
+                proba = np.empty_like(raw_prediction)
+            else:
+                gradient = np.empty_like(proba)
+        elif proba is None:
+            proba = np.empty_like(gradient)
+
+        return self._gradient_proba(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            gradient=gradient,
+            proba=proba,
+            n_threads=n_threads,
+        )
+
+
+_LOSSES = {
+    "squared_error": HalfSquaredError,
+    "absolute_error": AbsoluteError,
+    "pinball_loss": PinballLoss,
+    "poisson_loss": HalfPoissonLoss,
+    "gamma_loss": HalfGammaLoss,
+    "tweedie_loss": HalfTweedieLoss,
+    "binary_crossentropy": BinaryCrossEntropy,
+    "categorical_crossentropy": CategoricalCrossEntropy,
+}

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -466,9 +466,6 @@ class HalfSquaredError(IdentityLink, BaseLoss, cHalfSquaredError):
         gradient=None,
         n_threads=1,
     ):
-        # easier in numpy
-        # gradient = raw_prediction - y_true is easier in numpy
-
         # Be graceful to shape (n_samples, 1) -> (n_samples,)
         if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
             raw_prediction = raw_prediction.squeeze(1)
@@ -479,6 +476,7 @@ class HalfSquaredError(IdentityLink, BaseLoss, cHalfSquaredError):
         ):
             gradient = gradient.squeeze(1)
 
+        # gradient = raw_prediction - y_true is easier in numpy
         gradient = np.subtract(raw_prediction, y_true, out=gradient)
         if sample_weight is None:
             return gradient

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -560,8 +560,8 @@ class PinballLoss(IdentityLink, BaseLoss, cPinballLoss):
         loss(x_i) = rho_{quantile}(y_true_i - raw_prediction_i)
 
         rho_{quantile}(u) = u * (quantile - 1_{u<0})
-                          = -u (1 - quantile)  if u < 0
-                            u * quantile       if u >= 0
+                          = -u *(1 - quantile)  if u < 0
+                             u * quantile       if u >= 0
 
     Note: 2 * PinballLoss(quantile=0.5) equals AbsoluteError().
 
@@ -649,9 +649,9 @@ class HalfGammaLoss(LogLink, BaseLoss, cHalfGammaLoss):
         loss(x_i) = log(exp(raw_prediction_i)/y_true_i)
                     + y_true/exp(raw_prediction_i) - 1
 
-    Half the Gamma deviance is actually proportional the negative log
-    likelihood up constant terms (not involving raw_prediction) and simplifies
-    the computation of the gradients.
+    Half the Gamma deviance is actually proportional to the negative log
+    likelihood up to constant terms (not involving raw_prediction) and
+    simplifies the computation of the gradients.
     We also skip the constant term `-log(y_true_i) - 1`.
     """
 

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -87,6 +87,8 @@ class BaseLoss(BaseLink, cLossFunction):
         approximated, it should be larger or equal to the exact one.
     constant_hessian : bool
         Indicates whether the hessian is one for this loss.
+    is_multiclass : bool
+        Indicates whether n_classes > 2 is allowed.
     """
 
     # Inherited methods from BaseLink:
@@ -107,6 +109,7 @@ class BaseLoss(BaseLink, cLossFunction):
     # (https://statweb.stanford.edu/~jhf/ftp/trebst.pdf) for the theory.
     need_update_leaves_values = False
     differentiable = True
+    is_multiclass = False
 
     def __init__(self, n_classes=1):
         self.approx_hessian = False
@@ -808,6 +811,8 @@ class CategoricalCrossEntropy(
         Multinomial Regression."
         https://arxiv.org/pdf/1311.6529.pdf
     """
+
+    is_multiclass = True
 
     def __init__(self, sample_weight=None, n_classes=3):
         super().__init__(n_classes=n_classes)

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -451,7 +451,8 @@ class HalfSquaredError(IdentityLink, BaseLoss, cHalfSquaredError):
         loss(x_i) = 0.5 * (y_true_i - raw_prediction_i)**2
 
     The factor of 0.5 simplifies the computation of gradients and results in a
-    unit hessian (and be consistent with what is done in LightGBM).
+    unit hessian (and is consistent with what is done in LightGBM). It is also
+    half the Normal distribution deviance.
     """
 
     def __init__(self, sample_weight=None):
@@ -512,7 +513,7 @@ class HalfSquaredError(IdentityLink, BaseLoss, cHalfSquaredError):
 
 
 class AbsoluteError(IdentityLink, BaseLoss, cAbsoluteError):
-    """Least absolute error, for regression.
+    """Absolute error with identity link, for regression.
 
     Domain:
     y_true and y_pred all real numbers
@@ -734,7 +735,7 @@ class HalfTweedieLoss(LogLink, BaseLoss, cHalfTweedieLoss):
 
 
 class BinaryCrossEntropy(LogitLink, BaseLoss, cBinaryCrossEntropy):
-    """Binary cross entropy loss for binary classification.
+    """Binary cross entropy loss with logit link, for binary classification.
 
     Domain:
     y_true in [0, 1]
@@ -743,14 +744,20 @@ class BinaryCrossEntropy(LogitLink, BaseLoss, cBinaryCrossEntropy):
     Link:
     y_pred = expit(raw_prediction)
 
-    For a given sample x_i, the binary cross-entropy, aka log loss, is defined
-    as the negative log-likelihood of the Bernoulli distribution and can be
-    expressed as::
+    For a given sample x_i, the binary cross-entropy, is defined as the
+    negative log-likelihood of the Bernoulli distribution and can be expressed
+    as::
 
         loss(x_i) = log(1 + exp(raw_pred_i)) - y_true_i * raw_pred_i
 
     See The Elements of Statistical Learning, by Hastie, Tibshirani, Friedman,
     section 4.4.1 (about logistic regression).
+
+    This loss is also known as log loss or logistic loss.
+    Note that the formulation works for classification, y = {0, 1}, as well as
+    logistic regression, y = [0, 1].
+    If you add `constant_to_optimal_zero` to the loss, you get half the
+    Bernoulli/binomial deviance.
     """
 
     def __init__(self, sample_weight=None):
@@ -780,7 +787,7 @@ class BinaryCrossEntropy(LogitLink, BaseLoss, cBinaryCrossEntropy):
 class CategoricalCrossEntropy(
     MultinomialLogit, BaseLoss, cCategoricalCrossEntropy
 ):
-    """Categorical cross-entropy loss for multiclass classification.
+    """Categorical cross-entropy loss, for multiclass classification.
 
     Domain:
     y_true in {0, 1, 2, 3, .., n_classes - 1}
@@ -789,7 +796,9 @@ class CategoricalCrossEntropy(
     Link:
     y_pred = softmax(raw_prediction)
 
-    Note: We assume y_true to be already label encoded.
+    Note: We assume y_true to be already label encoded. The inverse link is
+    softmax. But the full link function is the symmetric multinomial logit
+    function.
 
     For a given sample x_i, the categorical cross-entropy loss is defined as
     the negative log-likelihood of the multinomial distribution, it

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -354,9 +354,7 @@ class BaseLoss(BaseLink, cLossFunction):
             n_threads=n_threads,
         )
 
-    def __call__(
-        self, y_true, raw_prediction, sample_weight=None, n_threads=1
-    ):
+    def __call__(self, y_true, raw_prediction, sample_weight=None, n_threads=1):
         """Compute the weighted average loss.
 
         Parameters
@@ -473,11 +471,7 @@ class HalfSquaredError(IdentityLink, BaseLoss, cHalfSquaredError):
         # Be graceful to shape (n_samples, 1) -> (n_samples,)
         if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
             raw_prediction = raw_prediction.squeeze(1)
-        if (
-            gradient is not None
-            and gradient.ndim == 2
-            and gradient.shape[1] == 1
-        ):
+        if gradient is not None and gradient.ndim == 2 and gradient.shape[1] == 1:
             gradient = gradient.squeeze(1)
 
         # gradient = raw_prediction - y_true is easier in numpy
@@ -588,7 +582,7 @@ class PinballLoss(IdentityLink, BaseLoss, cPinballLoss):
             self.constant_hessian = False
         if quantile <= 0 or quantile >= 1:
             raise ValueError(
-                f"PinballLoss aka quantile loss only accepts "
+                "PinballLoss aka quantile loss only accepts "
                 f"0 < quantile < 1; {quantile} was given."
             )
 
@@ -601,9 +595,7 @@ class PinballLoss(IdentityLink, BaseLoss, cPinballLoss):
         if sample_weight is None:
             return np.percentile(y_true, 100 * self.quantile, axis=0)
         else:
-            return _weighted_percentile(
-                y_true, sample_weight, 100 * self.quantile
-            )
+            return _weighted_percentile(y_true, sample_weight, 100 * self.quantile)
 
 
 class HalfPoissonLoss(LogLink, BaseLoss, cHalfPoissonLoss):
@@ -776,17 +768,13 @@ class BinaryCrossEntropy(LogitLink, BaseLoss, cBinaryCrossEntropy):
         # Be graceful to shape (n_samples, 1) -> (n_samples,)
         if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
             raw_prediction = raw_prediction.squeeze(1)
-        proba = np.empty(
-            (raw_prediction.shape[0], 2), dtype=raw_prediction.dtype
-        )
+        proba = np.empty((raw_prediction.shape[0], 2), dtype=raw_prediction.dtype)
         proba[:, 1] = self.inverse(raw_prediction)
         proba[:, 0] = 1 - proba[:, 1]
         return proba
 
 
-class CategoricalCrossEntropy(
-    MultinomialLogit, BaseLoss, cCategoricalCrossEntropy
-):
+class CategoricalCrossEntropy(MultinomialLogit, BaseLoss, cCategoricalCrossEntropy):
     """Categorical cross-entropy loss, for multiclass classification.
 
     Domain:

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -438,7 +438,7 @@ class BaseLoss(BaseLink, cLossFunction):
 
 
 class HalfSquaredError(IdentityLink, BaseLoss, cHalfSquaredError):
-    """Half Squared Error with identity link, for regression.
+    """Half squared error with identity link, for regression.
 
     Domain:
     y_true and y_pred all real numbers
@@ -446,7 +446,7 @@ class HalfSquaredError(IdentityLink, BaseLoss, cHalfSquaredError):
     Link:
     y_pred = raw_prediction
 
-    For a given sample x_i, half squares error is defined as::
+    For a given sample x_i, half squared error is defined as::
 
         loss(x_i) = 0.5 * (y_true_i - raw_prediction_i)**2
 
@@ -549,7 +549,7 @@ class AbsoluteError(IdentityLink, BaseLoss, cAbsoluteError):
 
 
 class PinballLoss(IdentityLink, BaseLoss, cPinballLoss):
-    """Quantile Loss aka Pinball Loss, for regression.
+    """Quantile loss aka pinball loss, for regression.
 
     Domain:
     y_true and y_pred all real numbers
@@ -558,7 +558,7 @@ class PinballLoss(IdentityLink, BaseLoss, cPinballLoss):
     Link:
     y_pred = raw_prediction
 
-    For a given sample x_i, the pinball loss loss is defined as::
+    For a given sample x_i, the pinball loss is defined as::
 
         loss(x_i) = rho_{quantile}(y_true_i - raw_prediction_i)
 
@@ -620,7 +620,7 @@ class HalfPoissonLoss(LogLink, BaseLoss, cHalfPoissonLoss):
         loss(x_i) = y_true_i * log(y_true_i/exp(raw_prediction_i))
                     - y_true_i + exp(raw_prediction_i)
 
-    Half the Poisson deviance is actually the negative log likelihood up to
+    Half the Poisson deviance is actually the negative log-likelihood up to
     constant terms (not involving raw_prediction) and simplifies the
     computation of the gradients.
     We also skip the constant term `y_true_i * log(y_true_i) - y_true_i`.
@@ -652,7 +652,7 @@ class HalfGammaLoss(LogLink, BaseLoss, cHalfGammaLoss):
         loss(x_i) = log(exp(raw_prediction_i)/y_true_i)
                     + y_true/exp(raw_prediction_i) - 1
 
-    Half the Gamma deviance is actually proportional to the negative log
+    Half the Gamma deviance is actually proportional to the negative log-
     likelihood up to constant terms (not involving raw_prediction) and
     simplifies the computation of the gradients.
     We also skip the constant term `-log(y_true_i) - 1`.
@@ -744,7 +744,7 @@ class BinaryCrossEntropy(LogitLink, BaseLoss, cBinaryCrossEntropy):
     y_pred = expit(raw_prediction)
 
     For a given sample x_i, the binary cross-entropy, aka log loss, is defined
-    as the negative log-likelihood of the Bernoulli distributions and can be
+    as the negative log-likelihood of the Bernoulli distribution and can be
     expressed as::
 
         loss(x_i) = log(1 + exp(raw_pred_i)) - y_true_i * raw_pred_i
@@ -784,7 +784,7 @@ class CategoricalCrossEntropy(
 
     Domain:
     y_true in {0, 1, 2, 3, .., n_classes - 1}
-    y_pred a n_classes array, each element in (0, 1)
+    y_pred has n_classes elements, each element in (0, 1)
 
     Link:
     y_pred = softmax(raw_prediction)
@@ -792,8 +792,8 @@ class CategoricalCrossEntropy(
     Note: We assume y_true to be already label encoded.
 
     For a given sample x_i, the categorical cross-entropy loss is defined as
-    the negative log-likelihood of the multinomial distribution, it generalizes
-    the binary cross-entropy to more than 2 classes::
+    the negative log-likelihood of the multinomial distribution, it
+    generalizes the binary cross-entropy to more than 2 classes::
 
         loss_i = log(sum(exp(raw_pred_{i, k}), k=0..n_classes-1))
                 - sum(y_true_{i, k} * raw_pred_{i, k}, k=0..n_classes-1)
@@ -855,7 +855,7 @@ class CategoricalCrossEntropy(
         proba=None,
         n_threads=1,
     ):
-        """Compute gradient and probabilities of loss w.r.t raw_prediction.
+        """Compute gradient and probabilities fow raw_prediction.
 
         Parameters
         ----------

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -824,7 +824,7 @@ class CategoricalCrossEntropy(
         y : ndarray
         """
         return is_in_interval_range(y, self.interval_y_true) and np.all(
-            y.astype(np.int) == y
+            y.astype(int) == y
         )
 
     def fit_intercept_only(self, y_true, sample_weight=None):

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -155,7 +155,7 @@ class BaseLoss(BaseLink, cLossFunction):
         loss : None or C-contiguous array of shape (n_samples,)
             A location into which the result is stored. If None, a new array
             might be created.
-        n_threads : int
+        n_threads : int, default=1
             Might use openmp thread parallelism.
 
         Returns
@@ -203,7 +203,7 @@ class BaseLoss(BaseLink, cLossFunction):
             of shape (n_samples, n_classes)
             A location into which the gradient is stored. If None, a new array
             might be created.
-        n_threads : int
+        n_threads : int, default=1
             Might use openmp thread parallelism.
 
         Returns
@@ -261,7 +261,7 @@ class BaseLoss(BaseLink, cLossFunction):
             of shape (n_samples, n_classes)
             A location into which the result is stored. If None, a new array
             might be created.
-        n_threads : int
+        n_threads : int, default=1
             Might use openmp thread parallelism.
 
         Returns
@@ -314,7 +314,7 @@ class BaseLoss(BaseLink, cLossFunction):
             of shape (n_samples, n_classes)
             A location into which the hessian is stored. If None, a new array
             might be created.
-        n_threads : int
+        n_threads : int, default=1
             Might use openmp thread parallelism.
 
         Returns
@@ -365,7 +365,7 @@ class BaseLoss(BaseLink, cLossFunction):
             Raw prediction values (in link space).
         sample_weight : None or C-contiguous array of shape (n_samples,)
             Sample weights.
-        n_threads : int
+        n_threads : int, default=1
             Might use openmp thread parallelism.
 
         Returns
@@ -868,7 +868,7 @@ class CategoricalCrossEntropy(
         proba : None or array of shape (n_samples, n_classes)
             A location into which the class probabilities are stored. If None,
             a new array might be created.
-        n_threads : int
+        n_threads : int, default=1
             Might use openmp thread parallelism.
 
         Returns

--- a/sklearn/_loss/setup.py
+++ b/sklearn/_loss/setup.py
@@ -8,7 +8,7 @@ def configuration(parent_package="", top_path=None):
         "_loss",
         sources=["_loss.pyx"],
         include_dirs=[numpy.get_include()],
-        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_13_API_VERSION")],
+        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
     )
     return config
 

--- a/sklearn/_loss/setup.py
+++ b/sklearn/_loss/setup.py
@@ -4,13 +4,9 @@ from numpy.distutils.misc_util import Configuration
 
 def configuration(parent_package="", top_path=None):
     config = Configuration("_loss", parent_package, top_path)
-
     config.add_extension(
         "_loss", sources=["_loss.pyx"], include_dirs=[numpy.get_include()]
     )
-
-    # config.add_subpackage("tests")
-
     return config
 
 

--- a/sklearn/_loss/setup.py
+++ b/sklearn/_loss/setup.py
@@ -8,7 +8,7 @@ def configuration(parent_package="", top_path=None):
         "_loss",
         sources=["_loss.pyx"],
         include_dirs=[numpy.get_include()],
-        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
+        # define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
     )
     return config
 

--- a/sklearn/_loss/setup.py
+++ b/sklearn/_loss/setup.py
@@ -5,7 +5,10 @@ from numpy.distutils.misc_util import Configuration
 def configuration(parent_package="", top_path=None):
     config = Configuration("_loss", parent_package, top_path)
     config.add_extension(
-        "_loss", sources=["_loss.pyx"], include_dirs=[numpy.get_include()]
+        "_loss",
+        sources=["_loss.pyx"],
+        include_dirs=[numpy.get_include()],
+        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_13_API_VERSION")],
     )
     return config
 

--- a/sklearn/_loss/setup.py
+++ b/sklearn/_loss/setup.py
@@ -1,0 +1,20 @@
+import numpy
+from numpy.distutils.misc_util import Configuration
+
+
+def configuration(parent_package="", top_path=None):
+    config = Configuration("_loss", parent_package, top_path)
+
+    config.add_extension(
+        "_loss", sources=["_loss.pyx"], include_dirs=[numpy.get_include()]
+    )
+
+    # config.add_subpackage("tests")
+
+    return config
+
+
+if __name__ == "__main__":
+    from numpy.distutils.core import setup
+
+    setup(**configuration().todict())

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -36,8 +36,7 @@ def test_is_in_range(interval):
 
     # x contains lower bound
     assert (
-        is_in_interval_range(np.r_[x, interval.low], interval)
-        == interval.low_inclusive
+        is_in_interval_range(np.r_[x, interval.low], interval) == interval.low_inclusive
     )
 
     # x contains upper bound
@@ -47,9 +46,9 @@ def test_is_in_range(interval):
     )
 
     # x contains upper and lower bound
-    assert is_in_interval_range(
-        np.r_[x, interval.low, interval.high], interval
-    ) == (interval.low_inclusive and interval.high_inclusive)
+    assert is_in_interval_range(np.r_[x, interval.low, interval.high], interval) == (
+        interval.low_inclusive and interval.high_inclusive
+    )
 
 
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
@@ -60,9 +59,7 @@ def test_link_inverse_identity(link):
     n_samples, n_classes = 100, None
     if link.multiclass:
         n_classes = 10
-        raw_prediction = rng.normal(
-            loc=0, scale=10, size=(n_samples, n_classes)
-        )
+        raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples, n_classes))
         if isinstance(link, MultinomialLogit):
             raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
     else:
@@ -83,9 +80,7 @@ def test_link_out_argument(link):
     n_samples, n_classes = 100, None
     if link.multiclass:
         n_classes = 10
-        raw_prediction = rng.normal(
-            loc=0, scale=10, size=(n_samples, n_classes)
-        )
+        raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples, n_classes))
         if isinstance(link, MultinomialLogit):
             raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
     else:

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -1,0 +1,107 @@
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+import pytest
+
+from sklearn._loss.link import (
+    _LINKS,
+    _inclusive_low_high,
+    MultinomialLogit,
+    Interval,
+    is_in_interval_range,
+)
+
+
+LINK_FUNCTIONS = list(_LINKS.values())
+
+
+@pytest.mark.parametrize(
+    "interval",
+    [
+        Interval(0, 1, False, False),
+        Interval(0, 1, False, True),
+        Interval(0, 1, True, False),
+        Interval(0, 1, True, True),
+        Interval(-np.inf, np.inf, False, False),
+        Interval(-np.inf, np.inf, False, True),
+        Interval(-np.inf, np.inf, True, False),
+        Interval(-np.inf, np.inf, True, True),
+    ],
+)
+def test_is_in_range(interval):
+    # make sure low and high are always within the interval, used for linspace
+    low, high = _inclusive_low_high(interval)
+
+    x = np.linspace(low, high, num=10)
+    assert is_in_interval_range(x, interval)
+
+    # x contains lower bound
+    assert (
+        is_in_interval_range(np.r_[x, interval.low], interval)
+        == interval.low_inclusive
+    )
+
+    # x contains upper bound
+    assert (
+        is_in_interval_range(np.r_[x, interval.high], interval)
+        == interval.high_inclusive
+    )
+
+    # x contains upper and lower bound
+    assert is_in_interval_range(
+        np.r_[x, interval.low, interval.high], interval
+    ) == (interval.low_inclusive and interval.high_inclusive)
+
+
+@pytest.mark.parametrize("link", LINK_FUNCTIONS)
+def test_link_inverse_identity(link):
+    # Test that link of inverse gives idendity.
+    rng = np.random.RandomState(42)
+    link = link()
+    n_samples, n_classes = 100, None
+    if link.multiclass:
+        n_classes = 10
+        raw_prediction = rng.normal(
+            loc=0, scale=10, size=(n_samples, n_classes)
+        )
+        if isinstance(link, MultinomialLogit):
+            raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
+    else:
+        # So far, the valid interval of raw_prediction is (-inf, inf) and
+        # we do not need to distinguish
+        raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples))
+
+    assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction)
+    y_pred = link.inverse(raw_prediction)
+    assert_allclose(link.inverse(link.link(y_pred)), y_pred)
+
+
+@pytest.mark.parametrize("link", LINK_FUNCTIONS)
+def test_link_out_argument(link):
+    # Test that out argument gets assigned the result.
+    rng = np.random.RandomState(42)
+    link = link()
+    n_samples, n_classes = 100, None
+    if link.multiclass:
+        n_classes = 10
+        raw_prediction = rng.normal(
+            loc=0, scale=10, size=(n_samples, n_classes)
+        )
+        if isinstance(link, MultinomialLogit):
+            raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
+    else:
+        # So far, the valid interval of raw_prediction is (-inf, inf) and
+        # we do not need to distinguish
+        raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples))
+
+    y_pred = link.inverse(raw_prediction, out=None)
+    out = np.empty_like(raw_prediction)
+    y_pred_2 = link.inverse(raw_prediction, out=out)
+    assert_allclose(y_pred, out)
+    assert_array_equal(out, y_pred_2)
+    assert np.shares_memory(out, y_pred_2)
+
+    out = np.empty_like(y_pred)
+    raw_prediction_2 = link.link(y_pred, out=out)
+    assert_allclose(raw_prediction, out)
+    assert_array_equal(out, raw_prediction_2)
+    assert np.shares_memory(out, raw_prediction_2)

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -54,7 +54,7 @@ def test_is_in_range(interval):
 
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
 def test_link_inverse_identity(link):
-    # Test that link of inverse gives idendity.
+    # Test that link of inverse gives identity.
     rng = np.random.RandomState(42)
     link = link()
     n_samples, n_classes = 100, None
@@ -67,7 +67,7 @@ def test_link_inverse_identity(link):
             raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
     else:
         # So far, the valid interval of raw_prediction is (-inf, inf) and
-        # we do not need to distinguish
+        # we do not need to distinguish.
         raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples))
 
     assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction)
@@ -90,7 +90,7 @@ def test_link_out_argument(link):
             raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
     else:
         # So far, the valid interval of raw_prediction is (-inf, inf) and
-        # we do not need to distinguish
+        # we do not need to distinguish.
         raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples))
 
     y_pred = link.inverse(raw_prediction, out=None)

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -135,26 +135,46 @@ def test_loss_boundary(loss):
     loss.loss(y_true=y_true, raw_prediction=raw_prediction)
 
 
+# Fixture to test valid value ranges.
+Y_COMMON_PARAMS = [
+    # (loss, [y success], [y fail])
+    (HalfSquaredError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+    (AbsoluteError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+    (PinballLoss(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+    (HalfPoissonLoss(), [0.1, 100], [-np.inf, -3, -0.1, np.inf]),
+    (HalfGammaLoss(), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+    (HalfTweedieLoss(power=-3), [0.1, 100], [-np.inf, np.inf]),
+    (HalfTweedieLoss(power=0), [0.1, 100], [-np.inf, np.inf]),
+    (HalfTweedieLoss(power=1.5), [0.1, 100], [-np.inf, -3, -0.1, np.inf]),
+    (HalfTweedieLoss(power=2), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+    (HalfTweedieLoss(power=3), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+    (BinaryCrossEntropy(), [0.1, 0.5, 0.9], [-np.inf, -1, 2, np.inf]),
+    (CategoricalCrossEntropy(), [], [-np.inf, -1, 1.1, np.inf]),
+]
+# y_pred and y_true do not always have the same domain (valid value range).
+# Hence, we define extra sets of parameters for each of them.
+Y_TRUE_PARAMS = [
+    # (loss, [y success], [y fail])
+    (HalfPoissonLoss(), [0], []),
+    (HalfTweedieLoss(power=-3), [-100, -0.1, 0], []),
+    (HalfTweedieLoss(power=0), [-100, 0], []),
+    (HalfTweedieLoss(power=1.5), [0], []),
+    (BinaryCrossEntropy(), [0, 1], []),
+    (CategoricalCrossEntropy(), [0.0, 1.0, 2], []),
+]
+Y_PRED_PARAMS = [
+    # (loss, [y success], [y fail])
+    (HalfPoissonLoss(), [], [0]),
+    (HalfTweedieLoss(power=-3), [], [-3, -0.1, 0]),
+    (HalfTweedieLoss(power=0), [], [-3, -0.1, 0]),
+    (HalfTweedieLoss(power=1.5), [], [0]),
+    (BinaryCrossEntropy(), [], [0, 1]),
+    (CategoricalCrossEntropy(), [0.1, 0.5], [0, 1]),
+]
+
+
 @pytest.mark.parametrize(
-    "loss, y_true_success, y_true_fail",
-    [
-        (HalfSquaredError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
-        (AbsoluteError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
-        (PinballLoss(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
-        (HalfPoissonLoss(), [0, 0.1, 100], [-np.inf, -3, -0.1, np.inf]),
-        (HalfGammaLoss(), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
-        (HalfTweedieLoss(power=-3), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
-        (HalfTweedieLoss(power=0), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
-        (
-            HalfTweedieLoss(power=1.5),
-            [0, 0.1, 100],
-            [-np.inf, -3, -0.1, np.inf],
-        ),
-        (HalfTweedieLoss(power=2), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
-        (HalfTweedieLoss(power=3), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
-        (BinaryCrossEntropy(), [0, 0.5, 1], [-np.inf, -1, 2, np.inf]),
-        (CategoricalCrossEntropy(), [0.0, 1.0, 2], [-np.inf, -1, 1.1, np.inf]),
-    ],
+    "loss, y_true_success, y_true_fail", Y_COMMON_PARAMS + Y_TRUE_PARAMS
 )
 def test_loss_boundary_y_true(loss, y_true_success, y_true_fail):
     # Test boundaries of y_true for loss functions.
@@ -165,29 +185,7 @@ def test_loss_boundary_y_true(loss, y_true_success, y_true_fail):
 
 
 @pytest.mark.parametrize(
-    "loss, y_pred_success, y_pred_fail",
-    [
-        (HalfSquaredError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
-        (AbsoluteError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
-        (PinballLoss(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
-        (HalfPoissonLoss(), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
-        (HalfGammaLoss(), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
-        (
-            HalfTweedieLoss(power=-3),
-            [0.1, 100],
-            [-np.inf, -3, -0.1, 0, np.inf],
-        ),
-        (HalfTweedieLoss(power=0), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
-        (
-            HalfTweedieLoss(power=1.5),
-            [0.1, 100],
-            [-np.inf, -3, -0.1, 0, np.inf],
-        ),
-        (HalfTweedieLoss(power=2), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
-        (HalfTweedieLoss(power=3), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
-        (BinaryCrossEntropy(), [0.1, 0.5], [-np.inf, 0, 1, np.inf]),
-        (CategoricalCrossEntropy(), [0.1, 0.5], [-np.inf, 0, 1, np.inf]),
-    ],
+    "loss, y_pred_success, y_pred_fail", Y_COMMON_PARAMS + Y_PRED_PARAMS
 )
 def test_loss_boundary_y_pred(loss, y_pred_success, y_pred_fail):
     # Test boundaries of y_pred for loss functions.

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -87,13 +87,11 @@ def random_y_true_raw_prediction(
 
 
 def numerical_derivative(func, x, eps):
-    """Helper function for numerical (first) derivatives.
-
+    """Helper function for numerical (first) derivatives."""
     # For numerical derivatives, see
     # https://en.wikipedia.org/wiki/Numerical_differentiation
     # https://en.wikipedia.org/wiki/Finite_difference_coefficient
     # We use central finite differences of accuracy 4.
-    """
     h = np.full_like(x, fill_value=eps)
     f_minus_2h = func(x - 2 * h)
     f_minus_1h = func(x - h)
@@ -348,7 +346,7 @@ def test_loss_same_as_C_functions(loss, sample_weight):
 @pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)
 @pytest.mark.parametrize("sample_weight", [None, "range"])
 def test_loss_gradients_are_the_same(loss, sample_weight):
-    # Test that loss and gradient are the same accross different functions
+    # Test that loss and gradient are the same across different functions.
     # Also test that output arguments contain correct result.
     y_true, raw_prediction = random_y_true_raw_prediction(
         loss=loss,

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -1,0 +1,814 @@
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+import pytest
+from pytest import approx
+from scipy.optimize import (
+    minimize,
+    minimize_scalar,
+    newton,
+)
+from scipy.special import logit
+
+from sklearn._loss.link import _inclusive_low_high
+from sklearn._loss.loss import (
+    _LOSSES,
+    AbsoluteError,
+    BinaryCrossEntropy,
+    CategoricalCrossEntropy,
+    HalfGammaLoss,
+    HalfPoissonLoss,
+    HalfSquaredError,
+    HalfTweedieLoss,
+    PinballLoss,
+)
+from sklearn.utils import assert_all_finite
+from sklearn.utils._testing import skip_if_32bit
+from sklearn.utils.fixes import sp_version, parse_version
+
+
+ALL_LOSSES = list(_LOSSES.values())
+
+LOSS_INSTANCES = [loss() for loss in ALL_LOSSES]
+# HalfTweedieLoss(power=1.5) is already there as default
+LOSS_INSTANCES += [
+    PinballLoss(quantile=0.25),
+    HalfTweedieLoss(power=-1.5),
+    HalfTweedieLoss(power=0),
+    HalfTweedieLoss(power=1),
+    HalfTweedieLoss(power=2),
+    HalfTweedieLoss(power=3.0),
+]
+
+
+def loss_instance_name(loss):
+    name = loss.__class__.__name__
+    if hasattr(loss, "quantile"):
+        name += f"(quantile={loss.quantile})"
+    elif hasattr(loss, "power"):
+        name += f"(power={loss.power})"
+    return name
+
+
+def random_y_true_raw_prediction(
+    loss, n_samples, y_bound=(-100, 100), raw_bound=(-5, 5), seed=42
+):
+    """Random generate y_true and raw_prediction in valid range."""
+    rng = np.random.RandomState(seed)
+    if loss.n_classes <= 2:
+        raw_prediction = rng.uniform(
+            low=raw_bound[0], high=raw_bound[0], size=n_samples
+        )
+        # generate a y_true in valid range
+        low, high = _inclusive_low_high(loss.interval_y_true)
+        low = max(low, y_bound[0])
+        high = min(high, y_bound[1])
+        y_true = rng.uniform(low, high, size=n_samples)
+        # set some values at special boundaries
+        if (
+            loss.interval_y_true.low == 0
+            and loss.interval_y_true.low_inclusive
+        ):
+            y_true[:: (n_samples // 3)] = 0
+        if (
+            loss.interval_y_true.high == 1
+            and loss.interval_y_true.high_inclusive
+        ):
+            y_true[1:: (n_samples // 3)] = 1
+    else:
+        raw_prediction = np.empty((n_samples, loss.n_classes))
+        raw_prediction.flat[:] = rng.uniform(
+            low=raw_bound[0],
+            high=raw_bound[1],
+            size=n_samples * loss.n_classes,
+        )
+        y_true = np.arange(n_samples).astype(float) % loss.n_classes
+
+    return y_true, raw_prediction
+
+
+def numerical_derivative(func, x, eps):
+    """Helper function for numerical (first) derivatives.
+
+    # For numerical derivatives, see
+    # https://en.wikipedia.org/wiki/Numerical_differentiation
+    # https://en.wikipedia.org/wiki/Finite_difference_coefficient
+    # We use central finite differences of accuracy 4.
+    """
+    h = np.full_like(x, fill_value=eps)
+    f_minus_2h = func(x - 2 * h)
+    f_minus_1h = func(x - h)
+    f_plus_1h = func(x + h)
+    f_plus_2h = func(x + 2 * h)
+    return (-f_plus_2h + 8 * f_plus_1h - 8 * f_minus_1h + f_minus_2h) / (
+        12.0 * eps
+    )
+
+
+@pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)
+def test_loss_boundary(loss):
+    # make sure low and high are always within the interval, used for linspace
+    if loss.n_classes is None or loss.n_classes <= 2:
+        low, high = _inclusive_low_high(loss.interval_y_true)
+        y_true = np.linspace(low, high, num=10)
+    else:
+        y_true = np.linspace(0, 9, num=10)
+
+    # add boundaries if they are included
+    if loss.interval_y_true.low_inclusive:
+        y_true = np.r_[y_true, loss.interval_y_true.low]
+    if loss.interval_y_true.high_inclusive:
+        y_true = np.r_[y_true, loss.interval_y_true.high]
+
+    assert loss.in_y_true_range(y_true)
+
+    low, high = _inclusive_low_high(loss.interval_y_pred)
+    if loss.n_classes is None or loss.n_classes <= 2:
+        y_pred = np.linspace(low, high, num=10)
+    else:
+        y_pred = np.empty((10, 3))
+        y_pred[:, 0] = np.linspace(low, high, num=10)
+        y_pred[:, 1] = 0.5 * (1 - y_pred[:, 0])
+        y_pred[:, 2] = 0.5 * (1 - y_pred[:, 0])
+
+    assert loss.in_y_pred_range(y_pred)
+
+    # calculating losses should not fail
+    raw_prediction = loss.link(y_pred)
+    loss.loss(y_true=y_true, raw_prediction=raw_prediction)
+
+
+@pytest.mark.parametrize(
+    "loss, y_true_success, y_true_fail",
+    [
+        (HalfSquaredError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+        (AbsoluteError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+        (PinballLoss(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+        (HalfPoissonLoss(), [0, 0.1, 100], [-np.inf, -3, -0.1, np.inf]),
+        (HalfGammaLoss(), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+        (HalfTweedieLoss(power=-3), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+        (HalfTweedieLoss(power=0), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+        (
+            HalfTweedieLoss(power=1.5),
+            [0, 0.1, 100],
+            [-np.inf, -3, -0.1, np.inf],
+        ),
+        (HalfTweedieLoss(power=2), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+        (HalfTweedieLoss(power=3), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+        (BinaryCrossEntropy(), [0, 0.5, 1], [-np.inf, -1, 2, np.inf]),
+        (CategoricalCrossEntropy(), [0.0, 1.0, 2], [-np.inf, -1, 1.1, np.inf]),
+    ],
+)
+def test_loss_boundary_y_true(loss, y_true_success, y_true_fail):
+    # Test boundaries of y_true for loss functions.
+    for y in y_true_success:
+        assert loss.in_y_true_range(np.array([y]))
+    for y in y_true_fail:
+        assert not loss.in_y_true_range(np.array([y]))
+
+
+@pytest.mark.parametrize(
+    "loss, y_pred_success, y_pred_fail",
+    [
+        (HalfSquaredError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+        (AbsoluteError(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+        (PinballLoss(), [-100, 0, 0.1, 100], [-np.inf, np.inf]),
+        (HalfPoissonLoss(), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+        (HalfGammaLoss(), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+        (
+            HalfTweedieLoss(power=-3),
+            [0.1, 100],
+            [-np.inf, -3, -0.1, 0, np.inf],
+        ),
+        (HalfTweedieLoss(power=0), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+        (
+            HalfTweedieLoss(power=1.5),
+            [0.1, 100],
+            [-np.inf, -3, -0.1, 0, np.inf],
+        ),
+        (HalfTweedieLoss(power=2), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+        (HalfTweedieLoss(power=3), [0.1, 100], [-np.inf, -3, -0.1, 0, np.inf]),
+        (BinaryCrossEntropy(), [0.1, 0.5], [-np.inf, 0, 1, np.inf]),
+        (CategoricalCrossEntropy(), [0.1, 0.5], [-np.inf, 0, 1, np.inf]),
+    ],
+)
+def test_loss_boundary_y_pred(loss, y_pred_success, y_pred_fail):
+    # Test boundaries of y_pred for loss functions.
+    for y in y_pred_success:
+        assert loss.in_y_pred_range(np.array([y]))
+    for y in y_pred_fail:
+        assert not loss.in_y_pred_range(np.array([y]))
+
+
+@pytest.mark.parametrize("loss", ALL_LOSSES)
+@pytest.mark.parametrize("dtype_in", [np.float32, np.float64])
+@pytest.mark.parametrize("dtype_out", [np.float32, np.float64])
+@pytest.mark.parametrize("sample_weight", [None, 1])
+@pytest.mark.parametrize("out1", [None, 1])
+@pytest.mark.parametrize("out2", [None, 1])
+@pytest.mark.parametrize("n_threads", [1, 2])
+def test_loss_dtype(
+    loss, dtype_in, dtype_out, sample_weight, out1, out2, n_threads
+):
+    # Test that loss accepts if all input arrays are either all float32 or all
+    # float64, and all output arrays are either all float32 or all float64.
+    loss = loss()
+    if loss.n_classes <= 2:
+        # generate a y_true in valid range
+        low, high = _inclusive_low_high(loss.interval_y_true, dtype=dtype_in)
+        y_true = np.array([0.5 * (high - low)], dtype=dtype_in)
+        raw_prediction = np.array([0.0], dtype=dtype_in)
+    else:
+        y_true = np.array([0], dtype=dtype_in)
+        raw_prediction = np.full(
+            shape=(1, loss.n_classes), fill_value=0.0, dtype=dtype_in
+        )
+
+    if sample_weight is not None:
+        sample_weight = np.array([2.0], dtype=dtype_in)
+    if out1 is not None:
+        out1 = np.empty_like(y_true, dtype=dtype_out)
+    if out2 is not None:
+        out2 = np.empty_like(raw_prediction, dtype=dtype_out)
+
+    loss.loss(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        loss=out1,
+        n_threads=n_threads,
+    )
+    loss.gradient(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        gradient=out2,
+        n_threads=n_threads,
+    )
+    loss.loss_gradient(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        loss=out1,
+        gradient=out2,
+        n_threads=n_threads,
+    )
+    if out1 is not None and loss.n_classes >= 3:
+        out1 = np.empty_like(raw_prediction, dtype=dtype_out)
+    loss.gradient_hessian(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        gradient=out1,
+        hessian=out2,
+        n_threads=n_threads,
+    )
+
+
+@pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)
+@pytest.mark.parametrize("sample_weight", [None, "range"])
+def test_loss_same_as_C_functions(loss, sample_weight):
+    y_true, raw_prediction = random_y_true_raw_prediction(
+        loss=loss,
+        n_samples=20,
+        y_bound=(-100, 100),
+        raw_bound=(-10, 10),
+        seed=42,
+    )
+    if sample_weight == "range":
+        sample_weight = np.linspace(1, y_true.shape[0], num=y_true.shape[0])
+
+    out_l1 = np.empty_like(y_true)
+    out_l2 = np.empty_like(y_true)
+    out_g1 = np.empty_like(raw_prediction)
+    out_g2 = np.empty_like(raw_prediction)
+    out_h1 = np.empty_like(raw_prediction)
+    out_h2 = np.empty_like(raw_prediction)
+    assert_allclose(
+        loss.loss(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            loss=out_l1,
+        ),
+        loss._loss(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            loss=out_l2,
+        ),
+    )
+    assert_allclose(
+        loss.gradient(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            gradient=out_g1,
+        ),
+        loss._gradient(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            gradient=out_g2,
+        ),
+    )
+    loss.loss_gradient(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        loss=out_l1,
+        gradient=out_g1,
+    )
+    loss._loss_gradient(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        loss=out_l2,
+        gradient=out_g2,
+    )
+    assert_allclose(out_l1, out_l2)
+    assert_allclose(out_g1, out_g2)
+    loss.gradient_hessian(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        gradient=out_g1,
+        hessian=out_h1,
+    )
+    loss._gradient_hessian(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        gradient=out_g2,
+        hessian=out_h2,
+    )
+    assert_allclose(out_g1, out_g2)
+    assert_allclose(out_h1, out_h2)
+
+
+@pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)
+@pytest.mark.parametrize("sample_weight", [None, "range"])
+def test_loss_gradients_are_the_same(loss, sample_weight):
+    # Test that loss and gradient are the same accross different functions
+    # Also test that output arguments contain correct result.
+    y_true, raw_prediction = random_y_true_raw_prediction(
+        loss=loss,
+        n_samples=20,
+        y_bound=(-100, 100),
+        raw_bound=(-10, 10),
+        seed=42,
+    )
+    if sample_weight == "range":
+        sample_weight = np.linspace(1, y_true.shape[0], num=y_true.shape[0])
+
+    out_l1 = np.empty_like(y_true)
+    out_l2 = np.empty_like(y_true)
+    out_g1 = np.empty_like(raw_prediction)
+    out_g2 = np.empty_like(raw_prediction)
+    out_g3 = np.empty_like(raw_prediction)
+    out_h3 = np.empty_like(raw_prediction)
+
+    l1 = loss.loss(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        loss=out_l1,
+    )
+    g1 = loss.gradient(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        gradient=out_g1,
+    )
+    l2, g2 = loss.loss_gradient(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        loss=out_l2,
+        gradient=out_g2,
+    )
+    g3, h3 = loss.gradient_hessian(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        gradient=out_g3,
+        hessian=out_h3,
+    )
+    assert_allclose(l1, l2)
+    assert_array_equal(l1, out_l1)
+    assert np.shares_memory(l1, out_l1)
+    assert_array_equal(l2, out_l2)
+    assert np.shares_memory(l2, out_l2)
+    assert_allclose(g1, g2)
+    assert_allclose(g1, g3)
+    assert_array_equal(g1, out_g1)
+    assert np.shares_memory(g1, out_g1)
+    assert_array_equal(g2, out_g2)
+    assert np.shares_memory(g2, out_g2)
+    assert_array_equal(g3, out_g3)
+    assert np.shares_memory(g3, out_g3)
+
+    if hasattr(loss, "gradient_proba"):
+        assert loss.n_classes >= 3  # only for CategoricalCrossEntropy
+        out_g4 = np.empty_like(raw_prediction)
+        out_proba = np.empty_like(raw_prediction)
+        g4, proba = loss.gradient_proba(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+            gradient=out_g4,
+            proba=out_proba,
+        )
+        assert_allclose(g1, out_g4)
+        assert_allclose(g1, g4)
+        assert_allclose(proba, out_proba)
+        assert_allclose(np.sum(proba, axis=1), 1)
+
+
+@pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)
+@pytest.mark.parametrize("sample_weight", ["ones", "random"])
+def test_sample_weight_multiplies_gradients(loss, sample_weight):
+    # Make sure that passing sample weights to the gradient and hessians
+    # computation methods is equivalent to multiplying by the weights.
+
+    n_samples = 100
+    y_true, raw_prediction = random_y_true_raw_prediction(
+        loss=loss,
+        n_samples=n_samples,
+        y_bound=(-100, 100),
+        raw_bound=(-5, 5),
+        seed=42,
+    )
+
+    if sample_weight == "ones":
+        sample_weight = np.ones(shape=n_samples, dtype=np.float64)
+    else:
+        rng = np.random.RandomState(42)
+        sample_weight = rng.normal(size=n_samples).astype(np.float64)
+
+    baseline_prediction = loss.fit_intercept_only(
+        y_true=y_true, sample_weight=None
+    )
+
+    if loss.n_classes <= 2:
+        raw_prediction = np.zeros(
+            shape=(n_samples,), dtype=baseline_prediction.dtype
+        )
+    else:
+        raw_prediction = np.zeros(
+            shape=(n_samples, loss.n_classes), dtype=baseline_prediction.dtype
+        )
+    raw_prediction += baseline_prediction
+
+    gradient, hessian = loss.gradient_hessian(
+        y_true=y_true, raw_prediction=raw_prediction, sample_weight=None
+    )
+
+    gradient_sw, hessian_sw = loss.gradient_hessian(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+    )
+
+    if loss.n_classes <= 2:
+        assert_allclose(gradient * sample_weight, gradient_sw)
+        assert_allclose(hessian * sample_weight, hessian_sw)
+    else:
+        assert_allclose(gradient * sample_weight[:, None], gradient_sw)
+        assert_allclose(hessian * sample_weight[:, None], hessian_sw)
+
+
+@pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)
+@pytest.mark.parametrize("sample_weight", [None, "range"])
+def test_loss_of_perfect_prediction(loss, sample_weight):
+    # Test that loss of y_true = y_pred plus constant_to_optimal_zero sums up
+    # to zero.
+    if loss.n_classes <= 2:
+        # Use small values such that exp(value) is not nan.
+        raw_prediction = np.array([-10, -0.1, 0, 0.1, 3, 10])
+        y_true = loss.inverse(raw_prediction)
+    else:
+        # CategoricalCrossEntropy
+        y_true = np.arange(loss.n_classes).astype(float)
+        # raw_prediction with entries -exp(10), but +exp(10) on the diagonal
+        # this is close enough to np.inf which would produce nan
+        raw_prediction = np.full(
+            shape=(loss.n_classes, loss.n_classes),
+            fill_value=-np.exp(10),
+            dtype=float,
+        )
+        raw_prediction.flat[:: loss.n_classes + 1] = np.exp(10)
+
+    if sample_weight == "range":
+        sample_weight = np.linspace(1, y_true.shape[0], num=y_true.shape[0])
+
+    loss_value = loss.loss(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+    )
+    constant_term = loss.constant_to_optimal_zero(
+        y_true=y_true, sample_weight=sample_weight
+    )
+    # Comparing loss_value + constant_term to zero would result in large
+    # round-off errors.
+    assert_allclose(loss_value, -constant_term, atol=1e-14, rtol=1e-15)
+
+
+@pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)
+@pytest.mark.parametrize("sample_weight", [None, "range"])
+def test_gradients_hessians_numerically(loss, sample_weight):
+    # Test that gradients are computed correctly by comparing to numerical
+    # derivatives of loss functions.
+    # Test that hessians are correct by numerical derivative of gradients.
+    n_samples = 20
+    y_true, raw_prediction = random_y_true_raw_prediction(
+        loss=loss,
+        n_samples=n_samples,
+        y_bound=(-100, 100),
+        raw_bound=(-5, 5),
+        seed=42,
+    )
+
+    if sample_weight == "range":
+        sample_weight = np.linspace(1, y_true.shape[0], num=y_true.shape[0])
+
+    g, h = loss.gradient_hessian(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+    )
+
+    assert g.shape == raw_prediction.shape
+    assert h.shape == raw_prediction.shape
+
+    if loss.n_classes <= 2:
+
+        def loss_func(x):
+            return loss.loss(
+                y_true=y_true, raw_prediction=x, sample_weight=sample_weight,
+            )
+
+        g_numeric = numerical_derivative(loss_func, raw_prediction, eps=1e-6)
+        assert_allclose(g, g_numeric, rtol=5e-6, atol=1e-10)
+
+        def grad_func(x):
+            return loss.gradient(
+                y_true=y_true, raw_prediction=x, sample_weight=sample_weight,
+            )
+
+        h_numeric = numerical_derivative(grad_func, raw_prediction, eps=1e-6)
+        if loss.approx_hessian:
+            assert np.all(h >= h_numeric)
+        else:
+            assert_allclose(h, h_numeric, rtol=5e-6, atol=1e-10)
+    else:
+        # For multiclass loss, we should only change the predictions of the
+        # class for which the derivative is taken for, e.g. offset[:, k] = eps
+        # for class k.
+        # As a softmax is computed, offsetting the whole array by a constant
+        # would have no effect on the probabilities, and thus on the loss.
+        for k in range(loss.n_classes):
+
+            def loss_func(x):
+                raw = raw_prediction.copy()
+                raw[:, k] = x
+                return loss.loss(
+                    y_true=y_true,
+                    raw_prediction=raw,
+                    sample_weight=sample_weight,
+                )
+
+            g_numeric = numerical_derivative(
+                loss_func, raw_prediction[:, k], eps=1e-5
+            )
+            assert_allclose(g[:, k], g_numeric, rtol=5e-6, atol=1e-10)
+
+            def grad_func(x):
+                raw = raw_prediction.copy()
+                raw[:, k] = x
+                return loss.gradient(
+                    y_true=y_true,
+                    raw_prediction=raw,
+                    sample_weight=sample_weight,
+                )[:, k]
+
+            h_numeric = numerical_derivative(
+                grad_func, raw_prediction[:, k], eps=1e-6
+            )
+            if loss.approx_hessian:
+                assert np.all(h >= h_numeric)
+            else:
+                assert_allclose(h[:, k], h_numeric, rtol=5e-6, atol=1e-10)
+
+
+@pytest.mark.parametrize(
+    "loss, x0, y_true",
+    [
+        ("squared_error", -2.0, 42),
+        ("squared_error", 117.0, 1.05),
+        ("squared_error", 0.0, 0.0),
+        # The argmin of binary_crossentropy for y_true=0 and y_true=1 is resp.
+        # -inf and +inf due to logit, cf. "complete separation". Therefore, we
+        # use 0 < y_true < 1.
+        ("binary_crossentropy", 0.3, 0.1),
+        ("binary_crossentropy", -12, 0.2),
+        ("binary_crossentropy", 30, 0.9),
+        ("poisson_loss", 12.0, 1.0),
+        ("poisson_loss", 0.0, 2.0),
+        ("poisson_loss", -22.0, 10.0),
+    ],
+)
+@pytest.mark.skipif(
+    sp_version == parse_version("1.2.0"),
+    reason="bug in scipy 1.2.0, see scipy issue #9608",
+)
+@skip_if_32bit
+def test_derivatives(loss, x0, y_true):
+    # Check that gradients are zero when the loss is minimized on a single
+    # value/sample using Halley's method with the first and second order
+    # derivatives computed by the Loss instance.
+    # Note that methods of Loss instances operate on arrays while the newton
+    # root finder expects a scalar or a one-element array for this purpose.
+
+    loss = _LOSSES[loss](sample_weight=None)
+    y_true = np.array([y_true], dtype=np.float64)
+    x0 = np.array([x0], dtype=np.float64)
+
+    def func(x: np.ndarray) -> np.ndarray:
+        # Add constant term such that loss has its minimum at zero, which is
+        # required by the newton method.
+        return loss.loss(
+            y_true=y_true, raw_prediction=x
+        ) + loss.constant_to_optimal_zero(y_true=y_true)
+
+    def fprime(x: np.ndarray) -> np.ndarray:
+        return loss.gradient(y_true=y_true, raw_prediction=x)
+
+    def fprime2(x: np.ndarray) -> np.ndarray:
+        return loss.gradient_hessian(y_true=y_true, raw_prediction=x)[1]
+
+    optimum = newton(
+        func,
+        x0=x0,
+        fprime=fprime,
+        fprime2=fprime2,
+        maxiter=100,
+        tol=5e-8,
+    )
+
+    # Need to ravel arrays because assert_allclose requires matching dimensions
+    y_true = y_true.ravel()
+    optimum = optimum.ravel()
+    assert_allclose(loss.inverse(optimum), y_true)
+    assert_allclose(func(optimum), 0, atol=1e-14)
+    assert_allclose(
+        loss.gradient(y_true=y_true, raw_prediction=optimum), 0, atol=5e-7
+    )
+
+
+@pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)
+@pytest.mark.parametrize("sample_weight", [None, "range"])
+def test_loss_intercept_only(loss, sample_weight):
+    # Test that fit_intercept_only returns the argmin of the loss and that the
+    # gradient is zero.
+    n_samples = 50
+    if loss.n_classes <= 2:
+        y_true = loss.inverse(np.linspace(-4, 4, num=n_samples))
+    else:
+        y_true = np.arange(n_samples).astype(float) % loss.n_classes
+        y_true[::5] = 0  # exceedance of class 0
+
+    if sample_weight == "range":
+        sample_weight = np.linspace(0.1, 2, num=n_samples)
+
+    a = loss.fit_intercept_only(y_true=y_true, sample_weight=sample_weight)
+
+    # find minimum by optimization
+    def fun(x):
+        if loss.n_classes <= 2:
+            raw_prediction = np.full(shape=(n_samples), fill_value=x)
+        else:
+            raw_prediction = np.ascontiguousarray(
+                np.broadcast_to(x, shape=(n_samples, loss.n_classes))
+            )
+        return loss(
+            y_true=y_true,
+            raw_prediction=raw_prediction,
+            sample_weight=sample_weight,
+        )
+
+    if loss.n_classes <= 2:
+        opt = minimize_scalar(fun, tol=1e-7, options={"maxiter": 100})
+        grad = loss.gradient(
+            y_true=y_true,
+            raw_prediction=np.full_like(y_true, a),
+            sample_weight=sample_weight,
+        )
+        assert a.shape == tuple()  # scalar
+        assert a.dtype == y_true.dtype
+        assert_all_finite(a)
+        a == approx(opt.x, rel=1e-7)
+        grad.sum() == approx(0, abs=1e-12)
+    else:
+        # constraint corresponds to sum(raw_prediction) = 0
+        # without the constraint, we would need to apply
+        # loss.symmetrize_raw_prediction to opt.x before comparing
+        # TODO: With scipy 1.1.0, one could use
+        # LinearConstraint(np.ones((1, loss.n_classes)), 0, 0)
+        opt = minimize(
+            fun,
+            np.empty((loss.n_classes)),
+            tol=1e-13,
+            options={"maxiter": 100},
+            method="SLSQP",
+            constraints={
+                "type": "eq",
+                "fun": lambda x: np.ones((1, loss.n_classes)) @ x
+            },
+        )
+        grad = loss.gradient(
+            y_true=y_true,
+            raw_prediction=np.tile(a, (n_samples, 1)),
+            sample_weight=sample_weight,
+        )
+        assert a.dtype == y_true.dtype
+        assert_all_finite(a)
+        assert_allclose(a, opt.x, rtol=5e-6, atol=1e-12)
+        assert_allclose(grad.sum(axis=0), 0, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "loss, func, link, low, high, random_dist",
+    [
+        (HalfSquaredError, np.mean, "identity", None, None, "normal"),
+        (AbsoluteError, np.median, "identity", None, None, "normal"),
+        (HalfPoissonLoss, np.mean, np.log, 0, None, "poisson"),
+        (BinaryCrossEntropy, np.mean, logit, 0, 1, "binomial"),
+    ],
+)
+def test_specific_fit_intercept_only(loss, func, link, low, high, random_dist):
+    rng = np.random.RandomState(0)
+    loss = loss()
+    if random_dist == "binomial":
+        y_train = rng.binomial(1, 0.5, size=100)
+    else:
+        y_train = getattr(rng, random_dist)(size=100)
+    baseline_prediction = loss.fit_intercept_only(y_true=y_train)
+    # Make sure baseline prediction is the expected one, i.e. func, e.g.
+    # mean or median.
+    assert_all_finite(baseline_prediction)
+    if link == "identity":
+        assert baseline_prediction == approx(func(y_train))
+        assert_allclose(loss.inverse(baseline_prediction), baseline_prediction)
+    else:
+        assert baseline_prediction == approx(link(func(y_train)))
+
+    # Test baseline at boundary
+    if low is not None:
+        y_train.fill(low)
+        baseline_prediction = loss.fit_intercept_only(y_true=y_train)
+        assert_all_finite(baseline_prediction)
+    if high is not None:
+        y_train.fill(high)
+        baseline_prediction = loss.fit_intercept_only(y_true=y_train)
+        assert_all_finite(baseline_prediction)
+
+
+def test_categorical_crossentropy_fit_intercept_only():
+    rng = np.random.RandomState(0)
+    n_classes = 4
+    loss = CategoricalCrossEntropy(n_classes=n_classes)
+    # Same logic as test_single_fit_intercept_only. Here inverse link function
+    # = softmax and link function = log - symmetry term
+    y_train = rng.randint(0, n_classes + 1, size=100).astype(np.float64)
+    baseline_prediction = loss.fit_intercept_only(y_true=y_train)
+    assert baseline_prediction.shape == (n_classes,)
+    p = np.zeros(n_classes, dtype=y_train.dtype)
+    for k in range(n_classes):
+        p[k] = (y_train == k).mean()
+    assert_allclose(baseline_prediction, np.log(p) - np.mean(np.log(p)))
+    assert_allclose(baseline_prediction[None, :], loss.link(p[None, :]))
+
+    for y_train in (np.zeros(shape=10), np.ones(shape=10)):
+        y_train = y_train.astype(np.float64)
+        baseline_prediction = loss.fit_intercept_only(y_true=y_train)
+        assert baseline_prediction.dtype == y_train.dtype
+        assert_all_finite(baseline_prediction)
+
+
+def test_binary_and_categorical_crossentropy():
+    # Test that CategoricalCrossEntropy with n_classes = 2 is the same as
+    # BinaryCrossEntropy
+    rng = np.random.RandomState(0)
+    n_samples = 20
+    bce = BinaryCrossEntropy()
+    cce = CategoricalCrossEntropy(n_classes=2)
+    y_train = rng.randint(0, 2, size=n_samples).astype(np.float64)
+    raw_prediction = rng.normal(size=n_samples)
+    raw_cce = np.empty((n_samples, 2))
+    raw_cce[:, 0] = -0.5 * raw_prediction
+    raw_cce[:, 1] = 0.5 * raw_prediction
+    assert_allclose(
+        bce.loss(y_true=y_train, raw_prediction=raw_prediction),
+        cce.loss(y_true=y_train, raw_prediction=raw_cce)
+    )

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -743,7 +743,7 @@ def test_loss_intercept_only(loss, sample_weight):
     [
         (HalfSquaredError(), np.mean, "normal"),
         (AbsoluteError(), np.median, "normal"),
-        (PinballLoss(quantile=0.25), lambda x: np.quantile(x, q=0.25), "normal"),
+        (PinballLoss(quantile=0.25), lambda x: np.percentile(x, q=25), "normal"),
         (HalfPoissonLoss(), np.mean, "poisson"),
         (HalfGammaLoss(), np.mean, "exponential"),
         (HalfTweedieLoss(), np.mean, "exponential"),


### PR DESCRIPTION
#### Reference Issues/PRs
Solves #15123.
Alternative PR using tempita to remove code duplication: #20567


#### What does this implement/fix? Explain your changes.
This PR introduces a new private module `sklearn._loss`. It implements most common loss functions, gradients and hessians, low-level Cython interface and high-level Python interface.

#### Any other comments?
- Solid test suite. (I hope so! Some more tests are possible.)
- `n_threads` for OpenMP parallelism can be set in any calling function.
- Implementation very similar to the losses in HGBT.

#### Losses implemented
- [x] squared error
- [x] absolute error
- [x] pinball/quantile loss
- [x] Poisson deviance (log link)
- [x] Gamma deviance (log link)
- [x] Tweedie deviance (log link)
- [x] Log-loss/Binary crossentropy (a numerically stable version)
- [x] Multinomial-loss/Categorical crossentropy (label encoded target)

#### Follow-up
See PR #19089 for loss replacement of HGBT and linear logistic regression.