### PR TITLE
ADD possibility of having 0% test split

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2355,7 +2355,8 @@ def train_test_split(*arrays,
                 "Stratified train/test split is not implemented for "
                 "shuffle=False")
 
-        n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,default_test_size=0.25)
+        n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,
+        default_test_size=0.25)
 
         train = np.arange(n_train)
         test = np.arange(n_train, n_train + n_test)

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2355,8 +2355,8 @@ def train_test_split(*arrays,
                 "Stratified train/test split is not implemented for "
                 "shuffle=False")
 
-        n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,
-                                              default_test_size=0.25)
+        n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,default_test_size=0.25)
+
         train = np.arange(n_train)
         test = np.arange(n_train, n_train + n_test)
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2348,16 +2348,13 @@ def train_test_split(*arrays,
 
     n_samples = _num_samples(arrays[0])
 
-
     if shuffle is False:
         if stratify is not None:
             raise ValueError(
                 "Stratified train/test split is not implemented for "
                 "shuffle=False")
-
         n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,
-        default_test_size=0.25)
-
+                                                  default_test_size=0.25)
         train = np.arange(n_train)
         test = np.arange(n_train, n_train + n_test)
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1982,17 +1982,17 @@ def _validate_shuffle_split(n_samples, test_size, train_size,
     test_size_type = np.asarray(test_size).dtype.kind
     train_size_type = np.asarray(train_size).dtype.kind
 
-    if (test_size_type == 'i' and (test_size >= n_samples or test_size <= 0)
-       or test_size_type == 'f' and (test_size <= 0 or test_size >= 1)):
+    if (test_size_type == 'i' and (test_size >= n_samples or test_size < 0)
+       or test_size_type == 'f' and (test_size < 0 or test_size >= 1)):
         raise ValueError('test_size={0} should be either positive and smaller'
                          ' than the number of samples {1} or a float in the '
-                         '(0, 1) range'.format(test_size, n_samples))
+                         '[0, 1) range'.format(test_size, n_samples))
 
-    if (train_size_type == 'i' and (train_size >= n_samples or train_size <= 0)
-       or train_size_type == 'f' and (train_size <= 0 or train_size >= 1)):
-        raise ValueError('train_size={0} should be either positive and smaller'
-                         ' than the number of samples {1} or a float in the '
-                         '(0, 1) range'.format(train_size, n_samples))
+    if (train_size_type == 'i' and (train_size > n_samples or train_size <= 0)
+       or train_size_type == 'f' and (train_size <= 0 or train_size > 1)):
+        raise ValueError('train_size={0} should be either positive and smaller or equal'
+                         ' to the number of samples {1} or a float in the '
+                         '(0, 1] range'.format(train_size, n_samples))
 
     if train_size is not None and train_size_type not in ('i', 'f'):
         raise ValueError("Invalid value for train_size: {}".format(train_size))
@@ -2347,8 +2347,7 @@ def train_test_split(*arrays,
     arrays = indexable(*arrays)
 
     n_samples = _num_samples(arrays[0])
-    n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,
-                                              default_test_size=0.25)
+
 
     if shuffle is False:
         if stratify is not None:
@@ -2356,6 +2355,8 @@ def train_test_split(*arrays,
                 "Stratified train/test split is not implemented for "
                 "shuffle=False")
 
+        n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,
+                                              default_test_size=0.25)
         train = np.arange(n_train)
         test = np.arange(n_train, n_train + n_test)
 
@@ -2365,8 +2366,8 @@ def train_test_split(*arrays,
         else:
             CVClass = ShuffleSplit
 
-        cv = CVClass(test_size=n_test,
-                     train_size=n_train,
+        cv = CVClass(test_size=test_size,
+                     train_size=train_size,
                      random_state=random_state)
 
         train, test = next(cv.split(X=arrays[0], y=stratify))

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2347,14 +2347,14 @@ def train_test_split(*arrays,
     arrays = indexable(*arrays)
 
     n_samples = _num_samples(arrays[0])
-
+    n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,
+                                              default_test_size=0.25)
     if shuffle is False:
         if stratify is not None:
             raise ValueError(
                 "Stratified train/test split is not implemented for "
                 "shuffle=False")
-        n_train, n_test = _validate_shuffle_split(n_samples, test_size, train_size,
-                                                  default_test_size=0.25)
+
         train = np.arange(n_train)
         test = np.arange(n_train, n_train + n_test)
 
@@ -2364,8 +2364,8 @@ def train_test_split(*arrays,
         else:
             CVClass = ShuffleSplit
 
-        cv = CVClass(test_size=test_size,
-                     train_size=train_size,
+        cv = CVClass(test_size=n_test,
+                     train_size=n_train,
                      random_state=random_state)
 
         train, test = next(cv.split(X=arrays[0], y=stratify))

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1186,7 +1186,7 @@ def test_train_test_split_errors():
     (0.8, -.2)])
 def test_train_test_split_invalid_sizes1(train_size, test_size):
     with pytest.raises(ValueError,
-                       match=r'should be .* in the'):
+                       match=r'should be either positive and smaller'):
         train_test_split(range(10), train_size=train_size, test_size=test_size)
 
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1185,8 +1185,7 @@ def test_train_test_split_errors():
     (0.8, 1.),
     (0.8, -.2)])
 def test_train_test_split_invalid_sizes1(train_size, test_size):
