### PR TITLE
Removed assert_warns_message from feature_selection/tests

### DIFF
--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -12,9 +12,7 @@ import pytest
 from sklearn.utils._testing import assert_almost_equal, _convert_container
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import assert_warns
 from sklearn.utils._testing import ignore_warnings
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils import safe_mask
 
 from sklearn.datasets import make_classification, make_regression
@@ -271,8 +269,8 @@ def test_select_kbest_zero():
     support = univariate_filter.get_support()
     gtruth = np.zeros(10, dtype=bool)
     assert_array_equal(support, gtruth)
-    X_selected = assert_warns_message(UserWarning, 'No features were selected',
-                                      univariate_filter.transform, X)
+    with pytest.warns(UserWarning, match="No features were selected"):
+        X_selected = univariate_filter.transform(X)
     assert X_selected.shape == (20, 0)
 
 
@@ -620,7 +618,9 @@ def test_f_classif_constant_feature():
 
     X, y = make_classification(n_samples=10, n_features=5)
     X[:, 0] = 2.0
-    assert_warns(UserWarning, f_classif, X, y)
+    with pytest.warns(UserWarning,
+                      match="One of the features is constant throughout"):
+        f_classif(X, y)
 
 
 def test_no_feature_selected():
@@ -639,8 +639,8 @@ def test_no_feature_selected():
     ]
     for selector in strict_selectors:
         assert_array_equal(selector.get_support(), np.zeros(10))
-        X_selected = assert_warns_message(
-            UserWarning, 'No features were selected', selector.transform, X)
+        with pytest.warns(UserWarning, match="No features were selected"):
+            X_selected = selector.transform(X)
         assert X_selected.shape == (40, 0)
 
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -618,7 +618,7 @@ def test_f_classif_constant_feature():
 
     X, y = make_classification(n_samples=10, n_features=5)
     X[:, 0] = 2.0
-    with ignore_warnings(category=UserWarning):
+    with pytest.warns(UserWarning):
         f_classif(X, y)
 
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -618,8 +618,7 @@ def test_f_classif_constant_feature():
 
     X, y = make_classification(n_samples=10, n_features=5)
     X[:, 0] = 2.0
-    with pytest.warns(UserWarning,
-                      match="Feature [0] are constant."):
+    with ignore_warnings(category=UserWarning):
         f_classif(X, y)
 
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -619,7 +619,7 @@ def test_f_classif_constant_feature():
     X, y = make_classification(n_samples=10, n_features=5)
     X[:, 0] = 2.0
     with pytest.warns(UserWarning,
-                      match="Features [0] are constant."):
+                      match="Feature [0] are constant."):
         f_classif(X, y)
 
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -619,7 +619,7 @@ def test_f_classif_constant_feature():
     X, y = make_classification(n_samples=10, n_features=5)
     X[:, 0] = 2.0
     with pytest.warns(UserWarning,
-                      match="One of the features is constant throughout"):
+                      match="Features [0] are constant."):
         f_classif(X, y)
 
 

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -30,6 +30,8 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
     For example, if an input sample is two dimensional and of the form
     [a, b], the degree-2 polynomial features are [1, a, b, a^2, ab, b^2].
 
+    Read more in the :ref:`User Guide <polynomial_features>`.
+
     Parameters
     ----------
     degree : int, default=2


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes Remove the use of assert_warns and assert_warns_message from the tests #19414 .

#### What does this implement/fix? Explain your changes.
I used pytest.warns and ignore_warnings instead of assert_warns and assert_warns_message.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
