### PR TITLE
TST Suppress multiple active versions of dataset warnings in `test_openml.py`

### DIFF
--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -797,6 +797,9 @@ def test_decode_iris(monkeypatch):
     _test_features_list(data_id)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Multiple active versions of the dataset matching the name"
+)
 @pytest.mark.parametrize('gzip_response', [True, False])
 def test_fetch_openml_iris_multitarget(monkeypatch, gzip_response):
     # classification dataset with numeric only columns
@@ -816,6 +819,9 @@ def test_fetch_openml_iris_multitarget(monkeypatch, gzip_response):
                                compare_default_target=False)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Multiple active versions of the dataset matching the name"
+)
 @pytest.mark.parametrize('gzip_response', [True, False])
 def test_fetch_openml_anneal(monkeypatch, gzip_response):
     # classification dataset with numeric and categorical columns
@@ -841,6 +847,9 @@ def test_decode_anneal(monkeypatch):
     _test_features_list(data_id)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Multiple active versions of the dataset matching the name"
+)
 @pytest.mark.parametrize('gzip_response', [True, False])
 def test_fetch_openml_anneal_multitarget(monkeypatch, gzip_response):
     # classification dataset with numeric and categorical columns
@@ -860,6 +869,9 @@ def test_fetch_openml_anneal_multitarget(monkeypatch, gzip_response):
                                compare_default_target=False)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Multiple active versions of the dataset matching the name"
+)
 @pytest.mark.parametrize('gzip_response', [True, False])
 def test_fetch_openml_cpu(monkeypatch, gzip_response):
     # regression dataset with numeric and categorical columns

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -778,7 +778,8 @@ def test_fetch_openml_iris(monkeypatch, gzip_response):
         " iris exist. Versions may be fundamentally different, "
         "returning version 1.",
         fetch_openml,
-        name=data_name
+        name=data_name,
+        as_frame=False
     )
 
 

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -3,14 +3,14 @@
 import gzip
 import warnings
 import json
-import numpy as np
 import os
 import re
+from io import BytesIO
+
+import numpy as np
 import scipy.sparse
 import sklearn
 import pytest
-
-from io import BytesIO
 from sklearn import config_context
 from sklearn.datasets import fetch_openml
 from sklearn.datasets._openml import (_open_openml_url,


### PR DESCRIPTION
#### Reference Issues/PRs
References #19349 

#### What does this implement/fix? Explain your changes.
Suppresses `UserWarning: Multiple active versions of the dataset ... exist` warnings, based on @glemaitre's recommendation.

#### Any other comments?
Two other UserWarnings still remain. 

```
UserWarning: Version 1 of dataset Australian is inactive, meaning that issues have been found in the dataset.
```
These stem from the call to fetch the Australian dataset in lines and 511 and 531.
