### PR TITLE
DOC Ensures that LinearRegression passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -98,7 +98,6 @@ DOCSTRING_IGNORE_LIST = [
     "LatentDirichletAllocation",
     "LedoitWolf",
     "LinearDiscriminantAnalysis",
-    "LinearRegression",
     "LinearSVC",
     "LinearSVR",
     "LocalOutlierFactor",

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -558,8 +558,7 @@ class RegressorMixin:
     _estimator_type = "regressor"
 
     def score(self, X, y, sample_weight=None):
-        """Return the coefficient of determination :math:`R^2` of the
-        prediction.
+        """Return the coefficient of determination :math:`R^2` of the prediction.
 
         The coefficient :math:`R^2` is defined as :math:`(1 - \\frac{u}{v})`,
         where :math:`u` is the residual sum of squares ``((y_true - y_pred)

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -637,7 +637,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
 
         Returns
         -------
-        self : Estimator
+        self : object
             Fitted Estimator.
         """
 

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -624,20 +624,21 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Training data
+            Training data.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            Target values. Will be cast to X's dtype if necessary
+            Target values. Will be cast to X's dtype if necessary.
 
         sample_weight : array-like of shape (n_samples,), default=None
-            Individual weights for each sample
+            Individual weights for each sample.
 
             .. versionadded:: 0.17
                parameter *sample_weight* support to LinearRegression.
 
         Returns
         -------
-        self : returns an instance of self.
+        self : Estimator
+            Fitted Estimator.
         """
 
         _normalize = _deprecate_normalize(


### PR DESCRIPTION
Reference Issues/PRs

Addresses #20308 for LinearRegression with my pair programming partner @caherrera-meli
What does this implement/fix? Explain your changes.

Added periods to docstring summaries and reorganized the classes docstring to follow the suggested order.
Any other comments?

#DataUmbrella sprint