### PR TITLE
DOC Specify the meaning of scoring=None in sklearn.metrics.check_scoring

### DIFF
--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -432,7 +432,7 @@ def check_scoring(estimator, scoring=None, *, allow_none=False):
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
-        If None, the provided estimator object's scoring method is used.
+        If None, the provided estimator object's 'score' method is used.
 
     allow_none : bool, default=False
         If no scoring is specified and the estimator has no score function, we

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -432,6 +432,7 @@ def check_scoring(estimator, scoring=None, *, allow_none=False):
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
+        If None, the provided estimator object's scoring method is used.
 
     allow_none : bool, default=False
         If no scoring is specified and the estimator has no score function, we

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -432,7 +432,7 @@ def check_scoring(estimator, scoring=None, *, allow_none=False):
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
-        If None, the provided estimator object's 'score' method is used.
+        If None, the provided estimator object's `score` method is used.
 
     allow_none : bool, default=False
         If no scoring is specified and the estimator has no score function, we


### PR DESCRIPTION


#### Reference Issues/PRs
Partially addresses #17295.



#### What does this implement/fix? Explain your changes.
This PR specifies the meaning of `scoring=None` for the function `check_scoring` in the `sklearn.metrics._scorer` module. 

#DataUmbrella sprint
