### PR TITLE
Change assert from sklearn to pytest style in module linear_model/tests

### DIFF
--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -20,9 +20,11 @@ from ..utils.validation import _deprecate_positional_args
 from ..utils.fixes import delayed
 from ..model_selection import check_cv
 
-premature = """ Orthogonal matching pursuit ended prematurely due to linear
-dependence in the dictionary. The requested precision might not have been met.
-"""
+premature = (
+    "Orthogonal matching pursuit ended prematurely due to linear"
+    " dependence in the dictionary. The requested precision might"
+    " not have been met."
+)
 
 
 def _cholesky_omp(X, y, n_nonzero_coefs, tol=None, copy_X=True,

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -19,8 +19,6 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_almost_equal
-from sklearn.utils._testing import assert_warns
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import _convert_container
@@ -646,7 +644,13 @@ def test_lasso_alpha_warning():
     Y = [-1, 0, 1]       # just a straight line
 
     clf = Lasso(alpha=0)
-    assert_warns(UserWarning, clf.fit, X, Y)
+    warning_message = (
+        "With alpha=0, this algorithm does not "
+        "converge well. You are advised to use the "
+        "LinearRegression estimator"
+    )
+    with pytest.warns(UserWarning, match=warning_message):
+        clf.fit(X, Y)
 
 
 def test_lasso_positive_constraint():
@@ -733,7 +737,12 @@ def test_multi_task_lasso_and_enet():
     assert_array_almost_equal(clf.coef_[0], clf.coef_[1])
 
     clf = MultiTaskElasticNet(alpha=1.0, tol=1e-8, max_iter=1)
-    assert_warns_message(ConvergenceWarning, 'did not converge', clf.fit, X, Y)
+    warning_message = (
+        "Objective did not converge. You might want to "
+        "increase the number of iterations."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        clf.fit(X, Y)
 
 
 def test_lasso_readonly_data():
@@ -1075,11 +1084,13 @@ def test_overrided_gram_matrix():
     X, y, _, _ = build_dataset(n_samples=20, n_features=10)
     Gram = X.T.dot(X)
     clf = ElasticNet(selection='cyclic', tol=1e-8, precompute=Gram)
-    assert_warns_message(UserWarning,
-                         "Gram matrix was provided but X was centered"
-                         " to fit intercept, "
-                         "or X was normalized : recomputing Gram matrix.",
-                         clf.fit, X, y)
+    warning_message = (
+        "Gram matrix was provided but X was centered"
+        " to fit intercept, "
+        "or X was normalized : recomputing Gram matrix."
+    )
+    with pytest.warns(UserWarning, match=warning_message):
+        clf.fit(X, y)
 
 
 @pytest.mark.parametrize('model', [ElasticNet, Lasso])
@@ -1214,7 +1225,12 @@ def test_enet_coordinate_descent(klass, n_classes, kwargs):
     y = np.ones((n_samples, n_classes))
     if klass == Lasso:
         y = y.ravel()
-    assert_warns(ConvergenceWarning, clf.fit, X, y)
+    warning_message = (
+        "Objective did not converge. You might want to"
+        " increase the number of iterations."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        clf.fit(X, y)
 
 
 def test_convergence_warnings():

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -10,7 +10,6 @@ from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import ignore_warnings
-from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import TempMemmap
 from sklearn.utils.fixes import np_version, parse_version
 from sklearn.exceptions import ConvergenceWarning
@@ -372,7 +371,11 @@ def test_lasso_lars_vs_lasso_cd_ill_conditioned2():
                 + alpha * linalg.norm(coef, 1))
 
     lars = linear_model.LassoLars(alpha=alpha, normalize=False)
-    assert_warns(ConvergenceWarning, lars.fit, X, y)
+    warning_message = (
+        "Regressors in active set degenerate."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        lars.fit(X, y)
     lars_coef_ = lars.coef_
     lars_obj = objective_function(lars_coef_)
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -19,9 +19,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.model_selection import cross_val_score
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 from sklearn.utils import compute_class_weight, _IS_32BIT
-from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import ignore_warnings
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils import shuffle
 from sklearn.linear_model import SGDClassifier
 from sklearn.preprocessing import scale
@@ -155,11 +153,13 @@ def test_lr_liblinear_warning():
     target = iris.target_names[iris.target]
 
     lr = LogisticRegression(solver='liblinear', n_jobs=2)
-    assert_warns_message(UserWarning,
-                         "'n_jobs' > 1 does not have any effect when"
-                         " 'solver' is set to 'liblinear'. Got 'n_jobs'"
-                         " = 2.",
-                         lr.fit, iris.data, target)
+    warning_message = (
+        "'n_jobs' > 1 does not have any effect when"
+        " 'solver' is set to 'liblinear'. Got 'n_jobs'"
+        " = 2."
+    )
+    with pytest.warns(UserWarning, match=warning_message):
+        lr.fit(iris.data, target)
 
 
 def test_predict_3_classes():
@@ -1194,7 +1194,31 @@ def test_max_iter():
     y_bin[y_bin == 2] = 0
 
     solvers = ['newton-cg', 'liblinear', 'sag', 'saga', 'lbfgs']
-
+    warning_messages = {
+        'newton-cg': (
+            "newton-cg failed to converge. Increase the"
+            " number of iterations."
+        ),
+        'liblinear': (
+            "Liblinear failed to converge, increase the"
+            " number of iterations."
+        ),
+        'sag': (
+            "The max_iter was reached which means the"
+            " coef_ did not converge"
+        ),
+        'saga': (
+            "The max_iter was reached which means the"
+            " coef_ did not converge"
+        ),
+        'lbfgs': (
+            r"lbfgs failed to converge .*[\n]*.*[\n]*"
+            r"Increase the number of iterations.*"
+            r"or scale the data.*[\n]*.*[\n]*"
+            r"Please also refer to the documentation "
+            r"for alternative solver options.*[\n]*.*"
+        )
+    }
     for max_iter in range(1, 5):
         for solver in solvers:
             for multi_class in ['ovr', 'multinomial']:
@@ -1203,7 +1227,9 @@ def test_max_iter():
                 lr = LogisticRegression(max_iter=max_iter, tol=1e-15,
                                         multi_class=multi_class,
                                         random_state=0, solver=solver)
-                assert_warns(ConvergenceWarning, lr.fit, X, y_bin)
+                with pytest.warns(ConvergenceWarning,
+                                  match=warning_messages[solver]):
+                    lr.fit(X, y_bin)
                 assert lr.n_iter_[0] == max_iter
 
 
@@ -1644,12 +1670,11 @@ def test_l1_ratio_param(l1_ratio):
                            l1_ratio=l1_ratio).fit(X, Y1)
 
     if l1_ratio is not None:
-        msg = ("l1_ratio parameter is only used when penalty is 'elasticnet'."
-               " Got (penalty=l1)")
-
-        assert_warns_message(UserWarning, msg,
-                             LogisticRegression(penalty='l1', solver='saga',
-                                                l1_ratio=l1_ratio).fit, X, Y1)
+        msg = (r"l1_ratio parameter is only used when penalty is"
+               r" 'elasticnet'\. Got \(penalty=l1\)")
+        with pytest.warns(UserWarning, match=msg):
+            LogisticRegression(penalty='l1', solver='saga',
+                               l1_ratio=l1_ratio).fit(X, Y1)
 
 
 @pytest.mark.parametrize('l1_ratios', ([], [.5, 2], None, 'something_wrong'))
@@ -1664,11 +1689,12 @@ def test_l1_ratios_param(l1_ratios):
                              l1_ratios=l1_ratios, cv=2).fit(X, Y1)
 
     if l1_ratios is not None:
-        msg = ("l1_ratios parameter is only used when penalty is "
-               "'elasticnet'. Got (penalty=l1)")
+        msg = (r"l1_ratios parameter is only used when penalty"
+               r" is 'elasticnet'. Got \(penalty=l1\)")
         function = LogisticRegressionCV(penalty='l1', solver='saga',
                                         l1_ratios=l1_ratios, cv=2).fit
-        assert_warns_message(UserWarning, msg, function, X, Y1)
+        with pytest.warns(UserWarning, match=msg):
+            function(X, Y1)
 
 
 @pytest.mark.parametrize('C', np.logspace(-3, 2, 4))
@@ -1769,7 +1795,8 @@ def test_penalty_none(solver):
 
     msg = "Setting penalty='none' will ignore the C"
     lr = LogisticRegression(penalty='none', solver=solver, C=4)
-    assert_warns_message(UserWarning, msg, lr.fit, X, y)
+    with pytest.warns(UserWarning, match=msg):
+        lr.fit(X, y)
 
     lr_none = LogisticRegression(penalty='none', solver=solver,
                                  random_state=0)

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -2,11 +2,11 @@
 # License: BSD 3 clause
 
 import numpy as np
+import pytest
 
 from sklearn.utils._testing import assert_raises
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import ignore_warnings
 
 
@@ -76,12 +76,16 @@ def test_unreachable_accuracy():
     assert_array_almost_equal(
         orthogonal_mp(X, y, tol=0),
         orthogonal_mp(X, y, n_nonzero_coefs=n_features))
-
-    assert_array_almost_equal(
-        assert_warns(RuntimeWarning, orthogonal_mp, X, y, tol=0,
-                     precompute=True),
-        orthogonal_mp(X, y, precompute=True,
-                      n_nonzero_coefs=n_features))
+    warning_message = (
+        "Orthogonal matching pursuit ended prematurely "
+        "due to linear\ndependence in the dictionary. "
+        "The requested precision might not have been met.\n"
+    )
+    with pytest.warns(RuntimeWarning, match=warning_message):
+        assert_array_almost_equal(
+            orthogonal_mp(X, y, tol=0, precompute=True),
+            orthogonal_mp(X, y, precompute=True,
+                          n_nonzero_coefs=n_features))
 
 
 def test_bad_input():
@@ -155,7 +159,13 @@ def test_identical_regressors():
     gamma = np.zeros(n_features)
     gamma[0] = gamma[1] = 1.
     newy = np.dot(newX, gamma)
-    assert_warns(RuntimeWarning, orthogonal_mp, newX, newy, 2)
+    warning_message = (
+        "Orthogonal matching pursuit ended prematurely "
+        "due to linear\ndependence in the dictionary. "
+        "The requested precision might not have been met.\n"
+    )
+    with pytest.warns(RuntimeWarning, match=warning_message):
+        orthogonal_mp(newX, newy, 2)
 
 
 def test_swapped_regressors():

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -78,8 +78,8 @@ def test_unreachable_accuracy():
         orthogonal_mp(X, y, n_nonzero_coefs=n_features))
     warning_message = (
         "Orthogonal matching pursuit ended prematurely "
-        "due to linear\ndependence in the dictionary. "
-        "The requested precision might not have been met.\n"
+        "due to linear dependence in the dictionary. "
+        "The requested precision might not have been met."
     )
     with pytest.warns(RuntimeWarning, match=warning_message):
         assert_array_almost_equal(
@@ -161,8 +161,8 @@ def test_identical_regressors():
     newy = np.dot(newX, gamma)
     warning_message = (
         "Orthogonal matching pursuit ended prematurely "
-        "due to linear\ndependence in the dictionary. "
-        "The requested precision might not have been met.\n"
+        "due to linear dependence in the dictionary. "
+        "The requested precision might not have been met."
     )
     with pytest.warns(RuntimeWarning, match=warning_message):
         orthogonal_mp(newX, newy, 2)

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -6,7 +6,6 @@ from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 
 from sklearn.utils import check_random_state
-from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import assert_raises_regexp
 from sklearn.utils._testing import assert_allclose
 from sklearn.datasets import make_regression
@@ -232,8 +231,14 @@ def test_ransac_warn_exceed_max_skips():
                                        is_data_valid=is_data_valid,
                                        max_skips=3,
                                        max_trials=5)
