### PR TITLE
Preserving dtype for numpy.float32 in Least Angle Regression 

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -339,6 +339,10 @@ Changelog
   is now faster. This is especially noticeable on large sparse input.
   :pr:`19734` by :user:`Fred Robinson <frrad>`.
 
+- |Enhancement| `fit` method preserves dtype for numpy.float32 in
+  :class:`Lars`, :class:`LassoLars`, :class:`LassoLars`, :class:`LarsCV` and :class:`LassoLarsCV`.
+  :pr:`20155` by :user:`Takeshi Oura <takoika>`.
+
 :mod:`sklearn.manifold`
 .......................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -340,8 +340,8 @@ Changelog
   :pr:`19734` by :user:`Fred Robinson <frrad>`.
 
 - |Enhancement| `fit` method preserves dtype for numpy.float32 in
-  :class:`Lars`, :class:`LassoLars`, :class:`LassoLars`, :class:`LarsCV` and :class:`LassoLarsCV`.
-  :pr:`20155` by :user:`Takeshi Oura <takoika>`.
+  :class:`Lars`, :class:`LassoLars`, :class:`LassoLars`, :class:`LarsCV` and
+  :class:`LassoLarsCV`. :pr:`20155` by :user:`Takeshi Oura <takoika>`.
 
 :mod:`sklearn.manifold`
 .......................

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -476,12 +476,21 @@ def _lars_path_solver(
 
     max_features = min(max_iter, n_features)
 
+    return_dtype = np.float64
+    for input_array in (X, y, Xy, Gram):
+        if input_array is not None:
+            return_dtype = input_array.dtype
+            break
+
     if return_path:
-        coefs = np.zeros((max_features + 1, n_features))
-        alphas = np.zeros(max_features + 1)
+        coefs = np.zeros((max_features + 1, n_features), dtype=return_dtype)
+        alphas = np.zeros(max_features + 1, dtype=return_dtype)
     else:
-        coef, prev_coef = np.zeros(n_features), np.zeros(n_features)
-        alpha, prev_alpha = np.array([0.]), np.array([0.])  # better ideas?
+        coef, prev_coef = (np.zeros(n_features, dtype=return_dtype),
+                           np.zeros(n_features, dtype=return_dtype))
+        alpha, prev_alpha = (np.array([0.], dtype=return_dtype),
+                             np.array([0.], dtype=return_dtype))
+        # above better ideas?
 
     n_iter, n_active = 0, 0
     active, indices = list(), np.arange(n_features)
@@ -948,7 +957,7 @@ class Lars(MultiOutputMixin, RegressorMixin, LinearModel):
 
         self.alphas_ = []
         self.n_iter_ = []
-        self.coef_ = np.empty((n_targets, n_features))
+        self.coef_ = np.empty((n_targets, n_features), dtype=X.dtype)
 
         if fit_path:
             self.active_ = []

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -476,12 +476,15 @@ def _lars_path_solver(
 
     max_features = min(max_iter, n_features)
 
-    return_dtype = np.float64
-    for input_array in (X, y, Xy, Gram):
-        if input_array is not None:
-            return_dtype = input_array.dtype
-            break
+    dtypes = set(a.dtype for a in (X, y, Xy, Gram) if a is not None)
+    if len(dtypes) == 1:
+        # use the precision level of input data if it is consistent
+        return_dtype = next(iter(dtypes))
+    else:
+        # fallback to double precision otherwise
+        return_dtype = np.float64
 
+    print(dtypes, return_dtype)
     if return_path:
         coefs = np.zeros((max_features + 1, n_features), dtype=return_dtype)
         alphas = np.zeros(max_features + 1, dtype=return_dtype)

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -484,7 +484,6 @@ def _lars_path_solver(
         # fallback to double precision otherwise
         return_dtype = np.float64
 
-    print(dtypes, return_dtype)
     if return_path:
         coefs = np.zeros((max_features + 1, n_features), dtype=return_dtype)
         alphas = np.zeros(max_features + 1, dtype=return_dtype)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -777,3 +777,14 @@ def test_copy_X_with_auto_gram():
     linear_model.lars_path(X, y, Gram='auto', copy_X=True, method='lasso')
     # X did not change
     assert_allclose(X, X_before)
+
+def test_lars_dtype_match():
+    rng = np.random.RandomState(0)
+    X = rng.rand(6, 6).astype(np.float32)
+    Y = rng.rand(6).astype(np.float32)
+
+    model = Lars(n_nonzero_coefs=1)
+    model.fit(X,Y)
+    assert model.coef_.dtype == np.float32
+    assert model.coef_path_.dtype == np.float32
+    assert model.intercept_.dtype == np.float32

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -786,15 +786,15 @@ def test_copy_X_with_auto_gram():
                           (LarsCV, True, {}),
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
-@pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
-    (np.float32, np.float32, np.float32),
-    (np.float64, np.float64, np.float64)))
+@pytest.mark.parametrize("data_type, expected_type", (
+    (np.float32, np.float32),
+    (np.float64, np.float64)))
 def test_lars_dtype_match(LARS, has_coef_path, args,
-                          x_data_type, y_data_type, expected_type):
+                          data_type, expected_type):
     # The test ensures that the fit method preserves input dtype
     rng = np.random.RandomState(0)
