### PR TITLE
ENH improve KernelCenterer documentation and tests

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -265,7 +265,7 @@ kernel :math:`\tilde{K}` is defined as:
 
 Thus, one could compute :math:`\tilde{K}` by mapping :math:`X` using the
 function :math:`\phi(\cdot)` and center the data in this new space. However,
-kernels are usually used because they allows some algebra calculations that
+kernels are often used because they allows some algebra calculations that
 avoid computing explicitly this mapping using :math:`\phi(\cdot)`. Indeed, one
 can implicitly center as shown in Appendix B in [Scholkopf1998]_:
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -243,25 +243,25 @@ If you have a kernel matrix of a kernel :math:`K` that computes a dot product
 in a feature space (possibly implicitly) defined by a function
 :math:`\phi(\cdot)`, a :class:`KernelCenterer` can transform the kernel matrix
 so that it contains inner products in the feature space defined by
-:math:`\phi(\cdot)` followed by removal of the mean in that space.
+:math:`\phi` followed by the removal of the mean in that space.
 
 **Mathematical formulation**
 
 We can have a look at the mathematical formulation now that we have the
-intuition. Let :math:`K` our kernel of shape `(n_samples, n_samples)` computed
+intuition. Let :math:`K` be a kernel matrix of shape `(n_samples, n_samples)` computed
 from :math:`X`, a data matrix of shape `(n_samples, n_features)`. :math:`K` is
 defined by
 
 .. math::
   K(X, X) = \phi(X) . \phi(X)^{T}
 
-:math:`\phi(X)` is a function mapping :math:`X` to a Hilbert space. A centered
+:math:`\phi(X)` is a function mapping of :math:`X` to a Hilbert space. A centered
 kernel :math:`\tilde{K}` is defined as:
 
 .. math::
   \tilde{K}(X, X) = \tilde{\phi}(X) . \tilde{\phi}(X)^{T}
 
-:math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert space.
+where :math:`\tilde{\phi}(X)` results from centering :math:`\phi(X)` in the Hilbert space.
 
 Thus, one could compute :math:`\tilde{K}` by mapping :math:`X` using the
 function :math:`\phi(\cdot)` and center the data in this new space. However,
@@ -286,7 +286,7 @@ centering :math:`K_{test}` is done as:
 .. math::
   \tilde{K}_{test}(X, Y) = K_{test} - 1'_{\text{n}_{samples}} K - K_{test} 1_{\text{n}_{samples}} + 1'_{\text{n}_{samples}} K 1_{\text{n}_{samples}}
 
-:math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples_test, n_samples)`
+:math:`1_{\text{n}_{samples}}` is a matrix of shape `(n_samples_test, n_samples)`
 where all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`.
 
 .. topic:: References

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -240,10 +240,47 @@ Centering kernel matrices
 -------------------------
 
 If you have a kernel matrix of a kernel :math:`K` that computes a dot product
-in a feature space defined by function :math:`\phi`,
-a :class:`KernelCenterer` can transform the kernel matrix
-so that it contains inner products in the feature space
-defined by :math:`\phi` followed by removal of the mean in that space.
+in a feature space defined by a function :math:`\phi(.)`, a
+:class:`KernelCenterer` can transform the kernel matrix so that it contains
+inner products in the feature space defined by :math:`\phi(.)` followed by
+removal of the mean in that space.
+
+We can have a look at the mathematical formulation now that we have the
+intuition. Let :math:`K` our kernel of shape `(n_samples, n_samples)` computed
+from :math:`X`, a data matrix of shape `(n_samples, n_features)`. :math:`K` is
+defined by
+
+.. math::
+  K(X, X) = \phi(X) . \phi(X)^{T} \ ,
+
+where :math:`\phi(X)` is a function mapping :math:`X` to a Hilbert space.
+
+A centered kernel :math:`\tilde{K}` is defined as:
+
+.. math::
+  \tilde{K(X, X)} = \tilde{\phi}(X) . \tilde{\phi}(X)^{T} \ ,
+
+where :math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert
+space.
+
+Thus, one could compute :math:`\tilde{K}` by mapping :math:`X` using the
+function :math:`\phi(.)` and center the data in this new space. However,
+kernels are usually used because they allows some algebra computations that
+avoid computing explicitly this mapping using :math:`\phi(.)`. Indeed, one
+can implicitly center as shown in Appendix B in [Scholkopf1998]:
+
+.. math::
+  \tilde{K} = K - 1_{\text{n}_{samples}} K - K 1_{\text{n}_{samples}} + 1_{n_{samples}\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,
+
+where :math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples, n_samples)`
+where all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`.
+
+.. topic:: References
+
+  .. [Scholkopf1998] B. Schölkopf, A. Smola, and K.R. Müller,
+    `"Nonlinear component analysis as a kernel eigenvalue problem."
+    <https://www.mlpack.org/papers/kpca.pdf>`_
+    Neural computation 10.5 (1998): 1299-1319.
 
 .. _preprocessing_transformer:
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -270,7 +270,7 @@ avoid computing explicitly this mapping using :math:`\phi(.)`. Indeed, one
 can implicitly center as shown in Appendix B in [Scholkopf1998]:
 
 .. math::
