### PR TITLE
DOC Replace broken link in clustering.rst

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1653,7 +1653,7 @@ Drawbacks
 
   * E. B. Fowkles and C. L. Mallows, 1983. "A method for comparing two
     hierarchical clusterings". Journal of the American Statistical Association.
-    http://wildfire.stat.ucla.edu/pdflibrary/fowlkes.pdf
+    https://www.tandfonline.com/doi/abs/10.1080/01621459.1983.10478008
 
   * `Wikipedia entry for the Fowlkes-Mallows Index
     <https://en.wikipedia.org/wiki/Fowlkes-Mallows_index>`_

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -1076,7 +1076,7 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse=False):
     .. [1] `E. B. Fowkles and C. L. Mallows, 1983. "A method for comparing two
        hierarchical clusterings". Journal of the American Statistical
        Association
-       <http://wildfire.stat.ucla.edu/pdflibrary/fowlkes.pdf>`_
+       <https://www.tandfonline.com/doi/abs/10.1080/01621459.1983.10478008>`_
 
     .. [2] `Wikipedia entry for the Fowlkes-Mallows Index
            <https://en.wikipedia.org/wiki/Fowlkes-Mallows_index>`_


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->


#### What does this implement/fix? Explain your changes.
The link http://wildfire.stat.ucla.edu/pdflibrary/fowlkes.pdf referenced [here](https://scikit-learn.org/stable/modules/clustering.html) is broken. 
I suggest replacing it with the publisher's link https://www.tandfonline.com/doi/abs/10.1080/01621459.1983.10478008

