### PR TITLE
TST explicit convert array to float that will contains np.nan

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -198,7 +198,7 @@ def precision_recall_curve_padded_thresholds(*args, **kwargs):
     return np.array([
         precision,
         recall,
-        np.pad(thresholds,
+        np.pad(thresholds.astype(np.float64),
                pad_width=(0, pad_threshholds),
                mode='constant',
                constant_values=[np.nan])


### PR DESCRIPTION
`np.pad` was called on an integer array and padded with `np.nan`. An implicit casting to `np.float64` was performed and is not longer allowed in NumPy `master`.