### PR TITLE
Dictionary Learning: transform_alpha default equal to alpha

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -70,6 +70,16 @@ Changelog
   in multicore settings. :pr:`19052` by
   :user:`Yusuke Nagasaka <YusukeNagasaka>`.
 
+:mod:`sklearn.decomposition`
+............................
+
+- |API| In :class:`decomposition.DictionaryLearning`,
+  :class:`decomposition.MiniBatchDictionaryLearning`,
+  :func:`dict_learning` and :func:`dict_learning_online`,
+  `transform_alpha` will be equal to `alpha` instead of 1.0 by default 
+  starting from 1.2
+  :pr:`19159` by :user:`Benoît Malézieux <bmalezieux>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -63,7 +63,7 @@ Changelog
   :class:`decomposition.MiniBatchDictionaryLearning`,
   :func:`dict_learning` and :func:`dict_learning_online`,
   `transform_alpha` will be equal to `alpha` instead of 1.0 by default 
-  starting from 1.2
+  starting from version 1.2
   :pr:`19159` by :user:`Benoît Malézieux <bmalezieux>`.
 
 - |Fix| Fixes incorrect multiple data-conversion warnings when clustering

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -914,7 +914,6 @@ class _BaseSparseCoding(TransformerMixin):
 
         # transform_alpha has to be changed in _transform
         # this is done for consistency with the value of alpha
-        transform_alpha = None
         if hasattr(self, "alpha") and self.alpha != 1.:
             if self.transform_alpha is None:
                 warnings.warn("By default transform_alpha will be equal to"
@@ -923,6 +922,8 @@ class _BaseSparseCoding(TransformerMixin):
                 transform_alpha = 1.  # TODO change to self.alpha in 1.2
             else:
                 transform_alpha = self.transform_alpha
+        else:
+            transform_alpha = self.transform_alpha
 
         code = sparse_encode(
             X, dictionary, algorithm=self.transform_algorithm,

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -6,6 +6,7 @@
 import time
 import sys
 import itertools
+import warnings
 
 from math import ceil
 
@@ -909,13 +910,20 @@ class _BaseSparseCoding(TransformerMixin):
         SparseCoder."""
         X = self._validate_data(X, reset=False)
 
+        # transform_alpha has to be changed in _transform
+        # this is done for consistency with the value of alpha
         if hasattr(self, "alpha") and self.transform_alpha is None:
-            self.transform_alpha = self.alpha
+            warnings.warn("By default transform_alpha will be equal to"
+                          "alpha instead of 1.0 starting from 1.2",
+                          FutureWarning)
+            transform_alpha = 1.  # TODO change to self.alpha in 1.2
+        else:
+            transform_alpha = self.transform_alpha
 
         code = sparse_encode(
             X, dictionary, algorithm=self.transform_algorithm,
             n_nonzero_coefs=self.transform_n_nonzero_coefs,
-            alpha=self.transform_alpha, max_iter=self.transform_max_iter,
+            alpha=transform_alpha, max_iter=self.transform_max_iter,
             n_jobs=self.n_jobs, positive=self.positive_code)
 
         if self.split_sign:
@@ -1187,8 +1195,9 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     transform_n_nonzero_coefs : int, default=None
         Number of nonzero coefficients to target in each column of the
-        solution. This is only used by `algorithm='lars'` and `algorithm='omp'`.
-        If `None`, then `transform_n_nonzero_coefs=int(n_features / 10)`.
+        solution. This is only used by `algorithm='lars'` and 
+        `algorithm='omp'`. If `None`, then
+        `transform_n_nonzero_coefs=int(n_features / 10)`.
 
     transform_alpha : float, default=None
         If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
@@ -1314,7 +1323,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
         self.dict_init = dict_init
         self.verbose = verbose
         self.random_state = random_state
-        self.positive_dict = positive_dict
+        self.positive_dict = positive_dict            
 
     def fit(self, X, y=None):
         """Fit the model from data in X.
@@ -1423,8 +1432,9 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     transform_n_nonzero_coefs : int, default=None
         Number of nonzero coefficients to target in each column of the
-        solution. This is only used by `algorithm='lars'` and `algorithm='omp'`.
-        If `None`, then `transform_n_nonzero_coefs=int(n_features / 10)`.
+        solution. This is only used by `algorithm='lars'` and
+        `algorithm='omp'`. If `None`, then
+        `transform_n_nonzero_coefs=int(n_features / 10)`.
 
     transform_alpha : float, default=None
         If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -917,7 +917,7 @@ class _BaseSparseCoding(TransformerMixin):
         if (hasattr(self, "alpha") and self.alpha != 1. and
                 self.transform_alpha is None):
             warnings.warn("By default transform_alpha will be equal to"
-                          "alpha instead of 1.0 starting from 1.2",
+                          "alpha instead of 1.0 starting from version 1.2",
                           FutureWarning)
             transform_alpha = 1.  # TODO change to self.alpha in 1.2
         else:

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -909,6 +909,9 @@ class _BaseSparseCoding(TransformerMixin):
         SparseCoder."""
         X = self._validate_data(X, reset=False)
 
+        if hasattr(self, "alpha") and self.transform_alpha is None:
+            self.transform_alpha = self.alpha
+
         code = sparse_encode(
             X, dictionary, algorithm=self.transform_algorithm,
             n_nonzero_coefs=self.transform_n_nonzero_coefs,
@@ -1297,9 +1300,6 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
                  split_sign=False, random_state=None, positive_code=False,
                  positive_dict=False, transform_max_iter=1000):
 
-        if transform_alpha is None:
-            transform_alpha = alpha
-
         super().__init__(
             transform_algorithm, transform_n_nonzero_coefs,
             transform_alpha, split_sign, n_jobs, positive_code,
@@ -1537,9 +1537,6 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
                  verbose=False, split_sign=False, random_state=None,
                  positive_code=False, positive_dict=False,
                  transform_max_iter=1000):
-
-        if transform_alpha is None:
-            transform_alpha = alpha
 
         super().__init__(
             transform_algorithm, transform_n_nonzero_coefs, transform_alpha,

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1195,7 +1195,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, `alpha` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `None`, default to `alpha`.
+        If `None`, defaults to `alpha`.
 
     n_jobs : int or None, default=None
         Number of parallel jobs to run.

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1146,7 +1146,9 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
         Number of dictionary elements to extract.
 
     alpha : float, default=1.0
-        Sparsity controlling parameter.
+        Sparsity controlling parameter. Warning: the parameter transform_alpha 
+        used to compute the sparse codes once the dictionary is learned is not
+        equal to alpha by default.
 
     max_iter : int, default=1000
         Maximum number of iterations to perform.

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1431,7 +1431,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, `alpha` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `None`, default to `alpha`.
+        If `None`, defaults to `alpha`.
 
     verbose : bool, default=False
         To control the verbosity of the procedure.

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1195,7 +1195,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     transform_n_nonzero_coefs : int, default=None
         Number of nonzero coefficients to target in each column of the
-        solution. This is only used by `algorithm='lars'` and 
+        solution. This is only used by `algorithm='lars'` and
         `algorithm='omp'`. If `None`, then
         `transform_n_nonzero_coefs=int(n_features / 10)`.
 
@@ -1323,7 +1323,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
         self.dict_init = dict_init
         self.verbose = verbose
         self.random_state = random_state
-        self.positive_dict = positive_dict            
+        self.positive_dict = positive_dict
 
     def fit(self, X, y=None):
         """Fit the model from data in X.

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1146,9 +1146,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
         Number of dictionary elements to extract.
 
     alpha : float, default=1.0
-        Sparsity controlling parameter. Warning: the parameter transform_alpha 
-        used to compute the sparse codes once the dictionary is learned is not
-        equal to alpha by default.
+        Sparsity controlling parameter.
 
     max_iter : int, default=1000
         Maximum number of iterations to perform.
@@ -1186,19 +1184,15 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     transform_n_nonzero_coefs : int, default=None
         Number of nonzero coefficients to target in each column of the
-        solution. This is only used by `algorithm='lars'` and `algorithm='omp'`
-        and is overridden by `alpha` in the `omp` case. If `None`, then
-        `transform_n_nonzero_coefs=int(n_features / 10)`.
+        solution. This is only used by `algorithm='lars'` and `algorithm='omp'`.
+        If `None`, then `transform_n_nonzero_coefs=int(n_features / 10)`.
 
     transform_alpha : float, default=None
         If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, `alpha` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, `alpha` is the tolerance parameter: the value of
-        the reconstruction error targeted. In this case, it overrides
-        `n_nonzero_coefs`.
-        If `None`, default to 1.0
+        If `None`, default to `alpha`.
 
     n_jobs : int or None, default=None
         Number of parallel jobs to run.
@@ -1302,6 +1296,9 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
                  n_jobs=None, code_init=None, dict_init=None, verbose=False,
                  split_sign=False, random_state=None, positive_code=False,
                  positive_dict=False, transform_max_iter=1000):
+
+        if transform_alpha is None:
+            transform_alpha = alpha
 
         super().__init__(
             transform_algorithm, transform_n_nonzero_coefs,
@@ -1426,19 +1423,15 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     transform_n_nonzero_coefs : int, default=None
         Number of nonzero coefficients to target in each column of the
-        solution. This is only used by `algorithm='lars'` and `algorithm='omp'`
-        and is overridden by `alpha` in the `omp` case. If `None`, then
-        `transform_n_nonzero_coefs=int(n_features / 10)`.
+        solution. This is only used by `algorithm='lars'` and `algorithm='omp'`.
+        If `None`, then `transform_n_nonzero_coefs=int(n_features / 10)`.
 
     transform_alpha : float, default=None
         If `algorithm='lasso_lars'` or `algorithm='lasso_cd'`, `alpha` is the
         penalty applied to the L1 norm.
         If `algorithm='threshold'`, `alpha` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
-        If `algorithm='omp'`, `alpha` is the tolerance parameter: the value of
-        the reconstruction error targeted. In this case, it overrides
-        `n_nonzero_coefs`.
-        If `None`, default to 1.
+        If `None`, default to `alpha`.
 
     verbose : bool, default=False
         To control the verbosity of the procedure.
@@ -1544,6 +1537,9 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
                  verbose=False, split_sign=False, random_state=None,
                  positive_code=False, positive_dict=False,
                  transform_max_iter=1000):
+
+        if transform_alpha is None:
+            transform_alpha = alpha
 
         super().__init__(
             transform_algorithm, transform_n_nonzero_coefs, transform_alpha,

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -914,14 +914,12 @@ class _BaseSparseCoding(TransformerMixin):
 
         # transform_alpha has to be changed in _transform
         # this is done for consistency with the value of alpha
-        if hasattr(self, "alpha") and self.alpha != 1.:
-            if self.transform_alpha is None:
-                warnings.warn("By default transform_alpha will be equal to"
-                              "alpha instead of 1.0 starting from 1.2",
-                              FutureWarning)
-                transform_alpha = 1.  # TODO change to self.alpha in 1.2
-            else:
-                transform_alpha = self.transform_alpha
+        if (hasattr(self, "alpha") and self.alpha != 1. and
+                self.transform_alpha is None):
+            warnings.warn("By default transform_alpha will be equal to"
+                          "alpha instead of 1.0 starting from 1.2",
+                          FutureWarning)
+            transform_alpha = 1.  # TODO change to self.alpha in 1.2
         else:
             transform_alpha = self.transform_alpha
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -912,13 +912,15 @@ class _BaseSparseCoding(TransformerMixin):
 
         # transform_alpha has to be changed in _transform
         # this is done for consistency with the value of alpha
-        if hasattr(self, "alpha") and self.transform_alpha is None:
-            warnings.warn("By default transform_alpha will be equal to"
-                          "alpha instead of 1.0 starting from 1.2",
-                          FutureWarning)
-            transform_alpha = 1.  # TODO change to self.alpha in 1.2
-        else:
-            transform_alpha = self.transform_alpha
+        transform_alpha = None
+        if hasattr(self, "alpha") and self.alpha != 1.:
+            if self.transform_alpha is None:
+                warnings.warn("By default transform_alpha will be equal to"
+                              "alpha instead of 1.0 starting from 1.2",
+                              FutureWarning)
+                transform_alpha = 1.  # TODO change to self.alpha in 1.2
+            else:
+                transform_alpha = self.transform_alpha
 
         code = sparse_encode(
             X, dictionary, algorithm=self.transform_algorithm,

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -573,3 +573,11 @@ def test_sparse_coder_n_features_in():
     d = np.array([[1, 2, 3], [1, 2, 3]])
     sc = SparseCoder(d)
     assert sc.n_features_in_ == d.shape[1]
+
+
+@pytest.mark.parametrize("Estimator", [DictionaryLearning,
+                                       MiniBatchDictionaryLearning])
+def test_warning_default_transform_alpha(Estimator):
+    dl = Estimator()
+    with pytest.warns(FutureWarning, match="default transform_alpha"):
+        dl.fit_transform(X)

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -578,6 +578,6 @@ def test_sparse_coder_n_features_in():
 @pytest.mark.parametrize("Estimator", [DictionaryLearning,
                                        MiniBatchDictionaryLearning])
 def test_warning_default_transform_alpha(Estimator):
-    dl = Estimator()
+    dl = Estimator(alpha=0.1)
     with pytest.warns(FutureWarning, match="default transform_alpha"):
         dl.fit_transform(X)


### PR DESCRIPTION
…ctionaryLearning

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #19154 

#### What does this implement/fix? Explain your changes.

Setting the default value of transform_alpha to alpha in order to avoid confusion. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
