### PR TITLE
CLN Replace self.steps[-1][-1] with self.steps[-1][1]

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -225,7 +225,7 @@ class Pipeline(_BaseComposition):
 
     @property
     def _estimator_type(self):
-        return self.steps[-1][-1]._estimator_type
+        return self.steps[-1][1]._estimator_type
 
     @property
     def named_steps(self):
@@ -234,7 +234,7 @@ class Pipeline(_BaseComposition):
 
     @property
     def _final_estimator(self):
-        estimator = self.steps[-1][-1]
+        estimator = self.steps[-1][1]
         return 'passthrough' if estimator is None else estimator
 
     def _log_message(self, step_idx):
@@ -416,7 +416,7 @@ class Pipeline(_BaseComposition):
         Xt = X
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict(Xt, **predict_params)
+        return self.steps[-1][1].predict(Xt, **predict_params)
 
     @if_delegate_has_method(delegate='_final_estimator')
     def fit_predict(self, X, y=None, **fit_params):
@@ -451,7 +451,7 @@ class Pipeline(_BaseComposition):
         fit_params_last_step = fit_params_steps[self.steps[-1][0]]
         with _print_elapsed_time('Pipeline',
                                  self._log_message(len(self.steps) - 1)):
-            y_pred = self.steps[-1][-1].fit_predict(Xt, y,
+            y_pred = self.steps[-1][1].fit_predict(Xt, y,
                                                     **fit_params_last_step)
         return y_pred
 
@@ -476,7 +476,7 @@ class Pipeline(_BaseComposition):
         Xt = X
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict_proba(Xt, **predict_proba_params)
+        return self.steps[-1][1].predict_proba(Xt, **predict_proba_params)
 
     @if_delegate_has_method(delegate='_final_estimator')
     def decision_function(self, X):
@@ -495,7 +495,7 @@ class Pipeline(_BaseComposition):
         Xt = X
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt)
-        return self.steps[-1][-1].decision_function(Xt)
+        return self.steps[-1][1].decision_function(Xt)
 
     @if_delegate_has_method(delegate='_final_estimator')
     def score_samples(self, X):
@@ -514,7 +514,7 @@ class Pipeline(_BaseComposition):
         Xt = X
         for _, _, transformer in self._iter(with_final=False):
             Xt = transformer.transform(Xt)
-        return self.steps[-1][-1].score_samples(Xt)
+        return self.steps[-1][1].score_samples(Xt)
 
     @if_delegate_has_method(delegate='_final_estimator')
     def predict_log_proba(self, X, **predict_log_proba_params):
@@ -537,7 +537,7 @@ class Pipeline(_BaseComposition):
         Xt = X
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt)
-        return self.steps[-1][-1].predict_log_proba(
+        return self.steps[-1][1].predict_log_proba(
             Xt, **predict_log_proba_params
         )
 
@@ -629,11 +629,11 @@ class Pipeline(_BaseComposition):
         score_params = {}
         if sample_weight is not None:
             score_params['sample_weight'] = sample_weight
-        return self.steps[-1][-1].score(Xt, y, **score_params)
+        return self.steps[-1][1].score(Xt, y, **score_params)
 
     @property
     def classes_(self):
-        return self.steps[-1][-1].classes_
+        return self.steps[-1][1].classes_
 
     def _more_tags(self):
         # check if first estimator expects pairwise input

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -225,7 +225,7 @@ class Pipeline(_BaseComposition):
 
     @property
     def _estimator_type(self):
-        return self.steps[-1][1]._estimator_type
+        return self.steps[-1][-1]._estimator_type
 
     @property
     def named_steps(self):
@@ -234,7 +234,7 @@ class Pipeline(_BaseComposition):
 
     @property
     def _final_estimator(self):
-        estimator = self.steps[-1][1]
+        estimator = self.steps[-1][-1]
         return 'passthrough' if estimator is None else estimator
 
     def _log_message(self, step_idx):


### PR DESCRIPTION
 `self.steps[-1][-1]` and `self.steps[-1][1]` are both used. The former appears eight times and the latter twice. This change makes the code more consistent. Thanks for the suggestion from @jnothman and @NicolasHug .

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
None

#### Any other comments?
None
