### PR TITLE
Use stable numpy scipy release for [icc-build] and [arm64] on travis

### DIFF
--- a/build_tools/travis/install_master.sh
+++ b/build_tools/travis/install_master.sh
@@ -50,23 +50,8 @@ conda update --yes conda
 conda create -n testenv --yes python=3.7
 
 source activate testenv
-
-if [[ $TRAVIS_CPU_ARCH == amd64 ]]; then
-    echo "Upgrading pip and setuptools."
-    pip install --upgrade pip setuptools
-    echo "Installing numpy, scipy and pandas master wheels."
-    dev_anaconda_url=https://pypi.anaconda.org/scipy-wheels-nightly/simple
-    pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy scipy pandas
-    echo "Installing cython pre-release wheels."
-    pip install --pre cython
-    echo "Installing joblib master."
-    pip install https://github.com/joblib/joblib/archive/master.zip
-    echo "Installing pillow master."
-    pip install https://github.com/python-pillow/Pillow/archive/master.zip
-else
-    conda install -y scipy numpy pandas cython
-    pip install joblib threadpoolctl
-fi
+conda install -y scipy numpy pandas cython
+pip install joblib threadpoolctl
 
 pip install $(get_dep pytest $PYTEST_VERSION) pytest-xdist
 


### PR DESCRIPTION
The scipy-dev builds have moved to Azure Pipelines and there is no
reason to not use stable versions of numpy and scipy to run the ICC
and ARM64 tests on travis.

This should fix the invalid wheel metadata failure observed on travis
which was already resolved on Azure Pipelines by using the legacy
pip dependency resolver for the scipy-dev build.

Here is an example of such a failure for the weekly travis ICC build:

https://travis-ci.com/github/scikit-learn/scikit-learn/jobs/471245966