### PR TITLE
TST Uses pytest.raises in model_selection/tests

### DIFF
--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -14,7 +14,6 @@ import scipy.sparse as sp
 import pytest
 
 from sklearn.utils._testing import (
-    assert_raise_message,
     assert_array_equal,
     assert_array_almost_equal,
     assert_allclose,
@@ -270,8 +269,8 @@ def test_grid_search_no_score():
 
     # giving no scoring function raises an error
     grid_search_no_score = GridSearchCV(clf_no_score, {'C': Cs})
-    assert_raise_message(TypeError, "no scoring", grid_search_no_score.fit,
-                         [[1]])
+    with pytest.raises(TypeError, match="no scoring"):
+        grid_search_no_score.fit([[1]])
 
 
 def test_grid_search_score_method():
@@ -316,11 +315,11 @@ def test_grid_search_groups():
 
     group_cvs = [LeaveOneGroupOut(), LeavePGroupsOut(2),
                  GroupKFold(n_splits=3), GroupShuffleSplit()]
+    error_msg = "The 'groups' parameter should not be None."
     for cv in group_cvs:
         gs = GridSearchCV(clf, grid, cv=cv)
-        assert_raise_message(ValueError,
-                             "The 'groups' parameter should not be None.",
-                             gs.fit, X, y)
+        with pytest.raises(ValueError, match=error_msg):
+            gs.fit(X, y)
         gs.fit(X, y, groups=groups)
 
     non_group_cvs = [StratifiedKFold(), StratifiedShuffleSplit()]
@@ -385,20 +384,21 @@ def test_no_refit():
         # error messages
         for fn_name in ('predict', 'predict_proba', 'predict_log_proba',
                         'transform', 'inverse_transform'):
-            assert_raise_message(NotFittedError,
-                                 ('refit=False. %s is available only after '
-                                  'refitting on the best parameters'
-                                  % fn_name), getattr(grid_search, fn_name), X)
+            error_msg = ('refit=False. %s is available only after refitting on'
+                         ' the best parameters' % fn_name)
+            with pytest.raises(NotFittedError, match=error_msg):
+                getattr(grid_search, fn_name)(X)
 
     # Test that an invalid refit param raises appropriate error messages
+    error_msg = ("For multi-metric scoring, the parameter refit must be set to"
+                 " a scorer key")
     for refit in ["", 5, True, 'recall', 'accuracy']:
-        assert_raise_message(ValueError, "For multi-metric scoring, the "
-                             "parameter refit must be set to a scorer key",
-                             GridSearchCV(clf, {}, refit=refit,
-                                          scoring={'acc': 'accuracy',
-                                                   'prec': 'precision'}
-                                          ).fit,
-                             X, y)
+        with pytest.raises(ValueError, match=error_msg):
+            GridSearchCV(
+                clf, {},
+                refit=refit,
+                scoring={'acc': 'accuracy', 'prec': 'precision'}
+            ).fit(X, y)
 
 
 def test_grid_search_error():
@@ -437,30 +437,33 @@ def test_grid_search_when_param_grid_includes_range():
 def test_grid_search_bad_param_grid():
     param_dict = {"C": 1}
     clf = SVC(gamma='auto')
-    assert_raise_message(
-        ValueError,
+    error_msg = re.escape(
         "Parameter grid for parameter (C) needs to"
         " be a list or numpy array, but got (<class 'int'>)."
         " Single values need to be wrapped in a list"
-        " with one element.",
-        GridSearchCV, clf, param_dict)
+        " with one element."
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        GridSearchCV(clf, param_dict)
 
     param_dict = {"C": []}
     clf = SVC()
-    assert_raise_message(
-        ValueError,
-        "Parameter values for parameter (C) need to be a non-empty sequence.",
-        GridSearchCV, clf, param_dict)
+    error_msg = re.escape(
+        "Parameter values for parameter (C) need to be a non-empty sequence."
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        GridSearchCV(clf, param_dict)
 
     param_dict = {"C": "1,2,3"}
     clf = SVC(gamma='auto')
-    assert_raise_message(
-        ValueError,
+    error_msg = re.escape(
         "Parameter grid for parameter (C) needs to"
         " be a list or numpy array, but got (<class 'str'>)."
         " Single values need to be wrapped in a list"
-        " with one element.",
-        GridSearchCV, clf, param_dict)
+        " with one element."
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        GridSearchCV(clf, param_dict)
 
     param_dict = {"C": np.ones((3, 2))}
     clf = SVC()
@@ -1293,10 +1296,13 @@ def test_fit_grid_point():
             assert n_test_samples == test.size
 
     # Should raise an error upon multimetric scorer
-    assert_raise_message(ValueError, "For evaluating multiple scores, use "
-                         "sklearn.model_selection.cross_validate instead.",
-                         fit_grid_point, X, y, svc, params, train, test,
-                         {'score': scorer}, verbose=True)
+    error_msg = ("For evaluating multiple scores, use "
+                 "sklearn.model_selection.cross_validate instead.")
+    with pytest.raises(ValueError, match=error_msg):
+        fit_grid_point(
+            X, y, svc, params, train, test, {'score': scorer},
+            verbose=True
+        )
 
 
 # FIXME remove test_fit_grid_point_deprecated as

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -384,8 +384,8 @@ def test_no_refit():
         # error messages
         for fn_name in ('predict', 'predict_proba', 'predict_log_proba',
                         'transform', 'inverse_transform'):
-            error_msg = ('refit=False. %s is available only after refitting on'
-                         ' the best parameters' % fn_name)
+            error_msg = (f"refit=False. {fn_name} is available only after "
+                         f"refitting on the best parameters")
             with pytest.raises(NotFittedError, match=error_msg):
                 getattr(grid_search, fn_name)(X)
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -897,28 +897,28 @@ def test_leave_one_p_group_out_error_on_fewer_number_of_groups():
 
     X = y = groups = np.ones(1)
     msg = re.escape(
-        "The groups parameter contains fewer than 2 unique groups ({}). "
-        "LeaveOneGroupOut expects at least 2.".format(groups)
+        f"The groups parameter contains fewer than 2 unique groups ({groups})."
+        f" LeaveOneGroupOut expects at least 2."
     )
     with pytest.raises(ValueError, match=msg):
         next(LeaveOneGroupOut().split(X, y, groups))
 
     X = y = groups = np.ones(1)
     msg = re.escape(
-        "The groups parameter contains fewer than (or equal to) n_groups "
-        "(3) numbers of unique groups ({}). LeavePGroupsOut expects "
-        "that at least n_groups + 1 (4) unique groups "
-        "be present".format(groups)
+        f"The groups parameter contains fewer than (or equal to) n_groups "
+        f"(3) numbers of unique groups ({groups}). LeavePGroupsOut expects "
+        f"that at least n_groups + 1 (4) unique groups "
+        f"be present"
     )
     with pytest.raises(ValueError, match=msg):
         next(LeavePGroupsOut(n_groups=3).split(X, y, groups))
 
     X = y = groups = np.arange(3)
     msg = re.escape(
-        "The groups parameter contains fewer than (or equal to) n_groups "
-        "(3) numbers of unique groups ({}). LeavePGroupsOut expects "
-        "that at least n_groups + 1 (4) unique groups "
-        "be present".format(groups)
+        f"The groups parameter contains fewer than (or equal to) n_groups "
+        f"(3) numbers of unique groups ({groups}). LeavePGroupsOut expects "
+        f"that at least n_groups + 1 (4) unique groups "
+        f"be present"
     )
     with pytest.raises(ValueError, match=msg):
         next(LeavePGroupsOut(n_groups=3).split(X, y, groups))

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1,6 +1,7 @@
 """Test the split module"""
 import warnings
 import pytest
+import re
 import numpy as np
 from scipy.sparse import coo_matrix, csc_matrix, csr_matrix
 from scipy import stats
@@ -12,7 +13,6 @@ from itertools import permutations
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_raise_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils.validation import _num_samples
 from sklearn.utils._mocking import MockDataFrame
@@ -116,10 +116,10 @@ def test_cross_validator_with_default_params():
 
     # ValueError for get_n_splits methods
     msg = "The 'X' parameter should not be None."
-    assert_raise_message(ValueError, msg,
-                         loo.get_n_splits, None, y, groups)
-    assert_raise_message(ValueError, msg,
-                         lpo.get_n_splits, None, y, groups)
+    with pytest.raises(ValueError, match=msg):
+        loo.get_n_splits(None, y, groups)
+    with pytest.raises(ValueError, match=msg):
+        lpo.get_n_splits(None, y, groups)
 
 
 def test_2d_y():
@@ -214,10 +214,10 @@ def test_kfold_valueerrors():
         KFold(1)
     error_string = ("k-fold cross-validation requires at least one"
                     " train/test split")
-    assert_raise_message(ValueError, error_string,
-                         StratifiedKFold, 0)
-    assert_raise_message(ValueError, error_string,
-                         StratifiedKFold, 1)
+    with pytest.raises(ValueError, match=error_string):
+        StratifiedKFold(0)
+    with pytest.raises(ValueError, match=error_string):
+        StratifiedKFold(1)
 
     # When n_splits is not integer:
     with pytest.raises(ValueError):
@@ -858,10 +858,10 @@ def test_leave_one_p_group_out():
         lpgo_2.get_n_splits(None, None, [0.0, np.inf, 0.0])
 
     msg = "The 'groups' parameter should not be None."
-    assert_raise_message(ValueError, msg,
-                         logo.get_n_splits, None, None, None)
-    assert_raise_message(ValueError, msg,
-                         lpgo_1.get_n_splits, None, None, None)
+    with pytest.raises(ValueError, match=msg):
+        logo.get_n_splits(None, None, None)
+    with pytest.raises(ValueError, match=msg):
+        lpgo_1.get_n_splits(None, None, None)
 
 
 def test_leave_group_out_changing_groups():
@@ -891,27 +891,37 @@ def test_leave_group_out_changing_groups():
 
 def test_leave_one_p_group_out_error_on_fewer_number_of_groups():
     X = y = groups = np.ones(0)
-    assert_raise_message(ValueError, "Found array with 0 sample(s)", next,
-                         LeaveOneGroupOut().split(X, y, groups))
+    msg = re.escape("Found array with 0 sample(s)")
+    with pytest.raises(ValueError, match=msg):
+        next(LeaveOneGroupOut().split(X, y, groups))
+
     X = y = groups = np.ones(1)
-    msg = ("The groups parameter contains fewer than 2 unique groups ({}). "
-           "LeaveOneGroupOut expects at least 2.").format(groups)
-    assert_raise_message(ValueError, msg, next,
-                         LeaveOneGroupOut().split(X, y, groups))
+    msg = re.escape(
+        "The groups parameter contains fewer than 2 unique groups ({}). "
+        "LeaveOneGroupOut expects at least 2.".format(groups)
+    )
+    with pytest.raises(ValueError, match=msg):
+        next(LeaveOneGroupOut().split(X, y, groups))
+
     X = y = groups = np.ones(1)
-    msg = ("The groups parameter contains fewer than (or equal to) n_groups "
-           "(3) numbers of unique groups ({}). LeavePGroupsOut expects "
-           "that at least n_groups + 1 (4) unique groups "
-           "be present").format(groups)
-    assert_raise_message(ValueError, msg, next,
-                         LeavePGroupsOut(n_groups=3).split(X, y, groups))
+    msg = re.escape(
+        "The groups parameter contains fewer than (or equal to) n_groups "
+        "(3) numbers of unique groups ({}). LeavePGroupsOut expects "
+        "that at least n_groups + 1 (4) unique groups "
+        "be present".format(groups)
+    )
+    with pytest.raises(ValueError, match=msg):
+        next(LeavePGroupsOut(n_groups=3).split(X, y, groups))
+
     X = y = groups = np.arange(3)
-    msg = ("The groups parameter contains fewer than (or equal to) n_groups "
-           "(3) numbers of unique groups ({}). LeavePGroupsOut expects "
-           "that at least n_groups + 1 (4) unique groups "
-           "be present").format(groups)
-    assert_raise_message(ValueError, msg, next,
-                         LeavePGroupsOut(n_groups=3).split(X, y, groups))
+    msg = re.escape(
+        "The groups parameter contains fewer than (or equal to) n_groups "
+        "(3) numbers of unique groups ({}). LeavePGroupsOut expects "
+        "that at least n_groups + 1 (4) unique groups "
+        "be present".format(groups)
+    )
+    with pytest.raises(ValueError, match=msg):
+        next(LeavePGroupsOut(n_groups=3).split(X, y, groups))
 
 
 @ignore_warnings


### PR DESCRIPTION
#### Reference Issues/PRs
References #14216.

#### What does this implement/fix? Explain your changes.
Replaces the use of `assert_raise_message` by `pytest.raises` in `model_selection/tests/`. 

#### Any other comments?
#DataUmbrella