### PR TITLE
ENH Enrich docstring on `inverse_transform` of `KernelPCA`

### DIFF
--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -352,10 +352,10 @@ class KernelPCA(TransformerMixin, BaseEstimator):
         vectors.
 
         .. note:
-            :meth:`~sklearn.decomposition.fit` will internally used a centered
-            kernel. As centered kernel no longer contains the information of the
-            mean of kernel features, such information is not taken into account
-            in reconstruction.
+            :meth:`~sklearn.decomposition.fit` internally uses a centered
+            kernel. As the centered kernel no longer contains the information
+            of the mean of kernel features, such information is not taken into
+            account in reconstruction.
 
         .. note::
             When users want to compute inverse transformation for 'linear'

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -351,13 +351,20 @@ class KernelPCA(TransformerMixin, BaseEstimator):
         regression of the original data on their low-dimensional representation
         vectors.
 
+        .. note:
+            :meth:`~sklearn.decomposition.fit` will internally used a centered
+            kernel. As centered kernel no longer contains the information of the
+            mean of kernel features, such information is not taken into account
+            in reconstruction.
+
         .. note::
             When users want to compute inverse transformation for 'linear'
             kernel, it is recommended that they use
             :class:`~sklearn.decomposition.PCA` instead. Unlike
             :class:`~sklearn.decomposition.PCA`,
             :class:`~sklearn.decomposition.KernelPCA`'s ``inverse_transform``
-            does not reconstruct the mean of data when 'linear' kernel is used.
+            does not reconstruct the mean of data when 'linear' kernel is used
+            due to the use of centered kernel.
 
         Parameters
         ----------

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -346,6 +346,19 @@ class KernelPCA(TransformerMixin, BaseEstimator):
     def inverse_transform(self, X):
         """Transform X back to original space.
 
+        ``inverse_transform`` approximates the inverse transformation using
+        a learned pre-image. The pre-image is learned by kernel ridge
+        regression of the original data on their low-dimensional representation
+        vectors.
+
+        .. note::
+            When users want to compute inverse transformation for 'linear'
+            kernel, it is recommended that they use
+            :class:`~sklearn.decomposition.PCA` instead. Unlike
+            :class:`~sklearn.decomposition.PCA`,
+            :class:`~sklearn.decomposition.KernelPCA`'s ``inverse_transform``
+            does not reconstruct the mean of data when 'linear' kernel is used.
+
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_components)


### PR DESCRIPTION
#### Reference Issues/PRs
See https://github.com/scikit-learn/scikit-learn/pull/19732#issuecomment-821791592

#### What does this implement/fix? Explain your changes.

Enrich the docstring of `KernelPCA.inverse_transform` to address the following points.

> *  advocate to use `PCA` instead of `kernel='linear'` (or maybe there is some reasons that we did not think about).
> *   improve the docstring of `kernelPCA` and notably `inverse_transform` to mention the approximation when reconstructing;