### PR TITLE
DOC Ensures that LogisticRegression passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -103,7 +103,6 @@ DOCSTRING_IGNORE_LIST = [
     "LinearSVR",
     "LocalOutlierFactor",
     "LocallyLinearEmbedding",
-    "LogisticRegression",
     "LogisticRegressionCV",
     "MDS",
     "MLPClassifier",


### PR DESCRIPTION
#DataUmbrella sprint

#### Reference Issues/PRs

Adresses #20308

cc.: @gitdoluquita pair programming partner 

#### What does this implement/fix? Explain your changes.

Removing LogisticRegression from DOCSTRING_IGNORE_LIST

#### Any other comments?

All tests already passed
