### PR TITLE
ENH Allow multiple scorers input to permutation_importance

### DIFF
--- a/doc/modules/permutation_importance.rst
+++ b/doc/modules/permutation_importance.rst
@@ -16,6 +16,16 @@ indicative of how much the model depends on the feature. This technique
 benefits from being model agnostic and can be calculated many times with
 different permutations of the feature.
 
+.. warning::
+
+  Features that are deemed of **low importance for a bad model** (low
+  cross-validation score) could be **very important for a good model**.
+  Therefore it is always important to evaluate the predictive power of a model
+  using a held-out set (or better with cross-validation) prior to computing
+  importances. Permutation importance does not reflect to the intrinsic
+  predictive value of a feature by itself but **how important this feature is
+  for a particular model**.
+
 The :func:`permutation_importance` function calculates the feature importance
 of :term:`estimators` for a given dataset. The ``n_repeats`` parameter sets the
 number of times a feature is randomly shuffled and returns a sample of feature
@@ -64,15 +74,43 @@ highlight which features contribute the most to the generalization power of the
 inspected model. Features that are important on the training set but not on the
 held-out set might cause the model to overfit.
 
-.. warning::
+The permutation feature importance is the decrease in a model score when a single
+feature value is randomly shuffled. The score function to be used for the
+computation of importances can be specified with the `scoring` argument,
+which also accepts multiple scorers. Using multiple scorers is more computationally
+efficient than sequentially calling :func:`permutation_importance` several times
+with a different scorer, as it reuses model predictions.
+Different metrics might lead to significantly different feature importances.
+An example of using multiple scorers is shown below, employing a list of metrics,
+but more input formats are possible, as documented in
+`multimetric-scoring <https://scikit-learn.org/stable/modules/model_evaluation.html#multimetric-scoring>`_.
 
-  Features that are deemed of **low importance for a bad model** (low
-  cross-validation score) could be **very important for a good model**.
-  Therefore it is always important to evaluate the predictive power of a model
-  using a held-out set (or better with cross-validation) prior to computing
-  importances. Permutation importance does not reflect to the intrinsic
-  predictive value of a feature by itself but **how important this feature is
-  for a particular model**.
+  >>> scoring = ['r2', 'neg_mean_absolute_percentage_error', 'explained_variance']
+  >>> r_multi = permutation_importance(model, X_val, y_val, n_repeats=30, random_state=0, scoring=scoring)
+  ...
+  >>> for metric in r_multi:
+  ...     print(f"{metric}")
+  ...     r = r_multi[metric]
+  ...     for i in r.importances_mean.argsort()[::-1]:
+  ...         if r.importances_mean[i] - 2 * r.importances_std[i] > 0:
+  ...             print(f"    {diabetes.feature_names[i]:<8}"
+  ...             f"{r.importances_mean[i]:.3f}"
+  ...             f" +/- {r.importances_std[i]:.3f}")
+  ...
+  r2
+      s5      0.204 +/- 0.050
+      bmi     0.176 +/- 0.048
+      bp      0.088 +/- 0.033
+      sex     0.056 +/- 0.023
+  neg_mean_absolute_percentage_error
+      s5      0.081 +/- 0.020
+      bmi     0.064 +/- 0.015
+      bp      0.029 +/- 0.010
+  explained_variance
+      s5      0.204 +/- 0.050
+      bmi     0.176 +/- 0.048
+      bp      0.088 +/- 0.033
+      sex     0.056 +/- 0.023
 
 Outline of the permutation importance algorithm
 -----------------------------------------------

--- a/doc/modules/permutation_importance.rst
+++ b/doc/modules/permutation_importance.rst
@@ -86,7 +86,8 @@ but more input formats are possible, as documented in
 `multimetric-scoring <https://scikit-learn.org/stable/modules/model_evaluation.html#multimetric-scoring>`_.
 
   >>> scoring = ['r2', 'neg_mean_absolute_percentage_error', 'explained_variance']
