### PR TITLE
FIX make sure OutputCodeClassifier rejects complex labels

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -51,6 +51,7 @@ from .utils._tags import _safe_tags
 from .utils.validation import _num_samples
 from .utils.validation import check_is_fitted
 from .utils.validation import column_or_1d
+from .utils.validation import _ensure_no_complex_data
 from .utils.validation import _assert_all_finite
 from .utils.multiclass import (_check_partial_fit_first_call,
                                check_classification_targets,
@@ -911,6 +912,7 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         """
         y = column_or_1d(y, warn=True)
         _assert_all_finite(y)
+        _ensure_no_complex_data(y)
 
         if self.code_size <= 0:
             raise ValueError("code_size should be greater than 0, got {0}"


### PR DESCRIPTION
This is a quick fix for the random failure reported in #20218 after the merge of #20192. I am not sure about the root cause of the randomness but we indeed need to factorize `y` validation when `X` is not validated in a meta-estimator as @jeremiedbb suggested elsewhere.

In the mean time, let's make sure that the CI can be green in main to avoid disturbing concurrent PRs.