### PR TITLE
ENH Add periodic extrapolation to SplineTransformer

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -192,7 +192,7 @@ Changelog
   polynomial ``degree`` of the splines, number of knots ``n_knots`` and knot
   positioning strategy ``knots``.
   :pr:`18368` by :user:`Christian Lorentzen <lorentzenchr>`.
-- |Enhancement| The :class:`preprocessing.SplineTransformer` supports periodic
+  :class:`preprocessing.SplineTransformer` also supports periodic
   splines via the ``extrapolation`` argument.
   :pr:`19483` by :user:`Malte Londschien <mlondschien>`.
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -172,6 +172,9 @@ Changelog
   polynomial ``degree`` of the splines, number of knots ``n_knots`` and knot
   positioning strategy ``knots``.
   :pr:`18368` by :user:`Christian Lorentzen <lorentzenchr>`.
+- |Enhancement| The :class:`preprocessing.SplineTransformer` supports periodic
+  splines via the ``extrapolation`` argument.
+  :pr:`19483` by :user:`Malte Londschien <mlondschien>`.
 
 :mod:`sklearn.tree`
 ...................

--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -39,6 +39,7 @@ print(__doc__)
 # Author: Mathieu Blondel
 #         Jake Vanderplas
 #         Christian Lorentzen
+#         Malte Londschien
 # License: BSD 3 clause
 
 import numpy as np

--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -151,12 +151,13 @@ plt.show()
 # ----------------
 # In the previous example we saw the limitations of polynomials and splines for
 # extrapolation beyond the range of the training observations. In some
-# settings, e.g. with seasonal effects, we expect periodic continuation of
+# settings, e.g. with seasonal effects, we expect a periodic continuation of
 # the underlying signal. Such effects can be modelled using periodic splines,
-# which have equal intercepts and derivatives at the first and last knot.
-# In the following case we show how periodic splines provide a better fit both within and
-# outside of the range of training data given the additional information of
-# periodicity.
+# which have equal function value and equal derivatives at the first and last
+# knot. In the following case we show how periodic splines provide a better fit
+# both within and outside of the range of training data given the additional
+# information of periodicity. The splines periodicity is the distance between
+# the first and last knot, which we specify manually.
 
 
 # %%
@@ -199,7 +200,4 @@ splt = SplineTransformer(
 ).fit(X_train)
 ax.plot(x_plot, splt.transform(X_plot))
 ax.legend(ax.lines, [f"spline {n}" for n in range(3)])
-
-# plot knots of spline
-ax.vlines(knots, ymin=0, ymax=0.8, linestyles='dashed')
 plt.show()

--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -41,7 +41,6 @@ print(__doc__)
 #         Christian Lorentzen
 #         Malte Londschien
 # License: BSD 3 clause
-# %%
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -157,8 +157,12 @@ plt.show()
 # which have equal function value and equal derivatives at the first and last
 # knot. In the following case we show how periodic splines provide a better fit
 # both within and outside of the range of training data given the additional
-# information of periodicity. The splines periodicity is the distance between
+# information of periodicity. The splines period is the distance between
 # the first and last knot, which we specify manually.
+#
+# Periodic splines can also be useful for naturally periodic features (such as
+# day of the year), as the smoothness at the boundary knots prevents a jump in
+# the transformed values (e.g. from Dec 31st to Jan 1st).
 
 
 # %%

--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -147,13 +147,14 @@ plt.show()
 # ``extrapolation``.
 
 # %%
-# ## Periodic Splines
-# In the previous example we saw that polynomials and splines are not well
-# suited for extrapolation beyond the range of training observations. In some
+# Periodic Splines
+# ----------------
+# In the previous example we saw the limitations of polynomials and splines for
+# extrapolation beyond the range of the training observations. In some
 # settings, e.g. with seasonal effects, we expect periodic continuation of
 # the underlying signal. Such effects can be modelled using periodic splines,
 # which have equal intercepts and derivatives at the first and last knot.
-# This example shows how periodic splines provide a better fit both within and
+# In the following case we show how periodic splines provide a better fit both within and
 # outside of the range of training data given the additional information of
 # periodicity.
 

--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -162,7 +162,10 @@ plt.show()
 #
 # Periodic splines can also be useful for naturally periodic features (such as
 # day of the year), as the smoothness at the boundary knots prevents a jump in
-# the transformed values (e.g. from Dec 31st to Jan 1st).
+# the transformed values (e.g. from Dec 31st to Jan 1st). For such naturally
+# periodic features or more generally features where the period is known, it is
+# advised to explicitly pass this information to the `SplineTransformer` by
+# setting the knots manually.
 
 
 # %%

--- a/examples/linear_model/plot_polynomial_interpolation.py
+++ b/examples/linear_model/plot_polynomial_interpolation.py
@@ -40,6 +40,7 @@ print(__doc__)
 #         Jake Vanderplas
 #         Christian Lorentzen
 # License: BSD 3 clause
+# %%
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -168,10 +169,14 @@ def g(x):
 
 y_train = g(x_train)
 
+# Extend the test data into the future:
+x_plot_ext = np.linspace(-1, 21, 200)
+X_plot_ext = x_plot_ext[:, np.newaxis]
+
 lw = 2
 fig, ax = plt.subplots()
 ax.set_prop_cycle(color=["black", "tomato", "teal"])
