### PR TITLE
fix for segmentation fault with SVC with probability = True and degree 3

### DIFF
--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -2460,13 +2460,16 @@ PREFIX(model) *PREFIX(train)(const PREFIX(problem) *prob, const svm_parameter *p
 		bool *nonzero = Malloc(bool,l);
 		for(i=0;i<l;i++)
 			nonzero[i] = false;
-                NAMESPACE::decision_function *f = Malloc(NAMESPACE::decision_function,nr_class*(nr_class-1)/2);
+
+                long malSize = (long)nr_class*(long)(nr_class-1)/2;
+
+                NAMESPACE::decision_function *f = Malloc(NAMESPACE::decision_function,malSize);
 
 		double *probA=NULL,*probB=NULL;
 		if (param->probability)
 		{
-			probA=Malloc(double,nr_class*(nr_class-1)/2);
-			probB=Malloc(double,nr_class*(nr_class-1)/2);
+                       probA=Malloc(double,malSize);
+                       probB=Malloc(double,malSize);
 		}
 
 		int p = 0;

--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -2230,11 +2230,11 @@ static double svm_svr_probability(
 
 // label: label name, start: begin of each class, count: #data of classes, perm: indices to the original data
 // perm, length l, must be allocated before calling this subroutine
-static void svm_group_classes(const PREFIX(problem) *prob, long *nr_class_ret, int **label_ret, int **start_ret, int **count_ret, int *perm)
+static void svm_group_classes(const PREFIX(problem) *prob, long long int *nr_class_ret, int **label_ret, int **start_ret, int **count_ret, int *perm)
 {
 	int l = prob->l;
 	int max_nr_class = 16;
-	long nr_class = 0;
+	long long int nr_class = 0;
 	int *label = Malloc(int,max_nr_class);
 	int *count = Malloc(int,max_nr_class);
 	int *data_label = Malloc(int,l);	
@@ -2416,7 +2416,7 @@ PREFIX(model) *PREFIX(train)(const PREFIX(problem) *prob, const svm_parameter *p
 	{
 		// classification
 		int l = prob->l;
-		long nr_class;
+		long long int nr_class;
 		int *label = NULL;
 		int *start = NULL;
 		int *count = NULL;
@@ -2639,7 +2639,7 @@ void PREFIX(cross_validation)(const PREFIX(problem) *prob, const svm_parameter *
 	int *fold_start = Malloc(int,nr_fold+1);
 	int l = prob->l;
 	int *perm = Malloc(int,l);
-	long nr_class;
+	long long int nr_class;
     if(param->random_seed >= 0)
     {
         set_seed(param->random_seed);
@@ -2886,7 +2886,7 @@ double PREFIX(predict_values)(const PREFIX(model) *model, const PREFIX(node) *x,
 
 double PREFIX(predict)(const PREFIX(model) *model, const PREFIX(node) *x, BlasFunctions *blas_functions)
 {
-	long nr_class = (long)model->nr_class;
+	long long int nr_class = (long long int)model->nr_class;
 	double *dec_values;
 	if(model->param.svm_type == ONE_CLASS ||
 	   model->param.svm_type == EPSILON_SVR ||
@@ -2906,7 +2906,7 @@ double PREFIX(predict_probability)(
 	    model->probA!=NULL && model->probB!=NULL)
 	{
 		int i;
-		long nr_class = (long)model->nr_class;
+		long long int nr_class = (long long int)model->nr_class;
 		double *dec_values = Malloc(double, nr_class*(nr_class-1)/2);
 		PREFIX(predict_values)(model, x, dec_values, blas_functions);
 

--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -2230,11 +2230,11 @@ static double svm_svr_probability(
 
 // label: label name, start: begin of each class, count: #data of classes, perm: indices to the original data
 // perm, length l, must be allocated before calling this subroutine
-static void svm_group_classes(const PREFIX(problem) *prob, long long int *nr_class_ret, int **label_ret, int **start_ret, int **count_ret, int *perm)
+static void svm_group_classes(const PREFIX(problem) *prob, int64_t *nr_class_ret, int **label_ret, int **start_ret, int **count_ret, int *perm)
 {
 	int l = prob->l;
 	int max_nr_class = 16;
-	long long int nr_class = 0;
+	int64_t nr_class = 0;
 	int *label = Malloc(int,max_nr_class);
 	int *count = Malloc(int,max_nr_class);
 	int *data_label = Malloc(int,l);	
@@ -2416,7 +2416,7 @@ PREFIX(model) *PREFIX(train)(const PREFIX(problem) *prob, const svm_parameter *p
 	{
 		// classification
 		int l = prob->l;
-		long long int nr_class;
+		int64_t nr_class;
 		int *label = NULL;
 		int *start = NULL;
 		int *count = NULL;
@@ -2639,7 +2639,7 @@ void PREFIX(cross_validation)(const PREFIX(problem) *prob, const svm_parameter *
 	int *fold_start = Malloc(int,nr_fold+1);
 	int l = prob->l;
 	int *perm = Malloc(int,l);
-	long long int nr_class;
+	int64_t nr_class;
     if(param->random_seed >= 0)
     {
         set_seed(param->random_seed);
@@ -2886,7 +2886,7 @@ double PREFIX(predict_values)(const PREFIX(model) *model, const PREFIX(node) *x,
 
 double PREFIX(predict)(const PREFIX(model) *model, const PREFIX(node) *x, BlasFunctions *blas_functions)
 {
-	long long int nr_class = (long long int)model->nr_class;
+	int64_t nr_class = (int64_t)model->nr_class;
 	double *dec_values;
 	if(model->param.svm_type == ONE_CLASS ||
 	   model->param.svm_type == EPSILON_SVR ||
@@ -2906,7 +2906,7 @@ double PREFIX(predict_probability)(
 	    model->probA!=NULL && model->probB!=NULL)
 	{
 		int i;
-		long long int nr_class = (long long int)model->nr_class;
+		int64_t nr_class = (int64_t)model->nr_class;
 		double *dec_values = Malloc(double, nr_class*(nr_class-1)/2);
 		PREFIX(predict_values)(model, x, dec_values, blas_functions);
 

--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -2230,11 +2230,11 @@ static double svm_svr_probability(
 
 // label: label name, start: begin of each class, count: #data of classes, perm: indices to the original data
 // perm, length l, must be allocated before calling this subroutine
-static void svm_group_classes(const PREFIX(problem) *prob, int *nr_class_ret, int **label_ret, int **start_ret, int **count_ret, int *perm)
+static void svm_group_classes(const PREFIX(problem) *prob, long *nr_class_ret, int **label_ret, int **start_ret, int **count_ret, int *perm)
 {
 	int l = prob->l;
 	int max_nr_class = 16;
-	int nr_class = 0;
+	long nr_class = 0;
 	int *label = Malloc(int,max_nr_class);
 	int *count = Malloc(int,max_nr_class);
 	int *data_label = Malloc(int,l);	
@@ -2416,7 +2416,7 @@ PREFIX(model) *PREFIX(train)(const PREFIX(problem) *prob, const svm_parameter *p
 	{
 		// classification
 		int l = prob->l;
-		int nr_class;
+		long nr_class;
 		int *label = NULL;
 		int *start = NULL;
 		int *count = NULL;
@@ -2460,16 +2460,13 @@ PREFIX(model) *PREFIX(train)(const PREFIX(problem) *prob, const svm_parameter *p
 		bool *nonzero = Malloc(bool,l);
 		for(i=0;i<l;i++)
 			nonzero[i] = false;
-
-                long malSize = (long)nr_class*(long)(nr_class-1)/2;
-
-                NAMESPACE::decision_function *f = Malloc(NAMESPACE::decision_function,malSize);
+                NAMESPACE::decision_function *f = Malloc(NAMESPACE::decision_function,nr_class*(nr_class-1)/2);
 
 		double *probA=NULL,*probB=NULL;
 		if (param->probability)
 		{
-                       probA=Malloc(double,malSize);
-                       probB=Malloc(double,malSize);
+			probA=Malloc(double,nr_class*(nr_class-1)/2);
+			probB=Malloc(double,nr_class*(nr_class-1)/2);
 		}
 
 		int p = 0;
@@ -2642,7 +2639,7 @@ void PREFIX(cross_validation)(const PREFIX(problem) *prob, const svm_parameter *
 	int *fold_start = Malloc(int,nr_fold+1);
 	int l = prob->l;
 	int *perm = Malloc(int,l);
-	int nr_class;
+	long nr_class;
     if(param->random_seed >= 0)
     {
         set_seed(param->random_seed);
@@ -2889,7 +2886,7 @@ double PREFIX(predict_values)(const PREFIX(model) *model, const PREFIX(node) *x,
 
 double PREFIX(predict)(const PREFIX(model) *model, const PREFIX(node) *x, BlasFunctions *blas_functions)
 {
-	int nr_class = model->nr_class;
+	long nr_class = (long)model->nr_class;
 	double *dec_values;
 	if(model->param.svm_type == ONE_CLASS ||
 	   model->param.svm_type == EPSILON_SVR ||
@@ -2909,7 +2906,7 @@ double PREFIX(predict_probability)(
 	    model->probA!=NULL && model->probB!=NULL)
 	{
 		int i;
-		int nr_class = model->nr_class;
+		long nr_class = (long)model->nr_class;
 		double *dec_values = Malloc(double, nr_class*(nr_class-1)/2);
 		PREFIX(predict_values)(model, x, dec_values, blas_functions);
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #15008
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixes an integer overflow when `nr_classes` gets too large. Causes issues when mallocing something of size `nr_classes*(nr_classes-1)/2`

Short C++ example demonstrating the issue
```
#include <iostream>

using namespace std;

int main()
{
  int nr_classes = 397882; // values for nr_classes on some runs
  long malSize = (long)nr_classes*(long)(nr_classes-1)/2;
  printf("%d", nr_classes*(nr_classes-1)/2);
  printf("\n%lu",malSize);
}
```


#### Any other comments?
First PR for scikit so not super familiar with the process. Please suggest any changes, Thanks! 🙂  

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
