### PR TITLE
MNT Remove HistGradientBoosting from experimental

### DIFF
--- a/asv_benchmarks/benchmarks/ensemble.py
+++ b/asv_benchmarks/benchmarks/ensemble.py
@@ -1,4 +1,3 @@
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import (RandomForestClassifier,
                               GradientBoostingClassifier,
                               HistGradientBoostingClassifier)

--- a/benchmarks/bench_hist_gradient_boosting.py
+++ b/benchmarks/bench_hist_gradient_boosting.py
@@ -4,8 +4,6 @@ import argparse
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.model_selection import train_test_split
-# To use this experimental feature, we need to explicitly ask for it:
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.datasets import make_classification

--- a/benchmarks/bench_hist_gradient_boosting_adult.py
+++ b/benchmarks/bench_hist_gradient_boosting_adult.py
@@ -4,7 +4,6 @@ from time import time
 from sklearn.model_selection import train_test_split
 from sklearn.datasets import fetch_openml
 from sklearn.metrics import accuracy_score, roc_auc_score
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.ensemble._hist_gradient_boosting.utils import (
     get_equivalent_estimator)

--- a/benchmarks/bench_hist_gradient_boosting_categorical_only.py
+++ b/benchmarks/bench_hist_gradient_boosting_categorical_only.py
@@ -3,7 +3,6 @@ from time import time
 
 from sklearn.preprocessing import KBinsDiscretizer
 from sklearn.datasets import make_classification
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.ensemble._hist_gradient_boosting.utils import (
     get_equivalent_estimator)

--- a/benchmarks/bench_hist_gradient_boosting_higgsboson.py
+++ b/benchmarks/bench_hist_gradient_boosting_higgsboson.py
@@ -9,8 +9,6 @@ import pandas as pd
 from joblib import Memory
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, roc_auc_score
-# To use this experimental feature, we need to explicitly ask for it:
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.ensemble._hist_gradient_boosting.utils import (
     get_equivalent_estimator)

--- a/benchmarks/bench_hist_gradient_boosting_threading.py
+++ b/benchmarks/bench_hist_gradient_boosting_threading.py
@@ -7,8 +7,6 @@ import numpy as np
 from threadpoolctl import threadpool_limits
 import sklearn
 from sklearn.model_selection import train_test_split
-# To use this experimental feature, we need to explicitly ask for it:
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.datasets import make_classification

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -358,7 +358,6 @@ carousel_thumbs = {'sphx_glr_plot_classifier_comparison_001.png': 600}
 
 # enable experimental module so that experimental estimators can be
 # discovered properly by sphinx
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.experimental import enable_iterative_imputer  # noqa
 from sklearn.experimental import enable_halving_search_cv  # noqa
 

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -415,6 +415,9 @@ Once the feature become stable, remove all `enable_my_experimental_feature`
 in the scikit-learn code (even feature highlights etc.) and make the
 `enable_my_experimental_feature` a no-op that just raises a warning:
 `enable_hist_gradient_boosting.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_hist_gradient_boosting.py>`__,
-and update the tests accordingly `test_enable_hist_gradient_boosting.py
+<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_hist_gradient_boosting.py>`__.
+The file should stay there indefinitely as we don't want to break users code:
+we just incentive them to remove that import with the warning.
+
+Also update the tests accordingly: `test_enable_hist_gradient_boosting.py
 <https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`__.

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -417,7 +417,7 @@ in the scikit-learn code (even feature highlights etc.) and make the
 `enable_hist_gradient_boosting.py
 <https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_hist_gradient_boosting.py>`__.
 The file should stay there indefinitely as we don't want to break users code:
-we just incentive them to remove that import with the warning.
+we just incentivize them to remove that import with the warning.
 
 Also update the tests accordingly: `test_enable_hist_gradient_boosting.py
 <https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`__.

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -372,7 +372,8 @@ or
 
   These are permalink as in 0.24, where these estimators are still
   experimental. They might be stable at the time of reading - hence the
-  permalink. See below for instructions on the transition to experimental to stable.
+  permalink. See below for instructions on the transition from experimental
+  to stable.
 
 Note that the public import path must be to a public subpackage (like
 ``sklearn/ensemble`` or ``sklearn/impute``), not just a ``.py`` module.
