### PR TITLE
DOC Improve the description of california_housing

### DIFF
--- a/sklearn/datasets/descr/california_housing.rst
+++ b/sklearn/datasets/descr/california_housing.rst
@@ -10,26 +10,32 @@ California Housing dataset
     :Number of Attributes: 8 numeric, predictive attributes and the target
 
     :Attribute Information:
-        - MedInc        median income in block
-        - HouseAge      median house age in block
-        - AveRooms      average number of rooms
-        - AveBedrms     average number of bedrooms
-        - Population    block population
-        - AveOccup      average house occupancy
-        - Latitude      house block latitude
-        - Longitude     house block longitude
+        - MedInc        median income in block group
+        - HouseAge      median house age in block group
+        - AveRooms      average number of rooms per household
+        - AveBedrms     average number of bedrooms per household
+        - Population    block group population
+        - AveOccup      average number of household members
+        - Latitude      block group latitude
+        - Longitude     block group longitude
 
     :Missing Attribute Values: None
 
 This dataset was obtained from the StatLib repository.
-http://lib.stat.cmu.edu/datasets/
+https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html
 
-The target variable is the median house value for California districts.
+The target variable is the median house value for California districts,
+expressed in hundreds of thousands of dollars ($100,000).
 
 This dataset was derived from the 1990 U.S. census, using one row per census
 block group. A block group is the smallest geographical unit for which the U.S.
 Census Bureau publishes sample data (a block group typically has a population
 of 600 to 3,000 people).
+
+An household is a group of people residing within a home. Since the average
+number of rooms and bedrooms in this dataset are provided per household, these
+columns may take surpinsingly large values for block groups with few households
+and many empty houses, such as vacation resorts.
 
 It can be downloaded/loaded using the
 :func:`sklearn.datasets.fetch_california_housing` function.


### PR DESCRIPTION
Hello, I found the description of the `california_housing` dataset a bit confusing and would like to suggest a few improvements.

#### What does this implement/fix? Explain your changes.

- Fix the source URL, the current one does not point to a source explaining the dataset, nor providing a link to it. This new URL comes from a comment in `_california_housing.py` pointing to the source. 
- Add the target's unit, it is hard to guess that the target is expressed in hundreds of thousands of dollars ($100,000) without looking at the source code.
- Explain why the average number of rooms and bedrooms sometimes contain arbitrarily large values.

#### Any other comments?

Regarding this last point it could also be worth considering providing access to the raw data without preprocessing, possibly through an argument to `fetch_california_housing`.

#### Reference Issues/PRs

This issue was first raised in the SciKit-Learn MOOC forum:
https://mooc-forums.inria.fr/moocsl/t/california-housing-dataset-issues/2824/8?u=Mirzon

When creating an issue on this repo, the "Documentation improvement" category was accompanied by a suggestion to submit a pull request instead, so here it is.