### PR TITLE
KBinsDiscretizer tidying up

### DIFF
--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -296,8 +296,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             Data in the binned space. Will be a sparse matrix if
             `self.encode='onehot'` and ndarray otherwise.
         """
-        ATOL = 1e-5
-        RTOL = 1e-8
+        ATOL, RTOL = 1e-5, 1e-8
         check_is_fitted(self)
 
         # check input and attribute dtypes

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -295,6 +295,8 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             Data in the binned space. Will be a sparse matrix if
             `self.encode='onehot'` and ndarray otherwise.
         """
+        ATOL = 1e-5
+        RTOL = 1e-8
         check_is_fitted(self)
 
         # check input and attribute dtypes
@@ -307,9 +309,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             # instability. Add eps to X so these values are binned correctly
             # with respect to their decimal truncation. See documentation of
             # numpy.isclose for an explanation of ``rtol`` and ``atol``.
-            rtol = 1.e-5
-            atol = 1.e-8
-            eps = atol + rtol * np.abs(Xt[:, jj])
+            eps = ATOL + RTOL * np.abs(Xt[:, jj])
             Xt[:, jj] = np.digitize(Xt[:, jj] + eps, bin_edges[jj][1:])
         np.clip(Xt, 0, self.n_bins_ - 1, out=Xt)
 

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -224,7 +224,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                     warnings.warn(
                         f"Bins whose width are too small (i.e., <= "
                         f"1e-8) in feature {jj} are removed. Consider "
-                        "decreasing the number of bins."
+                        f"decreasing the number of bins."
                     )
                     n_bins[jj] = len(bin_edges[jj]) - 1
 

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -249,7 +249,8 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         if isinstance(orig_bins, numbers.Number):
             if not isinstance(orig_bins, numbers.Integral):
                 raise ValueError(
-                    f"{KBinsDiscretizer.__name__} received an invalid n_bins type. "
+                    f"{KBinsDiscretizer.__name__} "
+                    f"received an invalid n_bins type. "
                     f"Received {type(orig_bins).__name__}, expected int."
                 )
             if orig_bins < 2:

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -166,14 +166,16 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         valid_encode = ('onehot', 'onehot-dense', 'ordinal')
         if self.encode not in valid_encode:
-            raise ValueError("Valid options for 'encode' are {}. "
-                             "Got encode={!r} instead."
-                             .format(valid_encode, self.encode))
+            raise ValueError(
+                f"Valid options for 'encode' are {valid_encode}. "
+                f"Got encode={self.encode!r} instead."
+            )
         valid_strategy = ('uniform', 'quantile', 'kmeans')
         if self.strategy not in valid_strategy:
-            raise ValueError("Valid options for 'strategy' are {}. "
-                             "Got strategy={!r} instead."
-                             .format(valid_strategy, self.strategy))
+            raise ValueError(
+                f"Valid options for 'strategy' are {valid_strategy}. "
+                f"Got strategy={self.strategy!r} instead."
+            )
 
         n_features = X.shape[1]
         n_bins = self._validate_n_bins(n_features)
@@ -184,8 +186,10 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             col_min, col_max = column.min(), column.max()
 
             if col_min == col_max:
-                warnings.warn("Feature %d is constant and will be "
-                              "replaced with 0." % jj)
+                warnings.warn(
+                    f"Feature {jj} is constant and will be "
+                    f"replaced with 0."
+                )
                 n_bins[jj] = 1
                 bin_edges[jj] = np.array([-np.inf, np.inf])
                 continue
@@ -217,9 +221,11 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                 mask = np.ediff1d(bin_edges[jj], to_begin=np.inf) > 1e-8
                 bin_edges[jj] = bin_edges[jj][mask]
                 if len(bin_edges[jj]) - 1 != n_bins[jj]:
-                    warnings.warn('Bins whose width are too small (i.e., <= '
-                                  '1e-8) in feature %d are removed. Consider '
-                                  'decreasing the number of bins.' % jj)
+                    warnings.warn(
+                        f"Bins whose width are too small (i.e., <= "
+                        f"1e-8) in feature {jj} are removed. Consider "
+                        "decreasing the number of bins."
+                    )
                     n_bins[jj] = len(bin_edges[jj]) - 1
 
         self.bin_edges_ = bin_edges
@@ -242,32 +248,36 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         orig_bins = self.n_bins
         if isinstance(orig_bins, numbers.Number):
             if not isinstance(orig_bins, numbers.Integral):
-                raise ValueError("{} received an invalid n_bins type. "
-                                 "Received {}, expected int."
-                                 .format(KBinsDiscretizer.__name__,
-                                         type(orig_bins).__name__))
+                raise ValueError(
+                    f"{KBinsDiscretizer.__name__} received an invalid n_bins type. "
+                    f"Received {type(orig_bins).__name__}, expected int."
+                )
             if orig_bins < 2:
-                raise ValueError("{} received an invalid number "
-                                 "of bins. Received {}, expected at least 2."
-                                 .format(KBinsDiscretizer.__name__, orig_bins))
+                raise ValueError(
+                    f"{KBinsDiscretizer.__name__} received an invalid number "
+                    f"of bins. Received {orig_bins}, expected at least 2."
+                )
             return np.full(n_features, orig_bins, dtype=int)
 
         n_bins = check_array(orig_bins, dtype=int, copy=True,
                              ensure_2d=False)
 
         if n_bins.ndim > 1 or n_bins.shape[0] != n_features:
-            raise ValueError("n_bins must be a scalar or array "
-                             "of shape (n_features,).")
+            raise ValueError(
+                "n_bins must be a scalar or array "
+                "of shape (n_features,)."
+            )
 
         bad_nbins_value = (n_bins < 2) | (n_bins != orig_bins)
 
         violating_indices = np.where(bad_nbins_value)[0]
         if violating_indices.shape[0] > 0:
             indices = ", ".join(str(i) for i in violating_indices)
-            raise ValueError("{} received an invalid number "
-                             "of bins at indices {}. Number of bins "
-                             "must be at least 2, and must be an int."
-                             .format(KBinsDiscretizer.__name__, indices))
+            raise ValueError(
+                f"{KBinsDiscretizer.__name__} received an invalid number "
+                f"of bins at indices {indices}. Number of bins "
+                f"must be at least 2, and must be an int."
+            )
         return n_bins
 
     def transform(self, X):
@@ -342,8 +352,10 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         Xinv = check_array(Xt, copy=True, dtype=(np.float64, np.float32))
         n_features = self.n_bins_.shape[0]
         if Xinv.shape[1] != n_features:
-            raise ValueError("Incorrect number of features. Expecting {}, "
-                             "received {}.".format(n_features, Xinv.shape[1]))
+            raise ValueError(
+                f"Incorrect number of features. Expecting {n_features}, "
+                f"received {Xinv.shape[1]}."
+            )
 
         for jj in range(n_features):
             bin_edges = self.bin_edges_[jj]


### PR DESCRIPTION
Changing old string formatting to f-strings;
Consistency changes (text in "", words in '');
Taking 'atol' and 'rtol' out of loop (no need to initialize them inside the loop).