### PR TITLE
MNT Use const memory views in DistanceMetric subclasses

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -98,6 +98,9 @@ Changelog
 - |API| :class:`cluster.Birch` attributes, `fit_` and `partial_fit_`, are
   deprecated and will be removed in 1.2. :pr:`19297` by `Thomas Fan`_.
 
+- |FIX| :class:`cluster.AgglomerativeClustering` now supports readonly
+  mem-mapped datasets. :pr:`19883` by `Julien Jerphanion <jjerphan>`.
+
 :mod:`sklearn.compose`
 ......................
 
@@ -305,6 +308,9 @@ Changelog
   complexity from :math:`\mathcal{O}(n^2)` to :math:`\mathcal{O}(n)`.
   :pr:`19473` by :user:`jiefangxuanyan <jiefangxuanyan>` and
   :user:`Julien Jerphanion <jjerphan>`.
+
+- |FIX| :class:`neighbors.DistanceMetric` subclasses now support readonly
+  mem-mapped datasets. :pr:`19883` by `Julien Jerphanion <jjerphan>`.
 
 :mod:`sklearn.pipeline`
 .......................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -99,7 +99,7 @@ Changelog
   deprecated and will be removed in 1.2. :pr:`19297` by `Thomas Fan`_.
 
 - |FIX| :class:`cluster.AgglomerativeClustering` now supports readonly
-  mem-mapped datasets. :pr:`19883` by `Julien Jerphanion <jjerphan>`.
+  memory-mapped datasets. :pr:`19883` by `Julien Jerphanion <jjerphan>`.
 
 :mod:`sklearn.compose`
 ......................
@@ -310,7 +310,7 @@ Changelog
   :user:`Julien Jerphanion <jjerphan>`.
 
 - |FIX| :class:`neighbors.DistanceMetric` subclasses now support readonly
-  mem-mapped datasets. :pr:`19883` by `Julien Jerphanion <jjerphan>`.
+  memory-mapped datasets. :pr:`19883` by `Julien Jerphanion <jjerphan>`.
 
 :mod:`sklearn.pipeline`
 .......................

--- a/sklearn/cluster/_hierarchical_fast.pyx
+++ b/sklearn/cluster/_hierarchical_fast.pyx
@@ -455,7 +455,7 @@ def single_linkage_label(L):
 @cython.boundscheck(False)
 @cython.nonecheck(False)
 def mst_linkage_core(
-        DTYPE_t [:, ::1] raw_data,
+        const DTYPE_t [:, ::1] raw_data,
         DistanceMetric dist_metric):
     """
     Compute the necessary elements of a minimum spanning

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -5,6 +5,7 @@ Several basic tests for hierarchical clustering procedures
 # Authors: Vincent Michel, 2010, Gael Varoquaux 2012,
 #          Matteo Visconti di Oleggio Castello 2014
 # License: BSD 3 clause
+import itertools
 from tempfile import mkdtemp
 import shutil
 import pytest
@@ -15,7 +16,11 @@ from scipy import sparse
 from scipy.cluster import hierarchy
 
 from sklearn.metrics.cluster import adjusted_rand_score
-from sklearn.utils._testing import assert_almost_equal
+from sklearn.neighbors.tests.test_dist_metrics import METRICS_DEFAULT_PARAMS
+from sklearn.utils._testing import (
+    assert_almost_equal,
+    create_memmap_backed_data
+)
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import ignore_warnings
 
@@ -28,8 +33,12 @@ from sklearn.feature_extraction.image import grid_to_graph
 from sklearn.metrics.pairwise import PAIRED_DISTANCES, cosine_distances,\
     manhattan_distances, pairwise_distances
 from sklearn.metrics.cluster import normalized_mutual_info_score
-from sklearn.neighbors import kneighbors_graph
-from sklearn.cluster._hierarchical_fast import average_merge, max_merge
+from sklearn.neighbors import kneighbors_graph, DistanceMetric
+from sklearn.cluster._hierarchical_fast import (
+    average_merge,
+    max_merge,
+    mst_linkage_core
+)
 from sklearn.utils._fast_dict import IntFloatDict
 from sklearn.utils._testing import assert_array_equal
 from sklearn.datasets import make_moons, make_circles
@@ -264,6 +273,14 @@ def test_agglomerative_clustering():
     assert_array_equal(clustering.labels_, clustering2.labels_)
 
 
+def test_agglomerative_clustering_mem_mapped():
+    """AgglomerativeClustering must work on mem-mapped dataset.
+    Non-regression test for issue #19875."""
+    rng = np.random.RandomState(0)
+    Xmm = create_memmap_backed_data(rng.randn(50, 100))
+    AgglomerativeClustering(affinity="euclidean", linkage="single").fit(Xmm)
+
+
 def test_ward_agglomeration():
     # Check that we obtain the correct solution in a simplistic case
     rng = np.random.RandomState(0)
