### PR TITLE
FIX correct Lasso.dual_gap_ to match the objective in its docstring

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -79,6 +79,10 @@ Changelog
 - |Enhancement| Validate user-supplied gram matrix passed to linear models
   via the `precompute` argument. :pr:`19004` by :user:`Adam Midvidy <amidvidy>`.
 
+- |Fix| :class:`Lasso`, :class:`ElasticNet` no longer have a `dual_gap_`
+  not corresponding to their objective. :pr:`19172` by
+  :user:`Mathurin Massias <mathurinm>`
+
 :mod:`sklearn.naive_bayes`
 ..........................
 

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -819,4 +819,5 @@ def enet_coordinate_descent_multi_task(
                               "increase the number of iterations. Duality "
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
+
     return np.asarray(W), gap, tol, n_iter + 1

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -249,8 +249,7 @@ def enet_coordinate_descent(floating[::1] w,
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
 
-    # scale gap: objective here is n_samples * objective in Lasso docstring.
-    return w, gap / n_samples, tol, n_iter + 1
+    return w, gap, tol, n_iter + 1
 
 
 def sparse_enet_coordinate_descent(floating [::1] w,
@@ -465,8 +464,7 @@ def sparse_enet_coordinate_descent(floating [::1] w,
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
 
-    # scale gap: objective here is n_samples * objective in Lasso docstring.
-    return w, gap / n_samples, tol, n_iter + 1
+    return w, gap, tol, n_iter + 1
 
 
 def enet_coordinate_descent_gram(floating[::1] w,
@@ -619,8 +617,7 @@ def enet_coordinate_descent_gram(floating[::1] w,
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
 
-    # scale gap: objective here is n_samples * objective in Lasso docstring.
-    return np.asarray(w), gap / n_samples, tol, n_iter + 1
+    return np.asarray(w), gap, tol, n_iter + 1
 
 
 def enet_coordinate_descent_multi_task(
@@ -822,5 +819,4 @@ def enet_coordinate_descent_multi_task(
                               "increase the number of iterations. Duality "
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
-    # scale gap: objective here is n_samples * objective in Lasso docstring.
-    return np.asarray(W), gap / n_samples, tol, n_iter + 1
+    return np.asarray(W), gap, tol, n_iter + 1

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -249,7 +249,8 @@ def enet_coordinate_descent(floating[::1] w,
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
 
-    return w, gap, tol, n_iter + 1
+    # scale gap: objective here is n_samples * objective in Lasso docstring.
+    return w, gap / n_samples, tol, n_iter + 1
 
 
 def sparse_enet_coordinate_descent(floating [::1] w,
@@ -464,7 +465,8 @@ def sparse_enet_coordinate_descent(floating [::1] w,
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
 
-    return w, gap, tol, n_iter + 1
+    # scale gap: objective here is n_samples * objective in Lasso docstring.
+    return w, gap / n_samples, tol, n_iter + 1
 
 
 def enet_coordinate_descent_gram(floating[::1] w,
@@ -617,7 +619,8 @@ def enet_coordinate_descent_gram(floating[::1] w,
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
 
-    return np.asarray(w), gap, tol, n_iter + 1
+    # scale gap: objective here is n_samples * objective in Lasso docstring.
+    return np.asarray(w), gap / n_samples, tol, n_iter + 1
 
 
 def enet_coordinate_descent_multi_task(
@@ -819,5 +822,5 @@ def enet_coordinate_descent_multi_task(
                               "increase the number of iterations. Duality "
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
-
-    return np.asarray(W), gap, tol, n_iter + 1
+    # scale gap: objective here is n_samples * objective in Lasso docstring.
+    return np.asarray(W), gap / n_samples, tol, n_iter + 1

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1956,6 +1956,9 @@ class MultiTaskElasticNet(Lasso):
                 self.coef_, l1_reg, l2_reg, X, y, self.max_iter, self.tol,
                 check_random_state(self.random_state), random)
 
+        # account for different objective scaling here and in cd_fast
+        self.dual_gap_ /= n_samples
+
         self._set_intercept(X_offset, y_offset, X_scale)
 
         # return self for chaining fit and predict calls

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -507,6 +507,7 @@ def enet_path(X, y, *, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
         coef_ = np.asfortranarray(coef_init, dtype=X.dtype)
 
     for i, alpha in enumerate(alphas):
+        # account for n_samples scaling in objectives between here and cd_fast
         l1_reg = alpha * l1_ratio * n_samples
         l2_reg = alpha * (1.0 - l1_ratio) * n_samples
         if not multi_output and sparse.isspmatrix(X):
@@ -535,7 +536,9 @@ def enet_path(X, y, *, l1_ratio=0.5, eps=1e-3, n_alphas=100, alphas=None,
                              "'auto' or array-like. Got %r" % precompute)
         coef_, dual_gap_, eps_, n_iter_ = model
         coefs[..., i] = coef_
-        dual_gaps[i] = dual_gap_
+        # we correct the scale of the returned dual gap, as the objective
+        # in cd_fast is n_samples * the objective in this docstring.
+        dual_gaps[i] = dual_gap_ / n_samples
         n_iters.append(n_iter_)
 
         if verbose:

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -220,7 +220,7 @@ def test_lasso_dual_gap():
     # dual pt: R / n_samples, dual constraint: norm(X.T @ theta, inf) <= alpha
     R /= np.max(np.abs(X.T @ R) / (n_samples * alpha))
     dual = 0.5 * (np.mean(y ** 2) - np.mean((y - R) ** 2))
-    np.testing.assert_allclose(clf.dual_gap_, primal - dual)
+    assert_allclose(clf.dual_gap_, primal - dual)
 
 
 def build_dataset(n_samples=50, n_features=200, n_informative_features=10,

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -205,6 +205,24 @@ def test_enet_toy():
     assert_almost_equal(clf.dual_gap_, 0)
 
 
+def test_lasso_dual_gap():
+    """
+    Check that Lasso.dual_gap_ matches its objective formulation, with the
+    datafit normalized by n_samples
+    """
+    X, y, _, _ = build_dataset(n_samples=10, n_features=30)
+    n_samples = len(y)
+    alpha = 0.01 * np.max(np.abs(X.T @ y)) / n_samples
+    clf = Lasso(alpha=alpha, fit_intercept=False).fit(X, y)
+    w = clf.coef_
+    R = y - X @ w
+    primal = 0.5 * np.mean(R ** 2) + clf.alpha * np.sum(np.abs(w))
+    # dual pt: R / n_samples, dual constraint: norm(X.T @ theta, inf) <= alpha
+    R /= np.max(np.abs(X.T @ R) / (n_samples * alpha))
+    dual = 0.5 * (np.mean(y ** 2) - np.mean((y - R) ** 2))
+    np.testing.assert_allclose(clf.dual_gap_, primal - dual)
+
+
 def build_dataset(n_samples=50, n_features=200, n_informative_features=10,
                   n_targets=1):
     """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
closes #19160 

#### What does this implement/fix? Explain your changes.
The Lasso objective in the docstring is 1 / n_samples * the objective minimized in the cython solvers. The duality gap returned by the solvers should therefore be scaled so that after fitting, Lasso.dual_gap_ corresponds to the formulation with 1/n_samples.

Importantly, this **does not affect the optimization process**: the stopping criterion is untouched, and the same number of iterations are run.



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
