### PR TITLE
DOC Add scikeras to related projects.

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -30,10 +30,6 @@ enhance the functionality of scikit-learn's estimators.
 - `sklearn_xarray <https://github.com/phausamann/sklearn-xarray/>`_ provides
   compatibility of scikit-learn estimators with xarray data structures.
 
-- `scikeras <https://github.com/adriangb/scikeras>`_ provides a wrapper around
-  Keras to interface it with Scikit-Learn. SciKeras is the successor
-  of `tf.keras.wrappers.scikit_learn`.
-
 **Auto-ML**
 
 - `auto-sklearn <https://github.com/automl/auto-sklearn/>`_
@@ -160,6 +156,10 @@ and tasks.
 
 - `skorch <https://github.com/dnouri/skorch>`_ A scikit-learn compatible
   neural network library that wraps PyTorch.
+
+- `scikeras <https://github.com/adriangb/scikeras>`_ provides a wrapper around
+  Keras to interface it with scikit-learn. SciKeras is the successor
+  of `tf.keras.wrappers.scikit_learn`.
 
 **Broad scope**
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -30,6 +30,10 @@ enhance the functionality of scikit-learn's estimators.
 - `sklearn_xarray <https://github.com/phausamann/sklearn-xarray/>`_ provides
   compatibility of scikit-learn estimators with xarray data structures.
 
+- `scikeras <https://github.com/adriangb/scikeras>`_ provides a wrapper around
+  Keras to interface it with Scikit-Learn. SciKeras is the successor
+  of `tf.keras.wrappers.scikit_learn`.
+
 **Auto-ML**
 
 - `auto-sklearn <https://github.com/automl/auto-sklearn/>`_


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The scikit-learn wrappers are definitely deprecated in tensorflow (see comment in [tensorflow#37201](https://github.com/tensorflow/tensorflow/pull/37201#issuecomment-669996101)).
They are now maintained in an autonomous project [scikeras](https://github.com/adriangb/scikeras).

I have added scikeras to the "related projects" page in the documentation.

#### Any other comments?
I couldn't find a better solution than adding it in 'data format'... :( I'm open to suggestions.