-  \tilde{K} = K - 1_{\text{n}_{samples}} K - K 1_{\text{n}_{samples}} + 1_{n_{samples}\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,
+  \tilde{K} = K - 1_{\text{n}_{samples}} K - K 1_{\text{n}_{samples}} + 1_{\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,
 
 where :math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples, n_samples)`
 where all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`.

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -245,6 +245,8 @@ in a feature space defined by a function :math:`\phi(\dot)`, a
 inner products in the feature space defined by :math:`\phi(\dot)` followed by
 removal of the mean in that space.
 
+**Mathematical formulation**
+
 We can have a look at the mathematical formulation now that we have the
 intuition. Let :math:`K` our kernel of shape `(n_samples, n_samples)` computed
 from :math:`X`, a data matrix of shape `(n_samples, n_features)`. :math:`K` is

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -267,7 +267,7 @@ Thus, one could compute :math:`\tilde{K}` by mapping :math:`X` using the
 function :math:`\phi(.)` and center the data in this new space. However,
 kernels are usually used because they allows some algebra computations that
 avoid computing explicitly this mapping using :math:`\phi(.)`. Indeed, one
-can implicitly center as shown in Appendix B in [Scholkopf1998]:
+can implicitly center as shown in Appendix B in [Scholkopf1998]_:
 
 .. math::
   \tilde{K} = K - 1_{\text{n}_{samples}} K - K 1_{\text{n}_{samples}} + 1_{\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -240,9 +240,9 @@ Centering kernel matrices
 -------------------------
 
 If you have a kernel matrix of a kernel :math:`K` that computes a dot product
-in a feature space defined by a function :math:`\phi(.)`, a
+in a feature space defined by a function :math:`\phi(\dot)`, a
 :class:`KernelCenterer` can transform the kernel matrix so that it contains
-inner products in the feature space defined by :math:`\phi(.)` followed by
+inner products in the feature space defined by :math:`\phi(\dot)` followed by
 removal of the mean in that space.
 
 We can have a look at the mathematical formulation now that we have the
@@ -253,19 +253,18 @@ defined by
 .. math::
   K(X, X) = \phi(X) . \phi(X)^{T} \ ,
 
-where :math:`\phi(X)` is a function mapping :math:`X` to a Hilbert space.
-
-A centered kernel :math:`\tilde{K}` is defined as:
+where :math:`\phi(X)` is a function mapping :math:`X` to a Hilbert space. A
+centered kernel :math:`\tilde{K}` is defined as:
 
 .. math::
-  \tilde{K(X, X)} = \tilde{\phi}(X) . \tilde{\phi}(X)^{T} \ ,
+  \tilde{K}(X, X) = \tilde{\phi}(X) . \tilde{\phi}(X)^{T} \ ,
 
 where :math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert
 space.
 
 Thus, one could compute :math:`\tilde{K}` by mapping :math:`X` using the
-function :math:`\phi(.)` and center the data in this new space. However,
-kernels are usually used because they allows some algebra computations that
+function :math:`\phi(\dot)` and center the data in this new space. However,
+kernels are usually used because they allows some algebra calculations that
 avoid computing explicitly this mapping using :math:`\phi(.)`. Indeed, one
 can implicitly center as shown in Appendix B in [Scholkopf1998]_:
 
@@ -273,10 +272,8 @@ can implicitly center as shown in Appendix B in [Scholkopf1998]_:
   \tilde{K} = K - 1_{\text{n}_{samples}} K - K 1_{\text{n}_{samples}} + 1_{\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,
 
 where :math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples, n_samples)`
-where all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`.
-
-During `transform`, the kernel becomes :math:`K_{test}(X, Y)` that is defined
-as:
+where all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`. At
+`transform`, the kernel becomes :math:`K_{test}(X, Y)` defined as:
 
 .. math::
   K_{test}(X, Y) = \phi(Y) . \phi(X)^{T} \ ,
@@ -286,7 +283,7 @@ thus :math:`K_{test}` is of shape `(n_samples_test, n_samples)`. In this case,
 centering :math:`K_{test}` is done as:
 
 .. math::
-  \tile{K}_{test}(X, Y) = K_{test} - 1'_{\text{n}_{samples}} K - K_{test} 1_{\text{n}_{samples}} + 1'_{\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,
+  \tilde{K}_{test}(X, Y) = K_{test} - 1'_{\text{n}_{samples}} K - K_{test} 1_{\text{n}_{samples}} + 1'_{\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,
 
 where :math:`1_{\text{n}_{samples}}` is a matrix of
 `(n_samples_test, n_samples)` where all entries are equal to

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -242,8 +242,10 @@ Centering kernel matrices
 If you have a kernel matrix of a kernel :math:`K` that computes a dot product
 in a feature space (possibly implicitly) defined by a function
 :math:`\phi(\cdot)`, a :class:`KernelCenterer` can transform the kernel matrix
-so that it contains inner products in the feature space defined by
-:math:`\phi` followed by the removal of the mean in that space.
+so that it contains inner products in the feature space defined by :math:`\phi`
+followed by the removal of the mean in that space. In other words,
+:class:`KernelCenterer` computes the centered Gram matrix associated to a
+positive semidefinite kernel :math:`K`.
 
 **Mathematical formulation**
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -240,9 +240,9 @@ Centering kernel matrices
 -------------------------
 
 If you have a kernel matrix of a kernel :math:`K` that computes a dot product
-in a feature space defined by a function :math:`\phi(\dot)`, a
+in a feature space defined by a function :math:`\phi(\cdot)`, a
 :class:`KernelCenterer` can transform the kernel matrix so that it contains
-inner products in the feature space defined by :math:`\phi(\dot)` followed by
+inner products in the feature space defined by :math:`\phi(\cdot)` followed by
 removal of the mean in that space.
 
 **Mathematical formulation**
@@ -265,9 +265,9 @@ where :math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert
 space.
 
 Thus, one could compute :math:`\tilde{K}` by mapping :math:`X` using the
-function :math:`\phi(\dot)` and center the data in this new space. However,
+function :math:`\phi(\cdot)` and center the data in this new space. However,
 kernels are usually used because they allows some algebra calculations that
-avoid computing explicitly this mapping using :math:`\phi(.)`. Indeed, one
+avoid computing explicitly this mapping using :math:`\phi(\cdot)`. Indeed, one
 can implicitly center as shown in Appendix B in [Scholkopf1998]_:
 
 .. math::

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -240,10 +240,10 @@ Centering kernel matrices
 -------------------------
 
 If you have a kernel matrix of a kernel :math:`K` that computes a dot product
-in a feature space defined by a function :math:`\phi(\cdot)`, a
-:class:`KernelCenterer` can transform the kernel matrix so that it contains
-inner products in the feature space defined by :math:`\phi(\cdot)` followed by
-removal of the mean in that space.
+in a feature space (possibly implicitly) defined by a function
+:math:`\phi(\cdot)`, a :class:`KernelCenterer` can transform the kernel matrix
+so that it contains inner products in the feature space defined by
+:math:`\phi(\cdot)` followed by removal of the mean in that space.
 
 **Mathematical formulation**
 
@@ -253,16 +253,15 @@ from :math:`X`, a data matrix of shape `(n_samples, n_features)`. :math:`K` is
 defined by
 
 .. math::
-  K(X, X) = \phi(X) . \phi(X)^{T} \ ,
+  K(X, X) = \phi(X) . \phi(X)^{T}
 
-where :math:`\phi(X)` is a function mapping :math:`X` to a Hilbert space. A
-centered kernel :math:`\tilde{K}` is defined as:
+:math:`\phi(X)` is a function mapping :math:`X` to a Hilbert space. A centered
+kernel :math:`\tilde{K}` is defined as:
 
 .. math::
-  \tilde{K}(X, X) = \tilde{\phi}(X) . \tilde{\phi}(X)^{T} \ ,
+  \tilde{K}(X, X) = \tilde{\phi}(X) . \tilde{\phi}(X)^{T}
 
-where :math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert
-space.
+:math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert space.
 
 Thus, one could compute :math:`\tilde{K}` by mapping :math:`X` using the
 function :math:`\phi(\cdot)` and center the data in this new space. However,
@@ -271,25 +270,24 @@ avoid computing explicitly this mapping using :math:`\phi(\cdot)`. Indeed, one
 can implicitly center as shown in Appendix B in [Scholkopf1998]_:
 
 .. math::
-  \tilde{K} = K - 1_{\text{n}_{samples}} K - K 1_{\text{n}_{samples}} + 1_{\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,
+  \tilde{K} = K - 1_{\text{n}_{samples}} K - K 1_{\text{n}_{samples}} + 1_{\text{n}_{samples}} K 1_{\text{n}_{samples}}
 
-where :math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples, n_samples)`
-where all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`. At
-`transform`, the kernel becomes :math:`K_{test}(X, Y)` defined as:
+:math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples, n_samples)` where
+all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`. At `transform`,
+the kernel becomes :math:`K_{test}(X, Y)` defined as:
 
 .. math::
-  K_{test}(X, Y) = \phi(Y) . \phi(X)^{T} \ ,
+  K_{test}(X, Y) = \phi(Y) . \phi(X)^{T}
 
-where :math:`Y` is the test dataset of shape `(n_samples_test, n_features)` and
-thus :math:`K_{test}` is of shape `(n_samples_test, n_samples)`. In this case,
+:math:`Y` is the test dataset of shape `(n_samples_test, n_features)` and thus
+:math:`K_{test}` is of shape `(n_samples_test, n_samples)`. In this case,
 centering :math:`K_{test}` is done as:
 
 .. math::
-  \tilde{K}_{test}(X, Y) = K_{test} - 1'_{\text{n}_{samples}} K - K_{test} 1_{\text{n}_{samples}} + 1'_{\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,
+  \tilde{K}_{test}(X, Y) = K_{test} - 1'_{\text{n}_{samples}} K - K_{test} 1_{\text{n}_{samples}} + 1'_{\text{n}_{samples}} K 1_{\text{n}_{samples}}
 
-where :math:`1_{\text{n}_{samples}}` is a matrix of
-`(n_samples_test, n_samples)` where all entries are equal to
-:math:`\frac{1}{\text{n}_{samples}}`.
+:math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples_test, n_samples)`
+where all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`.
 
 .. topic:: References
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -248,20 +248,21 @@ so that it contains inner products in the feature space defined by
 **Mathematical formulation**
 
 We can have a look at the mathematical formulation now that we have the
-intuition. Let :math:`K` be a kernel matrix of shape `(n_samples, n_samples)` computed
-from :math:`X`, a data matrix of shape `(n_samples, n_features)`. :math:`K` is
-defined by
+intuition. Let :math:`K` be a kernel matrix of shape `(n_samples, n_samples)`
+computed from :math:`X`, a data matrix of shape `(n_samples, n_features)`.
+:math:`K` is defined by
 
 .. math::
   K(X, X) = \phi(X) . \phi(X)^{T}
 
-:math:`\phi(X)` is a function mapping of :math:`X` to a Hilbert space. A centered
-kernel :math:`\tilde{K}` is defined as:
+:math:`\phi(X)` is a function mapping of :math:`X` to a Hilbert space. A
+centered kernel :math:`\tilde{K}` is defined as:
 
 .. math::
   \tilde{K}(X, X) = \tilde{\phi}(X) . \tilde{\phi}(X)^{T}
 
-where :math:`\tilde{\phi}(X)` results from centering :math:`\phi(X)` in the Hilbert space.
+where :math:`\tilde{\phi}(X)` results from centering :math:`\phi(X)` in the
+Hilbert space.
 
 Thus, one could compute :math:`\tilde{K}` by mapping :math:`X` using the
 function :math:`\phi(\cdot)` and center the data in this new space. However,
@@ -286,8 +287,9 @@ centering :math:`K_{test}` is done as:
 .. math::
   \tilde{K}_{test}(X, Y) = K_{test} - 1'_{\text{n}_{samples}} K - K_{test} 1_{\text{n}_{samples}} + 1'_{\text{n}_{samples}} K 1_{\text{n}_{samples}}
 
-:math:`1_{\text{n}_{samples}}` is a matrix of shape `(n_samples_test, n_samples)`
-where all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`.
+:math:`1_{\text{n}_{samples}}` is a matrix of shape
+`(n_samples_test, n_samples)` where all entries are equal to
+:math:`\frac{1}{\text{n}_{samples}}`.
 
 .. topic:: References
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -251,7 +251,7 @@ positive semidefinite kernel :math:`K`.
 
 We can have a look at the mathematical formulation now that we have the
 intuition. Let :math:`K` be a kernel matrix of shape `(n_samples, n_samples)`
-computed from :math:`X`, a data matrix of shape `(n_samples, n_features)`.
+computed from :math:`X`, a data matrix of shape `(n_samples, n_features)`, during the `fit` step.
 :math:`K` is defined by
 
 .. math::
@@ -276,7 +276,7 @@ can implicitly center as shown in Appendix B in [Scholkopf1998]_:
   \tilde{K} = K - 1_{\text{n}_{samples}} K - K 1_{\text{n}_{samples}} + 1_{\text{n}_{samples}} K 1_{\text{n}_{samples}}
 
 :math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples, n_samples)` where
-all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`. At `transform`,
+all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`. In the `transform` step,
 the kernel becomes :math:`K_{test}(X, Y)` defined as:
 
 .. math::
@@ -289,7 +289,7 @@ centering :math:`K_{test}` is done as:
 .. math::
   \tilde{K}_{test}(X, Y) = K_{test} - 1'_{\text{n}_{samples}} K - K_{test} 1_{\text{n}_{samples}} + 1'_{\text{n}_{samples}} K 1_{\text{n}_{samples}}
 
-:math:`1_{\text{n}_{samples}}` is a matrix of shape
+:math:`1'_{\text{n}_{samples}}` is a matrix of shape
 `(n_samples_test, n_samples)` where all entries are equal to
 :math:`\frac{1}{\text{n}_{samples}}`.
 

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -275,6 +275,23 @@ can implicitly center as shown in Appendix B in [Scholkopf1998]:
 where :math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples, n_samples)`
 where all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`.
 
