### PR TITLE
Fix min_pos when all negative + speed up

### DIFF
--- a/sklearn/utils/arrayfuncs.pyx
+++ b/sklearn/utils/arrayfuncs.pyx
@@ -19,8 +19,7 @@ np.import_array()
 
 
 def min_pos(np.ndarray X):
-    """
-    Find the minimum value of an array over positive values
+    """Find the minimum value of an array over positive values
 
     Returns the maximum representable value of the input dtype if none of the
     values are positive.

--- a/sklearn/utils/arrayfuncs.pyx
+++ b/sklearn/utils/arrayfuncs.pyx
@@ -19,27 +19,27 @@ np.import_array()
 
 
 def min_pos(np.ndarray X):
-   """
-   Find the minimum value of an array over positive values
+    """
+    Find the minimum value of an array over positive values
 
-   Returns the maximum representable value of the input dtype if none of the
-   values are positive.
-   """
-   if X.dtype == np.float32:
-      return _min_pos[float](<float *> X.data, X.size)
-   elif X.dtype == np.float64:
-      return _min_pos[double](<double *> X.data, X.size)
-   else:
-      raise ValueError('Unsupported dtype for array X')
+    Returns the maximum representable value of the input dtype if none of the
+    values are positive.
+    """
+    if X.dtype == np.float32:
+        return _min_pos[float](<float *> X.data, X.size)
+    elif X.dtype == np.float64:
+        return _min_pos[double](<double *> X.data, X.size)
+    else:
+        raise ValueError('Unsupported dtype for array X')
 
 
 cdef floating _min_pos(floating* X, Py_ssize_t size):
-   cdef Py_ssize_t i
-   cdef floating min_val = FLT_MAX if floating is float else DBL_MAX
-   for i in range(size):
-      if 0. < X[i] < min_val:
-         min_val = X[i]
-   return min_val
+    cdef Py_ssize_t i
+    cdef floating min_val = FLT_MAX if floating is float else DBL_MAX
+    for i in range(size):
+        if 0. < X[i] < min_val:
+            min_val = X[i]
+    return min_val
 
 
 # General Cholesky Delete.

--- a/sklearn/utils/arrayfuncs.pyx
+++ b/sklearn/utils/arrayfuncs.pyx
@@ -18,27 +18,28 @@ ctypedef np.float64_t DOUBLE
 np.import_array()
 
 
-def min_pos(np.ndarray X): 
-   """ 
-   Find the minimum value of an array over positive values 
- 
-   Returns a huge value if none of the values are positive 
-   """ 
-   if X.dtype == np.float32: 
-      return _min_pos[float](<float *> X.data, X.size) 
-   elif X.dtype == np.float64: 
-      return _min_pos[double](<double *> X.data, X.size) 
-   else: 
-      raise ValueError('Unsupported dtype for array X') 
+def min_pos(np.ndarray X):
+   """
+   Find the minimum value of an array over positive values
+
+   Returns the maximum representable value of the input dtype if none of the
+   values are positive.
+   """
+   if X.dtype == np.float32:
+      return _min_pos[float](<float *> X.data, X.size)
+   elif X.dtype == np.float64:
+      return _min_pos[double](<double *> X.data, X.size)
+   else:
+      raise ValueError('Unsupported dtype for array X')
 
 
-cdef floating _min_pos(floating* X, Py_ssize_t size): 
-   cdef Py_ssize_t i 
-   cdef floating min_val = FLT_MAX if floating is float else DBL_MAX 
-   for i in range(size): 
-      if 0. < X[i] < min_val: 
-         min_val = X[i] 
-   return min_val 
+cdef floating _min_pos(floating* X, Py_ssize_t size):
+   cdef Py_ssize_t i
+   cdef floating min_val = FLT_MAX if floating is float else DBL_MAX
+   for i in range(size):
+      if 0. < X[i] < min_val:
+         min_val = X[i]
+   return min_val
 
 
 # General Cholesky Delete.

--- a/sklearn/utils/arrayfuncs.pyx
+++ b/sklearn/utils/arrayfuncs.pyx
@@ -18,36 +18,27 @@ ctypedef np.float64_t DOUBLE
 np.import_array()
 
 
