### PR TITLE
eliminate performance regression when normalize is False

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -243,7 +243,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
             else:
                 X_offset = np.average(X, axis=0, weights=sample_weight)
 
-            X_offset = X_offset.astype(X.dtype)
+            X_offset = X_offset.astype(X.dtype, copy=False)
             X -= X_offset
 
         if normalize:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -235,17 +235,19 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
             if not return_mean:
                 X_offset[:] = X.dtype.type(0)
         else:
-            X_offset, X_var, _ = _incremental_mean_and_var(
-                X, last_mean=0., last_variance=0., last_sample_count=0.,
-                sample_weight=sample_weight
-            )
+            if normalize:
+                X_offset, X_var, _ = _incremental_mean_and_var(
+                    X, last_mean=0., last_variance=0., last_sample_count=0.,
+                    sample_weight=sample_weight
+                )
+            else:
+                X_offset = np.average(X, axis=0, weights=sample_weight)
 
             X_offset = X_offset.astype(X.dtype)
             X -= X_offset
 
-        X_var = X_var.astype(X.dtype, copy=False)
-
         if normalize:
+            X_var = X_var.astype(X.dtype, copy=False)
             # Detect constant features on the computed variance, before taking
             # the np.sqrt. Otherwise constant features cannot be detected with
             # sample_weights.


### PR DESCRIPTION
closes #19600

There was a major performance regression in the linear models. This was due to the new use of the `_incremental_mean_and_var()`. 
In the case when `normalize` parameter is not set in the linear model calculations of the variance are not necessary. This PR exchanges it for `np.average()` in case when `normalize` is set to False.

Performance (current main):

![main](https://user-images.githubusercontent.com/2219642/109808101-01298880-7c27-11eb-8402-dd4331967691.png)

zoomed into `_preprocess_data` at `_base.py`:

![main_zoom](https://user-images.githubusercontent.com/2219642/109808222-228a7480-7c27-11eb-81dc-c1a08036a7c6.png)


Performance (this PR):

![after](https://user-images.githubusercontent.com/2219642/109808271-2e763680-7c27-11eb-807c-8876c93f347d.png)

zoomed into `_preprocess_data` at `_base.py`:

![after_zoom](https://user-images.githubusercontent.com/2219642/109808303-37ff9e80-7c27-11eb-83df-700751f9501c.png)


The performance is measured using the code of @jeremiedbb :

```
from sklearn.linear_model import ElasticNet 
from asv_benchmarks.benchmarks.datasets import _synth_regression_dataset 
data = _synth_regression_dataset(n_samples=5000, n_features=10000) 
X, _, y, _ = data 
estimator = ElasticNet(precompute=False, alpha=100, random_state=0) 
%load_ext snakeviz 
%snakeviz estimator.fit(X, y)
```

cc @ogrisel @jeremiedbb @agramfort