+During `transform`, the kernel becomes :math:`K_{test}(X, Y)` that is defined
+as:
+
+.. math::
+  K_{test}(X, Y) = \phi(Y) . \phi(X)^{T} \ ,
+
+where :math:`Y` is the test dataset of shape `(n_samples_test, n_features)` and
+thus :math:`K_{test}` is of shape `(n_samples_test, n_samples)`. In this case,
+centering :math:`K_{test}` is done as:
+
+.. math::
+  \tile{K}_{test}(X, Y) = K_{test} - 1'_{\text{n}_{samples}} K - K_{test} 1_{\text{n}_{samples}} + 1'_{\text{n}_{samples}} K 1_{\text{n}_{samples}} \ ,
+
+where :math:`1_{\text{n}_{samples}}` is a matrix of
+`(n_samples_test, n_samples)` where all entries are equal to
+:math:`\frac{1}{\text{n}_{samples}}`.
+
 .. topic:: References
 
   .. [Scholkopf1998] B. Schölkopf, A. Smola, and K.R. Müller,

--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -251,8 +251,8 @@ positive semidefinite kernel :math:`K`.
 
 We can have a look at the mathematical formulation now that we have the
 intuition. Let :math:`K` be a kernel matrix of shape `(n_samples, n_samples)`
-computed from :math:`X`, a data matrix of shape `(n_samples, n_features)`, during the `fit` step.
-:math:`K` is defined by
+computed from :math:`X`, a data matrix of shape `(n_samples, n_features)`,
+during the `fit` step. :math:`K` is defined by
 
 .. math::
   K(X, X) = \phi(X) . \phi(X)^{T}
