### PR TITLE
Differences in penalties handled by solvers in Logistic Regression Documentation #19651

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1041,10 +1041,9 @@ class LogisticRegression(LinearClassifierMixin,
     Parameters
     ----------
     penalty : {'l1', 'l2', 'elasticnet', 'none'}, default='l2'
-        Used to specify the norm used in the penalization. The 'newton-cg',
-        'sag' and 'lbfgs' solvers support only l2 penalties. 'elasticnet' is
-        only supported by the 'saga' solver. If 'none' (not supported by the
-        liblinear solver), no regularization is applied.
+        Used to specify the norm used in the penalization. l2 is supported by the 'newton-cg',
+        'sag' and 'lbfgs' solvers. 'elasticnet' is only supported by the 'saga' solver. 
+        If 'none' (not supported by the liblinear solver), no regularization is applied.
 
         .. versionadded:: 0.19
            l1 penalty with SAGA solver (allowing 'multinomial' + L1)
@@ -1107,9 +1106,9 @@ class LogisticRegression(LinearClassifierMixin,
         - For multiclass problems, only 'newton-cg', 'sag', 'saga' and 'lbfgs'
           handle multinomial loss; 'liblinear' is limited to one-versus-rest
           schemes.
-        - 'newton-cg', 'lbfgs', 'sag' and 'saga' handle L2 or no penalty
-        - 'liblinear' and 'saga' also handle L1 penalty
-        - 'saga' also supports 'elasticnet' penalty
+        - 'newton-cg', 'lbfgs' and 'sag' handles only L2 penalty. whereas
+          'liblinear' and 'saga' handles L1 penalty.
+        - 'saga' also supports 'elasticnet' penalty.
         - 'liblinear' does not support setting ``penalty='none'``
 
         Note that 'sag' and 'saga' fast convergence is only guaranteed on

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1041,9 +1041,10 @@ class LogisticRegression(LinearClassifierMixin,
     Parameters
     ----------
     penalty : {'l1', 'l2', 'elasticnet', 'none'}, default='l2'
-        Used to specify the norm used in the penalization. l2 is supported by the 'newton-cg',
-        'sag' and 'lbfgs' solvers. 'elasticnet' is only supported by the 'saga' solver. 
-        If 'none' (not supported by the liblinear solver), no regularization is applied.
+        Used to specify the norm used in the penalization. l2 is supported
+        by the 'newton-cg','sag' and 'lbfgs' solvers. 'elasticnet' is only
+        supported by the 'saga' solver. If 'none' (not supported by the
+        liblinear solver),no regularization is applied.
 
         .. versionadded:: 0.19
            l1 penalty with SAGA solver (allowing 'multinomial' + L1)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Fixes #19651.
Differences in penalties handled by solvers in Logistic Regression Documentation #19651
-->


#### What does this implement/fix? Explain your changes.
Earlier not much clarity on which solver should use which penalty in Logistic Regression. In this request, clearly stated solvers and their supporting penalties in Logistic Regression documentation.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
