### PR TITLE
TST Add TransformedTargetRegressor to test_meta_estimators_delegate_data_validation

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -140,6 +140,12 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         feature(s).
 
         .. versionadded:: 1.0
+    
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying transformers expose such an attribute when fit.
+
+        .. versionadded:: 0.24
 
     Notes
     -----

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -140,7 +140,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         feature(s).
 
         .. versionadded:: 1.0
-    
+
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if the
         underlying transformers expose such an attribute when fit.

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -243,7 +243,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
         return pred_trans
 
     def _more_tags(self):
-        return {'poor_score': True}#, 'no_validation': True}
+        return {'poor_score': True, 'no_validation': True}
 
     @property
     def n_features_in_(self):

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -81,6 +81,12 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
 
     transformer_ : object
         Transformer used in ``fit`` and ``predict``.
+    
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying regressor exposes such an attribute when fit.
+
+        .. versionadded:: 0.24
 
     Examples
     --------

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -81,7 +81,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
 
     transformer_ : object
         Transformer used in ``fit`` and ``predict``.
-    
+
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if the
         underlying regressor exposes such an attribute when fit.
@@ -243,7 +243,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
         return pred_trans
 
     def _more_tags(self):
-        return {'poor_score': True, 'no_validation': True}
+        return {'poor_score': True}#, 'no_validation': True}
 
     @property
     def n_features_in_(self):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -261,7 +261,6 @@ def test_search_cv(estimator, check, request):
 #
 # check_classifiers_train would need to be updated with the error message
 N_FEATURES_IN_AFTER_FIT_MODULES_TO_IGNORE = {
-    'compose',
     'feature_extraction',
     'model_selection',
     'multiclass',

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -169,7 +169,7 @@ def _generate_meta_estimator_instances_with_pipeline():
     for _, Estimator in sorted(all_estimators()):
         sig = set(signature(Estimator).parameters)
 
-        if "estimator" in sig or "base_estimator" in sig:
+        if "estimator" in sig or "base_estimator" in sig or "regressor" in sig:
             if is_regressor(Estimator):
                 estimator = make_pipeline(TfidfVectorizer(), Ridge())
                 param_grid = {"ridge__alpha": [0.1, 1.0]}


### PR DESCRIPTION
Working on https://github.com/scikit-learn/scikit-learn/issues/19333, for the compose module, I noticed that the TransformedTargetRegressor was not included in the `test_meta_estimators_delegate_data_validation` test. It already passes it.

n_features_in_ is already in TransformedTargetRegressor and ColumnTransformer so the `compose` module can be removed from the list. Note that the ColumnTransformer is not tested anyway.