@@ -276,8 +276,8 @@ can implicitly center as shown in Appendix B in [Scholkopf1998]_:
   \tilde{K} = K - 1_{\text{n}_{samples}} K - K 1_{\text{n}_{samples}} + 1_{\text{n}_{samples}} K 1_{\text{n}_{samples}}
 
 :math:`1_{\text{n}_{samples}}` is a matrix of `(n_samples, n_samples)` where
-all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`. In the `transform` step,
-the kernel becomes :math:`K_{test}(X, Y)` defined as:
+all entries are equal to :math:`\frac{1}{\text{n}_{samples}}`. In the
+`transform` step, the kernel becomes :math:`K_{test}(X, Y)` defined as:
 
 .. math::
   K_{test}(X, Y) = \phi(Y) . \phi(X)^{T}

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1951,7 +1951,7 @@ class Binarizer(TransformerMixin, BaseEstimator):
 
 
 class KernelCenterer(TransformerMixin, BaseEstimator):
-    r"""Center a kernel matrix.
+    r"""Center an arbitrary kernel matrix :math:`K`.
 
     Let define a kernel :math:`K` such that:
 
@@ -1969,9 +1969,9 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
     where :math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert
     space.
 
-    `KernelCenterer` centers the data without explicitely computing the mapping
-    :math:`\phi(.)`. Working with sometimes necessary when dealing with
-    eigendecomposition for instance.
+    `KernelCenterer` centers the data without explicitly computing the mapping
+    :math:`\phi(\dot)`. Working with centered kernels is sometime expected
+    when dealing with algebra computation such as eigendecomposition.
 
     Read more in the :ref:`User Guide <kernel_centering>`.
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1953,11 +1953,25 @@ class Binarizer(TransformerMixin, BaseEstimator):
 class KernelCenterer(TransformerMixin, BaseEstimator):
     """Center a kernel matrix.
 
-    Let K(x, z) be a kernel defined by phi(x)^T phi(z), where phi is a
-    function mapping x to a Hilbert space. KernelCenterer centers (i.e.,
-    normalize to have zero mean) the data without explicitly computing phi(x).
-    It is equivalent to centering phi(x) with
-    sklearn.preprocessing.StandardScaler(with_std=False).
+    Let define a kernel :math:`K` such that:
+
+    .. math::
+        K(X, Y) = \phi(X) . \phi(Y)^{T} \ ,
+
+    where :math:`\phi(X)` is a function mapping :math:`X` to a Hilbert space
+    and :math:`K` is of shape `(n_samples, n_samples)`.
+
+    This class allows to compute :math:`\tilde{K}(X, Y)` such that:
+
+    .. math::
+        \tilde{K(X, Y)} = \tilde{\phi}(X) . \tilde{\phi}(Y)^{T} \ ,
+
+    where :math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert
+    space.
+
+    `KernelCenterer` centers the data without explicitely computing the mapping
+    :math:`\phi(.)`. Working with sometimes necessary when dealing with
+    eigendecomposition for instance.
 
     Read more in the :ref:`User Guide <kernel_centering>`.
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1966,7 +1966,7 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
     .. math::
         \tilde{K(X, Y)} = \tilde{\phi}(X) . \tilde{\phi}(Y)^{T}
 
-    :math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert
+    :math:`\tilde{\phi}(X)` is the centered mapped data in the Hilbert
     space.
 
     `KernelCenterer` centers the features without explicitly computing the
@@ -1986,10 +1986,10 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] Schölkopf, Bernhard, Alexander Smola, and Klaus-Robert Müller.
+    .. [1] `Schölkopf, Bernhard, Alexander Smola, and Klaus-Robert Müller.
        "Nonlinear component analysis as a kernel eigenvalue problem."
        Neural computation 10.5 (1998): 1299-1319.
