### PR TITLE
Fix underflow issues due to float precision

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -141,9 +141,8 @@ Changelog
 :mod:`sklearn.manifold`
 .......................
 
-- |Fix| The numerical precision in `manifold._utils._binary_search_perplexity`
-  was changed from `float` to `double` to prevent underflow issues
-  during affinity matrix computation for t-SNE.
+- |Fix| Change numerical precision to prevent underflow issues
+  during affinity matrix computation for :class:`TSNE`.
   :pr:`19472` by :user:`Dmitry Kobak <dkobak>`.
 
 :mod:`sklearn.metrics`

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -22,7 +22,7 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-- |Fix| :class:`TSNE` now avoids numerical underflow issues during affinity
+- |Fix| :class:`manifold.TSNE` now avoids numerical underflow issues during affinity
   matrix computation.
 
 Details are listed in the changelog below.
@@ -143,7 +143,7 @@ Changelog
 .......................
 
 - |Fix| Change numerical precision to prevent underflow issues
-  during affinity matrix computation for :class:`TSNE`.
+  during affinity matrix computation for :class:`manifold.TSNE`.
   :pr:`19472` by :user:`Dmitry Kobak <dkobak>`.
 
 :mod:`sklearn.metrics`

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -22,8 +22,8 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-- |Fix| :class:`manifold.TSNE` now avoids numerical underflow issues during affinity
-  matrix computation.
+- |Fix| :class:`manifold.TSNE` now avoids numerical underflow issues during
+  affinity matrix computation.
 
 Details are listed in the changelog below.
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -22,7 +22,8 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-
+- |Fix| :class:`TSNE` now avoids numerical underflow issues during affinity
+  matrix computation.
 
 Details are listed in the changelog below.
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -139,12 +139,12 @@ Changelog
   :user:`Alexandre Gramfort <agramfort>`.
 
 :mod:`sklearn.manifold`
-......................
+.......................
 
 - |Fix| The numerical precision in `manifold._utils._binary_search_perplexity`
- was changed from `float` to `double` to prevent underflow issues
- during affinity matrix computation for t-SNE.
- :pr:`19472` by :user:`Dmitry Kobak <dkobak>`.
+  was changed from `float` to `double` to prevent underflow issues
+  during affinity matrix computation for t-SNE.
+  :pr:`19472` by :user:`Dmitry Kobak <dkobak>`.
 
 :mod:`sklearn.metrics`
 ......................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -138,6 +138,14 @@ Changelog
   :pr:`17743` by :user:`Maria Telenczuk <maikia>` and
   :user:`Alexandre Gramfort <agramfort>`.
 
+:mod:`sklearn.manifold`
+......................
+
+- |Fix| The numerical precision in `manifold._utils._binary_search_perplexity`
+ was changed from `float` to `double` to prevent underflow issues
+ during affinity matrix computation for t-SNE.
+ :pr:`19472` by :user:`Dmitry Kobak <dkobak>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/manifold/_utils.pyx
+++ b/sklearn/manifold/_utils.pyx
@@ -51,18 +51,18 @@ cpdef np.ndarray[np.float32_t, ndim=2] _binary_search_perplexity(
     cdef long n_neighbors = sqdistances.shape[1]
     cdef int using_neighbors = n_neighbors < n_samples
     # Precisions of conditional Gaussian distributions
-    cdef float beta
-    cdef float beta_min
-    cdef float beta_max
-    cdef float beta_sum = 0.0
+    cdef double beta
+    cdef double beta_min
+    cdef double beta_max
+    cdef double beta_sum = 0.0
 
     # Use log scale
-    cdef float desired_entropy = math.log(desired_perplexity)
-    cdef float entropy_diff
+    cdef double desired_entropy = math.log(desired_perplexity)
+    cdef double entropy_diff
 
-    cdef float entropy
-    cdef float sum_Pi
-    cdef float sum_disti_Pi
+    cdef double entropy
+    cdef double sum_Pi
+    cdef double sum_disti_Pi
     cdef long i, j, k, l
 
     # This array is later used as a 32bit array. It has multiple intermediate

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -118,10 +118,10 @@ def test_binary_search():
     # A more challenging case that produces numeric underflow
     # in float precision.
     random_state = check_random_state(42)
-    data = random_state.randn(1,90).astype(np.float32) + 100
+    data = random_state.randn(1, 90).astype(np.float32) + 100
     desired_perplexity = 30.0
     P = _binary_search_perplexity(data, desired_perplexity, verbose=0)
-    perplexity = 2 ** -np.nansum(P[0,1:] * np.log2(P[0,1:]))
+    perplexity = 2 ** -np.nansum(P[0, 1:] * np.log2(P[0, 1:]))
     assert_almost_equal(perplexity, desired_perplexity, decimal=3)
 
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -115,8 +115,10 @@ def test_binary_search():
                                for i in range(P.shape[0])])
     assert_almost_equal(mean_perplexity, desired_perplexity, decimal=3)
 
-    # A more challenging case that produces numeric underflow
-    # in float precision.
+def test_binary_search_underflow(): 
+    # Test if the binary search finds Gaussians with desired perplexity.
+    # A more challenging case than the one above, producing numeric
+    # underflow in float precision (see issue #19471 and PR #19472).
     random_state = check_random_state(42)
     data = random_state.randn(1, 90).astype(np.float32) + 100
     desired_perplexity = 30.0

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -114,6 +114,15 @@ def test_binary_search():
     mean_perplexity = np.mean([np.exp(-np.sum(P[i] * np.log(P[i])))
                                for i in range(P.shape[0])])
     assert_almost_equal(mean_perplexity, desired_perplexity, decimal=3)
+    
+    # A more challenging case that produces numeric underflow
+    # in float precision.
+    random_state = check_random_state(42)
+    data = random_state.randn(1,90).astype(np.float32) + 100
+    desired_perplexity = 30.0
+    P = _binary_search_perplexity(data, desired_perplexity, verbose=0)
+    perplexity = 2 ** -np.nansum(P[0,1:] * np.log2(P[0,1:]))
+    assert_almost_equal(perplexity, desired_perplexity, decimal=3)
 
 
 def test_binary_search_neighbors():

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -114,7 +114,7 @@ def test_binary_search():
     mean_perplexity = np.mean([np.exp(-np.sum(P[i] * np.log(P[i])))
                                for i in range(P.shape[0])])
     assert_almost_equal(mean_perplexity, desired_perplexity, decimal=3)
-    
+
     # A more challenging case that produces numeric underflow
     # in float precision.
     random_state = check_random_state(42)

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -116,7 +116,7 @@ def test_binary_search():
     assert_almost_equal(mean_perplexity, desired_perplexity, decimal=3)
 
 
-def test_binary_search_underflow(): 
+def test_binary_search_underflow():
     # Test if the binary search finds Gaussians with desired perplexity.
     # A more challenging case than the one above, producing numeric
     # underflow in float precision (see issue #19471 and PR #19472).

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -115,6 +115,7 @@ def test_binary_search():
                                for i in range(P.shape[0])])
     assert_almost_equal(mean_perplexity, desired_perplexity, decimal=3)
 
+
 def test_binary_search_underflow(): 
     # Test if the binary search finds Gaussians with desired perplexity.
     # A more challenging case than the one above, producing numeric


### PR DESCRIPTION
Fixes #19471 by replacing `float`s with `double`s in the Cython code for `_binary_search_perplexity()`.