-    X = rng.rand(6, 6).astype(x_data_type)
-    y = rng.rand(6).astype(y_data_type)
+    X = rng.rand(6, 6).astype(data_type)
+    y = rng.rand(6).astype(data_type)
 
     model = LARS(**args)
     model.fit(X, y)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -811,6 +811,8 @@ def test_lars_dtype_match(LARS, has_coef_path, args,
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
 def test_lars_numeric_consistency(LARS, has_coef_path, args):
+    atol = 1e-6
+
     rng = np.random.RandomState(0)
     X_64 = rng.rand(6, 6)
     y_64 = rng.rand(6)
@@ -819,7 +821,7 @@ def test_lars_numeric_consistency(LARS, has_coef_path, args):
     model_32 = LARS(**args).fit(X_64.astype(np.float32),
                                 y_64.astype(np.float32))
 
-    assert_array_almost_equal(model_64.coef_, model_32.coef_)
+    assert_allclose(model_64.coef_, model_32.coef_, atol=atol)
     if has_coef_path:
-        assert_array_almost_equal(model_64.coef_path_, model_32.coef_path_)
-    assert_array_almost_equal(model_64.intercept_, model_32.intercept_)
+        assert_allclose(model_64.coef_path_, model_32.coef_path_, atol=atol)
+    assert_allclose(model_64.intercept_, model_32.intercept_, atol=atol)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -778,6 +778,7 @@ def test_copy_X_with_auto_gram():
     # X did not change
     assert_allclose(X, X_before)
 
+
 @pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
 @pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
     (np.float32, np.float32, np.float32),

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -811,7 +811,8 @@ def test_lars_dtype_match(LARS, has_coef_path, args,
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
 def test_lars_numeric_consistency(LARS, has_coef_path, args):
-    atol = 1e-6
+    rtol = 1e-5
+    atol = 1e-5
 
     rng = np.random.RandomState(0)
     X_64 = rng.rand(6, 6)
@@ -821,7 +822,9 @@ def test_lars_numeric_consistency(LARS, has_coef_path, args):
     model_32 = LARS(**args).fit(X_64.astype(np.float32),
                                 y_64.astype(np.float32))
 
-    assert_allclose(model_64.coef_, model_32.coef_, atol=atol)
+    assert_allclose(model_64.coef_, model_32.coef_, rtol=rtol, atol=atol)
     if has_coef_path:
-        assert_allclose(model_64.coef_path_, model_32.coef_path_, atol=atol)
-    assert_allclose(model_64.intercept_, model_32.intercept_, atol=atol)
+        assert_allclose(model_64.coef_path_, model_32.coef_path_,
+                        rtol=rtol, atol=atol)
+    assert_allclose(model_64.intercept_, model_32.intercept_,
+                    rtol=rtol, atol=atol)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -796,3 +796,18 @@ def test_lars_dtype_match(LARS, x_data_type, y_data_type, expected_type):
         for coef in model.coef_path_:
             assert coef.dtype == expected_type
     assert model.intercept_.dtype == expected_type
+
+
+@pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
+def test_lars_numeric_consistency(LARS):
+    rng = np.random.RandomState(0)
+    X_64 = rng.rand(6, 6)
+    y_64 = rng.rand(6)
+
+    model_64 = LARS().fit(X_64, y_64)
+    model_32 = LARS().fit(X_64.astype(np.float32), y_64.astype(np.float32))
+
+    assert_array_almost_equal(model_64.coef_, model_32.coef_)
+    if hasattr(model_64, "coef_path_"):
+        assert_array_almost_equal(model_64.coef_path_, model_32.coef_path_)
+    assert_array_almost_equal(model_64.intercept_, model_32.intercept_)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -786,22 +786,19 @@ def test_copy_X_with_auto_gram():
                           (LarsCV, True, {}),
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
-@pytest.mark.parametrize("data_type, expected_type", (
-    (np.float32, np.float32),
-    (np.float64, np.float64)))
-def test_lars_dtype_match(LARS, has_coef_path, args,
-                          data_type, expected_type):
+@pytest.mark.parametrize("dtype", (np.float32, np.float64))
+def test_lars_dtype_match(LARS, has_coef_path, args, dtype):
     # The test ensures that the fit method preserves input dtype
     rng = np.random.RandomState(0)
-    X = rng.rand(6, 6).astype(data_type)
-    y = rng.rand(6).astype(data_type)
+    X = rng.rand(6, 6).astype(dtype)
+    y = rng.rand(6).astype(dtype)
 
     model = LARS(**args)
     model.fit(X, y)
-    assert model.coef_.dtype == expected_type
+    assert model.coef_.dtype == dtype
     if has_coef_path:
-        assert model.coef_path_.dtype == expected_type
-    assert model.intercept_.dtype == expected_type
+        assert model.coef_path_.dtype == dtype
+    assert model.intercept_.dtype == dtype
 
 
 @pytest.mark.parametrize("LARS, has_coef_path, args",

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -779,11 +779,14 @@ def test_copy_X_with_auto_gram():
     assert_allclose(X, X_before)
 
 
-@pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
+@pytest.mark.parametrize("LARS, has_coef_path", ((Lars, True),
+                                                 (LassoLars, True),
+                                                 (LassoLarsIC, False)))
 @pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
     (np.float32, np.float32, np.float32),
     (np.float64, np.float64, np.float64)))
-def test_lars_dtype_match(LARS, x_data_type, y_data_type, expected_type):
+def test_lars_dtype_match(LARS, has_coef_path,
+                          x_data_type, y_data_type, expected_type):
     rng = np.random.RandomState(0)
     X = rng.rand(6, 6).astype(x_data_type)
     y = rng.rand(6).astype(y_data_type)
@@ -791,15 +794,15 @@ def test_lars_dtype_match(LARS, x_data_type, y_data_type, expected_type):
     model = LARS()
     model.fit(X, y)
     assert model.coef_.dtype == expected_type
-    if hasattr(model, "coef_path_"):
-        # coef_path_ can be list of array
-        for coef in model.coef_path_:
-            assert coef.dtype == expected_type
+    if has_coef_path:
+        assert model.coef_path_.dtype == expected_type
     assert model.intercept_.dtype == expected_type
 
 
-@pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
-def test_lars_numeric_consistency(LARS):
+@pytest.mark.parametrize("LARS, has_coef_path", ((Lars, True),
+                                                 (LassoLars, True),
+                                                 (LassoLarsIC, False)))
+def test_lars_numeric_consistency(LARS, has_coef_path):
     rng = np.random.RandomState(0)
     X_64 = rng.rand(6, 6)
     y_64 = rng.rand(6)
@@ -808,6 +811,6 @@ def test_lars_numeric_consistency(LARS):
     model_32 = LARS().fit(X_64.astype(np.float32), y_64.astype(np.float32))
 
     assert_array_almost_equal(model_64.coef_, model_32.coef_)
-    if hasattr(model_64, "coef_path_"):
+    if has_coef_path:
         assert_array_almost_equal(model_64.coef_path_, model_32.coef_path_)
     assert_array_almost_equal(model_64.intercept_, model_32.intercept_)

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -778,19 +778,20 @@ def test_copy_X_with_auto_gram():
     # X did not change
     assert_allclose(X, X_before)
 
-
+@pytest.mark.parametrize("LARS", (Lars, LassoLars, LassoLarsIC))
 @pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
     (np.float32, np.float32, np.float32),
     (np.float64, np.float64, np.float64)))
