### PR TITLE
TST Enables isotonic and manifold in test_check_n_features_in_after_fitting

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -267,8 +267,6 @@ N_FEATURES_IN_AFTER_FIT_MODULES_TO_IGNORE = {
     'calibration',
     'compose',
     'feature_extraction',
-    'isotonic',
-    'manifold',
     'mixture',
     'model_selection',
     'multiclass',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/issues/19333


#### What does this implement/fix? Explain your changes.
1. IsotonicRegression accepts 1d and 2d arrays with one feature. We do not have a `n_features_in_` defined for this situation.

2. `manifold` estimators only has `fit` and `fit_transform` functions, so it would pass `test_check_n_features_in_after_fitting` by default.
