### PR TITLE
MAINT Adds target_version to black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requires = [
 
 [tool.black]
 line-length = 88
+target_version = ['py37', 'py38', 'py39']
 exclude = '''
 /(
     \.eggs         # exclude a few common directories in the


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #20260

#### What does this implement/fix? Explain your changes.
I forgot to include this configuration option. It basically adds [trailing commas](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#trailing-commas) which was only support for python >= 3.6. You can see the diff at: https://github.com/scikit-learn/scikit-learn/pull/20294

With this change I think we need to update the "how to deal with merge conflicts" with an extra step:

1. `git merge --abort`
2. `git fetch upstream`
3. `git merge 0e7761cdc4f244adb4803f1a97f0a9fe4b365a99`
4. **New step**: `git cherry-pick THIS_PR`
5. `pip install black==21.6b0`
6. `black .`
7. Commit black formatted changes.
8. Merge with main.

CC @ogrisel @rth


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
