### PR TITLE
[DEBUG] TST check sparse dense equivalence in KMeans

### DIFF
--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1108,7 +1108,7 @@ def test_xxx():
     X_class = _safe_indexing(X, target_class_indices)
     X_class_sparse = sp.csr_matrix(X_class)
 
-    kmeans = KMeans(n_clusters=201, algorithm="full", random_state=0)
+    kmeans = KMeans(n_clusters=201, n_init=1, algorithm="full", random_state=0)
 
     kmeans_dense = clone(kmeans).fit(X_class)
     kmeans_sparse = clone(kmeans).fit(X_class_sparse)


### PR DESCRIPTION
It seems to be an example where dense is not equivalent to sparse.

Related to an issue found in imbalanced-learn: https://github.com/scikit-learn-contrib/imbalanced-learn/pull/788