### PR TITLE
MAINT Black formatting prework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,6 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 21.6b0
-    hooks:
-    - id: black
-      language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.8
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 21.6b0
+    hooks:
+    - id: black
+      language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.8
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
         versionSpec: '3.9'
     - bash: |
         # Include pytest compatibility with mypy
-        pip install pytest flake8 mypy==0.782 black
+        pip install pytest flake8 mypy==0.782 black==21.6b0
       displayName: Install linters
     - bash: |
         # Remove comment when code is formatted by black

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
         pip install pytest flake8 mypy==0.782 black
       displayName: Install linters
     - bash: |
-        # Commit out when code is formatted by black
+        # Remove comment when code is formatted by black
         # black --check .
       displayName: Run black
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,8 +45,12 @@ jobs:
         versionSpec: '3.9'
     - bash: |
         # Include pytest compatibility with mypy
-        pip install pytest flake8 mypy==0.782
+        pip install pytest flake8 mypy==0.782 black
       displayName: Install linters
+    - bash: |
+        # Commit out when code is formatted by black
+        # black --check .
+      displayName: Run black
     - bash: |
         ./build_tools/circle/linting.sh
       displayName: Run linting

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -225,6 +225,8 @@ latest up-to-date workflow.
   For contributors who are viewing these videos to set up their
   working environment and submitting a PR, ``master`` should be replaced to ``main``.
 
+.. _how_to_contribute:
+
 How to contribute
 -----------------
 
@@ -256,7 +258,7 @@ how to set up your git repository:
 
     .. prompt:: bash $
 
-       pip install cython pytest pytest-cov flake8 mypy
+       pip install cython pytest pytest-cov flake8 mypy black
 
 5. Install scikit-learn in editable mode:
 
@@ -428,7 +430,15 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    non-regression tests should fail for the code base in the ``main`` branch
    and pass for the PR code.
 
-5. **Make sure that your PR does not add PEP8 violations**. To check the
+5. Run `black` to auto-format your code. Installing the pre-commit hook as
+   described in the :ref:`how_to_contribute` section will run black before
+   each commit.
+
+   .. prompt:: bash $
+
+        black
+
+6. **Make sure that your PR does not add PEP8 violations**. To check the
    code that you changed, you can run the following command (see
    :ref:`above <upstream>` to set up the ``upstream`` remote):
 
@@ -438,14 +448,14 @@ complies with the following rules before marking a PR as ``[MRG]``. The
 
    or `make flake8-diff` which should work on unix-like system.
 
-6. Follow the :ref:`coding-guidelines`.
+7. Follow the :ref:`coding-guidelines`.
 
 
-7. When applicable, use the validation tools and scripts in the
+8. When applicable, use the validation tools and scripts in the
    ``sklearn.utils`` submodule.  A list of utility routines available
    for developers can be found in the :ref:`developers-utils` page.
 
-8. Often pull requests resolve one or more other issues (or pull requests).
+9. Often pull requests resolve one or more other issues (or pull requests).
    If merging your pull request means that some other issues/PRs should
    be closed, you should `use keywords to create link to them
    <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
@@ -455,7 +465,7 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    related to some other issues/PRs, create a link to them without using
    the keywords (e.g., ``See also #1234``).
 
-9. PRs should often substantiate the change, through benchmarks of
+10. PRs should often substantiate the change, through benchmarks of
    performance and efficiency (see :ref:`monitoring_performances`) or through
    examples of usage. Examples also illustrate the features and intricacies of
    the library to users. Have a look at other examples in the `examples/
@@ -464,14 +474,14 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    functionality is useful in practice and, if possible, compare it to other
    methods available in scikit-learn.
 
-10. New features have some maintenance overhead. We expect PR authors
+11. New features have some maintenance overhead. We expect PR authors
     to take part in the maintenance for the code they submit, at least
     initially. New features need to be illustrated with narrative
     documentation in the user guide, with small code snippets.
     If relevant, please also add references in the literature, with PDF links
     when possible.
 
-11. The user guide should also include expected time and space complexity
+12. The user guide should also include expected time and space complexity
     of the algorithm and scalability, e.g. "this algorithm can scale to a
     large number of samples > 100000, but does not scale in dimensionality:
     n_features is expected to be lower than 100".
@@ -1352,3 +1362,13 @@ make this task easier and faster (in no particular order).
     <https://git-scm.com/docs/git-grep#_examples>`_) is also extremely
     useful to see every occurrence of a pattern (e.g. a function call or a
     variable) in the code base.
+
+- We can configure `git blame` to ignore the commit that migrated the code
+  style to `black`.
+
+  .. prompt:: bash $
+
+      git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+  Find out more information in black's
+  `documentation for avoiding ruining git blame <https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html#avoiding-ruining-git-blame>`_.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -256,7 +256,7 @@ how to set up your git repository:
 
     .. prompt:: bash $
 
-       pip install cython pytest pytest-cov flake8 mypy black
+       pip install cython pytest pytest-cov flake8 mypy black==21.6b0
 
 5. Install scikit-learn in editable mode:
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -225,8 +225,6 @@ latest up-to-date workflow.
   For contributors who are viewing these videos to set up their
   working environment and submitting a PR, ``master`` should be replaced to ``main``.
 
