### PR TITLE
Update svm.rst. For the issue #20075

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -677,7 +677,7 @@ The primal problem can be equivalently formulated as
 
 .. math::
 
-    \min_ {w, b} \frac{1}{2} w^T w + C \sum_{i=1}\max(0, 1 - [y_i (w^T \phi(x_i) + b)]),
+    \min_ {w, b} \frac{1}{2} w^T w + C \sum_{i=1}\max(0, 1 - y_i (w^T \phi(x_i) + b)),
 
 where we make use of the `hinge loss
 <https://en.wikipedia.org/wiki/Hinge_loss>`_. This is the form that is

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -677,7 +677,7 @@ The primal problem can be equivalently formulated as
 
 .. math::
 
-    \min_ {w, b} \frac{1}{2} w^T w + C \sum_{i=1}\max(0, y_i (w^T \phi(x_i) + b)),
+    \min_ {w, b} \frac{1}{2} w^T w + C \sum_{i=1}\max(0, 1-y_i (w^T \phi(x_i) + b)),
 
 where we make use of the `hinge loss
 <https://en.wikipedia.org/wiki/Hinge_loss>`_. This is the form that is

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -677,7 +677,7 @@ The primal problem can be equivalently formulated as
 
 .. math::
 
-    \min_ {w, b} \frac{1}{2} w^T w + C \sum_{i=1}\max(0, 1-y_i (w^T \phi(x_i) + b)),
+    \min_ {w, b} \frac{1}{2} w^T w + C \sum_{i=1}\max(0, 1 - [y_i (w^T \phi(x_i) + b)]),
 
 where we make use of the `hinge loss
 <https://en.wikipedia.org/wiki/Hinge_loss>`_. This is the form that is


### PR DESCRIPTION
There was a wrong formulation of Linear SVC. In the hinge loss term "1-" was missing.

Fixes https://github.com/scikit-learn/scikit-learn/issues/20075