-  >>> r_multi = permutation_importance(model, X_val, y_val, n_repeats=30, random_state=0, scoring=scoring)
+  >>> r_multi = permutation_importance(
+  ...     model, X_val, y_val, n_repeats=30, random_state=0, scoring=scoring)
   ...
   >>> for metric in r_multi:
   ...     print(f"{metric}")

--- a/doc/modules/permutation_importance.rst
+++ b/doc/modules/permutation_importance.rst
@@ -80,11 +80,7 @@ computation of importances can be specified with the `scoring` argument,
 which also accepts multiple scorers. Using multiple scorers is more computationally
 efficient than sequentially calling :func:`permutation_importance` several times
 with a different scorer, as it reuses model predictions.
-The ranking of the features is approximately the same for different metrics even
-if the scales of the importance values are very different. However, this is not
-guaranteed and different metrics might lead to significantly different feature
-importances, in particular for models trained for imbalanced classification problems,
-for which the choice of the classification metric can be critical.
+
 An example of using multiple scorers is shown below, employing a list of metrics,
 but more input formats are possible, as documented in :ref:`multimetric_scoring`.
 
@@ -115,6 +111,12 @@ but more input formats are possible, as documented in :ref:`multimetric_scoring`
     bmi     872.694 +/- 240.296
     bp      438.681 +/- 163.025
     sex     277.382 +/- 115.126
+
+The ranking of the features is approximately the same for different metrics even
+if the scales of the importance values are very different. However, this is not
+guaranteed and different metrics might lead to significantly different feature
+importances, in particular for models trained for imbalanced classification problems,
+for which the choice of the classification metric can be critical.
 
 Outline of the permutation importance algorithm
 -----------------------------------------------

--- a/doc/modules/permutation_importance.rst
+++ b/doc/modules/permutation_importance.rst
@@ -94,8 +94,8 @@ but more input formats are possible, as documented in :ref:`multimetric_scoring`
   ...     for i in r.importances_mean.argsort()[::-1]:
   ...         if r.importances_mean[i] - 2 * r.importances_std[i] > 0:
   ...             print(f"    {diabetes.feature_names[i]:<8}"
-  ...             f"{r.importances_mean[i]:.3f}"
-  ...             f" +/- {r.importances_std[i]:.3f}")
+  ...                   f"{r.importances_mean[i]:.3f}"
+  ...                   f" +/- {r.importances_std[i]:.3f}")
   ...
   r2
     s5      0.204 +/- 0.050

--- a/doc/modules/permutation_importance.rst
+++ b/doc/modules/permutation_importance.rst
@@ -80,12 +80,15 @@ computation of importances can be specified with the `scoring` argument,
 which also accepts multiple scorers. Using multiple scorers is more computationally
 efficient than sequentially calling :func:`permutation_importance` several times
 with a different scorer, as it reuses model predictions.
-Different metrics might lead to significantly different feature importances.
+The ranking of the features is approximately the same for different metrics even
+if the scales of the importance values are very different. However, this is not
+guaranteed and different metrics might lead to significantly different feature
+importances, in particular for models trained for imbalanced classification problems,
+for which the choice of the classification metric can be critical.
 An example of using multiple scorers is shown below, employing a list of metrics,
-but more input formats are possible, as documented in
-`multimetric-scoring <https://scikit-learn.org/stable/modules/model_evaluation.html#multimetric-scoring>`_.
+but more input formats are possible, as documented in :ref:`multimetric_scoring`.
 
-  >>> scoring = ['r2', 'neg_mean_absolute_percentage_error', 'explained_variance']
+  >>> scoring = ['r2', 'neg_mean_absolute_percentage_error', 'neg_mean_squared_error']
   >>> r_multi = permutation_importance(
   ...     model, X_val, y_val, n_repeats=30, random_state=0, scoring=scoring)
   ...
@@ -99,19 +102,19 @@ but more input formats are possible, as documented in
   ...             f" +/- {r.importances_std[i]:.3f}")
   ...
   r2
