### PR TITLE
DOC Remove extra word from LOF docstring

### DIFF
--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -114,7 +114,7 @@ class LocalOutlierFactor(KNeighborsMixin,
         By default, LocalOutlierFactor is only meant to be used for outlier
         detection (novelty=False). Set novelty to True if you want to use
         LocalOutlierFactor for novelty detection. In this case be aware that
-        that you should only use predict, decision_function and score_samples
+        you should only use predict, decision_function and score_samples
         on new unseen data and not on the training set.
 
         .. versionadded:: 0.20


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #19475 



#### What does this implement/fix? Explain your changes.

In the `Local Outlier Detection` method docstring there was an extra word. The PR removes it.
