### PR TITLE
CI Use newer version of sphinx and remove patch

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -463,30 +463,8 @@ def generate_min_dependency_substitutions(app):
 # we use the issues path for PRs since the issues URL will forward
 issues_github_path = 'scikit-learn/scikit-learn'
 
-# Hack to get kwargs to appear in docstring #18434
-# TODO: Remove when https://github.com/sphinx-doc/sphinx/pull/8234 gets
-# merged
-from sphinx.util import inspect  # noqa
-from sphinx.ext.autodoc import ClassDocumenter  # noqa
-
-
-class PatchedClassDocumenter(ClassDocumenter):
-
-    def _get_signature(self):
-        old_signature = inspect.signature
-
-        def patch_signature(subject, bound_method=False, follow_wrapped=True):
-            # changes the default of follow_wrapped to True
-            return old_signature(subject, bound_method=bound_method,
-                                 follow_wrapped=follow_wrapped)
-        inspect.signature = patch_signature
-        result = super()._get_signature()
-        inspect.signature = old_signature
-        return result
-
 
 def setup(app):
-    app.registry.documenters['class'] = PatchedClassDocumenter
     app.connect('builder-inited', generate_min_dependency_table)
     app.connect('builder-inited', generate_min_dependency_substitutions)
     # to hide/show the prompt in code examples:

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -35,7 +35,7 @@ dependent_packages = {
     'flake8': ('3.8.2', 'tests'),
     'mypy': ('0.770', 'tests'),
     'pyamg': ('4.0.0', 'tests'),
-    'sphinx': ('3.2.0', 'docs'),
+    'sphinx': ('4.0.1', 'docs'),
     'sphinx-gallery': ('0.7.0', 'docs'),
     'numpydoc': ('1.0.0', 'docs'),
     'Pillow': ('7.1.2', 'docs'),


### PR DESCRIPTION
Related to https://github.com/scikit-learn/scikit-learn/issues/20027

There is an error with building with sphinx on 4.0:

```bash
WARNING: Failed to get a constructor signature for sklearn.tree.ExtraTreeRegressor: patch_signature() got an unexpected keyword argument 'type_aliases'
```

Removing the patch and using a newer version of sphinx resolves the original issue
