### PR TITLE
[FIX] Lasso.coef_ have same number of dimensions as target

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -814,6 +814,10 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
             _pre_fit(X, y, None, self.precompute, self.normalize,
                      self.fit_intercept, copy=should_copy,
                      check_input=check_input, sample_weight=sample_weight)
+        
+        # When y was passed as a 1d-array, we flatten the coefficients.
+        ravel = (y.ndim == 1)
+
         # coordinate descent needs F-ordered arrays and _pre_fit might have
         # called _rescale_data
         if check_input or sample_weight is not None:
@@ -863,11 +867,14 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
         if n_targets == 1:
             self.n_iter_ = self.n_iter_[0]
-            self.coef_ = coef_[0]
             self.dual_gap_ = dual_gaps_[0]
         else:
-            self.coef_ = coef_
             self.dual_gap_ = dual_gaps_
+
+        if ravel:
+            coef_ = coef_[0]
+        self.coef_ = coef_
+
 
         self._set_intercept(X_offset, y_offset, X_scale)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #19693
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### Explain your changes.
The problem is caused by the following code within the implementation of coordinate descent where `coef_` is flattened depending on number of targets instead of `y.ndim`
```python
 if n_targets == 1:
      self.n_iter_ = self.n_iter_[0]
      self.coef_ = coef_[0]
      self.dual_gap_ = dual_gaps_[0]
  else:
      self.coef_ = coef_
      self.dual_gap_ = dual_gaps_
```


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
