### PR TITLE
[WIP] Add example of calibration curve with confidence intervals

### DIFF
--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -84,16 +84,6 @@ typical for maximum-margin methods (compare Niculescu-Mizil and Caruana [1]_),
 which focus on difficult to classify samples that are close to the decision
 boundary (the support vectors).
 
-Confidence intervals for the fraction of positives in each bin can be drawn
-using standard deviation estimates by setting `return_std=True` in
-:func:`calibration_curve`. The standard deviation of the fraction of positives
-for each bin is estimated with the formula below, where :math:`\hat{p}` is the
-fraction of positives in the bin, and :math:`n` is the number of samples in the
-bin:
-
-.. math::
-       \sqrt{ \frac{ \hat{p} (1 - \hat{p}) }{ n } }
-
 Calibrating a classifier
 ------------------------
 

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -84,6 +84,16 @@ typical for maximum-margin methods (compare Niculescu-Mizil and Caruana [1]_),
 which focus on difficult to classify samples that are close to the decision
 boundary (the support vectors).
 
+Confidence intervals for the fraction of positives in each bin can be drawn
+using standard deviation estimates by setting `return_std=True` in
+:func:`calibration_curve`. The standard deviation of the fraction of positives
+for each bin is estimated with the formula below, where :math:`\hat{p}` is the
+fraction of positives in the bin, and :math:`n` is the number of samples in the
+bin:
+
+.. math::
+       \sqrt{ \frac{ \hat{p} (1 - \hat{p}) }{ n } }
+
 Calibrating a classifier
 ------------------------
 
@@ -227,6 +237,7 @@ one, a postprocessing is performed to normalize them.
 .. topic:: Examples:
 
    * :ref:`sphx_glr_auto_examples_calibration_plot_calibration_curve.py`
+   * :ref:`sphx_glr_auto_examples_calibration_plot_calibration_curve_with_ci.py`
    * :ref:`sphx_glr_auto_examples_calibration_plot_calibration_multiclass.py`
    * :ref:`sphx_glr_auto_examples_calibration_plot_calibration.py`
    * :ref:`sphx_glr_auto_examples_calibration_plot_compare_calibration.py`

