### PR TITLE
Add GroupTimeSeriesSplit with params - gap and test_size

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -892,6 +892,78 @@ Here is a visualization of the cross-validation behavior.
    :align: center
    :scale: 75%
 
+Group Time Series Split
+^^^^^^^^^^^^^^^^^^^^^^^
+
+:class:`GroupTimeSeriesSplit` combines :class:`TimeSeriesSplit` with the Group awareness
+of `GroupKFold`. Like :class:`TimeSeriesSplit` this also returns first :math:`k` folds
+as train set and the :math:`(k+1)` th fold as test set.
+Successive training sets are supersets of those that come before them.
+Also, it adds all surplus data to the first training partition, which
+is always used to train the model.
+This class can be used to cross-validate time series data samples
+that are observed at fixed time intervals.
+
+The same group will not appear in two different folds (the number of
+distinct groups has to be at least equal to the number of folds).
+
+The groups should be Continuous like below.
+['a', 'a', 'a', 'a', 'a', 'b', 'b', 'b', 'b', 'b', 'b', 'c', 'c', 'c', 'c', 'd', 'd', 'd']
+
+Non-continuous groups like below will give an error.
+['a', 'a', 'a', 'a', 'a', 'b','b', 'b', 'b', 'b', 'b', 'a', 'c', 'c', 'c', 'b', 'd', 'd']
+
+`GroupTimeSeriesSplit` is useful in cases where we have time series data for
+say multiple days with multiple data points within a day. 
+During cross-validation we may not want the training days to be be used in testing.
+Here the days can act as groups to keep the training and test splits separate.
+
+Example of 3-split time series cross-validation on a dataset with
+18 samples and 4 groups::
+
+    >>> import numpy as np
+    >>> from sklearn.model_selection import GroupTimeSeriesSplit
+    >>> groups = np.array(['a', 'a', 'a', 'a', 'a', 'a',
+    ...                    'b', 'b', 'b', 'b', 'b',
+    ...                    'c', 'c', 'c', 'c',
+    ...                    'd', 'd', 'd'])
+    >>> gtss = GroupTimeSeriesSplit(n_splits=3)
+    >>> for train_idx, test_idx in gtss.split(groups, groups=groups):
+    ...     print("TRAIN:", train_idx, "TEST:", test_idx)
+    ...     print("TRAIN GROUP:", groups[train_idx],
+    ...           "TEST GROUP:", groups[test_idx])
+    TRAIN: [0, 1, 2, 3, 4, 5] TEST: [6, 7, 8, 9, 10]
+    TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a']
+    TEST GROUP: ['b' 'b' 'b' 'b' 'b']
+    TRAIN: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] TEST: [11, 12, 13, 14]
+    TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a' 'b' 'b' 'b' 'b' 'b']
+    TEST GROUP: ['c' 'c' 'c' 'c']
+    TRAIN: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+    TEST: [15, 16, 17]
+    TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a' 'b' 'b' 'b' 'b' 'b' 'c' 'c' 'c' 'c']
+    TEST GROUP: ['d' 'd' 'd']
+
+Example of 2-split time series cross-validation on a dataset with
+18 samples and 4 groups and 1 test_size and 3 max_train_size and 1 period gap::
+
+    >>> import numpy as np
+    >>> from sklearn.model_selection import GroupTimeSeriesSplit
+    >>> groups = np.array(['a', 'a', 'a', 'a', 'a', 'a',\
+                           'b', 'b', 'b', 'b', 'b',\
+                           'c', 'c', 'c', 'c',\
+                           'd', 'd', 'd'])
+    >>> gtss = GroupTimeSeriesSplit(n_splits=2, test_size=1, gap=1,\
+                                    max_train_size=3)
+    >>> for train_idx, test_idx in gtss.split(groups, groups=groups):
+    ...     print("TRAIN:", train_idx, "TEST:", test_idx)
+    ...     print("TRAIN GROUP:", groups[train_idx],\
+                  "TEST GROUP:", groups[test_idx])
+    TRAIN: [0, 1, 2, 3, 4, 5] TEST: [11, 12, 13, 14]
+    TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a'] TEST GROUP: ['c' 'c' 'c' 'c']
+    TRAIN: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] TEST: [15, 16, 17]
+    TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a' 'b' 'b' 'b' 'b' 'b']
+    TEST GROUP: ['d' 'd' 'd']
+
 A note on shuffling
 ===================
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -948,16 +948,14 @@ Example of 2-split time series cross-validation on a dataset with
 
     >>> import numpy as np
     >>> from sklearn.model_selection import GroupTimeSeriesSplit