-      s5      0.204 +/- 0.050
-      bmi     0.176 +/- 0.048
-      bp      0.088 +/- 0.033
-      sex     0.056 +/- 0.023
+    s5      0.204 +/- 0.050
+    bmi     0.176 +/- 0.048
+    bp      0.088 +/- 0.033
+    sex     0.056 +/- 0.023
   neg_mean_absolute_percentage_error
-      s5      0.081 +/- 0.020
-      bmi     0.064 +/- 0.015
-      bp      0.029 +/- 0.010
-  explained_variance
-      s5      0.204 +/- 0.050
-      bmi     0.176 +/- 0.048
-      bp      0.088 +/- 0.033
-      sex     0.056 +/- 0.023
+    s5      0.081 +/- 0.020
+    bmi     0.064 +/- 0.015
+    bp      0.029 +/- 0.010
+  neg_mean_squared_error
+    s5      1013.903 +/- 246.460
+    bmi     872.694 +/- 240.296
+    bp      438.681 +/- 163.025
+    sex     277.382 +/- 115.126
 
 Outline of the permutation importance algorithm
 -----------------------------------------------

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -180,6 +180,13 @@ Changelog
   `Thomas Fan`_ and :user:`Amanda Dsouza <amy12xx>` and
   :user:`EL-ATEIF Sara <elateifsara>`.
 
