### PR TITLE
Fix RuntimeWarning: invalid value encountered in test_calibration.py

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -656,7 +656,9 @@ class _CalibratedClassifier:
         if n_classes == 2:
             proba[:, 0] = 1. - proba[:, 1]
         else:
-            proba /= np.sum(proba, axis=1)[:, np.newaxis]
+            denominator = np.sum(proba, axis=1)[:, np.newaxis]
+            proba = np.divide(proba, denominator, out=np.full_like(
+                proba, np.nan), where=denominator != 0)
 
         # XXX : for some reason all probas can be 0
         proba[np.isnan(proba)] = 1. / n_classes

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -658,8 +658,9 @@ class _CalibratedClassifier:
         else:
             denominator = np.sum(proba, axis=1)[:, np.newaxis]
             # XXX : for some reason all probas can be 0
-            proba = np.divide(proba, denominator, out=np.full_like(
-                proba, 1 / n_classes), where=denominator != 0)
+            uniform_proba = np.full_like(proba, 1 / n_classes)
+            proba = np.divide(proba, denominator, out=uniform_proba,
+                              where=denominator != 0)
 
         # Deal with cases where the predicted probability minimally exceeds 1.0
         proba[(1.0 < proba) & (proba <= 1.0 + 1e-5)] = 1.0

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -657,11 +657,9 @@ class _CalibratedClassifier:
             proba[:, 0] = 1. - proba[:, 1]
         else:
             denominator = np.sum(proba, axis=1)[:, np.newaxis]
+            # XXX : for some reason all probas can be 0
             proba = np.divide(proba, denominator, out=np.full_like(
-                proba, np.nan), where=denominator != 0)
-
-        # XXX : for some reason all probas can be 0
-        proba[np.isnan(proba)] = 1. / n_classes
+                proba, 1 / n_classes), where=denominator != 0)
 
         # Deal with cases where the predicted probability minimally exceeds 1.0
         proba[(1.0 < proba) & (proba <= 1.0 + 1e-5)] = 1.0

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -657,7 +657,9 @@ class _CalibratedClassifier:
             proba[:, 0] = 1. - proba[:, 1]
         else:
             denominator = np.sum(proba, axis=1)[:, np.newaxis]
-            # XXX : for some reason all probas can be 0
+            # In the edge case where for each class calibrator returns a null
+            # probability for a given sample, use the uniform distribution
+            # instead.
             uniform_proba = np.full_like(proba, 1 / n_classes)
             proba = np.divide(proba, denominator, out=uniform_proba,
                               where=denominator != 0)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -299,7 +299,7 @@ def test_calibration_zero_probability():
 
     probas = cal_clf.predict_proba(X)
 
-    # Check all probabilities are 1. / n_classes
+    # Check that all probabilities are uniformly 1. / n_classes
     assert_allclose(probas, np.full_like(probas, 1. / len(n_classes)))
 
 

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -279,7 +279,7 @@ def test_calibration_multiclass(method, ensemble, seed):
 def test_calibration_zero_probability():
     # Test an edge case where _CalibratedClassifier avoids numerical errors
     # in the multiclass normalization step if all the calibrators output
-    # zero all at once for a given sample and instead fallback to uniform
+    # are zero all at once for a given sample and instead fallback to uniform
     # probabilities.
     class ZeroCalibrator():
         # This function is called from _CalibratedClassifier.predict_proba.

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -293,7 +293,7 @@ def test_calibration_zero_probability():
     n_classes = np.unique(y)
 
     clf = FakeClassifier(n_classes)
-    calibrator = FakeCalibrator()
+    calibrator = ZeroCalibrator()
     cal_clf = _CalibratedClassifier(
         base_estimator=clf, calibrators=[calibrator], classes=n_classes)
 

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -300,7 +300,6 @@ def test_calibration_zero_probability():
     probas = cal_clf.predict_proba(X)
 
     # Check all probabilities are 1. / n_classes
-    assert False
     assert_allclose(probas, np.full_like(probas, 1. / len(n_classes)))
 
 

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -291,7 +291,7 @@ def test_calibration_zero_probability():
     clf = DummyClassifier().fit(X, y)
     calibrator = ZeroCalibrator()
     cal_clf = _CalibratedClassifier(
-        base_estimator=clf, calibrators=[calibrator], classes=n_classes)
+        base_estimator=clf, calibrators=[calibrator], classes=clf.classes_)
 
     probas = cal_clf.predict_proba(X)
 

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -284,7 +284,7 @@ def test_calibration_zero_probability():
     class ZeroCalibrator():
         # This function is called from _CalibratedClassifier.predict_proba.
         def predict(self, X):
-            return np.zeros_like(X)
+            return np.zeros(X.shape[0])
 
     X, y = make_blobs(n_samples=50, n_features=10, random_state=7,
                       centers=10, cluster_std=15.0)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -278,7 +278,7 @@ def test_calibration_multiclass(method, ensemble, seed):
 
 def test_calibration_zero_probability():
     # Test an edge case where _CalibratedClassifier avoids numerical errors
