### PR TITLE
MNT Move parameter validation from `__init__` to `fit` in `neighbors` module

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -370,8 +370,8 @@ Changelog
 
 - |FIX| :class:`neighbors.NearestNeighbors`, :class:`neighbors.KNeighborsClassifier`,
   :class:`neighbors.RadiusNeighborsClassifier`, :class:`neighbors.KNeighborsRegressor`
-  and :class:`neighbors.RadiusNeighborsRegressor` estimators now follows `scikit-learn`
-  design principles. :pr:`20072` by :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
+  and :class:`neighbors.RadiusNeighborsRegressor` classes now follow design principles
+  for estimators. :pr:`20072` by :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
 
 :mod:`sklearn.pipeline`
 .......................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -417,8 +417,9 @@ Changelog
 
 - |FIX| :class:`neighbors.NearestNeighbors`, :class:`neighbors.KNeighborsClassifier`,
   :class:`neighbors.RadiusNeighborsClassifier`, :class:`neighbors.KNeighborsRegressor`
-  and :class:`neighbors.RadiusNeighborsRegressor` classes now follow design principles
-  for estimators. :pr:`20072` by :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
+  and :class:`neighbors.RadiusNeighborsRegressor` does not validate `weights` in
+  `__init__` and validates `weights` in `fit` instead. :pr:`20072` by
+  :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
 
 :mod:`sklearn.pipeline`
 .......................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -368,6 +368,11 @@ Changelog
 - |FIX| :class:`neighbors.DistanceMetric` subclasses now support readonly
   memory-mapped datasets. :pr:`19883` by `Julien Jerphanion <jjerphan>`.
 
+- |FIX| :class:`neighbors.NearestNeighbors`, :class:`neighbors.KNeighborsClassifier`,
+  :class:`neighbors.RadiusNeighborsClassifier`, :class:`neighbors.KNeighborsRegressor`
+  and :class:`neighbors.RadiusNeighborsRegressor` estimators now follows `scikit-learn`
+  design principles. :pr:`20072` by :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
+
 :mod:`sklearn.pipeline`
 .......................
 

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -63,6 +63,8 @@ def _check_weights(weights):
         raise ValueError("weights not recognized: should be 'uniform', "
                          "'distance', or a callable function")
 
+    return weights
+
 
 def _get_weights(dist, weights):
     """Get the weights from an array of distances and a parameter ``weights``

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -58,11 +58,8 @@ VALID_METRICS_SPARSE = dict(ball_tree=[],
 
 def _check_weights(weights):
     """Check to make sure weights are valid"""
-    if weights in (None, 'uniform', 'distance'):
-        return weights
-    elif callable(weights):
-        return weights
-    else:
+    if (weights not in (None, 'uniform', 'distance') and
+            not callable(weights)):
         raise ValueError("weights not recognized: should be 'uniform', "
                          "'distance', or a callable function")
 
@@ -312,7 +309,6 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         self.metric_params = metric_params
         self.p = p
         self.n_jobs = n_jobs
-        self._check_algorithm_metric()
 
     def _check_algorithm_metric(self):
         if self.algorithm not in ['auto', 'brute',

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -154,7 +154,7 @@ class KNeighborsClassifier(KNeighborsMixin,
             leaf_size=leaf_size, metric=metric, p=p,
             metric_params=metric_params,
             n_jobs=n_jobs)
-        self.weights = _check_weights(weights)
+        self.weights = weights
 
     def fit(self, X, y):
         """Fit the k-nearest neighbors classifier from the training dataset.
