### PR TITLE
TST Remove test for sparse matrices and minkowski

### DIFF
--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -298,24 +298,13 @@ def callable_rbf_kernel(x, y, **kwds):
         (pairwise_kernels, callable_rbf_kernel, {"gamma": 0.1}),
     ],
 )
-@pytest.mark.parametrize("array_constr", [np.array, csr_matrix])
 @pytest.mark.parametrize("dtype", [np.float64, int])
-def test_pairwise_parallel(func, metric, kwds, array_constr, dtype):
+def test_pairwise_parallel(func, metric, kwds, dtype):
     rng = np.random.RandomState(0)
-    X = array_constr(5 * rng.random_sample((5, 4)), dtype=dtype)
-    Y = array_constr(5 * rng.random_sample((3, 4)), dtype=dtype)
+    X = np.array(5 * rng.random_sample((5, 4)), dtype=dtype)
+    Y = np.array(5 * rng.random_sample((3, 4)), dtype=dtype)
 
-    try:
-        S = func(X, metric=metric, n_jobs=1, **kwds)
-    except (TypeError, ValueError) as exc:
-        # Not all metrics support sparse input
-        # ValueError may be triggered by bad callable
-        if array_constr is csr_matrix:
-            with pytest.raises(type(exc)):
-                func(X, metric=metric, n_jobs=2, **kwds)
-            return
-        else:
-            raise
+    S = func(X, metric=metric, n_jobs=1, **kwds)
     S2 = func(X, metric=metric, n_jobs=2, **kwds)
     assert_allclose(S, S2)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/pull/20309

#### What does this implement/fix? Explain your changes.
Based on our docs:

https://github.com/scikit-learn/scikit-learn/blob/490b61d9ad7226043ef37e357bd7ab33f4c59635/sklearn/metrics/pairwise.py#L1747-L1748

we do not actually support `minkowski` for sparse matrices or any of the `scipy.spatial.distance` with sparse matrices.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
