### PR TITLE
Fixes divide by zero error thrown by _random_choice_csc during a test…

### DIFF
--- a/sklearn/utils/tests/test_random.py
+++ b/sklearn/utils/tests/test_random.py
@@ -109,7 +109,7 @@ def test_random_choice_csc(n_samples=10000, random_state=24):
     class_probabilities = [np.array([0.5, 0.5]), np.array([0.6, 0.1, 0.3])]
 
     got = _random_choice_csc(n_samples, classes, class_probabilities,
-                            random_state)
+                             random_state)
     assert sp.issparse(got)
 
     for k in range(len(classes)):
@@ -121,8 +121,8 @@ def test_random_choice_csc(n_samples=10000, random_state=24):
     class_probabilities = [np.array([0.5, 0.5]), np.array([0, 1/2, 1/2])]
 
     got = _random_choice_csc(n_samples=n_samples,
-                            classes=classes,
-                            random_state=random_state)
+                             classes=classes,
+                             random_state=random_state)
     assert sp.issparse(got)
 
     for k in range(len(classes)):
@@ -131,10 +131,10 @@ def test_random_choice_csc(n_samples=10000, random_state=24):
 
     # Edge case probabilities 1.0 and 0.0
     classes = [np.array([0, 1]),  np.array([0, 1, 2])]
-    class_probabilities = [np.array([1.0, 0.0]), np.array([0.0, 1.0, 0.0])]
+    class_probabilities = [np.array([0.0, 1.0]), np.array([0.0, 1.0, 0.0])]
 
     got = _random_choice_csc(n_samples, classes, class_probabilities,
-                            random_state)
+                             random_state)
     assert sp.issparse(got)
 
     for k in range(len(classes)):
@@ -147,8 +147,8 @@ def test_random_choice_csc(n_samples=10000, random_state=24):
     class_probabilities = [np.array([0.0, 1.0]), np.array([1.0])]
 
     got = _random_choice_csc(n_samples=n_samples,
-                            classes=classes,
-                            random_state=random_state)
+                             classes=classes,
+                             random_state=random_state)
     assert sp.issparse(got)
 
     for k in range(len(classes)):


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #19334 

#### What does this implement/fix? Explain your changes.
The runtime error was cause by an incorrect order between classes and class probabilities set during the test run. The referenced function in random.py is fine.