### PR TITLE
Replace onnxmltools by sklearn-onnx in the documentation

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -97,7 +97,7 @@ enhance the functionality of scikit-learn's estimators.
 
 **Model export for production**
 
-- `onnxmltools <https://github.com/onnx/onnxmltools>`_ Serializes many
+- `sklearn-onnx <https://github.com/onnx/sklearn-onnx>`_ Serialization of many
   Scikit-learn pipelines to `ONNX <https://onnx.ai/>`_ for interchange and
   prediction.
 

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -223,7 +223,7 @@ the document up to date as we work on these issues.
    (to be discussed);
 
    * Extend documentation to mention how to deploy models in Python-free
-     environments for instance  `ONNX <https://github.com/onnx/onnxmltools>`_.
+     environments for instance `ONNX <https://github.com/onnx/sklearn-onnx>`_.
      and use the above best practices to assess predictive consistency between
      scikit-learn and ONNX prediction functions on validation set.
    * Document good practices to detect temporal distribution drift for deployed


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix?
Update the documentation, replace module onnxmltools by sklearn-onnx in the documentation wherever it was found. It is better to directly use sklearn-onnx instead of using it through onnxmltools to convert scikit-learn's model.
