### PR TITLE
DOC Fix docstring of HalvingSearch estimators

### DIFF
--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -448,7 +448,7 @@ class HalvingGridSearchCV(BaseSuccessiveHalving):
 
         The refitted estimator is made available at the ``best_estimator_``
         attribute and permits using ``predict`` directly on this
-        ``GridSearchCV`` instance.
+        ``HalvingGridSearchCV`` instance.
 
     error_score : 'raise' or numeric
         Value to assign to the score if an error occurs in estimator fitting.
@@ -735,7 +735,7 @@ class HalvingRandomSearchCV(BaseSuccessiveHalving):
 
         The refitted estimator is made available at the ``best_estimator_``
         attribute and permits using ``predict`` directly on this
-        ``GridSearchCV`` instance.
+        ``HalvingRandomSearchCV`` instance.
 
     error_score : 'raise' or numeric
         Value to assign to the score if an error occurs in estimator fitting.


### PR DESCRIPTION
Of HalvingGridSearchCV and HalvingRandomSearchCV to refer to the respective classes

#### What does this implement/fix? Explain your changes.

The docstrings for both new classes, for the refit parameter, refer to "this `GridSearchCV` instance".  This PR fixes this to refer to the respective classes.

#### Any other comments?

Presumably the code/docstrings where copied from GridSearchCV and this minor detail was overlooked.
