### PR TITLE
[MRG] FIX top_k_accuracy_score ignoring labels for "multiclass" case

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -153,6 +153,10 @@ Changelog
   :func:`metrics.mutual_info_score` with NumPy 1.20+.
   :pr:`19179` by `Thomas Fan`_.
 
+- |Fix| :func:`metrics.top_k_accuracy_score` now supports multiclass problems
+  where only two classes appear in `y_true` and all the classes are specified in
+  `labels`. :pr:`19721` by :user:`Joris Clement <flyingdutchman23>`
+
 :mod:`sklearn.semi_supervised`
 ..............................
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -59,6 +59,14 @@ Changelog
 - |Fix|: Fixed a bug in :class:`linear_model.LogisticRegression`: the
   sample_weight object is not modified anymore. :pr:`19182` by
   :user:`Yosuke KOBAYASHI <m7142yosuke>`.
+  
+:mod:`sklearn.metrics`
+......................
+
+- |Fix| :func:`metrics.top_k_accuracy_score` now supports multiclass
+  problems where only two classes appear in `y_true` and all the classes
+  are specified in `labels`.
+  :pr:`19721` by :user:`Joris Clement <flyingdutchman23>`.
 
 :mod:`sklearn.model_selection`
 ..............................
@@ -152,10 +160,6 @@ Changelog
   :func:`metrics.adjusted_mutual_info_score` and
   :func:`metrics.mutual_info_score` with NumPy 1.20+.
   :pr:`19179` by `Thomas Fan`_.
-
-- |Fix| :func:`metrics.top_k_accuracy_score` now supports multiclass problems
-  where only two classes appear in `y_true` and all the classes are specified in
-  `labels`. :pr:`19721` by :user:`Joris Clement <flyingdutchman23>`
 
 :mod:`sklearn.semi_supervised`
 ..............................

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1655,7 +1655,7 @@ def top_k_accuracy_score(y_true, y_score, *, k=2, normalize=True,
     y_true = check_array(y_true, ensure_2d=False, dtype=None)
     y_true = column_or_1d(y_true)
     y_type = type_of_target(y_true)
-    if y_type == "binary" and labels and len(labels) > 2:
+    if y_type == "binary" and labels is not None and len(labels) > 2:
         y_type = "multiclass"
     y_score = check_array(y_score, ensure_2d=False)
     y_score = column_or_1d(y_score) if y_type == 'binary' else y_score

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1655,6 +1655,8 @@ def top_k_accuracy_score(y_true, y_score, *, k=2, normalize=True,
     y_true = check_array(y_true, ensure_2d=False, dtype=None)
     y_true = column_or_1d(y_true)
     y_type = type_of_target(y_true)
+    if y_type == "binary" and labels and len(labels) > 2:
+        y_type = "multiclass"
     y_score = check_array(y_score, ensure_2d=False)
     y_score = column_or_1d(y_score) if y_type == 'binary' else y_score
     check_consistent_length(y_true, y_score, sample_weight)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1598,7 +1598,7 @@ def top_k_accuracy_score(y_true, y_score, *, k=2, normalize=True,
         non-thresholded decision values (as returned by
         :term:`decision_function` on some classifiers). The binary case expects
         scores with shape (n_samples,) while the multiclass case expects scores
-        with shape (n_samples, n_classes). In the nulticlass case, the order of
+        with shape (n_samples, n_classes). In the multiclass case, the order of
         the class scores must correspond to the order of ``labels``, if
         provided, or else to the numerical or lexicographical order of the
         labels in ``y_true``.

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1661,6 +1661,7 @@ def test_top_k_accuracy_score_binary(y_score, k, true_score):
     (np.array([0, 1, 1, 2]), 0.75, [0, 1, 2, 3]),
     (np.array([0, 1, 1, 1]), 0.5, [0, 1, 2, 3]),
     (np.array([1, 1, 1, 1]), 0.5, [0, 1, 2, 3]),
+    (np.array(['a', 'e', 'e', 'a']), 0.75, ['a', 'b', 'd', 'e']),
 ])
 def test_top_k_accuracy_score_multiclass_with_labels(
         y_true, true_score, labels

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1663,9 +1663,12 @@ def test_top_k_accuracy_score_binary(y_score, k, true_score):
     (np.array([1, 1, 1, 1]), 0.5, [0, 1, 2, 3]),
     (np.array(['a', 'e', 'e', 'a']), 0.75, ['a', 'b', 'd', 'e']),
 ])
