### PR TITLE
TST replace assert_warns* by pytest.warns in model_selection/tests

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1473,7 +1473,7 @@ def _translate_train_sizes(train_sizes, n_max_training_samples):
     if n_ticks > train_sizes_abs.shape[0]:
         warnings.warn("Removed duplicate entries from 'train_sizes'. Number "
                       "of ticks will be less than the size of "
-                      "'train_sizes' %d instead of %d)."
+                      "'train_sizes': %d instead of %d."
                       % (train_sizes_abs.shape[0], n_ticks), RuntimeWarning)
 
     return train_sizes_abs

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -14,8 +14,6 @@ import scipy.sparse as sp
 import pytest
 
 from sklearn.utils._testing import (
-    assert_warns,
-    assert_warns_message,
     assert_raise_message,
     assert_array_equal,
     assert_array_almost_equal,
@@ -1433,7 +1431,12 @@ def test_grid_search_failing_classifier():
     # error in this test.
     gs = GridSearchCV(clf, [{'parameter': [0, 1, 2]}], scoring='accuracy',
                       refit=False, error_score=0.0)
-    assert_warns(FitFailedWarning, gs.fit, X, y)
+    warning_message = (
+        "Estimator fit failed. The score on this train-test partition "
+        "for these parameters will be set to 0.000000."
+    )
+    with pytest.warns(FitFailedWarning, match=warning_message):
+        gs.fit(X, y)
     n_candidates = len(gs.cv_results_['params'])
 
     # Ensure that grid scores were set to zero as required for those fits
@@ -1449,7 +1452,12 @@ def test_grid_search_failing_classifier():
 
     gs = GridSearchCV(clf, [{'parameter': [0, 1, 2]}], scoring='accuracy',
                       refit=False, error_score=float('nan'))
-    assert_warns(FitFailedWarning, gs.fit, X, y)
+    warning_message = (
+        "Estimator fit failed. The score on this train-test partition "
+        "for these parameters will be set to nan."
+    )
+    with pytest.warns(FitFailedWarning, match=warning_message):
+        gs.fit(X, y)
     n_candidates = len(gs.cv_results_['params'])
     assert all(np.all(np.isnan(get_cand_scores(cand_i)))
                for cand_i in range(n_candidates)
@@ -1492,8 +1500,8 @@ def test_parameters_sampler_replacement():
                         'than n_iter=%d. Running %d iterations. For '
                         'exhaustive searches, use GridSearchCV.'
                         % (grid_size, n_iter, grid_size))
-    assert_warns_message(UserWarning, expected_warning,
-                         list, sampler)
+    with pytest.warns(UserWarning, match=expected_warning):
+        list(sampler)
 
     # degenerates to GridSearchCV if n_iter the same as grid_size
     sampler = ParameterSampler(params, n_iter=8)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1433,7 +1433,7 @@ def test_grid_search_failing_classifier():
                       refit=False, error_score=0.0)
     warning_message = (
         "Estimator fit failed. The score on this train-test partition "
-        "for these parameters will be set to 0.000000."
+        "for these parameters will be set to 0.0.*."
     )
     with pytest.warns(FitFailedWarning, match=warning_message):
         gs.fit(X, y)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -14,7 +14,6 @@ from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_raises_regexp
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils.validation import _num_samples
@@ -193,8 +192,8 @@ def test_kfold_valueerrors():
     y = np.array([3, 3, -1, -1, 3])
 
     skf_3 = StratifiedKFold(3)
-    assert_warns_message(Warning, "The least populated class",
-                         next, skf_3.split(X2, y))
+    with pytest.warns(Warning, match="The least populated class"):
+        next(skf_3.split(X2, y))
 
     # Check that despite the warning the folds are still computed even
     # though all the classes are not necessarily represented at on each

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -855,8 +855,8 @@ def test_cross_val_predict():
 
     X, y = load_iris(return_X_y=True)
 
