### PR TITLE
Update the documentation URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ DOWNLOAD_URL = 'https://pypi.org/project/scikit-learn/#files'
 LICENSE = 'new BSD'
 PROJECT_URLS = {
     'Bug Tracker': 'https://github.com/scikit-learn/scikit-learn/issues',
-    'Documentation': 'https://scikit-learn.org/stable/documentation.html',
+    'Documentation': 'https://scikit-learn.org/stable/user_guide.html',
     'Source Code': 'https://github.com/scikit-learn/scikit-learn'
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
At some point the documentation URL has changed from https://scikit-learn.org/stable/documentation.html to https://scikit-learn.org/stable/user_guide.html . The former now redirects to the homepage.

#### Any other comments?

