### PR TITLE
DOC Ensures that OneHotEncoder passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -132,7 +132,6 @@ DOCSTRING_IGNORE_LIST = [
     "OAS",
     "OPTICS",
     "OneClassSVM",
-    "OneHotEncoder",
     "OneVsOneClassifier",
     "OneVsRestClassifier",
     "OrdinalEncoder",

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -449,7 +449,7 @@ class OneHotEncoder(_BaseEncoder):
 
         Returns
         -------
-        self:
+        self
             Fitted encoder.
         """
         self._validate_keywords()

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -449,7 +449,8 @@ class OneHotEncoder(_BaseEncoder):
 
         Returns
         -------
-        self
+        self:
+            Fitted encoder.
         """
         self._validate_keywords()
         self._fit(X, handle_unknown=self.handle_unknown, force_all_finite="allow-nan")


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308

#### What does this implement/fix? Explain your changes.
This PR ensures `OneHotEncoder` is compatible with numpydocd
  - Remove `OneHotEncoder` from `DOCSTRING_IGNORE_LIST`
  - Minor style fixes.

#### Any other comments?
Thanks #DataUmbrellla