@@ -373,6 +390,23 @@ def test_vector_scikit_single_vs_scipy_single(seed):
     cut = _hc_cut(n_clusters, children, n_leaves)
     cut_scipy = _hc_cut(n_clusters, children_scipy, n_leaves)
     assess_same_labelling(cut, cut_scipy)
+
+
+@pytest.mark.parametrize('metric', METRICS_DEFAULT_PARAMS)
+def test_mst_linkage_core_mem_mapped(metric):
+    """The MST-LINKAGE-CORE algorithm must work on mem-mapped dataset.
+    Non-regression test for issue #19875."""
+    rng = np.random.RandomState(seed=1)
+    X = rng.normal(size=(20, 4))
+    Xmm = create_memmap_backed_data(X)
+    argdict = METRICS_DEFAULT_PARAMS[metric]
+    keys = argdict.keys()
+    for vals in itertools.product(*argdict.values()):
+        kwargs = dict(zip(keys, vals))
+        distance_metric = DistanceMetric.get_metric(metric, **kwargs)
+        mst = mst_linkage_core(X, distance_metric)
+        mst_mm = mst_linkage_core(Xmm, distance_metric)
+        np.testing.assert_equal(mst, mst_mm)
 
 
 def test_identical_points():

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -275,7 +275,9 @@ def test_agglomerative_clustering():
 
 def test_agglomerative_clustering_mem_mapped():
     """AgglomerativeClustering must work on mem-mapped dataset.
-    Non-regression test for issue #19875."""
+    
+    Non-regression test for issue #19875.
+    """
     rng = np.random.RandomState(0)
     Xmm = create_memmap_backed_data(rng.randn(50, 100))
     AgglomerativeClustering(affinity="euclidean", linkage="single").fit(Xmm)

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -397,6 +397,7 @@ def test_vector_scikit_single_vs_scipy_single(seed):
 @pytest.mark.parametrize('metric', METRICS_DEFAULT_PARAMS)
 def test_mst_linkage_core_mem_mapped(metric):
     """The MST-LINKAGE-CORE algorithm must work on mem-mapped dataset.
+
     Non-regression test for issue #19875."""
     rng = np.random.RandomState(seed=1)
     X = rng.normal(size=(20, 4))

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -273,7 +273,7 @@ def test_agglomerative_clustering():
     assert_array_equal(clustering.labels_, clustering2.labels_)
 
 
