### PR TITLE
[MRG] Normalize linear_model decision_function scores.

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -286,10 +286,8 @@ class LinearClassifierMixin(ClassifierMixin):
         X = self._validate_data(X, accept_sparse='csr', reset=False)
         scores = safe_sparse_dot(X, self.coef_.T,
                                  dense_output=True) + self.intercept_
-        
-        coef_norms = np.linalg.norm(self.coef_, axis=1)        
-        scores    /= coef_norms
-        
+        coef_norms = np.linalg.norm(self.coef_, axis=1)
+        scores /= coef_norms        
         return scores.ravel() if scores.shape[1] == 1 else scores
 
     def predict(self, X):

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -287,7 +287,7 @@ class LinearClassifierMixin(ClassifierMixin):
         scores = safe_sparse_dot(X, self.coef_.T,
                                  dense_output=True) + self.intercept_
         coef_norms = np.linalg.norm(self.coef_, axis=1)
-        scores /= coef_norms        
+        scores /= coef_norms
         return scores.ravel() if scores.shape[1] == 1 else scores
 
     def predict(self, X):

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -266,8 +266,8 @@ class LinearClassifierMixin(ClassifierMixin):
         """
         Predict confidence scores for samples.
 
-        The confidence score for a sample is the signed distance of that
-        sample to the hyperplane.
+        The confidence score for a sample is proportional to the signed
+        distance of that sample to the hyperplane.
 
         Parameters
         ----------
@@ -286,8 +286,6 @@ class LinearClassifierMixin(ClassifierMixin):
         X = self._validate_data(X, accept_sparse='csr', reset=False)
         scores = safe_sparse_dot(X, self.coef_.T,
                                  dense_output=True) + self.intercept_
-        coef_norms = np.linalg.norm(self.coef_, axis=1)
-        scores /= coef_norms
         return scores.ravel() if scores.shape[1] == 1 else scores
 
     def predict(self, X):

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -284,7 +284,10 @@ class LinearClassifierMixin(ClassifierMixin):
         check_is_fitted(self)
 
         X = self._validate_data(X, accept_sparse='csr', reset=False)
-        scores = safe_sparse_dot(X, self.coef_.T,
+
+        # Coefficients must be unit norm for the scores to be the distance to each hyperplane
+        coefn  = self.coef_ / np.linalg.norm(self.coef_, axis=1)[:, np.newaxis]
+        scores = safe_sparse_dot(X, coefn.T,
                                  dense_output=True) + self.intercept_
         return scores.ravel() if scores.shape[1] == 1 else scores
 

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -284,11 +284,12 @@ class LinearClassifierMixin(ClassifierMixin):
         check_is_fitted(self)
 
         X = self._validate_data(X, accept_sparse='csr', reset=False)
-
-        # Coefficients must be unit norm for the scores to be the distance to each hyperplane
-        coefn  = self.coef_ / np.linalg.norm(self.coef_, axis=1)[:, np.newaxis]
-        scores = safe_sparse_dot(X, coefn.T,
+        scores = safe_sparse_dot(X, self.coef_.T,
                                  dense_output=True) + self.intercept_
+        
+        coef_norms = np.linalg.norm(self.coef_, axis=1)        
+        scores    /= coef_norms
+        
         return scores.ravel() if scores.shape[1] == 1 else scores
 
     def predict(self, X):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #19139.

#### What does this implement/fix? Explain your changes.
According to the docs, the decision_function scores in LinearClassifierMixin are supposed to be the distances of samples to corresponding hyperplanes. (I assume) the hyperplanes are defined by the coefficients and intercepts arrays. The scores are computed as the scalar product of each sample with each of the coefficients, plus the intercepts. The problem is that without normalizing these scores by the norm of their corresponding coefficients, the scores won't actually be the signed distances to the corresponding hyperplanes. This is because the signed distance of a point p to a hyperplane defined by c'x + b = 0 is (c'p + b)/|c|, not the (c'p + b) currently computed.

 I fix this problem by normalizing the scores by the norm of their corresponding coefficients.

#### Any other comments?
I ran pytest on linear_model and a few of the tests are failing, some because computed accuracies are being compared to hard-coded values. This may be expected if the hard-coded values reflect desired outputs using the previous, potentially incorrect, method of computing the scores. 

Also, I haven't done any checking for division by zero which would occur if any of the coefficients are all zeros, because I wasn't sure what sklearn best practices are for doing so, and it will be easy enough for whoever does know to add this. Some tests are failing because NaNs are appearing, presumably due to such division by zero.