-
-    assert_warns(ConvergenceWarning, ransac_estimator.fit, X, y)
+    warning_message = (
+        "RANSAC found a valid consensus set but exited "
+        "early due to skipping more iterations than "
+        "`max_skips`. See estimator attributes for "
+        "diagnostics."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        ransac_estimator.fit(X, y)
     assert ransac_estimator.n_skips_no_inliers_ == 0
     assert ransac_estimator.n_skips_invalid_data_ == 4
     assert ransac_estimator.n_skips_invalid_model_ == 0

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -10,7 +10,6 @@ from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import ignore_warnings
-from sklearn.utils._testing import assert_warns
 
 from sklearn.exceptions import ConvergenceWarning
 
@@ -162,10 +161,14 @@ def test_ridge_regression_convergence_fail():
     rng = np.random.RandomState(0)
     y = rng.randn(5)
     X = rng.randn(5, 10)
-
-    assert_warns(ConvergenceWarning, ridge_regression,
-                 X, y, alpha=1.0, solver="sparse_cg",
-                 tol=0., max_iter=None, verbose=1)
+    warning_message = (
+        r"sparse_cg did not converge after"
+        r" [0-9]+ iterations."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        ridge_regression(X, y,
+                         alpha=1.0, solver="sparse_cg",
+                         tol=0., max_iter=None, verbose=1)
 
 
 def test_ridge_sample_weights():

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -9,7 +9,6 @@ from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_raises_regexp
-from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils.fixes import parse_version
 
@@ -1446,7 +1445,13 @@ def test_tol_parameter():
 
     # Strict tolerance and small max_iter should trigger a warning
     model_3 = SGDClassifier(max_iter=3, tol=1e-3, random_state=0)
-    model_3 = assert_warns(ConvergenceWarning, model_3.fit, X, y)
+    warning_message = (
+        "Maximum number of iteration reached before "
+        "convergence. Consider increasing max_iter to "
+        "improve the fit."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        model_3.fit(X, y)
     assert model_3.n_iter_ == 3
 
 

--- a/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
@@ -1,11 +1,11 @@
 import numpy as np
+import pytest
 import scipy.sparse as sp
 
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_almost_equal
 
 from sklearn.utils._testing import ignore_warnings
-from sklearn.utils._testing import assert_warns
 from sklearn.exceptions import ConvergenceWarning
 
 from sklearn.linear_model import Lasso, ElasticNet, LassoCV, ElasticNetCV
@@ -297,4 +297,9 @@ def test_sparse_enet_coordinate_descent():
     n_features = 2
     X = sp.csc_matrix((n_samples, n_features)) * 1e50
     y = np.ones(n_samples)
-    assert_warns(ConvergenceWarning, clf.fit, X, y)
+    warning_message = (
+        "Objective did not converge. You might want "
+        "to increase the number of iterations."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        clf.fit(X, y)

--- a/sklearn/linear_model/tests/test_theil_sen.py
+++ b/sklearn/linear_model/tests/test_theil_sen.py
@@ -8,8 +8,9 @@ import os
 import sys
 from contextlib import contextmanager
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal, assert_array_less
-from numpy.testing import assert_array_almost_equal, assert_warns
+from numpy.testing import assert_array_almost_equal
 from scipy.linalg import norm
 from scipy.optimize import fmin_bfgs
 from sklearn.exceptions import ConvergenceWarning
@@ -154,7 +155,12 @@ def test_spatial_median_2d():
     fermat_weber = fmin_bfgs(cost_func, median, disp=False)
     assert_array_almost_equal(median, fermat_weber)
     # Check when maximum iteration is exceeded a warning is emitted
-    assert_warns(ConvergenceWarning, _spatial_median, X, max_iter=30, tol=0.)
+    warning_message = (
+        "Maximum number of iterations 30 reached"
+        " in spatial median."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        _spatial_median(X, max_iter=30, tol=0.)
 
 
 def test_theil_sen_1d():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Part of #19414 for linear_model/tests
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Removed use of assert_warns, assert_warns_message in linear_model/tests package

#### Any other comments?
The fix is part of complete fix for issue #19414

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
