### PR TITLE
FIX Use cho_solve when return_std=True for GaussianProcessRegressor

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -12,16 +12,6 @@ Version 0.24.2
 Changelog
 ---------
 
-:mod:`sklearn.gaussian_process`
-...............................
-
-- |Fix| Avoid explicitly forming inverse covariance matrix in
-  :class:`gaussian_process.GaussianProcessRegressor` when set to output
-  std. dev. With certain covariance matrices this inverse is unstable to
-  compute explicitly. Calling Cholesky solver mitigates this issue in
-  computation.
-  :pr:`19939` by :user:`Ian Halvic <iwhalvic>`.
-
 :mod:`sklearn.compose`
 ......................
 
@@ -44,6 +34,13 @@ Changelog
 
 :mod:`sklearn.gaussian_process`
 ...............................
+
+- |Fix| Avoid explicitly forming inverse covariance matrix in
+  :class:`gaussian_process.GaussianProcessRegressor` when set to output
+  std. dev. With certain covariance matrices this inverse is unstable to
+  compute explicitly. Calling Cholesky solver mitigates this issue in
+  computation.
+  :pr:`19939` by :user:`Ian Halvic <iwhalvic>`.
 
 - |Fix| Avoid division by zero when scaling constant target in
   :class:`gaussian_process.GaussianProcessRegressor`. It was due to a std. dev.

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -37,8 +37,8 @@ Changelog
 
 - |Fix| Avoid explicitly forming inverse covariance matrix in
   :class:`gaussian_process.GaussianProcessRegressor` when set to output
-  std. dev. With certain covariance matrices this inverse is unstable to
-  compute explicitly. Calling Cholesky solver mitigates this issue in
+  standard deviation. With certain covariance matrices this inverse is unstable
+  to compute explicitly. Calling Cholesky solver mitigates this issue in
   computation.
   :pr:`19939` by :user:`Ian Halvic <iwhalvic>`.
 

--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -20,7 +20,7 @@ Changelog
   std. dev. With certain covariance matrices this inverse is unstable to
   compute explicitly. Calling Cholesky solver mitigates this issue in
   computation.
-  :pr:`19939` by :user:`Ian Halvic <iwhalvic>
+  :pr:`19939` by :user:`Ian Halvic <iwhalvic>`.
 
 :mod:`sklearn.compose`
 ......................

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -361,7 +361,7 @@ class GaussianProcessRegressor(MultiOutputMixin,
 
                 # Compute variance of predictive distribution
                 # Use einsum to avoid explicitly forming the large matrix
-                # K_trans @ v just to extract its diagonal afterward.
+                # K_trans @ V just to extract its diagonal afterward.
                 y_var = self.kernel_.diag(X)
                 y_var -= np.einsum("ij,ji->i", K_trans, V)
 

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -20,10 +20,12 @@ from sklearn.gaussian_process.kernels import DotProduct, ExpSineSquared
 from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 from sklearn.exceptions import ConvergenceWarning
 
-from sklearn.utils._testing \
-    import (assert_array_less,
-            assert_almost_equal, assert_array_almost_equal,
-            assert_allclose)
+from sklearn.utils._testing import (
+    assert_array_less,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_allclose
+)
 
 
 def f(x):
@@ -555,10 +557,10 @@ def test_constant_target(kernel):
 
 def test_gpr_consistency_std_cov_non_invertible_kernel():
     """Check the consistency between the returned std. dev. and the covariance.
-    Inconsistencies were observed when the kernel cannot be inverted (or
-    numerically stable).
     Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/19936
+    Inconsistencies were observed when the kernel cannot be inverted (or
+    numerically stable).
     """
     kernel = (C(8.98576054e+05, (1e-12, 1e12)) *
               RBF([5.91326520e+02, 1.32584051e+03], (1e-12, 1e12)) +


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes Issue #19936

#### What does this implement/fix? Explain your changes.
Provides more consistency in `GaussianProcessRegressor ` when computing the predictive standard deviation (often taken as a form of predictive uncertainty). Specifically consistency between using `return_std=True` and `return_cov=True`. For certain kernel hyperparameters, `return_std=True` appears unstable. 

`return_cov=True` can be used as an alternative, and the end user can quickly find the standard deviation from the returned predictive covariance, however id the predicted dataset is large the covariance matrix may become too large for memory. 

The key to the inconsistency appears to be `return_std=True` attempting to explicitly form the inverse training kernel matrix. Typically in GP regression this inverse is never explicitly formed, instead the Cholesky decomposition is stored and cholesky solves take the place of the explicit inverse (this is the approach the `return_cov=True` ) uses. 

This fix attempts to improve consistency and stability by using the Cholesky solve in both cases, while still mitigating the large predictive covariance matrix formation when `return_std=True`.

Changes are localized to _gpr.py

before:
```
elif return_std:
    # cache result of K_inv computation
    if self._K_inv is None:
        # compute inverse K_inv of K based on its Cholesky
        # decomposition L and its inverse L_inv
        L_inv = solve_triangular(self.L_.T,
                                 np.eye(self.L_.shape[0]))
        self._K_inv = L_inv.dot(L_inv.T)

    # Compute variance of predictive distribution
    y_var = self.kernel_.diag(X)
    y_var -= np.einsum("ij,ij->i",
                       np.dot(K_trans, self._K_inv), K_trans)
```

after:
```
elif return_std:
    # cache result of K_inv computation,
    # this is done for compatibility, K_inv should be avoided
    if self._K_inv is None:
        # compute inverse K_inv of K based on its Cholesky
        # decomposition L and its inverse L_inv
        L_inv = solve_triangular(self.L_.T,
                                 np.eye(self.L_.shape[0]))
        self._K_inv = L_inv.dot(L_inv.T)
    v = cho_solve((self.L_, True), K_trans.T)  # Line 5

    # Compute variance of predictive distribution
    # Use einsum to avoid large matrix
    y_var = self.kernel_.diag(X)
    y_var -= np.einsum("ij,ji->i",
                       K_trans, v)
```

The matrix `v` has the same dimensions as `K_trans.T`, so size should not be an issue.

To my understanding the use of `np.einsum` avoids the formation of the (potentially large) covariance matrix `K_trans, v` just to get the diagonal entries.

The computation of `self._K_inv` is left in the code, even though it is useless in the built in workflows. This retains compatibility should an end user be leveraging `self._K_inv` in some workflow. I will defer to more experienced developers if this is the correct course of action.

#### Any other comments?
Running the reproducing code in Issue #19936 results in close agreement between the two computation methods now
```
[0.00754465 0.00633869 0.00642104 0.00834402]
[0.00754465 0.0063387  0.00642104 0.00834401]
```