-def test_agglomerative_clustering_mem_mapped():
+def test_agglomerative_clustering_memory_mapped():
     """AgglomerativeClustering must work on mem-mapped dataset.
     
     Non-regression test for issue #19875.
@@ -395,7 +395,7 @@ def test_vector_scikit_single_vs_scipy_single(seed):
 
 
 @pytest.mark.parametrize('metric', METRICS_DEFAULT_PARAMS)
-def test_mst_linkage_core_mem_mapped(metric):
+def test_mst_linkage_core_memory_mapped(metric):
     """The MST-LINKAGE-CORE algorithm must work on mem-mapped dataset.
 
     Non-regression test for issue #19875."""

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -275,7 +275,7 @@ def test_agglomerative_clustering():
 
 def test_agglomerative_clustering_memory_mapped():
     """AgglomerativeClustering must work on mem-mapped dataset.
-    
+
     Non-regression test for issue #19875.
     """
     rng = np.random.RandomState(0)

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -398,7 +398,8 @@ def test_vector_scikit_single_vs_scipy_single(seed):
 def test_mst_linkage_core_memory_mapped(metric):
     """The MST-LINKAGE-CORE algorithm must work on mem-mapped dataset.
 
-    Non-regression test for issue #19875."""
+    Non-regression test for issue #19875.
+    """
     rng = np.random.RandomState(seed=1)
     X = rng.normal(size=(20, 4))
     Xmm = create_memmap_backed_data(X)

--- a/sklearn/neighbors/_dist_metrics.pxd
+++ b/sklearn/neighbors/_dist_metrics.pxd
@@ -15,7 +15,7 @@ from ._typedefs import DTYPE, ITYPE
 #
 #  We use these for the default (euclidean) case so that they can be
 #  inlined.  This leads to faster computation for the most common case
-cdef inline DTYPE_t euclidean_dist(DTYPE_t* x1, DTYPE_t* x2,
+cdef inline DTYPE_t euclidean_dist(const DTYPE_t* x1, const DTYPE_t* x2,
                                    ITYPE_t size) nogil except -1:
     cdef DTYPE_t tmp, d=0
     cdef np.intp_t j
@@ -25,7 +25,7 @@ cdef inline DTYPE_t euclidean_dist(DTYPE_t* x1, DTYPE_t* x2,
     return sqrt(d)
 
 
-cdef inline DTYPE_t euclidean_rdist(DTYPE_t* x1, DTYPE_t* x2,
+cdef inline DTYPE_t euclidean_rdist(const DTYPE_t* x1, const DTYPE_t* x2,
                                     ITYPE_t size) nogil except -1:
     cdef DTYPE_t tmp, d=0
     cdef np.intp_t j
@@ -35,11 +35,11 @@ cdef inline DTYPE_t euclidean_rdist(DTYPE_t* x1, DTYPE_t* x2,
     return d
 
 
-cdef inline DTYPE_t euclidean_dist_to_rdist(DTYPE_t dist) nogil except -1:
+cdef inline DTYPE_t euclidean_dist_to_rdist(const DTYPE_t dist) nogil except -1:
     return dist * dist
 
 
-cdef inline DTYPE_t euclidean_rdist_to_dist(DTYPE_t dist) nogil except -1:
+cdef inline DTYPE_t euclidean_rdist_to_dist(const DTYPE_t dist) nogil except -1:
     return sqrt(dist)
 
 
@@ -61,7 +61,7 @@ cdef class DistanceMetric:
     cdef object func
     cdef object kwargs
 
-    cdef DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                       ITYPE_t size) nogil except -1
 
     cdef DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,

--- a/sklearn/neighbors/_dist_metrics.pyx
+++ b/sklearn/neighbors/_dist_metrics.pyx
@@ -300,7 +300,7 @@ cdef class DistanceMetric:
         """
         return
 
-    cdef DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                       ITYPE_t size) nogil except -1:
         """Compute the distance between vectors x1 and x2
 
@@ -308,7 +308,7 @@ cdef class DistanceMetric:
         """
         return -999
 
-    cdef DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                        ITYPE_t size) nogil except -1:
         """Compute the reduced distance between vectors x1 and x2.
 
@@ -321,7 +321,7 @@ cdef class DistanceMetric:
         """
         return self.dist(x1, x2, size)
 
-    cdef int pdist(self, DTYPE_t[:, ::1] X, DTYPE_t[:, ::1] D) except -1:
+    cdef int pdist(self, const DTYPE_t[:, ::1] X, DTYPE_t[:, ::1] D) except -1:
         """compute the pairwise distances between points in X"""
         cdef ITYPE_t i1, i2
         for i1 in range(X.shape[0]):
@@ -330,7 +330,7 @@ cdef class DistanceMetric:
                 D[i2, i1] = D[i1, i2]
         return 0
 
