### PR TITLE
CLN Fixes PendingDeprecationWarning in CountVectorizer

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -773,17 +773,29 @@ def test_vectorizer_inverse_transform(Vectorizer):
     vectorizer = Vectorizer()
     transformed_data = vectorizer.fit_transform(data)
     inversed_data = vectorizer.inverse_transform(transformed_data)
+    assert isinstance(inversed_data, list)
+
     analyze = vectorizer.build_analyzer()
     for doc, inversed_terms in zip(data, inversed_data):
         terms = np.sort(np.unique(analyze(doc)))
         inversed_terms = np.sort(np.unique(inversed_terms))
         assert_array_equal(terms, inversed_terms)
 
-    # Test that inverse_transform also works with numpy arrays
-    transformed_data = transformed_data.toarray()
-    inversed_data2 = vectorizer.inverse_transform(transformed_data)
+    assert sparse.issparse(transformed_data)
+    assert transformed_data.format == "csr"
+
+    # Test that inverse_transform also works with numpy arrays and
+    # scipy
+    transformed_data2 = transformed_data.toarray()
+    inversed_data2 = vectorizer.inverse_transform(transformed_data2)
     for terms, terms2 in zip(inversed_data, inversed_data2):
         assert_array_equal(np.sort(terms), np.sort(terms2))
+
+    # Check that inverse_transform also works on non CSR sparse data:
+    transformed_data3 = transformed_data.tocsc()
+    inversed_data3 = vectorizer.inverse_transform(transformed_data3)
+    for terms, terms3 in zip(inversed_data, inversed_data3):
+        assert_array_equal(np.sort(terms), np.sort(terms3))
 
 
 def test_count_vectorizer_pipeline_grid_selection():

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1274,17 +1274,23 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         if sp.issparse(X):
             # We need CSR format for fast row manipulations.
             X = X.tocsr()
+
+            def get_non_zero(i):
+                return X[i, :].nonzero()[1]
         else:
             # We need to convert X to a matrix, so that the indexing
             # returns 2D objects
-            X = np.asmatrix(X)
+            X = np.asarray(X)
+
+            def get_non_zero(i):
+                return np.flatnonzero(X[i, :])
         n_samples = X.shape[0]
 
         terms = np.array(list(self.vocabulary_.keys()))
         indices = np.array(list(self.vocabulary_.values()))
         inverse_vocabulary = terms[np.argsort(indices)]
 
-        return [inverse_vocabulary[X[i, :].nonzero()[1]].ravel()
+        return [inverse_vocabulary[get_non_zero(i)].ravel()
                 for i in range(n_samples)]
 
     def get_feature_names(self):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1270,28 +1270,20 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
             List of arrays of terms.
         """
         self._check_vocabulary()
-
-        if sp.issparse(X):
-            # We need CSR format for fast row manipulations.
-            X = X.tocsr()
-
-            def get_non_zero(i):
-                return X[i, :].nonzero()[1]
-        else:
-            # We need to convert X to a matrix, so that the indexing
-            # returns 2D objects
-            X = np.asarray(X)
-
-            def get_non_zero(i):
-                return np.flatnonzero(X[i, :])
+        # We need CSR format for fast row manipulations.
+        X = check_array(X, accept_sparse='csr')
         n_samples = X.shape[0]
 
         terms = np.array(list(self.vocabulary_.keys()))
         indices = np.array(list(self.vocabulary_.values()))
         inverse_vocabulary = terms[np.argsort(indices)]
 
-        return [inverse_vocabulary[get_non_zero(i)].ravel()
-                for i in range(n_samples)]
+        if sp.issparse(X):
+            return [inverse_vocabulary[X[i, :].nonzero()[1]].ravel()
+                    for i in range(n_samples)]
+        else:
+            return [inverse_vocabulary[np.flatnonzero(X[i, :])].ravel()
+                    for i in range(n_samples)]
 
     def get_feature_names(self):
         """Array mapping from feature integer indices to feature name.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Address a part of https://github.com/scikit-learn/scikit-learn/issues/12327

#### What does this implement/fix? Explain your changes.
Removes the use of `np.matrix` in `CountVectorizer.inverse_transform` 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
