### PR TITLE
CI Uses minimum version for doc-min-dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
       - SCIKIT_IMAGE_VERSION: 'min'
       - SPHINX_VERSION: 'min'
       - PANDAS_VERSION: 'min'
+      - SPHINX_GALLERY_VERSION: 'min'
+      - NUMPYDOC_VERSION: 'min'
+      - SPHINX_PROMPT_VERSION: 'min'
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
@@ -57,6 +60,9 @@ jobs:
       - SCIKIT_IMAGE_VERSION: 'latest'
       - SPHINX_VERSION: 'min'
       - PANDAS_VERSION: 'latest'
+      - SPHINX_GALLERY_VERSION: 'latest'
+      - NUMPYDOC_VERSION: 'latest'
+      - SPHINX_PROMPT_VERSION: 'latest'
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - MATPLOTLIB_VERSION: 'latest'
       - CYTHON_VERSION: 'latest'
       - SCIKIT_IMAGE_VERSION: 'latest'
-      - SPHINX_VERSION: 'min'
+      - SPHINX_VERSION: 'latest'
       - PANDAS_VERSION: 'latest'
       - SPHINX_GALLERY_VERSION: 'latest'
       - NUMPYDOC_VERSION: 'latest'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - MATPLOTLIB_VERSION: 'latest'
       - CYTHON_VERSION: 'latest'
       - SCIKIT_IMAGE_VERSION: 'latest'
-      - SPHINX_VERSION: 'latest'
+      - SPHINX_VERSION: 'min'
       - PANDAS_VERSION: 'latest'
       - SPHINX_GALLERY_VERSION: 'latest'
       - NUMPYDOC_VERSION: 'latest'

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -177,9 +177,9 @@ conda create -n $CONDA_ENV_NAME --yes --quiet \
     joblib memory_profiler packaging seaborn pillow pytest coverage
 
 source activate testenv
-pip install sphinx-gallery
-pip install numpydoc
-pip install sphinx-prompt
+pip install "$(get_dep sphinx-gallery $SPHINX_GALLERY_VERSION)"
+pip install "$(get_dep numpydoc $NUMPYDOC_VERSION)"
+pip install "$(get_dep sphinx-prompt $SPHINX_PROMPT_VERSION)"
 
 # Set parallelism to 3 to overlap IO bound tasks with CPU bound tasks on CI
 # workers with 2 cores when building the compiled extensions of scikit-learn.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/20026
Related to https://github.com/scikit-learn/scikit-learn/issues/20027


#### What does this implement/fix? Explain your changes.
Sets the minimum version for doc build dependencies


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
