### PR TITLE
DOC Fix typo in common_pitfalls.rst

### DIFF
--- a/doc/common_pitfalls.rst
+++ b/doc/common_pitfalls.rst
@@ -564,7 +564,7 @@ preformance by letting the estimator use a different RNG on each fold. This
 is done by passing a `RandomState` instance (or `None`) to the estimator
 initialization.
 
-When we pass an integer, the estimator will use the same RNG on each fold: if
+When we pass an integer, the estimator will use the same RNG on each fold:
 if the estimator performs well (or bad), as evaluated by CV, it might just be
 because we got lucky (or unlucky) with that specific seed. Passing instances
 leads to more robust CV results, and makes the comparison between various


### PR DESCRIPTION
Just fixed a typo in common_pitfalls.rst.

if followed by if, probably due to line break.