+:mod:`sklearn.inspection`
+.................................
+
+- |Fix| Allow multiple scorers input to
+  :func:`~sklearn.inspection.permutation_importance`.
+  :pr:`19411` by :user:`Simona Maggio <simonamaggio>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -103,7 +103,7 @@ Changelog
   :pr:`19035` by :user:`Liu Yu <ly648499246>`.
 
 :mod:`sklearn.inspection`
-.................................
+.........................
 
 - |Fix| Allow multiple scorers input to
   :func:`~sklearn.inspection.permutation_importance`.

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -196,7 +196,9 @@ def permutation_importance(estimator, X, y, *, scoring=None, n_repeats=5,
     random_state = check_random_state(random_state)
     random_seed = random_state.randint(np.iinfo(np.int32).max + 1)
 
-    if scoring is None or isinstance(scoring, str) or callable(scoring):
+    if callable(scoring):
+        scorer = scoring
+    elif scoring is None or isinstance(scoring, str):
         scorer = check_scoring(estimator, scoring=scoring)
     else:
         scorers_dict = _check_multimetric_scoring(estimator, scoring)

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -54,6 +54,7 @@ def _calculate_permutation_scores(estimator, X, y, sample_weight, col_idx,
 
     return scores
 
+
 def _create_importances_bunch(baseline_score, score):
     """Create output importances Bunch."""
     importances = baseline_score - np.array(score)

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -177,7 +177,7 @@ def permutation_importance(estimator, X, y, *, scoring=None, n_repeats=5,
     else:
         scorers = _check_multimetric_scoring(estimator, scoring)
         ret = dict()
-        for name, scorer in scorers:
+        for name, scorer in scorers.items():
             baseline_score = _weights_scorer(scorer, estimator, X, y,
                                              sample_weight)
 

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -191,10 +191,13 @@ def permutation_importance(estimator, X, y, *, scoring=None, n_repeats=5,
         ) for col_idx in range(X.shape[1]))
 
     if isinstance(baseline_score, dict):
-        ret = dict()
-        for name in baseline_score:
-            score = [scores[col_idx][name] for col_idx in range(X.shape[1])]
-            ret[name] = _create_importances_bunch(baseline_score[name], score)
-        return ret
+        return {
+            name: _create_importances_bunch(
+                baseline_score[name],
+                # unpack the permuted scores
+                [scores[col_idx][name] for col_idx in range(X.shape[1])]
+            )
+            for name in baseline_score
+        }
     else:
-        return _create_importances_bunch(baseline_score, score)
+        return _create_importances_bunch(baseline_score, scores)

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -122,7 +122,7 @@ def permutation_importance(estimator, X, y, *, scoring=None, n_repeats=5,
 
     Returns
     -------
-    result : :class:`~sklearn.utils.Bunch`
+    result : :class:`~sklearn.utils.Bunch` or dict
         Dictionary-like object, with the following attributes.
 
         importances_mean : ndarray, shape (n_features, )

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -124,7 +124,7 @@ def permutation_importance(estimator, X, y, *, scoring=None, n_repeats=5,
 
         Passing multiple scores to `scoring` is more efficient than calling
         `permutation_importance` for each of the scores as it reuses
-        predictions by avoiding redundant computation.
+        predictions to avoid redundant computation.
 
         If None, the estimator's default scorer is used.
 

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -129,14 +129,14 @@ def permutation_importance(estimator, X, y, *, scoring=None, n_repeats=5,
 
     Returns
     -------
-    result : :class:`~sklearn.utils.Bunch` or dict
+    result : :class:`~sklearn.utils.Bunch` or dict of such instances
         Dictionary-like object, with the following attributes.
 
-        importances_mean : ndarray, shape (n_features, )
+        importances_mean : ndarray of shape (n_features, )
             Mean of feature importance over `n_repeats`.
-        importances_std : ndarray, shape (n_features, )
+        importances_std : ndarray of shape (n_features, )
             Standard deviation over `n_repeats`.
-        importances : ndarray, shape (n_features, n_repeats)
+        importances : ndarray of shape (n_features, n_repeats)
             Raw permutation importance scores.
 
         If there are multiple scoring metrics in the scoring parameter

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -162,8 +162,8 @@ def permutation_importance(estimator, X, y, *, scoring=None, n_repeats=5,
             Raw permutation importance scores.
 
         If there are multiple scoring metrics in the scoring parameter
-        result is a dict with scorer names as keys (i.e., ``auc``) and
-        dictionary-like object like above as values.
+        `result` is a dict with scorer names as keys (e.g. 'roc_auc') and
+        `Bunch` objects like above as values.
 
     References
     ----------

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -55,9 +55,28 @@ def _calculate_permutation_scores(estimator, X, y, sample_weight, col_idx,
     return scores
 
 
-def _create_importances_bunch(baseline_score, score):
-    """Create output importances Bunch."""
-    importances = baseline_score - np.array(score)
+def _create_importances_bunch(baseline_score, permuted_score):
+    """Compute the importances as the decrease in score.
+
+    Parameters
+    ----------
+    baseline_score : ndarray of shape (n_features,)
+        The baseline score without permutation.
+    permuted_score : ndarray of shape (n_features, n_repeats)
+        The permuted scores for the `n` repetitions.
+
+    Returns
+    -------
+    importances : :class:`~sklearn.utils.Bunch`
+        Dictionary-like object, with the following attributes.
+        importances_mean : ndarray, shape (n_features, )
+            Mean of feature importance over `n_repeats`.
+        importances_std : ndarray, shape (n_features, )
+            Standard deviation over `n_repeats`.
+        importances : ndarray, shape (n_features, n_repeats)
+            Raw permutation importance scores.
+    """
+    importances = baseline_score - permuted_score
     return Bunch(importances_mean=np.mean(importances, axis=1),
                  importances_std=np.std(importances, axis=1),
                  importances=importances)
@@ -195,9 +214,10 @@ def permutation_importance(estimator, X, y, *, scoring=None, n_repeats=5,
             name: _create_importances_bunch(
                 baseline_score[name],
                 # unpack the permuted scores
-                [scores[col_idx][name] for col_idx in range(X.shape[1])]
+                np.array([scores[col_idx][name]
+                         for col_idx in range(X.shape[1])])
             )
             for name in baseline_score
         }
     else:
-        return _create_importances_bunch(baseline_score, scores)
+        return _create_importances_bunch(baseline_score, np.array(scores))

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -124,6 +124,10 @@ def permutation_importance(estimator, X, y, *, scoring=None, n_repeats=5,
           names and the values are the metric scores;
         - a dictionary with metric names as keys and callables a values.
 
+        Passing multiple scores to `scoring` is more efficient than calling
+        `permutation_importance` for each of the scores as it reuses
+        predictions by avoiding redundant computation.
+
         If None, the estimator's default scorer is used.
 
     n_repeats : int, default=5

--- a/sklearn/inspection/tests/test_permutation_importance.py
+++ b/sklearn/inspection/tests/test_permutation_importance.py
@@ -16,6 +16,11 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.impute import SimpleImputer
 from sklearn.inspection import permutation_importance
 from sklearn.model_selection import train_test_split
+from sklearn.metrics import (
+    get_scorer,
+    mean_squared_error,
+    r2_score,
+)
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.preprocessing import OneHotEncoder
@@ -23,8 +28,6 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.preprocessing import scale
 from sklearn.utils import parallel_backend
 from sklearn.utils._testing import _convert_container
-from sklearn.metrics import get_scorer
-
 
 
 @pytest.mark.parametrize("n_jobs", [1, 2])
@@ -438,27 +441,44 @@ def test_permutation_importance_no_weights_scoring_function():
                                sample_weight=w)
 
 
-@pytest.mark.parametrize("input_scorers", [
-    ["r2", "neg_mean_squared_error"],
-    {
-        "r2": get_scorer("r2"),
-        "neg_mean_squared_error": get_scorer("neg_mean_squared_error")
-    }])
-def test_permutation_importance_multi_metric(input_scorers):
+@pytest.mark.parametrize(
+    "list_single_scorer, multi_scorer",
+    [
+        (["r2", "neg_mean_squared_error"], ["r2", "neg_mean_squared_error"]),
+        (
+            ["r2", "neg_mean_squared_error"],
+            {
+                "r2": get_scorer("r2"),
+                "neg_mean_squared_error": get_scorer("neg_mean_squared_error"),
+            },
+        ),
+        (
+            ["r2", "neg_mean_squared_error"],
+            lambda estimator, X, y: {
+                "r2": r2_score(y, estimator.predict(X)),
+                "neg_mean_squared_error": -mean_squared_error(
+                    y, estimator.predict(X)
+                ),
+            },
+        ),
+    ],
+)
+def test_permutation_importance_multi_metric(list_single_scorer, multi_scorer):
     # Test permutation importance when scoring contains multiple scorers
 
     # Creating some data and estimator for the permutation test
     x, y = make_regression(n_samples=500, n_features=10, random_state=0)
     lr = LinearRegression().fit(x, y)
 
-    multi_importance = permutation_importance(lr, x, y, random_state=1,
-                                              scoring=input_scorers,
-                                              n_repeats=1)
+    multi_importance = permutation_importance(
+        lr, x, y, random_state=1, scoring=multi_scorer, n_repeats=2
+    )
+    assert set(multi_importance.keys()) == set(list_single_scorer)
 
-    for scorer in input_scorers:
+    for scorer in list_single_scorer:
         multi_result = multi_importance[scorer]
-        single_result = permutation_importance(lr, x, y, random_state=1,
-                                               scoring=scorer,
-                                               n_repeats=1)
+        single_result = permutation_importance(
+            lr, x, y, random_state=1, scoring=scorer, n_repeats=2
+        )
 
         assert_allclose(multi_result.importances, single_result.importances)

--- a/sklearn/inspection/tests/test_permutation_importance.py
+++ b/sklearn/inspection/tests/test_permutation_importance.py
@@ -461,5 +461,4 @@ def test_permutation_importance_multi_metric(input_scorers):
                                                scoring=scorer,
                                                n_repeats=1)
 
-        assert_allclose(multi_result.importances, single_result.importances,
-                        rtol=1e-1, atol=1e-6)
+        assert_allclose(multi_result.importances, single_result.importances)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Fixes #18701

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Input argument `scoring` can be a list, tuple or dict with multiple metrics.
The permutation feature importance is computed iteratively for the different metrics and 
the result is a dict with `metric_name:Bunch`containing the feature importances, mean and std for each of the requested input metrics.
