### PR TITLE
DOC Fix overlapping titles in clustering overview

### DIFF
--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -63,8 +63,8 @@ varied = datasets.make_blobs(n_samples=n_samples,
 # ============
 # Set up cluster parameters
 # ============
-plt.figure(figsize=(9 * 2 + 3, 12.5))
-plt.subplots_adjust(left=.02, right=.98, bottom=.001, top=.96, wspace=.05,
+plt.figure(figsize=(9 * 2 + 3, 13))
+plt.subplots_adjust(left=.02, right=.98, bottom=.001, top=.95, wspace=.05,
                     hspace=.01)
 
 plot_num = 1
@@ -173,7 +173,7 @@ for i_dataset, (dataset, algo_params) in enumerate(datasets):
 
         plt.subplot(len(datasets), len(clustering_algorithms), plot_num)
         if i_dataset == 0:
-            plt.title(name, size=16)
+            plt.title(name, size=18)
 
         colors = np.array(list(islice(cycle(['#377eb8', '#ff7f00', '#4daf4a',
                                              '#f781bf', '#a65628', '#984ea3',

--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -135,16 +135,16 @@ for i_dataset, (dataset, algo_params) in enumerate(datasets):
         n_components=params['n_clusters'], covariance_type='full')
 
     clustering_algorithms = (
-        ('MiniBatchKMeans', two_means),
-        ('AffinityPropagation', affinity_propagation),
+        ('MiniBatch\nKMeans', two_means),
+        ('Affinity\nPropagation', affinity_propagation),
         ('MeanShift', ms),
-        ('SpectralClustering', spectral),
+        ('Spectral\nClustering', spectral),
         ('Ward', ward),
-        ('AgglomerativeClustering', average_linkage),
+        ('Agglomerative\nClustering', average_linkage),
         ('DBSCAN', dbscan),
         ('OPTICS', optics),
         ('BIRCH', birch),
-        ('GaussianMixture', gmm)
+        ('Gaussian\nMixture', gmm)
     )
 
     for name, algorithm in clustering_algorithms:
@@ -173,7 +173,7 @@ for i_dataset, (dataset, algo_params) in enumerate(datasets):
 
         plt.subplot(len(datasets), len(clustering_algorithms), plot_num)
         if i_dataset == 0:
-            plt.title(name, size=18)
+            plt.title(name, size=16)
 
         colors = np.array(list(islice(cycle(['#377eb8', '#ff7f00', '#4daf4a',
                                              '#f781bf', '#a65628', '#984ea3',


### PR DESCRIPTION
#### Reference Issues/PRs
The comparison plot for the clustering overview contains overlapping titles. 

#### What does this implement/fix? Explain your changes.
I just split the long titles into to lines via '\n'. And slightly decreased the text size of the titles.


#### Any other comments?
The problem was mentioned  in  #9739.
I am not sure if you guys still want to rework the overview by transposing them.
If you are not happy with my solution just let me know.
