### PR TITLE
ENH Optimize dot product order for LogisticRegression for dense matrices

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -114,7 +114,7 @@ Changelog
 ...........................
 
 - |Efficiency| The implementation of :class:`linear_model.LogisticRegression`
-  has been optimised for dense matrices when using `solver==newton-cg` and
+  has been optimised for dense matrices when using `solver='newton-cg'` and
   `multi_class!='multinomial'`.
   :pr:`19571` by :user:`Julien Jerphanion <jjerphan>`.
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -113,6 +113,11 @@ Changelog
 :mod:`sklearn.linear_model`
 ...........................
 
+- |Efficiency| The implementation of :class:`linear_model.LogisticRegression`
+  has been optimised for dense matrices when using `solver==newton-cg` and
+  `multi_class!='multinomial'`.
+  :pr:`19571` by :user:`Julien Jerphanion <jjerphan>`.
+
 - |Enhancement| Validate user-supplied gram matrix passed to linear models
   via the `precompute` argument. :pr:`19004` by :user:`Adam Midvidy <amidvidy>`.
 

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -233,7 +233,11 @@ def _logistic_grad_hess(w, X, y, alpha, sample_weight=None):
 
     def Hs(s):
         ret = np.empty_like(s)
-        ret[:n_features] = np.linalg.multi_dot([X.T, dX, s[:n_features]])
+        if sparse.issparse(X):
+            XTdX = safe_sparse_dot(X.T, dX)
+            ret[:n_features] = safe_sparse_dot(XTdX, s[:n_features])
+        else:
+            ret[:n_features] = np.linalg.multi_dot([X.T, dX, s[:n_features]])
         ret[:n_features] += alpha * s[:n_features]
 
         # For the fit intercept case.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -234,8 +234,7 @@ def _logistic_grad_hess(w, X, y, alpha, sample_weight=None):
     def Hs(s):
         ret = np.empty_like(s)
         if sparse.issparse(X):
-            XTdX = safe_sparse_dot(X.T, dX)
-            ret[:n_features] = safe_sparse_dot(XTdX, s[:n_features])
+            ret[:n_features] = X.T.dot(dX.dot(s[:n_features]))
         else:
             ret[:n_features] = np.linalg.multi_dot([X.T, dX, s[:n_features]])
         ret[:n_features] += alpha * s[:n_features]

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -233,7 +233,7 @@ def _logistic_grad_hess(w, X, y, alpha, sample_weight=None):
 
     def Hs(s):
         ret = np.empty_like(s)
-        ret[:n_features] = X.T.dot(dX.dot(s[:n_features]))
+        ret[:n_features] = np.linalg.multi_dot([X.T, dX, s[:n_features]])
         ret[:n_features] += alpha * s[:n_features]
 
         # For the fit intercept case.


### PR DESCRIPTION
#### Reference Issues/PRs

Contributes to solve #17684 for `sklearn/linear_model/_logistic.py`.

#### What does this implement/fix? Explain your changes.

`np.linalg.multi_dot` quickly chooses the best order for the multiplication of three dense matrices, see [its implementation]( https://github.com/numpy/numpy/blob/860c8b82939d1535351f7b651c284a55efe21b10/numpy/linalg/linalg.py#L2742).

This PR uses it for the Hessian and gradient dot product.

#### Any other comments?

Sparse matrices are to be explored in another PR.
