### PR TITLE
API Raises an error when a negative threshold is chosen in VarianceThreshold

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -295,6 +295,10 @@ Changelog
   :pr:`17169` by :user:`Dmytro Lituiev <DSLituiev>`
   and :user:`Julien Jerphanion <jjerphan>`.
 
+- |Fix| Fixed a bug in class:`feature_selection.VarianceThreshold`
+  when a variance threshold is negative.
+  :pr:`20207` by :user:`Tomohiro Endo <europeanplaice>`
+
 :mod:`sklearn.inspection`
 .........................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -295,8 +295,8 @@ Changelog
   :pr:`17169` by :user:`Dmytro Lituiev <DSLituiev>`
   and :user:`Julien Jerphanion <jjerphan>`.
 
-- |Fix| Fixed a bug in class:`feature_selection.VarianceThreshold`
-  when a variance threshold is negative.
+- |API| Raises an error in :class:`feature_selection.VarianceThreshold`
+  when the variance threshold is negative.
   :pr:`20207` by :user:`Tomohiro Endo <europeanplaice>`
 
 :mod:`sklearn.inspection`

--- a/sklearn/feature_selection/_variance_threshold.py
+++ b/sklearn/feature_selection/_variance_threshold.py
@@ -48,7 +48,7 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
     """
 
     def __init__(self, threshold=0.):
-        if threshold < 0:
+        if threshold < 0.:
             warnings.warn("Threshold should be non-negative. Automatically set as zero.")
             self.threshold = 0.
         else:

--- a/sklearn/feature_selection/_variance_threshold.py
+++ b/sklearn/feature_selection/_variance_threshold.py
@@ -1,6 +1,7 @@
 # Author: Lars Buitinck
 # License: 3-clause BSD
 
+import warnings
 import numpy as np
 from ..base import BaseEstimator
 from ._base import SelectorMixin
@@ -47,6 +48,8 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
     """
 
     def __init__(self, threshold=0.):
+        if threshold < 0:
+            warnings.warn("Threshold must be non-negative.")
         self.threshold = threshold
 
     def fit(self, X, y=None):

--- a/sklearn/feature_selection/_variance_threshold.py
+++ b/sklearn/feature_selection/_variance_threshold.py
@@ -1,7 +1,6 @@
 # Author: Lars Buitinck
 # License: 3-clause BSD
 
-import warnings
 import numpy as np
 from ..base import BaseEstimator
 from ._base import SelectorMixin
@@ -48,12 +47,7 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
     """
 
     def __init__(self, threshold=0.):
-        if threshold < 0.:
-            warnings.warn("Threshold should be non-negative."
-                          "Automatically set as zero.")
-            self.threshold = 0.
-        else:
-            self.threshold = threshold
+        self.threshold = threshold
 
     def fit(self, X, y=None):
         """Learn empirical variances from X.
@@ -90,6 +84,8 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
             # for constant features
             compare_arr = np.array([self.variances_, peak_to_peaks])
             self.variances_ = np.nanmin(compare_arr, axis=0)
+        elif self.threshold < 0.:
+            raise ValueError("Threshold must be non-negative.")
 
         if np.all(~np.isfinite(self.variances_) |
                   (self.variances_ <= self.threshold)):

--- a/sklearn/feature_selection/_variance_threshold.py
+++ b/sklearn/feature_selection/_variance_threshold.py
@@ -49,8 +49,10 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
 
     def __init__(self, threshold=0.):
         if threshold < 0:
