### PR TITLE
Accept L2 and Precomputed affinity for Ward linkage

### DIFF
--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -852,8 +852,8 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
             raise ValueError("compute_full_tree must be True if "
                              "distance_threshold is set.")
 
-        if self.linkage == "ward" and self.affinity not in ["euclidean",
-                "l2", "precomputed"]:
+        if (self.linkage == "ward"
+                and self.affinity not in ["euclidean", "l2", "precomputed"]):
             raise ValueError("%s was provided as affinity. Ward can only "
                              "work with euclidean distances." %
                              (self.affinity, ))

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -696,9 +696,13 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
     affinity : str or callable, default='euclidean'
         Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
         "manhattan", "cosine", or "precomputed".
-        If linkage is "ward", only "euclidean" is accepted.
         If "precomputed", a distance matrix (instead of a similarity matrix)
         is needed as input for the fit method.
+        If linkage is "ward", only Euclidean distances ("euclidean", "l2", or
+        "precomputed") are accepted.
+        Note: When using a precomputed matrix together with "ward" linkage,
+        make sure that the precomputed matrix consists of Euclidean distances.
+
 
     memory : str or object with the joblib.Memory interface, default=None
         Used to cache the output of the computation of the tree.
@@ -848,7 +852,8 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
             raise ValueError("compute_full_tree must be True if "
                              "distance_threshold is set.")
 
-        if self.linkage == "ward" and self.affinity != "euclidean":
+        if self.linkage == "ward" and self.affinity not in ["euclidean",
+                "l2", "precomputed"]:
             raise ValueError("%s was provided as affinity. Ward can only "
                              "work with euclidean distances." %
                              (self.affinity, ))


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #18531. 

#### What does this implement/fix? Explain your changes.
For Agglomerative Clustering, update affinity check to accept l2 and precomputed when linkage is ward. 
Update docstring for this, and add a note to pass only euclidean precomputed distance matrix when linkage is ward.

#### Any other comments?
Existing test (test_hierarchical.py:234) checks for ValueError on Manhattan distance for Ward linkage. The test is unaffected and unmodified.
