### PR TITLE
CI Removes python 3.6 builds from wheel building

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python: [36, 37, 38, 39]
+        python: [37, 38, 39]
         bitness: [32, 64]
         manylinux_image: [manylinux1, manylinux2010]
         include:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,7 @@ jobs:
         name: Check build trigger
         run: bash build_tools/github/check_build_trigger.sh
 
-  # Build the wheels for Linux, Windows and macOS for Python 3.6 and newer
+  # Build the wheels for Linux, Windows and macOS for Python 3.7 and newer
   build_wheels:
     name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,6 +102,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl
           CIBW_TEST_COMMAND: bash {project}/build_tools/github/test_wheels.sh
           CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }} ${{ matrix.bitness }}
+          CIBW_BUILD_VERBOSITY: 1
 
         run: bash build_tools/github/build_wheels.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,8 @@ requires = [
     # see: https://github.com/scipy/oldest-supported-numpy/blob/master/setup.cfg
     "oldest-supported-numpy",
 
+    # Override oldest-supported-numpy setting because pandas 0.25.0 requires 1.14.6
+    "numpy==1.14.6; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'",
+
     "scipy>=1.1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,6 @@ requires = [
 
     # Override oldest-supported-numpy setting because pandas 0.25.0 requires 1.14.6
     "numpy==1.14.6; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'",
-
-    "scipy>=1.1.0",
+    "scipy==1.1.0; python_version=='3.7'",
+    "scipy>=1.1.0; python_version!='3.7'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ requires = [
     # wheels on PyPI
     #
     # see: https://github.com/scipy/oldest-supported-numpy/blob/master/setup.cfg
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; python_version!='3.7' or platform_machine=='aarch64' or platform_system=='AIX' or platform_python_implementation == 'PyPy'",
 
     # Override oldest-supported-numpy setting because pandas 0.25.0 requires 1.14.6
     "numpy==1.14.6; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'",
-    "scipy==1.1.0; python_version=='3.7'",
-    "scipy>=1.1.0; python_version!='3.7'",
+
+    "scipy>=1.1.0",
 ]


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/20189

Removes python 3.6 from wheel building