### PR TITLE
TST Remove `assert_warns_message` from `test_base` and `test_dummy`

### DIFF
--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -8,7 +8,6 @@ import pytest
 import sklearn
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_no_warnings
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import ignore_warnings
 
 from sklearn.base import BaseEstimator, clone, is_classifier, _is_pairwise
@@ -395,7 +394,8 @@ def test_pickle_version_warning_is_issued_upon_different_version():
         old_version="something",
         current_version=sklearn.__version__,
     )
-    assert_warns_message(UserWarning, message, pickle.loads, tree_pickle_other)
+    with pytest.warns(UserWarning, match=message):
+        pickle.loads(tree_pickle_other)
 
 
 class TreeNoVersion(DecisionTreeClassifier):

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -416,7 +416,8 @@ def test_pickle_version_warning_is_issued_when_no_version_info_in_pickle():
         current_version=sklearn.__version__,
     )
     # check we got the warning about using pre-0.18 pickle
-    assert_warns_message(UserWarning, message, pickle.loads, tree_pickle_noversion)
+    with pytest.warns(UserWarning, match=message):
+        pickle.loads(tree_pickle_noversion)
 
 
 def test_pickle_version_no_warning_is_issued_with_non_sklearn_estimator():

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -7,7 +7,6 @@ from sklearn.base import clone
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_almost_equal
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils.stats import _weighted_percentile
 
@@ -586,9 +585,8 @@ def test_uniform_strategy_sparse_target_warning():
     y = sp.csc_matrix(np.array([[2, 1], [2, 2], [1, 4], [4, 2], [1, 1]]))
 
     clf = DummyClassifier(strategy="uniform", random_state=0)
-    assert_warns_message(
-        UserWarning, "the uniform strategy would not save memory", clf.fit, X, y
-    )
+    with pytest.warns(UserWarning, match="the uniform strategy would not save memory"):
+        clf.fit(X, y)
 
     X = [[0]] * 500
     y_pred = clf.predict(X)


### PR DESCRIPTION
#### Reference Issues/PRs

#19414

#### What does this implement/fix? Explain your changes.

This PR swaps `assert_warns_message` for a `pytest.warns`-based approach for `test_base` and `test_dummy`, as described on the aforementioned issue
