### PR TITLE
[WIP] Add sparse matrix support for histgradientboostingclassifier

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/binning.py
@@ -89,16 +89,18 @@ def _find_binning_thresholds(col_data, max_bins):
     if sp.issparse(col_data):
         # Since col_data is only used for get unique values
         # and computing percentile, zeros don't matter
-        values = col_data[col_data.nonzero()[0]].toarray()
+        distinct_values = col_data[col_data.nonzero()[0]].toarray()
         if 0 in col_data:
-            values = np.append(values, 0)
-        col_data = values
-    # ignore missing values when computing bin thresholds
-    missing_mask = np.isnan(col_data)
-    if missing_mask.any():
-        col_data = col_data[~missing_mask]
-    col_data = np.ascontiguousarray(col_data, dtype=X_DTYPE)
-    distinct_values = np.unique(col_data)
+            distinct_values = np.append(distinct_values, 0)
+        distinct_values = np.unique(distinct_values)
+        col_data = col_data.toarray()
+    else:
+        # ignore missing values when computing bin thresholds
+        missing_mask = np.isnan(col_data)
+        if missing_mask.any():
+            col_data = col_data[~missing_mask]
+        col_data = np.ascontiguousarray(col_data, dtype=X_DTYPE)
+        distinct_values = np.unique(col_data)
     if len(distinct_values) <= max_bins:
         midpoints = distinct_values[:-1] + distinct_values[1:]
         midpoints *= .5

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
@@ -63,20 +63,20 @@ def test_find_binning_thresholds_sparse_data():
     data = np.linspace(0, 10, 11)
     data = sp.csr_matrix(
             (data, (data.astype(int), [0]*len(data))),
-            (len(data)+50, 1)
+            (len(data)+10, 1)
             )
 
     bin_thresholds = _find_binning_thresholds(data, max_bins=5)
-    assert_allclose(bin_thresholds, [2, 4, 6, 8])
+    assert_allclose(bin_thresholds, [0, 0, 2, 6])
 
     bin_thresholds = _find_binning_thresholds(data, max_bins=10)
-    assert_allclose(bin_thresholds, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    assert_allclose(bin_thresholds, [0, 0, 0, 0, 0, 2, 4, 6, 8])
 
-    bin_thresholds = _find_binning_thresholds(data, max_bins=11)
-    assert_allclose(bin_thresholds, np.arange(10) + .5)
+    bin_thresholds = _find_binning_thresholds(data, max_bins=21)
+    assert_allclose(bin_thresholds, [0]*10 + np.arange(10) + .5)
 
     bin_thresholds = _find_binning_thresholds(data, max_bins=255)
-    assert_allclose(bin_thresholds, np.arange(10) + .5)
+    assert_allclose(bin_thresholds, [0]*10 + np.arange(10) + .5)
 
 
 @pytest.mark.parametrize("n_samples, density, max_bins", [

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
@@ -79,6 +79,22 @@ def test_find_binning_thresholds_sparse_data():
     assert_allclose(bin_thresholds, np.arange(10) + .5)
 
 
+@pytest.mark.parametrize("n_samples, density, max_bins", [
+    (10, 0.8, 10),
+    (100, 0.5, 10),
+    (1000, 0.2, 50)
+])
+def test_find_binning_thresholds_big_large_sparse_data(n_samples, density,
+                                                       max_bins):
+    data = np.random.randn(n_samples).reshape(-1, 1)
+    data[:int(density*n_samples)] = 0
+    sparse_data = sp.csr_matrix(data)
+    thresholds = _find_binning_thresholds(data, max_bins=max_bins)
+    thresholds_sparse = _find_binning_thresholds(
+            sparse_data, max_bins=max_bins)
+    assert_array_equal(thresholds, thresholds_sparse)
+
+
 def test_find_binning_thresholds_low_n_bins():
     bin_thresholds = [_find_binning_thresholds(DATA[:, i], max_bins=128)
                       for i in range(2)]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->
This pull request adds a crude support of sparse matrix for HistGradientBoostingClassifier.
The handling of the sparse matrix is rather crude to minimize the PR and avoid touching cython for now.

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #15336 


#### What does this implement/fix? Explain your changes.
It implements sparse matrix support for HistGradientBoostingClassifier.
There are two major differences when handling sparse matrix : during fit and during transform.

##### Fit

At fitting time, the sparse matrix can be safely converted to a dense one because only unique values are important.
This is done by getting the non-null values and then appending 0 to the list of values.
The matrix can now be treated the same way a dense one is.

That way, it avoids duplicating the code and having to test a new algorithm.

##### Transform

Transform is more tricky.
The main problem here (as @NicolasHug explained) is that we want the bin with value 0 to be mapped to the value 0.
That way we can take advantage of the sparse structure to treat missing values as 0.
In the returned matrix, values in the bins [0, actual_bin_zero) are right-shifted by one and the bin actual_bin_zero is mapped to 0.
The transform function returns actual_bin_zero alongside the matrix.

The second short-term problem is that the core of the binning logic is done in _map_to_bins which is a cython function.
I prefer not having to touch to the cython code for now so I worked around it.

The process is the following :
1. We pass a 1x1 zero-filled matrix to _map_to_bins to determine the actual_bin_zero.
2. We pack the sparse matrix into a dense one (process described in details bellow)
3. We pass the packed matrix to _map_to_bins to map the bins.
4. We shift the mapped bins.
5. We unpack the dense matrix to a sparse one, conserving the original structure.

##### Packing / Unpacking

To allow _map_to_bins to "process" a sparse matrix, we pack it into a dense one.
This is done column wise and the resulting matrix is the smallest possible that can fit the data.
The function returns the packed matrix and the row indices of the former values.

Unpacking the matrix is the exact opposite : we use the row indices to put the values into the correct position in the sparse matrix.

Example :
```python
>>> a = csr_matrix(array(
      [[   1, 1000,    0],
       [   0,  999,   -1],
       [   2,    0,   -2],
       [   3,    0,   -3],
       [   0,    0,   -4]]))
>>> _pack_matrix(a)
(
array([[   1, 1000,   -1],
       [   2,  999,   -2],
       [   3,    0,   -3],
       [   0,    0,   -4]]), 
array([[ 0.,  0.,  1.],
       [ 2.,  1.,  2.],
       [ 3., nan,  3.],
       [nan, nan,  4.]])
)
```

#### Any other comments?

The main performance bottleneck is the packing / unpacking of the matrix.
I kept that fact in mind and always used the sparsity of the matrix to my advantage.

In the future, the cython code need to be retouched to make place to a cleaner flow.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