-    >>> groups = np.array(['a', 'a', 'a', 'a', 'a', 'a',\
-                           'b', 'b', 'b', 'b', 'b',\
-                           'c', 'c', 'c', 'c',\
-                           'd', 'd', 'd'])
-    >>> gtss = GroupTimeSeriesSplit(n_splits=2, test_size=1, gap=1,\
-                                    max_train_size=3)
+    >>> groups = np.array(['a', 'a', 'a', 'a', 'a', 'a',
+    ...                    'b', 'b', 'b', 'b', 'b',
+    ...                    'c', 'c', 'c', 'c',
+    ...                    'd', 'd', 'd'])
+    >>> gtss = GroupTimeSeriesSplit(n_splits=2, test_size=1, gap=1, max_train_size=3)
     >>> for train_idx, test_idx in gtss.split(groups, groups=groups):
     ...     print("TRAIN:", train_idx, "TEST:", test_idx)
-    ...     print("TRAIN GROUP:", groups[train_idx],\
-                  "TEST GROUP:", groups[test_idx])
+    ...     print("TRAIN GROUP:", groups[train_idx], "TEST GROUP:", groups[test_idx])
     TRAIN: [0, 1, 2, 3, 4, 5] TEST: [11, 12, 13, 14]
     TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a'] TEST GROUP: ['c' 'c' 'c' 'c']
     TRAIN: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] TEST: [15, 16, 17]

--- a/doc/modules/group_time_series_split.rst
+++ b/doc/modules/group_time_series_split.rst
@@ -1,0 +1,121 @@
+
+.. _GroupTimeSeriesSplit:
+
+=================================================
+sklearn.model_selection.GroupTimeSeriesSplit
+=================================================
+.. code-block:: python
+
+   class sklearn.model_selection.GroupTimeSeriesSplit(n_splits=5, *, max_train_size=None, test_size=None, gap=0)
+
+| *GroupTimeSeriesSplit* combines *TimeSeriesSplit* with the Group awareness of *GroupKFold*.
+|
+| Like *TimeSeriesSplit* this  also returns first *k* folds as train set and the *(k+1)* th fold as test set.
+|
+| Since the Group applies on this class, the same group will not appear in two different
+ folds(the number of distinct groups has to be at least equal to the number of folds) which make sure the i.i.d. assumption will not be broken.
+
+| All operations of this CV strategy are done at the group level.
+| So all our parameters, not limited to splits, including test_size, gap, and max_train_size, all represent the constraints on the number of groups.
+
+
+Parameters: 
+-----------
+| **n_splits;int,default=5**
+|
+|   Number of splits. Must be at least 2.
+|
+| **max_train_size:int, default=None**
+|
+|   Maximum number of groups for a single training set.
+|
+| **test_size:int, default=None**
+|
+|   Used to limit the number of groups in the test set. Defaults to ``n_samples // (n_splits + 1)``, which is the maximum allowed value with ``gap=0``.
+|
+| **gap:int, default=0**
+|
+|  Number of groups in samples to exclude from the end of each train set before the test set.
+
+Example 1:
+---------
+.. code-block:: python
+
+>>> import numpy as np
+>>> from sklearn.model_selection import GroupTimeSeriesSplit
+>>> groups = np.array(['a', 'a', 'a', 'a', 'a', 'a',
+...                    'b', 'b', 'b', 'b', 'b',
+...                    'c', 'c', 'c', 'c',
+...                    'd', 'd', 'd'])
+>>> gtss = GroupTimeSeriesSplit(n_splits=3)
+>>> for train_idx, test_idx in gtss.split(groups, groups=groups):
+...     print("TRAIN:", train_idx, "TEST:", test_idx)
+...     print("TRAIN GROUP:", groups[train_idx],
+...           "TEST GROUP:", groups[test_idx])
+TRAIN: [0, 1, 2, 3, 4, 5] TEST: [6, 7, 8, 9, 10]
+TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a']
+TEST GROUP: ['b' 'b' 'b' 'b' 'b']
+TRAIN: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] TEST: [11, 12, 13, 14]
+TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a' 'b' 'b' 'b' 'b' 'b']
+TEST GROUP: ['c' 'c' 'c' 'c']
+TRAIN: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+TEST: [15, 16, 17]
+TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a' 'b' 'b' 'b' 'b' 'b' 'c' 'c' 'c' 'c']
+TEST GROUP: ['d' 'd' 'd']
+
+Example 2:
+---------
+.. code-block:: python
+
+>>> import numpy as np
+>>> from sklearn.model_selection import GroupTimeSeriesSplit
+>>> groups = np.array(['a', 'a', 'a', 'a', 'a', 'a',\
+                       'b', 'b', 'b', 'b', 'b',\
+                       'c', 'c', 'c', 'c',\
+                       'd', 'd', 'd'])
+>>> gtss = GroupTimeSeriesSplit(n_splits=2, test_size=1, gap=1,\
+                                max_train_size=3)
+>>> for train_idx, test_idx in gtss.split(groups, groups=groups):
+...     print("TRAIN:", train_idx, "TEST:", test_idx)
+...     print("TRAIN GROUP:", groups[train_idx],\
+              "TEST GROUP:", groups[test_idx])
+TRAIN: [0, 1, 2, 3, 4, 5] TEST: [11, 12, 13, 14]
+TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a'] TEST GROUP: ['c' 'c' 'c' 'c']
+TRAIN: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] TEST: [15, 16, 17]
+TRAIN GROUP: ['a' 'a' 'a' 'a' 'a' 'a' 'b' 'b' 'b' 'b' 'b']
+TEST GROUP: ['d' 'd' 'd']
+
+Methods: 
+--------
+| **get_n_splits([X, y, groups])**
+|
+|   Returns the number of splitting iterations in the cross-validator
+|   *Parameters:*
+|       *X: object*
+|           Always ignored, exists for compatibility.
+|       *y: object*
+|           Always ignored, exists for compatibility.
+|       *groups: object*
+|           Always ignored, exists for compatibility.
+|   *Returns:*
+|       *n_splits: int*
+|           Returns the number of splitting iterations in the cross-validator.
+|
+| **split(X[groups, y])**
+|
+|   Generate indices to split data into training and test set by group.
+|   *Parameters:*
+|       *X : array-like of shape (n_samples, n_features)*
+|            Training data, where n_samples is the number of samples
+|            and n_features is the number of features.
+|       *y : array-like of shape (n_samples,)*
+|            Always ignored, exists for compatibility.
+|       *groups : array-like of shape (n_samples,)*
+|            Group labels for the samples used while splitting the dataset into
+|            train/test set.
+|   *Yields:*
+|       *train : ndarray*
+|            The training set indices for that split.
+|       *test : ndarray*
+|            The testing set indices for that split.
+

