### PR TITLE
TST Improve ridge solver consistency tests

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -39,7 +39,7 @@ from sklearn.model_selection import GroupKFold
 from sklearn.model_selection import cross_val_predict
 from sklearn.model_selection import LeaveOneOut
 
-from sklearn.preprocessing import scale
+from sklearn.preprocessing import minmax_scale
 from sklearn.utils import check_random_state
 from sklearn.datasets import make_multilabel_classification
 
@@ -427,8 +427,10 @@ def test_solver_consistency(
         bias=10, n_features=30, proportion_nonzero=proportion_nonzero,
         noise=noise, random_state=seed, n_samples=n_samples)
     if not normalize:
-        # Manually scale the data to avoid pathological cases.
-        X = scale(X, with_mean=False)
+        # Manually scale the data to avoid pathological cases. We use
+        # minmax_scale to deal with the sparse case without breaking
+        # the sparsity pattern.
+        X = minmax_scale(X)
     svd_ridge = Ridge(
         solver='svd', normalize=normalize, alpha=alpha).fit(X, y)
     X = X.astype(dtype, copy=False)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -39,6 +39,7 @@ from sklearn.model_selection import GroupKFold
 from sklearn.model_selection import cross_val_predict
 from sklearn.model_selection import LeaveOneOut
 
+from sklearn.preprocessing import scale
 from sklearn.utils import check_random_state
 from sklearn.datasets import make_multilabel_classification
 
@@ -415,24 +416,30 @@ def _make_sparse_offset_regression(
 @pytest.mark.parametrize(
     'n_samples,dtype,proportion_nonzero',
     [(20, 'float32', .1), (40, 'float32', 1.), (20, 'float64', .2)])
+@pytest.mark.parametrize('normalize', [True, False])
 @pytest.mark.parametrize('seed', np.arange(3))
 def test_solver_consistency(
-        solver, proportion_nonzero, n_samples, dtype, sparse_X, seed):
+        solver, proportion_nonzero, n_samples, dtype, sparse_X, seed,
+        normalize):
     alpha = 1.
     noise = 50. if proportion_nonzero > .9 else 500.
     X, y = _make_sparse_offset_regression(
         bias=10, n_features=30, proportion_nonzero=proportion_nonzero,
         noise=noise, random_state=seed, n_samples=n_samples)
+    if not normalize:
+        # Manually scale the data to avoid pathological cases.
+        X = scale(X, with_mean=False)
     svd_ridge = Ridge(
-        solver='svd', normalize=True, alpha=alpha).fit(X, y)
+        solver='svd', normalize=normalize, alpha=alpha).fit(X, y)
     X = X.astype(dtype, copy=False)
     y = y.astype(dtype, copy=False)
     if sparse_X:
         X = sp.csr_matrix(X)
     if solver == 'ridgecv':
-        ridge = RidgeCV(alphas=[alpha], normalize=True)
+        ridge = RidgeCV(alphas=[alpha], normalize=normalize)
     else:
-        ridge = Ridge(solver=solver, tol=1e-10, normalize=True, alpha=alpha)
+        ridge = Ridge(solver=solver, tol=1e-10, normalize=normalize,
+                      alpha=alpha)
     ridge.fit(X, y)
     assert_allclose(
         ridge.coef_, svd_ridge.coef_, atol=1e-3, rtol=1e-3)


### PR DESCRIPTION
Since we plan to deprecate the `normalize=True` option for linear models as it's inconsistent, buggy and not very explicit compared to explicit data-preprocessing, I want to increase the coverage the consistency of ridge solvers for the case where `normalize=False`.

I came up with this test coverage improvement while trying to investigate why #19426 is currently failing on this test but I think this should be merged to the main branch irrespective of what we do in  #19426 (and rebase #19426 on main after merge accordingly).