### PR TITLE
ASV specify main branch

### DIFF
--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -30,7 +30,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master
     // (for git) or "default" (for mercurial).
-    // "branches": ["main"], // for git
+    "branches": ["main"],
     // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically
@@ -73,7 +73,7 @@
     //
     "matrix": {
         "numpy": [],
-	    "scipy": [],
+        "scipy": [],
         "cython": [],
         "joblib": [],
         "threadpoolctl": []


### PR DESCRIPTION
The benchmarks (https://github.com/scikit-learn/scikit-learn-benchmarks) have not been published since we renamed master.

Even if we run the benchmarks on a specific commit, we still need to tell asv which branch it is for the html generation.