### PR TITLE
MAINT Adds pytest to dependencies for mypy in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,4 @@ repos:
     hooks:
      -  id: mypy
         files: sklearn/
+        additional_dependencies: [pytest==6.2.4]


### PR DESCRIPTION
This PR adds pytest > 6 to run mypy without errors.

Without `pytest` installed we get errors like with the pre-commit hook:

```
sklearn/decomposition/tests/test_sparse_pca.py:193: error: List item 0 has incompatible type "Type[SparsePCA]"; expected "Type[SparsePCA]"
```

CC @rth