### PR TITLE
DOC Update docs for StandardScaler.scale_ to include 0 variance

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -617,8 +617,11 @@ class StandardScaler(TransformerMixin, BaseEstimator):
     Attributes
     ----------
     scale_ : ndarray of shape (n_features,) or None
-        Per feature relative scaling of the data. This is calculated using
-        `np.sqrt(var_)`. Equal to ``None`` when ``with_std=False``.
+        Per feature relative scaling of the data to achieve zero mean and unit
+        variance. Generally this is calculated using `np.sqrt(var_)`. If a
+        variance is zero, we can't achieve unit variance, and the data is left
+        as-is, giving the scaling factor of 1. Equal to ``None`` when
+        ``with_std=False``.
 
         .. versionadded:: 0.17
            *scale_*

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -620,8 +620,8 @@ class StandardScaler(TransformerMixin, BaseEstimator):
         Per feature relative scaling of the data to achieve zero mean and unit
         variance. Generally this is calculated using `np.sqrt(var_)`. If a
         variance is zero, we can't achieve unit variance, and the data is left
-        as-is, giving the scaling factor of 1. Equal to ``None`` when
-        ``with_std=False``.
+        as-is, giving a scaling factor of 1. `scale_` is equal to `None`
+        when `with_std=False`.
 
         .. versionadded:: 0.17
            *scale_*


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #19104

#### What does this implement/fix? Explain your changes.
Updates the docstring of StandardScaler's scale_ attribute to include the scenario when variance is 0, so that scale_ is not sqrt(var).

#### Any other comments?
