### PR TITLE
TST replace assert_warns* by pytest.warns in ensemble/tests

### DIFF
--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -15,8 +15,6 @@ from sklearn.base import BaseEstimator
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_raises
-from sklearn.utils._testing import assert_warns
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import assert_raise_message
 
 from sklearn.dummy import DummyClassifier, DummyRegressor
@@ -348,14 +346,14 @@ def test_oob_score_classification():
         assert abs(test_score - clf.oob_score_) < 0.1
 
         # Test with few estimators
-        assert_warns(UserWarning,
-                     BaggingClassifier(base_estimator=base_estimator,
-                                       n_estimators=1,
-                                       bootstrap=True,
-                                       oob_score=True,
-                                       random_state=rng).fit,
-                     X_train,
-                     y_train)
+        with pytest.warns(UserWarning, match=r".*"):
+            BaggingClassifier(base_estimator=base_estimator,
+                              n_estimators=1,
+                              bootstrap=True,
+                              oob_score=True,
+                              random_state=rng).fit(
+                X_train,
+                y_train)
 
 
 def test_oob_score_regression():
@@ -377,14 +375,14 @@ def test_oob_score_regression():
     assert abs(test_score - clf.oob_score_) < 0.1
 
     # Test with few estimators
-    assert_warns(UserWarning,
-                 BaggingRegressor(base_estimator=DecisionTreeRegressor(),
-                                  n_estimators=1,
-                                  bootstrap=True,
-                                  oob_score=True,
-                                  random_state=rng).fit,
-                 X_train,
-                 y_train)
+    with pytest.warns(UserWarning, match=r".*"):
+        BaggingRegressor(base_estimator=DecisionTreeRegressor(),
+                         n_estimators=1,
+                         bootstrap=True,
+                         oob_score=True,
+                         random_state=rng).fit(
+            X_train,
+            y_train)
 
 
 def test_single_estimator():
@@ -654,9 +652,9 @@ def test_warm_start_equal_n_estimators():
     # modify X to nonsense values, this should not change anything
     X_train += 1.
 
-    assert_warns_message(UserWarning,
-                         "Warm-start fitting without increasing n_estimators does not",
-                         clf.fit, X_train, y_train)
+    with pytest.warns(UserWarning,
+                      match="Warm-start fitting without increasing n_estimators does not"):
+        clf.fit(X_train, y_train)
     assert_array_equal(y_pred, clf.predict(X_test))
 
 

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -346,18 +346,19 @@ def test_oob_score_classification():
         assert abs(test_score - clf.oob_score_) < 0.1
 
         # Test with few estimators
-        with pytest.warns(
-                UserWarning,
-                match="Some inputs do not have OOB scores. This probably "
-                      "means too few estimators were used to compute any "
-                      "reliable oob estimates."):
-            BaggingClassifier(base_estimator=base_estimator,
-                              n_estimators=1,
-                              bootstrap=True,
-                              oob_score=True,
-                              random_state=rng).fit(
-                X_train,
-                y_train)
+        warn_msg = (
+            "Some inputs do not have OOB scores. This probably means too few "
+            "estimators were used to compute any reliable oob estimates."
+        )
+        with pytest.warns(UserWarning, match=warn_msg):
+            clf = BaggingClassifier(
+                base_estimator=base_estimator,
+                n_estimators=1,
+                bootstrap=True,
+                oob_score=True,
+                random_state=rng,
+            )
+            clf.fit(X_train, y_train)
 
 
 def test_oob_score_regression():
@@ -379,18 +380,18 @@ def test_oob_score_regression():
     assert abs(test_score - clf.oob_score_) < 0.1
 
     # Test with few estimators
-    with pytest.warns(
-            UserWarning,
-            match="Some inputs do not have OOB scores. This probably means "
-                  "too few estimators were used to compute any reliable oob "
-                  "estimates."):
-        BaggingRegressor(base_estimator=DecisionTreeRegressor(),
-                         n_estimators=1,
-                         bootstrap=True,
-                         oob_score=True,
-                         random_state=rng).fit(
-            X_train,
-            y_train)
+    warn_msg = (
+        "Some inputs do not have OOB scores. This probably means too few "
+        "estimators were used to compute any reliable oob estimates."
+    )
+    with pytest.warns(UserWarning, match=warn_msg):
+        regr = BaggingRegressor(
+            base_estimator=DecisionTreeRegressor(),
+            n_estimators=1,
+            bootstrap=True,
+            oob_score=True,
+            random_state=rng)
+        regr.fit(X_train, y_train)
 
 
 def test_single_estimator():
