### PR TITLE
DOC Add communication guidelines.

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1275,8 +1275,8 @@ contributor to keep involved in the project. [1]_
   a follow-up PR.
 - Do not rush, take the time to make your comments clear and justify your
   suggestions.
-- You are the face of the project. Bad days occurs to everyone, in that
-  occasions you deserve a break: try to take your time and stay off line.
+- You are the face of the project. Bad days occur to everyone, in that
+  occasion you deserve a break: try to take your time and stay offline.
 
 .. [1] Adapted from the numpy `communication guidelines
        <https://numpy.org/devdocs/dev/reviewer_guidelines.html#communication-guidelines>`_.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1270,7 +1270,7 @@ contributor to keep involved in the project. [1]_
   with small pervasive issues.
 - Do not let perfect be the enemy of the good. If you find yourself making
   many small suggestions that are a matter of subjective taste rather than
-  somewhat objective. The following approaches are suggested:
+  somewhat objective, the following approaches are suggested:
 
   - refrain from submitting these;
   - prefix them as "Nit" so that the contributor knows it's OK not to address;

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1253,10 +1253,14 @@ from high-level questions to a more detailed check-list.
 
 :ref:`saved_replies` includes some frequent comments that reviewers may make.
 
-.. _communication::
+.. _communication:
 
-Communication Guidelines [1]_
------------------------------
+Communication Guidelines
+------------------------
+
+Reviewing open pull requests (PRs) helps move the project forward. It is a
+great way to get familiar with the codebase and should motivate the
+contributor to keep involved in the project. [1]_
 
 - Every PR, good or bad, is an act of generosity. Opening with a positive
   comment will help the author feel rewarded, and your subsequent remarks may
@@ -1275,7 +1279,7 @@ Communication Guidelines [1]_
   occasions you deserve a break: try to take your time and stay off line.
 
 .. [1] Adapted from the numpy `communication guidelines
-       <https://numpy.org/devdocs/dev/reviewer_guidelines.html#communication-guidelines>`_
+       <https://numpy.org/devdocs/dev/reviewer_guidelines.html#communication-guidelines>`_.
 
 Reading the existing code base
 ==============================

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1268,11 +1268,17 @@ contributor to keep involved in the project. [1]_
 - Begin if possible with the large issues, so the author knows they’ve been
   understood. Resist the temptation to immediately go line by line, or to open
   with small pervasive issues.
-- Do not let perfect be the enemy of the good, particularly for documentation.
-  If you find yourself making many small suggestions, or being too nitpicky
-  on style or grammar, consider merging the current PR when all important
-  concerns are addressed. There will always be the opportunity to improve it in
-  a follow-up PR.
+- Do not let perfect be the enemy of the good. If you find yourself making
+  many small suggestions that are a matter of subjective taste rather than
+  somewhat objective, consider that the frontier between a subjective nit and
+  an objective improvement is often subjective. The following approaches are
+  suggested:
+
+  - refrain from submitting these;
+  - prefix them as "Nit" so that the contributor knows it's OK not to address;
+  - follow up in a subsequent PR, out of courtesy, you may want to let the
+    original contributor know.
+
 - Do not rush, take the time to make your comments clear and justify your
   suggestions.
 - You are the face of the project. Bad days occur to everyone, in that

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1250,6 +1250,30 @@ from high-level questions to a more detailed check-list.
 
 :ref:`saved_replies` includes some frequent comments that reviewers may make.
 
+.. _communication::
+
+Communication Guidelines [1]_
+-----------------------------
+
+- Every PR, good or bad, is an act of generosity. Opening with a positive
+  comment will help the author feel rewarded, and your subsequent remarks may
+  be heard more clearly. You may feel good also.
+- Begin if possible with the large issues, so the author knows they’ve been
+  understood. Resist the temptation to immediately go line by line, or to open
+  with small pervasive issues.
+- Do not let perfect be the enemy of the good, particularly for documentation.
+  If you find yourself making many small suggestions, or being too nitpicky
+  on style or grammar, consider merging the current PR when all important
+  concerns are addressed. Then, either push a commit directly
+  (if you are a maintainer) or open a follow-up PR yourself.
+- Do not rush, take the time to make your comments clear and justify your
+  suggestions.
+- You are the face of the project. Bad days occurs to everyone, in that
+  occasions you deserve a break: try to take your time and stay off line.
+
+.. [1] Adapted from the numpy `communication guidelines
+       <https://numpy.org/devdocs/dev/reviewer_guidelines.html#communication-guidelines>`_
+
 Reading the existing code base
 ==============================
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1271,8 +1271,8 @@ contributor to keep involved in the project. [1]_
 - Do not let perfect be the enemy of the good, particularly for documentation.
   If you find yourself making many small suggestions, or being too nitpicky
   on style or grammar, consider merging the current PR when all important
-  concerns are addressed. Then, either push a commit directly
-  (if you are a maintainer) or open a follow-up PR yourself.
+  concerns are addressed. There will always be the opportunity to improve it in
+  a follow-up PR.
 - Do not rush, take the time to make your comments clear and justify your
   suggestions.
 - You are the face of the project. Bad days occurs to everyone, in that

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1270,9 +1270,7 @@ contributor to keep involved in the project. [1]_
   with small pervasive issues.
 - Do not let perfect be the enemy of the good. If you find yourself making
   many small suggestions that are a matter of subjective taste rather than
-  somewhat objective, consider that the frontier between a subjective nit and
-  an objective improvement is often subjective. The following approaches are
-  suggested:
+  somewhat objective. The following approaches are suggested:
 
   - refrain from submitting these;
   - prefix them as "Nit" so that the contributor knows it's OK not to address;


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Numpy has recently add to its documentation some [communication guidelines](https://numpy.org/devdocs/dev/reviewer_guidelines.html#communication-guidelines). I find them quite relevant, and I believe it could be useful to add them to our review guidelines. 

Thanks for considering it.

Perhaps @reshamas might want to have a look? Thanks!