+@pytest.mark.parametrize("labels_as_ndarray", [True, False])
 def test_top_k_accuracy_score_multiclass_with_labels(
-        y_true, true_score, labels
+        y_true, true_score, labels, labels_as_ndarray
 ):
+    if labels_as_ndarray:
+        labels = np.asarray(labels)
     y_score = np.array([
         [0.4, 0.3, 0.2, 0.1],
         [0.1, 0.3, 0.4, 0.2],

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1667,7 +1667,7 @@ def test_top_k_accuracy_score_binary(y_score, k, true_score):
 def test_top_k_accuracy_score_multiclass_with_labels(
         y_true, true_score, labels, labels_as_ndarray
 ):
-    """Test when y_true looks binary, but labels and y_score are multiclass."""
+    """Test when labels and y_score are multiclass."""
     if labels_as_ndarray:
         labels = np.asarray(labels)
     y_score = np.array([

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1667,6 +1667,7 @@ def test_top_k_accuracy_score_binary(y_score, k, true_score):
 def test_top_k_accuracy_score_multiclass_with_labels(
         y_true, true_score, labels, labels_as_ndarray
 ):
+    """Test when y_true looks binary, but labels and y_score are multiclass."""
     if labels_as_ndarray:
         labels = np.asarray(labels)
     y_score = np.array([

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1657,6 +1657,26 @@ def test_top_k_accuracy_score_binary(y_score, k, true_score):
     assert score == score_acc == pytest.approx(true_score)
 
 
+@pytest.mark.parametrize('y_true, true_score, labels', [
+    (np.array([0, 1, 2, 3]), 0.5, None),
+    (np.array([0, 1, 1, 2]), 0.75, [0, 1, 2, 3]),
+    (np.array([0, 1, 1, 1]), 0.5, [0, 1, 2, 3]),
+    (np.array([1, 1, 1, 1]), 0.5, [0, 1, 2, 3]),
+])
+def test_top_k_accuracy_score_multiclass_with_labels(
+        y_true, true_score, labels
+):
+    y_score = np.array([
+        [0.4, 0.3, 0.2, 0.1],
+        [0.1, 0.3, 0.4, 0.2],
+        [0.4, 0.1, 0.2, 0.3],
+        [0.3, 0.2, 0.4, 0.1],
+    ])
+
+    score = top_k_accuracy_score(y_true, y_score, k=2, labels=labels)
+    assert score == pytest.approx(true_score)
+
+
 def test_top_k_accuracy_score_increasing():
     # Make sure increasing k leads to a higher score
     X, y = datasets.make_classification(n_classes=10, n_samples=1000,

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1658,7 +1658,6 @@ def test_top_k_accuracy_score_binary(y_score, k, true_score):
 
 
 @pytest.mark.parametrize('y_true, true_score, labels', [
-    (np.array([0, 1, 2, 3]), 0.5, None),
     (np.array([0, 1, 1, 2]), 0.75, [0, 1, 2, 3]),
     (np.array([0, 1, 1, 1]), 0.5, [0, 1, 2, 3]),
     (np.array([1, 1, 1, 1]), 0.5, [0, 1, 2, 3]),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Same changes as #19300, which I accidentally closed, but can not reopen.

#### What does this implement/fix? Explain your changes.
See #19300 for these changes and review by @thomasjpfan. If wanted, I can copy that content here.

#### Any other comments?
I'm sorry for this extra work/confusion.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
