### PR TITLE
DOC Fix doc for single linkage in feature agglomeration

### DIFF
--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -1000,7 +1000,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
           the two sets.
         - complete or maximum linkage uses the maximum distances between
           all features of the two sets.
-        - single uses the minimum of the distances between all observations
+        - single uses the minimum of the distances between all features
           of the two sets.
 
     pooling_func : callable, default=np.mean

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -735,7 +735,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
           the two sets.
         - 'complete' or 'maximum' linkage uses the maximum distances between
           all observations of the two sets.
-        - 'single' uses the minimum of the distances between all observations
+        - 'single' uses the minimum of the distances between all features
           of the two sets.
 
         .. versionadded:: 0.20

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -735,7 +735,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
           the two sets.
         - 'complete' or 'maximum' linkage uses the maximum distances between
           all observations of the two sets.
-        - 'single' uses the minimum of the distances between all features
+        - 'single' uses the minimum of the distances between all observations
           of the two sets.
 
         .. versionadded:: 0.20


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #15259

#### What does this implement/fix? Explain your changes.
Changes the description of the 'single' value for the linkage parameter for the feature agglomeration function from 'single uses the minimum of the distances between all observations of the two sets.' to 'single uses the minimum of the distances between all features of the two sets.'

#### Any other comments?
