### PR TITLE
FIX GaussianProcessRegression(normalize_y=True).predict(X, return_cov=True)

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -309,7 +309,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
             Standard deviation of predictive distribution at query points.
             Only returned when `return_std` is True.
 
-        y_cov : ndarray of shape (n_samples, n_samples, [n_output_dims]), optional
+        y_cov : ndarray of shape (n_samples, n_samples,
+                                    [n_output_dims]), optional
             Covariance of joint predictive distribution a query points.
             Only returned when `return_cov` is True.
         """

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -203,8 +203,13 @@ class GaussianProcessRegressor(MultiOutputMixin,
             y = (y - self._y_train_mean) / self._y_train_std
 
         else:
-            self._y_train_mean = np.zeros(1)
-            self._y_train_std = 1
+            if hasattr(y[0], "__len__"):
+                self._y_train_mean = np.zeros(3)
+                self._y_train_std = np.ones(3)
+            else:
+                self._y_train_mean = np.zeros(1)
+                self._y_train_std = 1
+
 
         if np.iterable(self.alpha) \
            and self.alpha.shape[0] != y.shape[0]:

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -309,8 +309,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
             Standard deviation of predictive distribution at query points.
             Only returned when `return_std` is True.
 
-        y_cov : ndarray of shape (n_samples, n_samples,
-                                    [n_output_dims]), optional
+        y_cov : ndarray of shape (n_samples, n_samples, [n_output_dims]),
+        optional
             Covariance of joint predictive distribution a query points.
             Only returned when `return_cov` is True.
         """

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -358,7 +358,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
                     y_cov_x = y_cov.shape[0]
                     y_cov_y = y_cov.shape[1]
                     y_cov_copy = y_cov.reshape((y_cov_x, y_cov_y, 1))
