### PR TITLE
DOC unify None format of the metrics

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1593,7 +1593,7 @@ def precision_score(y_true, y_pred, *, labels=None, pos_label=1,
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
         scores for that label only.
 
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} \
+    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None \
             default='binary'
         This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise, this

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -686,8 +686,8 @@ def jaccard_score(y_true, y_pred, *, labels=None, pos_label=1,
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
         scores for that label only.
 
-    average : {None, 'micro', 'macro', 'samples', 'weighted', \
-            'binary'}, default='binary'
+    average : {'micro', 'macro', 'samples', 'weighted', \
+            'binary'} or None, default='binary'
         If ``None``, the scores for each class are returned. Otherwise, this
         determines the type of averaging performed on the data:
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -19,6 +19,7 @@ the lower the better.
 #          Saurabh Jha <saurabh.jhaa@gmail.com>
 #          Bernardo Stein <bernardovstein@gmail.com>
 #          Shangwu Yao <shangwuyao@gmail.com>
+#          Michal Karbownik <michakarbownik@gmail.com>
 # License: BSD 3 clause
 
 
@@ -599,11 +600,11 @@ def cohen_kappa_score(y1, y2, *, labels=None, weights=None,
 
     labels : array-like of shape (n_classes,), default=None
         List of labels to index the matrix. This may be used to select a
-        subset of labels. If None, all labels that appear at least once in
+        subset of labels. If ``None``, all labels that appear at least once in
         ``y1`` or ``y2`` are used.
 
     weights : {'linear', 'quadratic'}, default=None
-        Weighting type to calculate the score. None means no weighted;
+        Weighting type to calculate the score. ``None`` means no weighted;
         "linear" means linear weighted; "quadratic" means quadratic weighted.
 
     sample_weight : array-like of shape (n_samples,), default=None

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1711,7 +1711,7 @@ def recall_score(y_true, y_pred, *, labels=None, pos_label=1, average='binary',
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
         scores for that label only.
 
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} \
+    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None \
             default='binary'
         This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise, this

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -600,11 +600,11 @@ def cohen_kappa_score(y1, y2, *, labels=None, weights=None,
 
     labels : array-like of shape (n_classes,), default=None
         List of labels to index the matrix. This may be used to select a
-        subset of labels. If ``None``, all labels that appear at least once in
+        subset of labels. If `None`, all labels that appear at least once in
         ``y1`` or ``y2`` are used.
 
     weights : {'linear', 'quadratic'}, default=None
-        Weighting type to calculate the score. ``None`` means no weighted;
+        Weighting type to calculate the score. `None` means no weighted;
         "linear" means linear weighted; "quadratic" means quadratic weighted.
 
     sample_weight : array-like of shape (n_samples,), default=None

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -15,6 +15,7 @@ the lower the better.
 #          Lars Buitinck
 #          Joel Nothman <joel.nothman@gmail.com>
 #          Noel Dawe <noel@dawe.me>
+#          Michal Karbownik <michakarbownik@gmail.com>
 # License: BSD 3 clause
 
 
@@ -1213,7 +1214,7 @@ def _dcg_sample_scores(y_true, y_score, k=None,
         "decision_function" on some classifiers).
 
     k : int, default=None
-        Only consider the highest k scores in the ranking. If None, use all
+        Only consider the highest k scores in the ranking. If ``None``, use all
         outputs.
 
     log_base : float, default=2
@@ -1343,7 +1344,7 @@ def dcg_score(y_true, y_score, *, k=None,
         sharper discount (top results are more important).
 
     sample_weight : ndarray of shape (n_samples,), default=None
-        Sample weights. If None, all samples are given the same weight.
+        Sample weights. If ``None``, all samples are given the same weight.
 
     ignore_ties : bool, default=False
         Assume that there are no ties in y_score (which is likely to be the

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1492,11 +1492,11 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None,
         "decision_function" on some classifiers).
 
     k : int, default=None
-        Only consider the highest k scores in the ranking. If None, use all
+        Only consider the highest k scores in the ranking. If ``None``, use all
         outputs.
 
     sample_weight : ndarray of shape (n_samples,), default=None
-        Sample weights. If None, all samples are given the same weight.
+        Sample weights. If ``None``, all samples are given the same weight.
 
     ignore_ties : bool, default=False
         Assume that there are no ties in y_score (which is likely to be the

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1214,7 +1214,7 @@ def _dcg_sample_scores(y_true, y_score, k=None,
         "decision_function" on some classifiers).
 
     k : int, default=None
-        Only consider the highest k scores in the ranking. If ``None``, use all
+        Only consider the highest k scores in the ranking. If `None`, use all
         outputs.
 
     log_base : float, default=2
@@ -1344,7 +1344,7 @@ def dcg_score(y_true, y_score, *, k=None,
         sharper discount (top results are more important).
 
     sample_weight : ndarray of shape (n_samples,), default=None
-        Sample weights. If ``None``, all samples are given the same weight.
+        Sample weights. If `None`, all samples are given the same weight.
 
     ignore_ties : bool, default=False
         Assume that there are no ties in y_score (which is likely to be the
@@ -1492,11 +1492,11 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None,
         "decision_function" on some classifiers).
 
     k : int, default=None
-        Only consider the highest k scores in the ranking. If ``None``, use all
+        Only consider the highest k scores in the ranking. If `None`, use all
         outputs.
 
     sample_weight : ndarray of shape (n_samples,), default=None
-        Sample weights. If ``None``, all samples are given the same weight.
+        Sample weights. If `None`, all samples are given the same weight.
 
     ignore_ties : bool, default=False
         Assume that there are no ties in y_score (which is likely to be the

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -351,18 +351,18 @@ def cross_val_score(estimator, X, y=None, *, groups=None, scoring=None,
         Similar to :func:`cross_validate`
         but only a single metric is permitted.
 
-        If None, the estimator's default scorer (if available) is used.
+        If ``None``, the estimator's default scorer (if available) is used.
 
     cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
-        - None, to use the default 5-fold cross validation,
+        - ``None``, to use the default 5-fold cross validation,
         - int, to specify the number of folds in a `(Stratified)KFold`,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For int/None inputs, if the estimator is a classifier and ``y`` is
+        For ``int``/``None`` inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
         other cases, :class:`KFold` is used.
 
@@ -370,7 +370,7 @@ def cross_val_score(estimator, X, y=None, *, groups=None, scoring=None,
         cross-validation strategies that can be used here.
 
         .. versionchanged:: 0.22
-            ``cv`` default value if None changed from 3-fold to 5-fold.
+            ``cv`` default value if ``None`` changed from 3-fold to 5-fold.
 
     n_jobs : int, default=None
         Number of jobs to run in parallel. Training the estimator and computing
@@ -391,7 +391,7 @@ def cross_val_score(estimator, X, y=None, *, groups=None, scoring=None,
         explosion of memory consumption when more jobs get dispatched
         than CPUs can process. This parameter can be:
 
-            - None, in which case all the jobs are immediately
+            - ``None``, in which case all the jobs are immediately
               created and spawned. Use this for lightweight and
               fast-running jobs, to avoid delays due to on-demand
               spawning of the jobs

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -7,6 +7,7 @@ functions to validate the model.
 #         Gael Varoquaux <gael.varoquaux@normalesup.org>
 #         Olivier Grisel <olivier.grisel@ensta.org>
 #         Raghav RV <rvraghav93@gmail.com>
+#         Michal Karbownik <michakarbownik@gmail.com>
 # License: BSD 3 clause
 
 
@@ -1102,18 +1103,18 @@ def permutation_test_score(estimator, X, y, *, groups=None, cv=None,
         A single str (see :ref:`scoring_parameter`) or a callable
         (see :ref:`scoring`) to evaluate the predictions on the test set.
 
-        If None the estimator's score method is used.
+        If ``None`` the estimator's score method is used.
 
     cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
-        - None, to use the default 5-fold cross validation,
+        - ``None``, to use the default 5-fold cross validation,
         - int, to specify the number of folds in a `(Stratified)KFold`,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For int/None inputs, if the estimator is a classifier and ``y`` is
+        For ``int``/``None`` inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
         other cases, :class:`KFold` is used.
 
@@ -1121,7 +1122,7 @@ def permutation_test_score(estimator, X, y, *, groups=None, cv=None,
         cross-validation strategies that can be used here.
 
         .. versionchanged:: 0.22
-            ``cv`` default value if None changed from 3-fold to 5-fold.
+            ``cv`` default value if ``None`` changed from 3-fold to 5-fold.
 
     n_permutations : int, default=100
         Number of times to permute ``y``.

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -352,18 +352,18 @@ def cross_val_score(estimator, X, y=None, *, groups=None, scoring=None,
         Similar to :func:`cross_validate`
         but only a single metric is permitted.
 
-        If ``None``, the estimator's default scorer (if available) is used.
+        If `None`, the estimator's default scorer (if available) is used.
 
     cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
-        - ``None``, to use the default 5-fold cross validation,
+        - `None`, to use the default 5-fold cross validation,
         - int, to specify the number of folds in a `(Stratified)KFold`,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For ``int``/``None`` inputs, if the estimator is a classifier and ``y`` is
+        For `int`/`None` inputs, if the estimator is a classifier and `y` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
         other cases, :class:`KFold` is used.
 
@@ -371,7 +371,7 @@ def cross_val_score(estimator, X, y=None, *, groups=None, scoring=None,
         cross-validation strategies that can be used here.
 
         .. versionchanged:: 0.22
-            ``cv`` default value if ``None`` changed from 3-fold to 5-fold.
+            `cv` default value if `None` changed from 3-fold to 5-fold.
 
     n_jobs : int, default=None
         Number of jobs to run in parallel. Training the estimator and computing
@@ -1103,18 +1103,18 @@ def permutation_test_score(estimator, X, y, *, groups=None, cv=None,
         A single str (see :ref:`scoring_parameter`) or a callable
         (see :ref:`scoring`) to evaluate the predictions on the test set.
 
-        If ``None`` the estimator's score method is used.
+        If `None` the estimator's score method is used.
 
     cv : int, cross-validation generator or an iterable, default=None
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 
-        - ``None``, to use the default 5-fold cross validation,
+        - `None`, to use the default 5-fold cross validation,
         - int, to specify the number of folds in a `(Stratified)KFold`,
         - :term:`CV splitter`,
         - An iterable yielding (train, test) splits as arrays of indices.
 
-        For ``int``/``None`` inputs, if the estimator is a classifier and ``y`` is
+        For `int`/`None` inputs, if the estimator is a classifier and `y` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
         other cases, :class:`KFold` is used.
 
@@ -1122,7 +1122,7 @@ def permutation_test_score(estimator, X, y, *, groups=None, cv=None,
         cross-validation strategies that can be used here.
 
         .. versionchanged:: 0.22
-            ``cv`` default value if ``None`` changed from 3-fold to 5-fold.
+            `cv` default value if `None` changed from 3-fold to 5-fold.
 
     n_permutations : int, default=100
         Number of times to permute ``y``.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR unifies the way `None` keyword is documented across metrics.

- There were `None` value missing from a group of possible values.
- Some `None` keywords were not displayed as code.