### PR TITLE
MNT skip test_min_dependencies_readme on PyPy

### DIFF
--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -3,6 +3,7 @@
 
 import os
 import re
+import platform
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,9 @@ def test_min_dependencies_readme():
     # Test that the minimum dependencies in the README.rst file are
     # consistent with the minimum dependencies defined at the file:
     # sklearn/_min_dependencies.py
+
+    if platform.python_implementation() == "PyPy":
+        pytest.skip("PyPy does not always share the same minimum deps")
 
     pattern = re.compile(
         r"(\.\. \|)"


### PR DESCRIPTION
The PyPy run on Circle CI is currently failing with:

https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn/14709/workflows/30669894-75ba-4b13-8500-8b164498f4a3/jobs/141724