-    with pytest.raises(ValueError,
-                       match=r'should be either positive and smaller'):
+    with pytest.raises(ValueError):
         train_test_split(range(10), train_size=train_size, test_size=test_size)
 
 
@@ -1197,8 +1196,7 @@ def test_train_test_split_invalid_sizes1(train_size, test_size):
     (0.8, -10),
     (0.8, 11)])
 def test_train_test_split_invalid_sizes2(train_size, test_size):
-    with pytest.raises(ValueError,
-                       match=r'should be either positive and smaller'):
+    with pytest.raises(ValueError):
         train_test_split(range(10), train_size=train_size, test_size=test_size)
 
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -940,8 +940,7 @@ def test_leave_one_p_group_out():
     assert repr(logo) == 'LeaveOneGroupOut()'
     assert repr(lpgo_1) == 'LeavePGroupsOut(n_groups=1)'
     assert repr(lpgo_2) == 'LeavePGroupsOut(n_groups=2)'
-    assert (repr(LeavePGroupsOut(n_groups=3)) ==
-                 'LeavePGroupsOut(n_groups=3)')
+    assert (repr(LeavePGroupsOut(n_groups=3)) == 'LeavePGroupsOut(n_groups=3)')
 
     for j, (cv, p_groups_out) in enumerate(((logo, 1), (lpgo_1, 1),
                                             (lpgo_2, 2))):
@@ -1008,7 +1007,7 @@ def test_leave_group_out_changing_groups():
     # n_splits = no of 2 (p) group combinations of the unique groups = 3C2 = 3
     assert (
         3 == LeavePGroupsOut(n_groups=2).get_n_splits(X, y=X,
-                                                    groups=groups))
+                                                      groups=groups))
     # n_splits = no of unique groups (C(uniq_lbls, 1) = n_unique_groups)
     assert 3 == LeaveOneGroupOut().get_n_splits(X, y=X,
                                                 groups=groups)
@@ -1184,7 +1183,6 @@ def test_train_test_split_errors():
     (-.2, 0.8),
     (0.8, 1.2),
     (0.8, 1.),
-    (0.8, 0.),
     (0.8, -.2)])
 def test_train_test_split_invalid_sizes1(train_size, test_size):
     with pytest.raises(ValueError,
@@ -1197,7 +1195,6 @@ def test_train_test_split_invalid_sizes1(train_size, test_size):
     (0, 0.8),
     (11, 0.8),
     (0.8, -10),
-    (0.8, 0),
     (0.8, 11)])
 def test_train_test_split_invalid_sizes2(train_size, test_size):
     with pytest.raises(ValueError,
@@ -1462,8 +1459,7 @@ def test_group_kfold(kfold):
     # Check that folds have approximately the same size
     assert len(folds) == len(groups)
     for i in np.unique(folds):
-        assert (tolerance >=
-                             abs(sum(folds == i) - ideal_n_groups_per_fold))
+        assert (tolerance >= abs(sum(folds == i) - ideal_n_groups_per_fold))
 
     # Check that each group appears only in 1 fold
     for group in np.unique(groups):
@@ -1499,8 +1495,7 @@ def test_group_kfold(kfold):
     # Check that folds have approximately the same size
     assert len(folds) == len(groups)
     for i in np.unique(folds):
-        assert (tolerance >=
-                             abs(sum(folds == i) - ideal_n_groups_per_fold))
+        assert (tolerance >= abs(sum(folds == i) - ideal_n_groups_per_fold))
 
     # Check that each group appears only in 1 fold
     with warnings.catch_warnings():

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1170,9 +1170,9 @@ def test_train_test_split_errors():
                   shuffle=False, stratify=True)
 
     with pytest.raises(ValueError,
-                       match=r'train_size=11 should be either positive and '
-                             r'smaller than the number of samples 10 or a '
-                             r'float in the \(0, 1\) range'):
+                       match=r'train_size=11 should be either positive and smaller '
+                             r'or equal to the number of samples 10 or a '
+                             r'float in the \(0, 1\] range'):
         train_test_split(range(10), train_size=11, test_size=1)
 
 
@@ -1186,7 +1186,7 @@ def test_train_test_split_errors():
     (0.8, -.2)])
 def test_train_test_split_invalid_sizes1(train_size, test_size):
     with pytest.raises(ValueError,
-                       match=r'should be .* in the \(0, 1\) range'):
+                       match=r'should be .* in the'):
         train_test_split(range(10), train_size=train_size, test_size=test_size)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Fixes #20276.
Also, if shuffle is True now it only runs **_validate_shuffle_split** once in the **StratifiedShuffleSplit** or **ShuffleSplit** classes, before it was running twice
-->


Allows for users to have a 0% test and 100% training split.


Might wonder why use this function at all if no split is necessary but it can fit into some niche use cases like mentioned in #20276.

An example of a use case:
A user creating a training pipeline with several split scenarios might want to include a run with 100% allocated to test without adding extra logic, just passing the split into the **train_test_split** function