-    # in the multiclass normalization step if the all the calibrators output
+    # in the multiclass normalization step if all the calibrators output
     # zero all at once for a given sample and instead fallback to uniform
     # probabilities.
     class ZeroCalibrator():

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -288,10 +288,7 @@ def test_calibration_zero_probability():
 
     X, y = make_blobs(n_samples=50, n_features=10, random_state=7,
                       centers=10, cluster_std=15.0)
-    n_classes = np.unique(y)
-
-    clf = DummyClassifier()
-    clf.fit(X, y)
+    clf = DummyClassifier().fit(X, y)
     calibrator = ZeroCalibrator()
     cal_clf = _CalibratedClassifier(
         base_estimator=clf, calibrators=[calibrator], classes=n_classes)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -277,6 +277,10 @@ def test_calibration_multiclass(method, ensemble, seed):
 
 
 def test_calibration_zero_probability():
+    # Test an edge case where _CalibratedClassifier avoids numerical  errors
+    # in the multiclass normalization step if the all the calibrators output
+    # zero all at once for a given sample and instead fallback to uniform
+    # probabilities.
     class ZeroCalibrator():
         # This function is called from _CalibratedClassifier.predict_proba.
         def predict(self, X):

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose
 from scipy import sparse
 
 from sklearn.base import BaseEstimator
+from sklearn.dummy import DummyClassifier
 from sklearn.model_selection import LeaveOneOut, train_test_split
 
 from sklearn.utils._testing import (assert_array_almost_equal,
@@ -276,13 +277,6 @@ def test_calibration_multiclass(method, ensemble, seed):
 
 
 def test_calibration_zero_probability():
-    class FakeClassifier():
-        def __init__(self, n_classes):
-            self.classes_ = n_classes
-
-        def predict_proba(self, X):
-            return np.empty_like(X)
-
     class ZeroCalibrator():
         # This function is called from _CalibratedClassifier.predict_proba.
         def predict(self, X):
@@ -292,7 +286,8 @@ def test_calibration_zero_probability():
                       centers=10, cluster_std=15.0)
     n_classes = np.unique(y)
 
-    clf = FakeClassifier(n_classes)
+    clf = DummyClassifier()
+    clf.fit(X, y)
     calibrator = ZeroCalibrator()
     cal_clf = _CalibratedClassifier(
         base_estimator=clf, calibrators=[calibrator], classes=n_classes)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -298,8 +298,8 @@ def test_calibration_zero_probability():
 
     probas = cal_clf.predict_proba(X)
 
-    # Check that all probabilities are uniformly 1. / n_classes
-    assert_allclose(probas, np.full_like(probas, 1. / len(n_classes)))
+    # Check that all probabilities are uniformly 1. / len(n_classes)
+    assert_allclose(probas, 1. / len(n_classes))
 
 
 def test_calibration_prefit():

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -295,8 +295,8 @@ def test_calibration_zero_probability():
 
     probas = cal_clf.predict_proba(X)
 
-    # Check that all probabilities are uniformly 1. / len(n_classes)
-    assert_allclose(probas, 1. / len(n_classes))
+    # Check that all probabilities are uniformly 1. / clf.n_classes_
+    assert_allclose(probas, 1. / clf.n_classes_)
 
 
 def test_calibration_prefit():

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -283,7 +283,7 @@ def test_calibration_zero_probability():
         def predict_proba(self, X):
             return np.empty_like(X)
 
-    class FakeCalibrator():
+    class ZeroCalibrator():
         # This function is called from _CalibratedClassifier.predict_proba.
         def predict(self, X):
             return np.zeros_like(X)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -277,7 +277,7 @@ def test_calibration_multiclass(method, ensemble, seed):
 
 
 def test_calibration_zero_probability():
-    # Test an edge case where _CalibratedClassifier avoids numerical  errors
+    # Test an edge case where _CalibratedClassifier avoids numerical errors
     # in the multiclass normalization step if the all the calibrators output
     # zero all at once for a given sample and instead fallback to uniform
     # probabilities.

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -288,7 +288,7 @@ def test_calibration_zero_probability():
         def predict(self, X):
             return np.zeros_like(X)
 
-    X, y = make_blobs(n_samples=500, n_features=100, random_state=7,
+    X, y = make_blobs(n_samples=50, n_features=10, random_state=7,
                       centers=10, cluster_std=15.0)
     n_classes = np.unique(y)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

 #19334

#### What does this implement/fix? Explain your changes.

The runtime error was cause by `_CalibratedClassifier.predict_proba` function.
The error occurs when `np.sum(proba, axis=1)[:, np.newaxis]` has some zero elements.
So, I use `np.divide` to avoid this error. Without `out` parameter, we will get the warning from `assert_allclose(...)` in `test_calibration_multiclass`.

Note: 

Things I've tried that don't work.

* Use `with np.errstate(divide='ignore')`
  * With `pytest`, still get warnig.
* `np.divide(proba, denominator, where=denominator != 0.0)` (without `out` parameter)
  * The warning about zero division is resolved, but another warning will be raised from `assert_allclose(...)` in `test_calibration_multiclass`.
    * `proba[np.isnan(proba)] = 1. / n_classes` is not enough to this case. Some of values seems not to become NaN, so sum of `proba` cannnot be 1.0