### PR TITLE
FIX RuntimeWarning by dividing by zero in test_iforest_with_uniform_data 

### DIFF
--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -454,6 +454,8 @@ class IsolationForest(OutlierMixin, BaseBagging):
             len(self.estimators_) * _average_path_length([self.max_samples_])
         )
         scores = 2 ** (
+            # For a single training sample, denominator and depth are 0.
+            # Therefore, we set the score manually to 1.
             -np.divide(depths, denominator, np.ones_like(depths),
                        where=denominator != 0)
         )

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -456,7 +456,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
         scores = 2 ** (
             # For a single training sample, denominator and depth are 0.
             # Therefore, we set the score manually to 1.
-            -np.divide(depths, denominator, np.ones_like(depths),
+            -np.divide(depths, denominator, out=np.ones_like(depths),
                        where=denominator != 0)
         )
         return scores

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -450,11 +450,9 @@ class IsolationForest(OutlierMixin, BaseBagging):
                 + _average_path_length(n_samples_leaf)
                 - 1.0
             )
-
+        denominator = (len(self.estimators_)* _average_path_length([self.max_samples_]))
         scores = 2 ** (
-            -depths
-            / (len(self.estimators_)
-               * _average_path_length([self.max_samples_]))
+            -np.divide(depths,denominator,np.ones_like(depths), where=denominator!=0)
         )
         return scores
 

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -450,9 +450,12 @@ class IsolationForest(OutlierMixin, BaseBagging):
                 + _average_path_length(n_samples_leaf)
                 - 1.0
             )
-        denominator = (len(self.estimators_)* _average_path_length([self.max_samples_]))
+        denominator = (
+            len(self.estimators_) * _average_path_length([self.max_samples_])
+        )
         scores = 2 ** (
-            -np.divide(depths,denominator,np.ones_like(depths), where=denominator!=0)
+            -np.divide(depths, denominator, np.ones_like(depths),
+                       where=denominator != 0)
         )
         return scores
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -337,14 +337,6 @@ def test_iforest_with_uniform_data():
     assert all(iforest.predict(rng.randn(100, 10)) == 1)
     assert all(iforest.predict(np.ones((100, 10))) == 1)
 
-    # Single row
-    X = rng.randn(1, 10)
-    iforest = IsolationForest()
-    iforest.fit(X)
-
-    assert all(iforest.predict(X) == 1)
-    assert all(iforest.predict(rng.randn(100, 10)) == 1)
-    assert all(iforest.predict(np.ones((100, 10))) == 1)
 
 
 # FIXME: remove in 1.2

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -337,6 +337,14 @@ def test_iforest_with_uniform_data():
     assert all(iforest.predict(rng.randn(100, 10)) == 1)
     assert all(iforest.predict(np.ones((100, 10))) == 1)
 
+    # Single row
+    X = rng.randn(1, 10)
+    iforest = IsolationForest()
+    iforest.fit(X)
+
+    assert all(iforest.predict(X) == 1)
+    assert all(iforest.predict(rng.randn(100, 10)) == 1)
+    assert all(iforest.predict(np.ones((100, 10))) == 1)
 
 
 # FIXME: remove in 1.2


### PR DESCRIPTION
#### Reference Issues/PRs
#19334


#### What does this implement/fix? Explain your changes.
The runtime error was in the test on a single row of data. The zero division error was due to the fact that the average path length between points was 0. It does not make sense to me to use the isolation forest algorithm on 1d data. 

#### Any other comments?