-    cdef int cdist(self, DTYPE_t[:, ::1] X, DTYPE_t[:, ::1] Y,
+    cdef int cdist(self, const DTYPE_t[:, ::1] X, const DTYPE_t[:, ::1] Y,
                    DTYPE_t[:, ::1] D) except -1:
         """compute the cross-pairwise distances between arrays X and Y"""
         cdef ITYPE_t i1, i2
@@ -423,11 +423,11 @@ cdef class EuclideanDistance(DistanceMetric):
     def __init__(self):
         self.p = 2
 
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         return euclidean_dist(x1, x2, size)
 
-    cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         return euclidean_rdist(x1, x2, size)
 
@@ -463,7 +463,7 @@ cdef class SEuclideanDistance(DistanceMetric):
         if X.shape[1] != self.size:
             raise ValueError('SEuclidean dist: size of V does not match')
 
-    cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         cdef DTYPE_t tmp, d=0
         cdef np.intp_t j
@@ -472,7 +472,7 @@ cdef class SEuclideanDistance(DistanceMetric):
             d += tmp * tmp / self.vec_ptr[j]
         return d
 
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         return sqrt(self.rdist(x1, x2, size))
 
@@ -501,7 +501,7 @@ cdef class ManhattanDistance(DistanceMetric):
     def __init__(self):
         self.p = 1
 
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef DTYPE_t d = 0
         cdef np.intp_t j
@@ -534,7 +534,7 @@ cdef class ChebyshevDistance(DistanceMetric):
     def __init__(self):
         self.p = INF
 
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef DTYPE_t d = 0
         cdef np.intp_t j
@@ -565,7 +565,7 @@ cdef class MinkowskiDistance(DistanceMetric):
                              "For p=inf, use ChebyshevDistance.")
         self.p = p
 
-    cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         cdef DTYPE_t d=0
         cdef np.intp_t j
@@ -573,7 +573,7 @@ cdef class MinkowskiDistance(DistanceMetric):
             d += pow(fabs(x1[j] - x2[j]), self.p)
         return d
 
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         return pow(self.rdist(x1, x2, size), 1. / self.p)
 
@@ -625,7 +625,7 @@ cdef class WMinkowskiDistance(DistanceMetric):
             raise ValueError('WMinkowskiDistance dist: '
                              'size of w does not match')
 
-    cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         cdef DTYPE_t d=0
         cdef np.intp_t j
@@ -633,7 +633,7 @@ cdef class WMinkowskiDistance(DistanceMetric):
             d += pow(self.vec_ptr[j] * fabs(x1[j] - x2[j]), self.p)
         return d
 
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         return pow(self.rdist(x1, x2, size), 1. / self.p)
 
@@ -690,7 +690,7 @@ cdef class MahalanobisDistance(DistanceMetric):
         if X.shape[1] != self.size:
             raise ValueError('Mahalanobis dist: size of V does not match')
 
-    cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         cdef DTYPE_t tmp, d = 0
         cdef np.intp_t i, j
@@ -706,7 +706,7 @@ cdef class MahalanobisDistance(DistanceMetric):
             d += tmp * self.vec_ptr[i]
         return d
 
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         return sqrt(self.rdist(x1, x2, size))
 
@@ -735,7 +735,7 @@ cdef class HammingDistance(DistanceMetric):
     .. math::
        D(x, y) = \frac{1}{N} \sum_i \delta_{x_i, y_i}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int n_unequal = 0
         cdef np.intp_t j
@@ -757,7 +757,7 @@ cdef class CanberraDistance(DistanceMetric):
     .. math::
        D(x, y) = \sum_i \frac{|x_i - y_i|}{|x_i| + |y_i|}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef DTYPE_t denom, d = 0
         cdef np.intp_t j
@@ -780,7 +780,7 @@ cdef class BrayCurtisDistance(DistanceMetric):
     .. math::
        D(x, y) = \frac{\sum_i |x_i - y_i|}{\sum_i(|x_i| + |y_i|)}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef DTYPE_t num = 0, denom = 0
         cdef np.intp_t j