@@ -660,10 +661,8 @@ def test_warm_start_equal_n_estimators():
     # modify X to nonsense values, this should not change anything
     X_train += 1.
 
-    with pytest.warns(
-            UserWarning,
-            match="Warm-start fitting without increasing n_estimators "
-                  "does not"):
+    warn_msg = "Warm-start fitting without increasing n_estimators does not"
+    with pytest.warns(UserWarning, match=warn_msg):
         clf.fit(X_train, y_train)
     assert_array_equal(y_pred, clf.predict(X_test))
 

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -652,8 +652,10 @@ def test_warm_start_equal_n_estimators():
     # modify X to nonsense values, this should not change anything
     X_train += 1.
 
-    with pytest.warns(UserWarning,
-                      match="Warm-start fitting without increasing n_estimators does not"):
+    with pytest.warns(
+            UserWarning,
+            match="Warm-start fitting without increasing n_estimators "
+                  "does not"):
         clf.fit(X_train, y_train)
     assert_array_equal(y_pred, clf.predict(X_test))
 

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -346,7 +346,11 @@ def test_oob_score_classification():
         assert abs(test_score - clf.oob_score_) < 0.1
 
         # Test with few estimators
-        with pytest.warns(UserWarning, match=r".*"):
+        with pytest.warns(
+                UserWarning,
+                match="Some inputs do not have OOB scores. This probably "
+                      "means too few estimators were used to compute any "
+                      "reliable oob estimates."):
             BaggingClassifier(base_estimator=base_estimator,
                               n_estimators=1,
                               bootstrap=True,
@@ -375,7 +379,11 @@ def test_oob_score_regression():
     assert abs(test_score - clf.oob_score_) < 0.1
 
     # Test with few estimators
-    with pytest.warns(UserWarning, match=r".*"):
+    with pytest.warns(
+            UserWarning,
+            match="Some inputs do not have OOB scores. This probably means "
+                  "too few estimators were used to compute any reliable oob "
+                  "estimates."):
         BaggingRegressor(base_estimator=DecisionTreeRegressor(),
                          n_estimators=1,
                          bootstrap=True,

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1126,7 +1126,10 @@ def check_class_weight_errors(name):
     # Warning warm_start with preset
     clf = ForestClassifier(class_weight='balanced', warm_start=True,
                            random_state=0)
-    with pytest.warns(UserWarning, match=r".*"):
+    with pytest.warns(
+            UserWarning,
+            match="Warm-start fitting without increasing n_estimators does "
+                  "not fit new trees."):
         clf.fit(X, y)
         clf.fit(X, _y)
 
@@ -1228,7 +1231,10 @@ def check_warm_start_equal_n_estimators(name):
     # Now est_2 equals est.
 
     est_2.set_params(random_state=2)
-    with pytest.warns(UserWarning, match=r".*"):
+    with pytest.warns(
+            UserWarning,
+            match="Warm-start fitting without increasing n_estimators does "
+                  "not fit new trees."):
         est_2.fit(X, y)
     # If we had fit the trees again we would have got a different forest as we
     # changed the random state.

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -30,8 +30,6 @@ from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_raises
-from sklearn.utils._testing import assert_warns
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import _convert_container
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._testing import skip_if_no_parallel
@@ -1128,8 +1126,9 @@ def check_class_weight_errors(name):
     # Warning warm_start with preset
     clf = ForestClassifier(class_weight='balanced', warm_start=True,
                            random_state=0)
-    assert_warns(UserWarning, clf.fit, X, y)
-    assert_warns(UserWarning, clf.fit, X, _y)
+    with pytest.warns(UserWarning, match=r".*"):
+        clf.fit(X, y)
+        clf.fit(X, _y)
 
     # Not a list or preset for multi-output
     clf = ForestClassifier(class_weight=1, random_state=0)
@@ -1229,7 +1228,8 @@ def check_warm_start_equal_n_estimators(name):
     # Now est_2 equals est.
 
     est_2.set_params(random_state=2)
-    assert_warns(UserWarning, est_2.fit, X, y)
+    with pytest.warns(UserWarning, match=r".*"):
+        est_2.fit(X, y)
     # If we had fit the trees again we would have got a different forest as we
     # changed the random state.
     assert_array_equal(est.apply(X), est_2.apply(X))
@@ -1324,9 +1324,8 @@ def test_min_impurity_split():
 
     for Estimator in all_estimators:
         est = Estimator(min_impurity_split=0.1)
-        est = assert_warns_message(FutureWarning,
-                                   "min_impurity_decrease",
-                                   est.fit, X, y)
+        with pytest.warns(FutureWarning, match="min_impurity_decrease"):
+            est = est.fit(X, y)
         for tree in est.estimators_:
             assert tree.min_impurity_split == 0.1
 

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1126,13 +1126,12 @@ def check_class_weight_errors(name):
     # Warning warm_start with preset
     clf = ForestClassifier(class_weight='balanced', warm_start=True,
                            random_state=0)
+    clf.fit(X, y)
 
     warn_msg = (
         "Warm-start fitting without increasing n_estimators does not fit new "
         "trees."
     )
-    with pytest.warns(UserWarning, match=warn_msg):
-        clf.fit(X, y)
     with pytest.warns(UserWarning, match=warn_msg):
         clf.fit(X, _y)
 

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1126,11 +1126,14 @@ def check_class_weight_errors(name):
     # Warning warm_start with preset
     clf = ForestClassifier(class_weight='balanced', warm_start=True,
                            random_state=0)
-    with pytest.warns(
-            UserWarning,
-            match="Warm-start fitting without increasing n_estimators does "
-                  "not fit new trees."):
+
+    warn_msg = (
+        "Warm-start fitting without increasing n_estimators does not fit new "
+        "trees."
+    )
+    with pytest.warns(UserWarning, match=warn_msg):
         clf.fit(X, y)
+    with pytest.warns(UserWarning, match=warn_msg):
         clf.fit(X, _y)
 
     # Not a list or preset for multi-output
@@ -1231,10 +1234,11 @@ def check_warm_start_equal_n_estimators(name):
     # Now est_2 equals est.
 
     est_2.set_params(random_state=2)
-    with pytest.warns(
-            UserWarning,
-            match="Warm-start fitting without increasing n_estimators does "
-                  "not fit new trees."):
+    warn_msg = (
+        "Warm-start fitting without increasing n_estimators does not fit "
+        "new trees."
+    )
+    with pytest.warns(UserWarning, match=warn_msg):
         est_2.fit(X, y)
     # If we had fit the trees again we would have got a different forest as we
     # changed the random state.

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -558,11 +558,12 @@ def test_shape_y():
     # This will raise a DataConversionWarning that we want to
     # "always" raise, elsewhere the warnings gets ignored in the
     # later tests, and the tests that check for this warning fail
-    with pytest.warns(
-            DataConversionWarning,
-            match="A column-vector y was passed when a 1d array was expected. "
-                  "Please change the shape of y to \\(n_samples, \\), for "
-                  "example using ravel()."):
+    warn_msg = (
+        "A column-vector y was passed when a 1d array was expected. "
+        "Please change the shape of y to \\(n_samples, \\), for "
+        "example using ravel()."
+    )
+    with pytest.warns(DataConversionWarning, match=warn_msg):
         clf.fit(X, y_)
     assert_array_equal(clf.predict(T), true_result)
     assert 100 == len(clf.estimators_)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -558,7 +558,11 @@ def test_shape_y():
     # This will raise a DataConversionWarning that we want to
     # "always" raise, elsewhere the warnings gets ignored in the
     # later tests, and the tests that check for this warning fail
-    with pytest.warns(DataConversionWarning, match=r".*"):
+    with pytest.warns(
+            DataConversionWarning,
+            match="A column-vector y was passed when a 1d array was expected. "
+                  "Please change the shape of y to \\(n_samples, \\), for "
+                  "example using ravel()."):
         clf.fit(X, y_)
     assert_array_equal(clf.predict(T), true_result)
     assert 100 == len(clf.estimators_)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -29,8 +29,6 @@ from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_raise_message
-from sklearn.utils._testing import assert_warns
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import skip_if_32bit
 from sklearn.exceptions import DataConversionWarning
 from sklearn.exceptions import NotFittedError
@@ -560,7 +558,8 @@ def test_shape_y():
     # This will raise a DataConversionWarning that we want to
     # "always" raise, elsewhere the warnings gets ignored in the
     # later tests, and the tests that check for this warning fail
-    assert_warns(DataConversionWarning, clf.fit, X, y_)
+    with pytest.warns(DataConversionWarning, match=r".*"):
+        clf.fit(X, y_)
     assert_array_equal(clf.predict(T), true_result)
     assert 100 == len(clf.estimators_)
 
@@ -1000,9 +999,8 @@ def test_min_impurity_split(GBEstimator):
     X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
 
     est = GBEstimator(min_impurity_split=0.1)
-    est = assert_warns_message(FutureWarning,
-                               "min_impurity_decrease",
-                               est.fit, X, y)
+    with pytest.warns(FutureWarning, match="min_impurity_decrease"):
+        est = est.fit(X, y)
     for tree in est.estimators_.flat:
         assert tree.min_impurity_split == 0.1
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -100,9 +100,8 @@ def test_iforest_error():
     # The dataset has less than 256 samples, explicitly setting
     # max_samples > n_samples should result in a warning. If not set
     # explicitly there should be no warning
-    with pytest.warns(
-            UserWarning,
-            match="max_samples will be set to n_samples for estimation"):
+    warn_msg = "max_samples will be set to n_samples for estimation"
+    with pytest.warns(UserWarning, match=warn_msg):
         IsolationForest(max_samples=1000).fit(X)
     # note that assert_no_warnings does not apply since it enables a
     # PendingDeprecationWarning triggered by scipy.sparse's use of
@@ -139,9 +138,8 @@ def test_max_samples_attribute():
     assert clf.max_samples_ == X.shape[0]
 
     clf = IsolationForest(max_samples=500)
-    with pytest.warns(
-            UserWarning,
-            match="max_samples will be set to n_samples for estimation"):
+    warn_msg = "max_samples will be set to n_samples for estimation"
+    with pytest.warns(UserWarning, match=warn_msg):
         clf.fit(X)
     assert clf.max_samples_ == X.shape[0]
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -13,7 +13,6 @@ import numpy as np
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_raises
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._testing import assert_allclose
 
@@ -101,9 +100,9 @@ def test_iforest_error():
     # The dataset has less than 256 samples, explicitly setting
     # max_samples > n_samples should result in a warning. If not set
     # explicitly there should be no warning
-    assert_warns_message(UserWarning,
-                         "max_samples will be set to n_samples for estimation",
-                         IsolationForest(max_samples=1000).fit, X)
+    with pytest.warns(UserWarning,
+            match="max_samples will be set to n_samples for estimation"):
+        IsolationForest(max_samples=1000).fit(X)
     # note that assert_no_warnings does not apply since it enables a
     # PendingDeprecationWarning triggered by scipy.sparse's use of
     # np.matrix. See issue #11251.
@@ -139,9 +138,9 @@ def test_max_samples_attribute():
     assert clf.max_samples_ == X.shape[0]
 
     clf = IsolationForest(max_samples=500)
-    assert_warns_message(UserWarning,
-                         "max_samples will be set to n_samples for estimation",
-                         clf.fit, X)
+    with pytest.warns(UserWarning,
+            match="max_samples will be set to n_samples for estimation"):
+        clf.fit(X)
     assert clf.max_samples_ == X.shape[0]
 
     clf = IsolationForest(max_samples=0.4).fit(X)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -100,7 +100,8 @@ def test_iforest_error():
     # The dataset has less than 256 samples, explicitly setting
     # max_samples > n_samples should result in a warning. If not set
     # explicitly there should be no warning
-    with pytest.warns(UserWarning,
+    with pytest.warns(
+            UserWarning,
             match="max_samples will be set to n_samples for estimation"):
         IsolationForest(max_samples=1000).fit(X)
     # note that assert_no_warnings does not apply since it enables a
@@ -138,7 +139,8 @@ def test_max_samples_attribute():
     assert clf.max_samples_ == X.shape[0]
 
     clf = IsolationForest(max_samples=500)
-    with pytest.warns(UserWarning,
+    with pytest.warns(
+            UserWarning,
             match="max_samples will be set to n_samples for estimation"):
         clf.fit(X)
     assert clf.max_samples_ == X.shape[0]


### PR DESCRIPTION
#### Reference Issues/PRs

#19414 

#### What does this implement/fix? Explain your changes.

Remove the use of assert_warns and assert_warns_message from tests in ensemble/tests.


#### Any other comments?

The PR is for the part of #19414