### PR TITLE
[MRG] Fix Sparse PCA optimization task #19775

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -230,7 +230,7 @@ problem solved is a PCA problem (dictionary learning) with an
 
 .. math::
    (U^*, V^*) = \underset{U, V}{\operatorname{arg\,min\,}} & \frac{1}{2}
-                ||X-UV||_2^2+\alpha||V||_1 \\
+                ||X-UV||_{\text{F}}^2+\alpha||V||_{1,1} \\
                 \text{subject to } & ||U_k||_2 = 1 \text{ for all }
                 0 \leq k < n_{components}
 
@@ -510,7 +510,7 @@ dictionary fixed, and then updating the dictionary to best fit the sparse code.
 
 .. math::
    (U^*, V^*) = \underset{U, V}{\operatorname{arg\,min\,}} & \frac{1}{2}
-                ||X-UV||_2^2+\alpha||U||_1 \\
+                ||X-UV||_{\text{F}}^2+\alpha||U||_{1,1} \\
                 \text{subject to } & ||V_k||_2 = 1 \text{ for all }
                 0 \leq k < n_{\mathrm{atoms}}
 

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -234,8 +234,10 @@ problem solved is a PCA problem (dictionary learning) with an
                 \text{subject to } & ||U_k||_2 = 1 \text{ for all }
                 0 \leq k < n_{components}
 
-
-The sparsity-inducing :math:`\ell_1` norm also prevents learning
+:math:`||.||_{\text{F}}` stands for the Frobenius norm and :math:`||.||_{1,1}`
+stands for the entry-wise matrix norm which is the sum of the absolute values
+of all the entries in the matrix.
+The sparsity-inducing :math:`||.||_{1,1}` matrix norm also prevents learning
 components from noise when few training samples are available. The degree
 of penalization (and thus sparsity) can be adjusted through the
 hyperparameter ``alpha``. Small values lead to a gently regularized
@@ -525,7 +527,9 @@ dictionary fixed, and then updating the dictionary to best fit the sparse code.
 
 .. centered:: |pca_img2| |dict_img2|
 
-
+:math:`||.||_{\text{F}}` stands for the Frobenius norm and :math:`||.||_{1,1}`
+stands for the entry-wise matrix norm which is the sum of the absolute values
+of all the entries in the matrix.
 After using such a procedure to fit the dictionary, the transform is simply a
 sparse coding step that shares the same implementation with all dictionary
 learning objects (see :ref:`SparseCoder`).

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -230,11 +230,11 @@ problem solved is a PCA problem (dictionary learning) with an
 
 .. math::
    (U^*, V^*) = \underset{U, V}{\operatorname{arg\,min\,}} & \frac{1}{2}
-                ||X-UV||_{\text{F}}^2+\alpha||V||_{1,1} \\
+                ||X-UV||_{\text{Fro}}^2+\alpha||V||_{1,1} \\
                 \text{subject to } & ||U_k||_2 = 1 \text{ for all }
                 0 \leq k < n_{components}
 
-:math:`||.||_{\text{F}}` stands for the Frobenius norm and :math:`||.||_{1,1}`
+:math:`||.||_{\text{Fro}}` stands for the Frobenius norm and :math:`||.||_{1,1}`
 stands for the entry-wise matrix norm which is the sum of the absolute values
 of all the entries in the matrix.
 The sparsity-inducing :math:`||.||_{1,1}` matrix norm also prevents learning
@@ -512,7 +512,7 @@ dictionary fixed, and then updating the dictionary to best fit the sparse code.
 
 .. math::
    (U^*, V^*) = \underset{U, V}{\operatorname{arg\,min\,}} & \frac{1}{2}
-                ||X-UV||_{\text{F}}^2+\alpha||U||_{1,1} \\
+                ||X-UV||_{\text{Fro}}^2+\alpha||U||_{1,1} \\
                 \text{subject to } & ||V_k||_2 = 1 \text{ for all }
                 0 \leq k < n_{\mathrm{atoms}}
 
@@ -527,7 +527,7 @@ dictionary fixed, and then updating the dictionary to best fit the sparse code.
 
 .. centered:: |pca_img2| |dict_img2|
 
