### PR TITLE
FIX: adjusted_rand_score()

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -389,6 +389,10 @@ def adjusted_rand_score(labels_true, labels_pred):
     adjusted_mutual_info_score : Adjusted Mutual Information.
     """
     (tn, fp), (fn, tp) = pair_confusion_matrix(labels_true, labels_pred)
+    tn=int(tn)
+    fp=int(fp)
+    fn=int(fn)
+    tp=int(tp)
 
     # Special cases: empty data or full agreement
     if fn == 0 and fp == 0:


### PR DESCRIPTION
Follow up #20305
for large input adjusted_rand_score() give wrong values
converted variables from numpy.int64 to int to handle large values

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