-       https://www.mlpack.org/papers/kpca.pdf
+       <https://www.mlpack.org/papers/kpca.pdf>`_
 
     Examples
     --------

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1983,6 +1983,13 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
     K_fit_all_ : float
         Average of kernel matrix.
 
+    References
+    ----------
+    .. [1] Schölkopf, Bernhard, Alexander Smola, and Klaus-Robert Müller.
+       "Nonlinear component analysis as a kernel eigenvalue problem."
+       Neural computation 10.5 (1998): 1299-1319.
+       https://www.mlpack.org/papers/kpca.pdf
+
     Examples
     --------
     >>> from sklearn.preprocessing import KernelCenterer

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1956,22 +1956,23 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
     Let define a kernel :math:`K` such that:
 
     .. math::
-        K(X, Y) = \phi(X) . \phi(Y)^{T} \ ,
+        K(X, Y) = \phi(X) . \phi(Y)^{T}
 
-    where :math:`\phi(X)` is a function mapping :math:`X` to a Hilbert space
-    and :math:`K` is of shape `(n_samples, n_samples)`.
+    :math:`\phi(X)` is a function mapping of rows of :math:`X` to a
+    Hilbert space and :math:`K` is of shape `(n_samples, n_samples)`.
 
     This class allows to compute :math:`\tilde{K}(X, Y)` such that:
 
     .. math::
