### PR TITLE
MAINT Add @fails_if_pypy to test_nonnegative_hashing_vectorizer_result_indices

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1387,6 +1387,7 @@ def test_tie_breaking_sample_order_invariance():
     assert vocab1 == vocab2
 
 
+@fails_if_pypy
 def test_nonnegative_hashing_vectorizer_result_indices():
     # add test for pr 19035
     hashing = HashingVectorizer(n_features=1000000, ngram_range=(2, 3))


### PR DESCRIPTION
We got a nightly build failure on circle ci for the PyPy job because of a new test for `HashingVectorizer` that raises `NotImplementedError`.

Details:

https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn/10754/workflows/229b09b0-27fd-41dc-840f-c96c910a8c07/jobs/129460