@@ -399,8 +400,8 @@ Make sure every user-facing code you write explicitly mentions that the feature
 is experimental, and add a ``# noqa`` comment to avoid pep8-related warnings::
 
     # To use this experimental feature, we need to explicitly ask for it:
-    from sklearn.experimental import enable_hist_gradient_boosting# noqa
-    from sklearn.ensemble import HistGradientBoostingClassifier
+    from sklearn.experimental import enable_hist_gradient_boosting  # noqa
+    from sklearn.ensemble import HistGradientBoostingRegressor
 
 For the docs to render properly, please also import
 ``enable_my_experimental_feature`` in ``doc/conf.py``, else sphinx won't be

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -412,7 +412,7 @@ Note that some experimental classes / functions are not included in the
 Once the feature become stable, remove all `enable_my_experimental_feature`
 in the scikit-learn code (even feature highlights etc.) and make the
 `enable_my_experimental_feature` a no-op that just raises a warning:
-`test_enable_hist_gradient_boosting.py
+`enable_hist_gradient_boosting.py
 <https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_hist_gradient_boosting.py>`_,
 and update the tests accordingly `test_enable_hist_gradient_boosting.py
 <https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`_.

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -363,7 +363,7 @@ deprecation cycle.
 
 To create an experimental module, you can just copy and modify the content of
 `enable_hist_gradient_boosting.py
-<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/enable_hist_gradient_boosting.py>`_,
+<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/enable_hist_gradient_boosting.py>`__,
 or
 `enable_iterative_imputer.py
 <https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/enable_iterative_imputer.py>`_.
@@ -415,6 +415,6 @@ Once the feature become stable, remove all `enable_my_experimental_feature`
 in the scikit-learn code (even feature highlights etc.) and make the
 `enable_my_experimental_feature` a no-op that just raises a warning:
 `enable_hist_gradient_boosting.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_hist_gradient_boosting.py>`_,
+<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_hist_gradient_boosting.py>`__,
 and update the tests accordingly `test_enable_hist_gradient_boosting.py
 <https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`__.

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -396,12 +396,10 @@ Please also write basic tests following those in
 <https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`_.
 
 
-Make sure every user-facing code you write explicitly mentions that the feature
-is experimental, and add a ``# noqa`` comment to avoid pep8-related warnings::
-
-    # To use this experimental feature, we need to explicitly ask for it:
-    from sklearn.experimental import enable_hist_gradient_boosting  # noqa
-    from sklearn.ensemble import HistGradientBoostingRegressor
+Make sure every user-facing code you write explicitly mentions that the
+feature is experimental, and add a ``# noqa`` comment to avoid pep8-related
+warnings, as done `here
+<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/enable_hist_gradient_boosting.py#L11-L15>`_.
 
 For the docs to render properly, please also import
 ``enable_my_experimental_feature`` in ``doc/conf.py``, else sphinx won't be

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -362,8 +362,8 @@ experimental features / estimators that are subject to change without
 deprecation cycle.
 
 To create an experimental module, you can just copy and modify the content of
-`enable_hist_gradient_boosting.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_hist_gradient_boosting.py>`_,
+`enable_halving_search_cv.py
+<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_halving_search_cv.py>`_,
 or
 `enable_iterative_imputer.py
 <https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_iterative_imputer.py>`_.
@@ -372,7 +372,7 @@ Note that the public import path must be to a public subpackage (like
 ``sklearn/ensemble`` or ``sklearn/impute``), not just a ``.py`` module.
 Also, the (private) experimental features that are imported must be in a
 submodule/subpackage of the public subpackage, e.g.
-``sklearn/ensemble/_hist_gradient_boosting/`` or
+``sklearn/ensemble/_halving_search_cv/`` or
 ``sklearn/impute/_iterative.py``. This is needed so that pickles still work
 in the future when the features aren't experimental anymore.
 
