### PR TITLE
TST create instances from exotic estimators for docstring params check

### DIFF
--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -400,6 +400,9 @@ class SpectralBiclustering(BaseSpectral):
     column_labels_ : array-like of shape (n_cols,)
         Column partition labels.
 
+    biclusters_ : tuple of two ndarrays
+        The tuple contains the `rows_` and `columns_` arrays.
+
     n_features_in_ : int
         Number of features seen during :term:`fit`.
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1033,6 +1033,14 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
            This attribute is deprecated in 0.24 and will be removed in
            1.1 (renaming of 0.26). Use `dictionary` instead.
 
+    n_components_ : int
+        Number of atoms.
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
+        .. versionadded:: 0.24
+
     Examples
     --------
     >>> import numpy as np

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -351,6 +351,13 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
     named_estimators_ : :class:`~sklearn.utils.Bunch`
         Attribute to access any fitted sub-estimators by name.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying first transformer in `transformer_list` exposes such an
+        attribute when fit.
+
+        .. versionadded:: 0.24
+
     final_estimator_ : estimator
         The classifier which predicts given the output of `estimators_`.
 
@@ -611,9 +618,18 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
     named_estimators_ : :class:`~sklearn.utils.Bunch`
         Attribute to access any fitted sub-estimators by name.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying first transformer in `transformer_list` exposes such an
+        attribute when fit.
+
+        .. versionadded:: 0.24
 
     final_estimator_ : estimator
         The regressor to stacked the base estimators fitted.
+
+    stack_method_ : list of str
+        The method used by each base estimator.
 
     References
     ----------

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -353,8 +353,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
 
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if the
-        underlying first transformer in `transformer_list` exposes such an
-        attribute when fit.
+        underlying classifier exposes such an attribute when fit.
 
         .. versionadded:: 0.24
 
@@ -620,8 +619,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
 
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if the
-        underlying first transformer in `transformer_list` exposes such an
-        attribute when fit.
+        underlying regressor exposes such an attribute when fit.
 
         .. versionadded:: 0.24
 

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -200,10 +200,10 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         .. versionadded:: 0.20
 
     le_ : :class:`~sklearn.preprocessing.LabelEncoder`
-        Transformer used to encode the label during fit and decode during
+        Transformer used to encode the labels during fit and decode during
         prediction.
 
-    classes_ : array-like of shape (n_classes,)
+    classes_ : ndarray of shape (n_classes,)
         The classes labels.
 
     n_features_in_ : int

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -203,7 +203,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         Transformer used to encode the label during fit and decode during
         prediction.
 
-    classes_ : array-like of shape (n_predictions,)
+    classes_ : array-like of shape (n_classes,)
         The classes labels.
 
     n_features_in_ : int

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -199,8 +199,18 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
 
         .. versionadded:: 0.20
 
+    le_ : :class:`~sklearn.preprocessing.LabelEncoder`
+        Transformer used to encode the label during fit and decode during
+        prediction.
+
     classes_ : array-like of shape (n_predictions,)
         The classes labels.
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying classifier exposes such an attribute when fit.
+
+        .. versionadded:: 0.24
 
     See Also
     --------
@@ -430,6 +440,12 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         Attribute to access any fitted sub-estimators by name.
 
         .. versionadded:: 0.20
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying regressor exposes such an attribute when fit.
+
+        .. versionadded:: 0.24
 
     See Also
     --------

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -949,9 +949,9 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
     vocabulary_ : dict
         A mapping of terms to feature indices.
 
-    fixed_vocabulary_: boolean
+    fixed_vocabulary_ : bool
         True if a fixed vocabulary of term to indices mapping
-        is provided by the user
+        is provided by the user.
 
     stop_words_ : set
         Terms that were ignored because they either:
@@ -1684,9 +1684,9 @@ class TfidfVectorizer(CountVectorizer):
     vocabulary_ : dict
         A mapping of terms to feature indices.
 
-    fixed_vocabulary_: bool
+    fixed_vocabulary_ : bool
         True if a fixed vocabulary of term to indices mapping
-        is provided by the user
+        is provided by the user.
 
     idf_ : array of shape (n_features,)
         The inverse document frequency (IDF) vector; only defined

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -127,6 +127,12 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
         This is stored only when a non-fitted estimator is passed to the
         ``SelectFromModel``, i.e when prefit is False.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying estimator exposes such an attribute when fit.
