### PR TITLE
MNT Remove fixtures for Numpy 1.3 and 1.4 compatibility

### DIFF
--- a/sklearn/neighbors/_dist_metrics.pxd
+++ b/sklearn/neighbors/_dist_metrics.pxd
@@ -51,12 +51,8 @@ cdef class DistanceMetric:
     # Because we don't expect to instantiate a lot of these objects, the
     # extra memory overhead of this setup should not be an issue.
     cdef DTYPE_t p
-    #cdef DTYPE_t[::1] vec
-    #cdef DTYPE_t[:, ::1] mat
-    cdef np.ndarray vec
-    cdef np.ndarray mat
-    cdef DTYPE_t* vec_ptr
-    cdef DTYPE_t* mat_ptr
+    cdef DTYPE_t[::1] vec
+    cdef DTYPE_t[:, ::1] mat
     cdef ITYPE_t size
     cdef object func
     cdef object kwargs

--- a/sklearn/neighbors/_dist_metrics.pyx
+++ b/sklearn/neighbors/_dist_metrics.pyx
@@ -12,17 +12,6 @@ cimport numpy as np
 np.import_array()  # required in order to use C-API
 
 
-######################################################################
-# Numpy 1.3-1.4 compatibility utilities
-cdef DTYPE_t* get_vec_ptr(np.ndarray[DTYPE_t, ndim=1, mode='c'] vec):
-    return &vec[0]
-
-
-cdef DTYPE_t* get_mat_ptr(np.ndarray[DTYPE_t, ndim=2, mode='c'] mat):
-    return &mat[0, 0]
-######################################################################
-
-
 # First, define a function to get an ndarray from a memory bufffer
 cdef extern from "arrayobject.h":
     object PyArray_SimpleNewFromData(int nd, np.npy_intp* dims,
@@ -209,8 +198,6 @@ cdef class DistanceMetric:
         self.p = 2
         self.vec = np.zeros(1, dtype=DTYPE, order='c')
         self.mat = np.zeros((1, 1), dtype=DTYPE, order='c')
-        self.vec_ptr = get_vec_ptr(self.vec)
-        self.mat_ptr = get_mat_ptr(self.mat)
         self.size = 1
 
     def __reduce__(self):
@@ -224,8 +211,8 @@ cdef class DistanceMetric:
         get state for pickling
         """
         if self.__class__.__name__ == "PyFuncDistance":
-            return (float(self.p), self.vec, self.mat, self.func, self.kwargs)
-        return (float(self.p), self.vec, self.mat)
+            return (float(self.p), np.asarray(self.vec), np.asarray(self.mat), self.func, self.kwargs)
+        return (float(self.p), np.asarray(self.vec), np.asarray(self.mat))
 
     def __setstate__(self, state):
         """
@@ -237,8 +224,6 @@ cdef class DistanceMetric:
         if self.__class__.__name__ == "PyFuncDistance":
             self.func = state[3]
             self.kwargs = state[4]
-        self.vec_ptr = get_vec_ptr(self.vec)
-        self.mat_ptr = get_mat_ptr(self.mat)
         self.size = self.vec.shape[0]
 
     @classmethod
@@ -447,7 +432,6 @@ cdef class SEuclideanDistance(DistanceMetric):
     """
     def __init__(self, V):
         self.vec = np.asarray(V, dtype=DTYPE)
-        self.vec_ptr = get_vec_ptr(self.vec)
         self.size = self.vec.shape[0]
         self.p = 2
 
@@ -461,7 +445,7 @@ cdef class SEuclideanDistance(DistanceMetric):
         cdef np.intp_t j
         for j in range(size):
             tmp = x1[j] - x2[j]
-            d += tmp * tmp / self.vec_ptr[j]
+            d += tmp * tmp / self.vec[j]
         return d
 
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
@@ -609,7 +593,6 @@ cdef class WMinkowskiDistance(DistanceMetric):
                              "For p=inf, use ChebyshevDistance.")
         self.p = p
         self.vec = np.asarray(w, dtype=DTYPE)
-        self.vec_ptr = get_vec_ptr(self.vec)
         self.size = self.vec.shape[0]
 
     def _validate_data(self, X):
@@ -622,7 +605,7 @@ cdef class WMinkowskiDistance(DistanceMetric):
         cdef DTYPE_t d=0
         cdef np.intp_t j
         for j in range(size):
-            d += pow(self.vec_ptr[j] * fabs(x1[j] - x2[j]), self.p)
+            d += pow(self.vec[j] * fabs(x1[j] - x2[j]), self.p)
         return d
 
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
@@ -670,13 +653,11 @@ cdef class MahalanobisDistance(DistanceMetric):
             raise ValueError("V/VI must be square")
 
         self.mat = np.asarray(VI, dtype=float, order='C')
-        self.mat_ptr = get_mat_ptr(self.mat)
 
         self.size = self.mat.shape[0]
 
         # we need vec as a work buffer
         self.vec = np.zeros(self.size, dtype=DTYPE)
-        self.vec_ptr = get_vec_ptr(self.vec)
 
     def _validate_data(self, X):
         if X.shape[1] != self.size:
@@ -689,13 +670,13 @@ cdef class MahalanobisDistance(DistanceMetric):
 
         # compute (x1 - x2).T * VI * (x1 - x2)
         for i in range(size):
-            self.vec_ptr[i] = x1[i] - x2[i]
+            self.vec[i] = x1[i] - x2[i]
 
         for i in range(size):
             tmp = 0
             for j in range(size):
-                tmp += self.mat_ptr[i * size + j] * self.vec_ptr[j]
-            d += tmp * self.vec_ptr[i]
+                tmp += self.mat[i, j] * self.vec[j]
+            d += tmp * self.vec[i]
         return d
 
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,

--- a/sklearn/neighbors/_dist_metrics.pyx
+++ b/sklearn/neighbors/_dist_metrics.pyx
@@ -1,6 +1,7 @@
 #!python
 #cython: boundscheck=False
 #cython: wraparound=False
+#cython: initializedcheck=False
 #cython: cdivision=True
 
 # By Jake Vanderplas (2013) <jakevdp@cs.washington.edu>


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None.

#### What does this implement/fix? Explain your changes.

Some fixtures for Numpy 1.3 and Numpy 1.4 were included.
They are no longer needed.

Pointers to `vec` and `mat` arrays have also been dropped.

`vec` and `mat` are now memoryviews, and the state
for pickling has been adapted to explicitely cast
memoryview as numpy arrays to recover the same
behavior.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