-ax.plot(x_plot, g(x_plot), linewidth=lw, label="ground truth")
+ax.plot(x_plot_ext, g(x_plot_ext), linewidth=lw, label="ground truth")
 ax.scatter(x_train, y_train, label="training points")
 
 for transformer, label in [
@@ -184,8 +189,8 @@ for transformer, label in [
 ]:
     model = make_pipeline(transformer, Ridge(alpha=1e-3))
     model.fit(X_train, y_train)
-    y_plot = model.predict(X_plot)
-    ax.plot(x_plot, y_plot, label=label)
+    y_plot_ext = model.predict(X_plot_ext)
+    ax.plot(x_plot_ext, y_plot_ext, label=label)
 
 ax.legend()
 fig.show()
@@ -198,6 +203,6 @@ splt = SplineTransformer(
   degree=3,
   extrapolation="periodic"
 ).fit(X_train)
-ax.plot(x_plot, splt.transform(X_plot))
+ax.plot(x_plot_ext, splt.transform(X_plot_ext))
 ax.legend(ax.lines, [f"spline {n}" for n in range(3)])
 plt.show()

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -65,6 +65,10 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         'periodic', periodic splines with a periodicity equal to the distance
         between the first and last knot are used. Periodic splines enforce
         equal function values and derivatives at the first and last knot.
+        For example, this makes it possible to avoid introducing an arbitrary
+        jump between Dec 31st and Jan 1st in spline features derived from a
+        naturally periodic "day-of-year" input feature. In this case it is
+        recommended to manually set the knot values to control the period.
 
     include_bias : bool, default=True
         If True (default), then the last spline element inside the data range

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -292,7 +292,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                 base_knots[-(degree + 1): -1] - period,
                 base_knots,
                 base_knots[1: (degree + 1)] + period
-            ].astype(np.float)
+            ].astype(np.float64)
 
         else:
             # Eilers & Marx in "Flexible smoothing with B-splines and

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -267,7 +267,10 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         n_knots = base_knots.shape[0]
 
         if self.extrapolation == "periodic" and n_knots <= self.degree:
-            raise ValueError("Periodic splines require degree < n_knots.")
+            raise ValueError(
+                "Periodic splines require degree < n_knots. Got n_knots="
+                f"{self.n_knots} and degree={self.degree}."
+            )
 
         # number of splines basis functions
         if self.extrapolation != "periodic":

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -284,7 +284,6 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         n_out = n_features * n_splines
         # We have to add degree number of knots below, and degree number knots
         # above the base knots in order to make the spline basis complete.
-
         if self.extrapolation == "periodic":
             # For periodic splines the spacing of the first / last degree knots
             # needs to a continuation of the base_knot spacing.

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -294,7 +294,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                 base_knots[-(degree + 1): -1] - period,
                 base_knots,
                 base_knots[1: (degree + 1)] + period
-            ]
+            ].astype(np.float64)
 
         else:
             # Eilers & Marx in "Flexible smoothing with B-splines and

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -61,7 +61,8 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         constant extrapolation. If 'linear', a linear extrapolation is used.
         If 'continue', the splines are extrapolated as is, i.e. option
         `extrapolate=True` in :class:`scipy.interpolate.BSpline`. If
-        'periodic', periodic splines are used.
+        'periodic', periodic splines, which enforce equal function value
+        and derivatives at the first and last knots, are used.
 
     include_bias : bool, default=True
         If True (default), then the last spline element inside the data range
@@ -269,10 +270,10 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
             raise ValueError("Periodic splines require degree < n_knots.")
 
         # number of splines basis functions
-        # periodic splines have self.degree less degrees of freedom
         if self.extrapolation != "periodic":
             n_splines = n_knots + self.degree - 1
         else:
+            # periodic splines have self.degree less degrees of freedom
             n_splines = n_knots - 1
 
         degree = self.degree
@@ -374,7 +375,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                     # With periodic extrapolation we map x to the segment
                     # [spl.t[k], spl.t[n]].
                     # This is equivalent to BSpline(.., extrapolate="periodic")
-                    # for scipy>=1.6.1.
+                    # for scipy>=1.0.0.
                     n = spl.t.size - spl.k - 1
                     # Assign to new array to avoid inplace operation
                     x = spl.t[spl.k] + (X[:, i] - spl.t[spl.k]) % (

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -266,9 +266,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         n_knots = base_knots.shape[0]
 
         if self.extrapolation == "periodic" and n_knots <= self.degree:
-            raise ValueError(
-                "Periodic splines require degree < knots.shape[0]."
-            )
+            raise ValueError("Periodic splines require degree < n_knots.")
 
         # number of splines basis functions
         # periodic splines have self.degree less degrees of freedom

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -240,7 +240,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                 X, n_knots=self.n_knots, knots=self.knots
             )
         else:
-            base_knots = check_array(self.knots)
+            base_knots = check_array(self.knots, dtype=np.float64)
             if base_knots.shape[0] < 2:
                 raise ValueError(
                     "Number of knots, knots.shape[0], must be >= " "2."
@@ -294,7 +294,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                 base_knots[-(degree + 1): -1] - period,
                 base_knots,
                 base_knots[1: (degree + 1)] + period
-            ].astype(np.float64)
+            ]
 
         else:
             # Eilers & Marx in "Flexible smoothing with B-splines and

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -292,7 +292,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                 base_knots[-(degree + 1): -1] - period,
                 base_knots,
                 base_knots[1: (degree + 1)] + period
