### PR TITLE
MNT Clear travis installation script

### DIFF
--- a/build_tools/travis/install_main.sh
+++ b/build_tools/travis/install_main.sh
@@ -32,12 +32,7 @@ ccache --max-size 100M --show-stats
 # to setup a conda-based environment instead
 deactivate
 
-if [[ $TRAVIS_CPU_ARCH == arm64 ]]; then
-    # Different Miniconda URL for ARM64 architectures
-    MINICONDA_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh"
-else
-    MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-fi
+MINICONDA_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh"
 
 # Install Miniconda
 wget $MINICONDA_URL -O miniconda.sh


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR removes the `if` statement to use a different `Miniconda` URL for `ARM64` architectures. Currently, `travis` only uses `ARM64` architectures.