### PR TITLE
FIX Do not call get_feature_names for empty column selections

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -12,6 +12,13 @@ Version 0.24.2
 Changelog
 ---------
 
+:mod:`sklearn.compose`
+......................
+
+- |Fix| :meth:`compose.ColumnTransformer.get_feature_names` does not call
+  :term:`get_feature_names` on transformers with an empty column selection.
+  :pr:`19579` by `Thomas Fan`_.
+
 :mod:`sklearn.ensemble`
 .......................
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -351,8 +351,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         check_is_fitted(self)
         feature_names = []
         for name, trans, column, _ in self._iter(fitted=True):
-            if trans == 'drop' or (
-                    hasattr(column, '__len__') and not len(column)):
+            if trans == 'drop' or _is_empty_column_selection(column):
                 continue
             if trans == 'passthrough':
                 if self._feature_names_in is not None:

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1425,7 +1425,7 @@ def test_sk_visual_block_remainder_fitted_numpy(remainder):
 @pytest.mark.parametrize("selector", [[], [False, False]])
 def test_get_feature_names_empty_selection(selector):
     """Test that get_feature_names is only called for transformers that
-    were selected.
+    were selected. Non-regression test for #19550.
     """
     ct = ColumnTransformer([('ohe', OneHotEncoder(drop='first'), selector)])
     ct.fit([[1, 2], [3, 4]])

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1420,3 +1420,13 @@ def test_sk_visual_block_remainder_fitted_numpy(remainder):
     assert visual_block.names == ('scale', 'remainder')
     assert visual_block.name_details == ([0, 2], [1])
     assert visual_block.estimators == (scaler, remainder)
+
+
+@pytest.mark.parametrize("selector", [[], [False, False]])
+def test_get_feature_names_empty_selection(selector):
+    """Test that get_feature_names is only called for transformers that
+    were selected.
+    """
+    ct = ColumnTransformer([('ohe', OneHotEncoder(drop='first'), selector)])
+    ct.fit([[1, 2], [3, 4]])
+    assert ct.get_feature_names() == []


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/19550

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
