### PR TITLE
DOC Use term 'black people' instead of 'blacks' in Boston descr

### DIFF
--- a/sklearn/datasets/descr/boston_house_prices.rst
+++ b/sklearn/datasets/descr/boston_house_prices.rst
@@ -21,7 +21,7 @@ Boston house prices dataset
         - RAD      index of accessibility to radial highways
         - TAX      full-value property-tax rate per $10,000
         - PTRATIO  pupil-teacher ratio by town
-        - B        1000(Bk - 0.63)^2 where Bk is the proportion of blacks by town
+        - B        1000(Bk - 0.63)^2 where Bk is the proportion of black people by town
         - LSTAT    % lower status of the population
         - MEDV     Median value of owner-occupied homes in $1000's
 


### PR DESCRIPTION
Fixes #19657.

We can merge this PR while working on addressing #16155 in parallel.