### PR TITLE
More stable n_init runs for KMeans

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1059,7 +1059,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
             # determine if these results are the best so far
             # allow small tolerance on the inertia to accomodate for rounding
             # errors.
-            if best_inertia is None or inertia < best_inertia - 1e-7:
+            if best_inertia is None or inertia < best_inertia * (1 - 1e-7):
                 best_labels = labels
                 best_centers = centers
                 best_inertia = inertia

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1057,7 +1057,9 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
                 x_squared_norms=x_squared_norms, n_threads=self._n_threads)
 
             # determine if these results are the best so far
-            if best_inertia is None or inertia < best_inertia:
+            # allow small tolerance on the inertia to accomodate for rounding
+            # errors.
+            if best_inertia is None or inertia < best_inertia - 1e-7:
                 best_labels = labels
                 best_centers = centers
                 best_inertia = inertia

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1057,8 +1057,8 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
                 x_squared_norms=x_squared_norms, n_threads=self._n_threads)
 
             # determine if these results are the best so far
-            # allow small tolerance on the inertia to accomodate for rounding
-            # errors.
+            # allow small tolerance on the inertia to accommodate for
+            # non-deterministic rounding errors due to parallel computation
             if best_inertia is None or inertia < best_inertia * (1 - 1e-6):
                 best_labels = labels
                 best_centers = centers

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1059,7 +1059,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
             # determine if these results are the best so far
             # allow small tolerance on the inertia to accomodate for rounding
             # errors.
-            if best_inertia is None or inertia < best_inertia * (1 - 1e-7):
+            if best_inertia is None or inertia < best_inertia * (1 - 1e-6):
                 best_labels = labels
                 best_centers = centers
                 best_inertia = inertia


### PR DESCRIPTION
Fixes #20199. Also related to #19403.
Fixes  #20216

Sometimes a new run is selected to be the best although it's exactly the same clustering as the best run so far due to rounding errors for the inertia computation. This PR allows a small tol on the inertia to select a new run only if it has a better inertia beyond rounding errors.

It's hard to add a test since it's not triggered in the CI but has been observed locally, and it's hard to test because it come from rounding errors which might differ between machines. I guess that in this case the fact that it does not appear locally anymore is enough.