### PR TITLE
Elapsed step times for inference stage in Pipeline and FeatureUnion

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -74,9 +74,10 @@ class Pipeline(_BaseComposition):
         transformers is advantageous when fitting is time consuming.
 
     verbose : bool or int, default=False
-        If True or less than 10, the time elapsed while fitting each step will be printed as it
-        is completed.
-        If greater than or equal to 10,  the time elapsed while performing each step (fitting or inference)
+        If True or less than 10, the time elapsed while fitting
+        each step will be printed as it is completed.
+        If greater than or equal to 10,  the time elapsed
+        while performing each step (fitting or inference)
         will be printed as it is completed.
 
     Attributes
@@ -416,12 +417,15 @@ class Pipeline(_BaseComposition):
         y_pred : array-like
         """
         Xt = X
-        for idx, name, transform in self._iter(with_final=False, filter_passthrough=False):
-            with _print_elapsed_time('Pipeline', self._log_message(idx, False)):
+        for idx, name, transform in self._iter(with_final=False,
+                                               filter_passthrough=False):
+            with _print_elapsed_time('Pipeline',
+                                     self._log_message(idx, False)):
                 if (transform is None or transform == 'passthrough'):
                     continue
                 Xt = transform.transform(Xt)
-        with _print_elapsed_time('Pipeline', self._log_message(len(self.steps) - 1, False)):
+        with _print_elapsed_time('Pipeline',
+                                 self._log_message(len(self.steps) - 1, False)):
             y_pred = self.steps[-1][-1].predict(Xt, **predict_params)
         return y_pred
 
@@ -456,7 +460,8 @@ class Pipeline(_BaseComposition):
         Xt = self._fit(X, y, **fit_params_steps)
 
         fit_params_last_step = fit_params_steps[self.steps[-1][0]]
-        with _print_elapsed_time('Pipeline', self._log_message(len(self.steps) - 1, True)):
+        with _print_elapsed_time(
+                'Pipeline', self._log_message(len(self.steps) - 1, True)):
             y_pred = self.steps[-1][-1].fit_predict(Xt, y,
                                                     **fit_params_last_step)
         return y_pred
@@ -477,9 +482,11 @@ class Pipeline(_BaseComposition):
         """
         Xt = X
         for idx, name, transform in self._iter(with_final=False):
-            with _print_elapsed_time('Pipeline', self._log_message(idx, False)):
+            with _print_elapsed_time(
+                    'Pipeline', self._log_message(idx, False)):
                 Xt = transform.transform(Xt)
-        with _print_elapsed_time('Pipeline', self._log_message(len(self.steps) - 1, False)):
+        with _print_elapsed_time(
+                'Pipeline', self._log_message(len(self.steps) - 1, False)):
             y_proba = self.steps[-1][-1].predict_proba(Xt)
         return y_proba
 
@@ -499,9 +506,11 @@ class Pipeline(_BaseComposition):
         """
         Xt = X
         for idx, name, transform in self._iter(with_final=False):
-            with _print_elapsed_time('Pipeline', self._log_message(idx, False)):
+            with _print_elapsed_time('Pipeline',
+                                     self._log_message(idx, False)):
                 Xt = transform.transform(Xt)
-        with _print_elapsed_time('Pipeline', self._log_message(len(self.steps) - 1, False)):
+        with _print_elapsed_time(
+                'Pipeline', self._log_message(len(self.steps) - 1, False)):
             y_score = self.steps[-1][-1].decision_function(Xt)
         return y_score
 
@@ -521,9 +530,11 @@ class Pipeline(_BaseComposition):
         """
         Xt = X
         for idx, _, transformer in self._iter(with_final=False):
-            with _print_elapsed_time('Pipeline', self._log_message(idx, False)):
+            with _print_elapsed_time('Pipeline',
+                                     self._log_message(idx, False)):
                 Xt = transformer.transform(Xt)
-        with _print_elapsed_time('Pipeline', self._log_message(len(self.steps) - 1, False)):
+        with _print_elapsed_time(
+                'Pipeline', self._log_message(len(self.steps) - 1, False)):
             y_score = self.steps[-1][-1].score_samples(Xt)
         return y_score
 
@@ -543,9 +554,11 @@ class Pipeline(_BaseComposition):
         """
         Xt = X
         for idx, name, transform in self._iter(with_final=False):
-            with _print_elapsed_time('Pipeline', self._log_message(idx, False)):
+            with _print_elapsed_time('Pipeline',
+                                     self._log_message(idx, False)):
                 Xt = transform.transform(Xt)
-        with _print_elapsed_time('Pipeline', self._log_message(len(self.steps) - 1, False)):
+        with _print_elapsed_time(
+                'Pipeline', self._log_message(len(self.steps) - 1, False)):
             y_score = self.steps[-1][-1].predict_log_proba(Xt)
         return y_score
 
@@ -575,7 +588,8 @@ class Pipeline(_BaseComposition):
     def _transform(self, X):
         Xt = X
         for idx, _, transform in self._iter(filter_passthrough=False):
-            with _print_elapsed_time('Pipeline', self._log_message(idx, False)):
+            with _print_elapsed_time('Pipeline',
+                                     self._log_message(idx, False)):
                 if (transform is None or transform == 'passthrough'):
                     continue
                 Xt = transform.transform(Xt)
@@ -636,13 +650,15 @@ class Pipeline(_BaseComposition):
         """
         Xt = X
         for idx, name, transform in self._iter(with_final=False):
