### PR TITLE
correct doc comment for precompute with regard to sparse matrix handling

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -62,6 +62,10 @@ Changelog
 - |Fix| :meth:`ElasticNet.fit` no longer modifies `sample_weight` in place.
   :pr:`19055` by `Thomas Fan`_.
 
+- |Fix| Correct docstring for `precompute` parameter in
+  :class:`linear_model.ElasticNet` with regard to sparse matrix handling.
+  :pr:`19106` by `Adam Midvidy <amidvidy>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -940,7 +940,7 @@ class Lasso(ElasticNet):
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
         matrix can also be passed as argument. For sparse input
-        this option is always ``True`` to preserve sparsity.
+        this option is always ``False`` to preserve sparsity.
 
     copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.


### PR DESCRIPTION
corrects doc comment as detailed in #19105.