### PR TITLE
TST Replace the use of assert_warns messages in cluster/tests/ module

### DIFF
--- a/sklearn/cluster/tests/common.py
+++ b/sklearn/cluster/tests/common.py
@@ -19,7 +19,7 @@ def generate_clustered_data(seed=0, n_clusters=3, n_features=2,
                       [-1, -1, 0, 1],
                       [1, -1, 1, 1],
                       [-1, 1, 1, 0],
-                     ]) + 10
+                      ]) + 10
 
     X = np.empty((0, n_features))
     for i in range(n_clusters):

--- a/sklearn/cluster/tests/common.py
+++ b/sklearn/cluster/tests/common.py
@@ -19,7 +19,7 @@ def generate_clustered_data(seed=0, n_clusters=3, n_features=2,
                       [-1, -1, 0, 1],
                       [1, -1, 1, 1],
                       [-1, 1, 1, 0],
-                      ]) + 10
+                     ]) + 10
 
     X = np.empty((0, n_features))
     for i in range(n_clusters):

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -9,8 +9,7 @@ from scipy.sparse import csr_matrix
 
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils._testing import (
-    assert_array_equal, assert_warns,
-    assert_warns_message, assert_no_warnings)
+    assert_array_equal, assert_no_warnings)
 
 from sklearn.cluster import AffinityPropagation
 from sklearn.cluster._affinity_propagation import (
@@ -104,7 +103,8 @@ def test_affinity_propagation_fit_non_convergence():
     # Force non-convergence by allowing only a single iteration
     af = AffinityPropagation(preference=-10, max_iter=1, random_state=82)
 
-    assert_warns(ConvergenceWarning, af.fit, X)
+    with pytest.warns(ConvergenceWarning):
+        af.fit(X)
     assert_array_equal(np.empty((0, 2)), af.cluster_centers_)
     assert_array_equal(np.array([-1, -1, -1]), af.labels_)
 
@@ -114,16 +114,18 @@ def test_affinity_propagation_equal_mutual_similarities():
     S = -euclidean_distances(X, squared=True)
 
     # setting preference > similarity
-    cluster_center_indices, labels = assert_warns_message(
-        UserWarning, "mutually equal", affinity_propagation, S, preference=0)
+    with pytest.warns(UserWarning, match="mutually equal"):
+        cluster_center_indices, labels = affinity_propagation(
+            S, preference=0)
 
     # expect every sample to become an exemplar
     assert_array_equal([0, 1], cluster_center_indices)
     assert_array_equal([0, 1], labels)
 
     # setting preference < similarity
-    cluster_center_indices, labels = assert_warns_message(
-        UserWarning, "mutually equal", affinity_propagation, S, preference=-10)
+    with pytest.warns(UserWarning, match="mutually equal"):
+        cluster_center_indices, labels = affinity_propagation(
+            S, preference=-10)
 
     # expect one cluster, with arbitrary (first) sample as exemplar
     assert_array_equal([0], cluster_center_indices)
@@ -144,14 +146,15 @@ def test_affinity_propagation_predict_non_convergence():
     X = np.array([[0, 0], [1, 1], [-2, -2]])
 
     # Force non-convergence by allowing only a single iteration
-    af = assert_warns(ConvergenceWarning,
-                      AffinityPropagation(preference=-10,
-                                          max_iter=1, random_state=75).fit, X)
+    with pytest.warns(ConvergenceWarning):
+        af = AffinityPropagation(preference=-10,
+                                 max_iter=1, random_state=75).fit(X)
 
     # At prediction time, consider new samples as noise since there are no
     # clusters
     to_predict = np.array([[2, 2], [3, 3], [4, 4]])
-    y = assert_warns(ConvergenceWarning, af.predict, to_predict)
+    with pytest.warns(ConvergenceWarning):
+        y = af.predict(to_predict)
     assert_array_equal(np.array([-1, -1, -1]), y)
 
 

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -9,7 +9,7 @@ from scipy.sparse import csr_matrix
 
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils._testing import (
-    assert_array_equal, assert_no_warnings)
+    assert_array_equal)
 
 from sklearn.cluster import AffinityPropagation
 from sklearn.cluster._affinity_propagation import (
@@ -70,6 +70,7 @@ def test_affinity_propagation():
     af_2 = AffinityPropagation(affinity='precomputed', random_state=21)
     with pytest.raises(TypeError):
         af_2.fit(csr_matrix((3, 3)))
+
 
 def test_affinity_propagation_predict():
     # Test AffinityPropagation.predict
@@ -132,8 +133,10 @@ def test_affinity_propagation_equal_mutual_similarities():
     assert_array_equal([0, 0], labels)
 
     # setting different preferences
-    cluster_center_indices, labels = assert_no_warnings(
-        affinity_propagation, S, preference=[-20, -10], random_state=37)
+    with pytest.warns(None) as record:
+        cluster_center_indices, labels = affinity_propagation(
+            S, preference=[-20, -10], random_state=37)
+    assert not len(record)
 
     # expect one cluster, with highest-preference sample as exemplar
     assert_array_equal([1], cluster_center_indices)

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -8,8 +8,7 @@ import pytest
 from scipy.sparse import csr_matrix
 
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.utils._testing import (
-    assert_array_equal)
+from sklearn.utils._testing import assert_array_equal
 
 from sklearn.cluster import AffinityPropagation
 from sklearn.cluster._affinity_propagation import (

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -14,9 +14,9 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import ElasticNet
 from sklearn.metrics import pairwise_distances_argmin, v_measure_score
 
-from sklearn.utils._testing import (
-    assert_almost_equal, assert_array_equal,
-    assert_array_almost_equal)
+from sklearn.utils._testing import assert_almost_equal
+from sklearn.utils._testing import assert_array_equal
+from sklearn.utils._testing import assert_array_almost_equal
 
 
 def test_n_samples_leaves_roots():

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -14,11 +14,9 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import ElasticNet
 from sklearn.metrics import pairwise_distances_argmin, v_measure_score
 
-from sklearn.utils._testing import assert_almost_equal
-from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import assert_warns
-
+from sklearn.utils._testing import (
+    assert_almost_equal, assert_array_equal,
+    assert_array_almost_equal)
 
 def test_n_samples_leaves_roots():
     # Sanity check for the number of samples in leaves and roots
@@ -92,7 +90,8 @@ def test_n_clusters():
 
     # Test that a small number of clusters raises a warning.
     brc4 = Birch(threshold=10000.)
-    assert_warns(ConvergenceWarning, brc4.fit, X)
+    with pytest.warns(ConvergenceWarning):
+        brc4.fit(X)
 
 
 def test_sparse_X():

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -18,6 +18,7 @@ from sklearn.utils._testing import (
     assert_almost_equal, assert_array_equal,
     assert_array_almost_equal)
 
+
 def test_n_samples_leaves_roots():
     # Sanity check for the number of samples in leaves and roots
     X, y = make_blobs(n_samples=10)

--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -18,6 +18,8 @@ def test_feature_agglomeration():
                                         pooling_func=np.median)
     with pytest.warns(None) as record:
         agglo_mean.fit(X)
+    assert not len(record)
+    with pytest.warns(None) as record:
         agglo_median.fit(X)
     assert not len(record)
     assert np.size(np.unique(agglo_mean.labels_)) == n_clusters

--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -3,8 +3,8 @@ Tests for sklearn.cluster._feature_agglomeration
 """
 # Authors: Sergul Aydore 2017
 import numpy as np
+import pytest
 from sklearn.cluster import FeatureAgglomeration
-from sklearn.utils._testing import assert_no_warnings
 from sklearn.utils._testing import assert_array_almost_equal
 
 
@@ -16,8 +16,10 @@ def test_feature_agglomeration():
                                       pooling_func=np.mean)
     agglo_median = FeatureAgglomeration(n_clusters=n_clusters,
                                         pooling_func=np.median)
-    assert_no_warnings(agglo_mean.fit, X)
-    assert_no_warnings(agglo_median.fit, X)
+    with pytest.warns(None) as record:
+        agglo_mean.fit(X)
+        agglo_median.fit(X)
+    assert not len(record)
     assert np.size(np.unique(agglo_mean.labels_)) == n_clusters
     assert np.size(np.unique(agglo_median.labels_)) == n_clusters
     assert np.size(agglo_mean.labels_) == X.shape[1]

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -33,7 +33,6 @@ from sklearn.neighbors import kneighbors_graph
 from sklearn.cluster._hierarchical_fast import average_merge, max_merge
 from sklearn.utils._fast_dict import IntFloatDict
 from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_warns
 from sklearn.datasets import make_moons, make_circles
 
 
@@ -94,17 +93,18 @@ def test_unstructured_linkage_tree():
         # With specified a number of clusters just for the sake of
         # raising a warning and testing the warning code
         with ignore_warnings():
-            children, n_nodes, n_leaves, parent = assert_warns(
-                UserWarning, ward_tree, this_X.T, n_clusters=10)
+            with pytest.warns(UserWarning):
+                children, n_nodes, n_leaves, parent = ward_tree(
+                    this_X.T, n_clusters=10)
         n_nodes = 2 * X.shape[1] - 1
         assert len(children) + n_leaves == n_nodes
 
     for tree_builder in _TREE_BUILDERS.values():
         for this_X in (X, X[0]):
             with ignore_warnings():
-                children, n_nodes, n_leaves, parent = assert_warns(
-                    UserWarning, tree_builder, this_X.T, n_clusters=10)
-
+                with pytest.warns(UserWarning):
+                    children, n_nodes, n_leaves, parent = tree_builder(
+                        this_X.T, n_clusters=10)
             n_nodes = 2 * X.shape[1] - 1
             assert len(children) + n_leaves == n_nodes
 
@@ -550,7 +550,8 @@ def test_connectivity_fixing_non_lil():
     m = np.array([[True, False], [False, True]])
     c = grid_to_graph(n_x=2, n_y=2, mask=m)
     w = AgglomerativeClustering(connectivity=c, linkage='ward')
-    assert_warns(UserWarning, w.fit, x)
+    with pytest.warns(UserWarning):
+        w.fit(x)
 
 
 def test_int_float_dict():

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -10,7 +10,6 @@ import pickle
 
 from sklearn.utils import check_random_state
 from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_warns_message
 
 from sklearn.cluster import SpectralClustering, spectral_clustering
 from sklearn.cluster._spectral import discretize
@@ -132,7 +131,8 @@ def test_affinities():
     # nearest neighbors affinity
     sp = SpectralClustering(n_clusters=2, affinity='nearest_neighbors',
                             random_state=0)
-    assert_warns_message(UserWarning, 'not fully connected', sp.fit, X)
+    with pytest.warns(UserWarning, match='not fully connected'):
+        sp.fit(X)
     assert adjusted_rand_score(y, sp.labels_) == 1
 
     sp = SpectralClustering(n_clusters=2, gamma=2, random_state=0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Partial fix for #19414
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Removes the use of assert(_warns(_message)/_no_warnings) in sklearn/cluster/tests/


#### Any other comments?
Part of solution to #19414


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