+
+        .. versionadded:: 0.24
+
     threshold_ : float
         The threshold value used for feature selection.
 

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -473,6 +473,9 @@ class RFECV(RFE):
 
     Attributes
     ----------
+    classes_ : array-like of shape (n_classes,)
+        The classes labels. Only available when `estimator` is a classifier.
+
     estimator_ : ``Estimator`` instance
         The fitted estimator used to select features.
 
@@ -483,6 +486,12 @@ class RFECV(RFE):
 
     n_features_ : int
         The number of selected features with cross-validation.
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying estimator exposes such an attribute when fit.
+
+        .. versionadded:: 0.24
 
     ranking_ : narray of shape (n_features,)
         The feature ranking, such that `ranking_[i]`

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -99,11 +99,20 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
     Attributes
     ----------
+    classes_ : array-like of shape (n_classes,)
+        The classes labels. Only available when `estimator` is a classifier.
+
     estimator_ : ``Estimator`` instance
         The fitted estimator used to select features.
 
     n_features_ : int
         The number of selected features.
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying estimator exposes such an attribute when fit.
+
+        .. versionadded:: 0.24
 
     ranking_ : ndarray of shape (n_features,)
         The feature ranking, such that ``ranking_[i]`` corresponds to the

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -99,7 +99,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
     Attributes
     ----------
-    classes_ : array-like of shape (n_classes,)
+    classes_ : ndarray of shape (n_classes,)
         The classes labels. Only available when `estimator` is a classifier.
 
     estimator_ : ``Estimator`` instance
@@ -473,7 +473,7 @@ class RFECV(RFE):
 
     Attributes
     ----------
-    classes_ : array-like of shape (n_classes,)
+    classes_ : ndarray of shape (n_classes,)
         The classes labels. Only available when `estimator` is a classifier.
 
     estimator_ : ``Estimator`` instance

--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -76,6 +76,12 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin,
 
     Attributes
     ----------
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if the
+        underlying estimator exposes such an attribute when fit.
+
+        .. versionadded:: 0.24
+
     n_features_to_select_ : int
         The number of features that were selected.
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -83,6 +83,10 @@ class Pipeline(_BaseComposition):
         Read-only attribute to access any step parameter by user given name.
         Keys are step names and values are steps parameters.
 
+    classes_ : ndarray of shape (n_classes,)
+        The classes labels. Only exist if the last step of the pipeline is a
+        classifier.
+
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if the
         underlying first estimator in `steps` exposes such an attribute

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -591,6 +591,11 @@ class SparseRandomProjection(BaseRandomProjection):
     density_ : float in range 0.0 - 1.0
         Concrete density computed from when density = "auto".
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
+        .. versionadded:: 0.24
+
     Examples
     --------
     >>> import numpy as np

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -459,6 +459,11 @@ class GaussianRandomProjection(BaseRandomProjection):
     components_ : ndarray of shape (n_components, n_features)
         Random matrix used for the projection.
 
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
+        .. versionadded:: 0.24
+
     Examples
     --------
     >>> import numpy as np

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -204,7 +204,6 @@ def test_fit_docstring_attributes(name, Estimator):
 
     IGNORED = {
         'CountVectorizer', 'DictVectorizer', 'TfidfVectorizer',
-        'SelectFromModel',
         'GaussianRandomProjection', 'SparseCoder', 'SparseRandomProjection',
         'SpectralBiclustering',
         'SequentialFeatureSelector',

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -210,8 +210,7 @@ def test_fit_docstring_attributes(name, Estimator):
         'NoSampleWeightWrapper', 'RFE', 'RFECV',
         'RegressorChain', 'SelectFromModel',
         'SparseCoder', 'SparseRandomProjection',
-        'SpectralBiclustering', 'StackingClassifier',
-        'StackingRegressor', 'TfidfVectorizer', 'VotingClassifier',
+        'SpectralBiclustering', 'TfidfVectorizer', 'VotingClassifier',
         'VotingRegressor', 'SequentialFeatureSelector',
     }
 

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -206,7 +206,6 @@ def test_fit_docstring_attributes(name, Estimator):
         'CountVectorizer', 'DictVectorizer', 'TfidfVectorizer',
         'GaussianRandomProjection', 'SparseCoder', 'SparseRandomProjection',
         'SpectralBiclustering',
-        'SequentialFeatureSelector',
         'NoSampleWeightWrapper',
     }
 

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -232,8 +232,8 @@ def test_fit_docstring_attributes(name, Estimator):
         est.set_params(k=2)
     elif Estimator.__name__ == 'DummyClassifier':
         est.set_params(strategy="stratified")
