### PR TITLE
Removed assert_warns_message from gaussian_process/tests

### DIFF
--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -17,7 +17,7 @@ from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 from sklearn.exceptions import ConvergenceWarning
 
 from sklearn.utils._testing \
-    import assert_almost_equal, assert_array_equal, assert_warns_message
+    import assert_almost_equal, assert_array_equal
 
 
 def f(x):
@@ -189,14 +189,14 @@ def test_multi_class_n_jobs(kernel):
 def test_warning_bounds():
     kernel = RBF(length_scale_bounds=[1e-5, 1e-3])
     gpc = GaussianProcessClassifier(kernel=kernel)
-    assert_warns_message(ConvergenceWarning, "The optimal value found for "
-                                             "dimension 0 of parameter "
-                                             "length_scale is close to "
-                                             "the specified upper bound "
-                                             "0.001. Increasing the bound "
-                                             "and calling fit again may "
-                                             "find a better value.",
-                         gpc.fit, X, y)
+    warning_message = (
+        "The optimal value found for dimension 0 of parameter "
+        "length_scale is close to the specified upper bound "
+        "0.001. Increasing the bound and calling fit again may "
+        "find a better value."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        gpc.fit(X, y)
 
     kernel_sum = (WhiteKernel(noise_level_bounds=[1e-5, 1e-3]) +
                   RBF(length_scale_bounds=[1e3, 1e5]))

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -21,9 +21,8 @@ from sklearn.exceptions import ConvergenceWarning
 
 from sklearn.utils._testing \
     import (assert_array_less,
-            assert_almost_equal, assert_raise_message,
-            assert_array_almost_equal, assert_array_equal,
-            assert_allclose)
+            assert_almost_equal, assert_array_almost_equal,
+            assert_array_equal, assert_allclose)
 
 
 def f(x):
@@ -404,12 +403,15 @@ def test_gpr_correct_error_message():
     y = np.ones(6)
     kernel = DotProduct()
     gpr = GaussianProcessRegressor(kernel=kernel, alpha=0.0)
-    assert_raise_message(np.linalg.LinAlgError,
-                         "The kernel, %s, is not returning a "
-                         "positive definite matrix. Try gradually increasing "
-                         "the 'alpha' parameter of your "
-                         "GaussianProcessRegressor estimator."
-                         % kernel, gpr.fit, X, y)
+    message = (
+        "The kernel, %s, is not returning a "
+        "positive definite matrix. Try gradually increasing "
+        "the 'alpha' parameter of your "
+        "GaussianProcessRegressor estimator."
+        % kernel
+    )
+    with pytest.raises(np.linalg.LinAlgError, match=message):
+        gpr.fit(X, y)
 
 
 @pytest.mark.parametrize('kernel', kernels)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -5,6 +5,7 @@
 # License: BSD 3 clause
 
 import sys
+import re
 import numpy as np
 import warnings
 
@@ -410,7 +411,7 @@ def test_gpr_correct_error_message():
         "GaussianProcessRegressor estimator."
         % kernel
     )
-    with pytest.raises(np.linalg.LinAlgError, match=message):
+    with pytest.raises(np.linalg.LinAlgError, match=re.escape(message)):
         gpr.fit(X, y)
 
 

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -23,7 +23,7 @@ from sklearn.utils._testing \
     import (assert_array_less,
             assert_almost_equal, assert_raise_message,
             assert_array_almost_equal, assert_array_equal,
-            assert_allclose, assert_warns_message)
+            assert_allclose)
 
 
 def f(x):
@@ -474,14 +474,14 @@ def test_K_inv_reset(kernel):
 def test_warning_bounds():
     kernel = RBF(length_scale_bounds=[1e-5, 1e-3])
     gpr = GaussianProcessRegressor(kernel=kernel)
-    assert_warns_message(ConvergenceWarning, "The optimal value found for "
-                                             "dimension 0 of parameter "
-                                             "length_scale is close to "
-                                             "the specified upper bound "
-                                             "0.001. Increasing the bound "
-                                             "and calling fit again may "
-                                             "find a better value.",
-                         gpr.fit, X, y)
+    warning_message = (
+        "The optimal value found for dimension 0 of parameter "
+        "length_scale is close to the specified upper bound "
+        "0.001. Increasing the bound and calling fit again may "
+        "find a better value."
+    )
+    with pytest.warns(ConvergenceWarning, match=warning_message):
+        gpr.fit(X, y)
 
     kernel_sum = (WhiteKernel(noise_level_bounds=[1e-5, 1e-3]) +
                   RBF(length_scale_bounds=[1e3, 1e5]))

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -20,7 +20,6 @@ from sklearn.base import clone
 from sklearn.utils._testing import (assert_almost_equal, assert_array_equal,
                                     assert_array_almost_equal,
                                     assert_allclose,
-                                    assert_raise_message,
                                     fails_if_pypy)
 
 
@@ -361,7 +360,10 @@ def test_repr_kernels(kernel):
 
 def test_rational_quadratic_kernel():
     kernel = RationalQuadratic(length_scale=[1., 1.])
-    assert_raise_message(AttributeError,
-                         "RationalQuadratic kernel only supports isotropic "
-                         "version, please use a single "
-                         "scalar for length_scale", kernel, X)
+    message = (
+        "RationalQuadratic kernel only supports isotropic "
+        "version, please use a single "
+        "scalar for length_scale"
+    )
+    with pytest.raises(AttributeError, match=message):
+        kernel(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Part of #19414 for `gaussian_process/tests`

#### What does this implement/fix? Explain your changes.
Removed assert_warns_message from tests_gpr.py and tests_gpc.py

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
