### PR TITLE
[DOC] Clarify the docstring of dict learning about the inits

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -487,10 +487,12 @@ def dict_learning(X, n_components, *, alpha, max_iter=100, tol=1e-8,
         for more details.
 
     dict_init : ndarray of shape (n_components, n_features), default=None
-        Initial value for the dictionary for warm restart scenarios.
+        Initial value for the dictionary for warm restart scenarios. Only used
+        if `code_init` is not None.
 
     code_init : ndarray of shape (n_samples, n_components), default=None
-        Initial value for the sparse code for warm restart scenarios.
+        Initial value for the sparse code for warm restart scenarios. Only used
+        if `dict_init` is not None.
 
     callback : callable, default=None
         Callable that gets invoked every five iterations
@@ -1205,10 +1207,12 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
         for more details.
 
     code_init : ndarray of shape (n_samples, n_components), default=None
-        Initial value for the code, for warm restart.
+        Initial value for the code, for warm restart. Only used if `dict_init`
+        is not None.
 
     dict_init : ndarray of shape (n_components, n_features), default=None
-        Initial values for the dictionary, for warm restart.
+        Initial values for the dictionary, for warm restart. Only used if
+        `code_init` is not None.
 
     verbose : bool, default=False
         To control the verbosity of the procedure.

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -488,11 +488,11 @@ def dict_learning(X, n_components, *, alpha, max_iter=100, tol=1e-8,
 
     dict_init : ndarray of shape (n_components, n_features), default=None
         Initial value for the dictionary for warm restart scenarios. Only used
-        if `code_init` is not None.
+        if `code_init` and `dict_init` are not None.
 
     code_init : ndarray of shape (n_samples, n_components), default=None
         Initial value for the sparse code for warm restart scenarios. Only used
-        if `dict_init` is not None.
+        if `code_init` and `dict_init` are not None.
 
     callback : callable, default=None
         Callable that gets invoked every five iterations
@@ -1207,12 +1207,12 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
         for more details.
 
     code_init : ndarray of shape (n_samples, n_components), default=None
-        Initial value for the code, for warm restart. Only used if `dict_init`
-        is not None.
+        Initial value for the code, for warm restart. Only used if `code_init`
+        and `dict_init` are not None.
 
     dict_init : ndarray of shape (n_components, n_features), default=None
         Initial values for the dictionary, for warm restart. Only used if
-        `code_init` is not None.
+        `code_init` and `dict_init` are not None.
 
     verbose : bool, default=False
         To control the verbosity of the procedure.

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -55,11 +55,11 @@ class SparsePCA(TransformerMixin, BaseEstimator):
 
     U_init : ndarray of shape (n_samples, n_components), default=None
         Initial values for the loadings for warm restart scenarios. Only used
-        if `U_init` and `U_init` are not None.
+        if `U_init` and `V_init` are not None.
 
     V_init : ndarray of shape (n_components, n_features), default=None
         Initial values for the components for warm restart scenarios. Only used
-        if `U_init` and `U_init` are not None.
+        if `U_init` and `V_init` are not None.
 
     verbose : int or bool, default=False
         Controls the verbosity; the higher, the more messages. Defaults to 0.

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -55,11 +55,11 @@ class SparsePCA(TransformerMixin, BaseEstimator):
 
     U_init : ndarray of shape (n_samples, n_components), default=None
         Initial values for the loadings for warm restart scenarios. Only used
-        if `V_init` is not None.
+        if `U_init` and `U_init` are not None.
 
     V_init : ndarray of shape (n_components, n_features), default=None
         Initial values for the components for warm restart scenarios. Only used
-        if `U_init` is not None.
+        if `U_init` and `U_init` are not None.
 
     verbose : int or bool, default=False
         Controls the verbosity; the higher, the more messages. Defaults to 0.

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -54,10 +54,12 @@ class SparsePCA(TransformerMixin, BaseEstimator):
         for more details.
 
     U_init : ndarray of shape (n_samples, n_components), default=None
-        Initial values for the loadings for warm restart scenarios.
+        Initial values for the loadings for warm restart scenarios. Only used
+        if `V_init` is not None.
 
     V_init : ndarray of shape (n_components, n_features), default=None
-        Initial values for the components for warm restart scenarios.
+        Initial values for the components for warm restart scenarios. Only used
+        if `U_init` is not None.
 
     verbose : int or bool, default=False
         Controls the verbosity; the higher, the more messages. Defaults to 0.


### PR DESCRIPTION
Fixes #9081

The dict_init and code_init params are only used if both are provided.
SparsePCA uses dict_learning so it needs clarification too.