### PR TITLE
MNT skip doctests if matplotlib is not installed

### DIFF
--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -133,11 +133,17 @@ def pytest_collection_modifyitems(config, items):
     # run doctests only for numpy >= 1.14.
     skip_doctests = False
     try:
+        import matplotlib  # noqa
+    except ImportError:
+        skip_doctests = True
+        reason = "matplotlib is required to run the doctests"
+
+    try:
         if np_version < parse_version("1.14"):
             reason = "doctests are only run for numpy >= 1.14"
             skip_doctests = True
         elif _IS_32BIT:
-            reason = "doctest are only run when the default numpy int is " "64 bits."
+            reason = "doctest are only run when the default numpy int is 64 bits."
             skip_doctests = True
         elif sys.platform.startswith("win32"):
             reason = (

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -66,9 +66,9 @@ def plot_partial_dependence(
           >>> est1 = LinearRegression().fit(X, y)
           >>> est2 = RandomForestRegressor().fit(X, y)
           >>> disp1 = plot_partial_dependence(est1, X,
-          ...                                 [1, 2])  # doctest: +SKIP
+          ...                                 [1, 2])
           >>> disp2 = plot_partial_dependence(est2, X, [1, 2],
-          ...                                 ax=disp1.axes_)  # doctest: +SKIP
+          ...                                 ax=disp1.axes_)
 
     .. warning::
 


### PR DESCRIPTION
This was discussed in https://github.com/scikit-learn/scikit-learn/pull/20230#pullrequestreview-681913139 but I merged #20230 without addressing this issue first and now the scipy-dev nightly build failed because of this.

I tested locally without matplotlib and this seems to work as expected.

We could always decide to implement the explicit ignore list system we discussed instead of the all-or-nothing strategy but I don't think it's worth it in retrospect.

/cc @thomasjpfan @lesteve 