### PR TITLE
TST Adjust atol in test_ridge_regression_check_arguments on 32bit

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -5,6 +5,7 @@ from itertools import product
 
 import pytest
 
+from sklearn.utils import _IS_32BIT
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_almost_equal
@@ -1279,7 +1280,8 @@ def test_ridge_regression_check_arguments_validity(return_intercept,
     y += true_intercept
     X_testing = arr_type(X)
 
-    alpha, atol, tol = 1e-3, 1e-4, 1e-6
+    alpha, tol = 1e-3, 1e-6
+    atol = 1e-3 if _IS_32BIT else 1e-4
 
     if solver not in ['sag', 'auto'] and return_intercept:
         with pytest.raises(ValueError, match="In Ridge, only 'sag' solver"):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Saw failing test on https://github.com/scikit-learn/scikit-learn/pull/19418?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDE1Njc4NjQ3NjQ6NTQwMjYzMw%3D%3D#issuecomment-836513483


#### What does this implement/fix? Explain your changes.
Adjust the atol for 32bit.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