-            ]
+            ].astype(np.float)
 
         else:
             # Eilers & Marx in "Flexible smoothing with B-splines and

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -23,8 +23,9 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
     """Generate univariate B-spline bases for features.
 
     Generate a new feature matrix consisting of
-    `n_splines=n_knots + degree - 1` spline basis functions (B-splines) of
-    polynomial order=`degree` for each feature.
+    `n_splines=n_knots + degree - 1` (`n_knots - 1` for
+    `extrapolation="periodic"`) spline basis functions
+    (B-splines) of polynomial order=`degree` for each feature.
 
     Read more in the :ref:`User Guide <spline_transformer>`.
 

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -60,10 +60,10 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         splines at minimum and maximum value of the features is used as
         constant extrapolation. If 'linear', a linear extrapolation is used.
         If 'continue', the splines are extrapolated as is, i.e. option
-        `extrapolate=True` in :class:`scipy.interpolate.BSpline`. If 'periodic',
-        periodic splines with a periodicity equal to the distance between the
-        first and last knot are used. Periodic splines enforce equal function
-        values and derivatives at the first and last knot.
+        `extrapolate=True` in :class:`scipy.interpolate.BSpline`. If
+        'periodic', periodic splines with a periodicity equal to the distance
+        between the first and last knot are used. Periodic splines enforce
+        equal function values and derivatives at the first and last knot.
 
     include_bias : bool, default=True
         If True (default), then the last spline element inside the data range
@@ -120,7 +120,6 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
            [0.  , 0.08, 0.74, 0.18],
            [0.  , 0.  , 0.5 , 0.5 ]])
     """