-.. _how_to_contribute:
-
 How to contribute
 -----------------
 
@@ -438,9 +436,7 @@ complies with the following rules before marking a PR as ``[MRG]``. The
 
    See black's
    `editor integration documentation <https://black.readthedocs.io/en/stable/integrations/editors.html>`_
-   to configure your editor to run `black`. Installing the pre-commit hook as
-   described in the :ref:`how_to_contribute` section will run black before
-   each commit.
+   to configure your editor to run `black`.
 
 6. **Make sure that your PR does not add PEP8 violations**. To check the
    code that you changed, you can run the following command (see

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -470,13 +470,13 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    the keywords (e.g., ``See also #1234``).
 
 10. PRs should often substantiate the change, through benchmarks of
-   performance and efficiency (see :ref:`monitoring_performances`) or through
-   examples of usage. Examples also illustrate the features and intricacies of
-   the library to users. Have a look at other examples in the `examples/
-   <https://github.com/scikit-learn/scikit-learn/tree/main/examples>`_
-   directory for reference. Examples should demonstrate why the new
-   functionality is useful in practice and, if possible, compare it to other
-   methods available in scikit-learn.
+    performance and efficiency (see :ref:`monitoring_performances`) or through
+    examples of usage. Examples also illustrate the features and intricacies of
+    the library to users. Have a look at other examples in the `examples/
+    <https://github.com/scikit-learn/scikit-learn/tree/main/examples>`_
+    directory for reference. Examples should demonstrate why the new
+    functionality is useful in practice and, if possible, compare it to other
+    methods available in scikit-learn.
 
 11. New features have some maintenance overhead. We expect PR authors
     to take part in the maintenance for the code they submit, at least

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -430,13 +430,17 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    non-regression tests should fail for the code base in the ``main`` branch
    and pass for the PR code.
 
-5. Run `black` to auto-format your code. Installing the pre-commit hook as
-   described in the :ref:`how_to_contribute` section will run black before
-   each commit.
+5. Run `black` to auto-format your code.
 
    .. prompt:: bash $
 
-        black
+        black .
+
+   See black's
+   `editor integration documentation <https://black.readthedocs.io/en/stable/integrations/editors.html>`_
+   to configure your editor to run `black`. Installing the pre-commit hook as
+   described in the :ref:`how_to_contribute` section will run black before
+   each commit.
 
 6. **Make sure that your PR does not add PEP8 violations**. To check the
    code that you changed, you can run the following command (see
@@ -1363,8 +1367,8 @@ make this task easier and faster (in no particular order).
     useful to see every occurrence of a pattern (e.g. a function call or a
     variable) in the code base.
 
-- We can configure `git blame` to ignore the commit that migrated the code
-  style to `black`.
+- Configure `git blame` to ignore the commit that migrated the code style to
+  `black`.
 
   .. prompt:: bash $
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,24 +20,15 @@ requires = [
 [tool.black]
 line-length = 88
 exclude = '''
-
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.mypy_cache
-    | examples
-    | build
-    | dist
-    | doc
-    | sklearn/externals
-  )/
-)
-'''
-include = '''
-(
-  /(
-      doc/conf.py
-  )/
-)
+/(
+    \.eggs         # exclude a few common directories in the
+  | \.git          # root of the project
+  | \.mypy_cache
+  | examples
+  | build
+  | dist
+  | doc/tutorial
+  | doc/sphinxext
+  | sklearn/externals
+)/
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,6 @@ exclude = '''
   | doc/_build
   | doc/auto_examples
   | sklearn/externals
+  | asv_benchmarks/env
 )/
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ exclude = '''
   | build
   | dist
   | doc/tutorial
-  | doc/sphinxext
+  | doc/auto_examples
   | sklearn/externals
 )/
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ exclude = '''
   | build
   | dist
   | doc/tutorial
+  | doc/_build
   | doc/auto_examples
   | sklearn/externals
 )/

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -33,6 +33,7 @@ dependent_packages = {
     'pytest': (PYTEST_MIN_VERSION, 'tests'),
     'pytest-cov': ('2.9.0', 'tests'),
     'flake8': ('3.8.2', 'tests'),
+    'black': ('21.6b0', 'tests'),
     'mypy': ('0.770', 'tests'),
     'pyamg': ('4.0.0', 'tests'),
     'sphinx': ('3.2.0', 'docs'),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/pull/18948

#### What does this implement/fix? Explain your changes.
This PR adds the documentation and prepares the CI to check black's formatting. This PR also fixes the black config to run correctly with `black .` I think we can do this all on the main branch:

1. Merge this PR.
2. Merge PR that runs black formatting. This PR also turns on CI to check black formatting.
3. Merge PR to add a `.git-blame-ignore-revs` that ignores the black formatting commit.
4. Cherrypick this PR onto `0.24.x` to update docs.

#### Any other comments?
I experimented with resolving merge conflicts merging black formatted code into some PRs. I think they are not difficult to resolve and should not be a major blocker.

CC @rth @NicolasHug 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
