### PR TITLE
DOC Update Featuretools link in Related Project Page

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -46,7 +46,7 @@ enhance the functionality of scikit-learn's estimators.
   preprocessors as well as the estimators. Works as a drop-in replacement for a
   scikit-learn estimator.
   
-- `Featuretools <https://github.com/FeatureLabs/featuretools>`_
+- `Featuretools <https://github.com/alteryx/featuretools>`_
   A framework to perform automated feature engineering. It can be used for 
   transforming temporal and relational datasets into feature matrices for 
   machine learning.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR updates the link used for Featuretools in the Related Projects page of the documentation. The Featuretools repo was moved from the `FeatureLabs` organization to the `alteryx` organization, and this change points to the correct repo directly, bypassing the redirect that is in place with the old URL.