### PR TITLE
DOC: add import in binary tree class examples

### DIFF
--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -246,6 +246,7 @@ Examples
 Query for k-nearest neighbors
 
     >>> import numpy as np
+    >>> from sklearn.neighbors import {BinaryTree}
     >>> rng = np.random.RandomState(0)
     >>> X = rng.random_sample((10, 3))  # 10 points in 3 dimensions
     >>> tree = {BinaryTree}(X, leaf_size=2)              # doctest: +SKIP


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.

Currently in the doc string of the binary tree class examples it doesn't include an import statement e.g. in the examples section here https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.BallTree.html 
![Screenshot from 2021-04-26 15-24-31](https://user-images.githubusercontent.com/17162724/116139077-a00cb700-a6a3-11eb-9a21-eaf1446d824f.png)

A copy paste of the example code:
```
import numpy as np
rng = np.random.RandomState(0)
X = rng.random_sample((10, 3))  # 10 points in 3 dimensions
tree = BallTree(X, leaf_size=2)
```
returns `NameError: name 'BallTree' is not defined`

This PR adds the import statement at the top so it now reads
```
import numpy as np
from sklearn.neighbors import BallTree
rng = np.random.RandomState(0)
X = rng.random_sample((10, 3))  # 10 points in 3 dimensions
tree = BallTree(X, leaf_size=2)  
```

#### Any other comments?

I was able to builds the docs locally to test this

![Screenshot from 2021-04-26 15-32-33](https://user-images.githubusercontent.com/17162724/116139974-a64f6300-a6a4-11eb-8426-7540a8856e81.png)



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
