### PR TITLE
DOC Add Evalml to scikit-learn related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -61,6 +61,8 @@ enhance the functionality of scikit-learn's estimators.
 - `EvalML <https://github.com/alteryx/evalml>`_
   EvalML is an AutoML library which builds, optimizes, and evaluates
   machine learning pipelines using domain-specific objective functions.
+  It incorporates multiple modeling libraries under one API, and
+  the objects that EvalML creates use an sklearn-compatible API.
 
 **Experimentation frameworks**
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -58,6 +58,10 @@ enhance the functionality of scikit-learn's estimators.
   it can stream minibatches, use data checkpoints, build funky pipelines, and
   serialize models with custom per-step savers.
 
+- `EvalML <https://github.com/alteryx/evalml>`_
+  EvalML is an AutoML library which builds, optimizes, and evaluates
+  machine learning pipelines using domain-specific objective functions.
+
 **Experimentation frameworks**
 
 - `Sacred <https://github.com/IDSIA/Sacred>`_ Tool to help you configure,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None

#### What does this implement/fix? Explain your changes.
This implementation just adds [EvalML](https://github.com/alteryx/evalml) to the AutoML projects that use scikit-learn.

#### Any other comments?
Thanks for maintaining a great repo!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