-        \tilde{K(X, Y)} = \tilde{\phi}(X) . \tilde{\phi}(Y)^{T} \ ,
+        \tilde{K(X, Y)} = \tilde{\phi}(X) . \tilde{\phi}(Y)^{T}
 
-    where :math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert
+    :math:`\tilde{\phi}(X)` are the mapped centered data in the Hilbert
     space.
 
-    `KernelCenterer` centers the data without explicitly computing the mapping
-    :math:`\phi(\cdot)`. Working with centered kernels is sometime expected
-    when dealing with algebra computation such as eigendecomposition.
+    `KernelCenterer` centers the features without explicitly computing the
+    mapping :math:`\phi(\cdot)`. Working with centered kernels is sometime
+    expected when dealing with algebra computation such as eigendecomposition
+    for :class:`~sklearn.decomposition.KernelPCA` for instance.
 
     Read more in the :ref:`User Guide <kernel_centering>`.
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1970,14 +1970,14 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
     space.
 
     `KernelCenterer` centers the data without explicitly computing the mapping
-    :math:`\phi(\dot)`. Working with centered kernels is sometime expected
+    :math:`\phi(\cdot)`. Working with centered kernels is sometime expected
     when dealing with algebra computation such as eigendecomposition.
 
     Read more in the :ref:`User Guide <kernel_centering>`.
 
     Attributes
     ----------
-    K_fit_rows_ : array of shape (n_samples,)
+    K_fit_rows_ : ndarray of shape (n_samples,)
         Average of each column of kernel matrix.
 
     K_fit_all_ : float

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1951,7 +1951,7 @@ class Binarizer(TransformerMixin, BaseEstimator):
 
 
 class KernelCenterer(TransformerMixin, BaseEstimator):
-    """Center a kernel matrix.
+    r"""Center a kernel matrix.
 
     Let define a kernel :math:`K` such that:
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2171,7 +2171,8 @@ def test_center_kernel():
     # B. Schölkopf, A. Smola, and K.R. Müller,
     # "Nonlinear component analysis as a kernel eigenvalue problem"
 
