### PR TITLE
FIX Fixes issue with exatly_zero_info_score

### DIFF
--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -19,8 +19,8 @@ ctypedef np.float64_t DOUBLE
 def expected_mutual_information(contingency, int n_samples):
     """Calculate the expected mutual information for two labelings."""
     cdef int R, C
-    cdef DOUBLE N, gln_N, emi, term2, term3, gln, log_N
-    cdef np.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_nij
+    cdef DOUBLE N, gln_N, emi, term2, term3, gln
+    cdef np.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_Nnij
     cdef np.ndarray[DOUBLE] nijs, term1
     cdef np.ndarray[DOUBLE] log_a, log_b
     cdef np.ndarray[np.int32_t] a, b
@@ -40,8 +40,7 @@ def expected_mutual_information(contingency, int n_samples):
     # term2 uses the outer product
     log_a = np.log(a.astype(np.float64))
     log_b = np.log(b.astype(np.float64))
-    log_nij = np.log(nijs)
-    log_N = np.log(N)
+    log_Nnij = np.log(nijs) + np.log(N)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.
     gln_a = gammaln(a + 1)
@@ -60,7 +59,7 @@ def expected_mutual_information(contingency, int n_samples):
     for i in range(R):
         for j in range(C):
             for nij in range(start[i,j], end[i,j]):
