### PR TITLE
DOC Fix doc regarding required_parameters

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -641,7 +641,7 @@ In addition to the tags, estimators also need to declare any non-optional
 parameters to ``__init__`` in the ``_required_parameters`` class attribute,
 which is a list or tuple.  If ``_required_parameters`` is only
 ``["estimator"]`` or ``["base_estimator"]``, then the estimator will be
-instantiated with an instance of ``LinearDiscriminantAnalysis`` (or
+instantiated with an instance of ``LogisticRegression`` (or
 ``RidgeRegression`` if the estimator is a regressor) in the tests. The choice
 of these two models is somewhat idiosyncratic but both should provide robust
 closed-form solutions.


### PR DESCRIPTION
When estimator has a `(base)estimator(s)` required param, it's instanciated in the tests with Ridge for regression and LogisticRegression otherwise, see https://github.com/scikit-learn/scikit-learn/blob/071ddc75e92917d372f84e20a7fca15c1b7c6ca0/sklearn/utils/estimator_checks.py#L353