### PR TITLE
Add URL to reference of Minka paper used in PCA

### DIFF
--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -53,7 +53,8 @@ def _assess_dimension(spectrum, rank, n_samples):
     Notes
     -----
     This implements the method of `Thomas P. Minka:
-    Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604`
+    Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604
+    <https://proceedings.neurips.cc/paper/2000/file/7503cfacd12053d309b6bed5c89de212-Paper.pdf>`_
     """
 
     n_features = spectrum.shape[0]
@@ -273,6 +274,7 @@ class PCA(_BasePCA):
     ----------
     For n_components == 'mle', this class uses the method of *Minka, T. P.
     "Automatic choice of dimensionality for PCA". In NIPS, pp. 598-604*
+    See https://tminka.github.io/papers/pca/
 
     Implements the probabilistic PCA model from:
     Tipping, M. E., and Bishop, C. M. (1999). "Probabilistic principal

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -275,7 +275,7 @@ class PCA(_BasePCA):
     ----------
     For n_components == 'mle', this class uses the method from:
     `Minka, T. P.. "Automatic choice of dimensionality for PCA".
-    In NIPS, pp. 598-604 <https://tminka.github.io/papers/pca/>`_
+    In NIPS, pp. 598-604 <https://tminka.github.io/papers/pca/minka-pca.pdf>`_
 
     Implements the probabilistic PCA model from:
     `Tipping, M. E., and Bishop, C. M. (1999). "Probabilistic principal

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -32,7 +32,8 @@ def _assess_dimension(spectrum, rank, n_samples):
     """Compute the log-likelihood of a rank ``rank`` dataset.
 
     The dataset is assumed to be embedded in gaussian noise of shape(n,
-    dimf) having spectrum ``spectrum``.
+    dimf) having spectrum ``spectrum``. This implements the method of
+    T. P. Minka.
 
     Parameters
     ----------
@@ -50,8 +51,8 @@ def _assess_dimension(spectrum, rank, n_samples):
     ll : float
         The log-likelihood.
 
-    Notes
-    -----
+    References
+    ----------
     This implements the method of `Thomas P. Minka:
     Automatic Choice of Dimensionality for PCA. NIPS 2000: 598-604
     <https://proceedings.neurips.cc/paper/2000/file/7503cfacd12053d309b6bed5c89de212-Paper.pdf>`_
@@ -272,27 +273,30 @@ class PCA(_BasePCA):
 
     References
     ----------
-    For n_components == 'mle', this class uses the method of *Minka, T. P.
-    "Automatic choice of dimensionality for PCA". In NIPS, pp. 598-604*
-    See https://tminka.github.io/papers/pca/
+    For n_components == 'mle', this class uses the method from:
+    `Minka, T. P.. "Automatic choice of dimensionality for PCA".
+    In NIPS, pp. 598-604 <https://tminka.github.io/papers/pca/>`_
 
     Implements the probabilistic PCA model from:
-    Tipping, M. E., and Bishop, C. M. (1999). "Probabilistic principal
+    `Tipping, M. E., and Bishop, C. M. (1999). "Probabilistic principal
     component analysis". Journal of the Royal Statistical Society:
     Series B (Statistical Methodology), 61(3), 611-622.
+    <http://www.miketipping.com/papers/met-mppca.pdf>`_
     via the score and score_samples methods.
-    See http://www.miketipping.com/papers/met-mppca.pdf
 
     For svd_solver == 'arpack', refer to `scipy.sparse.linalg.svds`.
 
     For svd_solver == 'randomized', see:
-    *Halko, N., Martinsson, P. G., and Tropp, J. A. (2011).
+    `Halko, N., Martinsson, P. G., and Tropp, J. A. (2011).
     "Finding structure with randomness: Probabilistic algorithms for
     constructing approximate matrix decompositions".
-    SIAM review, 53(2), 217-288.* and also
-    *Martinsson, P. G., Rokhlin, V., and Tygert, M. (2011).
+    SIAM review, 53(2), 217-288.
+    <https://doi.org/10.1137/090771806>`_
+    and also
+    `Martinsson, P. G., Rokhlin, V., and Tygert, M. (2011).
     "A randomized algorithm for the decomposition of matrices".
-    Applied and Computational Harmonic Analysis, 30(1), 47-68.*
+    Applied and Computational Harmonic Analysis, 30(1), 47-68
+    <https://doi.org/10.1016/j.acha.2010.02.003>`_.
 
     Examples
     --------


### PR DESCRIPTION
This PR adds a link to the reference of the Minka paper implemented in the PCA for `method='mle'`. That paper is cited twice: In the method `_asses_dimension` I add a direct link to the exact paper, in the general docstring of the PCA I add a reference to Minka's page with the algorithm, because on that page there is an extended and updated write-up on this method in addition to a copy of the original paper. That write-up is more useful as an introduction to the method, but obviously has different equation numbers etc. thus it is not a good link for the `_asses_dimension` method, which explicitly refers to "equation (31) from the paper".

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
