### PR TITLE
FIX make check_complex_data deterministic

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -967,6 +967,7 @@ def check_complex_data(name, estimator_orig):
     # Something both valid for classification and regression
     y = rng.randint(low=0, high=2, size=10) + 1j
     estimator = clone(estimator_orig)
+    set_random_state(estimator, random_state=0)
     with raises(ValueError, match="Complex data not supported"):
         estimator.fit(X, y)
 


### PR DESCRIPTION
Fixes #20218 and replaces #20219.

This should fix the random failure of `check_complex_data` observed for `OutputCodeClassifier`.

The underlying root issue with the lack of validation for `_ConstantPredictor` is being discussed separately in #20205.