### PR TITLE
DOC Fix minimum version for building ZIP of the HTML

### DIFF
--- a/build_tools/circle/list_versions.py
+++ b/build_tools/circle/list_versions.py
@@ -39,7 +39,7 @@ def get_file_extension(version):
         return 'zip'
 
     current_version = LooseVersion(version)
-    min_zip_version = LooseVersion('1.0.0')
+    min_zip_version = LooseVersion('0.24')
 
     return 'zip' if current_version >= min_zip_version else 'pdf'
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
-->

#### Reference Issues/PRs

See https://github.com/scikit-learn/scikit-learn/pull/19199#discussion_r559800427.

#### What does this implement/fix? Explain your changes.

This PR sets the minimum version for building the ZIP of the HTML to `0.24`.

The [webpage](https://scikit-learn.org/stable//_downloads/scikit-learn-docs.pdf) is returning a `404: Not Found error` when trying to obtain the PDF for version `0.24.1` because the corresponding file does not exist (it has been replaced by the ZIP of the HTML).