### PR TITLE
MAINT Remove unused variables and fix imports indicated by lgtm.com

### DIFF
--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -1,4 +1,3 @@
-import os
 from os import environ
 from functools import wraps
 import platform
@@ -193,11 +192,12 @@ def pytest_runtest_setup(item):
     item : pytest item
         item to be processed
     """
-    try:
-        xdist_worker_count = int(os.environ["PYTEST_XDIST_WORKER_COUNT"])
-    except KeyError:
-        # raises when pytest-xdist is not installed
+    xdist_worker_count = environ.get("PYTEST_XDIST_WORKER_COUNT")
+    if xdist_worker_count is None:
+        # returns if pytest-xdist is not installed
         return
+    else:
+        xdist_worker_count = int(xdist_worker_count)
 
     openmp_threads = _openmp_effective_n_threads()
     threads_per_worker = max(openmp_threads // xdist_worker_count, 1)

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -1450,8 +1450,6 @@ class NMF(TransformerMixin, BaseEstimator):
                 "to X, or use a positive beta_loss."
             )
 
-        n_samples, n_features = X.shape
-
         # check parameters
         self._check_params(X)
 

--- a/sklearn/externals/_arff.py
+++ b/sklearn/externals/_arff.py
@@ -148,9 +148,8 @@ __author_email__ = ('renato.ppontes@gmail.com, '
 __version__ = '2.4.0'
 
 import re
-import sys
 import csv
-import typing
+from typing import TYPE_CHECKING
 from typing import Optional, List, Dict, Any, Iterator, Union, Tuple
 
 # CONSTANTS ===================================================================
@@ -173,7 +172,7 @@ ArffDenseDataType = Iterator[List]
 ArffSparseDataType = Tuple[List, ...]
 
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     # typing_extensions is available when mypy is installed
     from typing_extensions import TypedDict
 
@@ -297,7 +296,7 @@ def _parse_values(s):
         try:
             return {int(k): _unquote(v)
                     for k, v in _RE_SPARSE_KEY_VALUES.findall(s)}
-        except ValueError as exc:
+        except ValueError:
             # an ARFF syntax error in sparse data
             for match in _RE_SPARSE_KEY_VALUES.finditer(s):
                 if not match.group(1):

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1009,7 +1009,7 @@ class MinimalTransformer:
         return self
 
     def fit(self, X, y=None):
-        X = check_array(X)
+        check_array(X)
         self.is_fitted_ = True
         return self
 


### PR DESCRIPTION
#### Reference Issues/PRs
Progress towards #12167


#### What does this implement/fix? Explain your changes.
Applies some of the recommendations from [lgtm](https://lgtm.com/projects/g/scikit-learn/scikit-learn?mode=list&severity=recommendation):
- [Remove unused variables in the method _fit_transform from the class Non-negative matrix factorization](https://lgtm.com/projects/g/scikit-learn/scikit-learn/snapshot/0974bdf41b61cd215286b0137a405b2705a3698c/files/sklearn/decomposition/_nmf.py?sort=name&dir=ASC&mode=heatmap#xa5109f08d78908c2:1)
- Fix imports and remove unused variable from module externals _arff ([1](https://lgtm.com/projects/g/scikit-learn/scikit-learn/snapshot/0974bdf41b61cd215286b0137a405b2705a3698c/files/sklearn/externals/_arff.py?sort=name&dir=ASC&mode=heatmap#x9ee6ae340889bd01:1) and [2](https://lgtm.com/projects/g/scikit-learn/scikit-learn/snapshot/0974bdf41b61cd215286b0137a405b2705a3698c/files/sklearn/externals/_arff.py?sort=name&dir=ASC&mode=heatmap#x7c483de96751b918:1))
- [Change way in which the environment variable PYTEST_XDIST_WORKER_COUNT is loaded and remove unused import](https://lgtm.com/projects/g/scikit-learn/scikit-learn/snapshot/0974bdf41b61cd215286b0137a405b2705a3698c/files/sklearn/conftest.py#xe5aa666d72c68b2e:1)
- [Remove unused variable from MinimalTransformer's fit method](https://lgtm.com/projects/g/scikit-learn/scikit-learn/snapshot/0974bdf41b61cd215286b0137a405b2705a3698c/files/sklearn/utils/_testing.py?sort=name&dir=ASC&mode=heatmap#x6b3d36df1afae46:1)
