### PR TITLE
FIX ColumnTransformer raise TypeError when remainder columns have incompatible dtype

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -660,7 +660,13 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             return sparse.hstack(converted_Xs).tocsr()
         else:
             Xs = [f.toarray() if sparse.issparse(f) else f for f in Xs]
-            return np.hstack(Xs)
+
+            # convert to a common dtype explicitly before np.hstack
+            # detail see issue 20090
+            array_dtypes = [x.dtype if hasattr(x, 'dtype') else x.values.dtype
+                            for x in Xs]
+            common_dtype = np.find_common_type(array_dtypes, [])
+            return np.hstack([x.astype(common_dtype) for x in Xs])
 
     def _sk_visual_block_(self):
         if isinstance(self.remainder, str) and self.remainder == 'drop':


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a fix to #20090 

#### What does this implement/fix? Explain your changes.
As discussed in the issue thread, the error is raised because the remainder columns that got passed through has incompatible dtype. This fix converts all the columns into a common dtype explicitly before calling `np.hstack` to avoid the error.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
