### PR TITLE
DOC update whats new 0.24 for backport

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -19,6 +19,13 @@ Changelog
   with `sample_weight` parameter and `least_absolute_deviation` loss function.
   :pr:`19407` by :user:`Vadim Ushtanit <vadim-ushtanit>`.
 
+:mod:`sklearn.linear_model`
+...........................
+
+- |Fix|: Fixed a bug in :class:`linear_model.LogisticRegression`: the
+  sample_weight object is not modified anymore. :pr:`19182` by
+  :user:`Yosuke KOBAYASHI <m7142yosuke>`.
+
 :mod:`sklearn.preprocessing`
 ............................
 
@@ -26,6 +33,13 @@ Changelog
   :class:`preprocessing.OrdinalEncoder` to only allow for `'error'` and
   `'use_encoded_value'` strategies.
   :pr:`19234` by `Guillaume Lemaitre <glemaitre>`.
+
+:mod:`sklearn.semi_supervised`
+..............................
+
+- |Fix| Avoid NaN during label propagation in
+  :class:`~sklearn.semi_supervised.LabelPropagation`.
+  :pr:`19271` by :user:`Zhaowei Wang <ThuWangzw>`.
 
 .. _changes_0_24_1:
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -122,10 +122,6 @@ Changelog
   not corresponding to their objective. :pr:`19172` by
   :user:`Mathurin Massias <mathurinm>`
 
-- |Fix|: Fixed a bug in :class:`linear_model.LogisticRegression`: the
-  sample_weight object is not modified anymore. :pr:`19182` by
-  :user:`Yosuke KOBAYASHI <m7142yosuke>`.
-
 - |API|: The parameter ``normalize`` of :class:`linear_model.LinearRegression`
   is deprecated and will be removed in 1.2.
   Motivation for this deprecation: ``normalize`` parameter did not take any
@@ -179,13 +175,6 @@ Changelog
 - |Enhancement| Add `fontname` argument in :func:`tree.export_graphviz`
   for non-English characters. :pr:`18959` by :user:`Zero <Zeroto521>`
   and :user:`wstates <wstates>`.
-
-:mod:`sklearn.semi_supervised`
-..............................
-
-- |Fix| Avoid NaN during label propagation in
-  :class:`~sklearn.semi_supervised.LabelPropagation`.
-  :pr:`19271` by :user:`Zhaowei Wang <ThuWangzw>`.
 
 Code and Documentation Contributors
 -----------------------------------


### PR DESCRIPTION
Move some entry from 1.0 to 0.24.2 since we will backport these commits.
I added the "To backport" tag and the milestone "0.24.2" for these entries.