### PR TITLE
Fix misuse of self.partial_fit in Birch

### DIFF
--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -462,7 +462,7 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
 
     def _fit(self, X):
         has_root = getattr(self, 'root_', None)
-        first_call = self.fit_ or self.partial_fit and not has_root
+        first_call = self.fit_ or (self.partial_fit_ and not has_root)
 
         X = self._validate_data(X, accept_sparse='csr', copy=self.copy,
                                 reset=first_call)


### PR DESCRIPTION
It's a bug but the code was already working because self.partial_fit is the method of the class and always evaluates to True, so this change has no impact on the behavior.

I added parenthesis to make it clearer at first sight, but it's not necessary.