### PR TITLE
DEP start to raise warning with inconsistent combination of hyperparameters in SVM

### DIFF
--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -216,6 +216,12 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                     "'auto'. Got '{}' instead.".format(self.gamma)
                 )
         else:
+            if self.kernel == 'linear':
+                warnings.warn(
+                    "Setting 'gamma' when using 'linear' kernel may raise a "
+                    "`ValueError` starting in version 1.1 (renaming of 0.26).",
+                    DeprecationWarning
+                )
             self._gamma = self.gamma
 
         fit = self._sparse_fit if self._sparse else self._dense_fit

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -220,7 +220,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                 warnings.warn(
                     "Setting 'gamma' when using 'linear' kernel may raise a "
                     "`ValueError` starting in version 1.1 (renaming of 0.26).",
-                    DeprecationWarning
+                    FutureWarning
                 )
             self._gamma = self.gamma
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -686,7 +686,7 @@ def test_svm_gamma_error(Estimator, data):
 def test_svm_gamma_warning_with_linear_kernel(Estimator, data):
     est = Estimator(kernel='linear', gamma=1.0)
     warn_msg = "Setting 'gamma' when using 'linear' kernel"
-    with pytest.warns(DeprecationWarning, match=warn_msg):
+    with pytest.warns(FutureWarning, match=warn_msg):
         est.fit(*data)
 
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -675,6 +675,21 @@ def test_svm_gamma_error(Estimator, data):
         est.fit(X, y)
 
 
+@pytest.mark.parametrize(
+    'Estimator, data',
+    [(svm.SVC, datasets.load_iris(return_X_y=True)),
+     (svm.NuSVC, datasets.load_iris(return_X_y=True)),
+     (svm.SVR, datasets.load_diabetes(return_X_y=True)),
+     (svm.NuSVR, datasets.load_diabetes(return_X_y=True)),
+     (svm.OneClassSVM, datasets.load_iris(return_X_y=True))]
+)
+def test_svm_gamma_warning_with_linear_kernel(Estimator, data):
+    est = Estimator(kernel='linear', gamma=1.0)
+    warn_msg = "Setting 'gamma' when using 'linear' kernel"
+    with pytest.warns(DeprecationWarning, match=warn_msg):
+        est.fit(*data)
+
+
 def test_unicode_kernel():
     # Test that a unicode kernel name does not cause a TypeError
     clf = svm.SVC(kernel='linear', probability=True)


### PR DESCRIPTION
References #19614.

#### What does this implement/fix? Explain your changes.

Gives a `FutureWarning` when a user configures a `LibSVM` learner with 'linear' `kernel` but also non-default `gamma`.

```python
from sklearn.datasets import load_iris
from sklearn.svm import SVC

x, y = load_iris(return_X_y=True)
clf = SVC(kernel='linear', gamma=1e-6)
clf.fit(x, y)
print(clf.score(x, y))
```
previous output:
```
0.9933333333333333
```
current output:
```
...\scikit-learn\sklearn\svm\_base.py:220: FutureWarning: Setting 'gamma' when using 'linear' kernel may raise a `ValueError` starting in version 1.1 (renaming of 0.26).
  warnings.warn(
SVC(gamma=1e-06, kernel='linear')
0.9933333333333333
```

#### Any other comments?

Went with a `FutureWarning` instead of the `DeprecationWarning` as discussed in the issue, because:
 - `DeprecationWarning` is ignored by default (unless it's code from `__main__`),
 - It does not remove old functionality (setting `gamma` with `kernel='linear'` had no function).
 
I tried to find guidelines for this in the dev docs, but it either isn't there or I couldn't find it.
Just let me know if I should revert it to `DeprecationWarning`.
Also wasn't sure if a note of this should be added to the docs, since they already describe which parameter affects which kernel.

Tests ran with Windows/Py3.8:

```
pytest sklearn/svm
pytest doc/modules/svm.rst
pytest sklearn/tests/test_common.py -k SVC
```