### PR TITLE
DOC fix broken links in faq.rst and glossary.rst

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -20,7 +20,6 @@ sy-kit learn. sci stands for science!
 Why scikit?
 ------------
 There are multiple scikits, which are scientific toolboxes built around SciPy.
-You can find a list at `<https://scikits.appspot.com/scikits>`_.
 Apart from scikit-learn, another popular one is `scikit-image <https://scikit-image.org/>`_.
 
 How can I contribute to scikit-learn?

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -171,7 +171,7 @@ General Concepts
         one-hot encode categorical features.
         See also :ref:`preprocessing_categorical_features` and the
         `categorical-encoding
-        <https://contrib.scikit-learn.org/categorical-encoding>`_
+        <https://github.com/scikit-learn-contrib/category_encoders>`_
         package for tools related to encoding categorical features.
 
     clone


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->


#### What does this implement/fix? Explain your changes.
This PR fixes two broken links:
1. In `glossary.rst` [this](https://contrib.scikit-learn.org/categorical-encoding) broken link was replaced with [this](https://github.com/scikit-learn-contrib/category_encoders) one.
2. In `faq.rst` [this](https://scikits.appspot.com/scikits) broken link was removed completely since no equivalent was found.