-
     def __init__(
         self,
         n_knots=5,

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -287,8 +287,8 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         # above the base knots in order to make the spline basis complete.
         if self.extrapolation == "periodic":
             # For periodic splines the spacing of the first / last degree knots
-            # needs to be a continuation of the spacing of the last / first base
-            # knots.
+            # needs to be a continuation of the spacing of the last / first
+            # base knots.
             period = base_knots[-1] - base_knots[0]
             knots = np.r_[
                 base_knots[-(degree + 1): -1] - period,

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -121,6 +121,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
            [0.  , 0.08, 0.74, 0.18],
            [0.  , 0.  , 0.5 , 0.5 ]])
     """
+
     def __init__(
         self,
         n_knots=5,
@@ -287,7 +288,8 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
 
         if self.extrapolation == "periodic":
             # For periodic splines the spacing of the first / last degree knots
-            # needs to a continuation of the base_knot spacing.
+            # needs to be a continuation of the spacing of the last / first base
+            # knots.
             period = base_knots[-1] - base_knots[0]
             knots = np.r_[
                 base_knots[-(degree + 1): -1] - period,

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -270,7 +270,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         if self.extrapolation == "periodic" and n_knots <= self.degree:
             raise ValueError(
                 "Periodic splines require degree < n_knots. Got n_knots="
-                f"{self.n_knots} and degree={self.degree}."
+                f"{n_knots} and degree={self.degree}."
             )
 
         # number of splines basis functions
@@ -290,18 +290,18 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
             # needs to a continuation of the base_knot spacing.
             period = base_knots[-1] - base_knots[0]
             knots = np.r_[
-                base_knots[-(degree + 1) : -1] - period,
+                base_knots[-(degree + 1): -1] - period,
                 base_knots,
-                base_knots[1 : (degree + 1)] + period
+                base_knots[1: (degree + 1)] + period
             ]
 
         else:
-            # Eilers & Marx in "Flexible smoothing with B-splines and  penalties"
-            # https://doi.org/10.1214/ss/1038425655 advice against repeating first
-            # and last knot several times, which would have inferior behaviour at
-            # boundaries if combined with a penalty (hence P-Spline). We follow
-            # this advice even if our splines are unpenalized.
-            # Meaning we do not:
+            # Eilers & Marx in "Flexible smoothing with B-splines and
+            # penalties" https://doi.org/10.1214/ss/1038425655 advice
+            # against repeating first and last knot several times, which
+            # would have inferior behaviour at boundaries if combined with
+            # a penalty (hence P-Spline). We follow this advice even if our
+            # splines are unpenalized. Meaning we do not:
             # knots = np.r_[
             #     np.tile(base_knots.min(axis=0), reps=[degree, 1]),
             #     base_knots,

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -367,7 +367,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         )
 
         n_samples, n_features = X.shape
-        n_splines = self.bsplines_[0].c.shape[0]
+        n_splines = self.bsplines_[0].c.shape[1]
         degree = self.degree
 
         # Note that scipy BSpline returns float64 arrays and converts input

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -60,9 +60,10 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         splines at minimum and maximum value of the features is used as
         constant extrapolation. If 'linear', a linear extrapolation is used.
         If 'continue', the splines are extrapolated as is, i.e. option
-        `extrapolate=True` in :class:`scipy.interpolate.BSpline`. If
-        'periodic', periodic splines, which enforce equal function value
-        and derivatives at the first and last knots, are used.
+        `extrapolate=True` in :class:`scipy.interpolate.BSpline`. If 'periodic',
+        periodic splines with a periodicity equal to the distance between the
+        first and last knot are used. Periodic splines enforce equal function
+        values and derivatives at the first and last knot.
 
     include_bias : bool, default=True
         If True (default), then the last spline element inside the data range

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -294,7 +294,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                 base_knots[-(degree + 1): -1] - period,
                 base_knots,
                 base_knots[1: (degree + 1)] + period
-            ].astype(np.float64)
+            ]
 
         else:
             # Eilers & Marx in "Flexible smoothing with B-splines and

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -60,8 +60,8 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         splines at minimum and maximum value of the features is used as
         constant extrapolation. If 'linear', a linear extrapolation is used.
         If 'continue', the splines are extrapolated as is, i.e. option
-        `extrapolate=True` in :class:`scipy.interpolate.BSpline`. If 'periodic',
-        periodic splines are used.
+        `extrapolate=True` in :class:`scipy.interpolate.BSpline`. If
+        'periodic', periodic splines are used.
 
     include_bias : bool, default=True
         If True (default), then the last spline element inside the data range
@@ -84,8 +84,9 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
     n_features_out_ : int
         The total number of output features, which is computed as
         `n_features * n_splines`, where `n_splines` is
-        the number of bases elements of the B-splines, `n_knots + degree - 1` for
-        non-periodic splines and `n_knots - 1` else.
+        the number of bases elements of the B-splines,
+        `n_knots + degree - 1` for non-periodic splines and
+        `n_knots - 1` else.
         If `include_bias=False`, then it is only
         `n_features * (n_splines - 1)`.
 
@@ -265,7 +266,11 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         n_knots = base_knots.shape[0]
         # number of splines basis functions
         # periodic splines have self.degree less degrees of freedom
-        n_splines = n_knots + (1 - (self.extrapolation == "periodic")) * self.degree - 1
+        if self.extrapolation != "periodic":
+            n_splines = n_knots + self.degree - 1
+        else:
+            n_splines = n_knots - 1
+
         degree = self.degree
         n_out = n_features * n_splines
         # We have to add degree number of knots below, and degree number knots
@@ -278,16 +283,16 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         # Meaning we do not:
         # knots = np.r_[np.tile(base_knots.min(axis=0), reps=[degree, 1]),
         #              base_knots,
-        #              np.tile(base_knots.min(axis=0), reps=[degree, 1])
+        #              np.tile(base_knots.max(axis=0), reps=[degree, 1])
         #              ]
         # Instead, we reuse the distance of the 2 fist/last knots.
         dist_min = base_knots[1] - base_knots[0]
         dist_max = base_knots[-1] - base_knots[-2]
 
-        # For periodic splines the spacing of the first / last degree knots needs to
-        # be equal
+        # For periodic splines the spacing of the first / last degree knots
+        # needs to be equal
         if self.extrapolation == "periodic":
-            dist_min = dist_max =  (dist_min + dist_max) / 2
+            dist_min = dist_max = (dist_min + dist_max) / 2
 
         knots = np.r_[
             linspace(

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -372,7 +372,6 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                     # This is equivalent to BSpline(.., extrapolate="periodic")
                     # for scipy>=1.6.1.
                     n = spl.t.size - spl.k - 1
-                    import ipdb; ipdb.set_trace()
                     X[:, i] = spl.t[spl.k] + (X[:, i] - spl.t[spl.k]) % (
                         spl.t[n] - spl.t[spl.k]
                     )

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -86,7 +86,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         `n_features * n_splines`, where `n_splines` is
         the number of bases elements of the B-splines,
         `n_knots + degree - 1` for non-periodic splines and
-        `n_knots - 1` else.
+        `n_knots - 1` for periodic ones.
         If `include_bias=False`, then it is only
         `n_features * (n_splines - 1)`.
 

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -229,10 +229,11 @@ def test_spline_transformer_periodic_linear_regression(bias, intercept):
 def test_spline_transformer_periodic_spline_backport():
     """Test that the backport of extrapolate="periodic" works correctly"""
     X = np.linspace(-2, 3.5, 10)[:, None]
+    degree = 2
 
     # Use periodic extrapolation backport in SplineTransformer
     transformer = SplineTransformer(
-        degree=2,
+        degree=degree,
         extrapolation="periodic",
         knots=[[-1.0], [0.0], [1.0]]
     )
@@ -240,7 +241,7 @@ def test_spline_transformer_periodic_spline_backport():
 
     # Use periodic extrapolation in BSpline
     coef = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]])
-    spl = BSpline(np.arange(-3, 4), coef, 2, "periodic")
+    spl = BSpline(np.arange(-3, 4), coef, degree, "periodic")
     Xspl = spl(X[:, 0])
     assert_allclose(Xt, Xspl)
 
@@ -287,7 +288,7 @@ def test_spline_transformer_periodic_splines_smoothness(degree):
         Xt = Xt[1:, :] - Xt[:-1, :]
         assert (np.abs(Xt) < (tol ** d)).all()
 
-    assert np.abs(Xt[1:, :] - Xt[:-1, :]).max() > tol ** (degree + 1)
+    assert np.abs(dXt[1:, :] - dXt[:-1, :]).max() > tol ** (degree + 1)
 
 
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -5,7 +5,7 @@ from scipy.interpolate import BSpline
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import KBinsDiscretizer, SplineTransformer
-from sklearn.utils.fixes import sp_version
+from sklearn.utils.fixes import linspace, sp_version
 
 from pkg_resources import parse_version
 
@@ -207,8 +207,8 @@ def test_spline_transformer_periodicity_of_extrapolation(
     knots, n_knots, degree
 ):
     """Test that the SplineTransformer is periodic for multiple features."""
-    X_1 = np.linspace((-1, 0), (1, 5), 10)
-    X_2 = np.linspace((1, 5), (3, 10), 10)
+    X_1 = linspace((-1, 0), (1, 5), 10)
+    X_2 = linspace((1, 5), (3, 10), 10)
 
     splt = SplineTransformer(
         knots=knots,

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -171,7 +171,7 @@ def test_spline_transformer_linear_regression(bias, intercept):
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])
 def test_spline_transformer_periodic_linear_regression(bias, intercept):
     """Test that B-splines fit a periodic curve pretty well."""
-    # +2 to avoid the value 0 in assert_allclose
+    # "+ 3" to avoid the value 0 in assert_allclose
     def f(x):
         return np.sin(2*np.pi*x) - np.sin(8*np.pi*x) + 3
 

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -173,7 +173,7 @@ def test_spline_transformer_periodic_linear_regression(bias, intercept):
     """Test that B-splines fit a periodic curve pretty well."""
     # +2 to avoid the value 0 in assert_allclose
     def f(x):
-        return np.sin(2*np.pi*x) + np.sin(6*np.pi*x) - np.sin(8*np.pi*x) + 2
+        return np.sin(2*np.pi*x) - np.sin(8*np.pi*x) + 3
 
     X = np.linspace(0, 1, 101)[:, None]
     pipe = Pipeline(
@@ -181,7 +181,7 @@ def test_spline_transformer_periodic_linear_regression(bias, intercept):
             (
                 "spline",
                 SplineTransformer(
-                    n_knots=35,
+                    n_knots=20,
                     degree=3,
                     include_bias=bias,
                     extrapolation="periodic",
@@ -194,8 +194,7 @@ def test_spline_transformer_periodic_linear_regression(bias, intercept):
 
     # Generate larger array to check periodic extrapolation
     X_ = np.linspace(-1, 2, 301)[:, None]
-
-    assert_allclose(pipe.predict(X_), f(X_[:, 0]), rtol=1e-2)
+    assert_allclose(pipe.predict(X_), f(X_[:, 0]), atol=0.01, rtol=0.01)
 
 
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -1,5 +1,3 @@
-from distutils.version import LooseVersion
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
@@ -9,11 +7,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import KBinsDiscretizer, SplineTransformer
 from sklearn.utils.fixes import sp_version
 
-try:
-    from pkg_resources import parse_version  # type: ignore
-except ImportError:
-    # setuptools not installed
-    parse_version = LooseVersion  # type: ignore
+from pkg_resources import parse_version
 
 
 # TODO: add PolynomialFeatures if it moves to _polynomial.py
@@ -274,7 +268,6 @@ def test_spline_transformer_periodic_splines_smoothness(degree):
         extrapolation="periodic",
         knots=[[0.0], [1.0], [3.0], [4.0], [5.0], [8.0]]
     )
-
     Xt = transformer.fit_transform(X)
 
     tol = 0.02

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -154,7 +154,12 @@ def test_spline_transformer_feature_names():
 @pytest.mark.parametrize("n_knots", range(3, 5))
 @pytest.mark.parametrize("knots", ["uniform", "quantile"])
 @pytest.mark.parametrize("extrapolation", ["constant", "periodic"])
-def test_spline_transformer_unity_decomposition(degree, n_knots, knots, extrapolation):
+def test_spline_transformer_unity_decomposition(
+    degree,
+    n_knots,
+    knots,
+    extrapolation
+):
     """Test that B-splines are indeed a decomposition of unity.
 
     Splines basis functions must sum up to 1 per row, if we stay in between