-            warnings.warn("Threshold should be non-negative.")
-        self.threshold = threshold
+            warnings.warn("Threshold should be non-negative. Automatically set as zero.")
+            self.threshold = 0.
+        else:
+            self.threshold = threshold
 
     def fit(self, X, y=None):
         """Learn empirical variances from X.

--- a/sklearn/feature_selection/_variance_threshold.py
+++ b/sklearn/feature_selection/_variance_threshold.py
@@ -49,7 +49,8 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
 
     def __init__(self, threshold=0.):
         if threshold < 0.:
-            warnings.warn("Threshold should be non-negative. Automatically set as zero.")
+            warnings.warn("Threshold should be non-negative."
+                          "Automatically set as zero.")
             self.threshold = 0.
         else:
             self.threshold = threshold

--- a/sklearn/feature_selection/_variance_threshold.py
+++ b/sklearn/feature_selection/_variance_threshold.py
@@ -49,7 +49,7 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
 
     def __init__(self, threshold=0.):
         if threshold < 0:
-            warnings.warn("Threshold must be non-negative.")
+            warnings.warn("Threshold should be non-negative.")
         self.threshold = threshold
 
     def fit(self, X, y=None):

--- a/sklearn/feature_selection/_variance_threshold.py
+++ b/sklearn/feature_selection/_variance_threshold.py
@@ -85,7 +85,9 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
             compare_arr = np.array([self.variances_, peak_to_peaks])
             self.variances_ = np.nanmin(compare_arr, axis=0)
         elif self.threshold < 0.:
-            raise ValueError("Threshold must be non-negative.")
+            raise ValueError(
+                "Threshold must be non-negative."
+                f" Got: {self.threshold}")
 
         if np.all(~np.isfinite(self.variances_) |
                   (self.variances_ <= self.threshold)):

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -13,6 +13,7 @@ data = [[0, 1, 2, 3, 4],
 
 data2 = [[-0.13725701]] * 10
 
+
 def test_zero_variance():
     # Test VarianceThreshold with default setting, zero variance.
 

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -38,8 +38,7 @@ def test_variance_threshold():
 def test_variance_negative(X):
     """Test VarianceThreshold with negative variance."""
     var_threshold = VarianceThreshold(threshold=-1.)
-    msg = '^Threshold must be non-negative.' \
-          ' Got: -1.0$'
+    msg = r"^Threshold must be non-negative. Got: -1.0$"
     with pytest.raises(ValueError, match=msg):
         var_threshold.fit(X)
 

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -33,6 +33,14 @@ def test_variance_threshold():
         assert (len(data), 1) == X.shape
 
 
+def test_variance_negative():
+    # Test VarianceThreshold with negative variance.
+    for X in [data, csr_matrix(data)]:
+        X_neg = VarianceThreshold(threshold=-1.).fit_transform(X)
+        X_zero = VarianceThreshold(threshold=0.).fit_transform(X)
+        assert X_neg.shape == X_zero.shape
+
+
 @pytest.mark.skipif(np.var(data2) == 0,
                     reason=('This test is not valid for this platform, '
                             'as it relies on numerical instabilities.'))

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -34,11 +34,14 @@ def test_variance_threshold():
         assert (len(data), 1) == X.shape
 
 
-def test_variance_negative():
-    # Test VarianceThreshold with negative variance.
-    for X in [data, csr_matrix(data)]:
-        with pytest.raises(ValueError):
-            VarianceThreshold(threshold=-1.).fit(X)
+@pytest.mark.parametrize('X', [data, csr_matrix(data)])
+def test_variance_negative(X):
+    """Test VarianceThreshold with negative variance."""
+    var_threshold = VarianceThreshold(threshold=-1.)
+    msg = '^Threshold must be non-negative.' \
+          ' Got: -1.0$'
+    with pytest.raises(ValueError, match=msg):
+        var_threshold.fit(X)
 
 
 @pytest.mark.skipif(np.var(data2) == 0,

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -37,9 +37,8 @@ def test_variance_threshold():
 def test_variance_negative():
     # Test VarianceThreshold with negative variance.
     for X in [data, csr_matrix(data)]:
-        X_neg = VarianceThreshold(threshold=-1.).fit_transform(X)
-        X_zero = VarianceThreshold(threshold=0.).fit_transform(X)
-        assert X_neg.shape == X_zero.shape
+        with pytest.raises(ValueError):
+            VarianceThreshold(threshold=-1.).fit(X)
 
 
 @pytest.mark.skipif(np.var(data2) == 0,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #20206


#### What does this implement/fix? Explain your changes.

I made a quick fix of an unexpected behavior of `VarianceThreshold` when a negative value of threshold is chosen.
And I added a test code related to this problem.

