### PR TITLE
CLN Be consistent with docs for float and ints in parameters

### DIFF
--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -297,7 +297,7 @@ class LatentDirichletAllocation(TransformerMixin, BaseEstimator):
     def __init__(self, n_components=10, *, doc_topic_prior=None,
                  topic_word_prior=None, learning_method='batch',
                  learning_decay=.7, learning_offset=10., max_iter=10,
-                 batch_size=128, evaluate_every=-1, total_samples=1e6,
+                 batch_size=128, evaluate_every=-1, total_samples=1_000_000,
                  perp_tol=1e-1, mean_change_tol=1e-3, max_doc_update_iter=100,
                  n_jobs=None, verbose=0, random_state=None):
         self.n_components = n_components

--- a/sklearn/feature_selection/_variance_threshold.py
+++ b/sklearn/feature_selection/_variance_threshold.py
@@ -18,7 +18,7 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
 
     Parameters
     ----------
-    threshold : float, default=0
+    threshold : float, default=0.0
         Features with a training-set variance lower than this threshold will
         be removed. The default is to keep all features with non-zero variance,
         i.e. remove the features that have the same value in all samples.

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -114,7 +114,7 @@ class KernelRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
     KernelRidge(alpha=1.0)
     """
     @_deprecate_positional_args
-    def __init__(self, alpha=1, *, kernel="linear", gamma=None, degree=3,
+    def __init__(self, alpha=1.0, *, kernel="linear", gamma=None, degree=3,
                  coef0=1, kernel_params=None):
         self.alpha = alpha
         self.kernel = kernel

--- a/sklearn/linear_model/_theil_sen.py
+++ b/sklearn/linear_model/_theil_sen.py
@@ -293,7 +293,7 @@ class TheilSenRegressor(RegressorMixin, LinearModel):
     """
     @_deprecate_positional_args
     def __init__(self, *, fit_intercept=True, copy_X=True,
-                 max_subpopulation=1e4, n_subsamples=None, max_iter=300,
+                 max_subpopulation=1_000, n_subsamples=None, max_iter=300,
                  tol=1.e-3, random_state=None, n_jobs=None, verbose=False):
         self.fit_intercept = fit_intercept
         self.copy_X = copy_X


### PR DESCRIPTION
Fixes minor inconsistencies between the docstring for floats and ints parameters. (`1e4` is a float)