### PR TITLE
Allowing sparse inputs for prediction in AffinityPropagation

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -150,8 +150,9 @@ Changelog
 - |Efficiency| :class:`cluster.MiniBatchKMeans` is now faster in multicore
   settings. :pr:`17622` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
-- |Enhancement| :class:`cluster.AffinityPropagation` now supports sparse
-  data type as well for input data.
+- |Enhancement| The `predict` and `fit_predict` methods of
+  :class:`cluster.AffinityPropagation` now accept sparse data type for input
+  data.
   :pr:`20117` by :user:`Venkatachalam Natchiappan <venkyyuvy>`
 
 - |Fix| Fixed a bug in :class:`cluster.MiniBatchKMeans` where the sample

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -171,6 +171,10 @@ Changelog
   mini batches processed. :pr:`17622`
   by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |Enhancement| :class:`cluster.AffinityPropagation` now supports sparse
+  data type as well for input data.
+  :pr:`20117` by :user:`Venkatachalam Natchiappan <venkyyuvy>`
+
 :mod:`sklearn.compose`
 ......................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -150,6 +150,10 @@ Changelog
 - |Efficiency| :class:`cluster.MiniBatchKMeans` is now faster in multicore
   settings. :pr:`17622` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |Enhancement| :class:`cluster.AffinityPropagation` now supports sparse
+  data type as well for input data.
+  :pr:`20117` by :user:`Venkatachalam Natchiappan <venkyyuvy>`
+
 - |Fix| Fixed a bug in :class:`cluster.MiniBatchKMeans` where the sample
   weights were partially ignored when the input is sparse. :pr:`17622` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
@@ -170,10 +174,6 @@ Changelog
   number of started epochs and the `n_steps_` attribute reports the number of
   mini batches processed. :pr:`17622`
   by :user:`Jérémie du Boisberranger <jeremiedbb>`.
-
-- |Enhancement| :class:`cluster.AffinityPropagation` now supports sparse
-  data type as well for input data.
-  :pr:`20117` by :user:`Venkatachalam Natchiappan <venkyyuvy>`
 
 :mod:`sklearn.compose`
 ......................

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -436,7 +436,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
             Cluster labels.
         """
         check_is_fitted(self)
-        X = self._validate_data(X, reset=False)
+        X = self._validate_data(X, reset=False, accept_sparse='csr')
         if not hasattr(self, "cluster_centers_"):
             raise ValueError("Predict method is not supported when "
                              "affinity='precomputed'.")

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -239,19 +239,20 @@ def test_affinity_propagation_float32():
 
 
 def test_sparse_input_for_predict():
-    # Test to make sure sparse inputs are accepted for predict
+    # Test to make sure sparse inputs are accepted for fit_predict
     # (non-regression test for issue #10832)
     af = AffinityPropagation(affinity="euclidean", random_state=42)
     af.fit(X)
     labels = af.predict(csr_matrix((2, 2)))
     assert_array_equal(labels, (2, 2))
 
+
 def test_sparse_input_for_fit_predict():
     # Test to make sure sparse inputs are accepted for predict
     # (non-regression test for issue #10832)
     af = AffinityPropagation(affinity="euclidean", random_state=42)
     rng = np.random.RandomState(42)
-    X = csr_matrix(rng.randint(0, 2, size=(5,5)))
+    X = csr_matrix(rng.randint(0, 2, size=(5, 5)))
     labels = af.fit_predict(X)
     assert_array_equal(labels, (0, 1, 1, 2, 3))
 

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -238,6 +238,24 @@ def test_affinity_propagation_float32():
     assert_array_equal(afp.labels_, expected)
 
 
+def test_sparse_input_for_predict():
+    # Test to make sure sparse inputs are accepted for predict
+    # (non-regression test for issue #10832)
+    af = AffinityPropagation(affinity="euclidean", random_state=42)
+    af.fit(X)
+    labels = af.predict(csr_matrix((2, 2)))
+    assert_array_equal(labels, (2, 2))
+
+def test_sparse_input_for_fit_predict():
+    # Test to make sure sparse inputs are accepted for predict
+    # (non-regression test for issue #10832)
+    af = AffinityPropagation(affinity="euclidean", random_state=42)
+    rng = np.random.RandomState(42)
+    X = csr_matrix(rng.randint(0, 2, size=(5,5)))
+    labels = af.fit_predict(X)
+    assert_array_equal(labels, (0, 1, 1, 2, 3))
+
+
 # TODO: Remove in 1.1
 def test_affinity_propagation_pairwise_is_deprecated():
     afp = AffinityPropagation(affinity='precomputed')

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -240,7 +240,7 @@ def test_affinity_propagation_float32():
 
 def test_sparse_input_for_predict():
     # Test to make sure sparse inputs are accepted for fit_predict
-    # (non-regression test for issue #10832)
+    # (non-regression test for issue #20049)
     af = AffinityPropagation(affinity="euclidean", random_state=42)
     af.fit(X)
     labels = af.predict(csr_matrix((2, 2)))
@@ -249,7 +249,7 @@ def test_sparse_input_for_predict():
 
 def test_sparse_input_for_fit_predict():
     # Test to make sure sparse inputs are accepted for predict
-    # (non-regression test for issue #10832)
+    # (non-regression test for issue #20049)
     af = AffinityPropagation(affinity="euclidean", random_state=42)
     rng = np.random.RandomState(42)
     X = csr_matrix(rng.randint(0, 2, size=(5, 5)))

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -239,7 +239,7 @@ def test_affinity_propagation_float32():
 
 
 def test_sparse_input_for_predict():
-    # Test to make sure sparse inputs are accepted for fit_predict
+    # Test to make sure sparse inputs are accepted for predict
     # (non-regression test for issue #20049)
     af = AffinityPropagation(affinity="euclidean", random_state=42)
     af.fit(X)
@@ -248,7 +248,7 @@ def test_sparse_input_for_predict():
 
 
 def test_sparse_input_for_fit_predict():
-    # Test to make sure sparse inputs are accepted for predict
+    # Test to make sure sparse inputs are accepted for fit_predict
     # (non-regression test for issue #20049)
     af = AffinityPropagation(affinity="euclidean", random_state=42)
     rng = np.random.RandomState(42)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #20049
#### What does this implement/fix? Explain your changes.
Accepts sparse data inputs for affinitiy propagation model.