-                term2 = log_N + log_nij[nij] - log_a[i] - log_b[j]
+                term2 = log_Nnij[nij] - log_a[i] - log_b[j]
                 # Numerators are positive, denominators are negative.
                 gln = (gln_a[i] + gln_b[j] + gln_Na[i] + gln_Nb[j]
                      - gln_N - gln_nij[nij] - lgamma(a[i] - nij + 1)

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -38,8 +38,9 @@ def expected_mutual_information(contingency, int n_samples):
     term1 = nijs / N
     # term2 is log((N*nij) / (a * b)) == log(N * nij) - log(a * b)
     # term2 uses the outer product
-    log_a = np.log(a.astype(np.float64, copy=False))
-    log_b = np.log(b.astype(np.float64, copy=False))
+    log_a = np.log(a)
+    log_b = np.log(b)
+    # term2 uses N * nij
     log_Nnij = np.log(nijs) + np.log(N)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -38,10 +38,10 @@ def expected_mutual_information(contingency, int n_samples):
     term1 = nijs / N
     # term2 is log((N*nij) / (a * b)) == log(N * nij) - log(a * b)
     # term2 uses the outer product
-    log_a = np.log(a, dtype=np.float64)
-    log_b = np.log(b, dtype=np.float64)
-    log_nij = np.log(nijs, dtype=np.float64)
-    log_N = np.log(N, dtype=np.float64)
+    log_a = np.log(a.astype(np.float64))
+    log_b = np.log(b.astype(np.float64))
+    log_nij = np.log(nijs)
+    log_N = np.log(N)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.
     gln_a = gammaln(a + 1)

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -22,7 +22,6 @@ def expected_mutual_information(contingency, int n_samples):
     cdef DOUBLE N, gln_N, emi, term2, term3, gln, log_N
     cdef np.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_nij
     cdef np.ndarray[DOUBLE] nijs, term1
-    # cdef np.ndarray[DOUBLE, ndim=2] log_ab_outer
     cdef np.ndarray[DOUBLE] log_a, log_b
     cdef np.ndarray[np.int32_t] a, b
     #cdef np.ndarray[int, ndim=2] start, end

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -19,10 +19,11 @@ ctypedef np.float64_t DOUBLE
 def expected_mutual_information(contingency, int n_samples):
     """Calculate the expected mutual information for two labelings."""
     cdef int R, C
-    cdef DOUBLE N, gln_N, emi, term2, term3, gln
-    cdef np.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_Nnij
+    cdef DOUBLE N, gln_N, emi, term2, term3, gln, log_N
+    cdef np.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_nij
     cdef np.ndarray[DOUBLE] nijs, term1
-    cdef np.ndarray[DOUBLE, ndim=2] log_ab_outer
+    # cdef np.ndarray[DOUBLE, ndim=2] log_ab_outer
+    cdef np.ndarray[DOUBLE] log_a, log_b
     cdef np.ndarray[np.int32_t] a, b
     #cdef np.ndarray[int, ndim=2] start, end
     R, C = contingency.shape
@@ -32,15 +33,16 @@ def expected_mutual_information(contingency, int n_samples):
     # There are three major terms to the EMI equation, which are multiplied to
     # and then summed over varying nij values.
     # While nijs[0] will never be used, having it simplifies the indexing.
-    nijs = np.arange(0, max(np.max(a), np.max(b)) + 1, dtype='float')
+    nijs = np.arange(0, max(np.max(a), np.max(b)) + 1, dtype=np.float64)
     nijs[0] = 1  # Stops divide by zero warnings. As its not used, no issue.
     # term1 is nij / N
     term1 = nijs / N
     # term2 is log((N*nij) / (a * b)) == log(N * nij) - log(a * b)
     # term2 uses the outer product
-    log_ab_outer = np.log(a)[:, np.newaxis] + np.log(b)
-    # term2 uses N * nij
-    log_Nnij = np.log(N * nijs)
+    log_a = np.log(a, dtype=np.float64)
+    log_b = np.log(b, dtype=np.float64)
+    log_nij = np.log(nijs, dtype=np.float64)
+    log_N = np.log(N, dtype=np.float64)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.
     gln_a = gammaln(a + 1)
@@ -54,12 +56,12 @@ def expected_mutual_information(contingency, int n_samples):
     start = np.maximum(start, 1)
     end = np.minimum(np.resize(a, (C, R)).T, np.resize(b, (R, C))) + 1
     # emi itself is a summation over the various values.
-    emi = 0
+    emi = 0.0
     cdef Py_ssize_t i, j, nij
     for i in range(R):
         for j in range(C):
             for nij in range(start[i,j], end[i,j]):
-                term2 = log_Nnij[nij] - log_ab_outer[i,j]
+                term2 = log_N + log_nij[nij] - log_a[i] - log_b[j]
                 # Numerators are positive, denominators are negative.
                 gln = (gln_a[i] + gln_b[j] + gln_Na[i] + gln_Nb[j]
                      - gln_N - gln_nij[nij] - lgamma(a[i] - nij + 1)

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -40,7 +40,7 @@ def expected_mutual_information(contingency, int n_samples):
     # term2 uses the outer product
     log_a = np.log(a)
     log_b = np.log(b)
-    # term2 uses N * nij
+    # term2 uses log(N * nij)
     log_Nnij = np.log(nijs) + np.log(N)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -22,7 +22,7 @@ def expected_mutual_information(contingency, int n_samples):
     cdef DOUBLE N, gln_N, emi, term2, term3, gln
     cdef np.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_Nnij
     cdef np.ndarray[DOUBLE] nijs, term1
-    cdef np.ndarray[DOUBLE] log_a, log_b
+    cdef np.ndarray[DOUBLE, ndim=2] log_ab_outer
     cdef np.ndarray[np.int32_t] a, b
     #cdef np.ndarray[int, ndim=2] start, end
     R, C = contingency.shape
@@ -32,16 +32,15 @@ def expected_mutual_information(contingency, int n_samples):
     # There are three major terms to the EMI equation, which are multiplied to
     # and then summed over varying nij values.
     # While nijs[0] will never be used, having it simplifies the indexing.
-    nijs = np.arange(0, max(np.max(a), np.max(b)) + 1, dtype=np.float64)
+    nijs = np.arange(0, max(np.max(a), np.max(b)) + 1, dtype='float')
     nijs[0] = 1  # Stops divide by zero warnings. As its not used, no issue.
     # term1 is nij / N
     term1 = nijs / N
     # term2 is log((N*nij) / (a * b)) == log(N * nij) - log(a * b)
     # term2 uses the outer product
-    log_a = np.log(a)
-    log_b = np.log(b)
+    log_ab_outer = np.log(a)[:, np.newaxis] + np.log(b)
     # term2 uses N * nij
-    log_Nnij = np.log(nijs) + np.log(N)
+    log_Nnij = np.log(N * nijs)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.
     gln_a = gammaln(a + 1)
@@ -55,12 +54,12 @@ def expected_mutual_information(contingency, int n_samples):
     start = np.maximum(start, 1)
     end = np.minimum(np.resize(a, (C, R)).T, np.resize(b, (R, C))) + 1
     # emi itself is a summation over the various values.
-    emi = 0.0
+    emi = 0
     cdef Py_ssize_t i, j, nij
     for i in range(R):
         for j in range(C):
             for nij in range(start[i,j], end[i,j]):
-                term2 = log_Nnij[nij] - log_a[i] - log_b[j]
+                term2 = log_Nnij[nij] - log_ab_outer[i,j]
                 # Numerators are positive, denominators are negative.
                 gln = (gln_a[i] + gln_b[j] + gln_Na[i] + gln_Nb[j]
                      - gln_N - gln_nij[nij] - lgamma(a[i] - nij + 1)

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -22,7 +22,7 @@ def expected_mutual_information(contingency, int n_samples):
     cdef DOUBLE N, gln_N, emi, term2, term3, gln
     cdef np.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_Nnij
     cdef np.ndarray[DOUBLE] nijs, term1
-    cdef np.ndarray[DOUBLE, ndim=2] log_ab_outer
+    cdef np.ndarray[DOUBLE] log_a, log_b
     cdef np.ndarray[np.int32_t] a, b
     #cdef np.ndarray[int, ndim=2] start, end
     R, C = contingency.shape
@@ -38,9 +38,10 @@ def expected_mutual_information(contingency, int n_samples):
     term1 = nijs / N
     # term2 is log((N*nij) / (a * b)) == log(N * nij) - log(a * b)
     # term2 uses the outer product
-    log_ab_outer = np.log(a)[:, np.newaxis] + np.log(b)
+    log_a = np.log(a)
+    log_b = np.log(b)
     # term2 uses N * nij
-    log_Nnij = np.log(N * nijs)
+    log_Nnij = np.log(nijs) + np.log(N)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.
     gln_a = gammaln(a + 1)
@@ -54,12 +55,12 @@ def expected_mutual_information(contingency, int n_samples):
     start = np.maximum(start, 1)
     end = np.minimum(np.resize(a, (C, R)).T, np.resize(b, (R, C))) + 1
     # emi itself is a summation over the various values.
-    emi = 0
+    emi = 0.0
     cdef Py_ssize_t i, j, nij
     for i in range(R):
         for j in range(C):
             for nij in range(start[i,j], end[i,j]):
-                term2 = log_Nnij[nij] - log_ab_outer[i,j]
+                term2 = log_Nnij[nij] - log_a[i] - log_b[j]
                 # Numerators are positive, denominators are negative.
                 gln = (gln_a[i] + gln_b[j] + gln_Na[i] + gln_Nb[j]
                      - gln_N - gln_nij[nij] - lgamma(a[i] - nij + 1)

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -38,8 +38,8 @@ def expected_mutual_information(contingency, int n_samples):
     term1 = nijs / N
     # term2 is log((N*nij) / (a * b)) == log(N * nij) - log(a * b)
     # term2 uses the outer product
-    log_a = np.log(a)
-    log_b = np.log(b)
+    log_a = np.log(a.astype(np.float64, copy=False))
+    log_b = np.log(b.astype(np.float64, copy=False))
     log_Nnij = np.log(nijs) + np.log(N)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -38,8 +38,8 @@ def expected_mutual_information(contingency, int n_samples):
     term1 = nijs / N
     # term2 is log((N*nij) / (a * b)) == log(N * nij) - log(a * b)
     # term2 uses the outer product
-    log_a = np.log(a.astype(np.float64))
-    log_b = np.log(b.astype(np.float64))
+    log_a = np.log(a)
+    log_b = np.log(b)
     log_Nnij = np.log(nijs) + np.log(N)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -37,11 +37,10 @@ def expected_mutual_information(contingency, int n_samples):
     # term1 is nij / N
     term1 = nijs / N
     # term2 is log((N*nij) / (a * b)) == log(N * nij) - log(a * b)
-    # term2 uses the outer product
     log_a = np.log(a)
     log_b = np.log(b)
-    # term2 uses log(N * nij)
-    log_Nnij = np.log(nijs) + np.log(N)
+    # term2 uses log(N * nij) = log(N) + log(nij)
+    log_Nnij = np.log(N) + np.log(nijs)
     # term3 is large, and involved many factorials. Calculate these in log
     # space to stop overflows.
     gln_a = gammaln(a + 1)

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -790,10 +790,11 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     log_contingency_nm = np.log(nz_val)
     contingency_nm = nz_val / contingency_sum
     # Don't need to calculate the full outer product, just for non-zeroes
-    outer = pi.take(nzx) * pj.take(nzy)
-    log_outer = -np.log(outer) + np.log(pi.sum()) + np.log(pj.sum())
-    mi = log_contingency_nm - np.log(contingency_sum) + log_outer
-    mi *= contingency_nm
+    outer = (pi.take(nzx).astype(np.int64, copy=False)
+             * pj.take(nzy).astype(np.int64, copy=False))
+    log_outer = -np.log(outer) + log(pi.sum()) + log(pj.sum())
+    mi = (contingency_nm * (log_contingency_nm - log(contingency_sum)) +
+          contingency_nm * log_outer)
     mi = np.where(np.abs(mi) < np.finfo(mi.dtype).eps, 0.0, mi)
     return np.clip(mi.sum(), 0.0, None)
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -791,9 +791,11 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     contingency_nm = nz_val / contingency_sum
     # Don't need to calculate the full outer product, just for non-zeroes
     outer = pi.take(nzx) * pj.take(nzy)
-    log_outer = -np.log(outer) + np.log(pi.sum()) + np.log(pj.sum())
-    mi = (contingency_nm * (log_contingency_nm - np.log(contingency_sum)) +
-          contingency_nm * log_outer)
+    pi_sum = pi.sum()
+    pj_sum = pj.sum()
+    log_outer = -np.log(outer) + np.log(pi_sum) + np.log(pj_sum)
+    mi = log_contingency_nm - np.log(contingency_sum) + log_outer
+    mi *= contingency_nm
     return np.clip(mi.sum(), 0.0, None)
 
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -795,7 +795,7 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     log_outer = -np.log(outer) + log(pi.sum()) + log(pj.sum())
     mi = (contingency_nm * (log_contingency_nm - log(contingency_sum)) +
           contingency_nm * log_outer)
-    mi = np.where(np.abs(mi) < np.finfo(mi.dtype).eps, 0.0, mi)
+    np.around(mi, decimals=np.finfo(mi.dtype).precision, out=mi)
     return np.clip(mi.sum(), 0.0, None)
 
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -791,8 +791,8 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     contingency_nm = nz_val / contingency_sum
     # Don't need to calculate the full outer product, just for non-zeroes
     outer = pi.take(nzx) * pj.take(nzy)
-    log_outer = -np.log(outer) + log(pi.sum()) + log(pj.sum())
-    mi = (contingency_nm * (log_contingency_nm - log(contingency_sum)) +
+    log_outer = -np.log(outer) + np.log(pi.sum()) + np.log(pj.sum())
+    mi = (contingency_nm * (log_contingency_nm - np.log(contingency_sum)) +
           contingency_nm * log_outer)
     return np.clip(mi.sum(), 0.0, None)
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -791,11 +791,10 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     contingency_nm = nz_val / contingency_sum
     # Don't need to calculate the full outer product, just for non-zeroes
     outer = pi.take(nzx) * pj.take(nzy)
-    pi_sum = pi.sum()
-    pj_sum = pj.sum()
-    log_outer = -np.log(outer) + np.log(pi_sum) + np.log(pj_sum)
+    log_outer = -np.log(outer) + np.log(pi.sum()) + np.log(pj.sum())
     mi = log_contingency_nm - np.log(contingency_sum) + log_outer
     mi *= contingency_nm
+    mi = np.where(np.abs(mi) < np.finfo(mi.dtype).eps, 0.0, mi)
     return np.clip(mi.sum(), 0.0, None)
 
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -795,7 +795,7 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     log_outer = -np.log(outer) + log(pi.sum()) + log(pj.sum())
     mi = (contingency_nm * (log_contingency_nm - log(contingency_sum)) +
           contingency_nm * log_outer)
-    np.around(mi, decimals=np.finfo(mi.dtype).precision, out=mi)
+    mi = np.where(np.abs(mi) < np.finfo(mi.dtype).eps, 0.0, mi)
     return np.clip(mi.sum(), 0.0, None)
 
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -790,8 +790,7 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     log_contingency_nm = np.log(nz_val)
     contingency_nm = nz_val / contingency_sum
     # Don't need to calculate the full outer product, just for non-zeroes
-    outer = (pi.take(nzx).astype(np.int64, copy=False)
-             * pj.take(nzy).astype(np.int64, copy=False))
+    outer = pi.take(nzx) * pj.take(nzy)
     log_outer = -np.log(outer) + log(pi.sum()) + log(pj.sum())
     mi = (contingency_nm * (log_contingency_nm - log(contingency_sum)) +
           contingency_nm * log_outer)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/19165


#### What does this implement/fix? Explain your changes.
The issue stemmed from an numerical error where `log_N` did not cancel out `log_a`


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
