### PR TITLE
CI Reduce travis nightly load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ jobs:
         - BUILD_WITH_ICC=true
       if: type = cron OR commit_message =~ /\[icc-build\]/
 
-    
     # Manual trigger of linux/arm64 tests in PR without triggering the full
     # wheel building process for all the Python versions. 
     - python: 3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,11 @@ jobs:
         - CPU_COUNT=8
 
     # Linux environments to build the scikit-learn wheels for the ARM64
-    # arquitecture and Python 3.6 and newer. This is used both at release time
-    # with the manual trigger in the commit message in the releaase branch and
-    # as a scheduled task to build the weekly dev build on the master branch.
-    # The weekly frequency is meant to avoid depleting the Travis CI credits too
-    # much.
+    # architecture and Python 3.6 and newer. This is used both at release time
+    # with the manual trigger in the commit message in the release branch and as
+    # a scheduled task to build the weekly dev build on the master branch. The
+    # weekly frequency is meant to avoid depleting the Travis CI credits too
+    # fast.
     - python: 3.6
       os: linux
       arch: arm64

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
     - python: 3.9
       os: linux
       arch: arm64
-      # Nighlyt wheek build for linux/arm64 only on the most recent Python
+      # Nightly wheek build for linux/arm64 only on the most recent Python
       # version so as to spare the limited travis CI credits. This also serves
       # as a regular linux/arm64 test run because those tests are not run by
       # default in individual PRs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
     - python: 3.6
       os: linux
       arch: arm64
-      if: type = cron or type = commit_message =~ /\[cd build\]/
+      if: type = cron or commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true
         - CIBW_BUILD=cp36-manylinux_aarch64
@@ -63,7 +63,7 @@ jobs:
     - python: 3.7
       os: linux
       arch: arm64
-      if: type = cron or type = commit_message =~ /\[cd build\]/
+      if: type = cron or commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true
         - CIBW_BUILD=cp37-manylinux_aarch64
@@ -71,7 +71,7 @@ jobs:
     - python: 3.8
       os: linux
       arch: arm64
-      if: type = cron or type = commit_message =~ /\[cd build\]/
+      if: type = cron or commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true
         - CIBW_BUILD=cp38-manylinux_aarch64

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,18 @@ jobs:
         - BUILD_WITH_ICC=true
       if: type = cron OR commit_message =~ /\[icc-build\]/
 
-    # Linux environments to build the scikit-learn wheels
-    # for the ARM64 arquitecture and Python 3.6 and newer
+    
+    # Manual trigger of linux/arm64 tests in PR without triggering the full
+    # wheel building process for all the Python versions. 
+    - python: 3.9
+      os: linux
+      arch: arm64
+      if: commit_message =~ /\[arm64\]/
+      env:
+        - CPU_COUNT=8
+
+    # Linux environments to build the scikit-learn wheels for the ARM64
+    # arquitecture and Python 3.6 and newer
     - python: 3.6
       os: linux
       arch: arm64
@@ -65,8 +75,10 @@ jobs:
     - python: 3.9
       os: linux
       arch: arm64
-      # Nighlyt build for linux/arm64 only on the most recent Python version
-      # so as to spare the limited Travis CI credits
+      # Nighlyt wheek build for linux/arm64 only on the most recent Python
+      # version so as to spare the limited travis CI credits. This also serves
+      # as a regular linux/arm64 test run because those tests are not run by
+      # default in individual PRs.
       if: type = cron or commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,15 @@ jobs:
         - CPU_COUNT=8
 
     # Linux environments to build the scikit-learn wheels for the ARM64
-    # arquitecture and Python 3.6 and newer
+    # arquitecture and Python 3.6 and newer. This is used both at release time
+    # with the manual trigger in the commit message in the releaase branch and
+    # as a scheduled task to build the weekly dev build on the master branch.
+    # The weekly frequency is meant to avoid depleting the Travis CI credits too
+    # much.
     - python: 3.6
       os: linux
       arch: arm64
-      if: type = commit_message =~ /\[cd build\]/
+      if: type = cron or type = commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true
         - CIBW_BUILD=cp36-manylinux_aarch64
@@ -59,7 +63,7 @@ jobs:
     - python: 3.7
       os: linux
       arch: arm64
-      if: type = commit_message =~ /\[cd build\]/
+      if: type = cron or type = commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true
         - CIBW_BUILD=cp37-manylinux_aarch64
@@ -67,7 +71,7 @@ jobs:
     - python: 3.8
       os: linux
       arch: arm64
-      if: type = commit_message =~ /\[cd build\]/
+      if: type = cron or type = commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true
         - CIBW_BUILD=cp38-manylinux_aarch64
@@ -75,10 +79,6 @@ jobs:
     - python: 3.9
       os: linux
       arch: arm64
-      # Nightly wheek build for linux/arm64 only on the most recent Python
-      # version so as to spare the limited travis CI credits. This also serves
-      # as a regular linux/arm64 test run because those tests are not run by
-      # default in individual PRs.
       if: type = cron or commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,19 +36,12 @@ jobs:
         - BUILD_WITH_ICC=true
       if: type = cron OR commit_message =~ /\[icc-build\]/
 
-    - python: 3.7
-      os: linux
-      arch: arm64
-      if: type = cron OR commit_message =~ /\[arm64\]/
-      env:
-        - CPU_COUNT=8
-
     # Linux environments to build the scikit-learn wheels
     # for the ARM64 arquitecture and Python 3.6 and newer
     - python: 3.6
       os: linux
       arch: arm64
-      if: type = cron or commit_message =~ /\[cd build\]/
+      if: type = commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true
         - CIBW_BUILD=cp36-manylinux_aarch64
@@ -56,7 +49,7 @@ jobs:
     - python: 3.7
       os: linux
       arch: arm64
-      if: type = cron or commit_message =~ /\[cd build\]/
+      if: type = commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true
         - CIBW_BUILD=cp37-manylinux_aarch64
@@ -64,7 +57,7 @@ jobs:
     - python: 3.8
       os: linux
       arch: arm64
-      if: type = cron or commit_message =~ /\[cd build\]/
+      if: type = commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true
         - CIBW_BUILD=cp38-manylinux_aarch64
@@ -72,6 +65,8 @@ jobs:
     - python: 3.9
       os: linux
       arch: arm64
+      # Nighlyt build for linux/arm64 only on the most recent Python version
+      # so as to spare the limited Travis CI credits
       if: type = cron or commit_message =~ /\[cd build\]/
       env:
         - BUILD_WHEEL=true


### PR DESCRIPTION
In order to spare the limited build credits we have on travis, I was thinking we could reduce the number of cron builds we do there:

- we should migrated the icc build to Azure but this can be done in a dedicated PR (TODO)
- we can only do nightly linux/arm64 wheel build only for the latest Python version to spare resources: people who run scikit-learn bleeding edge builds are more likely to also run the latest Python version
- we can remove the linux/arm64 cron test job that is redundant with the nightly linux/arm64 wheel build.

Note that the linux/arm64 test fail with scipy 1.6.0 which is handled in the dedicated issue: #19111.