-    elif Estimator.__name__ in ('CCA', 'PLS'):
-        # default = 2 is invalid for single target.
+    elif Estimator.__name__ == 'CCA' or Estimator.__name__.startswith('PLS'):
+        # default = 2 is invalid for single target
         est.set_params(n_components=1)
     elif Estimator.__name__ in (
         "GaussianRandomProjection",

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -210,8 +210,7 @@ def test_fit_docstring_attributes(name, Estimator):
         'NoSampleWeightWrapper', 'RFE', 'RFECV',
         'RegressorChain', 'SelectFromModel',
         'SparseCoder', 'SparseRandomProjection',
-        'SpectralBiclustering', 'TfidfVectorizer', 'VotingClassifier',
-        'VotingRegressor', 'SequentialFeatureSelector',
+        'SpectralBiclustering', 'TfidfVectorizer', 'SequentialFeatureSelector',
     }
 
     if Estimator.__name__ in IGNORED or Estimator.__name__.startswith('_'):

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -193,7 +193,9 @@ def _construct_exotic(Estimator):
             [[0, 1, 0], [-1, -1, 2], [1, 1, 1], [0, 1, 1], [0, 2, 1]],
             dtype=np.float64,
         )
-    return Estimator(dictionary=dictionary)
+        return Estimator(dictionary=dictionary)
+    elif Estimator.__name__ == "GaussianRandomProjection":
+        return Estimator(n_components=2)
 
 
 N_FEATURES_MODULES_TO_IGNORE = {
@@ -215,7 +217,6 @@ def test_fit_docstring_attributes(name, Estimator):
         "CountVectorizer",
         "DictVectorizer",
         "TfidfVectorizer",
-        "GaussianRandomProjection",
         "SparseRandomProjection",
         "SpectralBiclustering",
     }
@@ -238,6 +239,7 @@ def test_fit_docstring_attributes(name, Estimator):
         est = _construct_compose_pipeline_instance(Estimator)
     elif Estimator.__name__ in (
         "SparseCoder",
+        "GaussianRandomProjection",
     ):
         est = _construct_exotic(Estimator)
     else:

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -204,7 +204,7 @@ def test_fit_docstring_attributes(name, Estimator):
 
     IGNORED = {
         'CountVectorizer', 'DictVectorizer', 'TfidfVectorizer',
-        'RFECV', 'SelectFromModel',
+        'SelectFromModel',
         'GaussianRandomProjection', 'SparseCoder', 'SparseRandomProjection',
         'SpectralBiclustering',
         'SequentialFeatureSelector',

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -24,6 +24,7 @@ from sklearn.utils.deprecation import _is_deprecated
 from sklearn.externals._pep562 import Pep562
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import FunctionTransformer
 
 import pytest
 
@@ -175,6 +176,17 @@ def _construct_searchcv_instance(SearchCV):
     return SearchCV(LogisticRegression(), {"C": [0.1, 1]})
 
 
+def _construct_compose_pipeline_instance(Estimator):
+    if Estimator.__name__ == "ColumnTransformer":
+        return Estimator(transformers=[("transformer", "passthrough", [0, 1])])
+    elif Estimator.__name__ == "Pipeline":
+        return Estimator(steps=[("clf", LogisticRegression())])
+    elif Estimator.__name__ == "FeatureUnion":
+        return Estimator(transformer_list=[
+            ("transformer", FunctionTransformer())
+        ])
+
+
 N_FEATURES_MODULES_TO_IGNORE = {
     'model_selection',
     'multioutput',
@@ -213,6 +225,12 @@ def test_fit_docstring_attributes(name, Estimator):
         "GridSearchCV",
     ):
         est = _construct_searchcv_instance(Estimator)
+    elif Estimator.__name__ in (
+        "ColumnTransformer",
+        "Pipeline",
+        "FeatureUnion",
+    ):
+        est = _construct_compose_pipeline_instance(Estimator)
     else:
         est = _construct_instance(Estimator)
 

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -177,6 +177,7 @@ def _construct_searchcv_instance(SearchCV):
 
 
 def _construct_compose_pipeline_instance(Estimator):
+    # Minimal / degenerate instances: only useful to test the docstrings.
     if Estimator.__name__ == "ColumnTransformer":
         return Estimator(transformers=[("transformer", "passthrough", [0, 1])])
     elif Estimator.__name__ == "Pipeline":
@@ -188,6 +189,7 @@ def _construct_compose_pipeline_instance(Estimator):
 
 
 def _construct_sparse_coder(Estimator):
+    # XXX: hard-coded assumption that n_features=3
     dictionary = np.array(
         [[0, 1, 0], [-1, -1, 2], [1, 1, 1], [0, 1, 1], [0, 2, 1]],
         dtype=np.float64,

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -220,7 +220,6 @@ def test_fit_docstring_attributes(name, Estimator):
         "CountVectorizer",
         "DictVectorizer",
         "TfidfVectorizer",
-        "SpectralBiclustering",
     }
 
     if Estimator.__name__ in IGNORED or Estimator.__name__.startswith('_'):

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -203,14 +203,12 @@ def test_fit_docstring_attributes(name, Estimator):
     attributes = doc['Attributes']
 
     IGNORED = {
-        'ClassifierChain',
-        'CountVectorizer', 'DictVectorizer',
-        'GaussianRandomProjection',
-        'MultiOutputClassifier', 'MultiOutputRegressor',
-        'NoSampleWeightWrapper', 'RFE', 'RFECV',
-        'RegressorChain', 'SelectFromModel',
-        'SparseCoder', 'SparseRandomProjection',
-        'SpectralBiclustering', 'TfidfVectorizer', 'SequentialFeatureSelector',
+        'CountVectorizer', 'DictVectorizer', 'TfidfVectorizer',
+        'RFECV', 'SelectFromModel',
+        'GaussianRandomProjection', 'SparseCoder', 'SparseRandomProjection',
+        'SpectralBiclustering',
+        'SequentialFeatureSelector',
+        'NoSampleWeightWrapper',
     }
 
     if Estimator.__name__ in IGNORED or Estimator.__name__.startswith('_'):

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -194,7 +194,10 @@ def _construct_exotic(Estimator):
             dtype=np.float64,
         )
         return Estimator(dictionary=dictionary)
