### PR TITLE
MNT fix bad shebang in build_doc.sh

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -1,4 +1,4 @@
-q#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -x
 set -e
 


### PR DESCRIPTION
Introduced by me in [`7e89011` (#20044)](https://github.com/scikit-learn/scikit-learn/pull/20044/commits/7e890119fca80b0e0b69bab9852440c5f6788605), thanks for noting @jjerphan 