### PR TITLE
MNT Fix error message for Minkowski metric parameter

### DIFF
--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -411,7 +411,8 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         if self.metric == 'minkowski':
             p = self.effective_metric_params_.pop('p', 2)
             if p < 1:
-                raise ValueError("p must be greater or equal to one for minkowski metric")
+                raise ValueError("p must be greater or equal to one for "
+                                 "minkowski metric")
             elif p == 1:
                 self.effective_metric_ = 'manhattan'
             elif p == 2:

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -355,7 +355,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             effective_p = self.p
 
         if self.metric in ['wminkowski', 'minkowski'] and effective_p < 1:
-            raise ValueError("p must be greater than one for minkowski metric")
+            raise ValueError("p must be greater or equal to one for minkowski metric")
 
     def _fit(self, X, y=None):
         if self._get_tags()["requires_y"]:
@@ -411,8 +411,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         if self.metric == 'minkowski':
             p = self.effective_metric_params_.pop('p', 2)
             if p < 1:
-                raise ValueError("p must be greater than one "
-                                 "for minkowski metric")
+                raise ValueError("p must be greater or equal to one for minkowski metric")
             elif p == 1:
                 self.effective_metric_ = 'manhattan'
             elif p == 2:

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -355,7 +355,8 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             effective_p = self.p
 
         if self.metric in ['wminkowski', 'minkowski'] and effective_p < 1:
-            raise ValueError("p must be greater or equal to one for minkowski metric")
+            raise ValueError("p must be greater or equal to one for "
+                             "minkowski metric")
 
     def _fit(self, X, y=None):
         if self._get_tags()["requires_y"]:


### PR DESCRIPTION
It is possible to pass p=1 for `minkowski` metric, even though internally the effective metric gets changed to `manhattan`.

This PR simply edits the two error messages to not confuse the users.