### PR TITLE
Remove assert warn from preprocessing tests

### DIFF
--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -20,8 +20,6 @@ from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_less
-from sklearn.utils._testing import assert_warns_message
-from sklearn.utils._testing import assert_no_warnings
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_allclose_dense_sparse
 from sklearn.utils._testing import skip_if_32bit
@@ -490,28 +488,37 @@ def test_standard_scaler_numerical_stability():
     x = np.full(8, np.log(1e-5), dtype=np.float64)
     # This does not raise a warning as the number of samples is too low
     # to trigger the problem in recent numpy
-    x_scaled = assert_no_warnings(scale, x)
+    with pytest.warns(None) as record:
+        scale(x)
+    assert len(record) == 0
     assert_array_almost_equal(scale(x), np.zeros(8))
 
     # with 2 more samples, the std computation run into numerical issues:
     x = np.full(10, np.log(1e-5), dtype=np.float64)
-    w = "standard deviation of the data is probably very close to 0"
-    x_scaled = assert_warns_message(UserWarning, w, scale, x)
+    warning_message = (
+        "standard deviation of the data is probably very close to 0"
+    )
+    with pytest.warns(UserWarning, match=warning_message):
+        x_scaled = scale(x)
     assert_array_almost_equal(x_scaled, np.zeros(10))
 
     x = np.full(10, 1e-100, dtype=np.float64)
-    x_small_scaled = assert_no_warnings(scale, x)
+    with pytest.warns(None) as record:
+        x_small_scaled = scale(x)
+    assert len(record) == 0
     assert_array_almost_equal(x_small_scaled, np.zeros(10))
 
     # Large values can cause (often recoverable) numerical stability issues:
     x_big = np.full(10, 1e100, dtype=np.float64)
-    w = "Dataset may contain too large values"
-    x_big_scaled = assert_warns_message(UserWarning, w, scale, x_big)
+    warning_message = (
+        "Dataset may contain too large values"
+    )
+    with pytest.warns(UserWarning, match=warning_message):
+        x_big_scaled = scale(x_big)
     assert_array_almost_equal(x_big_scaled, np.zeros(10))
     assert_array_almost_equal(x_big_scaled, x_small_scaled)
-
-    x_big_centered = assert_warns_message(UserWarning, w, scale, x_big,
-                                          with_std=False)
+    with pytest.warns(UserWarning, match=warning_message):
+        x_big_centered = scale(x_big, with_std=False)
     assert_array_almost_equal(x_big_centered, np.zeros(10))
     assert_array_almost_equal(x_big_centered, x_small_scaled)
 
@@ -1438,9 +1445,11 @@ def test_quantile_transform_sparse_ignore_zeros():
                                       n_quantiles=5)
 
     # dense case -> warning raise
-    assert_warns_message(UserWarning, "'ignore_implicit_zeros' takes effect"
-                         " only with sparse matrix. This parameter has no"
-                         " effect.", transformer.fit, X)
+    warning_message = ("'ignore_implicit_zeros' takes effect"
+                       " only with sparse matrix. This parameter has no"
+                       " effect.")
+    with pytest.warns(UserWarning, match=warning_message):
+        transformer.fit(X)
 
     X_expected = np.array([[0, 0],
                            [0, 0],

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -9,7 +9,6 @@ from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils._testing import (
     assert_array_almost_equal,
     assert_array_equal,
-    assert_warns_message,
     assert_allclose_dense_sparse
 )
 
@@ -109,9 +108,10 @@ def test_same_min_max(strategy):
                   [1, 0],
                   [1, 1]])
     est = KBinsDiscretizer(strategy=strategy, n_bins=3, encode='ordinal')
-    assert_warns_message(UserWarning,
-                         "Feature 0 is constant and will be replaced "
-                         "with 0.", est.fit, X)
+    warning_message = ("Feature 0 is constant and will be replaced "
+                       "with 0.")
+    with pytest.warns(UserWarning, match=warning_message):
+        est.fit(X)
     assert est.n_bins_[0] == 1
     # replace the feature with zeros
     Xt = est.transform(X)
