### PR TITLE
FIX nan bug in BaseLabelPropagation

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -146,6 +146,13 @@ Changelog
   for non-English characters. :pr:`18959` by :user:`Zero <Zeroto521>`
   and :user:`wstates <wstates>`.
 
+:mod:`sklearn.semi_supervised`
+.................................
+
+- |Fix| Avoid NaN during label propagation in
+  :class:`~sklearn.semi_supervised.LabelPropagation`.
+  :pr:`19271` by :user:`Zhaowei Wang <ThuWangzw>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -278,6 +278,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             if self._variant == 'propagation':
                 normalizer = np.sum(
                     self.label_distributions_, axis=1)[:, np.newaxis]
+                normalizer[normalizer == 0] = 1
                 self.label_distributions_ /= normalizer
                 self.label_distributions_ = np.where(unlabeled,
                                                      self.label_distributions_,

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -167,7 +167,7 @@ def test_label_propagation_non_zero_normalizer(LabelPropagationCls):
     # https://github.com/scikit-learn/scikit-learn/issues/9292
     X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
     y = np.array([0, 1, -1, -1])
-    mdl = label_propagation_class(kernel='knn',
+    mdl = LabelPropagationCls(kernel='knn',
                                   max_iter=100,
                                   n_neighbors=1)
     assert_no_warnings(mdl.fit, X, y)

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -204,11 +204,12 @@ def test_predict_sparse_callable_kernel():
     model.fit(X_train, y_train)
     assert model.score(X_test, y_test) >= 0.9
 
+
 def test_label_propagation_non_zero_normalizer_during_iter():
     # https://github.com/scikit-learn/scikit-learn/pull/19271
     X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
     y = np.array([0, 1, -1, -1])
     mdl = label_propagation.LabelPropagation(kernel='knn',
-                                           max_iter=100,
-                                           n_neighbors=1)
+                                             max_iter=100,
+                                             n_neighbors=1)
     assert_no_warnings(mdl.fit, X, y)

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -157,15 +157,19 @@ def test_convergence_warning():
     assert_no_warnings(mdl.fit, X, y)
 
 
-def test_label_propagation_non_zero_normalizer():
+@pytest.mark.parametrize("label_propagation_class",
+                         [label_propagation.LabelSpreading,
+                          label_propagation.LabelPropagation])
+def test_label_propagation_non_zero_normalizer(label_propagation_class):
     # check that we don't divide by zero in case of null normalizer
     # non-regression test for
     # https://github.com/scikit-learn/scikit-learn/pull/15946
+    # https://github.com/scikit-learn/scikit-learn/pull/19271
     X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
     y = np.array([0, 1, -1, -1])
-    mdl = label_propagation.LabelSpreading(kernel='knn',
-                                           max_iter=100,
-                                           n_neighbors=1)
+    mdl = label_propagation_class(kernel='knn',
+                                  max_iter=100,
+                                  n_neighbors=1)
     assert_no_warnings(mdl.fit, X, y)
 
 
@@ -203,13 +207,3 @@ def test_predict_sparse_callable_kernel():
     model = label_propagation.LabelPropagation(kernel=topk_rbf)
     model.fit(X_train, y_train)
     assert model.score(X_test, y_test) >= 0.9
-
-
-def test_label_propagation_non_zero_normalizer_during_iter():
-    # https://github.com/scikit-learn/scikit-learn/pull/19271
-    X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
-    y = np.array([0, 1, -1, -1])
-    mdl = label_propagation.LabelPropagation(kernel='knn',
-                                             max_iter=100,
-                                             n_neighbors=1)
-    assert_no_warnings(mdl.fit, X, y)

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -157,7 +157,7 @@ def test_convergence_warning():
     assert_no_warnings(mdl.fit, X, y)
 
 
-@pytest.mark.parametrize("label_propagation_class",
+@pytest.mark.parametrize("LabelPropagationCls",
                          [label_propagation.LabelSpreading,
                           label_propagation.LabelPropagation])
 def test_label_propagation_non_zero_normalizer(LabelPropagationCls):

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -164,7 +164,7 @@ def test_label_propagation_non_zero_normalizer(LabelPropagationCls):
     # check that we don't divide by zero in case of null normalizer
     # non-regression test for
     # https://github.com/scikit-learn/scikit-learn/pull/15946
-    # https://github.com/scikit-learn/scikit-learn/pull/19271
+    # https://github.com/scikit-learn/scikit-learn/issues/9292
     X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
     y = np.array([0, 1, -1, -1])
     mdl = label_propagation_class(kernel='knn',

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -160,7 +160,7 @@ def test_convergence_warning():
 @pytest.mark.parametrize("label_propagation_class",
                          [label_propagation.LabelSpreading,
                           label_propagation.LabelPropagation])
-def test_label_propagation_non_zero_normalizer(label_propagation_class):
+def test_label_propagation_non_zero_normalizer(LabelPropagationCls):
     # check that we don't divide by zero in case of null normalizer
     # non-regression test for
     # https://github.com/scikit-learn/scikit-learn/pull/15946

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -167,9 +167,7 @@ def test_label_propagation_non_zero_normalizer(label_propagation_class):
     # https://github.com/scikit-learn/scikit-learn/pull/19271
     X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
     y = np.array([0, 1, -1, -1])
-    mdl = label_propagation_class(kernel='knn',
-                                  max_iter=100,
-                                  n_neighbors=1)
+    mdl = label_propagation_class(kernel='knn', max_iter=100, n_neighbors=1)
     assert_no_warnings(mdl.fit, X, y)
 
 

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -203,3 +203,12 @@ def test_predict_sparse_callable_kernel():
     model = label_propagation.LabelPropagation(kernel=topk_rbf)
     model.fit(X_train, y_train)
     assert model.score(X_test, y_test) >= 0.9
+
+def test_label_propagation_non_zero_normalizer_during_iter():
+    # https://github.com/scikit-learn/scikit-learn/pull/19271
+    X = np.array([[100., 100.], [100., 100.], [0., 0.], [0., 0.]])
+    y = np.array([0, 1, -1, -1])
+    mdl = label_propagation.LabelPropagation(kernel='knn',
+                                           max_iter=100,
+                                           n_neighbors=1)
+    assert_no_warnings(mdl.fit, X, y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #9292. 


#### What does this implement/fix? Explain your changes.
Label distribution of some samples may be all zero, which causes nan error during normalization. Add `normalizer[normalizer == 0] = 1` will fix this bug. 