### PR TITLE
FIX RuntimeWarning division by zero in check_classifiers_one_label

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -476,8 +476,12 @@ class LinearDiscriminantAnalysis(LinearClassifierMixin,
         # (n_classes) centers
         _, S, Vt = linalg.svd(X, full_matrices=0)
 
-        self.explained_variance_ratio_ = (S**2 / np.sum(
-            S**2))[:self._max_components]
+        if self._max_components == 0:
+            self.explained_variance_ratio_ = np.empty((0,), dtype=S.dtype)
+        else:
+            self.explained_variance_ratio_ = (S**2 / np.sum(
+                S**2))[:self._max_components]
+
         rank = np.sum(S > self.tol * S[0])
         self.scalings_ = np.dot(scalings, Vt.T[:, :rank])
         coef = np.dot(self.means_ - self.xbar_, self.scalings_)

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -320,8 +320,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
         check_is_fitted(self)
         X = self._validate_data(X, accept_sparse='csr', reset=False)
         is_inlier = np.ones(X.shape[0], dtype=int)
-        #is_inlier[self.decision_function(X) < 0] = -1
-        np.where(is_inlier < 0, -1, is_inlier)
+        is_inlier[self.decision_function(X) < 0] = -1
         return is_inlier
 
     def decision_function(self, X):

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -320,7 +320,8 @@ class IsolationForest(OutlierMixin, BaseBagging):
         check_is_fitted(self)
         X = self._validate_data(X, accept_sparse='csr', reset=False)
         is_inlier = np.ones(X.shape[0], dtype=int)
-        is_inlier[self.decision_function(X) < 0] = -1
+        #is_inlier[self.decision_function(X) < 0] = -1
+        np.where(is_inlier < 0, -1, is_inlier)
         return is_inlier
 
     def decision_function(self, X):


### PR DESCRIPTION
#### Reference Issues/PRs
See [issue #19334](https://github.com/scikit-learn/scikit-learn/issues/19334).

#### What does this implement/fix? Explain your changes.

The warning stems from the LDA's fit method. There is a division by zero in the `LinearDiscriminantAnalysis#_solve_svd` method, when computing the explained variance ratio: `self.explained_variance_ratio_ = (S**2 / np.sum(S**2))[:self._max_components]`. Here, `S` is zero because it's the singular values vector of the zero matrix `X` given by `X = np.dot(((np.sqrt((n_samples * self.priors_) * fac)) * (self.means_ - self.xbar_).T).T, scalings)`. Here, we have `self.means_ == self.xbar_` because we are testing the LDA classifier with only one class (see `y = np.ones(10)`).


#### Any other comments?

I am still trying to figure out the right way to solve this problem. 