### PR TITLE
Make BaseShuffleSplit public

### DIFF
--- a/sklearn/model_selection/__init__.py
+++ b/sklearn/model_selection/__init__.py
@@ -1,6 +1,7 @@
 import typing
 
 from ._split import BaseCrossValidator
+from ._split import BaseShuffleSplit
 from ._split import KFold
 from ._split import GroupKFold
 from ._split import StratifiedKFold
@@ -41,6 +42,7 @@ if typing.TYPE_CHECKING:
 
 
 __all__ = ['BaseCrossValidator',
+           'BaseShuffleSplit',
            'GridSearchCV',
            'TimeSeriesSplit',
            'KFold',


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.

Added BaseShuffleSplit to the __init__ so it can be referenced directly for **type hints** without having to use both StratifiedShuffleSplit and ShuffleSplit when any type of shuffle split would suffice.

When accepting any shuffle split one has to do:
```
Union[model_selection.StratifiedShuffleSplit, model_selection.ShuffleSplit]
```
This is I believe unnecessary since both inherit from BaseShuffleSplit and could be easily solved by adding BaseShuffleSplit to the publicly visible init (since _split is not).

Also for accepting any splitter class from model_selection module in your function the type hints would need to be:
```
Union[model_selection.BaseShuffleSplit, model_selection.ShuffleSplit, model_selection.StratifiedShuffleSplit]
```

With this change now it would be only `BaseShuffleSplit` for any shuffle split and `Union[model_selection.BaseCrossValidator, model_selection.BaseShuffleSplit]` for any splitter class


#### Any other comments?
I have not seen anything why having this missing from the __init__ file would be intentional but let me know if I missed something that would make this change mess something up.

