### PR TITLE
TST Filter out warning for pyamg using deprecated behavior

### DIFF
--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -196,6 +196,9 @@ def test_discretize(n_samples):
 # https://github.com/scikit-learn/scikit-learn/issues/15913
 @pytest.mark.filterwarnings(
     "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")
+# TODO: Remove when pyamg removes the use of np.float
+@pytest.mark.filterwarnings(
+    "ignore:`np.float` is a deprecated alias:DeprecationWarning:pyamg.*")
 def test_spectral_clustering_with_arpack_amg_solvers():
     # Test that spectral_clustering is the same for arpack and amg solver
     # Based on toy example from plot_segmentation_toy.py

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -181,6 +181,9 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
 # https://github.com/scikit-learn/scikit-learn/issues/15913
 @pytest.mark.filterwarnings(
     "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")
+# TODO: Remove when pyamg removes the use of np.float
+@pytest.mark.filterwarnings(
+    "ignore:`np.float` is a deprecated alias:DeprecationWarning:pyamg.*")
 def test_spectral_embedding_amg_solver(seed=36):
     # Test spectral embedding with amg solver
     pytest.importorskip('pyamg')
@@ -211,11 +214,13 @@ def test_spectral_embedding_amg_solver(seed=36):
     _assert_equal_with_sign_flipping(embed_amg, embed_arpack, 1e-5)
 
 
-# TODO: Remove filterwarnings when pyamg does replaces sp.rand call with
-# np.random.rand:
+# TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
 # https://github.com/scikit-learn/scikit-learn/issues/15913
 @pytest.mark.filterwarnings(
     "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")
+# TODO: Remove when pyamg removes the use of np.float
+@pytest.mark.filterwarnings(
+    "ignore:`np.float` is a deprecated alias:DeprecationWarning:pyamg.*")
 def test_spectral_embedding_amg_solver_failure():
     # Non-regression test for amg solver failure (issue #13393 on github)
     pytest.importorskip('pyamg')

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -214,7 +214,8 @@ def test_spectral_embedding_amg_solver(seed=36):
     _assert_equal_with_sign_flipping(embed_amg, embed_arpack, 1e-5)
 
 
-# TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
+# TODO: Remove filterwarnings when pyamg does replaces sp.rand call with
+# np.random.rand:
 # https://github.com/scikit-learn/scikit-learn/issues/15913
 @pytest.mark.filterwarnings(
     "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*")


### PR DESCRIPTION
These tests are failing on main because pyamg is using `np.float`.

I opened https://github.com/pyamg/pyamg/pull/264 to remove the usage of `np.float`.