### PR TITLE
MNT remove deprecation of least_squares in HGBT

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -62,7 +62,8 @@ Changelog
     use `"squared_error"` instead which is now the default.
 
   - For :class:`ensemble.HistGradientBoostingRegressor`, `loss="least_squares"`
-    is deprecated, use `"squared_error"` instead which is now the default.
+    was renamed to `"squared_error"`. Note that in this case, there is no
+    deprecation cycle.
 
   - For :class:`linear_model.RANSACRegressor`, `loss="squared_loss"` is
     deprecated, use `"squared_error"` instead.
@@ -389,8 +390,8 @@ Changelog
   supporting sparse matrix and raise the appropriate error message.
   :pr:`19879` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |Efficiency| Changed ``algorithm`` argument for :class:`cluster.KMeans` in 
-  :class:`preprocessing.KBinsDiscretizer` from ``auto`` to ``full``. 
+- |Efficiency| Changed ``algorithm`` argument for :class:`cluster.KMeans` in
+  :class:`preprocessing.KBinsDiscretizer` from ``auto`` to ``full``.
   :pr:`19934` by :user:`Gleb Levitskiy <GLevV>`.
 
 :mod:`sklearn.tree`

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -3,7 +3,6 @@
 
 from abc import ABC, abstractmethod
 from functools import partial
-import warnings
 
 import numpy as np
 from timeit import default_timer as time
@@ -893,8 +892,8 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
     Parameters
     ----------
-    loss : {'squared_error', 'least_squares', 'least_absolute_deviation', \
-            'poisson'}, default='squared_error'
+    loss : {'squared_error', 'least_absolute_deviation', 'poisson'}, \
+            default='squared_error'
         The loss function to use in the boosting process. Note that the
         "least squares" and "poisson" losses actually implement
         "half least squares loss" and "half poisson deviance" to simplify the
@@ -904,9 +903,8 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         .. versionchanged:: 0.23
            Added option 'poisson'.
 
-        .. deprecated:: 1.0
-            The loss 'least_squares' was deprecated in v1.0 and will be removed
-            in version 1.2. Use `loss='squared_error'` which is equivalent.
+        .. versionchanged:: 1.0
+            The loss 'least_squares' was renamed to 'squared_error' in v1.0.
 
     learning_rate : float, default=0.1
         The learning rate, also known as *shrinkage*. This is used as a
@@ -1037,8 +1035,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     0.92...
     """
 
-    _VALID_LOSSES = ('squared_error', 'least_squares',
-                     'least_absolute_deviation', 'poisson')
+    _VALID_LOSSES = ('squared_error', 'least_absolute_deviation', 'poisson')
 
     @_deprecate_positional_args
     def __init__(self, loss='squared_error', *, learning_rate=0.1,
@@ -1113,14 +1110,6 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         return y
 
     def _get_loss(self, sample_weight):
-        if self.loss == "least_squares":
-            warnings.warn(
-                "The loss 'least_squares' was deprecated in v1.0 and will be "
-                "removed in version 1.2. Use 'squared_error' which is "
-                "equivalent.",
-                FutureWarning)
-            return _LOSSES["squared_error"](sample_weight=sample_weight)
-
         return _LOSSES[self.loss](sample_weight=sample_weight)
 
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -990,17 +990,3 @@ def test_uint8_predict(Est):
     est = Est()
     est.fit(X, y)
     est.predict(X)
-
-
-# TODO: Remove in v1.2
-def test_loss_least_squares_deprecated():
-    X, y = make_regression(n_samples=50, random_state=0)
-    est1 = HistGradientBoostingRegressor(loss="least_squares", random_state=0)
-
-    with pytest.warns(FutureWarning,
-                      match="The loss 'least_squares' was deprecated"):
-        est1.fit(X, y)
-
-    est2 = HistGradientBoostingRegressor(loss="squared_error", random_state=0)
-    est2.fit(X, y)
-    assert_allclose(est1.predict(X), est2.predict(X))


### PR DESCRIPTION
#### Reference Issues/PRs
Possible follow-up on #19310 and #19799.

#### What does this implement/fix? Explain your changes.
#19310 deprecated the use of `"least_squares"` in `HistGradientBoostingRegressor` and #19799 took HGBT out of experimental. As it still is experimental until the release, we don't need the usual deprecation cycle on changes.

#### Any other comments?
This is for discussion. A decision to keep the deprecation and not merge this PR is fine as well.