### PR TITLE
Fix: RuntimeWarning by dividing by zero in test_radius_neighbors_classifier_zero_distance

### DIFF
--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -23,7 +23,6 @@ from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_raises_regex
 from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_warns_message
-from sklearn.utils._testing import assert_no_warnings
 from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils.validation import check_random_state

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -66,7 +66,7 @@ def _weight_func(dist):
     # Dist could be multidimensional, flatten it so all values
     # can be looped
     with np.errstate(divide='ignore'):
-        retval = 1. / (dist + 1e-8)
+        retval = 1. / dist
     return retval ** 2
 
 
@@ -602,8 +602,8 @@ def test_radius_neighbors_classifier_zero_distance():
                                                       weights=weights,
                                                       algorithm=algorithm)
             clf.fit(X, y)
-            assert_array_equal(correct_labels1,
-                               assert_no_warnings(clf.predict, z1))
+            with np.errstate(invalid="ignore"):
+                assert_array_equal(correct_labels1, clf.predict(z1))
 
 
 def test_neighbors_regressors_zero_distance():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -65,7 +65,7 @@ def _weight_func(dist):
     # Dist could be multidimensional, flatten it so all values
     # can be looped
     with np.errstate(divide='ignore'):
-        retval = 1. / dist
+        retval = 1. / (dist + 1e-8)
     return retval ** 2
 
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -23,6 +23,7 @@ from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_raises_regex
 from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_warns_message
+from sklearn.utils._testing import assert_no_warnings
 from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils.validation import check_random_state
@@ -601,7 +602,8 @@ def test_radius_neighbors_classifier_zero_distance():
                                                       weights=weights,
                                                       algorithm=algorithm)
             clf.fit(X, y)
-            assert_array_equal(correct_labels1, clf.predict(z1))
+            assert_array_equal(correct_labels1,
+                               assert_no_warnings(clf.predict, z1))
 
 
 def test_neighbors_regressors_zero_distance():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -602,6 +602,8 @@ def test_radius_neighbors_classifier_zero_distance():
                                                       algorithm=algorithm)
             clf.fit(X, y)
             with np.errstate(invalid="ignore"):
+                # Ignore the warning raised in _weight_func when making
+                # predictions with null distances resulting in np.inf values.
                 assert_array_equal(correct_labels1, clf.predict(z1))
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

#19334 

#### What does this implement/fix? Explain your changes.

The runtime error is caused by `_weight_func` function which will be passed to `neighbors.RadiusNeighborsClassifier`.
The `dist` value becomes zero in this test, and this makes the returned value `inf`.
So, I added small value `1e-8` to denominator to avoid small value division.