### PR TITLE
TST Fix assert_warns in feature_extraction/tests/ module

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -385,8 +385,8 @@ def test_countvectorizer_uppercase_in_vocab():
                " be matched with any documents")
 
     vectorizer = CountVectorizer(lowercase=True, vocabulary=vocabulary)
-    assert_warns_message(UserWarning, message,
-                         vectorizer.fit_transform, vocabulary)
+    with pytest.warns(UserWarning, match=message):
+        vectorizer.fit_transform(vocabulary)
 
 
 def test_tf_idf_smoothing():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1203,7 +1203,7 @@ def test_vectorizer_stop_words_inconsistent():
     lstr = "['and', 'll', 've']"
     message = ('Your stop_words may be inconsistent with your '
                'preprocessing. Tokenizing the stop words generated '
-               'tokens %s not in stop_words.' % lstr)
+               'tokens \%s\ not in stop_words.' % lstr)
     for vec in [CountVectorizer(),
                 TfidfVectorizer(), HashingVectorizer()]:
         vec.set_params(stop_words=["you've", "you", "you'll", 'AND'])

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1212,10 +1212,10 @@ def _check_stop_words_consistency(estimator):
 
 @fails_if_pypy
 def test_vectorizer_stop_words_inconsistent():
-    lstr = "['and', 'll', 've']"
+    lstr = r"\['and', 'll', 've'\]"
     message = ('Your stop_words may be inconsistent with your '
                'preprocessing. Tokenizing the stop words generated '
-               'tokens \%s\ not in stop_words.' % lstr)
+               'tokens %s not in stop_words.' % lstr)
     for vec in [CountVectorizer(),
                 TfidfVectorizer(), HashingVectorizer()]:
         vec.set_params(stop_words=["you've", "you", "you'll", 'AND'])

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -29,7 +29,7 @@ from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 from sklearn.utils import IS_PYPY
 from sklearn.utils._testing import (assert_almost_equal,
-                                    assert_warns_message, assert_raise_message,
+                                    assert_raise_message,
                                     assert_no_warnings,
                                     fails_if_pypy,
                                     assert_allclose_dense_sparse,
@@ -417,8 +417,8 @@ def test_tfidf_no_smoothing():
     tr = TfidfTransformer(smooth_idf=False, norm='l2')
 
     in_warning_message = 'divide by zero'
-    assert_warns_message(RuntimeWarning, in_warning_message,
-                         tr.fit_transform, X).toarray()
+    with pytest.warns(RuntimeWarning, match=in_warning_message):
+        tr.fit_transform(X).toarray()
 
 
 def test_sublinear_tf():
@@ -1208,8 +1208,8 @@ def test_vectorizer_stop_words_inconsistent():
     for vec in [CountVectorizer(),
                 TfidfVectorizer(), HashingVectorizer()]:
         vec.set_params(stop_words=["you've", "you", "you'll", 'AND'])
-        assert_warns_message(UserWarning, message, vec.fit_transform,
-                             ['hello world'])
+        with pytest.warns(UserWarning, match=message):
+            vec.fit_transform(['hello world'])
         # reset stop word validation
         del vec._stop_words_id
         assert _check_stop_words_consistency(vec) is False
@@ -1220,8 +1220,8 @@ def test_vectorizer_stop_words_inconsistent():
 
     # Test caching of inconsistency assessment
     vec.set_params(stop_words=["you've", "you", "you'll", 'blah', 'AND'])
-    assert_warns_message(UserWarning, message, vec.fit_transform,
-                         ['hello world'])
+    with pytest.warns(UserWarning, match=message):
+        vec.fit_transform(['hello world'])
 
 
 @skip_if_32bit

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -30,7 +30,6 @@ from numpy.testing import assert_array_equal
 from sklearn.utils import IS_PYPY
 from sklearn.utils._testing import (assert_almost_equal,
                                     assert_raise_message,
-                                    assert_no_warnings,
                                     fails_if_pypy,
                                     assert_allclose_dense_sparse,
                                     skip_if_32bit)
@@ -1215,7 +1214,9 @@ def test_vectorizer_stop_words_inconsistent():
         assert _check_stop_words_consistency(vec) is False
 
     # Only one warning per stop list
-    assert_no_warnings(vec.fit_transform, ['hello world'])
+    with pytest.warns(None) as record:
+        vec.fit_transform(['hello world'])
+    assert not len(record)
     assert _check_stop_words_consistency(vec) is None
 
     # Test caching of inconsistency assessment


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Related to #19414
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Replaces the use of assert(_warns(_message)/_no_warnings) in the sklearn/feature_extraction module.


#### Any other comments?
Part of the solution to #19414

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
