### PR TITLE
FIX Fixes PLSRegression regression for constant Yk

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -19,6 +19,13 @@ Changelog
   :term:`get_feature_names` on transformers with an empty column selection.
   :pr:`19579` by `Thomas Fan`_.
 
+:mod:`sklearn.cross_decomposition`
+..................................
+
+- |Fix| :class:`cross_decomposition.PLSRegression` raises warning for
+  constant y residuals instead of a `StopIteration` error. :pr:`19922`
+  by `Thomas Fan`_.
+
 :mod:`sklearn.ensemble`
 .......................
 

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -52,7 +52,11 @@ def _get_first_singular_vectors_power_method(X, Y, mode="A", max_iter=500,
     """
 
     eps = np.finfo(X.dtype).eps
-    y_score = next(col for col in Y.T if np.any(np.abs(col) > eps))
+    try:
+        y_score = next(col for col in Y.T if np.any(np.abs(col) > eps))
+    except StopIteration as e:
+        raise StopIteration("Y residual is constant") from e
+
     x_weights_old = 100  # init to big value for first convergence check
 
     if mode == 'B':
@@ -261,9 +265,9 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
                         _get_first_singular_vectors_power_method(
                             Xk, Yk, mode=self.mode, max_iter=self.max_iter,
                             tol=self.tol, norm_y_weights=norm_y_weights)
-                except StopIteration:
-                    # _get_first_singular_vectors_power_method raise
-                    # StopIteration when Yk is constant
+                except StopIteration as e:
+                    if str(e) != "Y residual is constant":
+                        raise
                     warnings.warn(f"Y residual is constant at iteration {k}")
                     break
 

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -232,6 +232,11 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
         # paper.
         Y_eps = np.finfo(Yk.dtype).eps
         for k in range(n_components):
+            if np.all(np.dot(Yk.T, Yk) < Y_eps):
+                # Yk constant
+                warnings.warn('Y residual constant at iteration %s' % k)
+                break
+
             # Find first left and right singular vectors of the X.T.dot(Y)
             # cross-covariance matrix.
             if self.algorithm == "nipals":

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -247,7 +247,7 @@ class _PLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator,
                 except StopIteration:
                     # _get_first_singular_vectors_power_method raise
                     # StopIteration when Yk is constant
-                    warnings.warn(f"Y residual constant at iteration {k}")
+                    warnings.warn(f"Y residual is constant at iteration {k}")
                     break
 
                 self.n_iter_.append(n_iter_)

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -552,3 +552,16 @@ def test_svd_flip_1d():
 
     assert_allclose(v, v_expected.ravel())
     assert_allclose(v, [-1, -2, -3])
+
+
+def test_pls_constant_y():
+    """Checks warning when y is constant. Non-regression test for #19831"""
+    rng = np.random.RandomState(42)
+    x = rng.rand(100, 3)
+    y = np.zeros(100)
+
+    pls = PLSRegression()
+
+    msg = "Y residual constant at iteration"
+    with pytest.warns(UserWarning, match=msg):
+        pls.fit(x, y)

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -565,3 +565,5 @@ def test_pls_constant_y():
     msg = "Y residual constant at iteration"
     with pytest.warns(UserWarning, match=msg):
         pls.fit(x, y)
+
+    assert_allclose(pls.x_rotations_, 0)

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -562,7 +562,7 @@ def test_pls_constant_y():
 
     pls = PLSRegression()
 
-    msg = "Y residual constant at iteration"
+    msg = "Y residual is constant at iteration"
     with pytest.warns(UserWarning, match=msg):
         pls.fit(x, y)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #19831

#### What does this implement/fix? Explain your changes.
Places the check on y from 0.23.2 back into the loop.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
