### PR TITLE
MAINT Remove tests for metric configuration ignoring pos_label

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -342,16 +342,6 @@ METRICS_WITH_POS_LABEL = {
     "weighted_average_precision_score",
     "micro_average_precision_score",
     "samples_average_precision_score",
-
-    # pos_label support deprecated; to be removed in 0.18:
-    "weighted_f0.5_score", "weighted_f1_score", "weighted_f2_score",
-    "weighted_precision_score", "weighted_recall_score",
-
-    "micro_f0.5_score", "micro_f1_score", "micro_f2_score",
-    "micro_precision_score", "micro_recall_score",
-
-    "macro_f0.5_score", "macro_f1_score", "macro_f2_score",
-    "macro_precision_score", "macro_recall_score",
 }
 
 # Metrics with a "labels" argument


### PR DESCRIPTION
#### Reference Issues/PRs
Close #11148.
Credit @qinhanmin2014 who opened #11620 of which this PR is just a copy. Unfortunately he removed his branch so I couldn't retrieve his commits.

#### What does this implement/fix? Explain your changes.
Get rid of redundant tests, since 0.18 the listed metrics do not support `pos_label` anymore (if I understand correctly).