@@ -385,15 +385,15 @@ or `sklearn/impute/__init__.py
 for an example.
 
 Please also write basic tests following those in
-`test_enable_hist_gradient_boosting.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`_.
+`test_enable_halving_search_cv.py
+<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_halving_search_cv.py>`_.
 
 Make sure every user-facing code you write explicitly mentions that the feature
 is experimental, and add a ``# noqa`` comment to avoid pep8-related warnings::
 
     # To use this experimental feature, we need to explicitly ask for it:
-    from sklearn.experimental import enable_hist_gradient_boosting  # noqa
-    from sklearn.ensemble import HistGradientBoostingRegressor
+    from sklearn.experimental import enable_halving_search_cv  # noqa
+    from sklearn.model_selection import HalvingGridSearchCV
 
 For the docs to render properly, please also import
 ``enable_my_experimental_feature`` in ``doc/conf.py``, else sphinx won't be

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -362,38 +362,45 @@ experimental features / estimators that are subject to change without
 deprecation cycle.
 
 To create an experimental module, you can just copy and modify the content of
-`enable_halving_search_cv.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_halving_search_cv.py>`_,
+`enable_hist_gradient_boosting.py
+<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/enable_hist_gradient_boosting.py>`_,
 or
 `enable_iterative_imputer.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_iterative_imputer.py>`_.
+<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/enable_iterative_imputer.py>`_.
+
+.. note::
+
+  These are permalink as in 0.24, where these estimators are still
+  experimental. They might be stable at the time of reading - hence the
+  permalink. See below for instructions on the transition to experimental to stable.
 
 Note that the public import path must be to a public subpackage (like
 ``sklearn/ensemble`` or ``sklearn/impute``), not just a ``.py`` module.
 Also, the (private) experimental features that are imported must be in a
 submodule/subpackage of the public subpackage, e.g.
-``sklearn/ensemble/_halving_search_cv/`` or
+``sklearn/ensemble/_hist_gradient_boosting/`` or
 ``sklearn/impute/_iterative.py``. This is needed so that pickles still work
 in the future when the features aren't experimental anymore.
 
 To avoid type checker (e.g. mypy) errors a direct import of experimental
 estimators should be done in the parent module, protected by the
 ``if typing.TYPE_CHECKING`` check. See `sklearn/ensemble/__init__.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/ensemble/__init__.py>`_,
+<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/ensemble/__init__.py>`_,
 or `sklearn/impute/__init__.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/impute/__init__.py>`_
+<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/impute/__init__.py>`_
 for an example.
 
 Please also write basic tests following those in
-`test_enable_halving_search_cv.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_halving_search_cv.py>`_.
+`test_enable_hist_gradient_boosting.py
+<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`_.
+
 
 Make sure every user-facing code you write explicitly mentions that the feature
 is experimental, and add a ``# noqa`` comment to avoid pep8-related warnings::
 
     # To use this experimental feature, we need to explicitly ask for it:
-    from sklearn.experimental import enable_halving_search_cv  # noqa
-    from sklearn.model_selection import HalvingGridSearchCV
+    from sklearn.experimental import enable_hist_gradient_boosting# noqa
+    from sklearn.ensemble import HistGradientBoostingClassifier
 
 For the docs to render properly, please also import
 ``enable_my_experimental_feature`` in ``doc/conf.py``, else sphinx won't be
@@ -402,3 +409,11 @@ sklearn.experimental import *`` **does not work**.
 
 Note that some experimental classes / functions are not included in the
 :mod:`sklearn.experimental` module: ``sklearn.datasets.fetch_openml``.
+
+Once the feature become stable, remove all `enable_my_ecperimental_feature`
+in the scikit-learn code (even feature highlights etc.) and make the
+`enable_my_experimental_feature` a no-op that just raises a warning:
+`test_enable_hist_gradient_boosting.py
+<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_hist_gradient_boosting.py>`_,
+and update the tests accordingly `test_enable_hist_gradient_boosting.py
+<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`_.

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -393,13 +393,15 @@ for an example.
 
 Please also write basic tests following those in
 `test_enable_hist_gradient_boosting.py
-<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`_.
+<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`__.
 
 
-Make sure every user-facing code you write explicitly mentions that the
-feature is experimental, and add a ``# noqa`` comment to avoid pep8-related
-warnings, as done `here
-<https://github.com/scikit-learn/scikit-learn/blob/c9c89cfc85dd8dfefd7921c16c87327d03140a06/sklearn/experimental/enable_hist_gradient_boosting.py#L11-L15>`_.
+Make sure every user-facing code you write explicitly mentions that the feature
+is experimental, and add a ``# noqa`` comment to avoid pep8-related warnings::
+
+    # To use this experimental feature, we need to explicitly ask for it:
+    from sklearn.experimental import enable_hist_gradient_boosting  # noqa
+    from sklearn.ensemble import HistGradientBoostingRegressor
 
 For the docs to render properly, please also import
 ``enable_my_experimental_feature`` in ``doc/conf.py``, else sphinx won't be
