### PR TITLE
API Adds predict_params for Pipeline proba delegates

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -249,6 +249,14 @@ Changelog
   Use ``var_`` instead.
   :pr:`18842` by :user:`Hong Shao Yang <hongshaoyang>`.
 
+:mod:`sklearn.pipeline`
+.......................
+
+- |API| The `predict_proba` and `predict_log_proba` methods of the
+  :class:`Pipeline` class now support passing prediction kwargs to
+  the final estimator.
+  :pr:`19790` by :user:`Christopher Flynn <crflynn>`.
+
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -456,7 +456,7 @@ class Pipeline(_BaseComposition):
         return y_pred
 
     @if_delegate_has_method(delegate='_final_estimator')
-    def predict_proba(self, X):
+    def predict_proba(self, X, **predict_params):
         """Apply transforms, and predict_proba of the final estimator
 
         Parameters
@@ -465,6 +465,10 @@ class Pipeline(_BaseComposition):
             Data to predict on. Must fulfill input requirements of first step
             of the pipeline.
 
+        **predict_params : dict of string -> object
+            Parameters to the ``predict_proba`` called at the end of all
+            transformations in the pipeline.
+
         Returns
         -------
         y_proba : array-like of shape (n_samples, n_classes)
@@ -472,7 +476,7 @@ class Pipeline(_BaseComposition):
         Xt = X
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict_proba(Xt)
+        return self.steps[-1][-1].predict_proba(Xt, **predict_params)
 
     @if_delegate_has_method(delegate='_final_estimator')
     def decision_function(self, X):
@@ -513,7 +517,7 @@ class Pipeline(_BaseComposition):
         return self.steps[-1][-1].score_samples(Xt)
 
     @if_delegate_has_method(delegate='_final_estimator')
-    def predict_log_proba(self, X):
+    def predict_log_proba(self, X, **predict_params):
         """Apply transforms, and predict_log_proba of the final estimator
 
         Parameters
@@ -522,6 +526,10 @@ class Pipeline(_BaseComposition):
             Data to predict on. Must fulfill input requirements of first step
             of the pipeline.
 
+        **predict_params : dict of string -> object
+            Parameters to the ``predict_log_proba`` called at the end of all
+            transformations in the pipeline.
+
         Returns
         -------
         y_score : array-like of shape (n_samples, n_classes)
@@ -529,7 +537,7 @@ class Pipeline(_BaseComposition):
         Xt = X
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict_log_proba(Xt)
+        return self.steps[-1][-1].predict_log_proba(Xt, **predict_params)
 
     @property
     def transform(self):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -456,7 +456,7 @@ class Pipeline(_BaseComposition):
         return y_pred
 
     @if_delegate_has_method(delegate='_final_estimator')
-    def predict_proba(self, X, **predict_params):
+    def predict_proba(self, X, **predict_proba_params):
         """Apply transforms, and predict_proba of the final estimator
 
         Parameters
@@ -465,7 +465,7 @@ class Pipeline(_BaseComposition):
             Data to predict on. Must fulfill input requirements of first step
             of the pipeline.
 
-        **predict_params : dict of string -> object
+        **predict_proba_params : dict of string -> object
             Parameters to the ``predict_proba`` called at the end of all
             transformations in the pipeline.
 
@@ -476,7 +476,7 @@ class Pipeline(_BaseComposition):
         Xt = X
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict_proba(Xt, **predict_params)
+        return self.steps[-1][-1].predict_proba(Xt, **predict_proba_params)
 
     @if_delegate_has_method(delegate='_final_estimator')
     def decision_function(self, X):
@@ -517,7 +517,7 @@ class Pipeline(_BaseComposition):
         return self.steps[-1][-1].score_samples(Xt)
 
     @if_delegate_has_method(delegate='_final_estimator')
-    def predict_log_proba(self, X, **predict_params):
+    def predict_log_proba(self, X, **predict_log_proba_params):
         """Apply transforms, and predict_log_proba of the final estimator
 
         Parameters
@@ -526,7 +526,7 @@ class Pipeline(_BaseComposition):
             Data to predict on. Must fulfill input requirements of first step
             of the pipeline.
 
-        **predict_params : dict of string -> object
+        **predict_log_proba_params : dict of string -> object
             Parameters to the ``predict_log_proba`` called at the end of all
             transformations in the pipeline.
 
