### PR TITLE
TST Changes assert to pytest style in tests/test_config.py and tests/test_kernel_approximation.py

### DIFF
--- a/sklearn/tests/test_config.py
+++ b/sklearn/tests/test_config.py
@@ -1,5 +1,5 @@
+import pytest
 from sklearn import get_config, set_config, config_context
-from sklearn.utils._testing import assert_raises
 
 
 def test_config_context():
@@ -43,9 +43,12 @@ def test_config_context():
                             'display': 'text'}
 
     # No positional arguments
-    assert_raises(TypeError, config_context, True)
+    with pytest.raises(TypeError):
+        config_context(True)
+
     # No unknown arguments
-    assert_raises(TypeError, config_context(do_something_else=True).__enter__)
+    with pytest.raises(TypeError):
+        config_context(do_something_else=True).__enter__()
 
 
 def test_config_context_exception():
@@ -71,4 +74,5 @@ def test_set_config():
     assert get_config()['assume_finite'] is False
 
     # No unknown arguments
-    assert_raises(TypeError, set_config, do_something_else=True)
+    with pytest.raises(TypeError):
+        set_config(do_something_else=True)

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -1,9 +1,11 @@
+import re
+
 import numpy as np
 from scipy.sparse import csr_matrix
 import pytest
 
 from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_array_almost_equal, assert_raises
+from sklearn.utils._testing import assert_array_almost_equal
 
 from sklearn.metrics.pairwise import kernel_metrics
 from sklearn.kernel_approximation import RBFSampler
@@ -90,11 +92,18 @@ def test_additive_chi2_sampler():
     # test error is raised on negative input
     Y_neg = Y.copy()
     Y_neg[0, 0] = -1
-    assert_raises(ValueError, transform.transform, Y_neg)
+    msg = 'Negative values in data passed to'
+    with pytest.raises(ValueError, match=msg):
+        transform.transform(Y_neg)
 
     # test error on invalid sample_steps
     transform = AdditiveChi2Sampler(sample_steps=4)
-    assert_raises(ValueError, transform.fit, X)
+    msg = re.escape(
+        "If sample_steps is not in [1, 2, 3],"
+        " you need to provide sample_interval"
+    )
+    with pytest.raises(ValueError, match=msg):
+        transform.fit(X)
 
     # test that the sample interval is set correctly
     sample_steps_available = [1, 2, 3]
@@ -154,7 +163,9 @@ def test_skewed_chi2_sampler():
     # test error is raised on when inputs contains values smaller than -c
     Y_neg = Y.copy()
     Y_neg[0, 0] = -c * 2.
-    assert_raises(ValueError, transform.transform, Y_neg)
+    msg = 'X may not contain entries smaller than -skewedness'
+    with pytest.raises(ValueError, match=msg):
+        transform.transform(Y_neg)
 
 
 def test_additive_chi2_sampler_exceptions():


### PR DESCRIPTION
Reference Issues/PRs
References #14216

What does this implement/fix? Explain your changes.
Changed the assert_raises, assert_message, assert_warns in tests/test_naive_bayes.py to pytest.raises().
Added additional message checks for tests that seemed like could benefit from further clarification.