-    # K_centered = K - 1_M K - K 1_M + 1_M K 1_M
+    # K_centered = (I - 1_M) K (I - 1_M)
+    #            =  K - 1_M K - K 1_M + 1_M K 1_M
     ones_M = np.ones_like(K_fit) / K_fit.shape[0]
     K_fit_centered3 = (
         K_fit - ones_M @ K_fit - K_fit @ ones_M + ones_M @ K_fit @ ones_M

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2167,6 +2167,12 @@ def test_center_kernel():
     K_pred_centered2 = centerer.transform(K_pred)
     assert_array_almost_equal(K_pred_centered, K_pred_centered2)
 
+    # check the results coherence with the method proposed in:
+    # B. Schölkopf, A. Smola, and K.R. Müller,
+    # "Nonlinear component analysis as a kernel eigenvalue problem"
+    # * K_centered = K - 1_M K - K 1_M + 1_M K 1_M
+    # * K_test_centered = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
+    pass
 
 def test_cv_pipeline_precomputed():
     # Cross-validate a regression on four coplanar points with the same

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2170,9 +2170,22 @@ def test_center_kernel():
     # check the results coherence with the method proposed in:
     # B. Schölkopf, A. Smola, and K.R. Müller,
     # "Nonlinear component analysis as a kernel eigenvalue problem"
-    # * K_centered = K - 1_M K - K 1_M + 1_M K 1_M
-    # * K_test_centered = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
-    pass
+
+    # K_centered = K - 1_M K - K 1_M + 1_M K 1_M
+    ones_M = np.ones_like(K_fit) / K_fit.shape[0]
+    K_fit_centered3 = (
+        K_fit - ones_M @ K_fit - K_fit @ ones_M + ones_M @ K_fit @ ones_M
+    )
+    assert_allclose(K_fit_centered, K_fit_centered3)
+
+    # K_test_centered = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
+    ones_prime_M = np.ones_like(K_pred) / K_fit.shape[0]
+    K_pred_centered3 = (
+        K_pred - ones_prime_M @ K_fit - K_pred @ ones_M +
+        ones_prime_M @ K_fit @ ones_M
+    )
+    assert_allclose(K_pred_centered, K_pred_centered3)
+
 
 def test_cv_pipeline_precomputed():
     # Cross-validate a regression on four coplanar points with the same

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2187,6 +2187,55 @@ def test_center_kernel():
     assert_allclose(K_pred_centered, K_pred_centered3)
 
 
+def test_kernelcenterer_non_linear_kernel():
+    """Check kernel centering for non-linear kernel."""
+    rng = np.random.RandomState(0)
+    X, X_test = rng.randn(100, 50), rng.randn(20, 50)
+
+    def phi(X):
+        """Our mapping function phi."""
+        return np.vstack([
+            np.clip(X, a_min=0, a_max=None),
+            -np.clip(X, a_min=None, a_max=0),
+        ])
+
+    phi_X = phi(X)
+    phi_X_test = phi(X_test)
+
+    # centered the projection
+    scaler = StandardScaler(with_std=False)
+    phi_X_center = scaler.fit_transform(phi_X)
+    phi_X_test_center = scaler.transform(phi_X_test)
+
+    # create the different kernel
+    K = phi_X @ phi_X.T
+    K_test = phi_X_test @ phi_X.T
+    K_center = phi_X_center @ phi_X_center.T
+    K_test_center = phi_X_test_center @ phi_X_center.T
+
+    kernel_centerer = KernelCenterer()
+    kernel_centerer.fit(K)
+
+    assert_allclose(kernel_centerer.transform(K), K_center)
+    assert_allclose(kernel_centerer.transform(K_test), K_test_center)
+
+    # check the results coherence with the method proposed in:
+    # B. Schölkopf, A. Smola, and K.R. Müller,
+    # "Nonlinear component analysis as a kernel eigenvalue problem"
+
+    # K_centered = K - 1_M K - K 1_M + 1_M K 1_M
+    ones_M = np.ones_like(K) / K.shape[0]
+    K_center = K - ones_M @ K - K @ ones_M + ones_M @ K @ ones_M
+    assert_allclose(kernel_centerer.transform(K), K_center)
+
+    # K_test_centered = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
+    ones_prime_M = np.ones_like(K_test) / K.shape[0]
+    K_test_center = (
+        K_test - ones_prime_M @ K - K_test @ ones_M + ones_prime_M @ K @ ones_M
+    )
+    assert_allclose(kernel_centerer.transform(K_test), K_test_center)
+
+
 def test_cv_pipeline_precomputed():
     # Cross-validate a regression on four coplanar points with the same
     # value. Use precomputed kernel to ensure Pipeline with KernelCenterer

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2170,6 +2170,7 @@ def test_center_kernel():
     # check the results coherence with the method proposed in:
     # B. Schölkopf, A. Smola, and K.R. Müller,
     # "Nonlinear component analysis as a kernel eigenvalue problem"
+    # equation (B.3)
 
     # K_centered = (I - 1_M) K (I - 1_M)
     #            =  K - 1_M K - K 1_M + 1_M K 1_M
@@ -2179,7 +2180,8 @@ def test_center_kernel():
     )
     assert_allclose(K_fit_centered, K_fit_centered3)
 
