### PR TITLE
TST replace assert_warns* by pytest.warns in module svm/tests

### DIFF
--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -9,9 +9,8 @@ from sklearn.datasets import make_classification, load_digits, make_blobs
 from sklearn.svm.tests import test_svm
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.extmath import safe_sparse_dot
-from sklearn.utils._testing import (assert_warns,
-                                   assert_raise_message, ignore_warnings,
-                                   skip_if_32bit)
+from sklearn.utils._testing import (assert_raise_message, ignore_warnings,
+                                    skip_if_32bit)
 
 
 # test sample 1
@@ -348,8 +347,8 @@ def test_sparse_svc_clone_with_callable_kernel():
 def test_timeout():
     sp = svm.SVC(C=1, kernel=lambda x, y: x * y.T,
                  probability=True, random_state=0, max_iter=1)
-
-    assert_warns(ConvergenceWarning, sp.fit, X_sp, Y)
+    with pytest.warns(ConvergenceWarning, match=r".*"):
+        sp.fit(X_sp, Y)
 
 
 def test_consistent_proba():

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -347,9 +347,10 @@ def test_sparse_svc_clone_with_callable_kernel():
 def test_timeout():
     sp = svm.SVC(C=1, kernel=lambda x, y: x * y.T,
                  probability=True, random_state=0, max_iter=1)
-    warning_msg = r'Solver terminated early \(max_iter=1\).' \
-                  '  Consider pre-processing your data with' \
-                  ' StandardScaler or MinMaxScaler.'
+    warning_msg = (
+        r'Solver terminated early \(max_iter=1\).  Consider pre-processing '
+        r'your data with StandardScaler or MinMaxScaler.'
+    )
     with pytest.warns(ConvergenceWarning, match=warning_msg):
         sp.fit(X_sp, Y)
 

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -347,7 +347,10 @@ def test_sparse_svc_clone_with_callable_kernel():
 def test_timeout():
     sp = svm.SVC(C=1, kernel=lambda x, y: x * y.T,
                  probability=True, random_state=0, max_iter=1)
-    with pytest.warns(ConvergenceWarning, match=r".*"):
+    warning_msg = r'Solver terminated early \(max_iter=1\).' \
+                  '  Consider pre-processing your data with' \
+                  ' StandardScaler or MinMaxScaler.'
+    with pytest.warns(ConvergenceWarning, match=warning_msg):
         sp.fit(X_sp, Y)
 
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -978,7 +978,10 @@ def test_svc_bad_kernel():
 def test_timeout():
     a = svm.SVC(kernel=lambda x, y: np.dot(x, y.T), probability=True,
                 random_state=0, max_iter=1)
-    with pytest.warns(ConvergenceWarning, match=r".*"):
+    warning_msg = r'Solver terminated early \(max_iter=1\).' \
+                  '  Consider pre-processing your data with' \
+                  ' StandardScaler or MinMaxScaler.'
+    with pytest.warns(ConvergenceWarning, match=warning_msg):
         a.fit(np.array(X), Y)
 
 
@@ -1008,12 +1011,14 @@ def test_linear_svm_convergence_warnings():
     # Test that warnings are raised if model does not converge
 
     lsvc = svm.LinearSVC(random_state=0, max_iter=2)
-    with pytest.warns(ConvergenceWarning, match=r".*"):
+    warning_msg = "Liblinear failed to converge, increase" \
+                  " the number of iterations."
+    with pytest.warns(ConvergenceWarning, match=warning_msg):
         lsvc.fit(X, Y)
     assert lsvc.n_iter_ == 2
 
     lsvr = svm.LinearSVR(random_state=0, max_iter=2)
-    with pytest.warns(ConvergenceWarning, match=r".*"):
+    with pytest.warns(ConvergenceWarning, match=warning_msg):
         lsvr.fit(iris.data, iris.target)
     assert lsvr.n_iter_ == 2
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -19,7 +19,6 @@ from sklearn.datasets import make_classification, make_blobs
 from sklearn.metrics import f1_score
 from sklearn.metrics.pairwise import rbf_kernel
 from sklearn.utils import check_random_state
-from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._testing import assert_no_warnings
@@ -979,7 +978,8 @@ def test_svc_bad_kernel():
 def test_timeout():
     a = svm.SVC(kernel=lambda x, y: np.dot(x, y.T), probability=True,
                 random_state=0, max_iter=1)