--- a/examples/calibration/plot_calibration_curve_with_ci.py
+++ b/examples/calibration/plot_calibration_curve_with_ci.py
@@ -1,0 +1,103 @@
+"""
+========================================================
+Probability calibration curves with confidence intervals
+========================================================
+
+In practice, it's important to emphasize where along the range of predicted
+probabilities that a model's calibration cannot be confidently assessed.
+Plotting a calibration curve with confidence intervals is one way of
+quantifying how uncertain one should be in assessing a model's calibration.
+
+This example fits a logistic regression to a small and slightly noisy
+dataset. The first figure (without confidence intervals) indicates reasonably
+good calibration. While its histogram helpfully suggests that predicted
+probabilities in the middle range are scarce, it doesn't directly display how
+much this scarcity affects our guess as to where a model is well calibrated.
+Where is there enough data to evaluate calibration? Where is there not enough?
+
+Confidence intervals display how varied the fraction of positive cases could be
+for each bin of predicted probabilities. The interpretation of a 95% confidence
+interval for each bin is that out of 100 future test bins, 95 estimated
+intervals are expected to capture the true fraction of positives. For example,
+consider the last bin in the second figure. The 95% confidence interval,
+(0.84, 0.98), was estimated from test samples in the bin corresponding to
+predicted probabilities around 0.90. This interval may be too wide in some
+sensitive applications. Analogous interpretations for the rest of the bins may
+suggest that calibration can't be confidently assessed for predicted
+probabilities in any range except for those around 0.06 (the first bin).
+
+The conclusion we got from confidence intervals may not have been gotten from
+only looking at the histogram. It's tempting to be confident that a model is
+well calibrated for predicted probabilities around 0.90 (the last bin) by only
+looking at the histogram, as predictions are peaked at the ends. The confidence
+interval at the last bin is less ambiguous. In some sensitive applications,
+the interval that the second figure provides may be too wide. It suggests that
+more data needs to be collected to evaluate this model.
+"""
+print(__doc__)
+
+# Author: Alexandre Gramfort <alexandre.gramfort@telecom-paristech.fr>
+#         Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
+# License: BSD Style.
+
+import matplotlib.pyplot as plt
+
+from sklearn import datasets
+from sklearn.linear_model import LogisticRegression
+from sklearn.calibration import calibration_curve
+from sklearn.model_selection import train_test_split
+
+
+# Create dataset of classification task with seemingly good calibration but few
+# predicted probabilities in middle of 0-1 line
+X, y = datasets.make_classification(n_samples=1000, flip_y=0.1,
+                                    random_state=9139)
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2,
+                                                    random_state=9245)
+
+# Logistic regression with no calibration
+lr = LogisticRegression(C=1.)
+lr.fit(X_train, y_train)
+prob_pos = lr.predict_proba(X_test)[:, 1]
+fraction_of_positives, mean_predicted_value, fraction_of_positives_std = \
+    calibration_curve(y_test, prob_pos, n_bins=5, return_std=True)
+
+
+def plot_calibration_curve(fraction_of_positives, mean_predicted_value,
+                           fig_index, with_ci=False):
+    fig = plt.figure(fig_index, figsize=(10, 10))
+    ax1 = plt.subplot2grid((3, 1), (0, 0), rowspan=2)
+    ax2 = plt.subplot2grid((3, 1), (2, 0))
+
+    ax1.plot([0, 1], [0, 1], "k:", label="Perfectly calibrated")
+    if with_ci:
+        ax1.errorbar(mean_predicted_value, fraction_of_positives,
+                     yerr=2*fraction_of_positives_std, fmt="s-",
+                     label="Model with 95% CI", capsize=5)
+    else:
+        ax1.plot(mean_predicted_value, fraction_of_positives, "s-",
+                 label="Model")
+
+    ax2.hist(prob_pos, range=(0, 1), bins=10, label="Model",
+             histtype="step", lw=2)
+
+    ax1.set_ylabel("Fraction of positives")
+    ax1.set_ylim([-0.05, 1.05])
+    ax1.legend(loc="lower right")
+    ax1.set_title("Calibration plot (reliability curve)")
+
+    ax2.set_xlabel("Mean predicted value")
+    ax2.set_ylabel("Count")
+    ax2.legend(loc="upper center", ncol=2)
+
+    plt.tight_layout()
+
+# Plot calibration curve without 95% CIs
+plot_calibration_curve(fraction_of_positives, mean_predicted_value, 1)
+
+# Plot calibration curve with 95% CIs
+plot_calibration_curve(fraction_of_positives, mean_predicted_value, 2,
+                       with_ci=True)
+
+plt.show()

--- a/examples/calibration/plot_calibration_curve_with_ci.py
+++ b/examples/calibration/plot_calibration_curve_with_ci.py
@@ -66,7 +66,7 @@ fraction_of_positives, mean_predicted_value, fraction_of_positives_std = \
 
 def plot_calibration_curve(fraction_of_positives, mean_predicted_value,
                            fig_index, with_ci=False):
-    fig = plt.figure(fig_index, figsize=(10, 10))
+    _ = plt.figure(fig_index, figsize=(10, 10))
     ax1 = plt.subplot2grid((3, 1), (0, 0), rowspan=2)
     ax2 = plt.subplot2grid((3, 1), (2, 0))
 