-    warning_message = ('Number of classes in training fold \\(2\\) does '
-                       'not match total number of classes \\(3\\). '
+    warning_message = (r'Number of classes in training fold \(2\) does '
+                       'not match total number of classes \(3\). '
                        'Results may not be appropriate for your use case.')
     with pytest.warns(RuntimeWarning, match=warning_message):
         cross_val_predict(LogisticRegression(solver="liblinear"),
@@ -1209,7 +1209,7 @@ def test_learning_curve_remove_duplicate_sample_sizes():
     estimator = MockImprovingEstimator(2)
     warning_message = (
         "Removed duplicate entries from 'train_sizes'. Number of ticks "
-        "will be less than the size of 'train_sizes' 2 instead of 3\\)."
+        "will be less than the size of 'train_sizes': 2 instead of 3."
     )
     with pytest.warns(RuntimeWarning, match=warning_message):
         train_sizes, _, _ = learning_curve(

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -856,7 +856,7 @@ def test_cross_val_predict():
     X, y = load_iris(return_X_y=True)
 
     warning_message = (r'Number of classes in training fold \(2\) does '
-                       'not match total number of classes \(3\). '
+                       r'not match total number of classes \(3\). '
                        'Results may not be appropriate for your use case.')
     with pytest.warns(RuntimeWarning, match=warning_message):
         cross_val_predict(LogisticRegression(solver="liblinear"),

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -17,8 +17,6 @@ from sklearn.model_selection.tests.test_search import FailingClassifier
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_raise_message
-from sklearn.utils._testing import assert_warns
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import assert_raises_regex
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
@@ -857,13 +855,12 @@ def test_cross_val_predict():
 
     X, y = load_iris(return_X_y=True)
 
-    warning_message = ('Number of classes in training fold (2) does '
-                       'not match total number of classes (3). '
+    warning_message = ('Number of classes in training fold \\(2\\) does '
+                       'not match total number of classes \\(3\\). '
                        'Results may not be appropriate for your use case.')
-    assert_warns_message(RuntimeWarning, warning_message,
-                         cross_val_predict,
-                         LogisticRegression(solver="liblinear"),
-                         X, y, method='predict_proba', cv=KFold(2))
+    with pytest.warns(RuntimeWarning, match=warning_message):
+        cross_val_predict(LogisticRegression(solver="liblinear"),
+                          X, y, method='predict_proba', cv=KFold(2))
 
 
 def test_cross_val_predict_decision_function_shape():
@@ -1210,9 +1207,13 @@ def test_learning_curve_remove_duplicate_sample_sizes():
                                n_redundant=0, n_classes=2,
                                n_clusters_per_class=1, random_state=0)
     estimator = MockImprovingEstimator(2)
-    train_sizes, _, _ = assert_warns(
-        RuntimeWarning, learning_curve, estimator, X, y, cv=3,
-        train_sizes=np.linspace(0.33, 1.0, 3))
+    warning_message = (
+        "Removed duplicate entries from 'train_sizes'. Number of ticks "
+        "will be less than the size of 'train_sizes' 2 instead of 3\\)."
+    )
+    with pytest.warns(RuntimeWarning, match=warning_message):
+        train_sizes, _, _ = learning_curve(
+            estimator, X, y, cv=3, train_sizes=np.linspace(0.33, 1.0, 3))
     assert_array_equal(train_sizes, [1, 2])
 
 
@@ -1753,8 +1754,13 @@ def test_fit_and_score_failing():
     # passing error score to trigger the warning message
     fit_and_score_kwargs = {'error_score': 0}
     # check if the warning message type is as expected
-    assert_warns(FitFailedWarning, _fit_and_score, *fit_and_score_args,
-                 **fit_and_score_kwargs)
+    warning_message = (
+        "Estimator fit failed. The score on this train-test partition for "
+        "these parameters will be set to %f."
+        % (fit_and_score_kwargs['error_score'])
+    )
+    with pytest.warns(FitFailedWarning, match=warning_message):
+        _fit_and_score(*fit_and_score_args, **fit_and_score_kwargs)
     # since we're using FailingClassfier, our error will be the following
     error_message = "ValueError: Failing classifier failed as required"
     # the warning message we're expecting to see
@@ -1769,8 +1775,13 @@ def test_fit_and_score_failing():
         mtb = split[0] + '\n' + split[-1]
         return warning_message in mtb
     # check traceback is included
-    assert_warns_message(FitFailedWarning, test_warn_trace, _fit_and_score,
-                         *fit_and_score_args, **fit_and_score_kwargs)
+    warning_message = (
+        "Estimator fit failed. The score on this train-test partition for "
+        "these parameters will be set to %f."
+        % (fit_and_score_kwargs['error_score'])
+    )
+    with pytest.warns(FitFailedWarning, match=warning_message):
+        _fit_and_score(*fit_and_score_args, **fit_and_score_kwargs)
 
     fit_and_score_kwargs = {'error_score': 'raise'}
     # check if exception was raised, with default error_score='raise'


### PR DESCRIPTION
#### Reference Issues/PRs

#19414 

#### What does this implement/fix? Explain your changes.

Remove the use of assert_warns and assert_warns_message from tests in model_selection/tests.


#### Any other comments?

The PR is for the part of #19414