### PR TITLE
Removing the matplotlib decorated yticks in examples/inspection/plot_permutation_importance_multicollinear.py

### DIFF
--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -25,6 +25,7 @@ can mitigate those limitations.
 """
 print(__doc__)
 import matplotlib.pyplot as plt
+from matplotlib.ticker import FixedLocator
 import numpy as np
 
 from sklearn.datasets import fetch_openml
@@ -130,8 +131,8 @@ sorted_idx = tree_feature_importances.argsort()
 y_ticks = np.arange(0, len(feature_names))
 fig, ax = plt.subplots()
 ax.barh(y_ticks, tree_feature_importances[sorted_idx])
+ax.yaxis.set_major_locator(FixedLocator(y_ticks))
 ax.set_yticklabels(feature_names[sorted_idx])
-ax.set_yticks(y_ticks)
 ax.set_title("Random Forest Feature Importances (MDI)")
 fig.tight_layout()
 plt.show()

--- a/examples/inspection/plot_permutation_importance_multicollinear.py
+++ b/examples/inspection/plot_permutation_importance_multicollinear.py
@@ -60,7 +60,8 @@ tree_indices = np.arange(0, len(clf.feature_importances_)) + 0.5
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 8))
 ax1.barh(tree_indices,
          clf.feature_importances_[tree_importance_sorted_idx], height=0.7)
-
+ax1.set_yticks(tree_indices)
+ax1.set_yticklabels(data.feature_names[tree_importance_sorted_idx])
 ax1.set_ylim((0, len(clf.feature_importances_)))
 ax2.boxplot(result.importances[perm_sorted_idx].T, vert=False,
             labels=data.feature_names[perm_sorted_idx])

--- a/examples/inspection/plot_permutation_importance_multicollinear.py
+++ b/examples/inspection/plot_permutation_importance_multicollinear.py
@@ -20,6 +20,7 @@ print(__doc__)
 from collections import defaultdict
 
 import matplotlib.pyplot as plt
+from matplotlib.ticker import FixedLocator
 import numpy as np
 from scipy.stats import spearmanr
 from scipy.cluster import hierarchy
@@ -60,7 +61,7 @@ tree_indices = np.arange(0, len(clf.feature_importances_)) + 0.5
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 8))
 ax1.barh(tree_indices,
          clf.feature_importances_[tree_importance_sorted_idx], height=0.7)
-ax1.set_yticks(tree_indices)
+ax1.yaxis.set_major_locator(FixedLocator(tree_indices))
 ax1.set_yticklabels(data.feature_names[tree_importance_sorted_idx])
 ax1.set_ylim((0, len(clf.feature_importances_)))
 ax2.boxplot(result.importances[perm_sorted_idx].T, vert=False,

--- a/examples/inspection/plot_permutation_importance_multicollinear.py
+++ b/examples/inspection/plot_permutation_importance_multicollinear.py
@@ -60,8 +60,7 @@ tree_indices = np.arange(0, len(clf.feature_importances_)) + 0.5
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 8))
 ax1.barh(tree_indices,
          clf.feature_importances_[tree_importance_sorted_idx], height=0.7)
-ax1.set_yticklabels(data.feature_names[tree_importance_sorted_idx])
-ax1.set_yticks(tree_indices)
+
 ax1.set_ylim((0, len(clf.feature_importances_)))
 ax2.boxplot(result.importances[perm_sorted_idx].T, vert=False,
             labels=data.feature_names[perm_sorted_idx])


### PR DESCRIPTION
#### Reference Issues/PRs
References #19364 


#### What does this implement/fix? Explain your changes.
I re-organized decorated yticks to stop the code from generating error so it can display the ylabels properly

#### Any other comments?
cc: (pair programming) @Rukaya-lab
