### PR TITLE
WIP KBinsDiscretizer supports NaN as input values

### DIFF
--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -322,3 +322,20 @@ def test_32_equal_64(input_dtype, encode):
     Xt_64 = kbd_64.transform(X_input)
 
     assert_allclose_dense_sparse(Xt_32, Xt_64)
+
+
+@pytest.mark.parametrize('encode', ['onehot', 'onehot-dense', 'ordinal'])
+@pytest.mark.parametrize('strategy', ['uniform', 'quantile', 'kmeans'])
+def test_kbinsdiscretizer_with_nan_input(encode, strategy):
+    X = np.arange(20).reshape((-1, 1)).astype(float)
+    X[2] = np.nan
+    kbd = KBinsDiscretizer(n_bins=4, encode=encode, strategy=strategy)
+    encoded = kbd.fit_transform(X)
+    inversed = kbd.inverse_transform(encoded)
+    if encode == 'ordinal':
+        assert np.isnan(encoded).sum() == 1
+    elif encode == 'onehot-dense':
+        assert np.isnan(encoded).sum() == 0
+    elif encode == 'onehot':
+        assert np.isnan(encoded.toarray()).sum() == 0
+    assert np.isnan(inversed).sum() == 1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a fix to issue #19920 . Include the following changes:
- Add `force_all_finite=False`  in `self._validate_data`
- Propagate NaN values in `transform` and `inverse_transform` method

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
