### PR TITLE
Fix to check if len(y) > 1 when normalize option is enabled in GaussianProcess._gpr.fit

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -195,7 +195,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
                                        ensure_2d=False, dtype=None)
 
         # Normalize target value
-        if self.normalize_y:
+        if self.normalize_y and len(y) > 1:
             self._y_train_mean = np.mean(y, axis=0)
             self._y_train_std = np.std(y, axis=0)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#19361
#18388

#### What does this implement/fix? Explain your changes.
Normalizing `y` when `len(y) <= 1` does not make sense, as `self._y_train_std = np.std(y, axis=0)` will become `0`, which would lead to `divide-by-zero`. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
