### PR TITLE
DOC Added return value info to SimpleImputer.transform docstring

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -426,6 +426,11 @@ class SimpleImputer(_BaseImputer):
         ----------
         X : {array-like, sparse matrix}, shape (n_samples, n_features)
             The input data to complete.
+
+        Returns
+        -------
+        X_imputed : ndarray of shape (n_samples, n_features)
+            input X with imputed values
         """
         check_is_fitted(self)
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -429,7 +429,7 @@ class SimpleImputer(_BaseImputer):
 
         Returns
         -------
-        X_imputed : ndarray of shape (n_samples, n_features)
+        X_imputed : {ndarray, sparse matrix} of shape (n_samples, n_features)
             input X with imputed values
         """
         check_is_fitted(self)

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -429,7 +429,8 @@ class SimpleImputer(_BaseImputer):
 
         Returns
         -------
-        X_imputed : {ndarray, sparse matrix} of shape (n_samples, n_features)
+        X_imputed : {ndarray, sparse matrix} of shape (n_samples, \
+                    n_features_out)
             input X with imputed values
         """
         check_is_fitted(self)

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -429,9 +429,9 @@ class SimpleImputer(_BaseImputer):
 
         Returns
         -------
-        X_imputed : {ndarray, sparse matrix} of shape (n_samples, \
-                    n_features_out)
-            input X with imputed values
+        X_imputed : {ndarray, sparse matrix} of shape \
+                (n_samples, n_features_out)
+            `X` with imputed values.
         """
         check_is_fitted(self)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.
transform(X) in [SimpleImputer](https://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html#sklearn.impute.SimpleImputer.transform) documentation was missing return value. Also missing from the [definition ](https://github.com/scikit-learn/scikit-learn/blob/15a949460/sklearn/impute/_base.py#L422)as linked in documentation.

Added "Returns" section to the docstring for SimpleImputer.transform

#### Any other comments?
Wasn't entirely sure on the type being returned.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
