### PR TITLE
DOC Fix broken link to wikipedia in semi-supervised UG

### DIFF
--- a/doc/modules/semi_supervised.rst
+++ b/doc/modules/semi_supervised.rst
@@ -27,7 +27,7 @@ labeled points and a large amount of unlabeled points.
 
    Semi-supervised algorithms need to make assumptions about the distribution
    of the dataset in order to achieve performance gains. See `here
-   <https://en.wikipedia.org/wiki/Semi-supervised_learning#Assumptions_used>`_
+   <https://en.wikipedia.org/wiki/Semi-supervised_learning#Assumptions>`_
    for more details.
 
 .. _self_training:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The Wikipedia article on semi-supervised learning has changed slightly, and the current link to semi-supervised learning assumptions is broken. It currently links to an `#Assumptions_used` HTML anchor that was renamed to `#Assumptions` in the Wikipedia article.

This change fixes the link.