### PR TITLE
FIX make Cython class docstring consistant

### DIFF
--- a/sklearn/linear_model/_sgd_fast.pyx
+++ b/sklearn/linear_model/_sgd_fast.pyx
@@ -55,9 +55,9 @@ cdef class LossFunction:
         Parameters
         ----------
         p : double
-            The prediction, p = w^T x + intercept
+            The prediction, `p = w^T x + intercept`.
         y : double
-            The true value (aka target)
+            The true value (aka target).
 
         Returns
         -------
@@ -70,13 +70,37 @@ cdef class LossFunction:
         """Python version of `dloss` for testing.
 
         Pytest needs a python function and can't use cdef functions.
+
+        Parameters
+        ----------
+        p : double
+            The prediction, `p = w^T x`.
+        y : double
+            The true value (aka target).
+
+        Returns
+        -------
+        double
+            The derivative of the loss function with regards to `p`.
         """
         return self.dloss(p, y)
 
     def py_loss(self, double p, double y):
         """Python version of `loss` for testing.
-        
+
         Pytest needs a python function and can't use cdef functions.
+
+        Parameters
+        ----------
+        p : double
+            The prediction, `p = w^T x + intercept`.
+        y : double
+            The true value (aka target).
+
+        Returns
+        -------
+        double
+            The loss evaluated at `p` and `y`.
         """
         return self.loss(p, y)
 
@@ -87,9 +111,10 @@ cdef class LossFunction:
         Parameters
         ----------
         p : double
-            The prediction, p = w^T x
+            The prediction, `p = w^T x`.
         y : double
-            The true value (aka target)
+            The true value (aka target).
+
         Returns
         -------
         double

--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -1512,11 +1512,16 @@ cdef class BinaryTree:
             - 'linear'
             - 'cosine'
             Default is kernel = 'gaussian'
-        atol, rtol : float, default=0, 1e-8
-            Specify the desired relative and absolute tolerance of the result.
-            If the true result is K_true, then the returned result K_ret
+        atol : float, default=0
+            Specify the desired absolute tolerance of the result.
+            If the true result is `K_true`, then the returned result `K_ret`
             satisfies ``abs(K_true - K_ret) < atol + rtol * K_ret``
-            The default is zero (i.e. machine precision) for both.
+            The default is zero (i.e. machine precision).
+        rtol : float, default=1e-8
+            Specify the desired relative tolerance of the result.
+            If the true result is `K_true`, then the returned result `K_ret`
+            satisfies ``abs(K_true - K_ret) < atol + rtol * K_ret``
+            The default is `1e-8` (i.e. machine precision).
         breadth_first : bool, default=False
             If True, use a breadth-first search.  If False (default) use a
             depth-first search.  Breadth-first is generally faster for

--- a/sklearn/neighbors/_dist_metrics.pyx
+++ b/sklearn/neighbors/_dist_metrics.pyx
@@ -351,6 +351,16 @@ cdef class DistanceMetric:
         more efficient measure which preserves the rank of the true distance.
         For example, in the Euclidean distance metric, the reduced distance
         is the squared-euclidean distance.
+
+        Parameters
+        ----------
+        rdist : double
+            Reduced distance.
+
+        Returns
+        -------
+        double
+            True distance.
         """
         return rdist
 
@@ -361,6 +371,16 @@ cdef class DistanceMetric:
         more efficient measure which preserves the rank of the true distance.
         For example, in the Euclidean distance metric, the reduced distance
         is the squared-euclidean distance.
+
+        Parameters
+        ----------
+        dist : double
+            True distance.
+
+        Returns
+        -------
+        double
+            Reduced distance.
         """
         return dist
 
@@ -378,6 +398,7 @@ cdef class DistanceMetric:
         Y : array-like (optional)
             Array of shape (Ny, D), representing Ny points in D dimensions.
             If not specified, then Y=X.
+
         Returns
         -------
         dist : ndarray


### PR DESCRIPTION
This PR should solve the issue with the nightly builds regarding the failure in the `test_docstring_parameters`.
It is due to `Cython 3.0a7` that generates some new docstring where our style was not consistent with our test.