### PR TITLE
TST Fixes test and mis-matched pandas version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@
 .. _DOI: https://zenodo.org/badge/latestdoi/21369/scikit-learn/scikit-learn
 
 .. |PythonMinVersion| replace:: 3.7
-.. |NumPyMinVersion| replace:: 1.14.5
+.. |NumPyMinVersion| replace:: 1.14.6
 .. |SciPyMinVersion| replace:: 1.1.0
 .. |JoblibMinVersion| replace:: 0.11
 .. |ThreadpoolctlMinVersion| replace:: 2.0.0

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -15,7 +15,7 @@ Version 1.0.0
 Minimal dependencies
 --------------------
 
-Version 1.0.0 of scikit-learn requires python 3.7+, numpy 1.14.5+ and
+Version 1.0.0 of scikit-learn requires python 3.7+, numpy 1.14.6+ and
 scipy 1.1.0+. Optional minimal dependency is matplotlib 2.2.2+.
 
 Enforcing keyword-only arguments

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -7,7 +7,7 @@ import argparse
 if platform.python_implementation() == 'PyPy':
     NUMPY_MIN_VERSION = '1.19.0'
 else:
-    NUMPY_MIN_VERSION = '1.14.5'
+    NUMPY_MIN_VERSION = '1.14.6'
 
 SCIPY_MIN_VERSION = '1.1.0'
 JOBLIB_MIN_VERSION = '0.11'

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -27,7 +27,7 @@ dependent_packages = {
     'cython': (CYTHON_MIN_VERSION, 'build'),
     'matplotlib': ('2.2.2', 'benchmark, docs, examples, tests'),
     'scikit-image': ('0.14.5', 'docs, examples, tests'),
-    'pandas': ('0.23.4', 'benchmark, docs, examples, tests'),
+    'pandas': ('0.25.0', 'benchmark, docs, examples, tests'),
     'seaborn': ('0.9.0', 'docs, examples'),
     'memory_profiler': ('0.57.0', 'benchmark, docs'),
     'pytest': (PYTEST_MIN_VERSION, 'tests'),

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -37,9 +37,11 @@ def test_min_dependencies_readme():
                 continue
 
             package, version = matched.group(2), matched.group(5)
+            package = package.lower()
 
             if package in dependent_packages:
                 version = parse_version(version)
                 min_version = parse_version(dependent_packages[package][0])
 
-                assert version == min_version
+                assert version == min_version, (f"{package} has a mismatched "
+                                                "version")


### PR DESCRIPTION
Follow up to https://github.com/scikit-learn/scikit-learn/pull/20143

This PR fixes the test that catches mismatched versions between the readme and `_min_dependencies`.

CC @glemaitre @ogrisel 