### PR TITLE
TST Do not use cache in test in `test_fetch_openml_iris`

### DIFF
--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -772,15 +772,12 @@ def test_fetch_openml_iris(monkeypatch, gzip_response):
     data_name = 'iris'
 
     _monkey_patch_webbased_functions(monkeypatch, data_id, gzip_response)
-    assert_warns_message(
-        UserWarning,
-        "Multiple active versions of the dataset matching the name"
-        " iris exist. Versions may be fundamentally different, "
-        "returning version 1.",
-        fetch_openml,
-        name=data_name,
-        as_frame=False
-    )
+
+    msg = ("Multiple active versions of the dataset matching the name"
+           " iris exist. Versions may be fundamentally different, "
+           "returning version 1.")
+    with pytest.warns(UserWarning, match=msg):
+        fetch_openml(name=data_name, as_frame=False, cache=False)
 
 
 def test_decode_iris(monkeypatch):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/19587


#### What does this implement/fix? Explain your changes.
Test in `sklearn/datasets/tests/test_openml.py` should not be touching the cache.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
