### PR TITLE
DOC Explicitly remove support for `precompute='auto'` for Lasso

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -939,12 +939,11 @@ class Lasso(ElasticNet):
         :class:`~sklearn.preprocessing.StandardScaler` before calling ``fit``
         on an estimator with ``normalize=False``.
 
-    precompute : 'auto', bool or array-like of shape (n_features, n_features),\
+    precompute : bool or array-like of shape (n_features, n_features),\
                  default=False
         Whether to use a precomputed Gram matrix to speed up
-        calculations. If set to ``'auto'`` let us decide. The Gram
-        matrix can also be passed as argument. For sparse input
-        this option is always ``False`` to preserve sparsity.
+        calculations. The Gram matrix can also be passed as argument.
+        For sparse input this option is always ``False`` to preserve sparsity.
 
     copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -813,9 +813,11 @@ def test_precompute_invalid_argument():
         assert_raises_regex(ValueError, ".*should be.*True.*False.*auto.*"
                             "array-like.*Got 'invalid'", clf.fit, X, y)
 
-    # Precompute = 'auto' is not supported for ElasticNet
+    # Precompute = 'auto' is not supported for ElasticNet and Lasso
     assert_raises_regex(ValueError, ".*should be.*True.*False.*array-like.*"
                         "Got 'auto'", ElasticNet(precompute='auto').fit, X, y)
+    assert_raises_regex(ValueError, ".*should be.*True.*False.*array-like.*"
+                        "Got 'auto'", Lasso(precompute='auto').fit, X, y)
 
 
 def test_elasticnet_precompute_incorrect_gram():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #19283


#### What does this implement/fix? Explain your changes.

This was already not supported but the docstring of Lasso was not updated accordingly.