@@ -537,7 +537,9 @@ class Pipeline(_BaseComposition):
         Xt = X
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict_log_proba(Xt, **predict_params)
+        return self.steps[-1][-1].predict_log_proba(
+            Xt, **predict_log_proba_params
+        )
 
     @property
     def transform(self):

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -457,32 +457,16 @@ def test_fit_predict_with_intermediate_fit_params():
     assert 'should_succeed' not in pipe.named_steps['transf'].fit_params
 
 
-def test_predict_with_predict_params():
-    # tests that Pipeline passes predict_params to the final estimator
-    # when predict is invoked
+@pytest.mark.parametrize("method_name", [
+    "predict", "predict_proba", "predict_log_proba"
+])
+def test_predict_methods_with_predict_params(method_name):
+    # tests that Pipeline passes predict_* to the final estimator
+    # when predict_* is invoked
     pipe = Pipeline([('transf', Transf()), ('clf', DummyEstimatorParams())])
     pipe.fit(None, None)
-    pipe.predict(X=None, got_attribute=True)
-
-    assert pipe.named_steps['clf'].got_attribute
-
-
-def test_predict_proba_with_predict_params():
-    # tests that Pipeline passes predict_params to the final estimator
-    # when predict is invoked
-    pipe = Pipeline([('transf', Transf()), ('clf', DummyEstimatorParams())])
-    pipe.fit(None, None)
-    pipe.predict_proba(X=None, got_attribute=True)
-
-    assert pipe.named_steps['clf'].got_attribute
-
-
-def test_predict_log_proba_with_predict_params():
-    # tests that Pipeline passes predict_params to the final estimator
-    # when predict is invoked
-    pipe = Pipeline([('transf', Transf()), ('clf', DummyEstimatorParams())])
-    pipe.fit(None, None)
-    pipe.predict_log_proba(X=None, got_attribute=True)
+    method = getattr(pipe, method_name)
+    method(X=None, got_attribute=True)
 
     assert pipe.named_steps['clf'].got_attribute
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -160,6 +160,14 @@ class DummyEstimatorParams(BaseEstimator):
         self.got_attribute = got_attribute
         return self
 
+    def predict_proba(self, X, got_attribute=False):
+        self.got_attribute = got_attribute
+        return self
+
+    def predict_log_proba(self, X, got_attribute=False):
+        self.got_attribute = got_attribute
+        return self
+
 
 def test_pipeline_init():
     # Test the various init parameters of the pipeline.
@@ -455,6 +463,26 @@ def test_predict_with_predict_params():
     pipe = Pipeline([('transf', Transf()), ('clf', DummyEstimatorParams())])
     pipe.fit(None, None)
     pipe.predict(X=None, got_attribute=True)
+
+    assert pipe.named_steps['clf'].got_attribute
+
+
+def test_predict_proba_with_predict_params():
+    # tests that Pipeline passes predict_params to the final estimator
+    # when predict is invoked
+    pipe = Pipeline([('transf', Transf()), ('clf', DummyEstimatorParams())])
+    pipe.fit(None, None)
+    pipe.predict_proba(X=None, got_attribute=True)
+
+    assert pipe.named_steps['clf'].got_attribute
+
+
+def test_predict_log_proba_with_predict_params():
+    # tests that Pipeline passes predict_params to the final estimator
+    # when predict is invoked
+    pipe = Pipeline([('transf', Transf()), ('clf', DummyEstimatorParams())])
+    pipe.fit(None, None)
+    pipe.predict_log_proba(X=None, got_attribute=True)
 
     assert pipe.named_steps['clf'].got_attribute
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Implements some of the changes discussed in #12006.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Extends the `**predict_params` functionality of `Pipeline.predict` to `Pipeline.predict_proba` and `Pipeline.predict_log_proba`.


#### Any other comments?

As noted in #12006, there is currently no use case for this within sklearn. However, given the extensibility of the library and implementations in [lightgbm](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html#lightgbm.LGBMClassifier.predict_proba) and [xgboost](https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.predict_proba) it seems appropriate and provides a consistent signature across predict delegates.

I'd be happy to implement similar changes for the `decision_function` delegate as well if requested.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