@@ -412,7 +414,7 @@ Note that some experimental classes / functions are not included in the
 Once the feature become stable, remove all `enable_my_experimental_feature`
 in the scikit-learn code (even feature highlights etc.) and make the
 `enable_my_experimental_feature` a no-op that just raises a warning:
-`test_enable_hist_gradient_boosting.py
+`enable_hist_gradient_boosting.py
 <https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/enable_hist_gradient_boosting.py>`_,
 and update the tests accordingly `test_enable_hist_gradient_boosting.py
-<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`_.
+<https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py>`__.

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -411,7 +411,7 @@ sklearn.experimental import *`` **does not work**.
 Note that some experimental classes / functions are not included in the
 :mod:`sklearn.experimental` module: ``sklearn.datasets.fetch_openml``.
 
-Once the feature become stable, remove all `enable_my_ecperimental_feature`
+Once the feature become stable, remove all `enable_my_experimental_feature`
 in the scikit-learn code (even feature highlights etc.) and make the
 `enable_my_experimental_feature` a no-op that just raises a warning:
 `test_enable_hist_gradient_boosting.py

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -467,7 +467,7 @@ trees.
 
 .. note::
 
-  Scikit-learn 0.21 introduces two new experimental implementations of
+  Scikit-learn 0.21 introduces two new implementations of
   gradient boosting trees, namely :class:`HistGradientBoostingClassifier`
   and :class:`HistGradientBoostingRegressor`, inspired by
   `LightGBM <https://github.com/Microsoft/LightGBM>`__ (See [LightGBM]_).
@@ -898,7 +898,7 @@ based on permutation of the features.
 Histogram-Based Gradient Boosting
 =================================
 
-Scikit-learn 0.21 introduced two new experimental implementations of
+Scikit-learn 0.21 introduced two new implementations of
 gradient boosting trees, namely :class:`HistGradientBoostingClassifier`
 and :class:`HistGradientBoostingRegressor`, inspired by
 `LightGBM <https://github.com/Microsoft/LightGBM>`__ (See [LightGBM]_).
@@ -920,15 +920,6 @@ estimators is slightly different, and some of the features from
 :class:`GradientBoostingClassifier` and :class:`GradientBoostingRegressor`
 are not yet supported, for instance some loss functions.
 
-These estimators are still **experimental**: their predictions
-and their API might change without any deprecation cycle. To use them, you
-need to explicitly import ``enable_hist_gradient_boosting``::
-
-  >>> # explicitly require this experimental feature
-  >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
-  >>> # now you can import normally from ensemble
-  >>> from sklearn.ensemble import HistGradientBoostingClassifier
-
 .. topic:: Examples:
 
  * :ref:`sphx_glr_auto_examples_inspection_plot_partial_dependence.py`
@@ -941,7 +932,6 @@ Most of the parameters are unchanged from
 One exception is the ``max_iter`` parameter that replaces ``n_estimators``, and
 controls the number of iterations of the boosting process::
 
-  >>> from sklearn.experimental import enable_hist_gradient_boosting
   >>> from sklearn.ensemble import HistGradientBoostingClassifier
   >>> from sklearn.datasets import make_hastie_10_2
 
@@ -992,7 +982,6 @@ with missing values should go to the left or right child, based on the
 potential gain. When predicting, samples with missing values are assigned to
 the left or right child consequently::
 
-  >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
   >>> from sklearn.ensemble import HistGradientBoostingClassifier
   >>> import numpy as np
 
@@ -1146,7 +1135,6 @@ You can specify a monotonic constraint on each feature using the
 constraint, while -1 and 1 indicate a negative and positive constraint,
 respectively::
 
-  >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
   >>> from sklearn.ensemble import HistGradientBoostingRegressor
 
   ... # positive, negative, and no constraint on the 3 features

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -420,6 +420,10 @@ Support for Python 3.4 and below has been officially dropped.
     >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
     >>> # now you can import normally from sklearn.ensemble
     >>> from sklearn.ensemble import HistGradientBoostingClassifier