@@ -174,6 +174,8 @@ class KNeighborsClassifier(KNeighborsMixin,
         self : KNeighborsClassifier
             The fitted k-nearest neighbors classifier.
         """
+        _check_weights(self.weights)
+
         return self._fit(X, y)
 
     def predict(self, X):
@@ -415,7 +417,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin,
               leaf_size=leaf_size,
               metric=metric, p=p, metric_params=metric_params,
               n_jobs=n_jobs)
-        self.weights = _check_weights(weights)
+        self.weights = weights
         self.outlier_label = outlier_label
 
     def fit(self, X, y):
@@ -436,6 +438,8 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin,
         self : RadiusNeighborsClassifier
             The fitted radius neighbors classifier.
         """
+        _check_weights(self.weights)
+
         self._fit(X, y)
 
         classes_ = self.classes_

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -174,7 +174,7 @@ class KNeighborsClassifier(KNeighborsMixin,
         self : KNeighborsClassifier
             The fitted k-nearest neighbors classifier.
         """
-        _check_weights(self.weights)
+        self.weights = _check_weights(self.weights)
 
         return self._fit(X, y)
 
@@ -438,7 +438,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin,
         self : RadiusNeighborsClassifier
             The fitted radius neighbors classifier.
         """
-        _check_weights(self.weights)
+        self.weights = _check_weights(self.weights)
 
         self._fit(X, y)
 

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -185,7 +185,7 @@ class KNeighborsRegressor(KNeighborsMixin,
         self : KNeighborsRegressor
             The fitted k-nearest neighbors regressor.
         """
-        _check_weights(self.weights)
+        self.weights = _check_weights(self.weights)
 
         return self._fit(X, y)
 
@@ -374,7 +374,7 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin,
         self : RadiusNeighborsRegressor
             The fitted radius neighbors regressor.
         """
-        _check_weights(self.weights)
+        self.weights = _check_weights(self.weights)
 
         return self._fit(X, y)
 

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -152,7 +152,7 @@ class KNeighborsRegressor(KNeighborsMixin,
               algorithm=algorithm,
               leaf_size=leaf_size, metric=metric, p=p,
               metric_params=metric_params, n_jobs=n_jobs)
-        self.weights = _check_weights(weights)
+        self.weights = weights
 
     def _more_tags(self):
         # For cross-validation routines to split data correctly
@@ -185,6 +185,8 @@ class KNeighborsRegressor(KNeighborsMixin,
         self : KNeighborsRegressor
             The fitted k-nearest neighbors regressor.
         """
+        _check_weights(self.weights)
+
         return self._fit(X, y)
 
     def predict(self, X):
@@ -352,7 +354,7 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin,
               leaf_size=leaf_size,
               p=p, metric=metric, metric_params=metric_params,
               n_jobs=n_jobs)
-        self.weights = _check_weights(weights)
+        self.weights = weights
 
     def fit(self, X, y):
         """Fit the radius neighbors regressor from the training dataset.
@@ -372,6 +374,8 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin,
         self : RadiusNeighborsRegressor
             The fitted radius neighbors regressor.
         """
+        _check_weights(self.weights)
+
         return self._fit(X, y)
 
     def predict(self, X):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1172,17 +1172,21 @@ def test_neighbors_badargs():
     X3 = rng.random_sample((10, 3))
     y = np.ones(10)
 
+    est = neighbors.NearestNeighbors(algorithm='blah')
     with pytest.raises(ValueError):
-        neighbors.NearestNeighbors(algorithm='blah').fit(X)
+        est.fit(X)
 
     for cls in (neighbors.KNeighborsClassifier,
                 neighbors.RadiusNeighborsClassifier,
                 neighbors.KNeighborsRegressor,
                 neighbors.RadiusNeighborsRegressor):
+        est = cls(weights='blah')
         with pytest.raises(ValueError):
-            cls(weights='blah').fit(X, y)
+            est.fit(X, y)
+        est = cls(p=-1)
         with pytest.raises(ValueError):
-            cls(p=-1).fit(X, y)
+            est.fit(X, y)
+        est = cls(algorithm='blah')
         with pytest.raises(ValueError):
             cls(algorithm='blah').fit(X, y)
 
@@ -1253,11 +1257,11 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
             # KD tree doesn't support all metrics
             if (algorithm == 'kd_tree' and
                     metric not in neighbors.KDTree.valid_metrics):
+                est = neighbors.NearestNeighbors(algorithm=algorithm,
+                                                 metric=metric,
+                                                 metric_params=metric_params)
                 with pytest.raises(ValueError):
-                    neighbors.NearestNeighbors(
-                        algorithm=algorithm,
-                        metric=metric,
-                        metric_params=metric_params).fit(X)
+                    est.fit(X)
                 continue
             neigh = neighbors.NearestNeighbors(n_neighbors=n_neighbors,
                                                algorithm=algorithm,
@@ -1362,8 +1366,9 @@ def test_valid_brute_metric_for_auto_algorithm():
 def test_metric_params_interface():
     X = rng.rand(5, 5)
     y = rng.randint(0, 2, 5)
+    est = neighbors.KNeighborsClassifier(metric_params={'p': 3})
     with pytest.warns(SyntaxWarning):
-        neighbors.KNeighborsClassifier(metric_params={'p': 3}).fit(X, y)
+        est.fit(X, y)
 
 
 def test_predict_sparse_ball_kd_tree():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1167,24 +1167,24 @@ def test_radius_neighbors_graph_sparse(seed=36):
 
 def test_neighbors_badargs():
     # Test bad argument values: these should all raise ValueErrors
-    with pytest.raises(ValueError):
-        neighbors.NearestNeighbors(algorithm='blah')
-
     X = rng.random_sample((10, 2))
     Xsparse = csr_matrix(X)
     X3 = rng.random_sample((10, 3))
     y = np.ones(10)
+
+    with pytest.raises(ValueError):
+        neighbors.NearestNeighbors(algorithm='blah').fit(X)
 
     for cls in (neighbors.KNeighborsClassifier,
                 neighbors.RadiusNeighborsClassifier,
                 neighbors.KNeighborsRegressor,
                 neighbors.RadiusNeighborsRegressor):
         with pytest.raises(ValueError):
-            cls(weights='blah')
+            cls(weights='blah').fit(X, y)
         with pytest.raises(ValueError):
-            cls(p=-1)
+            cls(p=-1).fit(X, y)
         with pytest.raises(ValueError):
-            cls(algorithm='blah')
+            cls(algorithm='blah').fit(X, y)
 
         nbrs = cls(algorithm='ball_tree', metric='haversine')
         with pytest.raises(ValueError):
@@ -1254,9 +1254,10 @@ def test_neighbors_metrics(n_samples=20, n_features=3,
             if (algorithm == 'kd_tree' and
                     metric not in neighbors.KDTree.valid_metrics):
                 with pytest.raises(ValueError):
-                    neighbors.NearestNeighbors(algorithm=algorithm,
-                                               metric=metric,
-                                               metric_params=metric_params)
+                    neighbors.NearestNeighbors(
+                        algorithm=algorithm,
+                        metric=metric,
+                        metric_params=metric_params).fit(X)
                 continue
             neigh = neighbors.NearestNeighbors(n_neighbors=n_neighbors,
                                                algorithm=algorithm,
@@ -1359,8 +1360,10 @@ def test_valid_brute_metric_for_auto_algorithm():
 
 
 def test_metric_params_interface():
+    X = rng.rand(5, 5)
+    y = rng.randint(0, 2, 5)
     with pytest.warns(SyntaxWarning):
-        neighbors.KNeighborsClassifier(metric_params={'p': 3})
+        neighbors.KNeighborsClassifier(metric_params={'p': 3}).fit(X, y)
 
 
 def test_predict_sparse_ball_kd_tree():

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1188,7 +1188,7 @@ def test_neighbors_badargs():
             est.fit(X, y)
         est = cls(algorithm='blah')
         with pytest.raises(ValueError):
-            cls(algorithm='blah').fit(X, y)
+            est.fit(X, y)
 
         nbrs = cls(algorithm='ball_tree', metric='haversine')
         with pytest.raises(ValueError):


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #20060.

#### What does this implement/fix? Explain your changes.

This PR moves parameter validation from the `__init__` method to the `fit` method in the `neighbors` module to follow `scikit-learn` conventions.