### PR TITLE
TST Enable test docstring params for feature extraction module

### DIFF
--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -183,7 +183,6 @@ N_FEATURES_MODULES_TO_IGNORE = {
     'discriminant_analysis',
     'dummy',
     'ensemble',
-    'feature_extraction',
     'feature_selection',
     'gaussian_process',
     'impute',


### PR DESCRIPTION
Documentation of n_features_in_ was done in #20180 but I forgot to remove the module from the exclude list of `test_docstring_parameters`.