### PR TITLE
FIX race condition in get_data_home causing FileExistsError

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -52,8 +52,7 @@ def get_data_home(data_home=None) -> str:
         data_home = environ.get('SCIKIT_LEARN_DATA',
                                 join('~', 'scikit_learn_data'))
     data_home = expanduser(data_home)
-    if not exists(data_home):
-        makedirs(data_home)
+    makedirs(data_home, exist_ok=True)
     return data_home
 
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -12,7 +12,7 @@ import os
 import shutil
 from collections import namedtuple
 from os import environ, listdir, makedirs
-from os.path import dirname, exists, expanduser, isdir, join, splitext
+from os.path import dirname, expanduser, isdir, join, splitext
 
 from ..utils import Bunch
 from ..utils import check_random_state


### PR DESCRIPTION
It's safer to use `os.makedirs(..., exists_ok=True)` now that we don't have to support Python 2 anymore.

This should avoid spurious failures when running the tests with `pytest-xdist`:

https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=26901&view=logs&j=e6d5b7c0-0dfd-5ddf-13d5-c71bebf56ce2&t=c500742d-7cbe-569e-8da5-94db9b4cd21e&l=445

I don't think this change requires additional tests or a changelog entry. Let me know if you disagree.