### PR TITLE
Fix typo in elastic net docstring.

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -570,7 +570,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to::
 
-            a * L1 + b * L2
+            a * L1 + 0.5 * b * L2
 
     where::
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -570,7 +570,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to::
 
-            a * L1 + 0.5 * b * L2
+            a * ||w||_1 + 0.5 * b * ||w||_2^2
 
     where::
 


### PR DESCRIPTION
There was a typo in the [docstring](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html) in the relation between the `(a, b)` parameters and the `(alpha, l1_ratio)` parameters. CC @agramfort 