### PR TITLE
[MRG] DOC fix ambiguous instruction

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -206,7 +206,8 @@ console:
 
     python -c "import struct; print(struct.calcsize('P') * 8)"
 
-For 64-bit Python, you can configure the build environment by running the following commands in ``cmd`` or ``Anaconda Prompt`` (if you use ``Anaconda``):
+For 64-bit Python, configure the build environment by running the following
+commands in ``cmd`` or an Anaconda Prompt (if you use Anaconda):
 
     ::
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -206,7 +206,7 @@ console:
 
     python -c "import struct; print(struct.calcsize('P') * 8)"
 
-For 64-bit Python, configure the build environment with:
+For 64-bit Python, you can configure the build environment by running the following commands in ``cmd`` or ``Anaconda Prompt`` (if you use ``Anaconda``):
 
     ::
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
None, just document enhancement.


#### What does this implement/fix? Explain your changes.
I clearly mention to use `cmd` console (global environment) or `Anaconda Prompt` (in `Anaconda`) where to be executed the following commands:
```
$ SET DISTUTILS_USE_SDK=1
$ "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
```
I tried a lot and failed in PowerShell, and this could happen to others as well. So if they can know where to go, then they can avoid such a tricky problem.

#### Any other comments?

None

<!--
Please be aware that we are a loose team of volunteers, so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->