### PR TITLE
TST Changes assert to pytest style in tests/test_naive_bayes.py

### DIFF
--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -116,7 +116,7 @@ def test_gnb_neg_priors():
     """Test whether an error is raised in case of negative priors"""
     clf = GaussianNB(priors=np.array([-1., 2.]))
 
-    msg = re.escape('Priors must be non-negative.')
+    msg = 'Priors must be non-negative'
     with pytest.raises(ValueError, match=msg):
         clf.fit(X, y)
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -814,7 +814,7 @@ def test_alpha():
     X = np.array([[1, 0], [1, 1]])
     y = np.array([0, 1])
     nb = BernoulliNB(alpha=0.)
-    msg = re.escape(
+    msg = (
         "alpha too small will result in numeric errors,"
         " setting alpha = 1.0e-10"
     )

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -531,16 +531,18 @@ def test_mnb_prior_unobserved_targets():
 
     clf = MultinomialNB()
 
-    with pytest.warns(None):
+    with pytest.warns(None) as record:
         clf.partial_fit(X, y, classes=[0, 1, 2])
+    assert len(record) == 0
 
     assert clf.predict([[0, 1]]) == 0
     assert clf.predict([[1, 0]]) == 1
     assert clf.predict([[1, 1]]) == 0
 
     # add a training example with previously unobserved class
-    with pytest.warns(None):
+    with pytest.warns(None) as record:
         clf.partial_fit([[1, 1]], [2])
+    assert len(record) == 0
 
     assert clf.predict([[0, 1]]) == 0
     assert clf.predict([[1, 0]]) == 1

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -147,7 +147,7 @@ def test_gnb_wrong_nb_priors():
     from the number of class"""
     clf = GaussianNB(priors=np.array([.25, .25, .25, .25]))
 
-    msg = re.escape('Number of priors must match number of classes')
+    msg = 'Number of priors must match number of classes'
     with pytest.raises(ValueError, match=msg):
         clf.fit(X, y)
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -349,7 +349,7 @@ def test_discretenb_provide_prior(DiscreteNaiveBayes):
     with pytest.raises(ValueError, match=msg):
         clf.fit([[0], [1], [2]], [0, 1, 2])
 
-    msg = re.escape('is not the same as on last call to partial_fit')
+    msg = 'is not the same as on last call to partial_fit'
     with pytest.raises(ValueError, match=msg):
         clf.partial_fit([[0], [1]], [0, 1], classes=[0, 1, 1])
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -1,3 +1,4 @@
+import re
 
 import numpy as np
 import scipy.sparse
@@ -118,7 +119,10 @@ def test_gnb_sample_weight():
 def test_gnb_neg_priors():
     """Test whether an error is raised in case of negative priors"""
     clf = GaussianNB(priors=np.array([-1., 2.]))
-    assert_raises(ValueError, clf.fit, X, y)
+
+    msg = re.escape('Priors must be non-negative.')
+    with pytest.raises(ValueError, match=msg):
+        clf.fit(X, y)
 
 
 def test_gnb_priors():
@@ -146,13 +150,19 @@ def test_gnb_wrong_nb_priors():
     """ Test whether an error is raised if the number of prior is different
     from the number of class"""
     clf = GaussianNB(priors=np.array([.25, .25, .25, .25]))
-    assert_raises(ValueError, clf.fit, X, y)
+
+    msg = re.escape('Number of priors must match number of classes')
+    with pytest.raises(ValueError, match=msg):
+        clf.fit(X, y)
 
 
 def test_gnb_prior_greater_one():
     """Test if an error is raised if the sum of prior greater than one"""
     clf = GaussianNB(priors=np.array([2., 1.]))
-    assert_raises(ValueError, clf.fit, X, y)
+
+    msg = re.escape('The sum of the priors should be 1')
+    with pytest.raises(ValueError, match=msg):
+        clf.fit(X, y)
 
 
 def test_gnb_prior_large_bias():
@@ -339,9 +349,13 @@ def test_discretenb_provide_prior(DiscreteNaiveBayes):
     assert_array_almost_equal(prior, np.array([.5, .5]))
 
     # Inconsistent number of classes with prior
-    assert_raises(ValueError, clf.fit, [[0], [1], [2]], [0, 1, 2])
-    assert_raises(ValueError, clf.partial_fit, [[0], [1]], [0, 1],
-                  classes=[0, 1, 1])
+    msg_1 = re.escape('Number of priors must match number of classes')
+    with pytest.raises(ValueError, match=msg_1):
+        clf.fit([[0], [1], [2]], [0, 1, 2])
+
+    msg_2 = re.escape('is not the same as on last call to partial_fit')
+    with pytest.raises(ValueError, match=msg_2):
+        clf.partial_fit([[0], [1]], [0, 1], classes=[0, 1, 1])
 
 
 @pytest.mark.parametrize('DiscreteNaiveBayes', DISCRETE_NAIVE_BAYES_CLASSES)

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -156,7 +156,7 @@ def test_gnb_prior_greater_one():
     """Test if an error is raised if the sum of prior greater than one"""
     clf = GaussianNB(priors=np.array([2., 1.]))
 
-    msg = re.escape('The sum of the priors should be 1')
+    msg = 'The sum of the priors should be 1'
     with pytest.raises(ValueError, match=msg):
         clf.fit(X, y)
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -345,12 +345,12 @@ def test_discretenb_provide_prior(DiscreteNaiveBayes):
     assert_array_almost_equal(prior, np.array([.5, .5]))
 
     # Inconsistent number of classes with prior
-    msg_1 = re.escape('Number of priors must match number of classes')
-    with pytest.raises(ValueError, match=msg_1):
+    msg = re.escape('Number of priors must match number of classes')
+    with pytest.raises(ValueError, match=msg):
         clf.fit([[0], [1], [2]], [0, 1, 2])
 
-    msg_2 = re.escape('is not the same as on last call to partial_fit')
-    with pytest.raises(ValueError, match=msg_2):
+    msg = re.escape('is not the same as on last call to partial_fit')
+    with pytest.raises(ValueError, match=msg):
         clf.partial_fit([[0], [1]], [0, 1], classes=[0, 1, 1])
 
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -898,7 +898,7 @@ def test_alpha_vector():
     # Test alpha non-negative
     alpha = np.array([1., -0.1])
     m_nb = MultinomialNB(alpha=alpha)
-    expected_msg = re.escape(
+    expected_msg = (
         'Smoothing parameter alpha = -1.0e-01. alpha should be > 0.'
     )
     with pytest.raises(ValueError, match=expected_msg):

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -345,7 +345,7 @@ def test_discretenb_provide_prior(DiscreteNaiveBayes):
     assert_array_almost_equal(prior, np.array([.5, .5]))
 
     # Inconsistent number of classes with prior
-    msg = re.escape('Number of priors must match number of classes')
+    msg = 'Number of priors must match number of classes'
     with pytest.raises(ValueError, match=msg):
         clf.fit([[0], [1], [2]], [0, 1, 2])
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -481,7 +481,7 @@ def test_mnnb(kind):
     # Check the ability to predict the learning set.
     clf = MultinomialNB()
 
-    msg = re.escape('Negative values in data passed to')
+    msg = 'Negative values in data passed to'
     with pytest.raises(ValueError, match=msg):
         clf.fit(-X, y2)
     y_pred = clf.fit(X, y2).predict(X)


### PR DESCRIPTION
Reference Issues/PRs
References #14216

What does this implement/fix? Explain your changes.
Changed the assert_raises, assert_message, assert_warns in tests/test_naive_bayes.py to pytest.raises().
Added additional message checks for tests that seemed like could benefit from further clarification.