@@ -806,7 +806,7 @@ cdef class JaccardDistance(DistanceMetric):
     .. math::
        D(x, y) = \frac{N_{TF} + N_{FT}}{N_{TT} + N_{TF} + N_{FT}}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_eq = 0, nnz = 0
         cdef np.intp_t j
@@ -836,7 +836,7 @@ cdef class MatchingDistance(DistanceMetric):
     .. math::
        D(x, y) = \frac{N_{TF} + N_{FT}}{N}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_neq = 0
         cdef np.intp_t j
@@ -860,7 +860,7 @@ cdef class DiceDistance(DistanceMetric):
     .. math::
        D(x, y) = \frac{N_{TF} + N_{FT}}{2 * N_{TT} + N_{TF} + N_{FT}}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_neq = 0, ntt = 0
         cdef np.intp_t j
@@ -885,7 +885,7 @@ cdef class KulsinskiDistance(DistanceMetric):
     .. math::
        D(x, y) = 1 - \frac{N_{TT}}{N + N_{TF} + N_{FT}}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, ntt = 0, n_neq = 0
         cdef np.intp_t j
@@ -910,7 +910,7 @@ cdef class RogersTanimotoDistance(DistanceMetric):
     .. math::
        D(x, y) = \frac{2 (N_{TF} + N_{FT})}{N + N_{TF} + N_{FT}}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_neq = 0
         cdef np.intp_t j
@@ -934,7 +934,7 @@ cdef class RussellRaoDistance(DistanceMetric):
     .. math::
        D(x, y) = \frac{N - N_{TT}}{N}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, ntt = 0
         cdef np.intp_t j
@@ -958,7 +958,7 @@ cdef class SokalMichenerDistance(DistanceMetric):
     .. math::
        D(x, y) = \frac{2 (N_{TF} + N_{FT})}{N + N_{TF} + N_{FT}}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_neq = 0
         cdef np.intp_t j
