### PR TITLE
BIC and AIC scores in _bayesian_mixture.py

### DIFF
--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -792,21 +792,22 @@ class BayesianGaussianMixture(BaseMixture):
                                       self.precisions_cholesky_.T)
         else:
             self.precisions_ = self.precisions_cholesky_ ** 2
-    
+
     def _n_parameters(self, X):
         """Return the number of free parameters in the model."""
         _, n_features = self.means_.shape
-        n_effective_components = len(np.unique(self.predict(X)))
+        # Number of effective components equals the number of unique labels
+        n_effect_comp = len(np.unique(self.predict(X)))
         if self.covariance_type == 'full':
-            cov_params = n_effective_components * n_features * (n_features + 1) / 2.
+            cov_params = n_effect_comp * n_features * (n_features + 1) / 2.
         elif self.covariance_type == 'diag':
-            cov_params = n_effective_components * n_features
+            cov_params = n_effect_comp * n_features
         elif self.covariance_type == 'tied':
             cov_params = n_features * (n_features + 1) / 2.
         elif self.covariance_type == 'spherical':
-            cov_params = n_effective_components
-        mean_params = n_features * n_effective_components
-        return int(cov_params + mean_params + n_effective_components - 1)
+            cov_params = n_effect_comp
+        mean_params = n_features * n_effect_comp
+        return int(cov_params + mean_params + n_effect_comp - 1)
 
     def bic(self, X):
         """Bayesian information criterion for the current model on the input X.

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -20,6 +20,7 @@ from sklearn.mixture import BayesianGaussianMixture
 
 from sklearn.mixture.tests.test_gaussian_mixture import RandomData
 from sklearn.exceptions import ConvergenceWarning, NotFittedError
+from sklearn.utils.extmath import fast_logdet
 from sklearn.utils._testing import ignore_warnings
 
 
@@ -487,7 +488,7 @@ def test_bayesian_mixture_predict_predict_proba():
             assert_array_equal(Y_pred, Y_pred_proba)
             assert adjusted_rand_score(Y, Y_pred) >= .95
 
-def test_gaussian_mixture_aic_bic():
+def test_bgmm_aic_bic():
     # Test the aic and bic criteria
     rng = np.random.RandomState(0)
     n_samples, n_features, n_components = 50, 3, 2
@@ -502,12 +503,12 @@ def test_gaussian_mixture_aic_bic():
             random_state=rng, 
             max_iter=200)
         bgmm.fit(X)
-        aic = 2 * n_samples * sgh + 2 * g._n_parameters(X)
+        aic = 2 * n_samples * sgh + 2 * bgmm._n_parameters(X)
         bic = (2 * n_samples * sgh +
-               np.log(n_samples) * g._n_parameters(X))
+               np.log(n_samples) * bgmm._n_parameters(X))
         bound = n_features / np.sqrt(n_samples)
-        assert (g.aic(X) - aic) / n_samples < bound
-        assert (g.bic(X) - bic) / n_samples < bound
+        assert (bgmm.aic(X) - aic) / n_samples < bound
+        assert (bgmm.bic(X) - bic) / n_samples < bound
 
 def test_bic_1d_1component():
     # Test all of the covariance_types return the same BIC score for

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -498,9 +498,9 @@ def test_bgmm_aic_bic():
                  n_features * (1 + np.log(2 * np.pi)))
     for cv_type in COVARIANCE_TYPE:
         bgmm = BayesianGaussianMixture(
-            n_components=n_components, 
-            covariance_type=cv_type, 
-            random_state=rng, 
+            n_components=n_components,
+            covariance_type=cv_type,
+            random_state=rng,
             max_iter=200)
         bgmm.fit(X)
         aic = 2 * n_samples * sgh + 2 * bgmm._n_parameters(X)
@@ -517,10 +517,10 @@ def test_bic_1d_1component():
     n_samples, n_dim, n_components = 100, 1, 1
     X = rng.randn(n_samples, n_dim)
     bic_full = BayesianGaussianMixture(n_components=n_components,
-                               covariance_type='full',
-                               random_state=rng).fit(X).bic(X)
+                                       covariance_type='full',
+                                       random_state=rng).fit(X).bic(X)
     for covariance_type in ['tied', 'diag', 'spherical']:
         bic = BayesianGaussianMixture(n_components=n_components,
-                              covariance_type=covariance_type,
-                              random_state=rng).fit(X).bic(X)
+                                      covariance_type=covariance_type,
+                                      random_state=rng).fit(X).bic(X)
         assert_almost_equal(bic_full, bic)

--- a/sklearn/mixture/tests/test_bayesian_mixture.py
+++ b/sklearn/mixture/tests/test_bayesian_mixture.py
@@ -488,6 +488,7 @@ def test_bayesian_mixture_predict_predict_proba():
             assert_array_equal(Y_pred, Y_pred_proba)
             assert adjusted_rand_score(Y, Y_pred) >= .95
 
+
 def test_bgmm_aic_bic():
     # Test the aic and bic criteria
     rng = np.random.RandomState(0)
@@ -509,6 +510,7 @@ def test_bgmm_aic_bic():
         bound = n_features / np.sqrt(n_samples)
         assert (bgmm.aic(X) - aic) / n_samples < bound
         assert (bgmm.bic(X) - bic) / n_samples < bound
+
 
 def test_bic_1d_1component():
     # Test all of the covariance_types return the same BIC score for


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #19523 


#### What does this implement/fix? Explain your changes.
Added the possibility to get BIC and AIC scores for the Bayesian Gaussian Mixture class. Worked on `sklearn/mixture/_bayesian_mixture.py` and `sklearn/mixture/tests/test_bayesian_mixture.py`.


#### Any other comments?
This is based on how the BIC and AIC scores are calculated for the Gaussian Mixture class in `sklearn/mixture/_gaussian_mixture.py` with slight modifications. Unittests added in `sklearn/mixture/tests/test_bayesian_mixture.py`, based on the unittests for the corresponding functions in `sklearn/mixture/tests/test_gaussian_mixture.py`. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
