### PR TITLE
FIX RuntimeWarning by dividing by zero in test_sanity_check_pls_regression_constant_column_Y

### DIFF
--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -116,10 +116,8 @@ def test_sanity_check_pls_regression_constant_column_Y():
     # from the R-package plsdepot
     d = load_linnerud()
     X = d.data
-
     Y = d.target
     Y[:, 0] = 1
-
     pls = PLSRegression(n_components=X.shape[1])
     pls.fit(X, Y)
 

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -151,7 +151,8 @@ def test_sanity_check_pls_regression_constant_column_Y():
     x_loadings_sign_flip = np.sign(expected_x_loadings / pls.x_loadings_)
     x_weights_sign_flip = np.sign(expected_x_weights / pls.x_weights_)
 
-    y_loadings_sign_flip = np.sign(expected_y_loadings[1:] / pls.y_loadings_[1:])
+    y_loadings_sign_flip = np.sign(expected_y_loadings[1:] /
+                                   pls.y_loadings_[1:])
     y_loadings_sign_flip = np.insert(y_loadings_sign_flip, 0, 0, axis=0)
 
     assert_array_equal(x_loadings_sign_flip, x_weights_sign_flip)

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -116,8 +116,10 @@ def test_sanity_check_pls_regression_constant_column_Y():
     # from the R-package plsdepot
     d = load_linnerud()
     X = d.data
+
     Y = d.target
     Y[:, 0] = 1
+
     pls = PLSRegression(n_components=X.shape[1])
     pls.fit(X, Y)
 
@@ -148,7 +150,10 @@ def test_sanity_check_pls_regression_constant_column_Y():
 
     x_loadings_sign_flip = np.sign(expected_x_loadings / pls.x_loadings_)
     x_weights_sign_flip = np.sign(expected_x_weights / pls.x_weights_)
-    y_loadings_sign_flip = np.sign(expected_y_loadings / pls.y_loadings_)
+
+    y_loadings_sign_flip = np.sign(expected_y_loadings[1:] / pls.y_loadings_[1:])
+    y_loadings_sign_flip = np.insert(y_loadings_sign_flip, 0, 0, axis=0)
+
     assert_array_equal(x_loadings_sign_flip, x_weights_sign_flip)
     assert_array_equal(x_loadings_sign_flip[1:], y_loadings_sign_flip[1:])
 

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -148,13 +148,12 @@ def test_sanity_check_pls_regression_constant_column_Y():
 
     x_loadings_sign_flip = np.sign(expected_x_loadings / pls.x_loadings_)
     x_weights_sign_flip = np.sign(expected_x_weights / pls.x_weights_)
-
+    # we ignore the first full-zeros row for y
     y_loadings_sign_flip = np.sign(expected_y_loadings[1:] /
                                    pls.y_loadings_[1:])
-    y_loadings_sign_flip = np.insert(y_loadings_sign_flip, 0, 0, axis=0)
 
     assert_array_equal(x_loadings_sign_flip, x_weights_sign_flip)
-    assert_array_equal(x_loadings_sign_flip[1:], y_loadings_sign_flip[1:])
+    assert_array_equal(x_loadings_sign_flip[1:], y_loadings_sign_flip)
 
 
 def test_sanity_check_pls_canonical():


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #19334

#### What does this implement/fix? Explain your changes.
Fixes the `RuntimeWarning` caused by `test_sanity_check_pls_regression_constant_column_Y` in `sklearn/cross_decomposition/tests/test_pls.py`

#### Any other comments?
The array `pls.y_loadings_` looks like this: 
[[ 0.          0.          0.        ]
 [-0.43573004  0.58284789  0.21748017]
 [ 0.13537388 -0.24864229 -0.18103859]]

Therefore, an error caused by division by zero occurs. I fixed the error but please let me know if this is a good solution or not. 

#DataUmbrella sprint