@@ -169,7 +174,11 @@ def test_spline_transformer_unity_decomposition(degree, n_knots, knots, extrapol
         n_knots = n_knots + degree  # periodic splines require degree < n_knots
 
     splt = SplineTransformer(
-        n_knots=n_knots, degree=degree, knots=knots, include_bias=True, extrapolation=extrapolation
+        n_knots=n_knots,
+        degree=degree,
+        knots=knots,
+        include_bias=True,
+        extrapolation=extrapolation
     )
     splt.fit(X_train)
     for X in [X_train, X_test]:

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -238,6 +238,30 @@ def test_spline_transformer_periodic_spline_backport():
     assert_allclose(Xt, Xspl)
 
 
+def test_spline_transformer_periodic_splines_periodicity():
+    """
+    Test if shifted knots result in the same transformation up to permutation.
+    """
+    X = np.linspace(0, 10, 101)[:, None]
+
+    transformer_1 = SplineTransformer(
+        degree=3,
+        extrapolation="periodic",
+        knots=[[0], [1], [2], [3], [4], [5]]
+    )
+    transformer_2 = SplineTransformer(
+        degree=3,
+        extrapolation="periodic",
+        knots=[[1], [2], [3], [4], [5], [6]]
+    )
+
+    Xt_1 = transformer_1.fit_transform(X)
+    Xt_2 = transformer_2.fit_transform(X)
+
+    assert_allclose(Xt_1, Xt_2[:, [4, 0, 1, 2, 3]])
+    assert_allclose(Xt_1[:91, :], Xt_2[10:, :])
+
+
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])
 @pytest.mark.parametrize("degree", [1, 2, 3, 4, 5])
 def test_spline_transformer_extrapolation(bias, intercept, degree):

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -103,8 +103,8 @@ def test_spline_transformer_manual_knot_input():
 @pytest.mark.parametrize("extrapolation", ["continue", "periodic"])
 def test_spline_transformer_integer_knots(extrapolation):
     """Test that SplineTransformer accepts integer value knot positions."""
