### PR TITLE
Fix duplicate code on linear_model.rst

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -43,8 +43,6 @@ and will store the coefficients :math:`w` of the linear model in its
 
     >>> from sklearn import linear_model
     >>> reg = linear_model.LinearRegression()
-    >>> reg.fit ([[0, 0], [1, 1], [2, 2]], [0, 1, 2])
-    LinearRegression()
     >>> reg.fit([[0, 0], [1, 1], [2, 2]], [0, 1, 2])
     LinearRegression()
     >>> reg.coef_


### PR DESCRIPTION
#### Reference Issues/PRs

No PR found with this search keyword

```
is:open label:module:linear_model label:Documentation 
```

#### What does this implement/fix? Explain your changes.

Remove `.fit()` function called twice in example code in "Ordinary Least Squares" section