@@ -982,7 +982,7 @@ cdef class SokalSneathDistance(DistanceMetric):
     .. math::
        D(x, y) = \frac{N_{TF} + N_{FT}}{N_{TT} / 2 + N_{TF} + N_{FT}}
     """
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, ntt = 0, n_neq = 0
         cdef np.intp_t j
@@ -1016,13 +1016,13 @@ cdef class HaversineDistance(DistanceMetric):
             raise ValueError("Haversine distance only valid "
                              "in 2 dimensions")
 
-    cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         cdef DTYPE_t sin_0 = sin(0.5 * (x1[0] - x2[0]))
         cdef DTYPE_t sin_1 = sin(0.5 * (x1[1] - x2[1]))
         return (sin_0 * sin_0 + cos(x1[0]) * cos(x2[0]) * sin_1 * sin_1)
 
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         return 2 * asin(sqrt(self.rdist(x1, x2, size)))
 
@@ -1047,7 +1047,8 @@ cdef class HaversineDistance(DistanceMetric):
 # [This is not a true metric, so we will leave it out.]
 #
 #cdef class YuleDistance(DistanceMetric):
-#    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2, ITYPE_t size):
+#    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
+#                             ITYPE_t size):
 #        cdef int tf1, tf2, ntf = 0, nft = 0, ntt = 0, nff = 0
 #        cdef np.intp_t j
 #        for j in range(size):
@@ -1066,7 +1067,8 @@ cdef class HaversineDistance(DistanceMetric):
 # [This is not a true metric, so we will leave it out.]
 #
 #cdef class CosineDistance(DistanceMetric):
-#    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2, ITYPE_t size):
+#    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
+#                             ITYPE_t size):
 #        cdef DTYPE_t d = 0, norm1 = 0, norm2 = 0
 #        cdef np.intp_t j
 #        for j in range(size):
@@ -1082,7 +1084,8 @@ cdef class HaversineDistance(DistanceMetric):
 # [This is not a true metric, so we will leave it out.]
 #
 #cdef class CorrelationDistance(DistanceMetric):
-#    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2, ITYPE_t size):
+#    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
+#                             ITYPE_t size):
 #        cdef DTYPE_t mu1 = 0, mu2 = 0, x1nrm = 0, x2nrm = 0, x1Tx2 = 0
 #        cdef DTYPE_t tmp1, tmp2
 #
@@ -1125,11 +1128,11 @@ cdef class PyFuncDistance(DistanceMetric):
     # allowed in cython >= 0.26 since it is a redundant GIL acquisition. The
     # only way to be back compatible is to inherit `dist` from the base class
     # without GIL and called an inline `_dist` which acquire GIL.
-    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         return self._dist(x1, x2, size)
 
-    cdef inline DTYPE_t _dist(self, DTYPE_t* x1, DTYPE_t* x2,
+    cdef inline DTYPE_t _dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) except -1 with gil:
         cdef np.ndarray x1arr
         cdef np.ndarray x2arr

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -61,7 +61,7 @@ def test_cdist(metric, X1, X2):
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
         if metric == "mahalanobis":
-            pytest.skip("cdist with 'mahalanobis' fails on memmap data")
+            pytest.xfail("cdist with 'mahalanobis' fails on memmap data")
         elif metric == "wminkowski":
             if sp_version >= parse_version("1.8.0"):
                 pytest.skip("wminkowski will be removed in SciPy 1.8.0")
@@ -106,8 +106,7 @@ def test_pdist(metric, X1, X2):
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
         if metric == "mahalanobis":
-            pytest.skip("pdist with 'mahalanobis' fails on memmap data")
-
+            pytest.xfail("cdist with 'mahalanobis' fails on memmap data")
         elif metric == "wminkowski":
             if sp_version >= parse_version("1.8.0"):
                 pytest.skip("wminkowski will be removed in SciPy 1.8.0")

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -60,7 +60,9 @@ def test_cdist(metric, X1, X2):
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
-        if metric == "wminkowski":
+        if metric == "mahalanobis":
+            pytest.skip("cdist with 'mahalanobis' fails on memmap data")
+        elif metric == "wminkowski":
             if sp_version >= parse_version("1.8.0"):
                 pytest.skip("wminkowski will be removed in SciPy 1.8.0")
 
@@ -103,7 +105,10 @@ def test_pdist(metric, X1, X2):
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
-        if metric == "wminkowski":
+        if metric == "mahalanobis":
+            pytest.skip("pdist with 'mahalanobis' fails on memmap data")
+
+        elif metric == "wminkowski":
             if sp_version >= parse_version("1.8.0"):
                 pytest.skip("wminkowski will be removed in SciPy 1.8.0")
 

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -61,7 +61,9 @@ def test_cdist(metric, X1, X2):
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
         if metric == "mahalanobis":
-            pytest.xfail("cdist with 'mahalanobis' fails on memmap data")
+            # See: https://github.com/scipy/scipy/issues/13861
+            pytest.xfail("scipy#13861: cdist with 'mahalanobis' fails on"
+                         "memmap data")
         elif metric == "wminkowski":
             if sp_version >= parse_version("1.8.0"):
                 pytest.skip("wminkowski will be removed in SciPy 1.8.0")
@@ -106,7 +108,9 @@ def test_pdist(metric, X1, X2):
     for vals in itertools.product(*argdict.values()):
         kwargs = dict(zip(keys, vals))
         if metric == "mahalanobis":
-            pytest.xfail("cdist with 'mahalanobis' fails on memmap data")
+            # See: https://github.com/scipy/scipy/issues/13861
+            pytest.xfail("scipy#13861: pdist with 'mahalanobis' fails on"
+                         "memmap data")
         elif metric == "wminkowski":
             if sp_version >= parse_version("1.8.0"):
                 pytest.skip("wminkowski will be removed in SciPy 1.8.0")

--- a/sklearn/neighbors/tests/test_dist_metrics.py
+++ b/sklearn/neighbors/tests/test_dist_metrics.py
@@ -10,6 +10,7 @@ from scipy.spatial.distance import cdist
 from sklearn.neighbors import DistanceMetric
 from sklearn.neighbors import BallTree
 from sklearn.utils import check_random_state
+from sklearn.utils._testing import create_memmap_backed_data
 from sklearn.utils.fixes import sp_version, parse_version
 
 
@@ -24,9 +25,14 @@ n2 = 25
 X1 = rng.random_sample((n1, d)).astype('float64', copy=False)
 X2 = rng.random_sample((n2, d)).astype('float64', copy=False)
 
+[X1_mmap, X2_mmap] = create_memmap_backed_data([X1, X2])
+
 # make boolean arrays: ones and zeros
 X1_bool = X1.round(0)
 X2_bool = X2.round(0)
+
+[X1_bool_mmap, X2_bool_mmap] = create_memmap_backed_data([X1_bool, X2_bool])
+
 
 V = rng.random_sample((d, d))
 VI = np.dot(V, V.T)
@@ -47,9 +53,9 @@ METRICS_DEFAULT_PARAMS = {'euclidean': {},
                           'canberra': {},
                           'braycurtis': {}}
 
-
 @pytest.mark.parametrize('metric', METRICS_DEFAULT_PARAMS)
-def test_cdist(metric):
+@pytest.mark.parametrize('X1, X2', [(X1, X2), (X1_mmap, X2_mmap)])
+def test_cdist(metric, X1, X2):
     argdict = METRICS_DEFAULT_PARAMS[metric]
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):
@@ -71,7 +77,9 @@ def test_cdist(metric):
 
 
 @pytest.mark.parametrize('metric', BOOL_METRICS)
-def test_cdist_bool_metric(metric):
+@pytest.mark.parametrize('X1_bool, X2_bool', [(X1_bool, X2_bool),
+                                              (X1_bool_mmap, X2_bool_mmap)])
+def test_cdist_bool_metric(metric, X1_bool, X2_bool):
     D_true = cdist(X1_bool, X2_bool, metric)
     check_cdist_bool(metric, D_true)
 
@@ -89,7 +97,8 @@ def check_cdist_bool(metric, D_true):
 
 
 @pytest.mark.parametrize('metric', METRICS_DEFAULT_PARAMS)
-def test_pdist(metric):
+@pytest.mark.parametrize('X1, X2', [(X1, X2), (X1_mmap, X2_mmap)])
+def test_pdist(metric, X1, X2):
     argdict = METRICS_DEFAULT_PARAMS[metric]
     keys = argdict.keys()
     for vals in itertools.product(*argdict.values()):
@@ -111,7 +120,8 @@ def test_pdist(metric):
 
 
 @pytest.mark.parametrize('metric', BOOL_METRICS)
-def test_pdist_bool_metrics(metric):
+@pytest.mark.parametrize('X1_bool', [X1_bool, X1_bool_mmap])
+def test_pdist_bool_metrics(metric, X1_bool):
     D_true = cdist(X1_bool, X1_bool, metric)
     check_pdist_bool(metric, D_true)
 
@@ -143,7 +153,8 @@ def test_pickle(metric):
 
 
 @pytest.mark.parametrize('metric', BOOL_METRICS)
-def test_pickle_bool_metrics(metric):
+@pytest.mark.parametrize('X1_bool', [X1_bool, X1_bool_mmap])
+def test_pickle_bool_metrics(metric, X1_bool):
     dm = DistanceMetric.get_metric(metric)
     D1 = dm.pairwise(X1_bool)
     dm2 = pickle.loads(pickle.dumps(dm))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #19875.
See also #10624.


#### What does this implement/fix? Explain your changes.

Distances computations (`cluster.DistanceMetric`s) implemented in Cython do not support readonly datasets, which are obtained  when using mem-mapping for instance. This makes some interfaces relying on those implementation fail (see #19875).

This PR makes the Cython implementations use `const` memoryviews to be able computing those distances on memmapped datasets.

#### Any other comments?

5b61a29 fixes #19875, but maybe we should have the downstream issues be solved independently from this PR.

Also `scipy.spatial.distance.{cdist,pdist}` on memmapped datasets with `'mahalanobis'` as a metric fail.
I am inspecting why; in the meantime 716b330 skips the associated tests.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
