### PR TITLE
MNT: work around pytest bug for skipping doctests

### DIFF
--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -101,6 +101,14 @@ def setup_unsupervised_learning():
     )
 
 
+def skip_if_matplotlib_not_installed(fname):
+    try:
+        import matplotlib  # noqa
+    except ImportError:
+        basename = os.path.basename(fname)
+        raise SkipTest(f"Skipping doctests for {basename}, matplotlib not installed")
+
+
 def pytest_runtest_setup(item):
     fname = item.fspath.strpath
     is_index = fname.endswith("datasets/index.rst")
@@ -128,6 +136,16 @@ def pytest_runtest_setup(item):
         setup_preprocessing()
     elif fname.endswith("statistical_inference/unsupervised_learning.rst"):
         setup_unsupervised_learning()
+
+    rst_files_requiring_matplotlib = [
+        "modules/partial_dependence.rst",
+        "modules/tree.rst",
+        "tutorial/statistical_inference/settings.rst",
+        "tutorial/statistical_inference/supervised_learning.rst",
+    ]
+    for each in rst_files_requiring_matplotlib:
+        if fname.endswith(each):
+            skip_if_matplotlib_not_installed(fname)
 
 
 def pytest_configure(config):

--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -111,6 +111,10 @@ def skip_if_matplotlib_not_installed(fname):
 
 def pytest_runtest_setup(item):
     fname = item.fspath.strpath
+    # normalise filename to use forward slashes on Windows for easier handling
+    # later
+    fname = fname.replace(os.sep, "/")
+
     is_index = fname.endswith("datasets/index.rst")
     if fname.endswith("datasets/labeled_faces.rst") or is_index:
         setup_labeled_faces()

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -159,7 +159,8 @@ def pytest_collection_modifyitems(config, items):
 
         for item in items:
             if isinstance(item, DoctestItem):
-                # internal error with pytest if adding a skip mark to a doctest in a context manager
+                # work-around an internal error with pytest if adding a skip
+                # mark to a doctest in a contextmanager
                 if item.name != "sklearn._config.config_context":
                     item.add_marker(skip_marker)
     elif not _pilutil.pillow_installed:

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -159,7 +159,9 @@ def pytest_collection_modifyitems(config, items):
 
         for item in items:
             if isinstance(item, DoctestItem):
-                item.add_marker(skip_marker)
+                # internal error with pytest if adding a skip mark to a doctest in a context manager
+                if item.name != "sklearn._config.config_context":
+                    item.add_marker(skip_marker)
     elif not _pilutil.pillow_installed:
         skip_marker = pytest.mark.skip(reason="pillow (or PIL) not installed!")
         for item in items:

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -160,7 +160,9 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if isinstance(item, DoctestItem):
                 # work-around an internal error with pytest if adding a skip
-                # mark to a doctest in a contextmanager
+                # mark to a doctest in a contextmanager, see
+                # https://github.com/pytest-dev/pytest/issues/8796 for more
+                # details.
                 if item.name != "sklearn._config.config_context":
                     item.add_marker(skip_marker)
     elif not _pilutil.pillow_installed:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

https://github.com/scikit-learn/scikit-learn/pull/20347 highlighted a bug in our doctest skipping logic. This appeared in our nightly builds where we don't have matplotlib installed:

- Azure nightly build: https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=29772&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081&l=141
- pypy on CircleCI: https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn/14936/workflows/d11e2f02-353f-4322-98f0-c7a74baba725/jobs/142418

To me this is very likely a bug in pytest, when a skip marker is used on a doctest of a contextmanager ... I'll open an issue to see what they think about it. Edit: https://github.com/pytest-dev/pytest/issues/8796.

<details>
<summary>Full error</summary>

```
sssssssssssssssss.........INTERNALERROR> def worker_internal_error(self, node, formatted_error):
INTERNALERROR>         """
INTERNALERROR>         pytest_internalerror() was called on the worker.
INTERNALERROR>     
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR> E                 return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR> E                 self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR> E                 return outcome.get_result()
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR> E                 raise ex[1].with_traceback(ex[2])
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR> E                 res = hook_impl.function(*args)
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/_pytest/runner.py", line 109, in pytest_runtest_protocol
INTERNALERROR> E                 runtestprotocol(item, nextitem=nextitem)
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/_pytest/runner.py", line 120, in runtestprotocol
INTERNALERROR> E                 rep = call_and_report(item, "setup", log)
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/_pytest/runner.py", line 217, in call_and_report
INTERNALERROR> E                 report: TestReport = hook.pytest_runtest_makereport(item=item, call=call)
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR> E                 return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR> E                 return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR> E                 self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/callers.py", line 203, in _multicall
INTERNALERROR> E                 gen.send(outcome)
INTERNALERROR> E               File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/_pytest/skipping.py", line 314, in pytest_runtest_makereport
INTERNALERROR> E                 assert line is not None
INTERNALERROR> E             AssertionError
INTERNALERROR> E           assert False
INTERNALERROR> 
INTERNALERROR> /usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/xdist/dsession.py:187: AssertionError
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/_pytest/main.py", line 269, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/_pytest/main.py", line 323, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/manager.py", line 84, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/callers.py", line 203, in _multicall
INTERNALERROR>     gen.send(outcome)
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/xdist/dsession.py", line 112, in pytest_runtestloop
INTERNALERROR>     self.loop_once()
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/xdist/dsession.py", line 135, in loop_once
INTERNALERROR>     call(**kwargs)
INTERNALERROR>   File "/usr/share/miniconda/envs/testvenv/lib/python3.9/site-packages/xdist/dsession.py", line 174, in worker_workerfinished
INTERNALERROR>     assert not crashitem, (crashitem, node)
INTERNALERROR> AssertionError: ('_config.py::sklearn._config.config_context', <WorkerController gw0>)
INTERNALERROR> assert not '_config.py::sklearn._config.config_context'
```

