### PR TITLE
Fix johnson_lindestrauss_min_dim return type

### DIFF
--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -129,7 +129,7 @@ def johnson_lindenstrauss_min_dim(n_samples, *, eps=0.1):
             % n_samples)
 
     denominator = (eps ** 2 / 2) - (eps ** 3 / 3)
-    return (4 * np.log(n_samples) / denominator).astype(int)
+    return (4 * np.log(n_samples) / denominator).astype(np.int64)
 
 
 def _check_density(density, n_features):

--- a/sklearn/tests/test_random_projection.py
+++ b/sklearn/tests/test_random_projection.py
@@ -77,6 +77,10 @@ def test_input_size_jl_min_dim():
                                   eps=np.full((10, 10), 0.5))
 
 
+def test_overflow_jl_min_dim():
+    assert 368416070986 == johnson_lindenstrauss_min_dim(100, eps=0.00001)
+
+
 ###############################################################################
 # tests random matrix generation
 ###############################################################################


### PR DESCRIPTION
As per #17111, on some systems, the return of
johnson_lindenstrauss_min_dim can overflow. This commit modifies
the function's return type to be int64, and adds a test.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #17111. Building off of PR #17249.

#### What does this implement/fix? Explain your changes.
On certain systems the return value from `johnson_lindenstrauss_min_dim` 
can overflow. This PR changes the return value to `np.int64` to avoid
these issues, and adds a unit test.

#### Any other comments?
I'm not too sure if I should have put the unit test under one of the existing
test functions or made a new one as I have done, so some guidance here
would be nice.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