-    # K_test_centered = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
+    # K_test_centered = (K_test - 1'_M K)(I - 1_M)
+    #                 = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
     ones_prime_M = np.ones_like(K_pred) / K_fit.shape[0]
     K_pred_centered3 = (
         K_pred - ones_prime_M @ K_fit - K_pred @ ones_M +
@@ -2223,13 +2225,16 @@ def test_kernelcenterer_non_linear_kernel():
     # check the results coherence with the method proposed in:
     # B. Schölkopf, A. Smola, and K.R. Müller,
     # "Nonlinear component analysis as a kernel eigenvalue problem"
+    # equation (B.3)
 
-    # K_centered = K - 1_M K - K 1_M + 1_M K 1_M
+    # K_centered = (I - 1_M) K (I - 1_M)
+    #            =  K - 1_M K - K 1_M + 1_M K 1_M
     ones_M = np.ones_like(K) / K.shape[0]
     K_center = K - ones_M @ K - K @ ones_M + ones_M @ K @ ones_M
     assert_allclose(kernel_centerer.transform(K), K_center)
 
-    # K_test_centered = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
+    # K_test_centered = (K_test - 1'_M K)(I - 1_M)
+    #                 = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
     ones_prime_M = np.ones_like(K_test) / K.shape[0]
     K_test_center = (
         K_test - ones_prime_M @ K - K_test @ ones_M + ones_prime_M @ K @ ones_M

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2172,16 +2172,16 @@ def test_center_kernel():
     # "Nonlinear component analysis as a kernel eigenvalue problem"
     # equation (B.3)
 
-    # K_centered = (I - 1_M) K (I - 1_M)
-    #            =  K - 1_M K - K 1_M + 1_M K 1_M
+    # K_centered3 = (I - 1_M) K (I - 1_M)
+    #             =  K - 1_M K - K 1_M + 1_M K 1_M
     ones_M = np.ones_like(K_fit) / K_fit.shape[0]
     K_fit_centered3 = (
         K_fit - ones_M @ K_fit - K_fit @ ones_M + ones_M @ K_fit @ ones_M
     )
     assert_allclose(K_fit_centered, K_fit_centered3)
 
-    # K_test_centered = (K_test - 1'_M K)(I - 1_M)
-    #                 = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
+    # K_test_centered3 = (K_test - 1'_M K)(I - 1_M)
+    #                  = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
     ones_prime_M = np.ones_like(K_pred) / K_fit.shape[0]
     K_pred_centered3 = (
         K_pred - ones_prime_M @ K_fit - K_pred @ ones_M +
@@ -2230,16 +2230,16 @@ def test_kernelcenterer_non_linear_kernel():
     # K_centered = (I - 1_M) K (I - 1_M)
     #            =  K - 1_M K - K 1_M + 1_M K 1_M
     ones_M = np.ones_like(K) / K.shape[0]
-    K_center = K - ones_M @ K - K @ ones_M + ones_M @ K @ ones_M
-    assert_allclose(kernel_centerer.transform(K), K_center)
+    K_centered = K - ones_M @ K - K @ ones_M + ones_M @ K @ ones_M
+    assert_allclose(kernel_centerer.transform(K), K_centered)
 
     # K_test_centered = (K_test - 1'_M K)(I - 1_M)
     #                 = K_test - 1'_M K - K_test 1_M + 1'_M K 1_M
     ones_prime_M = np.ones_like(K_test) / K.shape[0]
-    K_test_center = (
+    K_test_centered = (
         K_test - ones_prime_M @ K - K_test @ ones_M + ones_prime_M @ K @ ones_M
     )
-    assert_allclose(kernel_centerer.transform(K_test), K_test_center)
+    assert_allclose(kernel_centerer.transform(K_test), K_test_centered)
 
 
 def test_cv_pipeline_precomputed():


### PR DESCRIPTION
This PR improves:

- the docstring of `KernelCenterer` with scikit-learn convention regarding `X`
- the user guide by adding a mathematical formulation and a link to the relevant reference
- add a test to check the consistence with the formulation provided in the reference
- add a test to check that the centering is working for non-linear kernel