### PR TITLE
[MRG] NEW Implementation of Erdős–Rényi Random Graph Sampling

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -127,6 +127,11 @@ Efficient Linear Algebra & Array Operations
 Efficient Random Sampling
 =========================
 
+- :func:`random.sample_erdos_renyi_gnm`: implements sampling of the
+  `G(n,m)`-model of Erdos-Renyi random graphs. The space complexity of
+  the method is asymptotically constant in the number of vertices `n`
+  (`n` must be representable in the `int64` data type).
+
 - :func:`random.sample_without_replacement`: implements efficient algorithms
   for sampling ``n_samples`` integers from a population of size ``n_population``
   without replacement.
@@ -196,7 +201,7 @@ Helper Functions
   to ``n``.  Used in :func:`~sklearn.decomposition.dict_learning` and
   :func:`~sklearn.cluster.k_means`.
 
-- :class:`gen_batches`: generator to create slices containing batch size elements 
+- :class:`gen_batches`: generator to create slices containing batch size elements
   from 0 to ``n``
 
 - :func:`safe_mask`: Helper function to convert a mask to the format expected

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1621,6 +1621,7 @@ Plotting
    utils.sparsefuncs.inplace_csr_column_scale
    utils.sparsefuncs_fast.inplace_csr_row_normalize_l1
    utils.sparsefuncs_fast.inplace_csr_row_normalize_l2
+   utils.random.sample_erdos_renyi_gnm
    utils.random.sample_without_replacement
    utils.validation.check_is_fitted
    utils.validation.check_memory

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -71,8 +71,9 @@ Changelog
 - |Fix| Better contains the CSS provided by :func:`utils.estimator_html_repr`
   by giving CSS ids to the html representation. :pr:`19417` by `Thomas Fan`_.
 
-- |Feature| Efficient sampling of the `G(n,m)`-model of Erdos-Renyi
-  random graphs using :func:`random.sample_without_replacement`.
+- |Feature| :user:`Nils Müller <NiMlr>` added efficient sampling of the
+  `G(n,m)`-model of Erdos-Renyi random graphs using
+  :func:`random.sample_without_replacement`.
 
 .. _changes_0_24_1:
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -71,9 +71,9 @@ Changelog
 - |Fix| Better contains the CSS provided by :func:`utils.estimator_html_repr`
   by giving CSS ids to the html representation. :pr:`19417` by `Thomas Fan`_.
 
-- |Feature| :user:`Nils Müller <NiMlr>` added efficient sampling of the
-  `G(n,m)`-model of Erdos-Renyi random graphs using
-  :func:`random.sample_without_replacement`.
+- |Feature| Added efficient sampling of the `G(n,m)`-model of Erdos-Renyi
+  random graphs using :func:`random.sample_without_replacement`. :pr:`19849`
+  by :user:`Nils Müller <NiMlr>`.
 
 .. _changes_0_24_1:
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -71,6 +71,9 @@ Changelog
 - |Fix| Better contains the CSS provided by :func:`utils.estimator_html_repr`
   by giving CSS ids to the html representation. :pr:`19417` by `Thomas Fan`_.
 
+- |Feature| Efficient sampling of the `G(n,m)`-model of Erdos-Renyi
+  random graphs using :func:`random.sample_without_replacement`.
+
 .. _changes_0_24_1:
 
 Version 0.24.1

