### PR TITLE
MAINT Adjusts pinv usage based on scipy version

### DIFF
--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -220,6 +220,10 @@ def test_discretize(n_samples):
 @pytest.mark.filterwarnings(
     "ignore:`np.float` is a deprecated alias:DeprecationWarning:pyamg.*"
 )
+# TODO: Remove when pyamg removes the use of pinv2
+@pytest.mark.filterwarnings(
+    "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
+)
 def test_spectral_clustering_with_arpack_amg_solvers():
     # Test that spectral_clustering is the same for arpack and amg solver
     # Based on toy example from plot_segmentation_toy.py

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -9,17 +9,27 @@ import warnings
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
-from scipy.linalg import pinv2, svd
+from scipy.linalg import svd
 
 from ..base import BaseEstimator, RegressorMixin, TransformerMixin
 from ..base import MultiOutputMixin
 from ..utils import check_array, check_consistent_length
+from ..utils.fixes import sp_version
+from ..utils.fixes import parse_version
 from ..utils.extmath import svd_flip
 from ..utils.validation import check_is_fitted, FLOAT_DTYPES
 from ..exceptions import ConvergenceWarning
 from ..utils.deprecation import deprecated
 
 __all__ = ["PLSCanonical", "PLSRegression", "PLSSVD"]
+
+
+if sp_version >= parse_version("1.7"):
+    # Starting in scipy 1.7 pinv2 was deprecated in favor of pinv.
+    # pinv now uses the svd to compute the pseudo-inverse.
+    from scipy.linalg import pinv as pinv2
+else:
+    from scipy.linalg import pinv2
 
 
 def _pinv2_old(a):

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -201,6 +201,10 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
 @pytest.mark.filterwarnings(
     "ignore:`np.float` is a deprecated alias:DeprecationWarning:pyamg.*"
 )
+# TODO: Remove when pyamg removes the use of pinv2
+@pytest.mark.filterwarnings(
+    "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
+)
 def test_spectral_embedding_amg_solver(seed=36):
     # Test spectral embedding with amg solver
     pytest.importorskip("pyamg")
@@ -249,6 +253,10 @@ def test_spectral_embedding_amg_solver(seed=36):
 # TODO: Remove when pyamg removes the use of np.float
 @pytest.mark.filterwarnings(
     "ignore:`np.float` is a deprecated alias:DeprecationWarning:pyamg.*"
+)
+# TODO: Remove when pyamg removes the use of pinv2
+@pytest.mark.filterwarnings(
+    "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
 def test_spectral_embedding_amg_solver_failure():
     # Non-regression test for amg solver failure (issue #13393 on github)

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1437,23 +1437,12 @@ def _pairwise_callable(X, Y, metric, force_all_finite=True, **kwds):
     """Handle the callable case for pairwise_{distances,kernels}."""
     X, Y = check_pairwise_arrays(X, Y, force_all_finite=force_all_finite)
 
-    X_is_sparse = issparse(X)
-    Y_is_sparse = issparse(Y)
-
-    def _metric(X_i, Y_j, **kwds):
-        # Scipy 1.7 metrics expects 1d arrays and sliced sparse matrices, X[i],
-        # are thread as 0d arrays. Forcing the sliced sparse matrix into a 1d object
-        # arrray reproduces the behavior from scipy < 1.7.
-        X_i = np.atleast_1d(X_i) if X_is_sparse else X_i
-        Y_j = np.atleast_1d(Y_j) if Y_is_sparse else Y_j
-        return metric(X_i, Y_j, **kwds)
-
     if X is Y:
         # Only calculate metric for upper triangle
         out = np.zeros((X.shape[0], Y.shape[0]), dtype="float")
         iterator = itertools.combinations(range(X.shape[0]), 2)
         for i, j in iterator:
-            out[i, j] = _metric(X[i], Y[j], **kwds)
+            out[i, j] = metric(X[i], Y[j], **kwds)
 
         # Make symmetric
         # NB: out += out.T will produce incorrect results
@@ -1463,14 +1452,14 @@ def _pairwise_callable(X, Y, metric, force_all_finite=True, **kwds):
         # NB: nonzero diagonals are allowed for both metrics and kernels
         for i in range(X.shape[0]):
             x = X[i]
-            out[i, i] = _metric(x, x, **kwds)
+            out[i, i] = metric(x, x, **kwds)
 
     else:
         # Calculate all cells
         out = np.empty((X.shape[0], Y.shape[0]), dtype="float")
         iterator = itertools.product(range(X.shape[0]), range(Y.shape[0]))
         for i, j in iterator:
-            out[i, j] = _metric(X[i], Y[j], **kwds)
+            out[i, j] = metric(X[i], Y[j], **kwds)
 
     return out
 


### PR DESCRIPTION
Resolves failing test on CI from the release of scipy 1.7

`pinv` now uses svd and `pinv2` is deprecated.