### PR TITLE
TST Adapts wminkowski for scipy 1.6.0

### DIFF
--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -34,7 +34,6 @@ from ..utils.validation import check_is_fitted
 from ..utils.validation import check_non_negative
 from ..utils.fixes import delayed
 from ..utils.fixes import parse_version
-from ..utils.fixes import sp_version
 from ..exceptions import DataConversionWarning, EfficiencyWarning
 
 VALID_METRICS = dict(ball_tree=BallTree.valid_metrics,
@@ -703,21 +702,9 @@ class KNeighborsMixin:
             else:
                 kwds = self.effective_metric_params_
 
-            effective_metric = self.effective_metric_
-
-            # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0
-            if (sp_version >= parse_version("1.6.0")
-                    and self.metric == "wminkowski"
-                    and 'w' in self.effective_metric_params_):
-
-                effective_metric = "minkowski"
-                p = self.effective_metric_params_.get('p', 2)
-                kwds = kwds.copy()
-                kwds['w'] = kwds['w'] ** p
-
             chunked_results = list(pairwise_distances_chunked(
                 X, self._fit_X, reduce_func=reduce_func,
-                metric=effective_metric, n_jobs=n_jobs,
+                metric=self.effective_metric_, n_jobs=n_jobs,
                 **kwds))
 
         elif self._fit_method in ['ball_tree', 'kd_tree']:

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -11,6 +11,7 @@ from functools import partial
 import warnings
 from abc import ABCMeta, abstractmethod
 import numbers
+from copy import deepcopy
 
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
@@ -34,6 +35,7 @@ from ..utils.validation import check_is_fitted
 from ..utils.validation import check_non_negative
 from ..utils.fixes import delayed
 from ..utils.fixes import parse_version
+from ..utils.fixes import sp_version
 from ..exceptions import DataConversionWarning, EfficiencyWarning
 
 VALID_METRICS = dict(ball_tree=BallTree.valid_metrics,
@@ -702,9 +704,21 @@ class KNeighborsMixin:
             else:
                 kwds = self.effective_metric_params_
 
+            effective_metric = self.effective_metric_
+
+            # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0
+            if (sp_version >= parse_version("1.6.0")
+                    and self.metric == "wminkowski"
+                    and 'w' in self.effective_metric_params_):
+
+                effective_metric = "minkowski"
+                p = self.effective_metric_params_.get('p', 2)
+                kwds = deepcopy(kwds)
+                kwds['w'] = kwds['w'] ** p
+
             chunked_results = list(pairwise_distances_chunked(
                 X, self._fit_X, reduce_func=reduce_func,
-                metric=self.effective_metric_, n_jobs=n_jobs,
+                metric=effective_metric, n_jobs=n_jobs,
                 **kwds))
 
         elif self._fit_method in ['ball_tree', 'kd_tree']:

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -11,7 +11,6 @@ from functools import partial
 import warnings
 from abc import ABCMeta, abstractmethod
 import numbers
-from copy import deepcopy
 
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
@@ -713,7 +712,7 @@ class KNeighborsMixin:
 
                 effective_metric = "minkowski"
                 p = self.effective_metric_params_.get('p', 2)
-                kwds = deepcopy(kwds)
+                kwds = kwds.copy()
                 kwds['w'] = kwds['w'] ** p
 
             chunked_results = list(pairwise_distances_chunked(

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -55,11 +55,15 @@ def test_cdist(metric):
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
-        if sp_version >= parse_version("1.6.0") and metric == "wminkowski":
-            # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0
-            new_kwargs = kwargs.copy()
-            new_kwargs['w'] = kwargs['w'] ** kwargs['p']
-            D_true = cdist(X1, X2, "minkowski", **new_kwargs)
+        if metric == "wminkowski":
+            if sp_version >= parse_version("1.8.0"):
+                pytest.skip("wminkowski will be removed in SciPy 1.8.0")
+            with pytest.warns(DeprecationWarning) as rec:
+                D_true = cdist(X1, X2, metric, **kwargs)
+
+            if sp_version >= parse_version("1.6.0"):
+                # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
+                assert rec
         else:
             D_true = cdist(X1, X2, metric, **kwargs)
 
@@ -90,13 +94,17 @@ def test_pdist(metric):
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
-        if sp_version >= parse_version("1.6.0") and metric == "wminkowski":
-            # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0
-            new_kwargs = kwargs.copy()
-            new_kwargs['w'] = new_kwargs['w'] ** new_kwargs['p']
-            D_true = cdist(X1, X1, "minkowski", **new_kwargs)
+        if metric == "wminkowski":
+            if sp_version >= parse_version("1.8.0"):
+                pytest.skip("wminkowski will be removed in SciPy 1.8.0")
+            with pytest.warns(DeprecationWarning) as rec:
+                D_true = cdist(X1, X1, metric, **kwargs)
+
+            if sp_version >= parse_version("1.6.0"):
+                # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
+                assert rec
         else:
-            D_true = cdist(X1, X1, metric, **kwargs)
+            D_true = cdist(X1, X2, metric, **kwargs)
 
         check_pdist(metric, kwargs, D_true)
 

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -58,12 +58,13 @@ def test_cdist(metric):
         if metric == "wminkowski":
             if sp_version >= parse_version("1.8.0"):
                 pytest.skip("wminkowski will be removed in SciPy 1.8.0")
-            with pytest.warns(DeprecationWarning) as rec:
-                D_true = cdist(X1, X2, metric, **kwargs)
 
+            # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
+            ExceptionToAssert = None
             if sp_version >= parse_version("1.6.0"):
-                # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
-                assert rec
+                ExceptionToAssert = DeprecationWarning
+            with pytest.warns(ExceptionToAssert):
+                D_true = cdist(X1, X2, metric, **kwargs)
         else:
             D_true = cdist(X1, X2, metric, **kwargs)
 
@@ -97,14 +98,15 @@ def test_pdist(metric):
         if metric == "wminkowski":
             if sp_version >= parse_version("1.8.0"):
                 pytest.skip("wminkowski will be removed in SciPy 1.8.0")
-            with pytest.warns(DeprecationWarning) as rec:
-                D_true = cdist(X1, X1, metric, **kwargs)
 
+            # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
+            ExceptionToAssert = None
             if sp_version >= parse_version("1.6.0"):
-                # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
-                assert rec
+                ExceptionToAssert = DeprecationWarning
+            with pytest.warns(ExceptionToAssert):
+                D_true = cdist(X1, X1, metric, **kwargs)
         else:
-            D_true = cdist(X1, X2, metric, **kwargs)
+            D_true = cdist(X1, X1, metric, **kwargs)
 
         check_pdist(metric, kwargs, D_true)
 

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -51,6 +51,10 @@ METRICS_DEFAULT_PARAMS = {'euclidean': {},
 
 @pytest.mark.parametrize('metric', METRICS_DEFAULT_PARAMS)
 def test_cdist(metric):
+    if sp_version >= parse_version('1.6.0') and metric == 'wminkowski':
+        pytest.skip("wminkowski is deprecated in 1.6.0 and will be removed in "
+                    "1.8.0")
+
     argdict = METRICS_DEFAULT_PARAMS[metric]
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):
@@ -79,6 +83,10 @@ def check_cdist_bool(metric, D_true):
 
 @pytest.mark.parametrize('metric', METRICS_DEFAULT_PARAMS)
 def test_pdist(metric):
+    if sp_version >= parse_version('1.6.0') and metric == 'wminkowski':
+        pytest.skip("wminkowski is deprecated in 1.6.0 and will be removed in "
+                    "1.8.0")
+
     argdict = METRICS_DEFAULT_PARAMS[metric]
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -1,7 +1,6 @@
 import itertools
 import pickle
 
-from copy import deepcopy
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
@@ -58,7 +57,7 @@ def test_cdist(metric):
         kwargs = dict(zip(keys, vals))
         if sp_version >= parse_version("1.6.0") and metric == "wminkowski":
             # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0
-            new_kwargs = deepcopy(kwargs)
+            new_kwargs = kwargs.copy()
             new_kwargs['w'] = kwargs['w'] ** kwargs['p']
             D_true = cdist(X1, X2, "minkowski", **new_kwargs)
         else:
@@ -93,7 +92,7 @@ def test_pdist(metric):
         kwargs = dict(zip(keys, vals))
         if sp_version >= parse_version("1.6.0") and metric == "wminkowski":
             # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0
-            new_kwargs = deepcopy(kwargs)
+            new_kwargs = kwargs.copy()
             new_kwargs['w'] = new_kwargs['w'] ** new_kwargs['p']
             D_true = cdist(X1, X1, "minkowski", **new_kwargs)
         else:

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -93,11 +93,11 @@ def test_pdist(metric):
         kwargs = dict(zip(keys, vals))
         if sp_version >= parse_version("1.6.0") and metric == "wminkowski":
             # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0
-            new_kwargs = kwargs.copy()
-            new_kwargs['w'] = kwargs['w'] ** kwargs['p']
-            D_true = cdist(X1, X2, "minkowski", **new_kwargs)
+            new_kwargs = deepcopy(kwargs)
+            new_kwargs['w'] = new_kwargs['w'] ** new_kwargs['p']
+            D_true = cdist(X1, X1, "minkowski", **new_kwargs)
         else:
-            D_true = cdist(X1, X2, metric, **kwargs)
+            D_true = cdist(X1, X1, metric, **kwargs)
 
         check_pdist(metric, kwargs, D_true)
 

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -1,6 +1,7 @@
 import itertools
 import pickle
 
+from copy import deepcopy
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
@@ -51,15 +52,18 @@ METRICS_DEFAULT_PARAMS = {'euclidean': {},
 
 @pytest.mark.parametrize('metric', METRICS_DEFAULT_PARAMS)
 def test_cdist(metric):
-    if sp_version >= parse_version('1.6.0') and metric == 'wminkowski':
-        pytest.skip("wminkowski is deprecated in 1.6.0 and will be removed in "
-                    "1.8.0. minkowski is already part of the parametrization")
-
     argdict = METRICS_DEFAULT_PARAMS[metric]
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
-        D_true = cdist(X1, X2, metric, **kwargs)
+        if sp_version >= parse_version("1.6.0") and metric == "wminkowski":
+            # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0
+            new_kwargs = deepcopy(kwargs)
+            new_kwargs['w'] = kwargs['w'] ** kwargs['p']
+            D_true = cdist(X1, X2, "minkowski", **new_kwargs)
+        else:
+            D_true = cdist(X1, X2, metric, **kwargs)
+
         check_cdist(metric, kwargs, D_true)
 
 
@@ -83,15 +87,18 @@ def check_cdist_bool(metric, D_true):
 
 @pytest.mark.parametrize('metric', METRICS_DEFAULT_PARAMS)
 def test_pdist(metric):
-    if sp_version >= parse_version('1.6.0') and metric == 'wminkowski':
-        pytest.skip("wminkowski is deprecated in 1.6.0 and will be removed in "
-                    "1.8.0. minkowski is already part of the parametrization")
-
     argdict = METRICS_DEFAULT_PARAMS[metric]
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
-        D_true = cdist(X1, X1, metric, **kwargs)
+        if sp_version >= parse_version("1.6.0") and metric == "wminkowski":
+            # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0
+            new_kwargs = kwargs.copy()
+            new_kwargs['w'] = kwargs['w'] ** kwargs['p']
+            D_true = cdist(X1, X2, "minkowski", **new_kwargs)
+        else:
+            D_true = cdist(X1, X2, metric, **kwargs)
+
         check_pdist(metric, kwargs, D_true)
 
 

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -53,7 +53,7 @@ METRICS_DEFAULT_PARAMS = {'euclidean': {},
 def test_cdist(metric):
     if sp_version >= parse_version('1.6.0') and metric == 'wminkowski':
         pytest.skip("wminkowski is deprecated in 1.6.0 and will be removed in "
-                    "1.8.0")
+                    "1.8.0. minkowski is already part of the parametrization")
 
     argdict = METRICS_DEFAULT_PARAMS[metric]
     keys = argdict.keys()
@@ -85,7 +85,7 @@ def check_cdist_bool(metric, D_true):
 def test_pdist(metric):
     if sp_version >= parse_version('1.6.0') and metric == 'wminkowski':
         pytest.skip("wminkowski is deprecated in 1.6.0 and will be removed in "
-                    "1.8.0")
+                    "1.8.0. minkowski is already part of the parametrization")
 
     argdict = METRICS_DEFAULT_PARAMS[metric]
     keys = argdict.keys()

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -26,6 +26,7 @@ from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils.validation import check_random_state
+from sklearn.utils.fixes import sp_version, parse_version
 
 import joblib
 
@@ -1244,6 +1245,9 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
     test = rng.rand(n_query_pts, n_features)
 
     for metric, metric_params in metrics:
+        if sp_version >= parse_version("1.6.0") and metric == 'wminkowski':
+            # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0"
+            continue
         results = {}
         p = metric_params.pop('p', 2)
         for algorithm in algorithms:

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -26,7 +26,6 @@ from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils.validation import check_random_state
-from sklearn.utils.fixes import sp_version, parse_version
 
 import joblib
 
@@ -1245,10 +1244,6 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
     test = rng.rand(n_query_pts, n_features)
 
     for metric, metric_params in metrics:
-        if sp_version >= parse_version("1.6.0") and metric == 'wminkowski':
-            # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0"
-            # minkowski is already tested
-            continue
         results = {}
         p = metric_params.pop('p', 2)
         for algorithm in algorithms:

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1247,6 +1247,7 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
     for metric, metric_params in metrics:
         if sp_version >= parse_version("1.6.0") and metric == 'wminkowski':
             # wminkowski is deprecated in 1.6.0 and will be removed in 1.8.0"
+            # minkowski is already tested
             continue
         results = {}
         p = metric_params.pop('p', 2)


### PR DESCRIPTION
Since wminkowski is deprecated in scipy 1.6.0, this PR skips those tests when scipy >= 1.6.0