### PR TITLE
MNT add path as a static abstract method to LinearModelCV

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1181,6 +1181,11 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
     def _is_multitask(self):
         """Bool indicating if class is meant for multidimensional target."""
 
+    @staticmethod
+    @abstractmethod
+    def path():
+        """Compute path with coordinate descent."""
+
     def fit(self, X, y):
         """Fit linear model with coordinate descent.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1183,7 +1183,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def path():
+    def path(X, y, **kwargs):
         """Compute path with coordinate descent."""
 
     def fit(self, X, y):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR adds `path` as a static abstract method to `LinearModelCV` which is defined as an abstract base class. This fixes a linter error and imposes child classes to actually define the `path` method (which they do) by design.