### PR TITLE
TST Fixes test_partial_fit_oneclass

### DIFF
--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1499,12 +1499,11 @@ def test_partial_fit_oneclass(klass):
     assert clf.coef_.shape == (X.shape[1], )
     assert clf.offset_.shape == (1,)
     assert clf.predict([[0, 0]]).shape == (1, )
-    id1 = id(clf.coef_.data)
+    previous_coefs = clf.coef_
 
     clf.partial_fit(X[third:])
-    id2 = id(clf.coef_.data)
     # check that coef_ haven't been re-allocated
-    assert id1 == id2
+    assert clf.coef_ is previous_coefs
 
     # raises ValueError if number of features does not match previous data
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/19810


#### What does this implement/fix? Explain your changes.
Instead of using the id on `data`, this PR uses object identity of `coef_`. I noticed sometimes the following would fail, while using `d is c` still returns True.

```python
import numpy as np
c = np.random.randn(1000)
d = c
assert id(d.data) == id(c.data)
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
