### PR TITLE
TST replace assert_raise with pytest.raises in calibration, check_build, metaestimators

### DIFF
--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -13,7 +13,7 @@ from sklearn.model_selection import LeaveOneOut, train_test_split
 from sklearn.utils._testing import (assert_array_almost_equal,
                                     assert_almost_equal,
                                     assert_array_equal,
-                                    assert_raises, ignore_warnings)
+                                    ignore_warnings)
 from sklearn.utils.extmath import softmax
 from sklearn.exceptions import NotFittedError
 from sklearn.datasets import make_classification, make_blobs
@@ -60,7 +60,8 @@ def test_calibration(data, method, ensemble):
     prob_pos_clf = clf.predict_proba(X_test)[:, 1]
 
     cal_clf = CalibratedClassifierCV(clf, cv=y.size + 1, ensemble=ensemble)
-    assert_raises(ValueError, cal_clf.fit, X, y)
+    with pytest.raises(ValueError):
+        cal_clf.fit(X, y)
 
     # Naive Bayes with calibration
     for this_X_train, this_X_test in [(X_train, X_test),
@@ -386,8 +387,8 @@ def test_sigmoid_calibration():
 
     # check that _SigmoidCalibration().fit only accepts 1d array or 2d column
     # arrays
-    assert_raises(ValueError, _SigmoidCalibration().fit,
-                  np.vstack((exF, exF)), exY)
+    with pytest.raises(ValueError):
+        _SigmoidCalibration().fit(np.vstack((exF, exF)), exY)
 
 
 def test_calibration_curve():
@@ -406,8 +407,8 @@ def test_calibration_curve():
 
     # probabilities outside [0, 1] should not be accepted when normalize
     # is set to False
-    assert_raises(ValueError, calibration_curve, [1.1], [-0.1],
-                  normalize=False)
+    with pytest.raises(ValueError):
+        calibration_curve([1.1], [-0.1], normalize=False)
 
     # test that quantiles work as expected
     y_true2 = np.array([0, 0, 0, 0, 1, 1])
@@ -421,8 +422,8 @@ def test_calibration_curve():
     assert_almost_equal(prob_pred_quantile, [0.1, 0.8])
 
     # Check that error is raised when invalid strategy is selected
-    assert_raises(ValueError, calibration_curve, y_true2, y_pred2,
-                  strategy='percentile')
+    with pytest.raises(ValueError):
+        calibration_curve(y_true2, y_pred2, strategy='percentile')
 
 
 @pytest.mark.parametrize('ensemble', [True, False])

--- a/sklearn/tests/test_check_build.py
+++ b/sklearn/tests/test_check_build.py
@@ -5,10 +5,11 @@ Smoke Test the check_build module
 # Author: G Varoquaux
 # License: BSD 3 clause
 
-from sklearn.__check_build import raise_build_error
+import pytest
 
-from sklearn.utils._testing import assert_raises
+from sklearn.__check_build import raise_build_error
 
 
 def test_raise_build_error():
-    assert_raises(ImportError, raise_build_error, ImportError())
+    with pytest.raises(ImportError):
+        raise_build_error(ImportError())

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -2,11 +2,11 @@
 import functools
 
 import numpy as np
+import pytest
 
 from sklearn.base import BaseEstimator
 from sklearn.datasets import make_classification
 
-from sklearn.utils._testing import assert_raises
 from sklearn.utils.validation import check_is_fitted
 from sklearn.pipeline import Pipeline
 from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
@@ -124,12 +124,12 @@ def test_metaestimator_delegation():
                     % (delegator_data.name, method))
             # delegation before fit raises a NotFittedError
             if method == 'score':
-                assert_raises(NotFittedError, getattr(delegator, method),
-                              delegator_data.fit_args[0],
-                              delegator_data.fit_args[1])
+                with pytest.raises(NotFittedError):
+                    getattr(delegator, method)(delegator_data.fit_args[0],
+                                               delegator_data.fit_args[1])
             else:
-                assert_raises(NotFittedError, getattr(delegator, method),
-                              delegator_data.fit_args[0])
+                with pytest.raises(NotFittedError):
+                    getattr(delegator, method)(delegator_data.fit_args[0])
 
         delegator.fit(*delegator_data.fit_args)
         for method in methods:


### PR DESCRIPTION

#### Reference Issues/PRs
References #14216 

#### What does this implement/fix? Explain your changes.
Changes the assert_raises to pytest.raises(...) for the smaller files with fewer changes in a single PR. Following files are affected:
- test_calibration
- test_check_build
- test_metaestimators

#### Any other comments?
#DataUmbrella
