### PR TITLE
TST Change assert from sklearn to pytest style in tests/test_multiclass.py

### DIFF
--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -399,7 +399,7 @@ def test_ovr_single_label_predict_proba():
 
     assert_almost_equal(Y_proba.sum(axis=1), 1.0)
     # predict assigns a label if the probability that the
-    # sample has the label is greater than 0.5.
+    # sample has the label with the greatest predictive probability.
     pred = Y_proba.argmax(axis=1)
     assert not (pred - Y_pred).any()
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -221,7 +221,6 @@ def test_ovr_always_present():
     y[5:, 0] = 1  # variable label
     ovr = OneVsRestClassifier(LogisticRegression())
 
-    # the warning message could be improved
     msg = r'Label not 1 is present in all training examples'
     with pytest.warns(UserWarning, match=msg):
         ovr.fit(X, y)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -400,7 +400,7 @@ def test_ovr_single_label_predict_proba():
     assert_almost_equal(Y_proba.sum(axis=1), 1.0)
     # predict assigns a label if the probability that the
     # sample has the label is greater than 0.5.
-    pred = np.array([label.argmax() for label in Y_proba])
+    pred = Y_proba.argmax(axis=1)
     assert not (pred - Y_pred).any()
 
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -126,7 +126,7 @@ def test_ovr_partial_fit_exceptions():
     y = [1, 1, 1, 1, 2, 3, 3, 0, 0, 2, 3, 1, 2, 3]
     ovr.partial_fit(X[:7], y[:7], np.unique(y))
     # If a new class that was not in the first call of partial fit is seen
-    # It should raise Value Error
+    # it should raise ValueError
     y1 = [5] + y[7:-1]
     msg = r"Mini-batch contains \[.+\] while classes must be subset of \[.+\]"
     with pytest.raises(ValueError, match=msg):

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -6,10 +6,6 @@ from re import escape
 
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_almost_equal
-from sklearn.utils._testing import assert_raises
-from sklearn.utils._testing import assert_warns
-from sklearn.utils._testing import assert_raise_message
-from sklearn.utils._testing import assert_raises_regexp
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._mocking import CheckingClassifier
 from sklearn.multiclass import OneVsRestClassifier
@@ -513,7 +509,8 @@ def test_ovr_deprecated_coef_intercept():
 
 def test_ovo_exceptions():
     ovo = OneVsOneClassifier(LinearSVC(random_state=0))
-    assert_raises(ValueError, ovo.predict, [])
+    with pytest.raises(NotFittedError):
+        ovo.predict([])
 
 
 def test_ovo_fit_on_list():
@@ -582,8 +579,8 @@ def test_ovo_partial_fit_predict():
     message_re = escape("Mini-batch contains {0} while "
                         "it must be subset of {1}".format(np.unique(error_y),
                                                           np.unique(y)))
-    assert_raises_regexp(ValueError, message_re, ovo.partial_fit, X[:7],
-                         error_y, np.unique(y))
+    with pytest.raises(ValueError, match=message_re):
+        ovo.partial_fit(X[:7], error_y, np.unique(y))
 
     # test partial_fit only exists if estimator has it:
     ovr = OneVsOneClassifier(SVC())
@@ -701,7 +698,9 @@ def test_ovo_one_class():
     y = np.array(['a'] * 4)
 
     ovo = OneVsOneClassifier(LinearSVC())
-    assert_raise_message(ValueError, "when only one class", ovo.fit, X, y)
+    msg = "when only one class"
+    with pytest.raises(ValueError, match=msg):
+        ovo.fit(X, y)
 
 
 def test_ovo_float_y():
@@ -710,12 +709,15 @@ def test_ovo_float_y():
     y = iris.data[:, 0]
 
     ovo = OneVsOneClassifier(LinearSVC())
-    assert_raise_message(ValueError, "Unknown label type", ovo.fit, X, y)
+    msg = "Unknown label type"
+    with pytest.raises(ValueError, match=msg):
+        ovo.fit(X, y)
 
 
 def test_ecoc_exceptions():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0))
-    assert_raises(ValueError, ecoc.predict, [])
+    with pytest.raises(NotFittedError):
+        ecoc.predict([])
 
 
 def test_ecoc_fit_predict():
@@ -747,10 +749,14 @@ def test_ecoc_float_y():
     y = iris.data[:, 0]
 
     ovo = OutputCodeClassifier(LinearSVC())
-    assert_raise_message(ValueError, "Unknown label type", ovo.fit, X, y)
+    msg = "Unknown label type"
+    with pytest.raises(ValueError, match=msg):
+        ovo.fit(X, y)
+
     ovo = OutputCodeClassifier(LinearSVC(), code_size=-1)
-    assert_raise_message(ValueError, "code_size should be greater than 0,"
-                         " got -1", ovo.fit, X, y)
+    msg = "code_size should be greater than 0, got -1"
+    with pytest.raises(ValueError, match=msg):
+        ovo.fit(X, y)
 
 
 def test_ecoc_delegate_sparse_base_estimator():

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -475,12 +475,6 @@ def test_ovr_coef_():
 # when the coef_ attribute is removed
 @ignore_warnings(category=FutureWarning)
 def test_ovr_coef_exceptions():
-
-    # An eval function is defined because we don't
-    # want coef_ to be evaluated right away
-    def coef_eval(est, x):
-        return est.coef_(x)
-
     # Not fitted exception!
     ovr = OneVsRestClassifier(LinearSVC(random_state=0))
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -485,7 +485,7 @@ def test_ovr_coef_exceptions():
     ovr = OneVsRestClassifier(LinearSVC(random_state=0))
 
     with pytest.raises(NotFittedError):
-        coef_eval(ovr, None)
+        ovr.coef_
 
     # Doesn't have coef_ exception!
     ovr = OneVsRestClassifier(DecisionTreeClassifier())

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -486,7 +486,7 @@ def test_ovr_coef_exceptions():
     ovr.fit(iris.data, iris.target)
     msg = "Base estimator doesn't have a coef_ attribute"
     with pytest.raises(AttributeError, match=msg):
-        coef_eval(ovr, None)
+        ovr.coef_
 
 
 # TODO: Remove this test in version 1.1 when


### PR DESCRIPTION
#### Reference Issues/PRs
References #14216 


#### What does this implement/fix? Explain your changes.
Changed the assert_raises, assert_message, assert_warns in tests/test_multiclass.py to pytest.raises() and pytest.warns().
Added additional message checks for tests that seemed like could benefit from further clarification.
Fixed several unrelated flake8 errors such as in test test_ovr_single_label_predict_proba.
In several cases, changed ValueError to NotFittedError since that seemed more appropriate.

#### Any other comments?
#DataUmbrella