### PR TITLE
ENH add parameter in accuracy_score for multilabel classification

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -401,13 +401,8 @@ Accuracy score
 --------------
 
 The :func:`accuracy_score` function computes the
-`accuracy <https://en.wikipedia.org/wiki/Accuracy_and_precision>`_, either the fraction
-(default) or the count (normalize=False) of correct predictions.
-
-
-In multilabel classification, the function returns the subset accuracy. If
-the entire set of predicted labels for a sample strictly match with the true
-set of labels, then the subset accuracy is 1.0; otherwise it is 0.0.
+`accuracy <https://en.wikipedia.org/wiki/Accuracy_and_precision>`_, either the
+fraction (default) or the count (normalize=False) of correct predictions.
 
 If :math:`\hat{y}_i` is the predicted value of
 the :math:`i`-th sample and :math:`y_i` is the corresponding true value,
@@ -430,16 +425,51 @@ where :math:`1(x)` is the `indicator function
   >>> accuracy_score(y_true, y_pred, normalize=False)
   2
 
-In the multilabel case with binary label indicators::
+For the multilabel case where the target `y` is a binary indicator matrix of
+shape :math:`n_\text{samples}` by :math:`n_\text{outputs}`, we can extend the
+previous formula. Thus, :math:`y_i` and :math:`\hat{y}_i` are vectors of length
+:math:`n_\text{outputs}` and a correct predictions is an exact match between
+the two vectors. This score is also known as the "exact match ratio"
+[Sorower2010]_. We give an example by computing the the exact match ratio on
+two samples where only a single sample strictly match:
 
-  >>> accuracy_score(np.array([[0, 1], [1, 1]]), np.ones((2, 2)))
+  >>> accuracy_score([[0, 1], [0, 1]], [[1, 1], [0, 1]],
+  ...                multilabel="exact-match")
   0.5
+
+This formulation is rather conservative and does not allow to consider partial
+correctness. Indeed, one can relax the constraint of the exact match and check
+the predictions at the level of each label instead. The accuracy is then
+formalized as
+
+.. math::
+
+  \texttt{accuracy}(y, \hat{y}) = \frac{1}{n_\text{samples}} \sum_{i=0}^{n_\text{samples}-1} \frac{\| \hat{y}_i \cap y_i \|}{\| \hat{y}_i \cup y_i \|}
+
+Passing the parameter `multilabel="average"` will use this definition:
+
+  >>> accuracy_score([[0, 1], [0, 1]], [[1, 1], [0, 1]],
+  ...                multilabel="average")
+  0.75
+
+This formulation is also known as the Hamming score [Sorower2010]_.
+
+.. note::
+  When `multilabel="average"`, the parameter `normalize` cannot be set to
+  `False`. Indeed, by comparing individual labels, we loose the "sample"
+  semantic.
 
 .. topic:: Example:
 
   * See :ref:`sphx_glr_auto_examples_feature_selection_plot_permutation_test_for_classification.py`
     for an example of accuracy score usage using permutations of
     the dataset.
+
+.. topic:: References:
+
+  .. [Sorower2010] S. M. Sorower, `A literature survey on algorithms for multi-label learning.
+     <https://api.semanticscholar.org/CorpusID:13222909>`_,
+     Oregon State University, Corvallis 18 (2010): 1-25.
 
 .. _top_k_accuracy_score:
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -266,6 +266,11 @@ Changelog
   :pr:`18328` by :user:`Albert Villanova del Moral <albertvillanova>` and
   :user:`Alonso Silva Allende <alonsosilvaallende>`.
 