--- a/sklearn/utils/random.py
+++ b/sklearn/utils/random.py
@@ -117,17 +117,17 @@ def sample_erdos_renyi_gnm(n, m, samples=1, random_state=None, method="auto",
     samples : int, default=1
         Number of independent realizations of the `G(n, m)` random variable.
 
-    method : {"auto", "tracking_selection", "reservoir_sampling", "pool"}, \
-            default="auto"
-        Determines which algorithm is used for sampling.
-        See :class:`~sklearn.utils.random.sample_without_replacement` for
-        more info.
-
     random_state : int, RandomState instance or None, default=None
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
+
+    method : {"auto", "tracking_selection", "reservoir_sampling", "pool"}, \
+            default="auto"
+        Determines which algorithm is used for sampling.
+        See :class:`~sklearn.utils.random.sample_without_replacement` for
+        more info.
 
     return_as : "adjacency_matrix" or "edge_array", default="edge_array"
         Determines whether the output is an an array containing pairs of

--- a/sklearn/utils/random.py
+++ b/sklearn/utils/random.py
@@ -94,3 +94,113 @@ def _random_choice_csc(n_samples, classes, class_probability=None,
     return sp.csc_matrix((data, indices, indptr),
                          (n_samples, len(classes)),
                          dtype=int)
+
+
+def sample_erdos_renyi_gnm(n, m, samples=1, random_state=None, method="auto",
+                           return_as="edge_array", dtype="int64"):
+    """Sample the `G(n, m)`-model of Erdos–Renyi random graphs.
+
+    The problem is solved by the denoting the edges by `0, ..., n(n-1)//2 - 1`,
+    sampling those and mapping the result onto the respective indices of the
+    adjacency matrix.
+
+
+    Parameters
+    ----------
+    n : int
+        Number of vertices of the graph.
+
+    m : int
+        Number of distinct edges to be in each sample.
+        Must fulfill `0 <= m <= n*(n-1)//2`.
+
+    samples : int, default=1
+        Number of independent realizations of the `G(n, m)` random variable.
+
+    method : {"auto", "tracking_selection", "reservoir_sampling", "pool"}, \
+            default="auto"
+        Determines which algorithm is used for sampling.
+        See :class:`~sklearn.utils.random.sample_without_replacement` for
+        more info.
+
+    random_state : int, RandomState instance or None, default=None
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
+
+    return_as : "adjacency_matrix" or "edge_array", default="edge_array"
+        Determines whether the output is an an array containing pairs of
+        vertices or a list of coo_matrices as samples of the adjacency matrix.
+
+    dtype : dtype or str, default="int64"
+        An integer data type. The value `n*(n-1)//2` must representable.
+        No checks are implemented.
+
+    Returns
+    -------
+    int ndarray or list of int coo_matrix:
+        If return_as == "adjacency_matrix", a list of length `samples`
+        containing sparse matrices of shape `(n, n)` with zeros and ones is
+        returned;
+        If return_as == "edge_array", an array of shape `(2, m, samples)`
+        containing vertex indices in `[0, ..., n-1]` is returned.
+
+    Examples
+    --------
+    >>> from sklearn.utils.random import sample_erdos_renyi_gnm
+    >>> sample_erdos_renyi_gnm(5, 4, 3, random_state=42)
+    array([[[4, 1, 4],
+            [2, 2, 2],
+            [3, 4, 1],
+            [1, 3, 4]],
+           [[2, 0, 3],
+            [0, 0, 1],
+            [2, 2, 0],
+            [0, 2, 0]]])
+
+    References
+    ----------
+    Erdős, P., Rényi, A. (1959).
+    `On Random Graphs. <https://www.renyi.hu/~p_erdos/1959-11.pdf>`_
+    Publicationes Mathematicae.
+    """
+    nedges = n*(n-1)//2
+
+    # each sample has m edges, this array will eventually store their vertices
+    if return_as == "adjacency_matrix":
+        # leave room for conjugate elements
+        er = np.empty([2, 2*m, samples], dtype=dtype)
+    else:
+        er = np.empty([2, m, samples], dtype=dtype)
+
+    # make sure random state is valid
+    random_state = check_random_state(random_state)
+
+    # sample edge indices
+    er[1, :m, :] = np.array(
+        [sample_without_replacement(nedges, m, method=method,
+                                    random_state=random_state)
+            for _ in range(samples)], dtype=dtype).T
+
+    # solves (t+1)*t//2 = er1+1 for t to get the left vertex index
+    er[0, :m, :] = np.ceil(np.sqrt((er[1, :m, :]+1.)*2.+.25)-.5).astype(dtype)
+
+    # computes er1 = er0-t*(t-1)//2 for the right vertex index
+    er[1, :m, :] -= er[0, :m, :]*(er[0, :m, :]-1)//2
+
+    if return_as == "adjacency_matrix":
+        # set conjugate elements
+        er[0, m:, :] = er[1, :m, :]
+        er[1, m:, :] = er[0, :m, :]
+        # set matrix values
+        vals = np.ones(2*m, dtype=dtype)
+        out = []
+        # build a sparse matrix for each sample
+        for k in range(samples):
+            A = sp.coo_matrix(
+                (vals, (er[0, :, k], er[1, :, k])), shape=(n, n), dtype=dtype)
+            out.append(A)
+        return out
+    else:
+        return er

--- a/sklearn/utils/tests/test_random.py
+++ b/sklearn/utils/tests/test_random.py
@@ -1,11 +1,14 @@
+from sklearn.utils._random import _our_rand_r_py
 import numpy as np
 import pytest
 import scipy.sparse as sp
 from scipy.special import comb
 from numpy.testing import assert_array_almost_equal
 
-from sklearn.utils.random import _random_choice_csc, sample_without_replacement
-from sklearn.utils._random import _our_rand_r_py
+from sklearn.utils.random import (_random_choice_csc,
+                                  sample_without_replacement,
+                                  sample_erdos_renyi_gnm,
+                                  check_random_state)
 
 
 ###############################################################################
@@ -185,3 +188,86 @@ def test_random_choice_csc_errors():
 def test_our_rand_r():
     assert 131541053 == _our_rand_r_py(1273642419)
     assert 270369 == _our_rand_r_py(0)
+
+
+###############################################################################
+# test sample_erdos_renyi_gnm
+###############################################################################
+
+def test_correctness_1_sample_erdos_renyi_gnm():
+    """Tests that the adjacency matrix output is correct for a very simple
+    hard-coded example."""
+    n = 5
+    m = 5
+    samples = 1
+    random_state = 1337
+    A = np.array([[0, 0, 0, 0, 0],
+                  [1, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0],
+                  [1, 1, 1, 0, 0],
+                  [1, 0, 0, 0, 0]])
+    B = sample_erdos_renyi_gnm(
+        n, m, samples, random_state=random_state, return_as="adjacency_matrix")
+    assert np.all(A == np.tril(B[0].todense()))
+
+
+def test_correctness_2_sample_erdos_renyi_gnm():
+    """Tests that sampling all edges returns a matrix with entries of
+    one everywhere but on the diagonal.
+    """
+    n = 10
+    m = 10*9//2
+    samples = 1
+    A = sample_erdos_renyi_gnm(
+        n, m, samples, return_as="adjacency_matrix")
+    assert np.all(A[0].todense() == np.ones((n, n))-np.eye(n))
+
+
+def test_correctness_3_sample_erdos_renyi_gnm():
+    """Tests that the edge array output is equal to that of a simple
+    imlementation for more than one sample.
+    """
+    n = 20
+    m = 60
+    samples = 20
+    random_state = 42
+    A = sample_erdos_renyi_gnm(
+        n, m, samples, random_state=random_state, return_as="edge_array")
+
+    random_state = check_random_state(random_state)
+    for j in range(samples):
+        edge_indices = sample_without_replacement(
+            n*(n-1)//2, m, random_state=random_state)
+        row_indices = []
+        column_indices = []
+        for ind in edge_indices:
+            k = 1
+            while ind != ind % k:
+                ind -= k
+                k += 1
+            row_indices.append(k)
+            column_indices.append(ind % k)
+
+        assert np.all(np.array([row_indices, column_indices]) == A[:, :, j])
+
+
+def test_consistency_sample_erdos_renyi_gnm():
+    """Tests that the edge_array output is consistent with the
+    adjacency_matrix output."""
+    n = 50
+    m = 50
+    samples = 10
+    random_state = 1337
+    A = sample_erdos_renyi_gnm(
+        n, m, samples, random_state=random_state, return_as="edge_array")
+    B = sample_erdos_renyi_gnm(
+        n, m, samples, random_state=random_state, return_as="adjacency_matrix")
+
+    for i in range(samples):
+        AA = set(tuple(a) for a in A[:, :, i].T)
+        BB1 = set(tuple(b)
+                  for b in np.stack(np.nonzero(np.tril(B[i].todense()))).T)
+        BB2 = set(tuple(b)[::-1]
+                  for b in np.stack(np.nonzero(np.triu(B[i].todense()))).T)
+        assert AA == BB1
+        assert AA == BB2

--- a/sklearn/utils/tests/test_random.py
+++ b/sklearn/utils/tests/test_random.py
@@ -1,4 +1,3 @@
-from sklearn.utils._random import _our_rand_r_py
 import numpy as np
 import pytest
 import scipy.sparse as sp
@@ -9,6 +8,7 @@ from sklearn.utils.random import (_random_choice_csc,
                                   sample_without_replacement,
                                   sample_erdos_renyi_gnm,
                                   check_random_state)
+from sklearn.utils._random import _our_rand_r_py
 
 
 ###############################################################################


### PR DESCRIPTION
Hi,


#### What does this implement?

This PR is an implementation of the `G(n, m)`-model of [Erdős–Rényi random graphs](https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93R%C3%A9nyi_model). Erdős–Rényi random graphs are useful for statistical modeling (e.g., through block models) and estimation/robustness of quantities related to graph or matrix algorithms.

#### Implementation details

The **simple** algorithm is based on the fast sampling of `m` edge indices in `0, 1, ..., n*(n-1)//2` using [`sklearn.utils.random.sample_without_replacement`](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/utils/_random.pyx#L223) and the subsequent sample-wise constant time mapping onto the indices of the adjacency matrix `A_{n, ij} -> (i, j)`, where the edge indices are associated with the corresponding matrix entry, due to undirectedness the cases `j < i` are sufficient, and
<br>
<p align="center">
<a href="https://www.codecogs.com/eqnedit.php?latex=A_n&space;=&space;\begin{pmatrix}&space;*&space;&&space;*\phantom{*}&space;&&space;\phantom{*}*&space;&&space;\phantom{*}*\phantom{*}&space;&&space;*\phantom{*}&space;&&space;*\\&space;0&space;&&space;*\phantom{*}&space;&&space;\phantom{*}*&space;&&space;\phantom{*}*\phantom{*}&space;&&space;*\phantom{*}&space;&&space;*\\&space;1&space;&&space;2\phantom{*}&space;&&space;\phantom{*}*&space;&&space;\phantom{*}*\phantom{*}&space;&&space;*\phantom{*}&space;&&space;*\\&space;3&space;&&space;4\phantom{*}&space;&&space;\phantom{*}5&space;&&space;\phantom{*}*\phantom{*}&space;&&space;*\phantom{*}&space;&&space;*\\&space;\vdots&space;&&space;&&space;&&space;\ddots&space;&&space;\ddots&space;&\vdots\vspace*{2mm}\\&space;\tfrac{n(n-3)}{2}&space;&plus;2&space;&&space;&\phantom{*}\dots&space;&&space;&&space;\tfrac{n(n-1)}{2}\phantom{*}&space;&&space;*&space;\end{pmatrix}&space;\,." target="_blank"><img src="https://latex.codecogs.com/gif.latex?A_n&space;=&space;\begin{pmatrix}&space;*&space;&&space;*\phantom{*}&space;&&space;\phantom{*}*&space;&&space;\phantom{*}*\phantom{*}&space;&&space;*\phantom{*}&space;&&space;*\\&space;0&space;&&space;*\phantom{*}&space;&&space;\phantom{*}*&space;&&space;\phantom{*}*\phantom{*}&space;&&space;*\phantom{*}&space;&&space;*\\&space;1&space;&&space;2\phantom{*}&space;&&space;\phantom{*}*&space;&&space;\phantom{*}*\phantom{*}&space;&&space;*\phantom{*}&space;&&space;*\\&space;3&space;&&space;4\phantom{*}&space;&&space;\phantom{*}5&space;&&space;\phantom{*}*\phantom{*}&space;&&space;*\phantom{*}&space;&&space;*\\&space;\vdots&space;&&space;&&space;&&space;\ddots&space;&&space;\ddots&space;&\vdots\vspace*{2mm}\\&space;\tfrac{n(n-3)}{2}&space;&plus;2&space;&&space;&\phantom{*}\dots&space;&&space;&&space;\tfrac{n(n-1)}{2}\phantom{*}&space;&&space;*&space;\end{pmatrix}&space;\,." title="A_n = \begin{pmatrix} * & *\phantom{*} & \phantom{*}* & \phantom{*}*\phantom{*} & *\phantom{*} & *\\ 0 & *\phantom{*} & \phantom{*}* & \phantom{*}*\phantom{*} & *\phantom{*} & *\\ 1 & 2\phantom{*} & \phantom{*}* & \phantom{*}*\phantom{*} & *\phantom{*} & *\\ 3 & 4\phantom{*} & \phantom{*}5 & \phantom{*}*\phantom{*} & *\phantom{*} & *\\ \vdots & & & \ddots & \ddots &\vdots\vspace*{2mm}\\ \tfrac{n(n-3)}{2} +2 & &\phantom{*}\dots & & \tfrac{n(n-1)}{2}\phantom{*} & * \end{pmatrix} \,." /></a>
</p>
<br>

The mapping can be done without explicit representation of `A_n` by solving a vectorized quadratic equation. Per sample of the random graphs, this results in `m` edge tuples of form `(i, j)` and represented as a `np.ndarray`.

The time and space complexity of the algorithm is in `O(m*samples)`. The result can be returned either as an integer `np.ndarray` of size `(2, m, samples)` or a `list`of integer `sp.sparse.coo_matrix`.


#### Empirical performance

Thanks to the powerful implementation of [`sklearn.utils.random.sample_without_replacement`](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/utils/_random.pyx#L223),
it turns out that the method in many cases is not only faster than that of other packages
```python
from sklearn.utils.random import sample_erdos_renyi_gnm
import networkx as nx

n = 50
m = 600
samples = 2000

%timeit sample_erdos_renyi_gnm(n, m, samples, return_as="edge_array")
# 116 ms ± 1.37 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit sample_erdos_renyi_gnm(n, m, samples, return_as="adjacency_matrix")
# 359 ms ± 15.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit [nx.gnm_random_graph(n, m) for _ in range(samples)]
# 4.66 s ± 142 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
but it opens up the use-case `n >> m`

```python
n = 1_000_000
m = 600
samples = 1

%timeit sample_erdos_renyi_gnm(n, m, samples, return_as="adjacency_matrix")
# 3.6 ms ± 196 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
%timeit [nx.gnm_random_graph(n, m) for _ in range(samples)]
# 931 ms ± 16.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# running nx.gnm_random_graph for even larger n will soon break down
```
#### Improvements

Profiling using [line_profiler](https://github.com/pyutils/line_profiler) reveals that improvements in [`sklearn.utils.random.sample_without_replacement`](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/utils/_random.pyx#L223) and in the optional [conversion to sparse matrices](https://github.com/scikit-learn/scikit-learn/pull/19849/files#diff-69a960702b7632b34cfeabcecb3168352150031970c6aac12448ad0413de5cabR201) are most promising. Varying the sample sizes and comparing the runtime shares indicates that both non-vectorized lines do not yield much overhead. See [profile-code.txt](https://github.com/scikit-learn/scikit-learn/files/6281804/profile-code.txt) for details.

I would also be happy to implement the somewhat simpler `G(n, p)`-model of [Erdős–Rényi random graphs](https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93R%C3%A9nyi_model).
