### PR TITLE
TST make sure to test SearchCV on both classification and regression

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -12,6 +12,7 @@ import sys
 import re
 import pkgutil
 from inspect import isgenerator
+from itertools import product
 from functools import partial
 
 import pytest
@@ -212,8 +213,11 @@ def test_class_support_removed():
 
 
 def _generate_search_cv_instances():
-    for SearchCV, (Estimator, param_grid) in zip(
-        [GridSearchCV, RandomizedSearchCV],
+    for SearchCV, (Estimator, param_grid) in product(
+        [
+            GridSearchCV,
+            RandomizedSearchCV,
+        ],
         [
             (Ridge, {"alpha": [0.1, 1.0]}),
             (LogisticRegression, {"C": [0.1, 1.0]}),
@@ -221,8 +225,11 @@ def _generate_search_cv_instances():
     ):
         yield SearchCV(Estimator(), param_grid)
 
-    for SearchCV, (Estimator, param_grid) in zip(
-        [GridSearchCV, RandomizedSearchCV],
+    for SearchCV, (Estimator, param_grid) in product(
+        [
+            GridSearchCV,
+            RandomizedSearchCV,
+        ],
         [
             (Ridge, {"ridge__alpha": [0.1, 1.0]}),
             (LogisticRegression, {"logisticregression__C": [0.1, 1.0]}),


### PR DESCRIPTION
We should use the product of the `SearchCV`, classifier, and regressor instead of a `zip`.
I don't think that I intended the current behaviour when creating the test.