-def test_lars_dtype_match(x_data_type, y_data_type, expected_type):
+def test_lars_dtype_match(LARS, x_data_type, y_data_type, expected_type):
     rng = np.random.RandomState(0)
     X = rng.rand(6, 6).astype(x_data_type)
     y = rng.rand(6).astype(y_data_type)
 
-    model = Lars()
+    model = LARS()
     model.fit(X, y)
     assert model.coef_.dtype == expected_type
-    # coef_path_ can be list of array
-    for coef in model.coef_path_:
-        assert coef.dtype == expected_type
+    if hasattr(model, "coef_path_"):
+        # coef_path_ can be list of array
+        for coef in model.coef_path_:
+            assert coef.dtype == expected_type
     assert model.intercept_.dtype == expected_type

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -791,6 +791,7 @@ def test_copy_X_with_auto_gram():
     (np.float64, np.float64, np.float64)))
 def test_lars_dtype_match(LARS, has_coef_path, args,
                           x_data_type, y_data_type, expected_type):
+    # The test ensures that the fit method preserves input dtype
     rng = np.random.RandomState(0)
     X = rng.rand(6, 6).astype(x_data_type)
     y = rng.rand(6).astype(y_data_type)
@@ -811,6 +812,8 @@ def test_lars_dtype_match(LARS, has_coef_path, args,
                           # max_iter=5 is for avoiding ConvergenceWarning
                           (LassoLarsCV, True, {"max_iter": 5})))
 def test_lars_numeric_consistency(LARS, has_coef_path, args):
