### PR TITLE
DOC Fix closing backtick in IterativeImputer

### DIFF
--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -68,7 +68,7 @@ class IterativeImputer(_BaseImputer):
         Maximum number of imputation rounds to perform before returning the
         imputations computed during the final round. A round is a single
         imputation of each feature with missing values. The stopping criterion
-        is met once `max(abs(X_t - X_{t-1}))/max(abs(X[known_vals]))` < tol,
+        is met once `max(abs(X_t - X_{t-1}))/max(abs(X[known_vals])) < tol`,
         where `X_t` is `X` at iteration `t`. Note that early stopping is only
         applied if ``sample_posterior=False``.
 

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -69,7 +69,7 @@ class IterativeImputer(_BaseImputer):
         imputations computed during the final round. A round is a single
         imputation of each feature with missing values. The stopping criterion
         is met once `max(abs(X_t - X_{t-1}))/max(abs(X[known_vals]))` < tol,
-        where `X_t` is `X` at iteration `t. Note that early stopping is only
+        where `X_t` is `X` at iteration `t`. Note that early stopping is only
         applied if ``sample_posterior=False``.
 
     tol : float, default=1e-3


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR jus fixes a typo in `sklearn.impute.IterativeImputer`.