### PR TITLE
DOC ensures SparsePCA docstring passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -190,7 +190,6 @@ DOCSTRING_IGNORE_LIST = [
     "SimpleImputer",
     "SkewedChi2Sampler",
     "SparseCoder",
-    "SparsePCA",
     "SparseRandomProjection",
     "SpectralBiclustering",
     "SpectralClustering",

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -40,6 +40,7 @@ class SparsePCA(TransformerMixin, BaseEstimator):
         Tolerance for the stopping condition.
 
     method : {'lars', 'cd'}, default='lars'
+        Method to be used for optimization.
         lars: uses the least angle regression method to solve the lasso problem
         (linear_model.lars_path)
         cd: uses the coordinate descent method to compute the
@@ -93,6 +94,12 @@ class SparsePCA(TransformerMixin, BaseEstimator):
 
         .. versionadded:: 0.24
 
+    See Also
+    --------
+    PCA : Base Principal Component Analysis implementation.
+    MiniBatchSparsePCA : Variant of SparsePCA that is faster but less accurate.
+    DictionaryLearning : Generic dictionary learning problem using a sparse code.
+
     Examples
     --------
     >>> import numpy as np
@@ -108,12 +115,6 @@ class SparsePCA(TransformerMixin, BaseEstimator):
     >>> # most values in the components_ are zero (sparsity)
     >>> np.mean(transformer.components_ == 0)
     0.9666...
-
-    See Also
-    --------
-    PCA
-    MiniBatchSparsePCA
-    DictionaryLearning
     """
 
     def __init__(
@@ -153,6 +154,7 @@ class SparsePCA(TransformerMixin, BaseEstimator):
             and n_features is the number of features.
 
         y : Ignored
+            Not used, present here for API consistency by convention.
 
         Returns
         -------

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -96,8 +96,8 @@ class SparsePCA(TransformerMixin, BaseEstimator):
 
     See Also
     --------
-    PCA : Base Principal Component Analysis implementation.
-    MiniBatchSparsePCA : Variant of SparsePCA that is faster but less accurate.
+    PCA : Principal Component Analysis implementation.
+    MiniBatchSparsePCA : Mini batch variant of `SparsePCA` that is faster but less accurate.
     DictionaryLearning : Generic dictionary learning problem using a sparse code.
 
     Examples

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -97,7 +97,8 @@ class SparsePCA(TransformerMixin, BaseEstimator):
     See Also
     --------
     PCA : Principal Component Analysis implementation.
-    MiniBatchSparsePCA : Mini batch variant of `SparsePCA` that is faster but less accurate.
+    MiniBatchSparsePCA : Mini batch variant of `SparsePCA` that is faster but less
+        accurate.
     DictionaryLearning : Generic dictionary learning problem using a sparse code.
 
     Examples


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #20308


#### What does this implement/fix? Explain your changes.
Makes `SparsePCA` compatible with numpydoc style.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
