### PR TITLE
DOC Generalise norm notation in NMF docstring.

### DIFF
--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -881,7 +881,6 @@ def non_negative_factorization(X, W=None, H=None, n_components=None, *,
 
     :math:`||vec(A)||_1 = \\sum_{i,j} abs(A_{ij})` (Elementwise L1 norm)
 
-    
     The generic norm :math:`||X - WH||_{loss}^2` may represent
     the Frobenius norm or another supported beta-divergence loss,
     defined by changing the `beta_loss` parameter.
@@ -1119,7 +1118,6 @@ class NMF(TransformerMixin, BaseEstimator):
 
     :math:`||vec(A)||_1 = \\sum_{i,j} abs(A_{ij})` (Elementwise L1 norm)
 
-    
     The generic norm :math:`||X - WH||_{loss}` may represent
     the Frobenius norm or another supported beta-divergence loss,
     defined by changing the `beta_loss` parameter.

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -882,9 +882,9 @@ def non_negative_factorization(X, W=None, H=None, n_components=None, *,
     :math:`||vec(A)||_1 = \\sum_{i,j} abs(A_{ij})` (Elementwise L1 norm)
 
     
-    The generic norm :math:`(0.5 * ||X - WH||_{loss}^2)` may represent
+    The generic norm :math:`||X - WH||_{loss}^2` may represent
     the Frobenius norm or another supported beta-divergence loss,
-    defined by changing the beta_loss parameter.
+    defined by changing the `beta_loss` parameter.
 
     The objective function is minimized with an alternating minimization of W
     and H. If H is given and update_H=False, it solves for W only.
@@ -1120,9 +1120,9 @@ class NMF(TransformerMixin, BaseEstimator):
     :math:`||vec(A)||_1 = \\sum_{i,j} abs(A_{ij})` (Elementwise L1 norm)
 
     
-    The generic norm :math:`(0.5 * ||X - WH||_{loss}^2)` may represent
+    The generic norm :math:`||X - WH||_{loss}` may represent
     the Frobenius norm or another supported beta-divergence loss,
-    defined by changing the beta_loss parameter.
+    defined by changing the `beta_loss` parameter.
 
     The objective function is minimized with an alternating minimization of W
     and H.

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -882,8 +882,8 @@ def non_negative_factorization(X, W=None, H=None, n_components=None, *,
     :math:`||vec(A)||_1 = \\sum_{i,j} abs(A_{ij})` (Elementwise L1 norm)
 
     The generic norm :math:`||X - WH||_{loss}^2` may represent
-    the Frobenius norm or another supported beta-divergence loss,
-    defined by changing the `beta_loss` parameter.
+    the Frobenius norm or another supported beta-divergence loss.
+    The choice between options is controlled by the `beta_loss` parameter.
 
     The objective function is minimized with an alternating minimization of W
     and H. If H is given and update_H=False, it solves for W only.
@@ -1119,8 +1119,8 @@ class NMF(TransformerMixin, BaseEstimator):
     :math:`||vec(A)||_1 = \\sum_{i,j} abs(A_{ij})` (Elementwise L1 norm)
 
     The generic norm :math:`||X - WH||_{loss}` may represent
-    the Frobenius norm or another supported beta-divergence loss,
-    defined by changing the `beta_loss` parameter.
+    the Frobenius norm or another supported beta-divergence loss.
+    The choice between options is controlled by the `beta_loss` parameter.
 
     The objective function is minimized with an alternating minimization of W
     and H.

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -867,7 +867,7 @@ def non_negative_factorization(X, W=None, H=None, n_components=None, *,
 
         .. math::
 
-            0.5 * ||X - WH||_{Fro}^2 + alpha * l1_{ratio} * ||vec(W)||_1
+            0.5 * ||X - WH||_{loss}^2 + alpha * l1_{ratio} * ||vec(W)||_1
 
             + alpha * l1_{ratio} * ||vec(H)||_1
 
@@ -881,9 +881,10 @@ def non_negative_factorization(X, W=None, H=None, n_components=None, *,
 
     :math:`||vec(A)||_1 = \\sum_{i,j} abs(A_{ij})` (Elementwise L1 norm)
 
-    For multiplicative-update ('mu') solver, the Frobenius norm
-    :math:`(0.5 * ||X - WH||_{Fro}^2)` can be changed into another
-    beta-divergence loss, by changing the beta_loss parameter.
+    
+    The generic norm :math:`(0.5 * ||X - WH||_{loss}^2)` may represent
+    the Frobenius norm or another supported beta-divergence loss,
+    defined by changing the beta_loss parameter.
 
     The objective function is minimized with an alternating minimization of W
     and H. If H is given and update_H=False, it solves for W only.
@@ -1104,7 +1105,7 @@ class NMF(TransformerMixin, BaseEstimator):
 
         .. math::
 
-            0.5 * ||X - WH||_{Fro}^2 + alpha * l1_{ratio} * ||vec(W)||_1
+            0.5 * ||X - WH||_{loss}^2 + alpha * l1_{ratio} * ||vec(W)||_1
 
             + alpha * l1_{ratio} * ||vec(H)||_1
 
@@ -1118,9 +1119,10 @@ class NMF(TransformerMixin, BaseEstimator):
 
     :math:`||vec(A)||_1 = \\sum_{i,j} abs(A_{ij})` (Elementwise L1 norm)
 
-    For multiplicative-update ('mu') solver, the Frobenius norm
-    (:math:`0.5 * ||X - WH||_{Fro}^2`) can be changed into another
-    beta-divergence loss, by changing the beta_loss parameter.
+    
+    The generic norm :math:`(0.5 * ||X - WH||_{loss}^2)` may represent
+    the Frobenius norm or another supported beta-divergence loss,
+    defined by changing the beta_loss parameter.
 
     The objective function is minimized with an alternating minimization of W
     and H.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
As discussed in debugging #16948, this PR generalise the norm notation in the NMF docstring.

ping @GaelVaroquaux @jeremiedbb @ogrisel 