### PR TITLE
oob_score requires bootstrap

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1074,7 +1074,8 @@ class RandomForestClassifier(ForestClassifier):
         whole dataset is used to build each tree.
 
     oob_score : bool, default=False
-        Whether to use out-of-bag samples to estimate the generalization score.
+        Whether to use out-of-bag samples to estimate the generalization score. 
+        Only available if bootstrap=True.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -461,4 +461,4 @@ def _ovr_decision_function(predictions, confidences, n_classes):
     # of 1 vote.
     transformed_confidences = (sum_of_confidences /
                                (3 * (np.abs(sum_of_confidences) + 1)))
-    return votes + transformed_confidences
+    return votes + transformed_confidences - (n_classes - 1) / 2


### PR DESCRIPTION
#### Reference Issues/PRs
#19431 

#### What does this implement/fix? Explain your changes.
Updates the documentation in sklearn/ensemble/_forest.py:RandomForestClassifier to mention that oob_score requires bootstrap