### PR TITLE
DOC Fix color palette in manifold example

### DIFF
--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -53,7 +53,7 @@ def plot_embedding(X, title=None):
     ax = plt.subplot(111)
     for i in range(X.shape[0]):
         plt.text(X[i, 0], X[i, 1], str(y[i]),
-                 color=plt.cm.Set1(y[i] / 10.),
+                 color=plt.cm.Dark2(y[i]),
                  fontdict={'weight': 'bold', 'size': 9})
 
     if hasattr(offsetbox, 'AnnotationBbox'):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The manifold learning [example ](https://scikit-learn.org/stable/auto_examples/manifold/plot_lle_digits.html) on handwritten digits codes 0 and 1 digits as red which makes the example somewhat confusing. I suggest to use Dark2 palette instead of Set1. Below you can see how the coloring changes:
<img width="564" alt="sklearn_palette-contrib" src="https://user-images.githubusercontent.com/37249897/108633355-21618680-7474-11eb-9249-625e1087b166.PNG">


#### Any other comments?
This is my first contribution to scikit-learn, tried to follow the guideline. Sorry if I missed out on something.