### PR TITLE
DOC Retroactive changed model entry

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -202,6 +202,9 @@ random sampling procedures.
 
 - |Fix| :class:`linear_model.Perceptron` when `penalty='elasticnet'`.
 
+- |Fix| Change in the random sampling procedures for the center initialization
+  of :class:`cluster.KMeans`.
+
 Details are listed in the changelog below.
 
 (While we are trying to better inform users by providing this information, we


### PR DESCRIPTION
#17928 changed the way we consume the rng for the center initialization of KMeans and we forgot to mention that in the changelog (as pointed out in #19990).

ping @glemaitre 