### PR TITLE
MAINT silence spurious mypy error

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -821,7 +821,7 @@ def test_regression_thresholded_inf_nan_input(metric, y_true, y_score):
     # Add an additional case for classification only
     # non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/6809
-    [([np.nan, 1, 2], [1, 2, 3])]
+    [([np.nan, 1, 2], [1, 2, 3])]  # type: ignore
 )
 def test_classification_inf_nan_input(metric, y_true, y_score):
     """check that classification metrics raise a message mentioning the


### PR DESCRIPTION
On the main branch, `mypy sklearn` reports:

```
sklearn/metrics/tests/test_common.py:824: error: List item 0 has incompatible type "float"; expected "int"
```

I believe this is a spurious detection. Although that might reveal that we should raise `TypeError` instead of `ValueError` for this case? I don't think it's making the input checks more complex.