+- |Enhancement| Add a parameter `multilabel` to :func:`metrics.accuracy_score`
+  allowing to whether imposed or not the exact label set constraint when
+  computing the ratio of correct predictions.
+  :pr:`19874` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -208,19 +208,15 @@ def accuracy_score(
     >>> accuracy_score(y_true, y_pred, normalize=False)
     2
 
-    In the multilabel case with binary label indicators, with exact sets
-    matching:
+    In multilabel, the parameter `multilabel` can enforce an exact match or
+    not for labels associated with a sample:
 
-    >>> y_true = [[0, 1], [1, 1]]
-    >>> y_pred = [[1, 1], [1, 1]]
-    >>> accuracy_score(y_true, y_pred)
-    0.5
-
-    If we want to be less strict and to average across all labels, we can
-    change the parameter `multilabel`:
-
+    >>> y_true = [[0, 1]]
+    >>> y_pred = [[1, 1]]
+    >>> accuracy_score(y_true, y_pred, multilabel="exact-match")
+    0.0
     >>> accuracy_score(y_true, y_pred, multilabel="average")
-    0.75
+    0.5
     """
 
     # Compute accuracy for each possible representation

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -138,29 +138,46 @@ def _weighted_sum(sample_score, sample_weight, normalize=False):
 
 
 @_deprecate_positional_args
-def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
+def accuracy_score(
+    y_true,
+    y_pred,
+    *,
+    normalize=True,
+    sample_weight=None,
+    multilabel="exact-match",
+):
     """Accuracy classification score.
 
-    In multilabel classification, this function computes subset accuracy:
-    the set of labels predicted for a sample must *exactly* match the
-    corresponding set of labels in y_true.
+    For multilabel classification, the accuracy is either computed as:
+
+    - an exact match between the set of the true labels and the set of the
+      predicted labels. Thus, a true classification is defined as an exact
+      match between a row of `y_true` and a row in `y_pred`;
+    - an average of the true labels over the total number of labels. Thus, we
+      do not group labels per rows.
 
     Read more in the :ref:`User Guide <accuracy_score>`.
 
     Parameters
     ----------
-    y_true : 1d array-like, or label indicator array / sparse matrix
+    y_true : {array-like, sparse matrix} of shape (n_samples,) or \
+            (n_samples, n_outputs)
         Ground truth (correct) labels.
 
-    y_pred : 1d array-like, or label indicator array / sparse matrix
+    y_pred : {array-like, sparse matrix} of shape (n_samples,) or \
+            (n_samples, n_outputs)
         Predicted labels, as returned by a classifier.
 
     normalize : bool, default=True
         If ``False``, return the number of correctly classified samples.
         Otherwise, return the fraction of correctly classified samples.
+        This option is not valid when `multilabel="average"`.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
+
+    multilabel : {"exact-match", "average"}, default="exact-match"
+        Only used when the targets are multilabel indicator.
 
     Returns
     -------
@@ -191,19 +208,45 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
     >>> accuracy_score(y_true, y_pred, normalize=False)
     2
 
-    In the multilabel case with binary label indicators:
+    In the multilabel case with binary label indicators, with exact sets
+    matching:
 
-    >>> import numpy as np
-    >>> accuracy_score(np.array([[0, 1], [1, 1]]), np.ones((2, 2)))
+    >>> y_true = [[0, 1], [1, 1]]
+    >>> y_pred = [[1, 1], [1, 1]]
+    >>> accuracy_score(y_true, y_pred)
     0.5
+
+    If we want to be less strict and to average across all labels, we can
+    change the parameter `multilabel`:
+
+    >>> accuracy_score(y_true, y_pred, multilabel="average")
+    0.75
     """
 
     # Compute accuracy for each possible representation
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
     check_consistent_length(y_true, y_pred, sample_weight)
+
     if y_type.startswith('multilabel'):
+        # validate the associated parameters
+        if multilabel not in {"exact-match", "average"}:
+            raise ValueError(
+                f"The parameter multilabel should be either 'exact-match' or "
+                f"'average'. Got '{multilabel}' instead."
+            )
+        if multilabel == "average" and not normalize:
+            raise ValueError(
+                "When multilabel='average', normalize should be set to True. "
+                "Otherwise, the score will not correspond to the number of "
+                "samples and would be ambiguous."
+            )
+
         differing_labels = count_nonzero(y_true - y_pred, axis=1)
-        score = differing_labels == 0
+        if multilabel == "exact-match":
+            score = differing_labels == 0
+        else:
+            n_outputs = y_true.shape[1]
+            score = (n_outputs - differing_labels) / n_outputs
     else:
         score = y_true == y_pred
 


### PR DESCRIPTION
closes #16832

Propose to add a parameter `multilabel` to `accuracy_score` to compute either the exact match ratio or the Hamming score.