+  
+  UPDATE: since version 1.0, these estimators are not experimental anymore and
+  you don't need to use `from sklearn.experimental import
+  enable_hist_gradient_boosting`.
 
   :pr:`12807` by :user:`Nicolas Hug<NicolasHug>`.
 

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -421,9 +421,10 @@ Support for Python 3.4 and below has been officially dropped.
     >>> # now you can import normally from sklearn.ensemble
     >>> from sklearn.ensemble import HistGradientBoostingClassifier
   
-  UPDATE: since version 1.0, these estimators are not experimental anymore and
-  you don't need to use `from sklearn.experimental import
-  enable_hist_gradient_boosting`.
+  .. note::
+      Update: since version 1.0, these estimators are not experimental
+      anymore and you don't need to use `from sklearn.experimental import
+      enable_hist_gradient_boosting`.
 
   :pr:`12807` by :user:`Nicolas Hug<NicolasHug>`.
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -133,7 +133,7 @@ Changelog
 - |Enhancement| :class:`~sklearn.ensemble.HistGradientBoostingClassifier` and
   :class:`~sklearn.ensemble.HistGradientBoostingRegressor` are no longer
   experimental. They are now considered stable and are subject to the same
-  deprecation cycles as all other estimators. :pr:`19799` by `Nicolas Hug`
+  deprecation cycles as all other estimators. :pr:`19799` by `Nicolas Hug`_.
 
 :mod:`sklearn.feature_extraction`
 .................................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -130,6 +130,11 @@ Changelog
   target. Additional private refactoring was performed.
   :pr:`19162` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |Enhancement| :class:`~sklearn.ensemble.HistGradientBoostingClassifier` and
+  :class:`~sklearn.ensemble.HistGradientBoostingRegressor` are no longer
+  experimental. They are now considered stable and are subject to the same
+  deprecation cycles as all other estimators. :pr:`19799` by `Nicolas Hug`
+
 :mod:`sklearn.feature_extraction`
 .................................
 

--- a/examples/ensemble/plot_gradient_boosting_categorical.py
+++ b/examples/ensemble/plot_gradient_boosting_categorical.py
@@ -45,7 +45,6 @@ print(f"Number of numerical features: {n_numerical_features}")
 # As a baseline, we create an estimator where the categorical features are
 # dropped:
 
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.pipeline import make_pipeline
 from sklearn.compose import make_column_transformer

--- a/examples/ensemble/plot_monotonic_constraints.py
+++ b/examples/ensemble/plot_monotonic_constraints.py
@@ -18,7 +18,6 @@ follow the general trend instead of being subject to the variations.
 This example was inspired by the `XGBoost documentation
 <https://xgboost.readthedocs.io/en/latest/tutorials/monotonic.html>`_.
 """
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.inspection import plot_partial_dependence
 import numpy as np

--- a/examples/ensemble/plot_stack_predictors.py
+++ b/examples/ensemble/plot_stack_predictors.py
@@ -160,7 +160,6 @@ rf_pipeline = make_pipeline(
 rf_pipeline
 
 # %%
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 gbdt_pipeline = make_pipeline(

--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -134,7 +134,6 @@ display.figure_.subplots_adjust(hspace=0.3)
 # Let's now fit a :class:`~sklearn.ensemble.HistGradientBoostingRegressor` and
 # compute the partial dependence on the same features.
 
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 print("Training HistGradientBoostingRegressor...")

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -258,7 +258,6 @@ score_estimator(poisson_glm, df_test)
 # least-squares loss. Here we only fit trees with the Poisson loss to keep this
 # example concise.
 
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.preprocessing import OrdinalEncoder
 

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -131,7 +131,6 @@ plt.show()
 # support for missing values (NaNs). This means that there is no need for
 # imputing data when training or predicting.
 
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingClassifier
 
 X = np.array([0, 1, 2, np.nan]).reshape(-1, 1)

--- a/examples/release_highlights/plot_release_highlights_0_23_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_23_0.py
@@ -36,7 +36,6 @@ or with conda::
 import numpy as np
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import PoissonRegressor
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 n_samples, n_features = 1000, 20
@@ -124,7 +123,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 from sklearn.model_selection import train_test_split
 from sklearn.inspection import plot_partial_dependence
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 n_samples = 500

--- a/sklearn/ensemble/__init__.py
+++ b/sklearn/ensemble/__init__.py
@@ -2,8 +2,6 @@
 The :mod:`sklearn.ensemble` module includes ensemble-based methods for
 classification, regression and anomaly detection.
 """
