### PR TITLE
DOC rename Birch to BIRCH in docs

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -103,7 +103,7 @@ Overview of clustering methods
      - Flat geometry, good for density estimation
      - Mahalanobis distances to  centers
 
-   * - :ref:`Birch`
+   * - :ref:`BIRCH <birch>`
      - branching factor, threshold, optional global clusterer.
      - Large ``n_clusters`` and ``n_samples``
      - Large dataset, outlier removal, data reduction.
@@ -943,7 +943,7 @@ represented as children of a larger parent cluster.
 
 .. _birch:
 
-Birch
+BIRCH
 =====
 
 The :class:`Birch` builds a tree called the Clustering Feature Tree (CFT)
@@ -962,7 +962,7 @@ the need to hold the entire input data in memory. This information includes:
 - Centroids - To avoid recalculation linear sum / n_samples.
 - Squared norm of the centroids.
 
-The Birch algorithm has two parameters, the threshold and the branching factor.
+The BIRCH algorithm has two parameters, the threshold and the branching factor.
 The branching factor limits the number of subclusters in a node and the
 threshold limits the distance between the entering sample and the existing
 subclusters.
@@ -996,13 +996,13 @@ clusters (labels) and the samples are mapped to the global label of the nearest 
   then this node is again split into two and the process is continued
   recursively, till it reaches the root.
 
-**Birch or MiniBatchKMeans?**
+**BIRCH or MiniBatchKMeans?**
 
- - Birch does not scale very well to high dimensional data. As a rule of thumb if
+ - BIRCH does not scale very well to high dimensional data. As a rule of thumb if
    ``n_features`` is greater than twenty, it is generally better to use MiniBatchKMeans.
  - If the number of instances of data needs to be reduced, or if one wants a
    large number of subclusters either as a preprocessing step or otherwise,
-   Birch is more useful than MiniBatchKMeans.
+   BIRCH is more useful than MiniBatchKMeans.
 
 
 **How to use partial_fit?**

--- a/examples/cluster/plot_birch_vs_minibatchkmeans.py
+++ b/examples/cluster/plot_birch_vs_minibatchkmeans.py
@@ -36,7 +36,7 @@ xx, yy = np.meshgrid(xx, yy)
 n_centres = np.hstack((np.ravel(xx)[:, np.newaxis],
                        np.ravel(yy)[:, np.newaxis]))
 
-# Generate blobs to do a comparison between MiniBatchKMeans and Birch.
+# Generate blobs to do a comparison between MiniBatchKMeans and BIRCH.
 X, y = make_blobs(n_samples=100000, centers=n_centres, random_state=0)
 
 # Use all colors that matplotlib provides by default.
@@ -45,7 +45,7 @@ colors_ = cycle(colors.cnames.keys())
 fig = plt.figure(figsize=(12, 4))
 fig.subplots_adjust(left=0.04, right=0.98, bottom=0.1, top=0.9)
 
-# Compute clustering with Birch with and without the final clustering step
+# Compute clustering with BIRCH with and without the final clustering step
 # and plot.
 birch_models = [Birch(threshold=1.7, n_clusters=None),
                 Birch(threshold=1.7, n_clusters=100)]
@@ -55,7 +55,7 @@ for ind, (birch_model, info) in enumerate(zip(birch_models, final_step)):
     t = time()
     birch_model.fit(X)
     time_ = time() - t
-    print("Birch %s as the final step took %0.2f seconds" % (
+    print("BIRCH %s as the final step took %0.2f seconds" % (
           info, (time() - t)))
 
     # Plot result
@@ -75,7 +75,7 @@ for ind, (birch_model, info) in enumerate(zip(birch_models, final_step)):
     ax.set_ylim([-25, 25])
     ax.set_xlim([-25, 25])
     ax.set_autoscaley_on(False)
-    ax.set_title('Birch %s' % info)
+    ax.set_title('BIRCH %s' % info)
 
 # Compute clustering with MiniBatchKMeans.
 mbk = MiniBatchKMeans(init='k-means++', n_clusters=100, batch_size=100,

--- a/examples/cluster/plot_birch_vs_minibatchkmeans.py
+++ b/examples/cluster/plot_birch_vs_minibatchkmeans.py
@@ -3,7 +3,7 @@
 Compare BIRCH and MiniBatchKMeans
 =================================
 
-This example compares the timing of Birch (with and without the global
+This example compares the timing of BIRCH (with and without the global
 clustering step) and MiniBatchKMeans on a synthetic dataset having
 100,000 samples and 2 features generated using make_blobs.
 

--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -143,7 +143,7 @@ for i_dataset, (dataset, algo_params) in enumerate(datasets):
         ('AgglomerativeClustering', average_linkage),
         ('DBSCAN', dbscan),
         ('OPTICS', optics),
-        ('Birch', birch),
+        ('BIRCH', birch),
         ('GaussianMixture', gmm)
     )
 

--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -333,7 +333,7 @@ class _CFSubcluster:
 
 
 class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
-    """Implements the Birch clustering algorithm.
+    """Implements the BIRCH clustering algorithm.
 
     It is a memory-efficient, online-learning algorithm provided as an
     alternative to :class:`MiniBatchKMeans`. It constructs a tree
@@ -674,7 +674,7 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
             self.subcluster_labels_ = np.arange(len(centroids))
             if not_enough_centroids:
                 warnings.warn(
-                    "Number of subclusters found (%d) by Birch is less "
+                    "Number of subclusters found (%d) by BIRCH is less "
                     "than (%d). Decrease the threshold."
                     % (len(centroids), self.n_clusters), ConvergenceWarning)
         else:


### PR DESCRIPTION
Fixes #19248.

Rename Birch to BIRCH in user guide documentation