### PR TITLE
DOC Fixes style for versionadded

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -787,12 +787,16 @@ div.admonition p.admonition-title + p, div.deprecated p {
 }
 
 div.admonition, div.deprecated,
-div.versionchanged, div.versionadded{
+div.versionchanged {
   margin-top: 0.5rem;
   padding: 0.5rem;
   border-radius: 0.5rem;
   margin-bottom: 0.5rem;
   border: 1px solid #ddd;
+}
+
+div.versionadded {
+  margin: 1rem 0;
 }
 
 div.admonition {


### PR DESCRIPTION
Removes the border for versionadded:

### This PR

<img width="549" alt="Screen Shot 2021-04-02 at 10 04 31 PM" src="https://user-images.githubusercontent.com/5402633/113465113-93c46f80-93ff-11eb-9ace-2fa460b6f059.png">

### main

<img width="552" alt="Screen Shot 2021-04-02 at 10 04 47 PM" src="https://user-images.githubusercontent.com/5402633/113465108-8ad39e00-93ff-11eb-8996-d761288cac5c.png">