+    # The test ensures numerical consistency between trained coefficients
+    # of float32 and float64.
     rtol = 1e-5
     atol = 1e-5
 

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -778,13 +778,19 @@ def test_copy_X_with_auto_gram():
     # X did not change
     assert_allclose(X, X_before)
 
-def test_lars_dtype_match():
-    rng = np.random.RandomState(0)
-    X = rng.rand(6, 6).astype(np.float32)
-    Y = rng.rand(6).astype(np.float32)
 
-    model = Lars(n_nonzero_coefs=1)
-    model.fit(X,Y)
-    assert model.coef_.dtype == np.float32
-    assert model.coef_path_.dtype == np.float32
-    assert model.intercept_.dtype == np.float32
+@pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
+    (np.float32, np.float32, np.float32),
+    (np.float64, np.float64, np.float64)))
+def test_lars_dtype_match(x_data_type, y_data_type, expected_type):
+    rng = np.random.RandomState(0)
+    X = rng.rand(6, 6).astype(x_data_type)
+    y = rng.rand(6).astype(y_data_type)
+
+    model = Lars()
+    model.fit(X, y)
+    assert model.coef_.dtype == expected_type
+    # coef_path_ can be list of array
+    for coef in model.coef_path_:
+        assert coef.dtype == expected_type
+    assert model.intercept_.dtype == expected_type

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -14,7 +14,7 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn import linear_model, datasets
 from sklearn.linear_model._least_angle import _lars_path_residues
 from sklearn.linear_model import LassoLarsIC, lars_path
