### PR TITLE
ENH Enables common test for bicluster estimators

### DIFF
--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -178,6 +178,19 @@ class BaseSpectral(BiclusterMixin, BaseEstimator, metaclass=ABCMeta):
         labels = model.labels_
         return centroid, labels
 
+    def _more_tags(self):
+        return {
+            "_xfail_checks": {
+                "check_estimators_dtypes": "raises nan error",
+                "check_fit2d_1sample": "_scale_normalize fails",
+                "check_fit2d_1feature": "raises apply_along_axis error",
+                "check_estimator_sparse_data": "does not fail gracefully",
+                "check_methods_subset_invariance": "empty array passed inside",
+                "check_dont_overwrite_parameters": "empty array passed inside",
+                "check_fit2d_predict1d": "emptry array passed inside",
+            }
+        }
+
 
 class SpectralCoclustering(BaseSpectral):
     """Spectral Co-Clustering algorithm (Dhillon, 2001).

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -23,7 +23,6 @@ from sklearn.exceptions import FitFailedWarning
 from sklearn.utils.estimator_checks import check_estimator
 
 import sklearn
-from sklearn.base import BiclusterMixin
 
 from sklearn.decomposition import PCA
 from sklearn.linear_model._base import LinearClassifierMixin
@@ -73,8 +72,6 @@ def test_get_check_estimator_ids(val, expected):
 
 def _tested_estimators():
     for name, Estimator in all_estimators():
-        if issubclass(Estimator, BiclusterMixin):
-            continue
         try:
             estimator = _construct_instance(Estimator)
         except SkipTest:


### PR DESCRIPTION
Adds `bicluster` modules back into common test using `xfail` for test that are failing.