@@ -257,9 +257,9 @@ def test_overwrite():
 def test_redundant_bins(strategy, expected_bin_edges):
     X = [[0], [0], [0], [0], [3], [3]]
     kbd = KBinsDiscretizer(n_bins=3, strategy=strategy)
-    msg = ("Bins whose width are too small (i.e., <= 1e-8) in feature 0 "
-           "are removed. Consider decreasing the number of bins.")
-    assert_warns_message(UserWarning, msg, kbd.fit, X)
+    warning_message = ("Consider decreasing the number of bins.")
+    with pytest.warns(UserWarning, match=warning_message):
+        kbd.fit(X)
     assert_array_almost_equal(kbd.bin_edges_[0], expected_bin_edges)
 
 
@@ -269,9 +269,10 @@ def test_percentile_numeric_stability():
     Xt = np.array([0, 0, 4]).reshape(-1, 1)
     kbd = KBinsDiscretizer(n_bins=10, encode='ordinal',
                            strategy='quantile')
-    msg = ("Bins whose width are too small (i.e., <= 1e-8) in feature 0 "
-           "are removed. Consider decreasing the number of bins.")
-    assert_warns_message(UserWarning, msg, kbd.fit, X)
+    warning_message = ("Consider decreasing the number of bins.")
+    with pytest.warns(UserWarning, match=warning_message):
+        kbd.fit(X)
+
     assert_array_almost_equal(kbd.bin_edges_[0], bin_edges)
     assert_array_almost_equal(kbd.transform(X), Xt)
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -12,7 +12,6 @@ from scipy.sparse import lil_matrix
 from sklearn.utils.multiclass import type_of_target
 
 from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils import _to_object_array
 
@@ -351,15 +350,14 @@ def test_multilabel_binarizer_unknown_class():
     mlb = MultiLabelBinarizer()
     y = [[1, 2]]
     Y = np.array([[1, 0], [0, 1]])
-    w = 'unknown class(es) [0, 4] will be ignored'
-    matrix = assert_warns_message(UserWarning, w,
-                                  mlb.fit(y).transform, [[4, 1], [2, 0]])
-    assert_array_equal(matrix, Y)
+    warning_message = 'will be ignored'
+    with pytest.warns(UserWarning, match=warning_message):
+        matrix = mlb.fit(y).transform([[4, 1], [2, 0]])
 
     Y = np.array([[1, 0, 0], [0, 1, 0]])
     mlb = MultiLabelBinarizer(classes=[1, 2, 3])
-    matrix = assert_warns_message(UserWarning, w,
-                                  mlb.fit(y).transform, [[4, 1], [2, 0]])
+    with pytest.warns(UserWarning, match=warning_message):
+        matrix = mlb.fit(y).transform([[4, 1], [2, 0]])
     assert_array_equal(matrix, Y)
 
 
@@ -535,7 +533,7 @@ def check_binarized_results(y, classes, pos_label, neg_label, expected):
                                                       output_type=y_type,
                                                       classes=classes,
                                                       threshold=((neg_label +
-                                                                 pos_label) /
+                                                                  pos_label) /
                                                                  2.))
 
         assert_array_equal(toarray(inversed), toarray(y))

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -350,7 +350,7 @@ def test_multilabel_binarizer_unknown_class():
     mlb = MultiLabelBinarizer()
     y = [[1, 2]]
     Y = np.array([[1, 0], [0, 1]])
-    warning_message = 'will be ignored'
+    warning_message = 'unknown class.* will be ignored'
     with pytest.warns(UserWarning, match=warning_message):
         matrix = mlb.fit(y).transform([[4, 1], [2, 0]])
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Part of #19414 for preprocessing/tests


#### What does this implement/fix? Explain your changes.

Removed use of assert_warns, assert_warns_message, assert_no_warnings in preprocessing/tests 
#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
