### PR TITLE
DOC Fix load iris datasets

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -166,6 +166,7 @@ options, including coloring nodes by their class (or value for regression) and
 using explicit variable and class names if desired. Jupyter notebooks also
 render these plots inline automatically::
 
+    >>> iris = load_iris()
     >>> dot_data = tree.export_graphviz(clf, out_file=None, # doctest: +SKIP
     ...                      feature_names=iris.feature_names,  # doctest: +SKIP
     ...                      class_names=iris.target_names,  # doctest: +SKIP

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -130,7 +130,8 @@ Using the Iris dataset, we can construct a tree as follows::
 
     >>> from sklearn.datasets import load_iris
     >>> from sklearn import tree
-    >>> X, y = load_iris(return_X_y=True)
+    >>> iris = load_iris()
+    >>> X, y = iris.data, iris.target
     >>> clf = tree.DecisionTreeClassifier()
     >>> clf = clf.fit(X, y)
 
@@ -166,7 +167,6 @@ options, including coloring nodes by their class (or value for regression) and
 using explicit variable and class names if desired. Jupyter notebooks also
 render these plots inline automatically::
 
-    >>> iris = load_iris()
     >>> dot_data = tree.export_graphviz(clf, out_file=None, # doctest: +SKIP
     ...                      feature_names=iris.feature_names,  # doctest: +SKIP
     ...                      class_names=iris.target_names,  # doctest: +SKIP


### PR DESCRIPTION
since the iris datasets is not defined above, the "name iris is not defined" error is thrown.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
