### PR TITLE
Update outdated link

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -447,7 +447,7 @@ fold cross validation should be preferred to LOO.
  * L. Breiman, P. Spector `Submodel selection and evaluation in regression: The X-random case
    <http://digitalassets.lib.berkeley.edu/sdtr/ucb/text/197.pdf>`_, International Statistical Review 1992;
  * R. Kohavi, `A Study of Cross-Validation and Bootstrap for Accuracy Estimation and Model Selection
-   <http://web.cs.iastate.edu/~jtian/cs573/Papers/Kohavi-IJCAI-95.pdf>`_, Intl. Jnt. Conf. AI
+   <https://www.ijcai.org/Proceedings/95-2/Papers/016.pdf>`_, Intl. Jnt. Conf. AI
  * R. Bharat Rao, G. Fung, R. Rosales, `On the Dangers of Cross-Validation. An Experimental Evaluation
    <https://people.csail.mit.edu/romer/papers/CrossVal_SDM08.pdf>`_, SIAM 2008;
  * G. James, D. Witten, T. Hastie, R Tibshirani, `An Introduction to


### PR DESCRIPTION
Original link to the paper "R. Kohavi, A Study of Cross-Validation and Bootstrap for Accuracy Estimation and Model Selection" from Intl. Jnt. Conf. AI seems broken.

I couldn't find the fixed version (if it even exists), so I chose the official conference link.

- **Original**: http://web.cs.iastate.edu/~jtian/cs573/Papers/Kohavi-IJCAI-95.pdf
- **New**: https://www.ijcai.org/Proceedings/95-2/Papers/016.pdf