### PR TITLE
CI Fixes regex label action labeler

### DIFF
--- a/.github/scripts/label_title_regex.py
+++ b/.github/scripts/label_title_regex.py
@@ -1,14 +1,19 @@
 """Labels PRs based on title. Must be run in a github action with the
 pull_request_target event."""
-from ghapi.all import context_github
-from ghapi.all import GhApi
-from ghapi.all import user_repo
-from ghapi.all import github_token
+from github import Github
+import os
+import json
 import re
 
-owner, repo = user_repo()
-pull_request = context_github.event.pull_request
-title = pull_request.title
+context_dict = json.loads(os.getenv("CONTEXT_GITHUB"))
+
+repo = context_dict["repository"]
+g = Github(context_dict["token"])
+repo = g.get_repo(repo)
+pr_number = context_dict["event"]["number"]
+issue = repo.get_issue(number=pr_number)
+title = issue.title
+
 
 regex_to_labels = [
     (r"\bDOC\b", "Documentation"),
@@ -21,5 +26,4 @@ labels_to_add = [
 ]
 
 if labels_to_add:
-    api = GhApi(owner=owner, repo=repo, token=github_token())
-    api.issues.add_labels(pull_request.number, labels=labels_to_add)
+    issue.add_to_labels(*labels_to_add)

--- a/.github/workflows/labeler-title-regex.yml
+++ b/.github/workflows/labeler-title-regex.yml
@@ -16,8 +16,8 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.9'
-    - name: Install ghapi
-      run: pip install -Uq ghapi
+    - name: Install PyGithub
+      run: pip install -Uq PyGithub
     - name: Label pull request
       run: python .github/scripts/label_title_regex.py
       env:

--- a/.github/workflows/labeler-title-regex.yml
+++ b/.github/workflows/labeler-title-regex.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     types: [opened, edited]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
 
   labeler:


### PR DESCRIPTION
Fixes: https://github.com/scikit-learn/scikit-learn/issues/20249

The regex labeler has been failing because it does not have write permissions. This PR gives the workflow the permission to write labels.

EDIT: I switched to using PyGithub because it works. I was not able to get `ghapi` to work on my fork.