### PR TITLE
[MRG] resolve ambiguity of the nested cross-val example

### DIFF
--- a/examples/model_selection/plot_nested_cross_validation_iris.py
+++ b/examples/model_selection/plot_nested_cross_validation_iris.py
@@ -80,11 +80,12 @@ for i in range(NUM_TRIALS):
     outer_cv = KFold(n_splits=4, shuffle=True, random_state=i)
 
     # Non_nested parameter search and scoring
-    clf = GridSearchCV(estimator=svm, param_grid=p_grid, cv=inner_cv)
+    clf = GridSearchCV(estimator=svm, param_grid=p_grid, cv=outer_cv)
     clf.fit(X_iris, y_iris)
     non_nested_scores[i] = clf.best_score_
 
     # Nested CV with parameter optimization
+    clf.set_params(cv=inner_cv)
     nested_score = cross_val_score(clf, X=X_iris, y=y_iris, cv=outer_cv)
     nested_scores[i] = nested_score.mean()
 

--- a/examples/model_selection/plot_nested_cross_validation_iris.py
+++ b/examples/model_selection/plot_nested_cross_validation_iris.py
@@ -85,7 +85,7 @@ for i in range(NUM_TRIALS):
     non_nested_scores[i] = clf.best_score_
 
     # Nested CV with parameter optimization
-    clf.set_params(cv=inner_cv)
+    clf = GridSearchCV(estimator=svm, param_grid=p_grid, cv=inner_cv)
     nested_score = cross_val_score(clf, X=X_iris, y=y_iris, cv=outer_cv)
     nested_scores[i] = nested_score.mean()
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

closes #20131

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Resolve the ambiguity of the nested cross-val example, which exists in Iris data example, as suggested in [the comment](https://github.com/scikit-learn/scikit-learn/issues/20131#issuecomment-847771333) simply.

#### Any other comments?

Not sure [the last comment](https://github.com/scikit-learn/scikit-learn/issues/20131#issuecomment-848385940). I think it has been reflected.
 
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