-    assert_warns(ConvergenceWarning, a.fit, np.array(X), Y)
+    with pytest.warns(ConvergenceWarning, match=r".*"):
+        a.fit(np.array(X), Y)
 
 
 def test_unfitted():
@@ -1008,11 +1008,13 @@ def test_linear_svm_convergence_warnings():
     # Test that warnings are raised if model does not converge
 
     lsvc = svm.LinearSVC(random_state=0, max_iter=2)
-    assert_warns(ConvergenceWarning, lsvc.fit, X, Y)
+    with pytest.warns(ConvergenceWarning, match=r".*"):
+        lsvc.fit(X, Y)
     assert lsvc.n_iter_ == 2
 
     lsvr = svm.LinearSVR(random_state=0, max_iter=2)
-    assert_warns(ConvergenceWarning, lsvr.fit, iris.data, iris.target)
+    with pytest.warns(ConvergenceWarning, match=r".*"):
+        lsvr.fit(iris.data, iris.target)
     assert lsvr.n_iter_ == 2
 
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -21,7 +21,6 @@ from sklearn.metrics.pairwise import rbf_kernel
 from sklearn.utils import check_random_state
 from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import ignore_warnings
-from sklearn.utils._testing import assert_no_warnings
 from sklearn.utils.validation import _num_samples
 from sklearn.utils import shuffle
 from sklearn.exceptions import ConvergenceWarning
@@ -978,9 +977,10 @@ def test_svc_bad_kernel():
 def test_timeout():
     a = svm.SVC(kernel=lambda x, y: np.dot(x, y.T), probability=True,
                 random_state=0, max_iter=1)
-    warning_msg = r'Solver terminated early \(max_iter=1\).' \
-                  '  Consider pre-processing your data with' \
-                  ' StandardScaler or MinMaxScaler.'
+    warning_msg = (
+        r'Solver terminated early \(max_iter=1\).  Consider pre-processing '
+        r'your data with StandardScaler or MinMaxScaler.'
+    )
     with pytest.warns(ConvergenceWarning, match=warning_msg):
         a.fit(np.array(X), Y)
 
@@ -1011,8 +1011,9 @@ def test_linear_svm_convergence_warnings():
     # Test that warnings are raised if model does not converge
 
     lsvc = svm.LinearSVC(random_state=0, max_iter=2)
-    warning_msg = "Liblinear failed to converge, increase" \
-                  " the number of iterations."
+    warning_msg = (
+        "Liblinear failed to converge, increase the number of iterations."
+    )
     with pytest.warns(ConvergenceWarning, match=warning_msg):
         lsvc.fit(X, Y)
     assert lsvc.n_iter_ == 2
@@ -1167,21 +1168,30 @@ def test_svc_ovr_tie_breaking(SVCClass):
 def test_gamma_auto():
     X, y = [[0.0, 1.2], [1.0, 1.3]], [0, 1]
 
-    assert_no_warnings(svm.SVC(kernel='linear').fit, X, y)
-    assert_no_warnings(svm.SVC(kernel='precomputed').fit, X, y)
+    with pytest.warns(None) as record:
+        svm.SVC(kernel='linear').fit(X, y)
+    assert not len(record)
+
+    with pytest.warns(None) as record:
+        svm.SVC(kernel='precomputed').fit(X, y)
+    assert not len(record)
 
 
 def test_gamma_scale():
     X, y = [[0.], [1.]], [0, 1]
 
     clf = svm.SVC()
-    assert_no_warnings(clf.fit, X, y)
+    with pytest.warns(None) as record:
+        clf.fit(X, y)
+    assert not len(record)
     assert_almost_equal(clf._gamma, 4)
 
     # X_var ~= 1 shouldn't raise warning, for when
     # gamma is not explicitly set.
     X, y = [[1, 2], [3, 2 * np.sqrt(6) / 3 + 2]], [0, 1]
-    assert_no_warnings(clf.fit, X, y)
+    with pytest.warns(None) as record:
+        clf.fit(X, y)
+    assert not len(record)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Part of #19414  for svm/tests
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Removed use of assert_warns, assert_warns_message in svm/tests package

#### Any other comments?
The fix is part of complete fix for issue #19414


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
