### PR TITLE
Rmsle (root mean squared log error)

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -21,6 +21,7 @@ the lower the better.
 #          Konstantin Shmelkov <konstantin.shmelkov@polytechnique.edu>
 #          Christian Lorentzen <lorentzen.ch@googlemail.com>
 #          Ashutosh Hathidara <ashutoshhathidara98@gmail.com>
+#          Uttam Kumar <bajiraouttamsinha@gmail.com>
 # License: BSD 3 clause
 
 import numpy as np

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -437,7 +437,7 @@ def mean_squared_error(
 
 
 def mean_squared_log_error(
-    y_true, y_pred, *, sample_weight=None, multioutput="uniform_average"
+    y_true, y_pred, *, sample_weight=None, multioutput="uniform_average", squared=True
 ):
     """Mean squared logarithmic error regression loss.
 
@@ -466,6 +466,9 @@ def mean_squared_log_error(
 
         'uniform_average' :
             Errors of all outputs are averaged with uniform weight.
+            
+        'squared' : bool, default=True
+        If True returns MSLE(mean squared log error) value, if False returns RMSLE(root mean squared log error) value.
 
     Returns
     -------
@@ -488,6 +491,8 @@ def mean_squared_log_error(
     array([0.00462428, 0.08377444])
     >>> mean_squared_log_error(y_true, y_pred, multioutput=[0.3, 0.7])
     0.060...
+    >>> mean_squared_log_error(y_true, y_pred, squared=False)
+    0.197...
     """
     y_type, y_true, y_pred, multioutput = _check_reg_targets(
         y_true, y_pred, multioutput
@@ -499,13 +504,19 @@ def mean_squared_log_error(
             "Mean Squared Logarithmic Error cannot be used when "
             "targets contain negative values."
         )
-
-    return mean_squared_error(
-        np.log1p(y_true),
-        np.log1p(y_pred),
-        sample_weight=sample_weight,
-        multioutput=multioutput,
-    )
+    if not squared:
+        return np.sqrt( mean_squared_error(
+            np.log1p(y_true),
+            np.log1p(y_pred),
+            sample_weight=sample_weight,
+            multioutput=multioutput,)
+    else:
+        return mean_squared_error(
+            np.log1p(y_true),
+            np.log1p(y_pred),
+            sample_weight=sample_weight,
+            multioutput=multioutput,
+        )
 
 
 def median_absolute_error(

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -469,7 +469,8 @@ def mean_squared_log_error(
             Errors of all outputs are averaged with uniform weight.
             
         'squared' : bool, default=True
-        If True returns MSLE(mean squared log error) value, if False returns RMSLE(root mean squared log error) value.
+        If True returns the mean squared log error (MSLE), if False returns the root
+        mean squared log error (RMSLE).
 
     Returns
     -------

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -505,19 +505,16 @@ def mean_squared_log_error(
             "Mean Squared Logarithmic Error cannot be used when "
             "targets contain negative values."
         )
-    if not squared:
-        return np.sqrt( mean_squared_error(
-            np.log1p(y_true),
-            np.log1p(y_pred),
-            sample_weight=sample_weight,
-            multioutput=multioutput,)
-    else:
-        return mean_squared_error(
+    msle = mean_squared_error(
             np.log1p(y_true),
             np.log1p(y_pred),
             sample_weight=sample_weight,
             multioutput=multioutput,
         )
+    if squared:
+        return msle
+    else:
+        return np.sqrt(msle)
 
 
 def median_absolute_error(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Fixes #20318

I had created  PR #20316  in which I had implemented the same, but as a function. In this PR I had updated the parameter named 'squared='


#### What does this implement/fix? Explain your changes.
By default  the value of `squared` is **True** which will return  `mean_square_log_error` but when it will turn to **False**  then it will  return `root_mean_square_log_error'.

`root_mean_square_log_error' is nothing but the square root of `mean_square_log_error'

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
