### PR TITLE
TST Use the estimator name exactly in numpydoc test

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -333,7 +333,7 @@ def test_docstring(Estimator, method, request):
 
     import_path = ".".join(import_path)
 
-    if any(re.search(regex, import_path) for regex in DOCSTRING_IGNORE_LIST):
+    if Estimator.__name__ in DOCSTRING_IGNORE_LIST:
         request.applymarker(
             pytest.mark.xfail(run=False, reason="TODO pass numpydoc validation")
         )


### PR DESCRIPTION
Follow up to https://github.com/scikit-learn/scikit-learn/pull/20304

Using regex sometimes ignore things that it should not ignore. For example, estimators like `MultiTaskLassoCV` would match on `MultiTaskElasticNet` and get ignored.