### PR TITLE
MRG fix Normalize for linear models when used with sample_weight

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -131,6 +131,12 @@ Changelog
   :pr:`17743` by :user:`Maria Telenczuk <maikia>` and
   :user:`Alexandre Gramfort <agramfort>`.
 
+- |Fix|: Fixed a bug in linear_model._base._preprocess_data when
+  `normalize=True` and `sample_weight` is set. `sample_weight` now weights
+  standard deviation as expected.
+  :pr:`19426` by :user:`Alexandre Gramfort <agramfort>` and
+  :user:`Maria Telenczuk <maikia>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -131,9 +131,9 @@ Changelog
   :pr:`17743` by :user:`Maria Telenczuk <maikia>` and
   :user:`Alexandre Gramfort <agramfort>`.
 
-- |Fix|: Fixed a bug in linear_model._base._preprocess_data when
-  `normalize=True` and `sample_weight` is set. `sample_weight` now weights
-  standard deviation as expected.
+- |Fix|: `sample_weight` are now fully taken into account in linear models
+  when `normalize=True` for both feature centering and feature
+  scaling.
   :pr:`19426` by :user:`Alexandre Gramfort <agramfort>` and
   :user:`Maria Telenczuk <maikia>`.
 

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -244,21 +244,18 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
             X_offset = X_offset.astype(X.dtype)
             X -= X_offset
 
-        X_var = X_var.astype(X.dtype)
+        X_var = X_var.astype(X.dtype, copy=False)
 
         if normalize:
             X_var *= X.shape[0]
-            X_scale = np.sqrt(X_var, X_var)
-            if np.any(X_scale == 0):
-                X_scale_ = X_scale.copy()
-                X_scale_[X_scale_ == 0] = 1
-            else:
-                X_scale_ = X_scale
+            X_scale = np.sqrt(X_var, out=X_var)
+            near_zero_mask = X_scale < np.finfo(X_scale.dtype).eps
+            if np.any(near_zero_mask):
+                X_scale[near_zero_mask] = 1
             if sp.issparse(X):
-                # import pdb; pdb.set_trace()
-                inplace_column_scale(X, 1. / X_scale_)
+                inplace_column_scale(X, 1. / X_scale)
             else:
-                X /= X_scale_
+                X /= X_scale
         else:
             X_scale = np.ones(X.shape[1], dtype=X.dtype)
 

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -263,6 +263,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
 
             if normalize:
                 X_scale = np.sqrt(X_var) * np.sqrt(len(X))
+                X_scale[X_scale == 0.0] = 1.0
                 X = X / X_scale
             else:
                 X_scale = np.ones(X.shape[1], dtype=X.dtype)

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -255,6 +255,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
             else:
                 X_scale_ = X_scale
             if sp.issparse(X):
+                # import pdb; pdb.set_trace()
                 inplace_column_scale(X, 1. / X_scale_)
             else:
                 X /= X_scale_

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -33,7 +33,7 @@ from ..utils.validation import FLOAT_DTYPES
 from ..utils.validation import _deprecate_positional_args
 from ..utils import check_random_state
 from ..utils.extmath import safe_sparse_dot
-from ..utils.extmath import _incremental_weighted_mean_and_var
+from ..utils.extmath import _incremental_mean_and_var
 from ..utils.sparsefuncs import mean_variance_axis, inplace_column_scale
 from ..utils.fixes import sparse_lsqr
 from ..utils._seq_dataset import ArrayDataset32, CSRDataset32
@@ -250,10 +250,11 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
 
         else:
             X_offset, X_var, _ = \
-                _incremental_weighted_mean_and_var(X, sample_weight,
-                                                   last_mean=0.,
-                                                   last_variance=0.,
-                                                   last_weight_sum=0.)
+                _incremental_mean_and_var(X,
+                                          last_mean=0.,
+                                          last_variance=0.,
+                                          last_sample_count=0.,
+                                          sample_weight=sample_weight)
             X -= X_offset
 
             if normalize:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -33,6 +33,7 @@ from ..utils.validation import FLOAT_DTYPES
 from ..utils.validation import _deprecate_positional_args
 from ..utils import check_random_state
 from ..utils.extmath import safe_sparse_dot
+from ..utils.extmath import _incremental_weighted_mean_and_var
 from ..utils.sparsefuncs import mean_variance_axis, inplace_column_scale
 from ..utils.fixes import sparse_lsqr
 from ..utils._seq_dataset import ArrayDataset32, CSRDataset32
@@ -40,7 +41,6 @@ from ..utils._seq_dataset import ArrayDataset64, CSRDataset64
 from ..utils.validation import check_is_fitted, _check_sample_weight
 
 from ..utils.fixes import delayed
-from ..preprocessing import normalize as f_normalize
 
 # TODO: bayesian_ridge_regression and bayesian_regression_ard
 # should be squashed into its respective objects.
@@ -229,12 +229,12 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
 
     if fit_intercept:
         if sp.issparse(X):
-            X_offset, X_var = mean_variance_axis(X, axis=0)
+            X_offset, X_var = mean_variance_axis(X, axis=0,
+                                                 weights=sample_weight)
             if not return_mean:
                 X_offset[:] = X.dtype.type(0)
 
             if normalize:
-
                 # TODO: f_normalize could be used here as well but the function
                 # inplace_csr_row_normalize_l2 must be changed such that it
                 # can return also the norms computed internally
@@ -249,13 +249,19 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
                 X_scale = np.ones(X.shape[1], dtype=X.dtype)
 
         else:
-            X_offset = np.average(X, axis=0, weights=sample_weight)
+            X_offset, X_var, _ = \
+                _incremental_weighted_mean_and_var(X, sample_weight,
+                                                   last_mean=0.,
+                                                   last_variance=0.,
+                                                   last_weight_sum=0.)
             X -= X_offset
+
             if normalize:
-                X, X_scale = f_normalize(X, axis=0, copy=False,
-                                         return_norm=True)
+                X_scale = np.sqrt(X_var) * np.sqrt(len(X))
+                X = X / X_scale
             else:
                 X_scale = np.ones(X.shape[1], dtype=X.dtype)
+
         y_offset = np.average(y, axis=0, weights=sample_weight)
         y = y - y_offset
     else:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -249,12 +249,16 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
                 X_scale = np.ones(X.shape[1], dtype=X.dtype)
 
         else:
+            xtype = X.dtype
+
             X_offset, X_var, _ = \
                 _incremental_mean_and_var(X,
                                           last_mean=0.,
                                           last_variance=0.,
                                           last_sample_count=0.,
                                           sample_weight=sample_weight)
+            X_offset = X_offset.astype(xtype)
+            X_var = X_var.astype(xtype)
             X -= X_offset
 
             if normalize:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -249,7 +249,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
         if normalize:
             X_var *= X.shape[0]
             X_scale = np.sqrt(X_var, X_var)
-            del X_var
+
             X_scale[X_scale == 0] = 1
             if sp.issparse(X):
                 inplace_column_scale(X, 1. / X_scale)

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -232,7 +232,6 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
             X_offset, X_var = mean_variance_axis(
                 X, axis=0, weights=sample_weight
             )
-
             if not return_mean:
                 X_offset[:] = X.dtype.type(0)
         else:
@@ -249,9 +248,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
         if normalize:
             X_var *= X.shape[0]
             X_scale = np.sqrt(X_var, out=X_var)
-            near_zero_mask = X_scale < np.finfo(X_scale.dtype).eps
-            if np.any(near_zero_mask):
-                X_scale[near_zero_mask] = 1
+            X_scale[X_scale < 10 * np.finfo(X_scale.dtype).eps] = 1.
             if sp.issparse(X):
                 inplace_column_scale(X, 1. / X_scale)
             else:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -255,6 +255,10 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
                                           last_variance=0.,
                                           last_sample_count=0.,
                                           sample_weight=sample_weight)
+
+            X_var = X_var.astype(X.dtype)
+            X_offset = X_offset.astype(X.dtype)
+
             X -= X_offset
 
             if normalize:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -249,12 +249,15 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
         if normalize:
             X_var *= X.shape[0]
             X_scale = np.sqrt(X_var, X_var)
-
-            X_scale[X_scale == 0] = 1
-            if sp.issparse(X):
-                inplace_column_scale(X, 1. / X_scale)
+            if np.any(X_scale == 0):
+                X_scale_ = X_scale.copy()
+                X_scale_[X_scale_ == 0] = 1
             else:
-                X /= X_scale
+                X_scale_ = X_scale
+            if sp.issparse(X):
+                inplace_column_scale(X, 1. / X_scale_)
+            else:
+                X /= X_scale_
         else:
             X_scale = np.ones(X.shape[1], dtype=X.dtype)
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -490,7 +490,9 @@ def test_preprocess_data_weighted(is_sparse):
     assert_array_almost_equal(X_mean, expected_X_mean)
     assert_array_almost_equal(y_mean, expected_y_mean)
     assert_array_almost_equal(X_norm, np.ones(n_features))
-    if not is_sparse:
+    if is_sparse:
+        assert_array_almost_equal(Xt.toarray(), X.toarray() - expected_X_mean)
+    else:
         assert_array_almost_equal(Xt, X - expected_X_mean)
     assert_array_almost_equal(yt, y - expected_y_mean)
 
@@ -500,8 +502,14 @@ def test_preprocess_data_weighted(is_sparse):
     assert_array_almost_equal(X_mean, expected_X_mean)
     assert_array_almost_equal(y_mean, expected_y_mean)
     assert_array_almost_equal(X_norm, expected_X_norm)
-    if not is_sparse:
-        assert_array_almost_equal(Xt, (X - expected_X_mean) / expected_X_norm)
+    if is_sparse:
+        assert_array_almost_equal(
+            Xt.toarray(), (X.toarray() - expected_X_mean) / expected_X_norm
+            )
+    else:
+        assert_array_almost_equal(
+            Xt, (X - expected_X_mean) / expected_X_norm
+            )
     assert_array_almost_equal(yt, y - expected_y_mean)
 
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -478,8 +478,7 @@ def test_preprocess_data_weighted(is_sparse):
     # better check the impact of feature scaling.
     X[:, 0] *= 10
     # Constant non-zero feature
-    # X[:, 2] = 1. # this edge case is not passing for sparse data because of
-    # the roundoff error and should be addressed elsewhere
+    X[:, 2] = 1.
     # Constant zero feature (non-materialized in the sparse case)
     X[:, 3] = 0.
     y = rng.rand(n_samples)
@@ -494,8 +493,8 @@ def test_preprocess_data_weighted(is_sparse):
                                      axis=0)
     expected_X_scale = np.sqrt(X_sample_weight_var) * np.sqrt(n_samples)
 
-    # near constant fetures should not be scaled
-    expected_X_scale[expected_X_scale < 1e-15] = 1
+    # near constant features should not be scaled
+    expected_X_scale[expected_X_scale < 10 * np.finfo(np.float64).eps] = 1
 
     if is_sparse:
         X = sparse.csr_matrix(X)

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -461,10 +461,7 @@ def test_preprocess_data_multioutput():
         assert_array_almost_equal(yt, y - y_mean)
 
 
-@pytest.mark.parametrize(
-    "is_sparse",
-    [False, True]
-)
+@pytest.mark.parametrize("is_sparse", [False, True])
 def test_preprocess_data_weighted(is_sparse):
     n_samples = 200
     n_features = 2

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -478,7 +478,7 @@ def test_preprocess_data_weighted(is_sparse):
     # better check the impact of feature scaling.
     X[:, 0] *= 10
     # Constant non-zero feature
-    # X[:, 2] = 1.
+    X[:, 2] = 1.
     # Constant zero feature (non-materialized in the sparse case)
     X[:, 3] = 0.
     y = rng.rand(n_samples)
@@ -518,15 +518,21 @@ def test_preprocess_data_weighted(is_sparse):
     assert_array_almost_equal(y_mean, expected_y_mean)
     assert_array_almost_equal(X_norm, expected_X_norm)
 
-    expected_X_norm[expected_X_norm == 0] = 1
+    if np.any(expected_X_norm == 0):
+        expected_X_norm_ = expected_X_norm.copy()
+        expected_X_norm_[expected_X_norm_ == 0] = 1
+    else:
+        expected_X_norm_ = expected_X_norm
+    # avoid roundoff errors
+    expected_X_norm_[expected_X_norm_ < 1e-10] = 1
     if is_sparse:
         # X is not centered
         assert_array_almost_equal(
-            Xt.toarray(), X.toarray() / expected_X_norm
+            Xt.toarray(), X.toarray() / expected_X_norm_
         )
     else:
         assert_array_almost_equal(
-            Xt, (X - expected_X_mean) / expected_X_norm
+            Xt, (X - expected_X_mean) / expected_X_norm_
         )
 
     # _preprocess_data with normalize=True scales the data by the feature-wise

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -477,6 +477,10 @@ def test_preprocess_data_weighted(is_sparse):
     # Scale the first feature of X to be 10 larger than the other to
     # better check the impact of feature scaling.
     X[:, 0] *= 10
+    # Constant non-zero feature
+    X[:, 2] = 1.
+    # Constant zero feature (non-materialized in the sparse case)
+    X[:, 3] = 0.
     y = rng.rand(n_samples)
 
     sample_weight = rng.rand(n_samples)

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -470,10 +470,11 @@ def test_preprocess_data_weighted():
     expected_X_mean = np.average(X, axis=0, weights=sample_weight)
     expected_y_mean = np.average(y, axis=0, weights=sample_weight)
 
-    # XXX: if normalize=True, should we expect a weighted standard deviation?
-    #      Currently not weighted, but calculated with respect to weighted mean
-    expected_X_norm = (np.sqrt(X.shape[0]) *
-                       np.mean((X - expected_X_mean) ** 2, axis=0) ** .5)
+    X_sample_weight_avg = np.average(X, weights=sample_weight, axis=0)
+    X_sample_weight_var = np.average((X-X_sample_weight_avg)**2,
+                                     weights=sample_weight,
+                                     axis=0)
+    expected_X_norm = np.sqrt(X_sample_weight_var) * np.sqrt(len(X))
 
     Xt, yt, X_mean, y_mean, X_norm = \
         _preprocess_data(X, y, fit_intercept=True, normalize=False,

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -476,7 +476,7 @@ def test_preprocess_data_weighted(is_sparse):
     expected_y_mean = np.average(y, axis=0, weights=sample_weight)
 
     X_sample_weight_avg = np.average(X, weights=sample_weight, axis=0)
-    X_sample_weight_var = np.average((X-X_sample_weight_avg)**2,
+    X_sample_weight_var = np.average((X - X_sample_weight_avg)**2,
                                      weights=sample_weight,
                                      axis=0)
     expected_X_norm = np.sqrt(X_sample_weight_var) * np.sqrt(len(X))
@@ -491,7 +491,7 @@ def test_preprocess_data_weighted(is_sparse):
     assert_array_almost_equal(y_mean, expected_y_mean)
     assert_array_almost_equal(X_norm, np.ones(n_features))
     if is_sparse:
-        assert_array_almost_equal(Xt.toarray(), X.toarray() - expected_X_mean)
+        assert_array_almost_equal(Xt.toarray(), X.toarray())
     else:
         assert_array_almost_equal(Xt, X - expected_X_mean)
     assert_array_almost_equal(yt, y - expected_y_mean)
@@ -504,7 +504,7 @@ def test_preprocess_data_weighted(is_sparse):
     assert_array_almost_equal(X_norm, expected_X_norm)
     if is_sparse:
         assert_array_almost_equal(
-            Xt.toarray(), (X.toarray() - expected_X_mean) / expected_X_norm
+            Xt.toarray(), X.toarray() / expected_X_norm
             )
     else:
         assert_array_almost_equal(

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -485,7 +485,7 @@ def test_preprocess_data_weighted(is_sparse):
     X_sample_weight_var = np.average((X - X_sample_weight_avg)**2,
                                      weights=sample_weight,
                                      axis=0)
-    expected_X_norm = np.sqrt(X_sample_weight_var) * np.sqrt(len(X))
+    expected_X_norm = np.sqrt(X_sample_weight_var) * np.sqrt(n_samples)
 
     if is_sparse:
         X = sparse.csr_matrix(X)

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -518,15 +518,22 @@ def test_preprocess_data_weighted(is_sparse):
         assert_array_almost_equal(
             Xt.toarray(), X.toarray() / expected_X_norm
         )
+    else:
+        assert_array_almost_equal(
+            Xt, (X - expected_X_mean) / expected_X_norm
+        )
+
+    # _preprocess_data with normalize=True scales the data by the feature-wise
+    # euclidean norms while StandardScaler scales the data by the feature-wise
+    # standard deviations.
+    # The two are equivalent up to a ration of np.sqrt(n_samples)
+    if is_sparse:
         scaler = StandardScaler(with_mean=False).fit(
             X, sample_weight=sample_weight)
         assert_array_almost_equal(
             scaler.transform(X).toarray() / np.sqrt(n_samples), Xt.toarray()
             )
     else:
-        assert_array_almost_equal(
-            Xt, (X - expected_X_mean) / expected_X_norm
-        )
         scaler = StandardScaler(with_mean=True).fit(
             X, sample_weight=sample_weight)
         assert_array_almost_equal(scaler.mean_, X_mean)

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -535,7 +535,7 @@ def test_preprocess_data_weighted(is_sparse):
     # _preprocess_data with normalize=True scales the data by the feature-wise
     # euclidean norms while StandardScaler scales the data by the feature-wise
     # standard deviations.
-    # The two are equivalent up to a ration of np.sqrt(n_samples)
+    # The two are equivalent up to a ratio of np.sqrt(n_samples)
     if is_sparse:
         scaler = StandardScaler(with_mean=False).fit(
             X, sample_weight=sample_weight)

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -478,7 +478,7 @@ def test_preprocess_data_weighted(is_sparse):
     # better check the impact of feature scaling.
     X[:, 0] *= 10
     # Constant non-zero feature
-    X[:, 2] = 1.
+    # X[:, 2] = 1.
     # Constant zero feature (non-materialized in the sparse case)
     X[:, 3] = 0.
     y = rng.rand(n_samples)
@@ -517,6 +517,8 @@ def test_preprocess_data_weighted(is_sparse):
     assert_array_almost_equal(X_mean, expected_X_mean)
     assert_array_almost_equal(y_mean, expected_y_mean)
     assert_array_almost_equal(X_norm, expected_X_norm)
+
+    expected_X_norm[expected_X_norm == 0] = 1
     if is_sparse:
         # X is not centered
         assert_array_almost_equal(

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -477,8 +477,12 @@ def test_preprocess_data_weighted(is_sparse):
     # Scale the first feature of X to be 10 larger than the other to
     # better check the impact of feature scaling.
     X[:, 0] *= 10
-    # Constant non-zero feature
-    X[:, 2] = 1.
+
+    # Constant non-zero feature: this edge-case is currently not handled
+    # correctly for sparse data, see:
+    # https://github.com/scikit-learn/scikit-learn/issues/19450
+    # X[:, 2] = 1.
+
     # Constant zero feature (non-materialized in the sparse case)
     X[:, 3] = 0.
     y = rng.rand(n_samples)

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -471,7 +471,7 @@ def test_preprocess_data_weighted(is_sparse):
     # zero.
     X = rng.rand(n_samples, n_features)
     X[X < 0.5] = 0.
-    
+
     # Scale the first feature of X to be 10 larger than the other to
     # better check the impact of feature scaling.
     X[:, 0] *= 10

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -466,7 +466,7 @@ def test_preprocess_data_multioutput():
 @pytest.mark.parametrize("is_sparse", [False, True])
 def test_preprocess_data_weighted(is_sparse):
     n_samples = 200
-    n_features = 2
+    n_features = 4
     # Generate random data with 50% of zero values to make sure
     # that the sparse variant of this test is actually sparse. This also
     # shifts the mean value for each columns in X further away from

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -520,6 +520,9 @@ def test_preprocess_data_weighted(is_sparse):
         )
         scaler = StandardScaler(with_mean=False).fit(
             X, sample_weight=sample_weight)
+        assert_array_almost_equal(
+            scaler.transform(X).toarray() / np.sqrt(n_samples), Xt.toarray()
+            )
     else:
         assert_array_almost_equal(
             Xt, (X - expected_X_mean) / expected_X_norm
@@ -527,7 +530,7 @@ def test_preprocess_data_weighted(is_sparse):
         scaler = StandardScaler(with_mean=True).fit(
             X, sample_weight=sample_weight)
         assert_array_almost_equal(scaler.mean_, X_mean)
-    assert_array_almost_equal(scaler.transform(X), Xt)
+        assert_array_almost_equal(scaler.transform(X) / np.sqrt(n_samples), Xt)
     assert_array_almost_equal(yt, y - expected_y_mean)
 
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -500,13 +500,14 @@ def test_preprocess_data_weighted(is_sparse):
     assert_array_almost_equal(y_mean, expected_y_mean)
     assert_array_almost_equal(X_norm, expected_X_norm)
     if is_sparse:
+        # X is not centered
         assert_array_almost_equal(
             Xt.toarray(), X.toarray() / expected_X_norm
-            )
+        )
     else:
         assert_array_almost_equal(
             Xt, (X - expected_X_mean) / expected_X_norm
-            )
+        )
     assert_array_almost_equal(yt, y - expected_y_mean)
 
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -465,7 +465,16 @@ def test_preprocess_data_multioutput():
 def test_preprocess_data_weighted(is_sparse):
     n_samples = 200
     n_features = 2
+    # Generate random data with 50% of zero values to make sure
+    # that the sparse variant of this test is actually sparse. This also
+    # shifts the mean value for each columns in X further away from
+    # zero.
     X = rng.rand(n_samples, n_features)
+    X[X < 0.5] = 0.
+    
+    # Scale the first feature of X to be 10 larger than the other to
+    # better check the impact of feature scaling.
+    X[:, 0] *= 10
     y = rng.rand(n_samples)
 
     sample_weight = rng.rand(n_samples)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -414,10 +414,10 @@ def test_model_pipeline_same_as_normalize_true(LinearModel, params):
 def test_linear_model_sample_weights_normalize_in_pipeline(
         with_mean, is_sparse, estimator, params
 ):
-    # Test that the results for running linear regression LinearRegression with
-    # sample_weight set and with normalize set to True gives similar results as
-    # LinearRegression with no normalize in a pipeline with a StandardScaler
-    # and set sample_weight.
+    # Test that the results for running linear model with sample_weight
+    # and with normalize set to True gives similar results as the same linear
+    # model with normalize set to False in a pipeline with
+    # a StandardScaler and sample_weight.
     model_name = estimator.__name__
 
     if model_name in ['Lasso', 'ElasticNet'] and is_sparse:

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -304,9 +304,12 @@ def test_lasso_cv_positive_constraint():
 
 
 def _scale_alpha_inplace(estimator, n_samples):
-    """"Rescale the parameter alpha from when the estimator is evoked with
+    """Rescale the alpha param to check equivalence with StandardScaler
+    
+    Rescale the alpha parameter from when the estimator is evoked with
     normalize set to True to when it is evoked in a Pipeline with normalize set
-    to False and with a StandardScaler."""
+    to False and with a StandardScaler.
+    """
     if 'alpha' not in estimator.get_params():
         return
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -303,7 +303,7 @@ def test_lasso_cv_positive_constraint():
     assert min(clf_constrained.coef_) >= 0
 
 
-def _scale_alpha(estimator, n_samples):
+def _scale_alpha_inplace(estimator, n_samples):
     """"Rescale the parameter alpha from when the estimator is evoked with
     normalize set to True to when it is evoked in a Pipeline with normalize set
     to False and with a StandardScaler."""
@@ -378,7 +378,7 @@ def test_model_pipeline_same_as_normalize_true(LinearModel, params):
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
 
-    _scale_alpha(pipeline[1], X_train.shape[0])
+    _scale_alpha_inplace(pipeline[1], X_train.shape[0])
 
     model_normalize.fit(X_train, y_train)
     y_pred_normalize = model_normalize.predict(X_test)
@@ -457,7 +457,7 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
         estimator(normalize=False, fit_intercept=True, **params)
     )
 
-    _scale_alpha(reg_with_scaler[1], X_train.shape[0])
+    _scale_alpha_inplace(reg_with_scaler[1], X_train.shape[0])
 
     kwargs = {reg_with_scaler.steps[0][0] + '__sample_weight':
               sample_weight,

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -451,7 +451,7 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
 
     sample_weight = rng.rand(X_train.shape[0])
 
-    # linear estimator with explicit sample_weight, normalize = True
+    # linear estimator with built-in feature normalization
     reg_with_normalize = estimator(normalize=True, fit_intercept=True,
                                    **params)
     reg_with_normalize.fit(X_train, y_train, sample_weight=sample_weight)
@@ -475,6 +475,7 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
     # sense that they predict exactly the same outcome.
     y_pred_nomalize = reg_with_normalize.predict(X_test)
     y_pred_scaler = reg_with_scaler.predict(X_test)
+    assert_allclose(y_pred_nomalize,  y_pred_scaler)
 
     y_train_mean = np.average(y_train, weights=sample_weight)
     if is_sparse:
@@ -485,7 +486,6 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
     assert (reg_with_normalize.intercept_ ==
             pytest.approx(y_train_mean -
                           reg_with_normalize.coef_.dot(X_train_mean)))
-    assert_allclose(y_pred_nomalize,  y_pred_scaler)
 
 
 # FIXME: 'normalize' to be removed in 1.2

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -473,10 +473,10 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
 
     # Check that the 2 regressions models are exactly equivalent in the
     # sense that they predict exactly the same outcome.
-    y_pred_nomalize = reg_with_normalize.predict(X_test)
+    y_pred_normalize = reg_with_normalize.predict(X_test)
     y_pred_scaler = reg_with_scaler.predict(X_test)
-    assert_allclose(y_pred_nomalize,  y_pred_scaler)
-
+    assert_allclose(y_pred_normalize,  y_pred_scaler)
+    # Check intercept computation when normalize is True
     y_train_mean = np.average(y_train, weights=sample_weight)
     if is_sparse:
         X_train_mean, _ = mean_variance_axis(X_train, axis=0,

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -304,6 +304,9 @@ def test_lasso_cv_positive_constraint():
 
 
 def _scale_alpha(estimator, n_samples):
+    """"Rescale the parameter alpha from when the estimator is evoked with
+    normalize set to True to when it is evoked in a Pipeline with normalize set
+    to False and with a StandardScaler."""
     if 'alpha' not in estimator.get_params():
         return
 
@@ -321,7 +324,9 @@ def _scale_alpha(estimator, n_samples):
     estimator.set_params(alpha=alpha)
 
 
-# FIXME: 'normalize' to be removed in 1.2
+# FIXME: 'normalize' to be removed in 1.2 for all the models excluding:
+# OrthogonalMatchingPursuit, Lars, LassoLars, LarsCV, LassoLarsCV
+# for which it is to be removed in 1.4
 @pytest.mark.filterwarnings("ignore:'normalize' was deprecated")
 @pytest.mark.parametrize(
     "LinearModel, params",

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -400,12 +400,12 @@ def test_model_pipeline_same_as_normalize_true(LinearModel, params):
 @pytest.mark.parametrize(
     "estimator, params",
     [
-     (Lasso, {"tol": 1e-16, "alpha": 0.1}),
-     (RidgeClassifier, {"solver": 'sparse_cg', "alpha": 0.1}),
-     (ElasticNet, {"tol": 1e-16, 'l1_ratio': 1, "alpha": 0.1}),
-     (ElasticNet, {"tol": 1e-16, 'l1_ratio': 0, "alpha": 0.1}),
-     (Ridge, {"solver": 'sparse_cg', 'tol': 1e-12, "alpha": 0.1}),
-     (LinearRegression, {}),
+         (Lasso, {"tol": 1e-16, "alpha": 0.1}),
+         (RidgeClassifier, {"solver": 'sparse_cg', "alpha": 0.1}),
+         (ElasticNet, {"tol": 1e-16, 'l1_ratio': 1, "alpha": 0.1}),
+         (ElasticNet, {"tol": 1e-16, 'l1_ratio': 0, "alpha": 0.1}),
+         (Ridge, {"solver": 'sparse_cg', 'tol': 1e-12, "alpha": 0.1}),
+         (LinearRegression, {}),
      ]
 )
 @pytest.mark.parametrize(

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -394,7 +394,7 @@ def test_model_pipeline_same_as_normalize_true(LinearModel, params):
     "estimator, params",
     [
      (Lasso, {"tol": 1e-16, "alpha": 0.1}),
-     # (RidgeClassifier, {"solver": 'sparse_cg', "alpha": 0.1}),
+     (RidgeClassifier, {"solver": 'sparse_cg', "alpha": 0.1}),
      (ElasticNet, {"tol": 1e-16, 'l1_ratio': 1, "alpha": 0.1}),
      (ElasticNet, {"tol": 1e-16, 'l1_ratio': 0, "alpha": 0.1}),
      (Ridge, {"solver": 'sparse_cg', 'tol': 1e-12, "alpha": 0.1}),
@@ -424,6 +424,9 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
     rng = np.random.RandomState(0)
     X, y = make_regression(n_samples=20, n_features=5, noise=1e-2,
                            random_state=rng)
+
+    if is_classifier(estimator):
+        y = np.sign(y)
 
     # make sure the data is not centered to make the problem more
     # difficult

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -471,8 +471,8 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
 
     reg_with_scaler.fit(X_train, y_train, **fit_params)
 
-    y_pred_norm = reg_with_normalize.predict(X_test)
-    y_pred_pip = reg_with_scaler.predict(X_test)
+    y_pred_nomalize = reg_with_normalize.predict(X_test)
+    y_pred_scaler = reg_with_scaler.predict(X_test)
 
     y_train_mean = np.average(y_train, weights=sample_weight)
     if is_sparse:
@@ -483,7 +483,7 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
     assert (reg_with_normalize.intercept_ ==
             pytest.approx(y_train_mean -
                           reg_with_normalize.coef_.dot(X_train_mean)))
-    assert_allclose(y_pred_norm, y_pred_pip)
+    assert_allclose(y_pred_nomalize,  y_pred_scaler)
 
 
 # FIXME: 'normalize' to be removed in 1.2

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -417,7 +417,7 @@ def test_model_pipeline_same_as_normalize_true(LinearModel, params):
     ]
 )
 def test_linear_model_sample_weights_normalize_in_pipeline(
-        with_mean, is_sparse, estimator, params
+        is_sparse, with_mean, estimator, params
 ):
     # Test that the results for running linear model with sample_weight
     # and with normalize set to True gives similar results as the same linear

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -317,8 +317,11 @@ def _scale_alpha_inplace(estimator, n_samples):
     if isinstance(estimator, (ElasticNet, MultiTaskElasticNet)):
         if estimator.l1_ratio == 1:
             alpha = estimator.alpha * np.sqrt(n_samples)
-        if estimator.l1_ratio == 0:
+        elif estimator.l1_ratio == 0:
             alpha = estimator.alpha * n_samples
+        else:
+            # To avoid silent errors in case of refactoring
+            raise NotImplementedError
 
     estimator.set_params(alpha=alpha)
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -401,11 +401,11 @@ def test_model_pipeline_same_as_normalize_true(LinearModel, params):
 )
 @pytest.mark.parametrize(
     "is_sparse",
-    [False] #, True]
+    [False]  # , True]
 )
 @pytest.mark.parametrize(
     "with_mean",
-    [True, False]
+    [True]  # , False]
 )
 def test_linear_model_sample_weights_normalize_in_pipeline(
         with_mean, is_sparse, estimator, params

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -393,7 +393,10 @@ def test_model_pipeline_same_as_normalize_true(LinearModel, params):
     "estimator, is_sparse, with_mean",
     [(LinearRegression, True, False),
      (LinearRegression, False, True),
-     (LinearRegression, False, False)]
+     (LinearRegression, False, False),
+     (Ridge, True, False),
+     (Ridge, False, True),
+     (Ridge, False, False)]
 )
 def test_linear_model_sample_weights_normalize_in_pipeline(
         estimator, is_sparse, with_mean
@@ -425,7 +428,9 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
         StandardScaler(with_mean=with_mean),
         estimator(normalize=False)
     )
-    kwargs = {reg_with_scaler.steps[-1][0] + '__sample_weight':
+    kwargs = {reg_with_scaler.steps[0][0] + '__sample_weight':
+              sample_weight,
+              reg_with_scaler.steps[-1][0] + '__sample_weight':
               sample_weight}
     reg_with_scaler.fit(X_train, y_train, **kwargs)
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -439,7 +439,8 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
 
     # make sure the data is not centered to make the problem more
     # difficult
-    X += 10
+    X[X < 0] = 0
+
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5,
                                                         random_state=rng)
     if is_sparse:

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -471,6 +471,8 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
 
     reg_with_scaler.fit(X_train, y_train, **fit_params)
 
+    # Check that the 2 regressions models are exactly equivalent in the
+    # sense that they predict exactly the same outcome.
     y_pred_nomalize = reg_with_normalize.predict(X_test)
     y_pred_scaler = reg_with_scaler.predict(X_test)
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -419,7 +419,7 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
     model_name = estimator.__name__
 
     if model_name in ['Lasso', 'ElasticNet'] and is_sparse:
-        pytest.skip(f'{model_name} does not suppert sample_weight with sparse')
+        pytest.skip(f'{model_name} does not support sample_weight with sparse')
 
     rng = np.random.RandomState(0)
     X, y = make_regression(n_samples=20, n_features=5, noise=1e-2,

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -304,9 +304,7 @@ def test_lasso_cv_positive_constraint():
 
 
 def _scale_alpha_inplace(estimator, n_samples):
-    """Rescale the alpha param to check equivalence with StandardScaler
-    
-    Rescale the alpha parameter from when the estimator is evoked with
+    """Rescale the parameter alpha from when the estimator is evoked with
     normalize set to True to when it is evoked in a Pipeline with normalize set
     to False and with a StandardScaler.
     """
@@ -441,7 +439,7 @@ def test_linear_model_sample_weights_normalize_in_pipeline(
         y = np.sign(y)
 
     # make sure the data is not centered to make the problem more
-    # difficult
+    # difficult + add 0s for the sparse case
     X[X < 0] = 0
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5,

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -310,12 +310,11 @@ def _scale_alpha_inplace(estimator, n_samples):
     if 'alpha' not in estimator.get_params():
         return
 
-    model_name = estimator.__class__.__name__
-    if model_name in ['Lasso', 'LassoLars', 'MultiTaskLasso']:
+    if isinstance(estimator, (Lasso, LassoLars, MultiTaskLasso)):
         alpha = estimator.alpha * np.sqrt(n_samples)
-    if model_name in ['Ridge', 'RidgeClassifier']:
+    if isinstance(estimator, (Ridge, RidgeClassifier)):
         alpha = estimator.alpha * n_samples
-    if model_name in ['ElasticNet', 'MultiTaskElasticNet']:
+    if isinstance(estimator, (ElasticNet, MultiTaskElasticNet)):
         if estimator.l1_ratio == 1:
             alpha = estimator.alpha * np.sqrt(n_samples)
         if estimator.l1_ratio == 0:


### PR DESCRIPTION
`_preprocess_data` in `_base` for linear models, when evoked with `normalize = True` and `sample_weight` does not weight standard deviation and therefore does not behave as expected. This PR updates it.

Currently we are working on deprecation of `normalize`: https://github.com/scikit-learn/scikit-learn/issues/3020
as pointed out by @ogrisel in https://github.com/scikit-learn/scikit-learn/pull/17743#discussion_r561712881 when testing for the same result when running  lasso or ridge with `normalize` set to True or in a pipeline with StandardScaler with `normalize` set to False, the test fails.

After through investigation @agramfort realized the above mentioned issue. If not updated we cannot expect the pipeline with a StandardScaler to give the same results as linear_model with normalize set to True.

This issue has been also noted previously by @jnothman https://github.com/scikit-learn/scikit-learn/blob/1ea79056f7f2b3c7d8b022d28abb8c26ad9c91d2/sklearn/linear_model/tests/test_base.py#L473

Possibly it might also related to: #17444

cc @glemaitre 