-:math:`||.||_{\text{F}}` stands for the Frobenius norm and :math:`||.||_{1,1}`
+:math:`||.||_{\text{Fro}}` stands for the Frobenius norm and :math:`||.||_{1,1}`
 stands for the entry-wise matrix norm which is the sum of the absolute values
 of all the entries in the matrix.
 After using such a procedure to fit the dictionary, the transform is simply a

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -436,11 +436,11 @@ def dict_learning(X, n_components, *, alpha, max_iter=100, tol=1e-8,
     Finds the best dictionary and the corresponding sparse code for
     approximating the data matrix X by solving::
 
-        (U^*, V^*) = argmin 0.5 || X - U V ||_F^2 + alpha * || U ||_1,1
+        (U^*, V^*) = argmin 0.5 || X - U V ||_Fro^2 + alpha * || U ||_1,1
                      (U,V)
                     with || V_k ||_2 = 1 for all  0 <= k < n_components
 
-    where V is the dictionary and U is the sparse code. ||.||_F stands for
+    where V is the dictionary and U is the sparse code. ||.||_Fro stands for
     the Frobenius norm and ||.||_1,1 stands for the entry-wise matrix norm
     which is the sum of the absolute values of all the entries in the matrix.
 
@@ -639,11 +639,11 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
     Finds the best dictionary and the corresponding sparse code for
     approximating the data matrix X by solving::
 
-        (U^*, V^*) = argmin 0.5 || X - U V ||_F^2 + alpha * || U ||_1,1
+        (U^*, V^*) = argmin 0.5 || X - U V ||_Fro^2 + alpha * || U ||_1,1
                      (U,V)
                      with || V_k ||_2 = 1 for all  0 <= k < n_components
 
-    where V is the dictionary and U is the sparse code. ||.||_F stands for
+    where V is the dictionary and U is the sparse code. ||.||_Fro stands for
     the Frobenius norm and ||.||_1,1 stands for the entry-wise matrix norm
     which is the sum of the absolute values of all the entries in the matrix.
     This is accomplished by repeatedly iterating over mini-batches by slicing
@@ -1141,11 +1141,11 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     Solves the optimization problem::
 
-        (U^*,V^*) = argmin 0.5 || X - U V ||_F^2 + alpha * || U ||_1,1
+        (U^*,V^*) = argmin 0.5 || X - U V ||_Fro^2 + alpha * || U ||_1,1
                     (U,V)
                     with || V_k ||_2 = 1 for all  0 <= k < n_components
 
-    ||.||_F stands for the Frobenius norm and ||.||_1,1 stands for
+    ||.||_Fro stands for the Frobenius norm and ||.||_1,1 stands for
     the entry-wise matrix norm which is the sum of the absolute values
     of all the entries in the matrix.
 
@@ -1375,11 +1375,11 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     Solves the optimization problem::
 
-       (U^*,V^*) = argmin 0.5 || X - U V ||_F^2 + alpha * || U ||_1,1
+       (U^*,V^*) = argmin 0.5 || X - U V ||_Fro^2 + alpha * || U ||_1,1
                     (U,V)
                     with || V_k ||_2 = 1 for all  0 <= k < n_components
 
-    ||.||_F stands for the Frobenius norm and ||.||_1,1 stands for
+    ||.||_Fro stands for the Frobenius norm and ||.||_1,1 stands for
     the entry-wise matrix norm which is the sum of the absolute values
     of all the entries in the matrix.
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -436,11 +436,13 @@ def dict_learning(X, n_components, *, alpha, max_iter=100, tol=1e-8,
     Finds the best dictionary and the corresponding sparse code for
     approximating the data matrix X by solving::
 
-        (U^*, V^*) = argmin 0.5 || X - U V ||_2^2 + alpha * || U ||_1
+        (U^*, V^*) = argmin 0.5 || X - U V ||_F^2 + alpha * || U ||_1,1
                      (U,V)
                     with || V_k ||_2 = 1 for all  0 <= k < n_components
 
-    where V is the dictionary and U is the sparse code.
+    where V is the dictionary and U is the sparse code. ||.||_F stands for
+    the Frobenius norm and ||.||_1,1 stands for the entry-wise matrix norm
+    which is the sum of the absolute values of all the entries in the matrix.
 
     Read more in the :ref:`User Guide <DictionaryLearning>`.
 
@@ -637,12 +639,14 @@ def dict_learning_online(X, n_components=2, *, alpha=1, n_iter=100,
     Finds the best dictionary and the corresponding sparse code for
     approximating the data matrix X by solving::
 
-        (U^*, V^*) = argmin 0.5 || X - U V ||_2^2 + alpha * || U ||_1
+        (U^*, V^*) = argmin 0.5 || X - U V ||_F^2 + alpha * || U ||_1,1
                      (U,V)
                      with || V_k ||_2 = 1 for all  0 <= k < n_components
 
-    where V is the dictionary and U is the sparse code. This is
-    accomplished by repeatedly iterating over mini-batches by slicing
+    where V is the dictionary and U is the sparse code. ||.||_F stands for
+    the Frobenius norm and ||.||_1,1 stands for the entry-wise matrix norm
+    which is the sum of the absolute values of all the entries in the matrix.
+    This is accomplished by repeatedly iterating over mini-batches by slicing
     the input data.
 
     Read more in the :ref:`User Guide <DictionaryLearning>`.
@@ -1137,9 +1141,13 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     Solves the optimization problem::
 
-        (U^*,V^*) = argmin 0.5 || X - U V ||_2^2 + alpha * || U ||_1
+        (U^*,V^*) = argmin 0.5 || X - U V ||_F^2 + alpha * || U ||_1,1
                     (U,V)
                     with || V_k ||_2 = 1 for all  0 <= k < n_components
+
+    ||.||_F stands for the Frobenius norm and ||.||_1,1 stands for
+    the entry-wise matrix norm which is the sum of the absolute values
+    of all the entries in the matrix.
 
     Read more in the :ref:`User Guide <DictionaryLearning>`.
 
@@ -1367,9 +1375,13 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     Solves the optimization problem::
 
-       (U^*,V^*) = argmin 0.5 || X - U V ||_2^2 + alpha * || U ||_1
+       (U^*,V^*) = argmin 0.5 || X - U V ||_F^2 + alpha * || U ||_1,1
                     (U,V)
                     with || V_k ||_2 = 1 for all  0 <= k < n_components
+
+    ||.||_F stands for the Frobenius norm and ||.||_1,1 stands for
+    the entry-wise matrix norm which is the sum of the absolute values
+    of all the entries in the matrix.
 
     Read more in the :ref:`User Guide <DictionaryLearning>`.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
#19775

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
- Changes
  - I Changed ```||X-UV||_2^2+\alpha||V||_1``` to ```||X-UV||_{\text{F}}^2+\alpha||V||_{1,1}``` in documentation for Sparse PCA and Dictionary learning.
- Comments
  > In user guide for Sparse PCA and Dictionary learning we minimize 1/2 ||X-UV||_2^2 + \alpha ||V||_1. Do we really use Euclidian norm in the first term? It seems that it is Frobenius norm, not Euclidian.
  
  Indeed, looking at the following code, it seems that Frobenius is used, unlike Euclidian.
  https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/decomposition/_dict_learning.py#L604-L605
  However, the symbol for the matrix norm does not seem to be so rigidly defined.
  So to avoid misunderstandings, perhaps we should refer to the [Matrix norms](https://en.wikipedia.org/wiki/Matrix_norm) and standardize the symbols.
  
  > Also I wonder do we really penalize matrix V in sparse PCA? Because it seems for me more logical to penalize V^T because L_1 norm penalizes columns (and principal component directions are located in rows of matrix V).
  
  Similarly, looking at the following code, it looks like this code  is using ||・||_{1,1}（use the [Matrix norms](https://en.wikipedia.org/wiki/Matrix_norm) symbol） as a penalty .
    https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/decomposition/_dict_learning.py#L604-L605
  



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
