### PR TITLE
FIX bug in SplineTransformer.n_features_out_

### DIFF
--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -307,7 +307,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         ]
         self.bsplines_ = bsplines
 
-        self.n_features_out_ = n_out - n_features * self.include_bias
+        self.n_features_out_ = n_out - n_features * (1 - self.include_bias)
         return self
 
     def transform(self, X):
@@ -336,7 +336,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
 
         # Note that scipy BSpline returns float64 arrays and converts input
         # x=X[:, i] to c-contiguous float64.
-        n_out = self.n_features_out_ + n_features * self.include_bias
+        n_out = self.n_features_out_ + n_features * (1 - self.include_bias)
         if X.dtype in FLOAT_DTYPES:
             dtype = X.dtype
         else:

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -245,12 +245,13 @@ def test_spline_transformer_kbindiscretizer():
     assert_allclose(splines, kbins, rtol=1e-13)
 
 
+@pytest.mark.parametrize("n_knots", [5, 10])
 @pytest.mark.parametrize("include_bias", [True, False])
 @pytest.mark.parametrize("degree", [3, 5])
-def test_spline_transformer_n_features_out(include_bias, degree):
+def test_spline_transformer_n_features_out(n_knots, include_bias, degree):
     """Test that transform results in n_features_out_ features."""
     splt = SplineTransformer(
-        n_knots=5,
+        n_knots=n_knots,
         degree=degree,
         include_bias=include_bias
     )

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -243,3 +243,18 @@ def test_spline_transformer_kbindiscretizer():
     # Though they should be exactly equal, we test approximately with high
     # accuracy.
     assert_allclose(splines, kbins, rtol=1e-13)
+
+
+@pytest.mark.parametrize("include_bias", [True, False])
+@pytest.mark.parametrize("degree", [3, 5])
+def test_spline_transformer_n_features_out(include_bias, degree):
+    """Test that transform results in n_features_out_ features."""
+    splt = SplineTransformer(
+        n_knots=5,
+        degree=degree,
+        include_bias=include_bias
+    )
+    X = np.linspace(0, 1, 10)[:, None]
+    splt.fit(X)
+
+    assert splt.transform(X).shape[1] == splt.n_features_out_


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Found this while working on #19483 extending #18368 (@lorentzenchr).

#### What does this implement/fix? Explain your changes.
The `n_features_out_` attribute of the `SplineTransformer` is currently incorrect. On master:

```
In [1]: from sklearn.preprocessing import SplineTransformer
   ...: import numpy as np
   ...: 
   ...: X=np.linspace(0, 1, 10)[:, None]
   ...: transformer = SplineTransformer(
   ...:     n_knots=3,
   ...:     degree=3,
   ...:     include_bias=False
   ...: )
   ...: 
   ...: transformer.fit(X)
   ...: transformer.n_features_out_
Out[1]: 5

In [2]: transformer.transform(X).shape
Out[2]: (10, 4)
```
See also the added test.