-import typing
-
 from ._base import BaseEnsemble
 from ._forest import RandomForestClassifier
 from ._forest import RandomForestRegressor

--- a/sklearn/ensemble/__init__.py
+++ b/sklearn/ensemble/__init__.py
@@ -21,13 +21,9 @@ from ._voting import VotingClassifier
 from ._voting import VotingRegressor
 from ._stacking import StackingClassifier
 from ._stacking import StackingRegressor
-
-if typing.TYPE_CHECKING:
-    # Avoid errors in type checkers (e.g. mypy) for experimental estimators.
-    # TODO: remove this check once the estimator is no longer experimental.
-    from ._hist_gradient_boosting.gradient_boosting import (  # noqa
-        HistGradientBoostingRegressor, HistGradientBoostingClassifier
-    )
+from ._hist_gradient_boosting.gradient_boosting import (
+    HistGradientBoostingRegressor, HistGradientBoostingClassifier
+)
 
 __all__ = ["BaseEnsemble",
            "RandomForestClassifier", "RandomForestRegressor",
@@ -37,4 +33,5 @@ __all__ = ["BaseEnsemble",
            "GradientBoostingRegressor", "AdaBoostClassifier",
            "AdaBoostRegressor", "VotingClassifier", "VotingRegressor",
            "StackingClassifier", "StackingRegressor",
+           'HistGradientBoostingClassifier', 'HistGradientBoostingRegressor',
            ]

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -887,17 +887,6 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     This implementation is inspired by
     `LightGBM <https://github.com/Microsoft/LightGBM>`_.
 
-    .. note::
-
-      This estimator is still **experimental** for now: the predictions
-      and the API might change without any deprecation cycle. To use it,
-      you need to explicitly import ``enable_hist_gradient_boosting``::
-
-        >>> # explicitly require this experimental feature
-        >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
-        >>> # now you can import normally from ensemble
-        >>> from sklearn.ensemble import HistGradientBoostingRegressor
-
     Read more in the :ref:`User Guide <histogram_based_gradient_boosting>`.
 
     .. versionadded:: 0.21
@@ -1040,8 +1029,6 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
     Examples
     --------
-    >>> # To use this experimental feature, we need to explicitly ask for it:
-    >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
     >>> from sklearn.ensemble import HistGradientBoostingRegressor
     >>> from sklearn.datasets import load_diabetes
     >>> X, y = load_diabetes(return_X_y=True)
@@ -1155,17 +1142,6 @@ class HistGradientBoostingClassifier(ClassifierMixin,
 
     This implementation is inspired by
     `LightGBM <https://github.com/Microsoft/LightGBM>`_.
-
-    .. note::
-
-      This estimator is still **experimental** for now: the predictions
-      and the API might change without any deprecation cycle. To use it,
-      you need to explicitly import ``enable_hist_gradient_boosting``::
-
-        >>> # explicitly require this experimental feature
-        >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
-        >>> # now you can import normally from ensemble
-        >>> from sklearn.ensemble import HistGradientBoostingClassifier
 
     Read more in the :ref:`User Guide <histogram_based_gradient_boosting>`.
 
@@ -1304,8 +1280,6 @@ class HistGradientBoostingClassifier(ClassifierMixin,
 
     Examples
     --------
-    >>> # To use this experimental feature, we need to explicitly ask for it:
-    >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
     >>> from sklearn.ensemble import HistGradientBoostingClassifier
     >>> from sklearn.datasets import load_iris
     >>> X, y = load_iris(return_X_y=True)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_compare_lightgbm.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_compare_lightgbm.py
@@ -4,8 +4,6 @@ from sklearn.datasets import make_classification, make_regression
 import numpy as np
 import pytest
 
-# To use this experimental feature, we need to explicitly ask for it:
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.ensemble._hist_gradient_boosting.binning import _BinMapper

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -13,8 +13,6 @@ from sklearn.dummy import DummyRegressor
 from sklearn.exceptions import NotFittedError
 from sklearn.compose import make_column_transformer
 
-# To use this experimental feature, we need to explicitly ask for it:
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.ensemble._hist_gradient_boosting.loss import _LOSSES

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -10,7 +10,6 @@ from sklearn.ensemble._hist_gradient_boosting.splitting import (
     compute_node_value
 )
 from sklearn.ensemble._hist_gradient_boosting.histogram import HistogramBuilder
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.ensemble import HistGradientBoostingClassifier
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
@@ -7,8 +7,6 @@ import pytest
 from sklearn.base import clone
 from sklearn.datasets import make_classification, make_regression
 
-# To use this experimental feature, we need to explicitly ask for it:
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.metrics import check_scoring

--- a/sklearn/experimental/enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/enable_hist_gradient_boosting.py
@@ -6,6 +6,8 @@ It used to enable the use of
 :term:`experimental`, but these estimators are now stable and can be imported
 normally from `sklearn.ensemble`.
 """
+# Don't remove this file, we don't want to break users code just because the
+# feature isn't experimental anymore.
 
 
 import warnings

--- a/sklearn/experimental/enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/enable_hist_gradient_boosting.py
@@ -7,7 +7,9 @@ It used to enable the use of
 normally from `sklearn.ensemble`.
 """
 
+
 import warnings
+
 
 warnings.warn(
     "Since version 1.0, "

--- a/sklearn/experimental/enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/enable_hist_gradient_boosting.py
@@ -1,36 +1,17 @@
-"""Enables histogram-based gradient boosting estimators.
+"""This is now a no-op and can be safely removed from your code.
 
-The API and results of these estimators might change without any deprecation
-cycle.
-
-Importing this file dynamically sets the
+It used to enable the use of
 :class:`~sklearn.ensemble.HistGradientBoostingClassifier` and
-:class:`~sklearn.ensemble.HistGradientBoostingRegressor` as attributes of the
-ensemble module::
-
-    >>> # explicitly require this experimental feature
-    >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
-    >>> # now you can import normally from ensemble
-    >>> from sklearn.ensemble import HistGradientBoostingClassifier
-    >>> from sklearn.ensemble import HistGradientBoostingRegressor
-
-
-The ``# noqa`` comment comment can be removed: it just tells linters like
-flake8 to ignore the import, which appears as unused.
+:class:`~sklearn.ensemble.HistGradientBoostingRegressor` when they were still
+:term:`experimental`, but these estimators are now stable and can be imported
+normally from `sklearn.ensemble`.
 """
 
-from ..ensemble._hist_gradient_boosting.gradient_boosting import (
-    HistGradientBoostingClassifier,
-    HistGradientBoostingRegressor
+import warnings
+
+warnings.warn(
+    "Since version 1.0, "
+    "it is not needed to import enable_hist_gradient_boosting anymore. "
+    "HistGradientBoostingClassifier and HistGradientBoostingRegressor are now "
+    "stable and can be normally imported from sklearn.ensemble."
 )
-
-from .. import ensemble
-
-# use settattr to avoid mypy errors when monkeypatching
-setattr(ensemble, "HistGradientBoostingClassifier",
-        HistGradientBoostingClassifier)
-setattr(ensemble, "HistGradientBoostingRegressor",
-        HistGradientBoostingRegressor)
-
-ensemble.__all__ += ['HistGradientBoostingClassifier',
-                     'HistGradientBoostingRegressor']

--- a/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
@@ -1,45 +1,8 @@
 """Tests for making sure experimental imports work as expected."""
 
-import textwrap
-
-from sklearn.utils._testing import assert_run_python_script
+import pytest
 
 
-def test_imports_strategies():
-    # Make sure different import strategies work or fail as expected.
-
-    # Since Python caches the imported modules, we need to run a child process
-    # for every test case. Else, the tests would not be independent
-    # (manually removing the imports from the cache (sys.modules) is not
-    # recommended and can lead to many complications).
-
-    good_import = """
-    from sklearn.experimental import enable_hist_gradient_boosting
-    from sklearn.ensemble import GradientBoostingClassifier
-    from sklearn.ensemble import GradientBoostingRegressor
-    """
-    assert_run_python_script(textwrap.dedent(good_import))
-
-    good_import_with_ensemble_first = """
-    import sklearn.ensemble
-    from sklearn.experimental import enable_hist_gradient_boosting
-    from sklearn.ensemble import GradientBoostingClassifier
-    from sklearn.ensemble import GradientBoostingRegressor
-    """
-    assert_run_python_script(textwrap.dedent(good_import_with_ensemble_first))
-
-    bad_imports = """
-    import pytest
-
-    with pytest.raises(ImportError):
-        from sklearn.ensemble import HistGradientBoostingClassifier
-
-    with pytest.raises(ImportError):
-        from sklearn.ensemble._hist_gradient_boosting import (
-            HistGradientBoostingClassifier)
-
-    import sklearn.experimental
-    with pytest.raises(ImportError):
-        from sklearn.ensemble import HistGradientBoostingClassifier
-    """
-    assert_run_python_script(textwrap.dedent(bad_imports))
+def test_import_raises_warning():
+    with pytest.warns(UserWarning, match="It is not needed to import"):
+        from sklearn.experimental import enable_hist_gradient_boosting

--- a/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
@@ -5,4 +5,4 @@ import pytest
 
 def test_import_raises_warning():
     with pytest.warns(UserWarning, match="It is not needed to import"):
-        from sklearn.experimental import enable_hist_gradient_boosting
+        from sklearn.experimental import enable_hist_gradient_boosting  # noqa

--- a/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
@@ -1,8 +1,14 @@
 """Tests for making sure experimental imports work as expected."""
 
-import pytest
+import textwrap
+
+from sklearn.utils._testing import assert_run_python_script
 
 
 def test_import_raises_warning():
-    with pytest.warns(UserWarning, match="It is not needed to import"):
+    code = """
+    import pytest
+    with pytest.warns(UserWarning, match="it is not needed to import"):
         from sklearn.experimental import enable_hist_gradient_boosting  # noqa
+    """
+    assert_run_python_script(textwrap.dedent(code))

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -10,7 +10,6 @@ from sklearn import datasets
 from sklearn.linear_model import LogisticRegression, SGDClassifier, Lasso
 from sklearn.svm import LinearSVC
 from sklearn.feature_selection import SelectFromModel
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import (RandomForestClassifier,
                               HistGradientBoostingClassifier)
 from sklearn.linear_model import PassiveAggressiveClassifier

--- a/sklearn/feature_selection/tests/test_sequential.py
+++ b/sklearn/feature_selection/tests/test_sequential.py
@@ -8,7 +8,6 @@ from sklearn.pipeline import make_pipeline
 from sklearn.feature_selection import SequentialFeatureSelector
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -15,7 +15,6 @@ from sklearn.inspection._partial_dependence import (
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.linear_model import LinearRegression

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -69,7 +69,6 @@ from sklearn.metrics.pairwise import euclidean_distances
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import Ridge, SGDClassifier, LinearRegression
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingClassifier
 
 from sklearn.model_selection.tests.common import OneTimeSplitter

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -36,7 +36,6 @@ from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_extraction.text import CountVectorizer
-from sklearn.experimental import enable_hist_gradient_boosting  # noqa
 from sklearn.ensemble import HistGradientBoostingClassifier
 from sklearn.impute import SimpleImputer
 


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/19792

The last obstacle to make these estimators stable was https://github.com/scikit-learn/scikit-learn/issues/18894. The preferred solution has not ETA yet and should be backward compatible anyway, so it's not worth delaying the "stabilization" of the estimators any longer.

importing `enable_hist_gradient_boosting` now throws a warning - no strong opinion, but it's probably better to encourage users to remove the imports, hence the warning.

for ref:
```bash
(sklearn-dev) ➜  scikit-learn git:(exp_gbdt) ✗ git grep enable_hist
doc/modules/classes.rst:   experimental.enable_hist_gradient_boosting
doc/whats_new/v0.21.rst:  need to explicitly import ``enable_hist_gradient_boosting``::
doc/whats_new/v0.21.rst:    >>> from sklearn.experimental import enable_hist_gradient_boosting  # noqa
doc/whats_new/v0.21.rst:  enable_hist_gradient_boosting`.
sklearn/experimental/enable_hist_gradient_boosting.py:    "it is not needed to import enable_hist_gradient_boosting anymore. "
sklearn/experimental/tests/test_enable_hist_gradient_boosting.py:        from sklearn.experimental import enable_hist_gradient_boosting
```