### PR TITLE
Improve numerical stability in BayesianRidge._update_coef_ method:

### DIFF
--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -358,7 +358,8 @@ class BayesianRidge(RegressorMixin, LinearModel):
                                               alpha_)[None, :],
                                          U.T, y])
 
-        rmse_ = np.sum((y - np.dot(X, coef_)) ** 2)
+        dot_ = np.dot(X, coef_)
+        rmse_ = np.sum(dot_**2 + y*(y-2*dot_))
 
         return coef_, rmse_
 


### PR DESCRIPTION
	- Execution with a stochastic arithmetic (MCA) shows numerical instability in _update_coef function line 354.
	- Rewrites np.sum((y - np.dot(X, coef_)) ** 2) -> np.sum(dot**2 + y*(y-2*dot)) with dot = np.dot(X, coef_) 
	  helps preventing catastrophic cancellation.
	- Tested on example https://scikit-learn.org/dev/auto_examples/linear_model/plot_bayesian_ridge.html

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

This PR proposes an improvement of the numerical quality of the `BayesianRidge._update_coef_` function.
More specifically, a rewriting for the [L354](https://github.com/scikit-learn/scikit-learn/blob/81102146e35c81d7aab16d448f1c2b66d8a67ed9/sklearn/linear_model/_bayes.py#L354):

```python
np.sum((y - np.dot(X, coef_)) ** 2) 
```

to 
```python
dot = np.dot(X, coef_)
np.sum(dot**2 + y*(y-2*dot))
```

This rewriting has been found by using the [Herbie](https://herbie.uwplse.org/demo/6585a27d91fddeb2abf129ffa83ebee9944eff89.b9fb4a99a678c42719f1af4df2435bfd560a1c86/graph.html) tool.

#### Any other comments?

This PR comes from the work of the [Pytracer](https://github.com/yohanchatelain/pytracer) tool developed at [Big Data Infrastructures for Neuroinformatics](https://big-data-lab-team.github.io/apply.html) laboratory, Concordia University. Pytracer aims at tracing and visualising numerical stability of Python functions. Pytracer automatically instruments selected modules and functions and produces traces that are then gathered to compute statistics. Finally, Pytracer embedded a dash/plotly server to visualise numerical stability of called functions overtime. For detecting instabilities, we use the [Fuzzy](https://github.com/verificarlo/fuzzy) environment. This environment provides a Python interpreter as well as several Python libraries (lapack/blas, numpy, scipy, sklearn) using the Monte Carlo Arithmetic ([MCA](http://web.cs.ucla.edu/~stott/mca/CSD-970002.ps.gz)) through the [verificarlo](https://github.com/verificarlo/verificarlo) compiler.  The idea of MCA is to add a random error to each floating-point operations and to execute a program several times to measure the spread between the results. MCA also provides a metric called significant digits that measure the number of correct digits in a floating-point number, last bits can be considered as noise.

We tested Pytracer+Fuzzy on the  [Bayesian Ridge Regression](https://scikit-learn.org/dev/auto_examples/linear_model/plot_bayesian_ridge.html#sphx-glr-auto-examples-linear-model-plot-bayesian-ridge-py) test. 

Experimental setup:
- 5 samples were run
- MCA options: `export VFC_BACKENDS="libinterflop_mca.so -m rr --precision-binary64=53 --precision-binary=24`.
- matplotlib plots were commented.

Figure [coef_rmse_sig_original](https://user-images.githubusercontent.com/7467329/119183741-81030a00-ba42-11eb-8144-ea9dc4b78960.png) shows the number of significant digits of [`return coef_,rmse_`](https://github.com/scikit-learn/scikit-learn/blob/81102146e35c81d7aab16d448f1c2b66d8a67ed9/sklearn/linear_model/_bayes.py#L356) values over time. We can see that the precision of the results decreases over time until reaching less than 3 bits significant in average.

Figure coef_rmse_sig_modified: [coef_rmse_sig_mod](https://user-images.githubusercontent.com/7467329/119184986-1783fb00-ba44-11eb-8ec8-ed44824fcbf4.png) shows the same as previous figure but using the correction proposed by this PR. We can see now that the precision decreases less over time by reaching ~20 significant bits.

Moreover, this impacts the results of the [predicts](https://github.com/scikit-learn/scikit-learn/blob/36a4dcafedbcbb112e1d96fd04e73ba922523bae/examples/linear_model/plot_bayesian_ridge.py#L105) function. Figure coef_sig_zoom_original: [coef_sig_zoom_original](https://user-images.githubusercontent.com/7467329/119185083-4b5f2080-ba44-11eb-9113-2e8996fe7582.png) shows the number of significant digits per element of `coef_`. We can see each element has ~3 significant bits.

Figure coef_sig_zoom_modified: [coef_sig_zoom_modified](https://user-images.githubusercontent.com/7467329/119187925-f6bda480-ba47-11eb-9304-60baf8306d93.png) shows the same figure as previous but using the correction.
We can see now that number of significant bits ~20, an improving of 17 bits.
 
Finally, we can see that this modification benefits to overall numerical stability on figure [general_view_original](https://user-images.githubusercontent.com/7467329/119188753-1bfee280-ba49-11eb-94d8-d0e5bf75ea42.png) that is a general view of all functions traced by Pytracer for the original code and figure [general_view_modified](https://user-images.githubusercontent.com/7467329/119188772-21f4c380-ba49-11eb-867d-9aaf66ff42da.png) for the modified one.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