-    X = np.arange(20)[:, None]
-    knots = [[0], [1], [5], [11], [12]]
+    X = np.arange(20).reshape(10, 2)
+    knots = [[0, 1], [1, 2], [5, 5], [11, 10], [12, 11]]
     _ = SplineTransformer(
         degree=3,
         knots=knots,

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -168,11 +168,13 @@ def test_spline_transformer_linear_regression(bias, intercept):
     assert_allclose(pipe.predict(X), y, rtol=1e-3)
 
 
-@pytest.mark.parametrize(["bias", "intercept"], [(True, False) , (False, True)])
+@pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])
 def test_spline_transformer_periodic_linear_regression(bias, intercept):
     """Test that B-splines fit a periodic curve pretty well."""
     # +2 to avoid the value 0 in assert_allclose
-    f = lambda x: np.sin(2*np.pi*x) + np.sin(6*np.pi*x) - np.sin(8*np.pi*x) + 2
+    def f(x):
+        return np.sin(2*np.pi*x) + np.sin(6*np.pi*x) - np.sin(8*np.pi*x) + 2
+
     X = np.linspace(0, 1, 101)[:, None]
     pipe = Pipeline(
         steps=[

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -194,7 +194,9 @@ def test_spline_transformer_periodic_linear_regression(bias, intercept):
 
     # Generate larger array to check periodic extrapolation
     X_ = np.linspace(-1, 2, 301)[:, None]
-    assert_allclose(pipe.predict(X_), f(X_[:, 0]), atol=0.01, rtol=0.01)
+    predictions = pipe.predict(X_)
+    assert_allclose(predictions, f(X_[:, 0]), atol=0.01, rtol=0.01)
+    assert_allclose(predictions[0:100], predictions[100:200], rtol=1e-3)
 
 
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -103,8 +103,8 @@ def test_spline_transformer_manual_knot_input():
 @pytest.mark.parametrize("extrapolation", ["continue", "periodic"])
 def test_spline_transformer_integer_knots(extrapolation):
     """Test that SplineTransformer accepts integer value knot positions."""
-    X = np.arange(20).reshape(10, 2)
-    knots = [[0, 1], [1, 2], [5, 10], [6, 11]]
+    X = np.arange(20)[:, None]
+    knots = [[0], [1], [5], [11], [12]]
     _ = SplineTransformer(
         degree=3,
         knots=knots,

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -194,6 +194,33 @@ def test_spline_transformer_linear_regression(bias, intercept):
     assert_allclose(pipe.predict(X), y, rtol=1e-3)
 
 
+@pytest.mark.parametrize("knots, n_knots, degree", [
+    ("uniform", 5, 3),
+    ("uniform", 12, 8),
+    (
+        [[-1.0, 0.0], [0, 1.0], [0.1, 2.0], [0.2, 3.0], [0.3, 4.0], [1, 5.0]],
+        100,  # this gets ignored.
+        3
+    )
+])
+def test_spline_transformer_periodicity_of_extrapolation(
+    knots, n_knots, degree
+):
+    """Test that the SplineTransformer is periodic for multiple features."""
+    X_1 = np.linspace((-1, 0), (1, 5), 10)
+    X_2 = np.linspace((1, 5), (3, 10), 10)
+
+    splt = SplineTransformer(
+        knots=knots,
+        n_knots=n_knots,
+        degree=degree,
+        extrapolation="periodic"
+    )
+    splt.fit(X_1)
+
+    assert_allclose(splt.transform(X_1), splt.transform(X_2))
+
+
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])
 def test_spline_transformer_periodic_linear_regression(bias, intercept):
     """Test that B-splines fit a periodic curve pretty well."""

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -69,11 +69,13 @@ def test_polynomial_and_spline_array_order(est):
         ({"include_bias": "string"}, "include_bias must be bool."),
         (
             {"extrapolation": "periodic", "n_knots": 3, "degree": 3},
-            "Periodic splines require degree < n_knots."
+            "Periodic splines require degree < n_knots. Got n_knots="
+            "3 and degree=3."
         ),
         (
             {"extrapolation": "periodic", "knots": [[0], [1]], "degree": 2},
-            "Periodic splines require degree < n_knots."
+            "Periodic splines require degree < n_knots. Got n_knots=2 and "
+            "degree=2."
         )
     ],
 )

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -34,7 +34,7 @@ def test_polynomial_and_spline_array_order(est):
         ({"n_knots": 1}, "n_knots must be a positive integer >= 2."),
         ({"n_knots": 2.5}, "n_knots must be a positive integer >= 2."),
         ({"n_knots": "string"}, "n_knots must be a positive integer >= 2."),
