### PR TITLE
DOC Move Sacred to "Experimentation frameworks"

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -60,6 +60,9 @@ enhance the functionality of scikit-learn's estimators.
 
 **Experimentation frameworks**
 
+- `Sacred <https://github.com/IDSIA/Sacred>`_ Tool to help you configure,
+  organize, log and reproduce experiments
+
 - `REP <https://github.com/yandex/REP>`_ Environment for conducting data-driven
   research in a consistent and reproducible way
 
@@ -259,9 +262,6 @@ Other packages useful for data analysis and machine learning.
 
 - `PyMC <https://pymc-devs.github.io/pymc/>`_ Bayesian statistical models and
   fitting algorithms.
-
-- `Sacred <https://github.com/IDSIA/Sacred>`_ Tool to help you configure,
-  organize, log and reproduce experiments
 
 - `Seaborn <https://stanford.edu/~mwaskom/software/seaborn/>`_ Visualization library based on
   matplotlib. It provides a high-level interface for drawing attractive statistical graphics.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->


#### What does this implement/fix? Explain your changes.

Moves the link to the Sacred project from the *Statistical learning with Python* section to the *Experimentation frameworks*, because
> Sacred is a tool to help you configure, organize, log and reproduce experiments.