### PR TITLE
[FIX] Ridge.coef_ return a single dimension array when target type is not continuous-multiple

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -381,7 +381,7 @@ class LinearClassifierMixin(ClassifierMixin):
         X = self._validate_data(X, accept_sparse='csr', reset=False)
         scores = safe_sparse_dot(X, self.coef_.T,
                                  dense_output=True) + self.intercept_
-        return scores.ravel() if scores.shape[1] == 1 else scores
+        return scores.ravel() if (scores.ndim > 1 and scores.shape[1] == 1) else scores
 
     def predict(self, X):
         """

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -415,10 +415,8 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
     if y.ndim > 2:
         raise ValueError("Target y has the wrong shape %s" % str(y.shape))
 
-    ravel = False
     if y.ndim == 1:
         y = y.reshape(-1, 1)
-        ravel = True
 
     n_samples_, n_targets = y.shape
 
@@ -504,8 +502,7 @@ def _ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
                             ' inputs currently')
         coef = _solve_svd(X, y, alpha)
 
-    if ravel:
-        # When y was passed as a 1d-array, we flatten the coefficients.
+    if n_targets == 1:
         coef = coef.ravel()
 
     if return_n_iter and return_intercept:
@@ -1567,6 +1564,8 @@ class _RidgeGCV(LinearModel):
         self.best_score_ = best_score
         self.dual_coef_ = best_coef
         self.coef_ = safe_sparse_dot(self.dual_coef_.T, X)
+        if y.ndim == 1 or y.shape[1] == 1:
+            self.coef_ = self.coef_.ravel()
 
         X_offset += X_mean * X_scale
         self._set_intercept(X_offset, y_offset, X_scale)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -233,7 +233,7 @@ def test_ridge_shapes():
     assert ridge.intercept_.shape == ()
 
     ridge.fit(X, Y1)
-    assert ridge.coef_.shape == (1, n_features)
+    assert ridge.coef_.shape == (n_features,)
     assert ridge.intercept_.shape == (1, )
 
     ridge.fit(X, Y)
@@ -553,6 +553,8 @@ def test_ridge_gcv_sample_weights(
     ridge_reg = Ridge(alpha=kfold.alpha_, fit_intercept=fit_intercept)
     splits = cv.split(X_tiled, y_tiled, groups=indices)
     predictions = cross_val_predict(ridge_reg, X_tiled, y_tiled, cv=splits)
+    if predictions.shape != y_tiled.shape:
+        predictions = predictions.reshape(y_tiled.shape)
     kfold_errors = (y_tiled - predictions)**2
     kfold_errors = [
         np.sum(kfold_errors[indices == i], axis=0) for


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a fix to issue #19693 following the discussion from @thomasjpfan 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