-    elif Estimator.__name__ == "GaussianRandomProjection":
+    elif Estimator.__name__ in (
+        "GaussianRandomProjection",
+        "SparseRandomProjection",
+    ):
         return Estimator(n_components=2)
 
 
@@ -217,7 +220,6 @@ def test_fit_docstring_attributes(name, Estimator):
         "CountVectorizer",
         "DictVectorizer",
         "TfidfVectorizer",
-        "SparseRandomProjection",
         "SpectralBiclustering",
     }
 
@@ -240,6 +242,7 @@ def test_fit_docstring_attributes(name, Estimator):
     elif Estimator.__name__ in (
         "SparseCoder",
         "GaussianRandomProjection",
+        "SparseRandomProjection",
     ):
         est = _construct_exotic(Estimator)
     else:

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -187,6 +187,15 @@ def _construct_compose_pipeline_instance(Estimator):
         ])
 
 
+def _construct_exotic(Estimator):
+    if Estimator.__name__ == "SparseCoder":
+        dictionary = np.array(
+            [[0, 1, 0], [-1, -1, 2], [1, 1, 1], [0, 1, 1], [0, 2, 1]],
+            dtype=np.float64,
+        )
+    return Estimator(dictionary=dictionary)
+
+
 N_FEATURES_MODULES_TO_IGNORE = {
     'model_selection',
     'multioutput',
@@ -203,10 +212,12 @@ def test_fit_docstring_attributes(name, Estimator):
     attributes = doc['Attributes']
 
     IGNORED = {
-        'CountVectorizer', 'DictVectorizer', 'TfidfVectorizer',
-        'GaussianRandomProjection', 'SparseCoder', 'SparseRandomProjection',
-        'SpectralBiclustering',
-        'NoSampleWeightWrapper',
+        "CountVectorizer",
+        "DictVectorizer",
+        "TfidfVectorizer",
+        "GaussianRandomProjection",
+        "SparseRandomProjection",
+        "SpectralBiclustering",
     }
 
     if Estimator.__name__ in IGNORED or Estimator.__name__.startswith('_'):
@@ -225,6 +236,10 @@ def test_fit_docstring_attributes(name, Estimator):
         "FeatureUnion",
     ):
         est = _construct_compose_pipeline_instance(Estimator)
+    elif Estimator.__name__ in (
+        "SparseCoder",
+    ):
+        est = _construct_exotic(Estimator)
     else:
         est = _construct_instance(Estimator)
 


### PR DESCRIPTION
Some additional coming from work resolving #19333

Create specific instances for exotic estimators requiring parameters to check that their docstring is up-to-date.