--- a/examples/calibration/plot_calibration_curve_with_ci.py
+++ b/examples/calibration/plot_calibration_curve_with_ci.py
@@ -93,6 +93,7 @@ def plot_calibration_curve(fraction_of_positives, mean_predicted_value,
 
     plt.tight_layout()
 
+
 # Plot calibration curve without 95% CIs
 plot_calibration_curve(fraction_of_positives, mean_predicted_value, 1)
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -787,7 +787,7 @@ class _SigmoidCalibration(RegressorMixin, BaseEstimator):
 
 
 def calibration_curve(y_true, y_prob, *, normalize=False, n_bins=5,
-                      strategy='uniform'):
+                      strategy='uniform', return_std=False):
     """Compute true and predicted probabilities for a calibration curve.
 
     The method assumes the inputs come from a binary classifier, and
@@ -824,6 +824,12 @@ def calibration_curve(y_true, y_prob, *, normalize=False, n_bins=5,
         quantile
             The bins have the same number of samples and depend on `y_prob`.
 
+    return_std : bool, default=False
+        Whether or not to return the standard deviation of the estimated
+        proportion of samples whose class is the positive class, in each bin.
+        These estimates can be used to create confidence intervals, which may
+        be important when some bins contain few samples (say, < 100).
+
     Returns
     -------
     prob_true : ndarray of shape (n_bins,) or smaller
@@ -832,6 +838,10 @@ def calibration_curve(y_true, y_prob, *, normalize=False, n_bins=5,
 
     prob_pred : ndarray of shape (n_bins,) or smaller
         The mean predicted probability in each bin.
+
+    prob_true_std : ndarray of shape (n_bins,) or smaller
+        The standard deviation of the estimated proportion of positives in each
+        bin. Only returned when `return_std` is True.
 
     References
     ----------
@@ -888,4 +898,9 @@ def calibration_curve(y_true, y_prob, *, normalize=False, n_bins=5,
     prob_true = bin_true[nonzero] / bin_total[nonzero]
     prob_pred = bin_sums[nonzero] / bin_total[nonzero]
 
-    return prob_true, prob_pred
+    if return_std:
+        prob_true_var = prob_true*(1 - prob_true) / bin_total[nonzero]
+        prob_true_std = np.sqrt(prob_true_var)
+        return prob_true, prob_pred, prob_true_std
+    else:
+        return prob_true, prob_pred

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -787,7 +787,7 @@ class _SigmoidCalibration(RegressorMixin, BaseEstimator):
 
 
 def calibration_curve(y_true, y_prob, *, normalize=False, n_bins=5,
-                      strategy='uniform', return_std=False):
+                      strategy='uniform', return_bin_size=False):
     """Compute true and predicted probabilities for a calibration curve.
 
     The method assumes the inputs come from a binary classifier, and
