### PR TITLE
EXA Fix plot_map_data_to_normal.py example legend

### DIFF
--- a/examples/preprocessing/plot_map_data_to_normal.py
+++ b/examples/preprocessing/plot_map_data_to_normal.py
@@ -132,7 +132,7 @@ for distribution, color, axes in zip(distributions, colors, axes_list):
         ax.hist(X_trans, color=color, bins=BINS)
         title = 'After {}'.format(meth_name)
         if lmbda is not None:
-            title += r'\n$\lambda$ = {}'.format(lmbda)
+            title += '\n$\\lambda$ = {}'.format(lmbda)
         ax.set_title(title, fontsize=FONT_SIZE)
         ax.tick_params(axis='both', which='major', labelsize=FONT_SIZE)
         ax.set_xlim([-3.5, 3.5])


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

In this [example](https://scikit-learn.org/dev/auto_examples/preprocessing/plot_map_data_to_normal.html)
`\lambda` was very likely meant to be on a different line in the title.

### `main`
![image](https://user-images.githubusercontent.com/1680079/115397720-b1a71800-a1e6-11eb-804e-bac768a7b381.png)


### This PR
![image](https://user-images.githubusercontent.com/1680079/115397544-83293d00-a1e6-11eb-81cc-7f2cabac3c36.png)

#### Any other comments?

The title font is probably too small for useful purposes but I tried to increase the font but that did not play well with matplotlib tight layout and I could not fix it in less than 5 minutes ... so maybe for another PR?
