### PR TITLE
Enable and validate user ability to provide specific   landmark points for Nystroem kernel approximation.

### DIFF
--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -41,7 +41,9 @@ the data on which the kernel is evaluated.
 By default :class:`Nystroem` uses the ``rbf`` kernel, but it can use any
 kernel function or a precomputed kernel matrix.
 The number of samples used - which is also the dimensionality of the features computed -
-is given by the parameter ``n_components``.
+is given by the parameter ``n_components``. In addition, it is possible to
+pre-select the best samples to approximate the matrix. They can be given as
+``landmarks`` parameter.
 
 .. _rbf_kernel_approx:
 
@@ -71,10 +73,12 @@ the ``transform`` method performs the mapping of the data.  Because of the
 inherent randomness of the process, results may vary between different calls to
 the ``fit`` function.
 
-The ``fit`` function takes two arguments:
+The ``fit`` function takes three arguments:
 ``n_components``, which is the target dimensionality of the feature transform,
-and ``gamma``, the parameter of the RBF-kernel.  A higher ``n_components`` will
-result in a better approximation of the kernel and will yield results more
+``gamma``, the parameter of the RBF-kernel, and ``landmarks`` - list of
+pre-selected samples, which will be used for the approximation.
+A higher ``n_components`` (or bigger ``landmarks``) will result in a better
+approximation of the kernel and will yield results more
 similar to those produced by a kernel SVM. Note that "fitting" the feature
 function does not actually depend on the data given to the ``fit`` function.
 Only the dimensionality of the data is used.
@@ -94,6 +98,12 @@ use of larger feature spaces more efficient.
 .. topic:: Examples:
 
     * :ref:`sphx_glr_auto_examples_miscellaneous_plot_kernel_approximation.py`
+
+Samples for fit can be selected, using the methods implemented in sklearn.
+
+.. seealso::
+
+   :ref:`feature_selection` for a selection methods.
 
 .. _additive_chi_kernel_approx:
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -176,6 +176,13 @@ Changelog
   :func:`~sklearn.inspection.permutation_importance`.
   :pr:`19411` by :user:`Simona Maggio <simonamaggio>`.
 
+:mod:`sklearn.kernel_approximation`
+...................................
+
+- |Enhancement| Enable and validate user ability to provide specific
+  landmark points for Nystroem kernel approximation.
+  :pr:`XXXXX` by :user:`Sergei Kliavinek <hurricane642>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 
@@ -276,7 +283,7 @@ Changelog
   :pr:`18649` by `Leandro Hermida <hermidalc>` and
   `Rodion Martynov <marrodion>`.
 
-- |Fix| The `fit` method of the successive halving parameter search 
+- |Fix| The `fit` method of the successive halving parameter search
   (:class:`model_selection.HalvingGridSearchCV`, and
   :class:`model_selection.HalvingRandomSearchCV`) now correctly handles the
   `groups` parameter. :pr:`19847` by :user:`Xiaoyu Chai <xiaoyuchai>`.

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -332,3 +332,24 @@ def test_nystroem_precomputed_kernel():
                       **param)
         with pytest.raises(ValueError, match=msg):
             ny.fit(K)
+
+
+def test_landmarks_using():
+    # Basic tests to check the work of the landmarks selection.
+    rnd = np.random.RandomState(0)
+    X = rnd.uniform(size=(10, 4))
+    # test that as a result of the fit we really get the components that we
+    # originally chose
+    landmarks = rnd.permutation(X.shape[0])
+    for i in range(1, len(landmarks)):
+        nystroem = Nystroem(n_components=i, kernel=_linear_kernel,
+                            random_state=rnd)
+        nystroem.fit(X, landmarks=landmarks[:i])
+        assert_array_almost_equal(X[landmarks[:i]], nystroem.components_)
+    # test correctly returned error in case the landmarks are out of range
+    msg = 'landmarks indices out of X range'
+    landmarks = [X.shape[0]]
+    nystroem = Nystroem(n_components=1, kernel=_linear_kernel,
+                        random_state=rnd)
+    with pytest.raises(IndexError, match=msg):
+        nystroem.fit(X, landmarks=landmarks)


### PR DESCRIPTION
Hi all, this is the second run on kernel_approximation. This time, comments have been added, tests have been reworked, flake8 design has been checked, and changes have been added to the documentation. Also made the changes noted earlier by @rosecers. Any suggestions are welcome. 