-            with _print_elapsed_time('Pipeline', self._log_message(idx, False)):
+            with _print_elapsed_time('Pipeline',
+                                     self._log_message(idx, False)):
                 Xt = transform.transform(Xt)
         score_params = {}
         if sample_weight is not None:
             score_params['sample_weight'] = sample_weight
 
-        with _print_elapsed_time('Pipeline', self._log_message(len(self.steps) - 1, False)):
+        with _print_elapsed_time(
+                'Pipeline', self._log_message(len(self.steps) - 1, False)):
             score = self.steps[-1][-1].score(Xt, y, **score_params)
         return score
 
@@ -731,9 +747,10 @@ def make_pipeline(*steps, memory=None, verbose=False):
         transformers is advantageous when fitting is time consuming.
 
     verbose : bool or int, default=False
-        If True or less than 10, the time elapsed while fitting each step will be printed as it
-        is completed.
-        If greater than or equal to 10,  the time elapsed while performing each step (fitting or inference)
+        If True or less than 10, the time elapsed while fitting
+        each step will be printed as it is completed.
+        If greater than or equal to 10, the time elapsed
+        while performing each step (fitting or inference)
         will be printed as it is completed.
 
     See Also

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -239,7 +239,7 @@ class Pipeline(_BaseComposition):
         estimator = self.steps[-1][1]
         return 'passthrough' if estimator is None else estimator
 
-    def _log_message(self, step_idx, is_fitting):
+    def _log_message(self, step_idx, is_fitting=True):
         if not self.verbose or (self.verbose < 10 and not is_fitting):
             return None
         name, _ = self.steps[step_idx]

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -424,8 +424,8 @@ class Pipeline(_BaseComposition):
                 if (transform is None or transform == 'passthrough'):
                     continue
                 Xt = transform.transform(Xt)
-        with _print_elapsed_time('Pipeline',
-                                 self._log_message(len(self.steps) - 1, False)):
+        with _print_elapsed_time(
+                'Pipeline', self._log_message(len(self.steps) - 1, False)):
             y_pred = self.steps[-1][-1].predict(Xt, **predict_params)
         return y_pred
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1021,7 +1021,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
 
         return self._hstack(Xs)
 
-    def _log_message(self, name, idx, total, is_fitting):
+    def _log_message(self, name, idx, total, is_fitting=True):
         if not self.verbose or (self.verbose < 10 and not is_fitting):
             return None
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1011,7 +1011,8 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
             hstack of results of transformers. sum_n_components is the
             sum of n_components (output dimension) over transformers.
         """
-        results = self._parallel_func(X, y, fit_params, _fit_transform_one, True)
+        results = self._parallel_func(X, y, fit_params,
+                                      _fit_transform_one, True)
         if not results:
             # All transformers are None
             return np.zeros((X.shape[0], 0))
@@ -1037,7 +1038,8 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         return Parallel(n_jobs=self.n_jobs)(delayed(func)(
             transformer, X, y, weight,
             message_clsname='FeatureUnion',
-            message=self._log_message(name, idx, len(transformers), is_fitting),
+            message=self._log_message(name, idx,
+                                      len(transformers), is_fitting),
             **fit_params) for idx, (name, transformer,
                                     weight) in enumerate(transformers, 1))
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1157,7 +1157,7 @@ parameter_grid_test_verbose = ((est, pattern, method) for
       r'\[FeatureUnion\].*\(step 2 of 2\) Processing mult2.* total=.*\n$'),
      (FeatureUnion([('mult1', 'drop'), ('mult2', Mult()), ('mult3', 'drop')]),
       r'\[FeatureUnion\].*\(step 1 of 1\) Processing mult2.* total=.*\n$')
-    ], ['fit', 'fit_transform', 'fit_predict'])
+    ], ['fit', 'fit_transform', 'fit_predict', 'transform', 'predict'])
     if hasattr(est, method) and not (
         method == 'fit_transform' and hasattr(est, 'steps') and
         isinstance(est.steps[-1][1], FitParamT))
@@ -1172,11 +1172,26 @@ def test_verbose(est, method, pattern, capsys):
     y = [[7], [8]]
 
     est.set_params(verbose=False)
-    func(X, y)
+    if method in ['transform', 'predict']:
+        est.fit(X, y)
+        func(X)
+    else:
+        func(X, y)
     assert not capsys.readouterr().out, 'Got output for verbose=False'
 
     est.set_params(verbose=True)
-    func(X, y)
+    if method in ['transform', 'predict']:
+        func(X)
+        assert not capsys.readouterr().out, 'Got output for verbose=False'
+    else:
+        func(X, y)
+        assert re.match(pattern, capsys.readouterr().out)
+
+    est.set_params(verbose=10)
+    if method in ['transform', 'predict']:
+        func(X)
+    else:
+        func(X, y)
     assert re.match(pattern, capsys.readouterr().out)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/issues/19291



#### What does this implement/fix? Explain your changes.

Hello!

I think possibility to print elapsed time for steps on inference stage can be useful. Previously it was possible only for fitting stage. Now when parameter `verbose` is greater than or equal to 10 logs will be printed for both fitting and inference stages.

