### PR TITLE
DictionaryLearning: Fix several issues in the dict update

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -70,6 +70,20 @@ Changelog
   in multicore settings. :pr:`19052` by
   :user:`Yusuke Nagasaka <YusukeNagasaka>`.
 
+:mod:`sklearn.decomposition`
+............................
+
+- |Fix| Fixed a bug in :class:`MiniBatchDictionaryLearning`,
+  :class:`MiniBatchSparsePCA` and :func:`dict_learning_online` where the
+  update of the dictionary was incorrect. :pr:`19198` by
+  :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
+- |Fix| Fixed a bug in :class:`DictionaryLearning`, :class:`SparsePCA`,
+  :class:`MiniBatchDictionaryLearning`, :class:`MiniBatchSparsePCA`,
+  :func:`dict_learning` and :func:`dict_learning_online` where the restart of
+  unused atoms during the dictionary update was not working as expected.
+  :pr:`19198` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -420,7 +420,7 @@ def _update_dict(dictionary, Y, code, A=None, B=None, verbose=False,
         # Projection on the constraint ||V_k|| == 1
         dictionary[k] /= linalg.norm(dictionary[k])
 
-    if verbose:
+    if verbose and n_unused > 0:
         print(f"{n_unused} unused atoms resampled.")
 
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -354,27 +354,29 @@ def sparse_encode(X, dictionary, *, gram=None, cov=None,
     return code
 
 
-def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
-                 random_state=None, positive=False):
+def _update_dict(dictionary, Y, code, A=None, B=None, verbose=False,
+                 return_r2=False, random_state=None, positive=False):
     """Update the dense dictionary factor in place.
 
     Parameters
     ----------
-    dictionary : ndarray of shape (n_features, n_components)
+    dictionary : ndarray of shape (n_components, n_features)
         Value of the dictionary at the previous iteration.
 
-    Y : ndarray of shape (n_features, n_samples)
+    Y : ndarray of shape (n_samples, n_features)
         Data matrix.
 
-    code : ndarray of shape (n_components, n_samples)
+    code : ndarray of shape (n_samples, n_components)
         Sparse coding of the data against which to optimize the dictionary.
+
+    A : ndarray of shape (n_components, n_components), default=None
+        With B, sufficient stats of the online model.
+
+    B : ndarray of shape (n_features, n_components), default=None
+        With A, sufficient stats of the online model.
 
     verbose: bool, default=False
         Degree of output the procedure will print.
-
-    return_r2 : bool, default=False
-        Whether to compute and return the residual sum of squares corresponding
-        to the computed solution.
 
     random_state : int, RandomState instance or None, default=None
         Used for randomly initializing the dictionary. Pass an int for
@@ -385,54 +387,37 @@ def _update_dict(dictionary, Y, code, verbose=False, return_r2=False,
         Whether to enforce positivity when finding the dictionary.
 
         .. versionadded:: 0.20
-
-    Returns
-    -------
-    dictionary : ndarray of shape (n_features, n_components)
-        Updated dictionary.
     """
-    n_components = len(code)
-    n_features = Y.shape[0]
+    n_samples, n_components = code.shape
     random_state = check_random_state(random_state)
-    # Get BLAS functions
-    gemm, = linalg.get_blas_funcs(('gemm',), (dictionary, code, Y))
-    ger, = linalg.get_blas_funcs(('ger',), (dictionary, code))
-    nrm2, = linalg.get_blas_funcs(('nrm2',), (dictionary,))
-    # Residuals, computed with BLAS for speed and efficiency
-    # R <- -1.0 * U * V^T + 1.0 * Y
-    # Outputs R as Fortran array for efficiency
-    R = gemm(-1.0, dictionary, code, 1.0, Y)
+
+    if A is None:
+        A = np.dot(code.T, code)
+    if B is None:
+        B = np.dot(Y.T, code)
+
     for k in range(n_components):
-        # R <- 1.0 * U_k * V_k^T + R
-        R = ger(1.0, dictionary[:, k], code[k, :], a=R, overwrite_a=True)
-        dictionary[:, k] = np.dot(R, code[k, :])
-        if positive:
-            np.clip(dictionary[:, k], 0, None, out=dictionary[:, k])
-        # Scale k'th atom
-        # (U_k * U_k) ** 0.5
-        atom_norm = nrm2(dictionary[:, k])
-        if atom_norm < 1e-10:
+        if A[k, k] > 1e-6:
+            dictionary[k] += (B[:, k] - A[k].dot(dictionary)) / A[k, k]
+        else:
+            # kth atom is almost never used -> sample a new one from the data
             if verbose == 1:
                 sys.stdout.write("+")
                 sys.stdout.flush()
             elif verbose:
                 print("Adding new random atom")
-            dictionary[:, k] = random_state.randn(n_features)
-            if positive:
-                np.clip(dictionary[:, k], 0, None, out=dictionary[:, k])
-            # Setting corresponding coefs to 0
-            code[k, :] = 0.0
-            # (U_k * U_k) ** 0.5
-            atom_norm = nrm2(dictionary[:, k])
-            dictionary[:, k] /= atom_norm
-        else:
-            dictionary[:, k] /= atom_norm
-            # R <- -1.0 * U_k * V_k^T + R
-            R = ger(-1.0, dictionary[:, k], code[k, :], a=R, overwrite_a=True)
-    if return_r2:
-        R = nrm2(R) ** 2.0
-        return dictionary, R
-    return dictionary
+
+            newd = Y[random_state.choice(n_samples)]
+            # add small noise to avoid making the sparse coding ill conditioned
+            noise = random_state.normal(0, 0.01 * newd.std(), size=len(newd))
+            dictionary[k] = newd + noise
+            code[:, k] = 0
+
+        if positive:
+            np.clip(dictionary[k], 0, None, out=dictionary[k])
+
+        # Projection on the constraint ||V_k|| == 1
+        dictionary[k] /= linalg.norm(dictionary[k])
 
 
 @_deprecate_positional_args
@@ -574,10 +559,9 @@ def dict_learning(X, n_components, *, alpha, max_iter=100, tol=1e-8,
         dictionary = np.r_[dictionary,
                            np.zeros((n_components - r, dictionary.shape[1]))]
 
-    # Fortran-order dict, as we are going to access its row vectors
+    # Fortran-order dict better suited for the sparse coding which is the
+    # bottleneck of this algorithm.
     dictionary = np.array(dictionary, order='F')
-
-    residuals = 0
 
     errors = []
     current_cost = np.nan
@@ -602,15 +586,14 @@ def dict_learning(X, n_components, *, alpha, max_iter=100, tol=1e-8,
         code = sparse_encode(X, dictionary, algorithm=method, alpha=alpha,
                              init=code, n_jobs=n_jobs, positive=positive_code,
                              max_iter=method_max_iter, verbose=verbose)
-        # Update dictionary
-        dictionary, residuals = _update_dict(dictionary.T, X.T, code.T,
-                                             verbose=verbose, return_r2=True,
-                                             random_state=random_state,
-                                             positive=positive_dict)
-        dictionary = dictionary.T
+
+        # Update dictionary in place
+        _update_dict(dictionary, X, code, verbose=verbose,
+                     random_state=random_state, positive=positive_dict)
 
         # Cost function
-        current_cost = 0.5 * residuals + alpha * np.sum(np.abs(code))
+        current_cost = (0.5 * np.sum((X - code @ dictionary)**2)
+                        + alpha * np.sum(np.abs(code)))
         errors.append(current_cost)
 
         if ii > 0:
@@ -802,7 +785,7 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
     else:
         X_train = X
 
-    dictionary = check_array(dictionary.T, order='F', dtype=np.float64,
+    dictionary = check_array(dictionary, order='F', dtype=np.float64,
                              copy=False)
     dictionary = np.require(dictionary, requirements='W')
 
@@ -834,11 +817,11 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
                 print("Iteration % 3i (elapsed time: % 3is, % 4.1fmn)"
                       % (ii, dt, dt / 60))
 
-        this_code = sparse_encode(this_X, dictionary.T, algorithm=method,
+        this_code = sparse_encode(this_X, dictionary, algorithm=method,
                                   alpha=alpha, n_jobs=n_jobs,
                                   check_input=False,
                                   positive=positive_code,
-                                  max_iter=method_max_iter, verbose=verbose).T
+                                  max_iter=method_max_iter, verbose=verbose)
 
         # Update the auxiliary variables
         if ii < batch_size - 1:
@@ -848,15 +831,13 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
         beta = (theta + 1 - batch_size) / (theta + 1)
 
         A *= beta
-        A += np.dot(this_code, this_code.T)
+        A += np.dot(this_code.T, this_code)
         B *= beta
-        B += np.dot(this_X.T, this_code.T)
+        B += np.dot(this_X.T, this_code)
 
-        # Update dictionary
-        dictionary = _update_dict(dictionary, B, A, verbose=verbose,
-                                  random_state=random_state,
-                                  positive=positive_dict)
-        # XXX: Can the residuals be of any use?
+        # Update dictionary in place
+        _update_dict(dictionary, this_X, this_code, A, B, verbose=verbose,
+                     random_state=random_state, positive=positive_dict)
 
         # Maybe we need a stopping criteria based on the amount of
         # modification in the dictionary
@@ -865,15 +846,15 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
 
     if return_inner_stats:
         if return_n_iter:
-            return dictionary.T, (A, B), ii - iter_offset + 1
+            return dictionary, (A, B), ii - iter_offset + 1
         else:
-            return dictionary.T, (A, B)
+            return dictionary, (A, B)
     if return_code:
         if verbose > 1:
             print('Learning code...', end=' ')
         elif verbose == 1:
             print('|', end=' ')
-        code = sparse_encode(X, dictionary.T, algorithm=method, alpha=alpha,
+        code = sparse_encode(X, dictionary, algorithm=method, alpha=alpha,
                              n_jobs=n_jobs, check_input=False,
                              positive=positive_code, max_iter=method_max_iter,
                              verbose=verbose)
@@ -881,14 +862,14 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
             dt = (time.time() - t0)
             print('done (total time: % 3is, % 4.1fmn)' % (dt, dt / 60))
         if return_n_iter:
-            return code, dictionary.T, ii - iter_offset + 1
+            return code, dictionary, ii - iter_offset + 1
         else:
-            return code, dictionary.T
+            return code, dictionary
 
     if return_n_iter:
-        return dictionary.T, ii - iter_offset + 1
+        return dictionary, ii - iter_offset + 1
     else:
-        return dictionary.T
+        return dictionary
 
 
 class _BaseSparseCoding(TransformerMixin):

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1250,7 +1250,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
     We can check the level of sparsity of `X_transformed`:
 
     >>> np.mean(X_transformed == 0)
-    0.88...
+    0.87...
 
     We can compare the average squared euclidean norm of the reconstruction
     error of the sparse coded signal relative to the squared euclidean norm of
@@ -1258,7 +1258,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     >>> X_hat = X_transformed @ dict_learner.components_
     >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
-    0.07...
+    0.08...
 
     Notes
     -----
@@ -1490,7 +1490,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
     We can check the level of sparsity of `X_transformed`:
 
     >>> np.mean(X_transformed == 0)
-    0.87...
+    0.86...
 
     We can compare the average squared euclidean norm of the reconstruction
     error of the sparse coded signal relative to the squared euclidean norm of
@@ -1498,7 +1498,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     >>> X_hat = X_transformed @ dict_learner.components_
     >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
-    0.10...
+    0.07...
 
     Notes
     -----

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -408,8 +408,11 @@ def _update_dict(dictionary, Y, code, A=None, B=None, verbose=False,
                 print("Adding new random atom")
 
             newd = Y[random_state.choice(n_samples)]
+
             # add small noise to avoid making the sparse coding ill conditioned
-            noise = random_state.normal(0, 0.01 * newd.std(), size=len(newd))
+            noise_level = 0.01 * (newd.std() or 1)  # avoid 0 std
+            noise = random_state.normal(0, noise_level, size=len(newd))
+
             dictionary[k] = newd + noise
             code[:, k] = 0
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -355,7 +355,7 @@ def sparse_encode(X, dictionary, *, gram=None, cov=None,
 
 
 def _update_dict(dictionary, Y, code, A=None, B=None, verbose=False,
-                 return_r2=False, random_state=None, positive=False):
+                 random_state=None, positive=False):
     """Update the dense dictionary factor in place.
 
     Parameters
@@ -392,13 +392,14 @@ def _update_dict(dictionary, Y, code, A=None, B=None, verbose=False,
     random_state = check_random_state(random_state)
 
     if A is None:
-        A = np.dot(code.T, code)
+        A = code.T @ code
     if B is None:
-        B = np.dot(Y.T, code)
+        B = Y.T @ code
 
     for k in range(n_components):
         if A[k, k] > 1e-6:
-            dictionary[k] += (B[:, k] - A[k].dot(dictionary)) / A[k, k]
+            # 1e-6 is arbitrary but consistent with the spams implementation
+            dictionary[k] += (B[:, k] - A[k] @ dictionary) / A[k, k]
         else:
             # kth atom is almost never used -> sample a new one from the data
             if verbose == 1:

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -418,7 +418,7 @@ def _update_dict(dictionary, Y, code, A=None, B=None, verbose=False,
         if positive:
             np.clip(dictionary[k], 0, None, out=dictionary[k])
 
-        # Projection on the constraint ||V_k|| == 1
+        # Projection on the constraint set ||V_k|| == 1
         dictionary[k] /= linalg.norm(dictionary[k])
 
     if verbose and n_unused > 0:

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -371,10 +371,12 @@ def _update_dict(dictionary, Y, code, A=None, B=None, verbose=False,
         Sparse coding of the data against which to optimize the dictionary.
 
     A : ndarray of shape (n_components, n_components), default=None
-        With `B`, sufficient stats of the online model.
+        Together with `B`, sufficient stats of the online model to update the
+        dictionary.
 
     B : ndarray of shape (n_features, n_components), default=None
-        With `A`, sufficient stats of the online model.
+        Together with `A`, sufficient stats of the online model to update the
+        dictionary.
 
     verbose: bool, default=False
         Degree of output the procedure will print.
@@ -570,7 +572,7 @@ def dict_learning(X, n_components, *, alpha, max_iter=100, tol=1e-8,
 
     # Fortran-order dict better suited for the sparse coding which is the
     # bottleneck of this algorithm.
-    dictionary = np.array(dictionary, order='F')
+    dictionary = np.asfortranarray(dictionary)
 
     errors = []
     current_cost = np.nan
@@ -794,6 +796,8 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
     else:
         X_train = X
 
+    # Fortran-order dict better suited for the sparse coding which is the
+    # bottleneck of this algorithm.
     dictionary = check_array(dictionary, order='F', dtype=np.float64,
                              copy=False)
     dictionary = np.require(dictionary, requirements='W')

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -609,4 +609,3 @@ def test_warning_default_transform_alpha(Estimator):
     dl = Estimator(alpha=0.1)
     with pytest.warns(FutureWarning, match="default transform_alpha"):
         dl.fit_transform(X)
-

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -579,29 +579,25 @@ def test_sparse_coder_n_features_in():
 
 
 def test_update_dict():
-    # Check that the dict update is correct in batch and online mode
+    # Check the dict update in batch mode vs online mode
+    rng = np.random.RandomState(0)
+
     code = np.array([[0.5, -0.5],
                      [0.1, 0.9]])
     dictionary = np.array([[1., 0.],
                            [0.6, 0.8]])
 
-    # Create X s.t. the dictionary is already optimal
-    X = np.dot(code, dictionary)
+    X = np.dot(code, dictionary) + rng.randn(2, 2)
 
-    # Since ||d_k|| = 1, we expect the update to not change the dictionary.
-    expected = dictionary.copy()
+    # batch update
+    newd_batch = dictionary.copy()
+    _update_dict(newd_batch, X, code)
 
-    # batch mode
-    new_dict = dictionary.copy()
-    _update_dict(new_dict, X, code)
-
-    assert_allclose(new_dict, expected)
-
-    # online mode
+    # online update
     A = np.dot(code.T, code)
     B = np.dot(X.T, code)
 
-    new_dict = dictionary.copy()
-    _update_dict(new_dict, X, code, A, B)
+    newd_online = dictionary.copy()
+    _update_dict(newd_online, X, code, A, B)
 
-    assert_allclose(new_dict, expected)
+    assert_allclose(newd_batch, newd_online)

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -580,6 +580,7 @@ def test_sparse_coder_n_features_in():
 
 def test_update_dict():
     # Check the dict update in batch mode vs online mode
+    # Non-regression test for #4866
     rng = np.random.RandomState(0)
 
     code = np.array([[0.5, -0.5],
@@ -589,14 +590,13 @@ def test_update_dict():
 
     X = np.dot(code, dictionary) + rng.randn(2, 2)
 
-    # batch update
+    # full batch update
     newd_batch = dictionary.copy()
     _update_dict(newd_batch, X, code)
 
     # online update
     A = np.dot(code.T, code)
     B = np.dot(X.T, code)
-
     newd_online = dictionary.copy()
     _update_dict(newd_online, X, code, A, B)
 


### PR DESCRIPTION
- Fixes #4866: minor bug in the dict update when used by MiniBatchDictionaryLearning. I added a test which currently fail on master.

- `_update_dict` seems to make smart things to update the residuals incrementally but I found that it's actually much faster (~10x to 20x) to write the function more naively and compute the objective function from scratch at the end. The impact on the time for the whole dict learning is negligible since the bottleneck is the sparse coding but I find version much more readable (and by reading the related issues I'm not the only one).

- When an atom is not used, the current strategy is to generate a new one from a normal distribution. But it's very likely that it will still not be used. A discussion with @tomMoral lead us think that sample a new atom from the data may be a better strategy. Below is a plot of the objective function for both strategies.
 
![dl_loss](https://user-images.githubusercontent.com/34657725/104950506-12913b00-59c1-11eb-8827-daef6e1a42b2.png)

- more small adjustments. I explain thoses in dedicated comments