### PR TITLE
ENH Better error for corrupted files in fetch_kddcup99

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -68,6 +68,9 @@ Changelog
   `Thomas Fan`_ and :user:`Amanda Dsouza <amy12xx>` and
   :user:`EL-ATEIF Sara <elateifsara>`.
 
+- |Enhancement| :func:`datasets.fetch_kddcup99` raises a better message
+  when the cached file is invalid. :pr:`19669` `Thomas Fan`_.
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -35,8 +35,11 @@ def _fetch_fixture(f):
         kwargs['download_if_missing'] = download_if_missing
         try:
             return f(*args, **kwargs)
-        except IOError:
-            pytest.skip("test is enabled when SKLEARN_SKIP_NETWORK_TESTS=0")
+        except IOError as e:
+            if str(e) != "Data not found and `download_if_missing` is False":
+                raise
+            pytest.skip("test is enabled when "
+                        "SKLEARN_SKIP_NETWORK_TESTS=0")
     return pytest.fixture(lambda: wrapped)
 
 

--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -315,7 +315,17 @@ def _fetch_brute_kddcup99(data_home=None,
     column_names = [c[0] for c in dt]
     target_names = column_names[-1]
     feature_names = column_names[:-1]
-    if download_if_missing and not available:
+
+    if available:
+        try:
+            X = joblib.load(samples_path)
+            y = joblib.load(targets_path)
+        except Exception as e:
+            raise IOError(
+                "The cache for fetch_kddcup99 is invalid, please delete "
+                f"{str(kddcup_dir)} and run the fetch_kddcup99 again") from e
+
+    elif download_if_missing:
         _mkdirp(kddcup_dir)
         logger.info("Downloading %s" % archive.url)
         _fetch_remote(archive, dirname=kddcup_dir)
@@ -343,15 +353,8 @@ def _fetch_brute_kddcup99(data_home=None,
 
         joblib.dump(X, samples_path, compress=0)
         joblib.dump(y, targets_path, compress=0)
-    elif not available:
-        if not download_if_missing:
-            raise IOError("Data not found and `download_if_missing` is False")
-
-    try:
-        X, y
-    except NameError:
-        X = joblib.load(samples_path)
-        y = joblib.load(targets_path)
+    else:
+        raise IOError("Data not found and `download_if_missing` is False")
 
     return Bunch(
         data=X,

--- a/sklearn/datasets/tests/test_kddcup99.py
+++ b/sklearn/datasets/tests/test_kddcup99.py
@@ -58,3 +58,19 @@ def test_fetch_kddcup99_shuffle(fetch_kddcup99_fxt):
 
 def test_pandas_dependency_message(fetch_kddcup99_fxt, hide_available_pandas):
     check_pandas_dependency_message(fetch_kddcup99_fxt)
+
+
+def test_corrupted_file_error_message(fetch_kddcup99_fxt, tmp_path):
+    """Check that a nice error message is raised when cache is corrupted."""
+    kddcup99_dir = tmp_path / "kddcup99_10-py3"
+    kddcup99_dir.mkdir()
+    samples_path = kddcup99_dir / "samples"
+
+    with samples_path.open("wb") as f:
+        f.write(b"THIS IS CORRUPTED")
+
+    msg = (f"The cache for fetch_kddcup99 is invalid, please "
+           f"delete {str(kddcup99_dir)} and run the fetch_kddcup99 again")
+
+    with pytest.raises(IOError, match=msg):
+        fetch_kddcup99_fxt(data_home=str(tmp_path))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Resolves https://github.com/scikit-learn/scikit-learn/issues/19667


#### What does this implement/fix? Explain your changes.
This PR adds a nicer error message when the file can not be loaded from cache.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