-        ({"knots": "string"}, "Expected 2D array, got scalar array instead:"),
+        ({"knots": 1}, "Expected 2D array, got scalar array instead:"),
         ({"knots": [1, 2]}, "Expected 2D array, got 1D array instead:"),
         (
             {"knots": [[1]]},

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -87,26 +87,29 @@ def test_spline_transformer_input_validation(params, err_msg):
         SplineTransformer(**params).fit(X)
 
 
-@pytest.mark.parametrize("extrapolation", ["continue", "periodic"])
-def test_spline_transformer_manual_knot_input(extrapolation):
+def test_spline_transformer_manual_knot_input():
     """
     Test that array-like knot positions in SplineTransformer are accepted.
     """
     X = np.arange(20).reshape(10, 2)
-    knots = [[0, 1], [1, 2], [5, 10], [6, 11]]
-    st1 = SplineTransformer(
-        degree=3,
-        knots=knots,
-        extrapolation=extrapolation
-    ).fit(X)
+    knots = [[0.5, 1], [1.5, 2], [5, 10]]
+    st1 = SplineTransformer(degree=3, knots=knots).fit(X)
     knots = np.asarray(knots)
-    st2 = SplineTransformer(
-        degree=3,
-        knots=knots,
-        extrapolation=extrapolation
-    ).fit(X)
+    st2 = SplineTransformer(degree=3, knots=knots).fit(X)
     for i in range(X.shape[1]):
         assert_allclose(st1.bsplines_[i].t, st2.bsplines_[i].t)
+
+
+@pytest.mark.parametrize("extrapolation", ["continue", "periodic"])
+def test_spline_transformer_integer_knots(extrapolation):
+    """Test that SplineTransformer accepts integer value knot positions."""
+    X = np.arange(20).reshape(10, 2)
+    knots = [[0, 1], [1, 2], [5, 10], [6, 11]]
+    _ = SplineTransformer(
+        degree=3,
+        knots=knots,
+        extrapolation=extrapolation
+    ).fit_transform(X)
 
 
 def test_spline_transformer_feature_names():

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -153,7 +153,8 @@ def test_spline_transformer_feature_names():
 @pytest.mark.parametrize("degree", range(1, 5))
 @pytest.mark.parametrize("n_knots", range(3, 5))
 @pytest.mark.parametrize("knots", ["uniform", "quantile"])
-def test_spline_transformer_unity_decomposition(degree, n_knots, knots):
+@pytest.mark.parametrize("extrapolation", ["constant", "periodic"])
+def test_spline_transformer_unity_decomposition(degree, n_knots, knots, extrapolation):
     """Test that B-splines are indeed a decomposition of unity.
 
     Splines basis functions must sum up to 1 per row, if we stay in between
@@ -163,8 +164,12 @@ def test_spline_transformer_unity_decomposition(degree, n_knots, knots):
     # make the boundaries 0 and 1 part of X_train, for sure.
     X_train = np.r_[[[0]], X[::2, :], [[1]]]
     X_test = X[1::2, :]
+
+    if extrapolation == "periodic":
+        n_knots = n_knots + degree  # periodic splines require degree < n_knots
+
     splt = SplineTransformer(
-        n_knots=n_knots, degree=degree, knots=knots, include_bias=True
+        n_knots=n_knots, degree=degree, knots=knots, include_bias=True, extrapolation=extrapolation
     )
     splt.fit(X_train)
     for X in [X_train, X_test]:

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -283,10 +283,11 @@ def test_spline_transformer_periodic_splines_smoothness(degree):
     Xt = transformer.fit_transform(X)
 
     tol = 0.02
+    dXt = Xt
 
     for d in range(1, degree + 1):
-        Xt = Xt[1:, :] - Xt[:-1, :]
-        assert (np.abs(Xt) < (tol ** d)).all()
+        dXt = dXt[1:, :] - dXt[:-1, :]
+        assert (np.abs(dXt) < (tol ** d)).all()
 
     assert np.abs(dXt[1:, :] - dXt[:-1, :]).max() > tol ** (degree + 1)
 

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -285,14 +285,16 @@ def test_spline_transformer_periodic_splines_smoothness(degree):
     )
     Xt = transformer.fit_transform(X)
 
-    tol = 0.02
+    delta = (X.max() - X.min()) / len(X)
+    tol = 10
+
     dXt = Xt
 
     for d in range(1, degree + 1):
         dXt = dXt[1:, :] - dXt[:-1, :]
-        assert (np.abs(dXt) < (tol ** d)).all()
+        assert (np.abs(dXt) < tol * (delta ** d)).all()
 
-    assert np.abs(dXt[1:, :] - dXt[:-1, :]).max() > tol ** (degree + 1)
+    assert np.abs(dXt[1:, :] - dXt[:-1, :]).max() > tol * delta ** (degree + 1)
 
 
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -92,7 +92,9 @@ def test_spline_transformer_input_validation(params, err_msg):
 
 
 def test_spline_transformer_manual_knot_input():
-    """Test that array-like knot positions in SplineTransformer are accepted."""
+    """
+    Test that array-like knot positions in SplineTransformer are accepted.
+    """
     X = np.arange(20).reshape(10, 2)
     knots = [[0.5, 1], [1.5, 2], [5, 10]]
     st1 = SplineTransformer(degree=3, knots=knots).fit(X)
@@ -303,7 +305,9 @@ def test_spline_transformer_kbindiscretizer():
     )
     splines = splt.fit_transform(X)
 
-    kbd = KBinsDiscretizer(n_bins=n_bins, encode="onehot-dense", strategy="quantile")
+    kbd = KBinsDiscretizer(
+        n_bins=n_bins, encode="onehot-dense", strategy="quantile"
+    )
     kbins = kbd.fit_transform(X)
 
     # Though they should be exactly equal, we test approximately with high

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -73,6 +73,14 @@ def test_polynomial_and_spline_array_order(est):
         ({"include_bias": None}, "include_bias must be bool."),
         ({"include_bias": 1}, "include_bias must be bool."),
         ({"include_bias": "string"}, "include_bias must be bool."),
+        (
+            {"extrapolation": "periodic", "n_knots": 3, "degree": 3},
+            "Periodic splines require degree < n_knots."
+        ),
+        (
+            {"extrapolation": "periodic", "knots": [[0], [1]], "degree": 2},
+            "Periodic splines require degree < n_knots."
+        )
     ],
 )
 def test_spline_transformer_input_validation(params, err_msg):

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -227,7 +227,9 @@ def test_spline_transformer_periodic_spline_backport():
 
     # Use periodic extrapolation backport in SplineTransformer
     transformer = SplineTransformer(
-        degree=2, extrapolation="periodic", knots=[[-1], [0], [1]]
+        degree=2,
+        extrapolation="periodic",
+        knots=[[-1.0], [0.0], [1.0]]
     )
     Xt = transformer.fit_transform(X)
 
@@ -247,19 +249,19 @@ def test_spline_transformer_periodic_splines_periodicity():
     transformer_1 = SplineTransformer(
         degree=3,
         extrapolation="periodic",
-        knots=[[0], [1], [2], [3], [4], [5]]
+        knots=[[0.0], [1.0], [3.0], [4.0], [5.0], [8.0]]
     )
+
     transformer_2 = SplineTransformer(
         degree=3,
         extrapolation="periodic",
-        knots=[[1], [2], [3], [4], [5], [6]]
+        knots=[[1.0], [3.0], [4.0], [5.0], [8.0], [9.0]]
     )
 
     Xt_1 = transformer_1.fit_transform(X)
     Xt_2 = transformer_2.fit_transform(X)
 
     assert_allclose(Xt_1, Xt_2[:, [4, 0, 1, 2, 3]])
-    assert_allclose(Xt_1[:91, :], Xt_2[10:, :])
 
 
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -327,7 +327,7 @@ def test_spline_transformer_periodic_splines_smoothness(degree):
     Xt = transformer.fit_transform(X)
 
     delta = (X.max() - X.min()) / len(X)
-    tol = 1e-2
+    tol = 10 * delta
 
     dXt = Xt
     # We expect splines of degree `degree` to be (`degree`-1) times
@@ -350,7 +350,7 @@ def test_spline_transformer_periodic_splines_smoothness(degree):
     # differentiable at the knots, the `degree + 1`-th numeric derivative
     # should have spikes at the knots.
     diff = np.diff(dXt, axis=0)
-    assert np.abs(diff).max() > 100 * tol
+    assert np.abs(diff).max() > 1
 
 
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -87,15 +87,24 @@ def test_spline_transformer_input_validation(params, err_msg):
         SplineTransformer(**params).fit(X)
 
 
-def test_spline_transformer_manual_knot_input():
+@pytest.mark.parametrize("extrapolation", ["continue", "periodic"])
+def test_spline_transformer_manual_knot_input(extrapolation):
     """
     Test that array-like knot positions in SplineTransformer are accepted.
     """
     X = np.arange(20).reshape(10, 2)
-    knots = [[0.5, 1], [1.5, 2], [5, 10]]
-    st1 = SplineTransformer(degree=3, knots=knots).fit(X)
+    knots = [[0, 1], [1, 2], [5, 10], [6, 11]]
+    st1 = SplineTransformer(
+        degree=3,
+        knots=knots,
+        extrapolation=extrapolation
+    ).fit(X)
     knots = np.asarray(knots)
-    st2 = SplineTransformer(degree=3, knots=knots).fit(X)
+    st2 = SplineTransformer(
+        degree=3,
+        knots=knots,
+        extrapolation=extrapolation
+    ).fit(X)
     for i in range(X.shape[1]):
         assert_allclose(st1.bsplines_[i].t, st2.bsplines_[i].t)
 

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -264,6 +264,28 @@ def test_spline_transformer_periodic_splines_periodicity():
     assert_allclose(Xt_1, Xt_2[:, [4, 0, 1, 2, 3]])
 
 
+@pytest.mark.parametrize("degree", [3, 5])
+def test_spline_transformer_periodic_splines_smoothness(degree):
+    """Test that spline transformation is smooth at first / last knot."""
+    X = np.linspace(0, 10, 1000)[:, None]
+
+    transformer = SplineTransformer(
+        degree=degree,
+        extrapolation="periodic",
+        knots=[[0.0], [1.0], [3.0], [4.0], [5.0], [8.0]]
+    )
+
+    Xt = transformer.fit_transform(X)
+
+    tol = 0.02
+
+    for d in range(1, degree + 1):
+        Xt = Xt[1:, :] - Xt[:-1, :]
+        assert (np.abs(Xt) < (tol ** d)).all()
+
+    assert np.abs(Xt[1:, :] - Xt[:-1, :]).max() > tol ** (degree + 1)
+
+
 @pytest.mark.parametrize(["bias", "intercept"], [(True, False), (False, True)])
 @pytest.mark.parametrize("degree", [1, 2, 3, 4, 5])
 def test_spline_transformer_extrapolation(bias, intercept, degree):


### PR DESCRIPTION
#### Reference Issues/PRs
Extends #18368.

#### What does this implement/fix? Explain your changes.
This PR adds the option for periodic extrapolation (with periodic splines) to the `SplineTransformer`.

#### Any other comments?
Thank you @lorentzenchr for adding the `SplineTransformer`! I often use periodic splines e.g. to model effects for the day of the year and would believe this feature to be very helpful. Please let me know if we should expand documenting code / examples.