### PR TITLE
Remove the unused import of csc_matrix

### DIFF
--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -29,7 +29,6 @@ cimport numpy as np
 np.import_array()
 
 from scipy.sparse import issparse
-from scipy.sparse import csc_matrix
 from scipy.sparse import csr_matrix
 
 from ._utils cimport Stack


### PR DESCRIPTION
`csc_matrix` is imported, but not being used anywhere. 