### PR TITLE
DOC Fix typo in LDA User Guide

### DIFF
--- a/doc/modules/lda_qda.rst
+++ b/doc/modules/lda_qda.rst
@@ -136,7 +136,7 @@ Mathematical formulation of LDA dimensionality reduction
 
 First note that the K means :math:`\mu_k` are vectors in
 :math:`\mathcal{R}^d`, and they lie in an affine subspace :math:`H` of
-dimension at least :math:`K - 1` (2 points lie on a line, 3 points lie on a
+dimension at most :math:`K - 1` (2 points lie on a line, 3 points lie on a
 plane, etc).
 
 As mentioned above, we can interpret LDA as assigning :math:`x` to the class


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
"They lie in an affine subspace of dimension at least K-1" should be "at most K-1"
i.e. 3 points must lie in a plane but could lie on a line

#### Any other comments?
Ref: Elements of Statistical Learning Pg 113