### PR TITLE
DOC do not mention freenode.net in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,10 +177,10 @@ Communication
 ~~~~~~~~~~~~~
 
 - Mailing list: https://mail.python.org/mailman/listinfo/scikit-learn
-- IRC channel: ``#scikit-learn`` at ``webchat.freenode.net``
 - Gitter: https://gitter.im/scikit-learn/scikit-learn
 - Twitter: https://twitter.com/scikit_learn
 - Stack Overflow: https://stackoverflow.com/questions/tagged/scikit-learn
+- Github Discussions: https://github.com/scikit-learn/scikit-learn/discussions
 - Website: https://scikit-learn.org
 
 Citation


### PR DESCRIPTION
Let's stop pointing our users to freenode after the [hostile take over](https://en.wikipedia.org/wiki/Freenode#Ownership_change_and_conflict) of the platform.

I added GitHub Discussions instead. If there are any IRC addict around here we could always open an "official" scikit-learn channel on https://libera.chat/ or similar but I don't think it's necessary of none of the maintainers plan to connect to it.