-from sklearn.linear_model import Lars, LassoLars
+from sklearn.linear_model import Lars, LassoLars, LarsCV, LassoLarsCV
 
 # TODO: use another dataset that has multiple drops
 diabetes = datasets.load_diabetes()
@@ -779,19 +779,23 @@ def test_copy_X_with_auto_gram():
     assert_allclose(X, X_before)
 
 
-@pytest.mark.parametrize("LARS, has_coef_path", ((Lars, True),
-                                                 (LassoLars, True),
-                                                 (LassoLarsIC, False)))
+@pytest.mark.parametrize("LARS, has_coef_path, args",
+                         ((Lars, True, {}),
+                          (LassoLars, True, {}),
+                          (LassoLarsIC, False, {}),
+                          (LarsCV, True, {}),
+                          # max_iter=5 is for avoiding ConvergenceWarning
+                          (LassoLarsCV, True, {"max_iter": 5})))
 @pytest.mark.parametrize("x_data_type, y_data_type, expected_type", (
     (np.float32, np.float32, np.float32),
     (np.float64, np.float64, np.float64)))
-def test_lars_dtype_match(LARS, has_coef_path,
+def test_lars_dtype_match(LARS, has_coef_path, args,
                           x_data_type, y_data_type, expected_type):
     rng = np.random.RandomState(0)
     X = rng.rand(6, 6).astype(x_data_type)
     y = rng.rand(6).astype(y_data_type)
 
-    model = LARS()
+    model = LARS(**args)
     model.fit(X, y)
     assert model.coef_.dtype == expected_type
     if has_coef_path:
@@ -799,16 +803,21 @@ def test_lars_dtype_match(LARS, has_coef_path,
     assert model.intercept_.dtype == expected_type
 
 
-@pytest.mark.parametrize("LARS, has_coef_path", ((Lars, True),
-                                                 (LassoLars, True),
-                                                 (LassoLarsIC, False)))
-def test_lars_numeric_consistency(LARS, has_coef_path):
+@pytest.mark.parametrize("LARS, has_coef_path, args",
+                         ((Lars, True, {}),
+                          (LassoLars, True, {}),
+                          (LassoLarsIC, False, {}),
+                          (LarsCV, True, {}),
+                          # max_iter=5 is for avoiding ConvergenceWarning
+                          (LassoLarsCV, True, {"max_iter": 5})))
+def test_lars_numeric_consistency(LARS, has_coef_path, args):
     rng = np.random.RandomState(0)
     X_64 = rng.rand(6, 6)
     y_64 = rng.rand(6)
 
-    model_64 = LARS().fit(X_64, y_64)
-    model_32 = LARS().fit(X_64.astype(np.float32), y_64.astype(np.float32))
+    model_64 = LARS(**args).fit(X_64, y_64)
+    model_32 = LARS(**args).fit(X_64.astype(np.float32),
+                                y_64.astype(np.float32))
 
     assert_array_almost_equal(model_64.coef_, model_32.coef_)
     if has_coef_path:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
This PR is part of  #11000 .

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR makes trained coefficients of Least Angle Regression to be numpy.float32 if input data is numpy.float32.

Conventionally when you pass numpy.float32 to Least Angle Regression, trained coefficients turn to be numpy.float64. This is inconsistent.

#### Any other comments?

We can pass training data x and target y to Least Angle Regressor. Test cases in this PR are that both are numpy.flaot32 or numpy.float64, because it is unclear which type is appropriate when x's type is different from y's type. This is the same with #13243 .

Further test cases may be required because this PR does not cover argument variations.

I used #13303 and #13243 as references to make this.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
