### PR TITLE
[DOC] Fix listing all available versions for the documentation

### DIFF
--- a/build_tools/circle/list_versions.py
+++ b/build_tools/circle/list_versions.py
@@ -34,7 +34,7 @@ def human_readable_data_quantity(quantity, multiple=1024):
 
 
 def get_file_extension(version):
-    if version == 'dev':
+    if 'dev' in version:
         # The 'dev' branch should be explictly handled
         return 'zip'
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR fixes the `get_file_extension` function in `build_tools/circle/list_versions.py` to solve the documentation failure.

#### Any other comments?

The command `python build_tools/circle/list_versions.py` outputs:

```
:orphan:

Available documentation for Scikit-learn
========================================

Web-based documentation is available for versions listed below:

* `Scikit-learn 1.0.dev0 (dev) documentation <https://scikit-learn.org/dev/>`_ (`ZIP 66.8 MB <https://scikit-learn.org/dev//_downloads/scikit-learn-docs.zip>`_)
* `Scikit-learn 0.24.0 (stable) documentation <https://scikit-learn.org/stable/>`_ (`PDF 53.7 MB <https://scikit-learn.org/stable//_downloads/scikit-learn-docs.pdf>`_)
* `Scikit-learn 0.23.2 documentation <https://scikit-learn.org/0.23/>`_ (`PDF 51.0 MB <https://scikit-learn.org/0.23//_downloads/scikit-learn-docs.pdf>`_)
* `Scikit-learn 0.22.2 documentation <https://scikit-learn.org/0.22/>`_ (`PDF 48.5 MB <https://scikit-learn.org/0.22//_downloads/scikit-learn-docs.pdf>`_)
* `Scikit-learn 0.21.3 documentation <https://scikit-learn.org/0.21/>`_ (`PDF 46.7 MB <https://scikit-learn.org/0.21//_downloads/scikit-learn-docs.pdf>`_)
* `Scikit-learn 0.20.4 documentation <https://scikit-learn.org/0.20/>`_ (`PDF 45.2 MB <https://scikit-learn.org/0.20//_downloads/scikit-learn-docs.pdf>`_)
* `Scikit-learn 0.19.2 documentation <https://scikit-learn.org/0.19/>`_ (`PDF 42.2 MB <https://scikit-learn.org/0.19//_downloads/scikit-learn-docs.pdf>`_)
* `Scikit-learn 0.18.2 documentation <https://scikit-learn.org/0.18/>`_ (`PDF 46.5 MB <https://scikit-learn.org/0.18//_downloads/scikit-learn-docs.pdf>`_)
* `Scikit-learn 0.17.1 documentation <https://scikit-learn.org/0.17/>`_ (`PDF 46.0 MB <https://scikit-learn.org/0.17//_downloads/scikit-learn-docs.pdf>`_)
* `Scikit-learn 0.16.1 documentation <https://scikit-learn.org/0.16/>`_ (`PDF 56.8 MB <https://scikit-learn.org/0.16//_downloads/scikit-learn-docs.pdf>`_)
* `Scikit-learn 0.15-git documentation <https://scikit-learn.org/0.15/>`_
```