### PR TITLE
FIX Gives a unique id to html visualization

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -20,6 +20,12 @@ Changelog
   `'use_encoded_value'` strategies.
   :pr:`19234` by `Guillaume Lemaitre <glemaitre>`.
 
+:mod:`sklearn.utils`
+....................
+
+- |Fix| Better contains the CSS provided by :func:`utils.estimator_html_repr`
+  by giving CSS ids to the html representation. :pr:`19417` by `Thomas Fan`_.
+
 .. _changes_0_24_1:
 
 Version 0.24.1

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -147,9 +147,12 @@ def _write_estimator_html(out, estimator, estimator_label,
 
 
 _STYLE = """
-#$id div.sk-top-container {
+#$id {
   color: black;
   background-color: white;
+}
+#$id pre{
+  padding: 0;
 }
 #$id div.sk-toggleable {
   background-color: white;
@@ -303,10 +306,10 @@ def estimator_html_repr(estimator):
     """
     with closing(StringIO()) as out:
         container_id = uuid.uuid4()
-        s = Template(_STYLE)
-        style_with_id = s.substitute(id=container_id)
+        style_template = Template(_STYLE)
+        style_with_id = style_template.substitute(id=container_id)
         out.write(f'<style>{style_with_id}</style>'
-                  f'<div class="sk-top-container" id="{container_id}">'
+                  f'<div id="{container_id}">'
                   '<div class="sk-container">')
         _write_estimator_html(out, estimator, estimator.__class__.__name__,
                               str(estimator), first_call=True)

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -1,6 +1,7 @@
 from contextlib import closing
 from contextlib import suppress
 from io import StringIO
+from string import Template
 import uuid
 import html
 
@@ -146,14 +147,14 @@ def _write_estimator_html(out, estimator, estimator_label,
 
 
 _STYLE = """
-div.sk-top-container {
+#$id div.sk-top-container {
   color: black;
   background-color: white;
 }
-div.sk-toggleable {
+#$id div.sk-toggleable {
   background-color: white;
 }
-label.sk-toggleable__label {
+#$id label.sk-toggleable__label {
   cursor: pointer;
   display: block;
   width: 100%;
@@ -162,31 +163,31 @@ label.sk-toggleable__label {
   box-sizing: border-box;
   text-align: center;
 }
-div.sk-toggleable__content {
+#$id div.sk-toggleable__content {
   max-height: 0;
   max-width: 0;
   overflow: hidden;
   text-align: left;
   background-color: #f0f8ff;
 }
-div.sk-toggleable__content pre {
+#$id div.sk-toggleable__content pre {
   margin: 0.2em;
   color: black;
   border-radius: 0.25em;
   background-color: #f0f8ff;
 }
-input.sk-toggleable__control:checked~div.sk-toggleable__content {
+#$id input.sk-toggleable__control:checked~div.sk-toggleable__content {
   max-height: 200px;
   max-width: 100%;
   overflow: auto;
 }
-div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {
+#$id div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {
   background-color: #d4ebff;
 }
-div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {
+#$id div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {
   background-color: #d4ebff;
 }
-input.sk-hidden--visually {
+#$id input.sk-hidden--visually {
   border: 0;
   clip: rect(1px 1px 1px 1px);
   clip: rect(1px, 1px, 1px, 1px);
@@ -197,7 +198,7 @@ input.sk-hidden--visually {
   position: absolute;
   width: 1px;
 }
-div.sk-estimator {
+#$id div.sk-estimator {
   font-family: monospace;
   background-color: #f0f8ff;
   margin: 0.25em 0.25em;
@@ -205,19 +206,19 @@ div.sk-estimator {
   border-radius: 0.25em;
   box-sizing: border-box;
 }
-div.sk-estimator:hover {
+#$id div.sk-estimator:hover {
   background-color: #d4ebff;
 }
-div.sk-parallel-item::after {
+#$id div.sk-parallel-item::after {
   content: "";
   width: 100%;
   border-bottom: 1px solid gray;
   flex-grow: 1;
 }
-div.sk-label:hover label.sk-toggleable__label {
+#$id div.sk-label:hover label.sk-toggleable__label {
   background-color: #d4ebff;
 }
-div.sk-serial::before {
+#$id div.sk-serial::before {
   content: "";
   position: absolute;
   border-left: 1px solid gray;
@@ -226,39 +227,39 @@ div.sk-serial::before {
   bottom: 0;
   left: 50%;
 }
-div.sk-serial {
+#$id div.sk-serial {
   display: flex;
   flex-direction: column;
   align-items: center;
   background-color: white;
 }
-div.sk-item {
+#$id div.sk-item {
   z-index: 1;
 }
-div.sk-parallel {
+#$id div.sk-parallel {
   display: flex;
   align-items: stretch;
   justify-content: center;
   background-color: white;
 }
-div.sk-parallel-item {
+#$id div.sk-parallel-item {
   display: flex;
   flex-direction: column;
   position: relative;
   background-color: white;
 }
-div.sk-parallel-item:first-child::after {
+#$id div.sk-parallel-item:first-child::after {
   align-self: flex-end;
   width: 50%;
 }
-div.sk-parallel-item:last-child::after {
+#$id div.sk-parallel-item:last-child::after {
   align-self: flex-start;
   width: 50%;
 }
-div.sk-parallel-item:only-child::after {
+#$id div.sk-parallel-item:only-child::after {
   width: 0;
 }
-div.sk-dashed-wrapped {
+#$id div.sk-dashed-wrapped {
   border: 1px dashed gray;
   margin: 0.2em;
   box-sizing: border-box;
@@ -266,19 +267,19 @@ div.sk-dashed-wrapped {
   background-color: white;
   position: relative;
 }
-div.sk-label label {
+#$id div.sk-label label {
   font-family: monospace;
   font-weight: bold;
   background-color: white;
   display: inline-block;
   line-height: 1.2em;
 }
-div.sk-label-container {
+#$id div.sk-label-container {
   position: relative;
   z-index: 2;
   text-align: center;
 }
-div.sk-container {
+#$id div.sk-container {
   display: inline-block;
   position: relative;
 }
@@ -301,8 +302,12 @@ def estimator_html_repr(estimator):
         HTML representation of estimator.
     """
     with closing(StringIO()) as out:
-        out.write(f'<style>{_STYLE}</style>'
-                  f'<div class="sk-top-container"><div class="sk-container">')
+        container_id = uuid.uuid4()
+        s = Template(_STYLE)
+        style_with_id = s.substitute(id=container_id)
+        out.write(f'<style>{style_with_id}</style>'
+                  f'<div class="sk-top-container" id="{container_id}">'
+                  '<div class="sk-container">')
         _write_estimator_html(out, estimator, estimator.__class__.__name__,
                               str(estimator), first_call=True)
         out.write('</div></div>')

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -305,11 +305,11 @@ def estimator_html_repr(estimator):
         HTML representation of estimator.
     """
     with closing(StringIO()) as out:
-        container_id = uuid.uuid4()
+        container_id = "sk-" + str(uuid.uuid4())
         style_template = Template(_STYLE)
         style_with_id = style_template.substitute(id=container_id)
         out.write(f'<style>{style_with_id}</style>'
-                  f'<div id="{container_id}">'
+                  f'<div id="{container_id}" class"sk-top-container">'
                   '<div class="sk-container">')
         _write_estimator_html(out, estimator, estimator.__class__.__name__,
                               str(estimator), first_call=True)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
The CSS is now targeted to a specific container by ID, which helps isolated the CSS from other elements. Using an ID increases the specificity of the selector which gives the style in scikit-learn higher precedence.

#### What does this implement/fix? Explain your changes.
This resolves the issue here: https://github.com/INRIA/scikit-learn-mooc/issues/146

![Screen Shot 2021-02-09 at 1 56 08 PM](https://user-images.githubusercontent.com/5402633/107413278-94ffad00-6ade-11eb-8bce-fc02d71a9160.png)

CC @lesteve 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
