### PR TITLE
CLN Remove kwargs Neighbors __init__

### DIFF
--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -147,14 +147,13 @@ class KNeighborsClassifier(KNeighborsMixin,
     @_deprecate_positional_args
     def __init__(self, n_neighbors=5, *,
                  weights='uniform', algorithm='auto', leaf_size=30,
-                 p=2, metric='minkowski', metric_params=None, n_jobs=None,
-                 **kwargs):
+                 p=2, metric='minkowski', metric_params=None, n_jobs=None):
         super().__init__(
             n_neighbors=n_neighbors,
             algorithm=algorithm,
             leaf_size=leaf_size, metric=metric, p=p,
             metric_params=metric_params,
-            n_jobs=n_jobs, **kwargs)
+            n_jobs=n_jobs)
         self.weights = _check_weights(weights)
 
     def fit(self, X, y):
@@ -415,7 +414,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin,
               algorithm=algorithm,
               leaf_size=leaf_size,
               metric=metric, p=p, metric_params=metric_params,
-              n_jobs=n_jobs, **kwargs)
+              n_jobs=n_jobs)
         self.weights = _check_weights(weights)
         self.outlier_label = outlier_label
 

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -146,13 +146,12 @@ class KNeighborsRegressor(KNeighborsMixin,
     @_deprecate_positional_args
     def __init__(self, n_neighbors=5, *, weights='uniform',
                  algorithm='auto', leaf_size=30,
-                 p=2, metric='minkowski', metric_params=None, n_jobs=None,
-                 **kwargs):
+                 p=2, metric='minkowski', metric_params=None, n_jobs=None):
         super().__init__(
               n_neighbors=n_neighbors,
               algorithm=algorithm,
               leaf_size=leaf_size, metric=metric, p=p,
-              metric_params=metric_params, n_jobs=n_jobs, **kwargs)
+              metric_params=metric_params, n_jobs=n_jobs)
         self.weights = _check_weights(weights)
 
     def _more_tags(self):
@@ -346,14 +345,13 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin,
     @_deprecate_positional_args
     def __init__(self, radius=1.0, *, weights='uniform',
                  algorithm='auto', leaf_size=30,
-                 p=2, metric='minkowski', metric_params=None, n_jobs=None,
-                 **kwargs):
+                 p=2, metric='minkowski', metric_params=None, n_jobs=None):
         super().__init__(
               radius=radius,
               algorithm=algorithm,
               leaf_size=leaf_size,
               p=p, metric=metric, metric_params=metric_params,
-              n_jobs=n_jobs, **kwargs)
+              n_jobs=n_jobs)
         self.weights = _check_weights(weights)
 
     def fit(self, X, y):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -978,7 +978,6 @@ def test_RadiusNeighborsRegressor_multioutput_with_uniform_weight():
 def test_RadiusNeighborsRegressor_multioutput(n_samples=40,
                                               n_features=5,
                                               n_test_pts=10,
-                                              n_neighbors=3,
                                               random_state=0):
     # Test k-neighbors in multi-output regression with various weight
     rng = np.random.RandomState(random_state)
@@ -991,8 +990,7 @@ def test_RadiusNeighborsRegressor_multioutput(n_samples=40,
     weights = ['uniform', 'distance', _weight_func]
 
     for algorithm, weights in product(ALGORITHMS, weights):
-        rnn = neighbors.RadiusNeighborsRegressor(n_neighbors=n_neighbors,
-                                                 weights=weights,
+        rnn = neighbors.RadiusNeighborsRegressor(weights=weights,
                                                  algorithm=algorithm)
         rnn.fit(X, y)
         epsilon = 1E-5 * (2 * rng.rand(1, n_features) - 1)


### PR DESCRIPTION
These estimators have `**kwargs` in `__init__` and it looks like they can be safely removed.