-                    y_cov = np.zeros((y_cov_x, y_cov_x, 
+                    y_cov = np.zeros((y_cov_x, y_cov_x,
                                       self._y_train_std.shape[0]))
                     idx = 0
                     for line in y_cov_copy:

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -352,17 +352,23 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 y_cov = self.kernel_(X) - K_trans.dot(v)  # Line 6
 
                 # undo normalisation
-                if hasattr(self._y_train_std, "__len__"):   # for multitarget data
-                  y_cov_temp = y_cov.reshape((y_cov.shape[0], y_cov.shape[1], 1))
-                  y_cov = np.zeros((y_cov.shape[0], y_cov.shape[1], self._y_train_std.shape[0]))
-                  idx = 0
-                  for line in y_cov_temp:
-                    line = line * self._y_train_std**2
-                    y_cov[idx] = line
-                    idx += 1 
-                else:   # for single target data
-                  y_cov = y_cov * self._y_train_std**2 
 
+                # for multitarget data:
+                if hasattr(self._y_train_std, "__len__"):
+                    y_cov_x = y_cov.shape[0]
+                    y_cov_y = y_cov.shape[1]
+                    y_cov_copy = y_cov.reshape((y_cov_x, y_cov_y, 1))
+                    y_cov = np.zeros((y_cov_x, y_cov_x, 
+                                      self._y_train_std.shape[0]))
+                    idx = 0
+                    for line in y_cov_copy:
+                        line = line * self._y_train_std**2
+                        y_cov[idx] = line
+                        idx += 1
+
+                # for single target data
+                else:
+                    y_cov = y_cov * self._y_train_std**2
 
                 return y_mean, y_cov
             elif return_std:
@@ -388,12 +394,15 @@ class GaussianProcessRegressor(MultiOutputMixin,
                     y_var[y_var_negative] = 0.0
 
                 # undo normalisation
-                if hasattr(self._y_train_std, "__len__"):   # for multitarget data
-                  y_var = y_var.reshape((-1,1))
-                  y_var = y_var * self._y_train_std**2
-                else:   # for single target data 
-                  y_var = y_var * self._y_train_std**2
-                  
+
+                # for multitarget data
+                if hasattr(self._y_train_std, "__len__"):
+                    y_var = y_var.reshape((-1, 1))
+                    y_var = y_var * self._y_train_std**2
+                # for single target data
+                else:
+                    y_var = y_var * self._y_train_std**2
+
                 return y_mean, np.sqrt(y_var)
             else:
                 return y_mean

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -352,16 +352,17 @@ class GaussianProcessRegressor(MultiOutputMixin,
                 y_cov = self.kernel_(X) - K_trans.dot(v)  # Line 6
 
                 # undo normalisation
-                if (self._y_train_std.ndim==0):   # for single-target data
-                  y_cov = y_cov * self._y_train_std**2  
-                elif (self._y_train_std.ndim==1):   # for multitarget data
+                if hasattr(self._y_train_std, "__len__"):   # for multitarget data
                   y_cov_temp = y_cov.reshape((y_cov.shape[0], y_cov.shape[1], 1))
                   y_cov = np.zeros((y_cov.shape[0], y_cov.shape[1], self._y_train_std.shape[0]))
                   idx = 0
                   for line in y_cov_temp:
                     line = line * self._y_train_std**2
                     y_cov[idx] = line
-                    idx += 1
+                    idx += 1 
+                else:   # for single target data
+                  y_cov = y_cov * self._y_train_std**2 
+
 
                 return y_mean, y_cov
             elif return_std:
@@ -387,13 +388,12 @@ class GaussianProcessRegressor(MultiOutputMixin,
                     y_var[y_var_negative] = 0.0
 
                 # undo normalisation
-                if (self._y_train_std.ndim==0):   # for single-target data
-                  y_var = y_var * self._y_train_std**2  
-                  
-                elif (self._y_train_std.ndim==1):   # for multitarget data 
+                if hasattr(self._y_train_std, "__len__"):   # for multitarget data
                   y_var = y_var.reshape((-1,1))
                   y_var = y_var * self._y_train_std**2
-
+                else:   # for single target data 
+                  y_var = y_var * self._y_train_std**2
+                  
                 return y_mean, np.sqrt(y_var)
             else:
                 return y_mean

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -204,8 +204,8 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
         else:
             if hasattr(y[0], "__len__"):
-                self._y_train_mean = np.zeros(3)
-                self._y_train_std = np.ones(3)
+                self._y_train_mean = np.zeros(y.shape[1])
+                self._y_train_std = np.ones(y.shape[1])
             else:
                 self._y_train_mean = np.zeros(1)
                 self._y_train_std = 1

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -360,7 +360,7 @@ def test_y_multioutput():
     # Standard deviation and covariance do not depend on output
     assert_almost_equal(y_std_1d, y_std_2d[:, 0])
     assert_almost_equal(y_std_1d, y_std_2d[:, 1])
-    
+
     assert_almost_equal(y_cov_1d, y_cov_2d[:, :, 0])
     assert_almost_equal(y_cov_1d, y_cov_2d[:, :, 1])
 

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -358,8 +358,11 @@ def test_y_multioutput():
     assert_almost_equal(y_pred_1d, y_pred_2d[:, 1] / 2)
 
     # Standard deviation and covariance do not depend on output
-    assert_almost_equal(y_std_1d, y_std_2d)
-    assert_almost_equal(y_cov_1d, y_cov_2d)
+    assert_almost_equal(y_std_1d, y_std_2d[:, 0])
+    assert_almost_equal(y_std_1d, y_std_2d[:, 1])
+    
+    assert_almost_equal(y_cov_1d, y_cov_2d[:, :, 0])
+    assert_almost_equal(y_cov_1d, y_cov_2d[:, :, 1])
 
     y_sample_1d = gpr.sample_y(X2, n_samples=10)
     y_sample_2d = gpr_2d.sample_y(X2, n_samples=10)


### PR DESCRIPTION
 Problem with GPR predictions on multitarget data. Fixes issues [#17394](https://github.com/scikit-learn/scikit-learn/issues/17394#issue-627790316) and [#18065 ](https://github.com/scikit-learn/scikit-learn/issues/18065#issue-671705701)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->



#### What does this fix?
Initially, when a multitarget data was given, the _gpr.py was not able to undo the normalisation of `y_cov` and` y_var` in the predict() function (lines [355](https://github.com/scikit-learn/scikit-learn/blob/0d7d46f3bef0a2f943ee321f0f979ced165e0477/sklearn/gaussian_process/_gpr.py#L355) and [381](https://github.com/scikit-learn/scikit-learn/blob/0d7d46f3bef0a2f943ee321f0f979ced165e0477/sklearn/gaussian_process/_gpr.py#L381)). The problem was the fact that the code was trying to multiply two horizontal vectors in both cases and returned error `ValueError: operands could not be broadcast together with shapes (a,) (b,) `(e.g. number of samples 'a' = 4, number of target components 'b' = 3). I solved this by reshaping the `y_var` vector and rows of` y_cov `into vertical form before multiplication with the `y_train_std` vector. As a result, we obtain` y_std` of form` (n_samples, n_output_dims) `and `y_cov` of form `(n_samples, n_samples, n_output_dims)`. When targets are single values the undo normalisation is performed as usual. 
The solution is based on the solution from Rasmussen and Williams' [book](http://www.gaussianprocess.org/gpml/chapters/RW.pdf) for cases when classes of outputs are independent from each other. 

#### Comment
This solution will work only if the target classes are independent. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
