### PR TITLE
TST Adds Halving CV into common test

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -13,6 +13,7 @@ import re
 import pkgutil
 from inspect import isgenerator
 from functools import partial
+from itertools import product
 
 import pytest
 
@@ -212,7 +213,7 @@ def test_class_support_removed():
 
 
 def _generate_search_cv_instances():
-    for SearchCV, (Estimator, param_grid) in zip(
+    for SearchCV, (Estimator, param_grid) in product(
         [GridSearchCV, RandomizedSearchCV],
         [
             (Ridge, {"alpha": [0.1, 1.0]}),
@@ -221,7 +222,7 @@ def _generate_search_cv_instances():
     ):
         yield SearchCV(Estimator(), param_grid)
 
-    for SearchCV, (Estimator, param_grid) in zip(
+    for SearchCV, (Estimator, param_grid) in product(
         [GridSearchCV, RandomizedSearchCV],
         [
             (Ridge, {"ridge__alpha": [0.1, 1.0]}),

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -31,6 +31,11 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import Ridge
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import RandomizedSearchCV
+
+from sklearn.experimental import enable_halving_search_cv  # noqa
+from sklearn.model_selection import HalvingGridSearchCV
+from sklearn.model_selection import HalvingRandomSearchCV
+
 from sklearn.pipeline import make_pipeline
 
 from sklearn.utils import IS_PYPY
@@ -213,8 +218,11 @@ def test_class_support_removed():
 
 
 def _generate_search_cv_instances():
+    SearchCVs = [GridSearchCV, RandomizedSearchCV,
+                 HalvingGridSearchCV, HalvingRandomSearchCV]
+
     for SearchCV, (Estimator, param_grid) in product(
-        [GridSearchCV, RandomizedSearchCV],
+        SearchCVs,
         [
             (Ridge, {"alpha": [0.1, 1.0]}),
             (LogisticRegression, {"C": [0.1, 1.0]}),
@@ -223,7 +231,7 @@ def _generate_search_cv_instances():
         yield SearchCV(Estimator(), param_grid)
 
     for SearchCV, (Estimator, param_grid) in product(
-        [GridSearchCV, RandomizedSearchCV],
+        SearchCVs,
         [
             (Ridge, {"ridge__alpha": [0.1, 1.0]}),
             (LogisticRegression, {"logisticregression__C": [0.1, 1.0]}),


### PR DESCRIPTION
Follow up to #18158

`product` is used to check every pair of SearchCVs x [Classifier, Regressor]