--- a/examples/model_selection/plot_cv_indices.py
+++ b/examples/model_selection/plot_cv_indices.py
@@ -159,8 +159,6 @@ cvs = [KFold, GroupKFold, ShuffleSplit, StratifiedKFold, StratifiedGroupKFold,
 for cv in cvs:
     this_cv = cv(n_splits=n_splits)
     fig, ax = plt.subplots(figsize=(6, 3))
-    if cv == GroupTimeSeriesSplit:
-        groups = unevengroups
     plot_cv_indices(this_cv, X, y, groups, ax, n_splits)
 
     ax.legend([Patch(color=cmap_cv(.8)), Patch(color=cmap_cv(.02))],

--- a/examples/model_selection/plot_cv_indices.py
+++ b/examples/model_selection/plot_cv_indices.py
@@ -11,9 +11,10 @@ This example visualizes the behavior of several common scikit-learn objects
 for comparison.
 """
 
-from sklearn.model_selection import (TimeSeriesSplit, KFold, ShuffleSplit,
-                                     StratifiedKFold, GroupShuffleSplit,
-                                     GroupKFold, StratifiedShuffleSplit,
+from sklearn.model_selection import (TimeSeriesSplit, GroupTimeSeriesSplit,
+                                     KFold, ShuffleSplit, StratifiedKFold,
+                                     GroupShuffleSplit, GroupKFold,
+                                     StratifiedShuffleSplit,
                                      StratifiedGroupKFold)
 import numpy as np
 import matplotlib.pyplot as plt
@@ -151,12 +152,15 @@ for cv in cvs:
 # Note how some use the group/class information while others do not.
 
 cvs = [KFold, GroupKFold, ShuffleSplit, StratifiedKFold, StratifiedGroupKFold,
-       GroupShuffleSplit, StratifiedShuffleSplit, TimeSeriesSplit]
+       GroupShuffleSplit, StratifiedShuffleSplit, TimeSeriesSplit,
+       GroupTimeSeriesSplit]
 
 
 for cv in cvs:
     this_cv = cv(n_splits=n_splits)
     fig, ax = plt.subplots(figsize=(6, 3))
+    if cv == GroupTimeSeriesSplit:
+        groups = unevengroups
     plot_cv_indices(this_cv, X, y, groups, ax, n_splits)
 
     ax.legend([Patch(color=cmap_cv(.8)), Patch(color=cmap_cv(.02))],

--- a/sklearn/model_selection/__init__.py
+++ b/sklearn/model_selection/__init__.py
@@ -3,6 +3,7 @@ import typing
 from ._split import BaseCrossValidator
 from ._split import KFold
 from ._split import GroupKFold
+from ._split import GroupTimeSeriesSplit
 from ._split import StratifiedKFold
 from ._split import TimeSeriesSplit
 from ._split import LeaveOneGroupOut
@@ -46,6 +47,7 @@ __all__ = ['BaseCrossValidator',
            'KFold',
            'GroupKFold',
            'GroupShuffleSplit',
+           'GroupTimeSeriesSplit',
            'LeaveOneGroupOut',
            'LeaveOneOut',
            'LeavePGroupsOut',

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2154,6 +2154,7 @@ class PredefinedSplit(BaseCrossValidator):
         """
         return len(self.unique_folds)
 
+
 class GroupTimeSeriesSplit(_BaseKFold):
     """Time Series cross-validator variant with non-overlapping groups.
 
@@ -2194,15 +2195,15 @@ class GroupTimeSeriesSplit(_BaseKFold):
 
     max_train_size : int, default=None
         Maximum number of groups for a single training set.
-    
+
     test_size : int, default=None
         Used to limit the number of groups in the test set. Defaults to
         ``n_samples // (n_splits + 1)``, which is the maximum allowed value
         with ``gap=0``.
 
     gap : int, default=0
-        Number of groups in samples to exclude from the end of each train set before
-        the test set.
+        Number of groups in samples to exclude from the end of each train set
+        before the test set.
 
     Examples
     --------
@@ -2315,26 +2316,27 @@ class GroupTimeSeriesSplit(_BaseKFold):
                 (f"Cannot have number of folds={n_folds} greater"
                  f" than the number of groups={n_groups}."))
         if n_groups - gap - (group_test_size * n_splits) <= 0:
-            raise ValueError(
-                (f"Too many splits={n_splits} for number of groups"
-                 f"={n_groups} with test_size={group_test_size} and gap={gap}."))
-        
+            raise ValueError((
+                f"Too many splits={n_splits} for number of groups"
+                f"={n_groups} with test_size={group_test_size} and gap={gap}."
+                ))
+
         for group_test_start in range(n_groups - n_splits * group_test_size,
                                       n_groups, group_test_size):
             train_array = []
             test_array = []
             train_group_idxs = unique_groups[:group_test_start]
             train_end = train_group_idxs.size
-            # handle gap: remove gap amount of groups from the end of 
+            # handle gap: remove gap amount of groups from the end of
             # train_group_idxs
             if gap:
                 train_group_idxs = train_group_idxs[:train_end - gap]
                 train_end -= gap
-            # handle max_train_size: remove max_train_size amount of group 
+            # handle max_train_size: remove max_train_size amount of group
             # from the beginning of train_group_idxs
             if max_train_size and max_train_size < train_end:
-                train_group_idxs = train_group_idxs[train_end -
-                                          max_train_size:train_end]
+                train_group_idxs = train_group_idxs[
+                    train_end - max_train_size:train_end]
             for train_group_idx in train_group_idxs:
                 train_array_tmp = group_dict[train_group_idx]
                 train_array = np.sort(np.unique(
@@ -2350,6 +2352,7 @@ class GroupTimeSeriesSplit(_BaseKFold):
                                                               test_array_tmp)),
                                      axis=None), axis=None)
             yield [int(i) for i in train_array], [int(i) for i in test_array]
+
 
 class _CVIterableWrapper(BaseCrossValidator):
     """Wrapper class for old style cv objects and iterables."""

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1824,7 +1824,7 @@ def test_group_time_series_more_folds_than_group():
     with pytest.raises(
             ValueError,
             match="Cannot have number of folds=4 greater"
-                  " than the number of groups=2"):
+                  " than the number of samples=2"):
         next(GroupTimeSeriesSplit(n_splits=3).split(X, y, groups))
 
 
@@ -1922,8 +1922,8 @@ def test_group_time_series_non_continuous():
     X = y = np.ones(len(groups))
     with pytest.raises(
             ValueError,
-            match="The groups should be continuous."
-                  " Found a non-continuous group at"
+            match="The groups should be contiguous."
+                  " Found a non-contiguous group at"
                   " index=15"):
         next(GroupTimeSeriesSplit(n_splits=3).split(X, y, groups))
 


### PR DESCRIPTION
#### To @getgaurav2:
.rst is from @getgaurav2 's branch d6c7f0f28358f6704206f446d0c8768656bfc740 (Because it seems to have been merged by parent Issue #14257 and #16236). **Please contact me about recovering your contribution in this pull request.**

#### What I Accomplished:
I rewrote the GroupTimeSeriesSplit (resolve #14257), added the `gap` and `test_size`, and changed the behavior of `max_train_size` (fixes #19072) .
Because #19072 is in response to a comment by @albertvillanova, he mentioned that `test_size` should specify the number of groups in the test set.
So in this pull request, `gap`, `test_size`, and `max_train_size` will be representing the number of groups instead of the number of samples.

#### Design Document
More test details and ideas: https://drive.google.com/file/d/1umQrTNrNs8U2pIACKbCk3gL77tdqoFfL/view?usp=sharing
