### PR TITLE
[affinity propagation] change logic in edge case where all similarities and preferences are equal

### DIFF
--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -135,7 +135,7 @@ def affinity_propagation(S, *, preference=None, convergence_iter=15,
         # n_samples clusters, depending on preferences
         warnings.warn("All samples have mutually equal similarities. "
                       "Returning arbitrary cluster center(s).")
-        if preference.flat[0] >= S.flat[n_samples - 1]:
+        if preference.flat[0] > S.flat[n_samples - 1]:
             return ((np.arange(n_samples), np.arange(n_samples), 0)
                     if return_n_iter
                     else (np.arange(n_samples), np.arange(n_samples)))


### PR DESCRIPTION
**Example** of behaviour changed by this PR:

```python
from sklearn.cluster import AffinityPropagation
c = [[0], [0], [0], [0], [0], [0], [0], [0]]
af = AffinityPropagation(damping = 0.5,affinity = 'euclidean').fit (c)
print (af.labels_)
```

output before this PR:

```
[0 1 0 1 2 1 1 0]
```

output after this PR:

```
[0 0 0 0 0 0 0 0]
```

### explanation

as in https://stats.stackexchange.com/questions/156924/affinity-propagation-sklearn-strange-behavior/323665

* if affinity propagation receives points with all features being equal it will currently assign a cluster for each of the point
* this is due to the PR https://github.com/scikit-learn/scikit-learn/pull/9635 which introduced a check to avoid running affinity propagation when all similarities and preferences are all equal (not necessarily preferences equal to the similarities)
* this PR changes the logic of that protection to avoid having many clusters in case of all equal points.

#### Reference Issues/PRs

* no issue was found related to this

#### What does this implement/fix? Explain your changes.

* it just changes a `>=` into a `>`


