### PR TITLE
Add a test to check the consistency of the Ridge and ElasticNet(l1_ratio=0) solutions

### DIFF
--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -244,10 +244,20 @@ def enet_coordinate_descent(floating[::1] w,
         else:
             # for/else, runs if for doesn't end with a `break`
             with gil:
-                warnings.warn("Objective did not converge. You might want to "
-                              "increase the number of iterations. Duality "
-                              "gap: {}, tolerance: {}".format(gap, tol),
-                              ConvergenceWarning)
+                message = (
+                    "Objective did not converge. You might want to increase "
+                    "the number of iterations, check the scale of the "
+                    "features or consider increasing regularisation. "
+                    f"Duality gap: {gap:.3e}, tolerance: {tol:.3e}"
+                )
+                if alpha < np.finfo(np.float64).eps:
+                    message += (
+                        " Linear regression models with null weight for the "
+                        "l1 regularization term are more efficiently fitted "
+                        "using one of the solvers implemented in "
+                        "sklearn.linear_model.Ridge/RidgeCV instead."
+                    )
+                warnings.warn(message, ConvergenceWarning)
 
     return w, gap, tol, n_iter + 1
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -15,7 +15,6 @@ from sklearn.model_selection import train_test_split
 from sklearn.pipeline import make_pipeline
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
-from sklearn.preprocessing import scale
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_almost_equal

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1437,10 +1437,18 @@ def test_enet_ridge_consistency(normalize, ridge_alpha):
         l1_ratio=0.,
         max_iter=1000,
     )
-    with ignore_warnings(category=ConvergenceWarning):
-        # XXX: it seems that the duality gap convergence criterion is never met
-        # when l1_ratio is 0 and for any value of the `tol` parameter. Should
-        # this be considered a bug?
+    # Even when the ElasticNet model has actually converged, the duality gap
+    # convergence criterion is never met when l1_ratio is 0 and for any value
+    # of the `tol` parameter. The convergence message should point the user to
+    # Ridge instead:
+    expected_msg = (
+        r"Objective did not converge\. .* "
+        r"Linear regression models with null weight for the "
+        r"l1 regularization term are more efficiently fitted "
+        r"using one of the solvers implemented in "
+        r"sklearn\.linear_model\.Ridge/RidgeCV instead\."
+    )
+    with pytest.warns(ConvergenceWarning, match=expected_msg):
         enet.fit(X, y, sample_weight=sw)
 
     assert_allclose(ridge.coef_, enet.coef_)


### PR DESCRIPTION
This checks that the coordinate descent solver of `ElasticNet` converges to the same solution as the default `cholesky` solver of `Ridge` when `ElasticNet` is fit with `l1_ratio=0`. The value of the regularization parameter `alpha` needs to be adapted but this should be expected (see the docstring of respective models for more details).

This test was extracted from the draft #19616 PR. They should pass on the main branch so I think it's good to merge as a non-regression test without waiting for the rest of #19616 to be completed.

@agramfort it seems that the dual gap convergence criterion of `ElasticNet` is never met when fitting with `l1_ratio=0`. Not sure if this is expected or not. If not we should probably open a dedicated issue. If it is expected maybe we should change the `ConvergenceWarning` to advise the user about `l1_ratio=0`