### PR TITLE
DOC Document n_features_in_ in cluster

### DIFF
--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -309,6 +309,9 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
     n_iter_ : int
         Number of iterations taken to converge.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
     Notes
     -----
     For an example, see :ref:`examples/cluster/plot_affinity_propagation.py

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -773,6 +773,9 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         .. versionadded:: 0.21
             ``n_connected_components_`` was added to replace ``n_components_``.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
     children_ : array-like of shape (n_samples-1, 2)
         The children of each non-leaf node. Values less than `n_samples`
         correspond to leaves of the tree which are the original samples.
@@ -1038,6 +1041,9 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
 
         .. versionadded:: 0.21
             ``n_connected_components_`` was added to replace ``n_components_``.
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
 
     children_ : array-like of shape (n_nodes-1, 2)
         The children of each non-leaf node. Values less than `n_features`

--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -255,6 +255,9 @@ class SpectralCoclustering(BaseSpectral):
     column_labels_ : array-like of shape (n_cols,)
         The bicluster label of each column.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
     Examples
     --------
     >>> from sklearn.cluster import SpectralCoclustering
@@ -391,6 +394,9 @@ class SpectralBiclustering(BaseSpectral):
 
     column_labels_ : array-like of shape (n_cols,)
         Column partition labels.
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
 
     Examples
     --------

--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -401,6 +401,9 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
         if partial_fit is used instead of fit, they are assigned to the
         last batch of data.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
     See Also
     --------
     MiniBatchKMeans : Alternative implementation that does incremental updates

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -217,6 +217,9 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         Cluster labels for each point in the dataset given to fit().
         Noisy samples are given the label -1.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
     Examples
     --------
     >>> from sklearn.cluster import DBSCAN

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -766,6 +766,9 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
     n_iter_ : int
         Number of iterations run.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
     See Also
     --------
     MiniBatchKMeans : Alternative online implementation that does incremental
@@ -1464,6 +1467,9 @@ class MiniBatchKMeans(KMeans):
         .. deprecated:: 0.24
            This attribute is deprecated in 0.24 and will be removed in
            1.1 (renaming of 0.26).
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
 
     See Also
     --------

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -311,6 +311,9 @@ class MeanShift(ClusterMixin, BaseEstimator):
 
         .. versionadded:: 0.22
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
     Examples
     --------
     >>> from sklearn.cluster import MeanShift

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -178,6 +178,9 @@ class OPTICS(ClusterMixin, BaseEstimator):
         ``X[ordering_][start:end + 1]`` form a cluster.
         Only available when ``cluster_method='xi'``.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
     See Also
     --------
     DBSCAN : A similar clustering for a specified neighborhood radius (eps).

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -418,6 +418,9 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
     labels_ : ndarray of shape (n_samples,)
         Labels of each point
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
     Examples
     --------
     >>> from sklearn.cluster import SpectralClustering

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -176,7 +176,6 @@ def _construct_searchcv_instance(SearchCV):
 
 
 N_FEATURES_MODULES_TO_IGNORE = {
-    'cluster',
     'compose',
     'covariance',
     'decomposition',


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #19333

#### What does this implement/fix? Explain your changes.
Add `n_features_in_` attribute to docstrings in `cluster`.

#### Any other comments?
From what I can tell, there are no other existing attributes (such as `n_features_`) which have to be deprecated in the docstrings. Let me know if this is right and I can continue working on the other modules.