### PR TITLE
CI Fix string comparison in check milestone workflow

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check the milestone
         run: |
           set -xe
-          if [ ${{ github.event.pull_request.milestone.title }} == "" ]
+          if [ "${{ github.event.pull_request.milestone.title }}" == "" ]
           then
               echo "No milestone has been set."
               exit 1


### PR DESCRIPTION
#### Reference Issues/PRs
Follow-up of #19833. Thanks @NicolasHug for noticing.
The variable in the comparison was no longer a string.

Cc @thomasjpfan 