### PR TITLE
DOC Updates css consistent admonition styling

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -786,43 +786,44 @@ div.admonition p.admonition-title + p, div.deprecated p {
   display: inline;
 }
 
-div.admonition, div.deprecated {
+div.admonition, div.deprecated,
+div.versionchanged, div.versionadded{
+  margin-top: 0.5rem;
   padding: 0.5rem;
   border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
   border: 1px solid #ddd;
-  margin-bottom: 1rem;
 }
 
 div.admonition {
   background-color: #eee;
 }
 
-div.admonition p, div.admonition dl, div.admonition dd {
+div.admonition p, div.admonition dl, div.admonition dd,
+div.deprecated p, div.versionchanged p, div.versionadded p{
   margin-bottom: 0
 }
 
 div.deprecated {
   color: #b94a48;
   background-color: #F3E5E5;
-  border: 1px solid #eed3d7;
+  border-color: #eed3d7;
 }
 
 div.seealso {
   background-color: #FFFBE8;
-  border: 1px solid #fbeed5;
+  border-color: #fbeed5;
   color: #AF8A4B;
 }
 
 div.versionchanged {
-  margin-top: 0.5rem;
-  padding: 0.5rem;
   background-color: #FFFBE8;
-  border: 1px solid #fbeed5;
-  border-radius: 0.5rem;
+  border-color: #fbeed5;
 }
 
-div.versionchanged p {
-  margin-bottom: 0;
+div.versionadded {
+  background-color: #f0ffed;
+  border-color: #d4febc;
 }
 
 dt.label {

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -821,11 +821,6 @@ div.versionchanged {
   border-color: #fbeed5;
 }
 
-div.versionadded {
-  background-color: #f0ffed;
-  border-color: #d4febc;
-}
-
 dt.label {
   float: left;
   padding-right: 0.5rem;


### PR DESCRIPTION
This PR gives more style to `versionadded`:

![Screen Shot 2021-01-22 at 3 50 24 PM](https://user-images.githubusercontent.com/5402633/105545033-a157cd80-5cc9-11eb-92b3-666079a7d6a7.png)

Also some refactoring so all of these admonitions have the same rounded look.