### PR TITLE
FIX RuntimeWarning by dividing by zero in test_kernel_gradient

### DIFF
--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1689,7 +1689,6 @@ class Matern(RBF):
                 denominator = np.sqrt(D.sum(2))[:, :, np.newaxis]
                 K_gradient = K[..., np.newaxis] * \
                     np.divide(D, denominator, where=denominator != 0)
-                K_gradient[~np.isfinite(K_gradient)] = 0
             elif self.nu == 1.5:
                 K_gradient = \
                     3 * D * np.exp(-np.sqrt(3 * D.sum(-1)))[..., np.newaxis]

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1687,8 +1687,7 @@ class Matern(RBF):
 
             if self.nu == 0.5:
                 denominator = np.sqrt(D.sum(2))[:, :, np.newaxis]
-                denominator[denominator == 0.0] = 1e-8
-                K_gradient = K[..., np.newaxis] * D / denominator
+                K_gradient = K[..., np.newaxis] * np.divide(D, denominator, where=denominator != 0)
                 K_gradient[~np.isfinite(K_gradient)] = 0
             elif self.nu == 1.5:
                 K_gradient = \

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1687,7 +1687,8 @@ class Matern(RBF):
 
             if self.nu == 0.5:
                 denominator = np.sqrt(D.sum(2))[:, :, np.newaxis]
-                K_gradient = K[..., np.newaxis] * np.divide(D, denominator, where=denominator != 0)
+                K_gradient = K[..., np.newaxis] * \
+                    np.divide(D, denominator, where=denominator != 0)
                 K_gradient[~np.isfinite(K_gradient)] = 0
             elif self.nu == 1.5:
                 K_gradient = \

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1686,8 +1686,9 @@ class Matern(RBF):
                 D = squareform(dists**2)[:, :, np.newaxis]
 
             if self.nu == 0.5:
-                K_gradient = K[..., np.newaxis] * D \
-                    / np.sqrt(D.sum(2))[:, :, np.newaxis]
+                denominator = np.sqrt(D.sum(2))[:, :, np.newaxis]
+                denominator[denominator==0.0] = 1e-8
+                K_gradient = K[..., np.newaxis] * D / denominator
                 K_gradient[~np.isfinite(K_gradient)] = 0
             elif self.nu == 1.5:
                 K_gradient = \

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1687,7 +1687,7 @@ class Matern(RBF):
 
             if self.nu == 0.5:
                 denominator = np.sqrt(D.sum(2))[:, :, np.newaxis]
-                denominator[denominator==0.0] = 1e-8
+                denominator[denominator == 0.0] = 1e-8
                 K_gradient = K[..., np.newaxis] * D / denominator
                 K_gradient[~np.isfinite(K_gradient)] = 0
             elif self.nu == 1.5:

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1686,7 +1686,7 @@ class Matern(RBF):
                 D = squareform(dists**2)[:, :, np.newaxis]
 
             if self.nu == 0.5:
-                denominator = np.sqrt(D.sum(2))[:, :, np.newaxis]
+                denominator = np.sqrt(D.sum(axis=2))[:, :, np.newaxis]
                 K_gradient = K[..., np.newaxis] * \
                     np.divide(D, denominator, where=denominator != 0)
             elif self.nu == 1.5:

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -20,7 +20,6 @@ from sklearn.base import clone
 from sklearn.utils._testing import (assert_almost_equal, assert_array_equal,
                                     assert_array_almost_equal,
                                     assert_allclose,
-                                    assert_no_warnings,
                                     assert_raise_message)
 
 
@@ -53,7 +52,7 @@ for metric in PAIRWISE_KERNEL_FUNCTIONS:
 @pytest.mark.parametrize('kernel', kernels)
 def test_kernel_gradient(kernel):
     # Compare analytic and numeric gradient of kernels.
-    K, K_gradient = assert_no_warnings(kernel, X, eval_gradient=True)
+    K, K_gradient = kernel(X, eval_gradient=True)
 
     assert K_gradient.shape[0] == X.shape[0]
     assert K_gradient.shape[1] == X.shape[0]

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -19,7 +19,8 @@ from sklearn.base import clone
 
 from sklearn.utils._testing import (assert_almost_equal, assert_array_equal,
                                     assert_array_almost_equal,
-                                    assert_allclose, assert_no_warnings,
+                                    assert_allclose,
+                                    assert_no_warnings,
                                     assert_raise_message)
 
 

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -19,7 +19,7 @@ from sklearn.base import clone
 
 from sklearn.utils._testing import (assert_almost_equal, assert_array_equal,
                                     assert_array_almost_equal,
-                                    assert_allclose,
+                                    assert_allclose, assert_no_warnings,
                                     assert_raise_message)
 
 
@@ -51,8 +51,10 @@ for metric in PAIRWISE_KERNEL_FUNCTIONS:
 
 @pytest.mark.parametrize('kernel', kernels)
 def test_kernel_gradient(kernel):
+    def create_kernel(kernel, X):
+        return kernel(X, eval_gradient=True)
     # Compare analytic and numeric gradient of kernels.
-    K, K_gradient = kernel(X, eval_gradient=True)
+    K, K_gradient = assert_no_warnings(create_kernel, kernel, X)
 
     assert K_gradient.shape[0] == X.shape[0]
     assert K_gradient.shape[1] == X.shape[0]

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -52,8 +52,6 @@ for metric in PAIRWISE_KERNEL_FUNCTIONS:
 
 @pytest.mark.parametrize('kernel', kernels)
 def test_kernel_gradient(kernel):
-    def create_kernel(kernel, X):
-        return kernel(X, eval_gradient=True)
     # Compare analytic and numeric gradient of kernels.
     K, K_gradient = assert_no_warnings(kernel, X, eval_gradient=True)
 

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -55,7 +55,7 @@ def test_kernel_gradient(kernel):
     def create_kernel(kernel, X):
         return kernel(X, eval_gradient=True)
     # Compare analytic and numeric gradient of kernels.
-    K, K_gradient = assert_no_warnings(create_kernel, kernel, X)
+    K, K_gradient = assert_no_warnings(kernel, X, eval_gradient=True)
 
     assert K_gradient.shape[0] == X.shape[0]
     assert K_gradient.shape[1] == X.shape[0]


### PR DESCRIPTION
#### Reference Issues/PRs

#19334 

#### What does this implement/fix? Explain your changes.

The runtime error is caused by `Matern::__call__` function.
The error will be raised when `D` has a zero element.
So, I added small value `1e-8` to `np.sqrt(D.sum(2))[:, :, np.newaxis]` before dividing `K[..., np.newaxis]`  by it.
Because `K[..., np.newaxis] * D` will be zero, I think above tweaking is no problem.