### PR TITLE
MAINT Adds .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Since git version 2.23, git-blame has a feature to ignore
+# certain commits.
+#
+# This file contains a list of commits that are not likely what
+# you are looking for in `git blame`. You can set this file as
+# a default ignore file for blame by running the following
+# command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# PR 18948: Migrate code style to Black
+82df48934eba1df9a1ed3be98aaace8eada59e6e


### PR DESCRIPTION
Follow up to https://github.com/scikit-learn/scikit-learn/pull/20289

This PR adds `.git-blame-ignore-revs` so `git blame` works locally.