### PR TITLE
Remove unused variables in TfidfTransformer's transform method

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1570,8 +1570,6 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
         if not sp.issparse(X):
             X = sp.csr_matrix(X, dtype=np.float64)
 
-        n_samples, n_features = X.shape
-
         if self.sublinear_tf:
             np.log(X.data, X.data)
             X.data += 1


### PR DESCRIPTION
#### Reference Issues/PRs
Progress towards #12167


#### What does this implement/fix? Explain your changes.
Removes unused variable assignments as flagged by [lgtm.com](https://lgtm.com/projects/g/scikit-learn/scikit-learn/snapshot/0974bdf41b61cd215286b0137a405b2705a3698c/files/sklearn/feature_extraction/text.py?sort=name&dir=ASC&mode=heatmap#x84ffa19f13aa7f6f:1)
