### PR TITLE
MAINT Skip unstable GPR tests on 32 bit Python

### DIFF
--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -51,8 +51,8 @@ non_fixed_kernels = [kernel for kernel in kernels if kernel != fixed_kernel]
 
 @pytest.mark.parametrize("kernel", kernels)
 def test_gpr_interpolation(kernel):
-    if sys.maxsize <= 2 ** 32 and sys.version_info[:2] == (3, 6):
-        pytest.xfail("This test may fail on 32bit Py3.6")
+    if sys.maxsize <= 2 ** 32:
+        pytest.xfail("This test may fail on 32 bit Python")
 
     # Test the interpolating property for different kernels.
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
@@ -79,8 +79,8 @@ def test_gpr_interpolation_structured():
 
 @pytest.mark.parametrize("kernel", non_fixed_kernels)
 def test_lml_improving(kernel):
-    if sys.maxsize <= 2 ** 32 and sys.version_info[:2] == (3, 6):
-        pytest.xfail("This test may fail on 32bit Py3.6")
+    if sys.maxsize <= 2 ** 32:
+        pytest.xfail("This test may fail on 32 bit Python")
 
     # Test that hyperparameter-tuning improves log-marginal likelihood.
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
@@ -192,8 +192,8 @@ def test_no_optimizer():
 @pytest.mark.parametrize("kernel", kernels)
 @pytest.mark.parametrize("target", [y, np.ones(X.shape[0], dtype=np.float64)])
 def test_predict_cov_vs_std(kernel, target):
-    if sys.maxsize <= 2 ** 32 and sys.version_info[:2] == (3, 6):
-        pytest.xfail("This test may fail on 32bit Py3.6")
+    if sys.maxsize <= 2 ** 32:
+        pytest.xfail("This test may fail on 32 bit Python")
 
     # Test that predicted std.-dev. is consistent with cov's diagonal.
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)


### PR DESCRIPTION
Those tests failed with Python 3.7 and 3.8 on 32 bit linux on the nightly `[cd build]` runs since a few days (possibly related to scipy 1.7.0) but those tests were also previously skipped on Python 3.6.

Lists of impacted tests:

- `test_gpr_interpolation`
- `test_lml_improving`
- `test_predict_cov_vs_std`

Observed failures:

```python
      @pytest.mark.parametrize("kernel", kernels)
      def test_gpr_interpolation(kernel):
          if sys.maxsize <= 2 ** 32 and sys.version_info[:2] == (3, 6):
              pytest.xfail("This test may fail on 32bit Py3.6")
      
          # Test the interpolating property for different kernels.
          gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
          y_pred, y_cov = gpr.predict(X, return_cov=True)
      
  >       assert_almost_equal(y_pred, y)
  E       AssertionError: 
  E       Arrays are not almost equal to 7 decimals
  E       
  E       Mismatched elements: 6 / 6 (100%)
  E       Max absolute difference: 3.21747557
  E       Max relative difference: 7.59985682
  E        x: array([ 1.9365826, -2.7941155, -2.407411 , -0.29458  ,  3.0978149,
  E               7.7699864])
  E        y: array([ 0.841471 ,  0.42336  , -4.7946214, -1.676493 ,  4.5989062,
  E               7.914866 ])
```

```python
      @pytest.mark.parametrize("kernel", non_fixed_kernels)
      def test_lml_improving(kernel):
          if sys.maxsize <= 2 ** 32 and sys.version_info[:2] == (3, 6):
              pytest.xfail("This test may fail on 32bit Py3.6")
      
          # Test that hyperparameter-tuning improves log-marginal likelihood.
          gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
  >       assert gpr.log_marginal_likelihood(gpr.kernel_.theta) > gpr.log_marginal_likelihood(
              kernel.theta
          )
  E       assert -111266738064.26326 > -48.88011095337428
```

Note that `test_predict_cov_vs_std` was not recently failing but I suspect that this is not numerically stable on 32 bit Python either because it used to fail under Python 3.6.