@@ -824,10 +824,9 @@ def calibration_curve(y_true, y_prob, *, normalize=False, n_bins=5,
         quantile
             The bins have the same number of samples and depend on `y_prob`.
 
-    return_std : bool, default=False
-        Whether or not to return the standard deviation of the estimated
-        proportion of samples whose class is the positive class, in each bin.
-        These estimates can be used to create confidence intervals, which may
+    return_bin_size : bool, default=False
+        Whether or not to return the total number of samples in each bin. These
+        quantities can be useful to create confidence intervals, which may
         be important when some bins contain few samples (say, < 100).
 
     Returns
@@ -839,9 +838,9 @@ def calibration_curve(y_true, y_prob, *, normalize=False, n_bins=5,
     prob_pred : ndarray of shape (n_bins,) or smaller
         The mean predicted probability in each bin.
 
-    prob_true_std : ndarray of shape (n_bins,) or smaller
-        The standard deviation of the estimated proportion of positives in each
-        bin. Only returned when `return_std` is True.
+    bin_size : ndarray of shape (n_bins,) or smaller
+        The total number of samples in each bin. Only returned when
+        `return_bin_size` is True.
 
     References
     ----------
@@ -898,9 +897,8 @@ def calibration_curve(y_true, y_prob, *, normalize=False, n_bins=5,
     prob_true = bin_true[nonzero] / bin_total[nonzero]
     prob_pred = bin_sums[nonzero] / bin_total[nonzero]
 
-    if return_std:
-        prob_true_var = prob_true*(1 - prob_true) / bin_total[nonzero]
-        prob_true_std = np.sqrt(prob_true_var)
-        return prob_true, prob_pred, prob_true_std
+    if return_bin_size:
+        bin_size = bin_total[nonzero]
+        return prob_true, prob_pred, bin_size
     else:
         return prob_true, prob_pred

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -428,7 +428,7 @@ def test_calibration_curve():
         calibration_curve(y_true3, y_pred3, n_bins=2, return_std=True)
     correct_std = np.sqrt((1/3 * 2/3) / 3)
     assert len(prob_true_std) == 2
-    assert_allclose(prob_true_std, [correct_std, correct_std])
+    assert_almost_equal(prob_true_std, [correct_std, correct_std])
 
     # Check that error is raised when invalid strategy is selected
     with pytest.raises(ValueError):

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -421,6 +421,15 @@ def test_calibration_curve():
     assert_almost_equal(prob_true_quantile, [0, 2 / 3])
     assert_almost_equal(prob_pred_quantile, [0.1, 0.8])
 
+    # test that estimated standard deviations are correct
+    y_true3 = np.array([0, 0, 1, 0, 1, 1])
+    y_pred3 = np.array([0., 0.1, 0.2, 0.8, 0.9, 1.])
+    _, _, prob_true_std = \
+        calibration_curve(y_true3, y_pred3, n_bins=2, return_std=True)
+    correct_std = np.sqrt((1/3 * 2/3) / 3)
+    assert len(prob_true_std) == 2
+    assert_almost_equal(prob_true_std, [correct_std, correct_std])
+
     # Check that error is raised when invalid strategy is selected
     with pytest.raises(ValueError):
         calibration_curve(y_true2, y_pred2, strategy='percentile')

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -421,14 +421,13 @@ def test_calibration_curve():
     assert_almost_equal(prob_true_quantile, [0, 2 / 3])
     assert_almost_equal(prob_pred_quantile, [0.1, 0.8])
 
-    # test that estimated standard deviations are correct
+    # test that bin sizes are correct
     y_true3 = np.array([0, 0, 1, 0, 1, 1])
     y_pred3 = np.array([0., 0.1, 0.2, 0.8, 0.9, 1.])
-    _, _, prob_true_std = \
-        calibration_curve(y_true3, y_pred3, n_bins=2, return_std=True)
-    correct_std = np.sqrt((1/3 * 2/3) / 3)
-    assert len(prob_true_std) == 2
-    assert_almost_equal(prob_true_std, [correct_std, correct_std])
+    _, _, bin_size = \
+        calibration_curve(y_true3, y_pred3, n_bins=2, return_bin_size=True)
+    assert len(bin_size) == 2
+    assert_array_equal(bin_size, [3, 3])
 
     # Check that error is raised when invalid strategy is selected
     with pytest.raises(ValueError):

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -428,7 +428,7 @@ def test_calibration_curve():
         calibration_curve(y_true3, y_pred3, n_bins=2, return_std=True)
     correct_std = np.sqrt((1/3 * 2/3) / 3)
     assert len(prob_true_std) == 2
-    assert_almost_equal(prob_true_std, [correct_std, correct_std])
+    assert_allclose(prob_true_std, [correct_std, correct_std])
 
     # Check that error is raised when invalid strategy is selected
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

None (new feature)

#### What does this implement/fix? Explain your changes.

Returns a standard deviation estimate for the fraction of positives in each bin by adding a parameter `return_std=True` in [`calibration_curve`](https://scikit-learn.org/stable/modules/generated/sklearn.calibration.calibration_curve.html#sklearn.calibration.calibration_curve). These estimates allow one to draw confidence intervals on a calibration curve, which is useful to see for bins with few samples.

#### Any other comments?

See the [example](https://github.com/kddubey/scikit-learn/blob/31030f76e45dc88f6b1e382c033950d8bad720cd/examples/calibration/plot_calibration_curve_with_ci.py).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