-def min_pos(np.ndarray X):
-   """
-   Find the minimum value of an array over positive values
-
-   Returns a huge value if none of the values are positive
-   """
-   if X.dtype.name == 'float32':
-      return _float_min_pos(<float *> X.data, X.size)
-   elif X.dtype.name == 'float64':
-      return _double_min_pos(<double *> X.data, X.size)
-   else:
-      raise ValueError('Unsupported dtype for array X')
-
-
-cdef float _float_min_pos(float *X, Py_ssize_t size):
-   cdef Py_ssize_t i
-   cdef float min_val = DBL_MAX
-   for i in range(size):
-      if 0. < X[i] < min_val:
-         min_val = X[i]
-   return min_val
+def min_pos(np.ndarray X): 
+   """ 
+   Find the minimum value of an array over positive values 
+ 
+   Returns a huge value if none of the values are positive 
+   """ 
+   if X.dtype == np.float32: 
+      return _min_pos[float](<float *> X.data, X.size) 
+   elif X.dtype == np.float64: 
+      return _min_pos[double](<double *> X.data, X.size) 
+   else: 
+      raise ValueError('Unsupported dtype for array X') 
 
 
-cdef double _double_min_pos(double *X, Py_ssize_t size):
-   cdef Py_ssize_t i
-   cdef np.float64_t min_val = FLT_MAX
-   for i in range(size):
-      if 0. < X[i] < min_val:
-         min_val = X[i]
-   return min_val
+cdef floating _min_pos(floating* X, Py_ssize_t size): 
+   cdef Py_ssize_t i 
+   cdef floating min_val = FLT_MAX if floating is float else DBL_MAX 
+   for i in range(size): 
+      if 0. < X[i] < min_val: 
+         min_val = X[i] 
+   return min_val 
 
 
 # General Cholesky Delete.

--- a/sklearn/utils/tests/test_arrayfuncs.py
+++ b/sklearn/utils/tests/test_arrayfuncs.py
@@ -20,7 +20,7 @@ def test_min_pos():
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_min_pos_no_positive(dtype):
     # Check that the return value of min_pos is the maximum representable
-    # value of the input dtype
+    # value of the input dtype when all input elements are <= 0
     X = np.full(100, -1.).astype(dtype, copy=False)
 
     assert min_pos(X) == np.finfo(dtype).max

--- a/sklearn/utils/tests/test_arrayfuncs.py
+++ b/sklearn/utils/tests/test_arrayfuncs.py
@@ -1,0 +1,26 @@
+import pytest
+import numpy as np
+
+from sklearn.utils._testing import assert_allclose
+from sklearn.utils.arrayfuncs import min_pos
+
+
+def test_min_pos():
+    # Check that min_pos returns a positive value and that it's consistent
+    # between float and double
+    X = np.random.RandomState(0).randn(100)
+
+    min_double = min_pos(X)
+    min_float = min_pos(X.astype(np.float32))
+
+    assert_allclose(min_double, min_float)
+    assert min_double >= 0
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_min_pos_no_positive(dtype):
+    # Check that the return value of min_pos is the maximum representable
+    # value of the input dtype
+    X = np.full(100, -1.).astype(dtype, copy=False)
+
+    assert min_pos(X) == np.finfo(dtype).max

--- a/sklearn/utils/tests/test_arrayfuncs.py
+++ b/sklearn/utils/tests/test_arrayfuncs.py
@@ -20,7 +20,7 @@ def test_min_pos():
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_min_pos_no_positive(dtype):
     # Check that the return value of min_pos is the maximum representable
-    # value of the input dtype when all input elements are <= 0
+    # value of the input dtype when all input elements are <= 0 (#19328)
     X = np.full(100, -1.).astype(dtype, copy=False)
 
     assert min_pos(X) == np.finfo(dtype).max


### PR DESCRIPTION
When all input elements are <= 0, min_pos returns the max float (resp. double) if input is float (resp.double). However, the max values are switched and it's actually returning the max double for float input and the max float for double input. Unlikely that it already cause an error in practice but that would have been a sneaky bug :)
I added a test that fails on main. I also added a generic test since the function was not tested at all.

I took the opportunity to fuse type the function.

I also noticed that the call to X.dtype.name is not free, whereas X.dtype is. When the inputs are rather small arrays, for instance in dict_learning they have shape ~ (n_components,), the computation can be completely dominated by the name finding:
```
X = np.random.RandomState(0).randn(100)                                                                                                                        

# main
%timeit min_pos(X)                                                                                                                                             
5.9 µs ± 35.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

# pr
%timeit min_pos(X)                                                                                                                                              
297 ns ± 2.41 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```
Turns out it was taking a significant proportion of the time spent in the sparse coding.