### PR TITLE
CLN Improve doc/error consistency for GaussianProcessRegressor

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -302,7 +302,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Returns
         -------
-        y_mean : ndarray of shape (n_samples, [n_targets])
+        y_mean : ndarray of shape (n_samples,) or (n_samples, n_targets)
             Mean of predictive distribution a query points.
 
         y_std : ndarray of shape (n_samples,), optional
@@ -403,7 +403,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Returns
         -------
-        y_samples : ndarray of shape (n_samples, [n_targets], n_samples)
+        y_samples : ndarray of shape (n_samples, n_samples), or \
+            (n_samples, n_targets, n_samples)
             Values of n_samples samples drawn from Gaussian process and
             evaluated at query points.
         """

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -341,14 +341,14 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 return y_mean
         else:  # Predict based on GP posterior
             K_trans = self.kernel_(X, self.X_train_)
-            y_mean = K_trans @ self.alpha_  # Line 4 (y_mean = f_star)
+            y_mean = K_trans.dot(self.alpha_)  # Line 4 (y_mean = f_star)
 
             # undo normalisation
             y_mean = self._y_train_std * y_mean + self._y_train_mean
 
             if return_cov:
                 v = cho_solve((self.L_, True), K_trans.T)  # Line 5
-                y_cov = self.kernel_(X) - K_trans @ v  # Line 6
+                y_cov = self.kernel_(X) - K_trans.dot(v)  # Line 6
 
                 # undo normalisation
                 y_cov = y_cov * self._y_train_std**2
@@ -361,12 +361,12 @@ class GaussianProcessRegressor(MultiOutputMixin,
                     # decomposition L and its inverse L_inv
                     L_inv = solve_triangular(self.L_.T,
                                              np.eye(self.L_.shape[0]))
-                    self._K_inv = L_inv @ L_inv.T
+                    self._K_inv = L_inv.dot(L_inv.T)
 
                 # Compute variance of predictive distribution
                 y_var = self.kernel_.diag(X)
                 y_var -= np.einsum("ij,ij->i",
-                                   K_trans @ self._K_inv, K_trans)
+                                   np.dot(K_trans, self._K_inv), K_trans)
 
                 # Check if any of the variances is negative because of
                 # numerical issues. If yes: set the variance to 0.

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -30,9 +30,9 @@ class GaussianProcessRegressor(MultiOutputMixin,
     GaussianProcessRegressor:
 
        * allows prediction without prior fitting (based on the GP prior)
-       * provides an additional method sample_y(X), which evaluates samples
+       * provides an additional method `sample_y(X)`, which evaluates samples
          drawn from the GPR (prior or posterior) at given inputs
-       * exposes a method log_marginal_likelihood(theta), which can be used
+       * exposes a method `log_marginal_likelihood(theta)`, which can be used
          externally for other ways of selecting hyperparameters, e.g., via
          Markov chain Monte Carlo.
 
@@ -68,8 +68,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
         must have the signature::
 
             def optimizer(obj_func, initial_theta, bounds):
-                # * 'obj_func' is the objective function to be minimized, which
-                #   takes the hyperparameters theta as parameter and an
+                # * 'obj_func': the objective function to be minimized, which
+                #   takes the hyperparameters theta as a parameter and an
                 #   optional flag eval_gradient, which determines if the
                 #   gradient is returned additionally to the function value
                 # * 'initial_theta': the initial value for theta, which can be
@@ -80,7 +80,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 # the corresponding value of the target function.
                 return theta_opt, func_min
 
-        Per default, the 'L-BGFS-B' algorithm from scipy.optimize.minimize
+        Per default, the 'L-BFGS-B' algorithm from scipy.optimize.minimize
         is used. If None is passed, the kernel's parameters are kept fixed.
         Available internal optimizers are::
 
@@ -113,7 +113,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
     random_state : int, RandomState instance or None, default=None
         Determines random number generation used to initialize the centers.
         Pass an int for reproducible results across multiple function calls.
-        See :term: `Glossary <random_state>`.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------
@@ -302,7 +302,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         Returns
         -------
-        y_mean : ndarray of shape (n_samples, [n_output_dims])
+        y_mean : ndarray of shape (n_samples, [n_targets])
             Mean of predictive distribution a query points.
 
         y_std : ndarray of shape (n_samples,), optional
@@ -399,11 +399,11 @@ class GaussianProcessRegressor(MultiOutputMixin,
             Determines random number generation to randomly draw samples.
             Pass an int for reproducible results across multiple function
             calls.
-            See :term: `Glossary <random_state>`.
+            See :term:`Glossary <random_state>`.
 
         Returns
         -------
-        y_samples : ndarray of shape (n_samples_X, [n_output_dims], n_samples)
+        y_samples : ndarray of shape (n_samples, [n_targets], n_samples)
             Values of n_samples samples drawn from Gaussian process and
             evaluated at query points.
         """


### PR DESCRIPTION
Improves the documentation for `GaussianProcessRegressor`.

* correctly links to Glossary
* fixes typo (BGFS should be BFGS)
* consistently uses `n_targets` instead of a combination of `n_targets` and `n_output_dims`

Regarding the last note though, it seems like scikit-learn hasn't standardized on the proper word to describe a multi-target / multi-output regression. Some models use "target," while others use "output." I chose to use `n_targets` here because it is used by most of the linear models, and no other page used `n_output_dims`. (Several others use `n_outputs`.)