### PR TITLE
Don't import pkg_resources unless we need to parse dev version numbers.

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -24,11 +24,18 @@ from .._config import config_context, get_config
 
 from .deprecation import deprecated
 
-try:
-    from pkg_resources import parse_version  # type: ignore
-except ImportError:
-    # setuptools not installed
-    parse_version = LooseVersion  # type: ignore
+
+def parse_version(v):
+    if not set(v).issubset("0123456789."):
+        # Avoid importing pkg_resources (which is slow) unless we need to parse
+        # dev version numbers.
+        try:
+            import pkg_resources
+        except ImportError:  # setuptools not installed.
+            pass
+        else:
+            return pkg_resources.parse_version(v)
+    return LooseVersion(v)
 
 
 np_version = parse_version(np.__version__)


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/19098.


#### What does this implement/fix? Explain your changes.
pkg_resources can be very slow to import, although this depends on the
details of the python setup.  On my machine, avoiding to import it (this
PR) speeds up `import sklearn` (with no dev versions of anything other
than sklearn installed) by ~33%, from ~550ms to ~360ms.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
