### PR TITLE
DOC oob_score is only available when bootstrap=True

### DIFF
--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -488,7 +488,7 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
 
     oob_score : bool, default=False
         Whether to use out-of-bag samples to estimate
-        the generalization error.
+        the generalization error. Only available if bootstrap=True.
 
     warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit
@@ -897,7 +897,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
 
     oob_score : bool, default=False
         Whether to use out-of-bag samples to estimate
-        the generalization error.
+        the generalization error. Only available if bootstrap=True.
 
     warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1075,6 +1075,7 @@ class RandomForestClassifier(ForestClassifier):
 
     oob_score : bool, default=False
         Whether to use out-of-bag samples to estimate the generalization score.
+        Only available if bootstrap=True.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
@@ -1398,6 +1399,7 @@ class RandomForestRegressor(ForestRegressor):
 
     oob_score : bool, default=False
         Whether to use out-of-bag samples to estimate the generalization score.
+        Only available if bootstrap=True.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
@@ -1680,6 +1682,7 @@ class ExtraTreesClassifier(ForestClassifier):
 
     oob_score : bool, default=False
         Whether to use out-of-bag samples to estimate the generalization score.
+        Only available if bootstrap=True.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
@@ -1999,6 +2002,7 @@ class ExtraTreesRegressor(ForestRegressor):
 
     oob_score : bool, default=False
         Whether to use out-of-bag samples to estimate the generalization score.
+        Only available if bootstrap=True.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes issue #19431 

#### What does this implement/fix? Explain your changes.

This updates the docstrings for the `oob_score` argument to indicate that it depends on the `bootstrap` argument. It applies to six classes: `{Bagging,ExtraTrees,RandomForest}{Classifier,Regressor}`

#### Any other comments?

The following code demonstrates that when the constraint is violated, the code raises an exception:

```python
from sklearn.ensemble import BaggingClassifier, ExtraTreesClassifier, RandomForestClassifier
from sklearn.datasets import load_iris
X, y = load_iris(return_X_y=True)
for cls in [BaggingClassifier, ExtraTreesClassifier, RandomForestClassifier]:
    est = cls(bootstrap=False, oob_score=True)
    try:
        est.fit(X, y)
    except ValueError as e:
        print(f"{cls.__name__}: {e}")

from sklearn.ensemble import BaggingRegressor, ExtraTreesRegressor, RandomForestRegressor
from sklearn.datasets import make_regression
X, y = make_regression(n_samples=200, n_features=4, n_informative=2)
for cls in [BaggingRegressor, ExtraTreesRegressor, RandomForestRegressor]:
    est = cls(bootstrap=False, oob_score=True)
    try:
        est.fit(X, y)
    except ValueError as e:
        print(f"{cls.__name__}: {e}")
```

Output:

```
BaggingClassifier: Out of bag estimation only available if bootstrap=True
ExtraTreesClassifier: Out of bag estimation only available if bootstrap=True
RandomForestClassifier: Out of bag estimation only available if bootstrap=True
BaggingRegressor: Out of bag estimation only available if bootstrap=True
ExtraTreesRegressor: Out of bag estimation only available if bootstrap=True
RandomForestRegressor: Out of bag estimation only available if bootstrap=True
```