### PR TITLE
TST Change assert from sklearn to pytest style in tests/test_pipeline.py

### DIFF
--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -14,13 +14,9 @@ import joblib
 
 from sklearn.utils.fixes import parse_version
 from sklearn.utils._testing import (
-    assert_raises,
-    assert_raises_regex,
-    assert_raise_message,
     assert_allclose,
     assert_array_equal,
     assert_array_almost_equal,
-    assert_no_warnings,
     MinimalClassifier,
     MinimalRegressor,
     MinimalTransformer,
@@ -167,14 +163,17 @@ class DummyEstimatorParams(BaseEstimator):
 
 def test_pipeline_init():
     # Test the various init parameters of the pipeline.
-    assert_raises(TypeError, Pipeline)
+    with pytest.raises(TypeError):
+        Pipeline()
+
     # Check that we can't instantiate pipelines with objects without fit
     # method
-    assert_raises_regex(TypeError,
-                        'Last step of Pipeline should implement fit '
-                        'or be the string \'passthrough\''
-                        '.*NoFit.*',
-                        Pipeline, [('clf', NoFit())])
+    msg = ('Last step of Pipeline should implement fit '
+           'or be the string \'passthrough\''
+           '.*NoFit.*')
+    with pytest.raises(TypeError, match=msg):
+        Pipeline([('clf', NoFit())])
+
     # Smoke test with only an estimator
     clf = NoTrans()
     pipe = Pipeline([('svc', clf)])
@@ -200,10 +199,9 @@ def test_pipeline_init():
 
     # Check that we can't instantiate with non-transformers on the way
     # Note that NoTrans implements fit, but not transform
-    assert_raises_regex(TypeError,
-                        'All intermediate steps should be transformers'
-                        '.*\\bNoTrans\\b.*',
-                        Pipeline, [('t', NoTrans()), ('svc', clf)])
+    msg = 'All intermediate steps should be transformers.*\\bNoTrans\\b.*'
+    with pytest.raises(TypeError, match=msg):
+        Pipeline([('t', NoTrans()), ('svc', clf)])
 
     # Check that params are set
     pipe.set_params(svc__C=0.1)
@@ -212,10 +210,13 @@ def test_pipeline_init():
     repr(pipe)
 
     # Check that params are not set when naming them wrong
-    assert_raises(ValueError, pipe.set_params, anova__C=0.1)
+    msg = 'Invalid parameter C for estimator SelectKBest'
+    with pytest.raises(ValueError, match=msg):
+        pipe.set_params(anova__C=0.1)
 
     # Test clone
-    pipe2 = assert_no_warnings(clone, pipe)
+    with pytest.warns(None):
+        pipe2 = clone(pipe)
     assert not pipe.named_steps['svc'] is pipe2.named_steps['svc']
 
     # Check that apart from estimators, the parameters are the same
@@ -273,11 +274,10 @@ def test_pipeline_fit_params():
     assert pipe.named_steps['transf'].a is None
     assert pipe.named_steps['transf'].b is None
     # invalid parameters should raise an error message
-    assert_raise_message(
-        TypeError,
-        "fit() got an unexpected keyword argument 'bad'",
-        pipe.fit, None, None, clf__bad=True
-    )
+
+    msg = re.escape(r"fit() got an unexpected keyword argument 'bad'")
+    with pytest.raises(TypeError, match=msg):
+        pipe.fit(None, None, clf__bad=True)
 
 
 def test_pipeline_sample_weight_supported():
@@ -298,11 +298,12 @@ def test_pipeline_sample_weight_unsupported():
     pipe.fit(X, y=None)
     assert pipe.score(X) == 3
     assert pipe.score(X, sample_weight=None) == 3
-    assert_raise_message(
-        TypeError,
-        "score() got an unexpected keyword argument 'sample_weight'",
-        pipe.score, X, sample_weight=np.array([2, 3])
+
+    msg = re.escape(
+        "score() got an unexpected keyword argument 'sample_weight'"
     )
+    with pytest.raises(TypeError, match=msg):
+        pipe.score(X, sample_weight=np.array([2, 3]))
 
 
 def test_pipeline_raise_set_params_error():
@@ -310,20 +311,18 @@ def test_pipeline_raise_set_params_error():
     pipe = Pipeline([('cls', LinearRegression())])
 
     # expected error message
-    error_msg = ('Invalid parameter %s for estimator %s. '
-                 'Check the list of available parameters '
-                 'with `estimator.get_params().keys()`.')
+    error_msg = re.escape(
+        f"Invalid parameter fake for estimator {pipe}. "
+        'Check the list of available parameters '
+        'with `estimator.get_params().keys()`.'
+    )
 
-    assert_raise_message(ValueError,
-                         error_msg % ('fake', pipe),
-                         pipe.set_params,
-                         fake='nope')
+    with pytest.raises(ValueError, match=error_msg):
+        pipe.set_params(fake='nope')
 
     # nested model check
-    assert_raise_message(ValueError,
-                         error_msg % ("fake", pipe),
-                         pipe.set_params,
-                         fake__estimator='nope')
+    with pytest.raises(ValueError, match=error_msg):
+        pipe.set_params(fake__estimator='nope')
 
 
 def test_pipeline_methods_pca_svm():
@@ -431,9 +430,10 @@ def test_fit_predict_on_pipeline_without_fit_predict():
     scaler = StandardScaler()
     pca = PCA(svd_solver='full')
     pipe = Pipeline([('scaler', scaler), ('pca', pca)])
-    assert_raises_regex(AttributeError,
-                        "'PCA' object has no attribute 'fit_predict'",
-                        getattr, pipe, 'fit_predict')
+
+    msg = "'PCA' object has no attribute 'fit_predict'"
+    with pytest.raises(AttributeError, match=msg):
+        getattr(pipe, 'fit_predict')
 
 
 def test_fit_predict_with_intermediate_fit_params():
@@ -484,7 +484,8 @@ def test_feature_union():
     assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
 
     # Test clone
-    fs2 = assert_no_warnings(clone, fs)
+    with pytest.warns(None):
+        fs2 = clone(fs)
     assert fs.transformer_list[0][1] is not fs2.transformer_list[0][1]
 
     # test setting parameters
@@ -497,11 +498,9 @@ def test_feature_union():
     assert X_transformed.shape == (X.shape[0], 8)
 
     # test error if some elements do not support transform
-    assert_raises_regex(TypeError,
-                        'All estimators should implement fit and '
-                        'transform.*\\bNoTrans\\b',
-                        FeatureUnion,
-                        [("transform", Transf()), ("no_transform", NoTrans())])
+    msg = 'All estimators should implement fit and transform.*\\bNoTrans\\b'
+    with pytest.raises(TypeError, match=msg):
+        FeatureUnion([("transform", Transf()), ("no_transform", NoTrans())])
 
     # test that init accepts tuples
     fs = FeatureUnion((("svd", svd), ("select", select)))
@@ -523,13 +522,13 @@ def test_make_union_kwargs():
     fu = make_union(pca, mock, n_jobs=3)
     assert fu.transformer_list == make_union(pca, mock).transformer_list
     assert 3 == fu.n_jobs
+
     # invalid keyword parameters should raise an error message
-    assert_raise_message(
-        TypeError,
-        "make_union() got an unexpected "
-        "keyword argument 'transformer_weights'",
-        make_union, pca, mock, transformer_weights={'pca': 10, 'Transf': 1}
+    msg = re.escape(
+        "make_union() got an unexpected keyword argument 'transformer_weights'"
     )
+    with pytest.raises(TypeError, match=msg):
+        make_union(pca, mock, transformer_weights={'pca': 10, 'Transf': 1})
 
 
 def test_pipeline_transform():
@@ -600,8 +599,14 @@ def test_pipeline_index():
     assert pipe['transf'] == transf
     assert pipe[-1] == clf
     assert pipe['clf'] == clf
-    assert_raises(IndexError, lambda: pipe[3])
-    assert_raises(KeyError, lambda: pipe['foobar'])
+
+    # should raise an error if slicing out of range
+    with pytest.raises(IndexError):
+        pipe[3]
+
+    # should raise an error if indexing with wrong element name
+    with pytest.raises(KeyError):
+        pipe['foobar']
 
 
 def test_set_pipeline_steps():
@@ -626,8 +631,15 @@ def test_set_pipeline_steps():
 
     # With invalid data
     pipeline.set_params(steps=[('junk', ())])
-    assert_raises(TypeError, pipeline.fit, [[1]], [1])
-    assert_raises(TypeError, pipeline.fit_transform, [[1]], [1])
+    msg = re.escape(
+        "Last step of Pipeline should implement fit or be the "
+        "string 'passthrough'."
+        )
+    with pytest.raises(TypeError, match=msg):
+        pipeline.fit([[1]], [1])
+        
+    with pytest.raises(TypeError, match=msg):
+        pipeline.fit_transform([[1]], [1])
 
 
 def test_pipeline_named_steps():
@@ -727,9 +739,10 @@ def test_set_pipeline_step_passthrough(passthrough):
     assert_array_equal([[exp]], pipeline.fit(X, y).transform(X))
     assert_array_equal([[exp]], pipeline.fit_transform(X, y))
     assert_array_equal(X, pipeline.inverse_transform([[exp]]))
-    assert_raise_message(AttributeError,
-                         "'str' object has no attribute 'predict'",
-                         getattr, pipeline, 'predict')
+
+    msg = "'str' object has no attribute 'predict'"
+    with pytest.raises(AttributeError, match=msg):
+        getattr(pipeline, 'predict')
 
     # Check 'passthrough' step at construction time
     exp = 2 * 5
@@ -872,9 +885,12 @@ def test_feature_union_feature_names():
     assert len(feature_names) == 35
 
     ft = FeatureUnion([("tr1", Transf())]).fit([[1]])
-    assert_raise_message(AttributeError,
-                         'Transformer tr1 (type Transf) does not provide '
-                         'get_feature_names', ft.get_feature_names)
+
+    msg = re.escape(
+        'Transformer tr1 (type Transf) does not provide get_feature_names'
+    )
+    with pytest.raises(AttributeError, match=msg):
+        ft.get_feature_names()
 
 
 def test_classes_property():
@@ -883,10 +899,12 @@ def test_classes_property():
 
     reg = make_pipeline(SelectKBest(k=1), LinearRegression())
     reg.fit(X, y)
-    assert_raises(AttributeError, getattr, reg, "classes_")
+    with pytest.raises(AttributeError):
+        getattr(reg, 'classes_')
 
     clf = make_pipeline(SelectKBest(k=1), LogisticRegression(random_state=0))
-    assert_raises(AttributeError, getattr, clf, "classes_")
+    with pytest.raises(AttributeError):
+        getattr(clf, 'classes_')
     clf.fit(X, y)
     assert_array_equal(clf.classes_, np.unique(y))
 
@@ -961,6 +979,11 @@ def test_set_feature_union_step_drop():
 
 
 def test_step_name_validation():
+    error_message_1 = r"Estimator names must not contain __: got \['a__q'\]"
+    error_message_2 = re.escape("Names provided are not unique: ['a', 'a']")
+    error_message_3 = re.escape("Estimator names conflict with constructor "
+                                "arguments: ['%s']"
+                    )
     bad_steps1 = [('a__q', Mult(2)), ('b', Mult(3))]
     bad_steps2 = [('a', Mult(2)), ('a', Mult(3))]
     for cls, param in [(Pipeline, 'steps'),
@@ -968,29 +991,32 @@ def test_step_name_validation():
         # we validate in construction (despite scikit-learn convention)
         bad_steps3 = [('a', Mult(2)), (param, Mult(3))]
         for bad_steps, message in [
-            (bad_steps1, "Estimator names must not contain __: got ['a__q']"),
-            (bad_steps2, "Names provided are not unique: ['a', 'a']"),
-            (bad_steps3, "Estimator names conflict with constructor "
-                         "arguments: ['%s']" % param),
+            (bad_steps1, error_message_1),
+            (bad_steps2, error_message_2),
+            (bad_steps3, error_message_3 % param),
         ]:
             # three ways to make invalid:
             # - construction
-            assert_raise_message(ValueError, message, cls,
-                                 **{param: bad_steps})
+            with pytest.raises(ValueError, match=message):
+                cls(**{param: bad_steps})
 
             # - setattr
             est = cls(**{param: [('a', Mult(1))]})
             setattr(est, param, bad_steps)
-            assert_raise_message(ValueError, message, est.fit, [[1]], [1])
-            assert_raise_message(ValueError, message, est.fit_transform,
-                                 [[1]], [1])
+            with pytest.raises(ValueError, match=message):
+                est.fit([[1]], [1])
+            
+            with pytest.raises(ValueError, match=message):
+                est.fit_transform([[1]], [1])
 
             # - set_params
             est = cls(**{param: [('a', Mult(1))]})
             est.set_params(**{param: bad_steps})
-            assert_raise_message(ValueError, message, est.fit, [[1]], [1])
-            assert_raise_message(ValueError, message, est.fit_transform,
-                                 [[1]], [1])
+            with pytest.raises(ValueError, match=message):
+                est.fit([[1]], [1])
+
+            with pytest.raises(ValueError, match=message):
+                est.fit_transform([[1]], [1])
 
 
 def test_set_params_nested_pipeline():
@@ -1012,9 +1038,13 @@ def test_pipeline_wrong_memory():
     memory = 1
     cached_pipe = Pipeline([('transf', DummyTransf()),
                             ('svc', SVC())], memory=memory)
-    assert_raises_regex(ValueError, "'memory' should be None, a string or"
-                        " have the same interface as joblib.Memory."
-                        " Got memory='1' instead.", cached_pipe.fit, X, y)
+
+    msg = re.escape(
+        "'memory' should be None, a string or have the same interface "
+        "as joblib.Memory. Got memory='1' instead."
+    )
+    with pytest.raises(ValueError, match=msg):
+        cached_pipe.fit(X, y)
 
 
 class DummyMemory:
@@ -1034,9 +1064,12 @@ def test_pipeline_with_cache_attribute():
     dummy = WrongDummyMemory()
     pipe = Pipeline([('transf', Transf()), ('clf', Mult())],
                     memory=dummy)
-    assert_raises_regex(ValueError, "'memory' should be None, a string or"
-                        " have the same interface as joblib.Memory."
-                        " Got memory='{}' instead.".format(dummy), pipe.fit, X)
+    msg = re.escape(
+        "'memory' should be None, a string or have the same interface "
+        f"as joblib.Memory. Got memory='{dummy}' instead."
+    )
+    with pytest.raises(ValueError, match=msg):
+        pipe.fit(X)
 
 
 def test_pipeline_memory():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -979,7 +979,9 @@ def test_set_feature_union_step_drop():
 
 
 def test_step_name_validation():
-    error_message_1 = r"Estimator names must not contain __: got \['a__q'\]"
+    error_message_1 = re.escape(
+        "Estimator names must not contain __: got ['a__q']"
+    )
     error_message_2 = re.escape("Names provided are not unique: ['a', 'a']")
     error_message_3 = re.escape(
         "Estimator names conflict with constructor arguments: ['%s']"

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -981,9 +981,9 @@ def test_set_feature_union_step_drop():
 def test_step_name_validation():
     error_message_1 = r"Estimator names must not contain __: got \['a__q'\]"
     error_message_2 = re.escape("Names provided are not unique: ['a', 'a']")
-    error_message_3 = re.escape("Estimator names conflict with constructor "
-                                "arguments: ['%s']"
-                                )
+    error_message_3 = re.escape(
+        "Estimator names conflict with constructor arguments: ['%s']"
+    )
     bad_steps1 = [('a__q', Mult(2)), ('b', Mult(3))]
     bad_steps2 = [('a', Mult(2)), ('a', Mult(3))]
     for cls, param in [(Pipeline, 'steps'),

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -178,8 +178,8 @@ def test_pipeline_init():
     clf = NoTrans()
     pipe = Pipeline([('svc', clf)])
     assert (pipe.get_params(deep=True) ==
-                 dict(svc__a=None, svc__b=None, svc=clf,
-                      **pipe.get_params(deep=False)))
+            dict(svc__a=None, svc__b=None, svc=clf,
+                 **pipe.get_params(deep=False)))
 
     # Check that params are set
     pipe.set_params(svc__a=0.1)
@@ -637,7 +637,7 @@ def test_set_pipeline_steps():
         )
     with pytest.raises(TypeError, match=msg):
         pipeline.fit([[1]], [1])
-        
+
     with pytest.raises(TypeError, match=msg):
         pipeline.fit_transform([[1]], [1])
 
@@ -704,15 +704,15 @@ def test_set_pipeline_step_passthrough(passthrough):
     assert_array_equal([exp], pipeline.fit(X).predict(X))
     assert_array_equal(X, pipeline.inverse_transform([[exp]]))
     assert (pipeline.get_params(deep=True) ==
-                      {'steps': pipeline.steps,
-                       'm2': mult2,
-                       'm3': passthrough,
-                       'last': mult5,
-                       'memory': None,
-                       'm2__mult': 2,
-                       'last__mult': 5,
-                       'verbose': False
-                       })
+            {'steps': pipeline.steps,
+             'm2': mult2,
+             'm3': passthrough,
+             'last': mult5,
+             'memory': None,
+             'm2__mult': 2,
+             'last__mult': 5,
+             'verbose': False
+             })
 
     pipeline.set_params(m2=passthrough)
     exp = 5
@@ -983,7 +983,7 @@ def test_step_name_validation():
     error_message_2 = re.escape("Names provided are not unique: ['a', 'a']")
     error_message_3 = re.escape("Estimator names conflict with constructor "
                                 "arguments: ['%s']"
-                    )
+                                )
     bad_steps1 = [('a__q', Mult(2)), ('b', Mult(3))]
     bad_steps2 = [('a', Mult(2)), ('a', Mult(3))]
     for cls, param in [(Pipeline, 'steps'),
@@ -1005,7 +1005,7 @@ def test_step_name_validation():
             setattr(est, param, bad_steps)
             with pytest.raises(ValueError, match=message):
                 est.fit([[1]], [1])
-            
+
             with pytest.raises(ValueError, match=message):
                 est.fit_transform([[1]], [1])
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -979,11 +979,10 @@ def test_set_feature_union_step_drop():
 
 
 def test_step_name_validation():
-    error_message_1 = "Estimator names must not contain __: got \['a__q'\]"
-    error_message_2 = re.escape("Names provided are not unique: ['a', 'a']")
-    error_message_3 = re.escape(
-        "Estimator names conflict with constructor arguments: ['%s']"
-    )
+    error_message_1 = r"Estimator names must not contain __: got \['a__q'\]"
+    error_message_2 = r"Names provided are not unique: \['a', 'a'\]"
+    error_message_3 = r"Estimator names conflict with constructor "
+                      r"arguments: \['%s'\]"
     bad_steps1 = [('a__q', Mult(2)), ('b', Mult(3))]
     bad_steps2 = [('a', Mult(2)), ('a', Mult(3))]
     for cls, param in [(Pipeline, 'steps'),

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -275,7 +275,7 @@ def test_pipeline_fit_params():
     assert pipe.named_steps['transf'].b is None
     # invalid parameters should raise an error message
 
-    msg = re.escape(r"fit() got an unexpected keyword argument 'bad'")
+    msg = re.escape("fit() got an unexpected keyword argument 'bad'")
     with pytest.raises(TypeError, match=msg):
         pipe.fit(None, None, clf__bad=True)
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -634,7 +634,7 @@ def test_set_pipeline_steps():
     msg = re.escape(
         "Last step of Pipeline should implement fit or be the "
         "string 'passthrough'."
-        )
+    )
     with pytest.raises(TypeError, match=msg):
         pipeline.fit([[1]], [1])
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -979,9 +979,7 @@ def test_set_feature_union_step_drop():
 
 
 def test_step_name_validation():
-    error_message_1 = re.escape(
-        "Estimator names must not contain __: got ['a__q']"
-    )
+    error_message_1 = "Estimator names must not contain __: got \['a__q'\]"
     error_message_2 = re.escape("Names provided are not unique: ['a', 'a']")
     error_message_3 = re.escape(
         "Estimator names conflict with constructor arguments: ['%s']"

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -981,8 +981,9 @@ def test_set_feature_union_step_drop():
 def test_step_name_validation():
     error_message_1 = r"Estimator names must not contain __: got \['a__q'\]"
     error_message_2 = r"Names provided are not unique: \['a', 'a'\]"
-    error_message_3 = r"Estimator names conflict with constructor "
-                      r"arguments: \['%s'\]"
+    error_message_3 = (
+        r"Estimator names conflict with constructor arguments: \['%s'\]"
+    )
     bad_steps1 = [('a__q', Mult(2)), ('b', Mult(3))]
     bad_steps2 = [('a', Mult(2)), ('a', Mult(3))]
     for cls, param in [(Pipeline, 'steps'),


### PR DESCRIPTION
Reference Issues/PRs
References #14216

What does this implement/fix? Explain your changes.
Changed the assert_raises, assert_message, assert_warns in tests/test_pipeline.py to pytest.raises().
Added additional message checks for tests that seemed like could benefit from further clarification.