### PR TITLE
DOC Ensures that KMeans passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -75,7 +75,6 @@ DOCSTRING_IGNORE_LIST = [
     "IsotonicRegression",
     "IterativeImputer",
     "KBinsDiscretizer",
-    "KMeans",
     "KNNImputer",
     "KNeighborsClassifier",
     "KNeighborsRegressor",


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308

#### What does this implement/fix? Explain your changes.
This PR ensures `KMeans` is compatible with numpydocd
  - Remove `KMeans` from `DOCSTRING_IGNORE_LIST`
  - Verify all tests passing.

#### Any other comments?
Thanks #DataUmbrellla
CC @pibieta @g4brielvs (pair programming 2021 Latin America scikit-learn open source sprint)
