### PR TITLE
Fix check_decision_proba_consistency random failure

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2915,8 +2915,13 @@ def check_decision_proba_consistency(name, estimator_orig):
             hasattr(estimator, "predict_proba")):
 
         estimator.fit(X_train, y_train)
-        a = estimator.predict_proba(X_test)[:, 1]
-        b = estimator.decision_function(X_test)
+        # Since the link function from decision_function() to predict_proba()
+        # is sometimes not precise enough (typically expit), we round to the
+        # 10th decimal to avoid numerical issues: we rather compare the rank
+        # with deterministic ties rather than get platform specific rank
+        # inversions in case of machine level differences.
+        a = estimator.predict_proba(X_test)[:, 1].round(decimals=10)
+        b = estimator.decision_function(X_test).round(decimals=10)
         assert_array_equal(rankdata(a), rankdata(b))
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2907,18 +2907,16 @@ def check_decision_proba_consistency(name, estimator_orig):
     centers = [(2, 2), (4, 4)]
     X, y = make_blobs(n_samples=100, random_state=0, n_features=4,
                       centers=centers, cluster_std=1.0, shuffle=True)
-    X_test = np.random.randn(20, 2) + 4
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2,
+                                                        random_state=0)
     estimator = clone(estimator_orig)
 
     if (hasattr(estimator, "decision_function") and
             hasattr(estimator, "predict_proba")):
 
-        estimator.fit(X, y)
-        # Since the link function from decision_function() to predict_proba()
-        # is sometimes not precise enough (typically expit), we round to the
-        # 10th decimal to avoid numerical issues.
-        a = estimator.predict_proba(X_test)[:, 1].round(decimals=10)
-        b = estimator.decision_function(X_test).round(decimals=10)
+        estimator.fit(X_train, y_train)
+        a = estimator.predict_proba(X_test)[:, 1]
+        b = estimator.decision_function(X_test)
         assert_array_equal(rankdata(a), rankdata(b))
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2917,7 +2917,7 @@ def check_decision_proba_consistency(name, estimator_orig):
         estimator.fit(X_train, y_train)
         # Since the link function from decision_function() to predict_proba()
         # is sometimes not precise enough (typically expit), we round to the
-        # 10th decimal to avoid numerical issues: we rather compare the rank
+        # 10th decimal to avoid numerical issues: we compare the rank
         # with deterministic ties rather than get platform specific rank
         # inversions in case of machine level differences.
         a = estimator.predict_proba(X_test)[:, 1].round(decimals=10)


### PR DESCRIPTION
Tentative fix for #19224.

- I noticed that `X_test` was generated from the RNG singleton of `np.random` and therefore the test was not deterministic.
- I now generate `X_test` from the same bloby distribution as the training set which is less likely to result in samples close to the decision boundary although I am not sure this has any actual impact. But it seems more natural to do so.
- <del>I removed the rounding thingy that I did not understand. How rounding could possibly reduce the likelihood of ties?</del>

Anyway lets see how the CI likes this including the `[cd build]`.