### PR TITLE
FIX Uses code literals in deprecated to prevent linking

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -222,7 +222,7 @@ latest up-to-date workflow.
   `Video <https://youtu.be/dyxS9KKCNzA>`__,
   `Transcript
   <https://github.com/data-umbrella/event-transcripts/blob/main/2021/27-thomas-pr.md>`__
-  
+
 .. note::
   In January 2021, the default branch name changed from ``master`` to ``main``
   for the scikit-learn GitHub repository to use more inclusive terms.
@@ -1115,8 +1115,8 @@ use the decorator ``deprecated`` on a property. Please note that the
 decorator for the docstrings to be rendered properly.
 E.g., renaming an attribute ``labels_`` to ``classes_`` can be done as::
 
-    @deprecated("Attribute labels_ was deprecated in version 0.13 and "
-                "will be removed in 0.15. Use 'classes_' instead")
+    @deprecated("Attribute `labels_` was deprecated in version 0.13 and "
+                "will be removed in 0.15. Use `classes_` instead")
     @property
     def labels_(self):
         return self.classes_

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -652,8 +652,8 @@ class _CalibratedClassifier:
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "calibrators_ is deprecated in 0.24 and will be removed in 1.1"
-        "(renaming of 0.26). Use calibrators instead."
+        "`calibrators_` is deprecated in 0.24 and will be removed in 1.1"
+        "(renaming of 0.26). Use `calibrators` instead."
     )
     @property
     def calibrators_(self):

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -400,7 +400,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -473,7 +473,9 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
 
     # TODO: Remove in 1.2
     # mypy error: Decorated property not supported
-    @deprecated("fit_ is deprecated in 1.0 and will be removed in 1.2")  # type: ignore
+    @deprecated(  # type: ignore
+        "`fit_` is deprecated in 1.0 and will be removed in 1.2"
+    )
     @property
     def fit_(self):
         return self._deprecated_fit
@@ -481,7 +483,7 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
     # TODO: Remove in 1.2
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "partial_fit_ is deprecated in 1.0 and will be removed in 1.2"
+        "`partial_fit_` is deprecated in 1.0 and will be removed in 1.2"
     )
     @property
     def partial_fit_(self):

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1697,7 +1697,7 @@ class MiniBatchKMeans(KMeans):
         self.reassignment_ratio = reassignment_ratio
 
     @deprecated(  # type: ignore
-        "The attribute 'counts_' is deprecated in 0.24"
+        "The attribute `counts_` is deprecated in 0.24"
         " and will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -1705,7 +1705,7 @@ class MiniBatchKMeans(KMeans):
         return self._counts
 
     @deprecated(  # type: ignore
-        "The attribute 'init_size_' is deprecated in "
+        "The attribute `init_size_` is deprecated in "
         "0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -1713,7 +1713,7 @@ class MiniBatchKMeans(KMeans):
         return self._init_size
 
     @deprecated(  # type: ignore
-        "The attribute 'random_state_' is deprecated "
+        "The attribute `random_state_` is deprecated "
         "in 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -637,7 +637,7 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -260,6 +260,6 @@ def test_sparse_input_for_fit_predict():
 # TODO: Remove in 1.1
 def test_affinity_propagation_pairwise_is_deprecated():
     afp = AffinityPropagation(affinity="precomputed")
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         afp._pairwise

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -181,7 +181,7 @@ def test_birch_n_clusters_long_int():
 @pytest.mark.parametrize("attribute", ["fit_", "partial_fit_"])
 def test_birch_fit_attributes_deprecated(attribute):
     """Test that fit_ and partial_fit_ attributes are deprecated."""
-    msg = f"{attribute} is deprecated in 1.0 and will be removed in 1.2"
+    msg = f"`{attribute}` is deprecated in 1.0 and will be removed in 1.2"
     X, y = make_blobs(n_samples=10)
     brc = Birch().fit(X, y)
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -986,7 +986,7 @@ def test_minibatch_kmeans_deprecated_attributes(attr):
     # check that we raise a deprecation warning when accessing `init_size_`
     # FIXME: remove in 1.1
     depr_msg = (
-        f"The attribute '{attr}' is deprecated in 0.24 and will be " f"removed in 1.1"
+        f"The attribute `{attr}` is deprecated in 0.24 and will be " f"removed in 1.1"
     )
     km = MiniBatchKMeans(n_clusters=2, n_init=1, init="random", random_state=0)
     km.fit(X)

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -305,6 +305,6 @@ def test_verbose(assign_labels, capsys):
 @pytest.mark.parametrize("affinity", ["precomputed", "precomputed_nearest_neighbors"])
 def test_pairwise_is_deprecated(affinity):
     sp = SpectralClustering(affinity=affinity)
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         sp._pairwise

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -931,8 +931,9 @@ class GraphicalLassoCV(GraphicalLasso):
     # TODO: Remove in 1.1 when grid_scores_ is deprecated
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "The grid_scores_ attribute is deprecated in version 0.24 in favor "
-        "of cv_results_ and will be removed in version 1.1 (renaming of 0.26)."
+        "The `grid_scores_` attribute is deprecated in version 0.24 in favor "
+        "of `cv_results_` and will be removed in version 1.1 "
+        "(renaming of 0.26)."
     )
     @property
     def grid_scores_(self):
@@ -945,8 +946,8 @@ class GraphicalLassoCV(GraphicalLasso):
     # TODO: Remove in 1.1 when cv_alphas_ is deprecated
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "The cv_alphas_ attribute is deprecated in version 0.24 in favor "
-        "of cv_results_['alpha'] and will be removed in version 1.1 "
+        "The `cv_alphas_` attribute is deprecated in version 0.24 in favor "
+        "of `cv_results_['alpha']` and will be removed in version 1.1 "
         "(renaming of 0.26)."
     )
     @property

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -180,16 +180,16 @@ def test_graphical_lasso_cv_grid_scores_and_cv_alphas_deprecated():
 
     total_alphas = n_refinements * n_alphas + 1
     msg = (
-        r"The grid_scores_ attribute is deprecated in version 0\.24 in "
-        r"favor of cv_results_ and will be removed in version 1\.1 "
+        r"The `grid_scores_` attribute is deprecated in version 0\.24 in "
+        r"favor of `cv_results_` and will be removed in version 1\.1 "
         r"\(renaming of 0\.26\)."
     )
     with pytest.warns(FutureWarning, match=msg):
         assert cov.grid_scores_.shape == (total_alphas, splits)
 
     msg = (
-        r"The cv_alphas_ attribute is deprecated in version 0\.24 in "
-        r"favor of cv_results_\['alpha'\] and will be removed in version "
+        r"The `cv_alphas_` attribute is deprecated in version 0\.24 in "
+        r"favor of `cv_results_\['alpha'\]` and will be removed in version "
         r"1\.1 \(renaming of 0\.26\)"
     )
     with pytest.warns(FutureWarning, match=msg):

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -465,7 +465,7 @@ class _PLS(
 
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute norm_y_weights was deprecated in version 0.24 and "
+        "Attribute `norm_y_weights` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -473,7 +473,7 @@ class _PLS(
         return self._norm_y_weights
 
     @deprecated(  # type: ignore
-        "Attribute x_mean_ was deprecated in version 0.24 and "
+        "Attribute `x_mean_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -481,7 +481,7 @@ class _PLS(
         return self._x_mean
 
     @deprecated(  # type: ignore
-        "Attribute y_mean_ was deprecated in version 0.24 and "
+        "Attribute `y_mean_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -489,7 +489,7 @@ class _PLS(
         return self._y_mean
 
     @deprecated(  # type: ignore
-        "Attribute x_std_ was deprecated in version 0.24 and "
+        "Attribute `x_std_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -497,7 +497,7 @@ class _PLS(
         return self._x_std
 
     @deprecated(  # type: ignore
-        "Attribute y_std_ was deprecated in version 0.24 and "
+        "Attribute `y_std_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -1013,7 +1013,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
 
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute x_scores_ was deprecated in version 0.24 and "
+        "Attribute `x_scores_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26). Use est.transform(X) on "
         "the training data instead."
     )
@@ -1023,7 +1023,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
 
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute y_scores_ was deprecated in version 0.24 and "
+        "Attribute `y_scores_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26). Use est.transform(X, Y) "
         "on the training data instead."
     )
@@ -1032,7 +1032,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         return self._y_scores
 
     @deprecated(  # type: ignore
-        "Attribute x_mean_ was deprecated in version 0.24 and "
+        "Attribute `x_mean_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -1040,7 +1040,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         return self._x_mean
 
     @deprecated(  # type: ignore
-        "Attribute y_mean_ was deprecated in version 0.24 and "
+        "Attribute `y_mean_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -1048,7 +1048,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         return self._y_mean
 
     @deprecated(  # type: ignore
-        "Attribute x_std_ was deprecated in version 0.24 and "
+        "Attribute `x_std_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -1056,7 +1056,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         return self._x_std
 
     @deprecated(  # type: ignore
-        "Attribute y_std_ was deprecated in version 0.24 and "
+        "Attribute `y_std_` was deprecated in version 0.24 and "
         "will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -510,7 +510,7 @@ class _PLS(
         if not isinstance(self, PLSRegression):
             pass
             warnings.warn(
-                "Attribute x_scores_ was deprecated in version 0.24 and "
+                "Attribute `x_scores_` was deprecated in version 0.24 and "
                 "will be removed in 1.1 (renaming of 0.26). Use "
                 "est.transform(X) on the training data instead.",
                 FutureWarning,
@@ -522,7 +522,7 @@ class _PLS(
         # TODO: raise error in 1.1 instead
         if not isinstance(self, PLSRegression):
             warnings.warn(
-                "Attribute y_scores_ was deprecated in version 0.24 and "
+                "Attribute `y_scores_` was deprecated in version 0.24 and "
                 "will be removed in 1.1 (renaming of 0.26). Use "
                 "est.transform(X) on the training data instead.",
                 FutureWarning,

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -500,9 +500,9 @@ def test_scores_deprecations(Est):
     X = rng.randn(10, 5)
     Y = rng.randn(10, 3)
     est = Est().fit(X, Y)
-    with pytest.warns(FutureWarning, match="x_scores_ was deprecated"):
+    with pytest.warns(FutureWarning, match="`x_scores_` was deprecated"):
         assert_allclose(est.x_scores_, est.transform(X))
-    with pytest.warns(FutureWarning, match="y_scores_ was deprecated"):
+    with pytest.warns(FutureWarning, match="`y_scores_` was deprecated"):
         assert_allclose(est.y_scores_, est.transform(X, Y)[1])
 
 
@@ -512,7 +512,7 @@ def test_norm_y_weights_deprecation(Est):
     X = rng.randn(10, 5)
     Y = rng.randn(10, 3)
     est = Est().fit(X, Y)
-    with pytest.warns(FutureWarning, match="norm_y_weights was deprecated"):
+    with pytest.warns(FutureWarning, match="`norm_y_weights` was deprecated"):
         est.norm_y_weights
 
 
@@ -524,7 +524,7 @@ def test_mean_and_std_deprecation(Estimator, attribute):
     X = rng.randn(10, 5)
     Y = rng.randn(10, 3)
     estimator = Estimator().fit(X, Y)
-    with pytest.warns(FutureWarning, match=f"{attribute} was deprecated"):
+    with pytest.warns(FutureWarning, match=f"`{attribute}` was deprecated"):
         getattr(estimator, attribute)
 
 

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -344,7 +344,7 @@ def test_convergence_fail():
         pls_nipals.fit(X, Y)
 
 
-@pytest.mark.filterwarnings("ignore:.*scores_ was deprecated")  # 1.1
+@pytest.mark.filterwarnings("ignore:.*`scores_` was deprecated")  # 1.1
 @pytest.mark.parametrize("Est", (PLSSVD, PLSRegression, PLSCanonical))
 def test_attibutes_shapes(Est):
     # Make sure attributes are of the correct shape depending on n_components

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -15,6 +15,7 @@ from sklearn.datasets import make_regression
 from sklearn.utils import check_random_state
 from sklearn.utils.extmath import svd_flip
 from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils._testing import ignore_warnings
 
 
 def assert_matrix_orthogonal(M):
@@ -355,9 +356,13 @@ def test_attibutes_shapes(Est):
     pls = Est(n_components=n_components)
     pls.fit(X, Y)
     assert all(
-        attr.shape[1] == n_components
-        for attr in (pls.x_scores_, pls.y_scores_, pls.x_weights_, pls.y_weights_)
+        attr.shape[1] == n_components for attr in (pls.x_weights_, pls.y_weights_)
     )
+    # TODO: remove in 1.1
+    with ignore_warnings(category=FutureWarning):
+        assert all(
+            attr.shape[1] == n_components for attr in (pls.x_scores_, pls.y_scores_)
+        )
 
 
 @pytest.mark.parametrize("Est", (PLSRegression, PLSCanonical, CCA))

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1262,9 +1262,9 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
         return self
 
     @deprecated(  # type: ignore
-        "The attribute 'components_' is deprecated "
+        "The attribute `components_` is deprecated "
         "in 0.24 and will be removed in 1.1 (renaming of 0.26). Use the "
-        "'dictionary' instead."
+        "`dictionary` instead."
     )
     @property
     def components_(self):

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -239,7 +239,7 @@ class KernelPCA(TransformerMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -626,7 +626,7 @@ def test_sparse_coder_deprecation():
     init_dict = rng.rand(n_components, n_features)
     sc = SparseCoder(init_dict)
 
-    with pytest.warns(FutureWarning, match="'components_' is deprecated"):
+    with pytest.warns(FutureWarning, match="`components_` is deprecated"):
         sc.components_
 
 

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -530,6 +530,6 @@ def test_kernel_pcc_pairwise_is_deprecated():
     Tests that a `FutureWarning` is issued when `_pairwise` is accessed.
     """
     kp = KernelPCA(kernel="precomputed")
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         kp._pairwise

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -468,8 +468,8 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
     # TODO: Remove in 1.2
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute n_features_ was deprecated in version 1.0 and will be "
-        "removed in 1.2. Use 'n_features_in_' instead."
+        "Attribute `n_features_` was deprecated in version 1.0 and will be "
+        "removed in 1.2. Use `n_features_in_` instead."
     )
     @property
     def n_features_(self):

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -610,8 +610,8 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
     # TODO: Remove in 1.2
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute n_features_ was deprecated in version 1.0 and will be "
-        "removed in 1.2. Use 'n_features_in_' instead."
+        "Attribute `n_features_` was deprecated in version 1.0 and will be "
+        "removed in 1.2. Use `n_features_in_` instead."
     )
     @property
     def n_features_(self):

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -884,8 +884,8 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
     # TODO: Remove in 1.2
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute n_features_ was deprecated in version 1.0 and will be "
-        "removed in 1.2. Use 'n_features_in_' instead."
+        "Attribute `n_features_` was deprecated in version 1.0 and will be "
+        "removed in 1.2. Use `n_features_in_` instead."
     )
     @property
     def n_features_(self):
@@ -1910,7 +1910,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     # FIXME: to be removed in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute n_classes_ was deprecated "
+        "Attribute `n_classes_` was deprecated "
         "in version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -959,5 +959,5 @@ def test_n_features_deprecation(Estimator):
     y = np.array([1, 0])
     est = Estimator().fit(X, y)
 
-    with pytest.warns(FutureWarning, match="n_features_ was deprecated"):
+    with pytest.warns(FutureWarning, match="`n_features_` was deprecated"):
         est.n_features_

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1752,7 +1752,7 @@ def test_n_features_deprecation(Estimator):
     y = np.array([1, 0])
     est = Estimator().fit(X, y)
 
-    with pytest.warns(FutureWarning, match="n_features_ was deprecated"):
+    with pytest.warns(FutureWarning, match="`n_features_` was deprecated"):
         est.n_features_
 
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1380,7 +1380,7 @@ def test_gbr_deprecated_attr():
 
 
 # TODO: Remove in 1.1 when `n_classes_` is deprecated
-@pytest.mark.filterwarnings("ignore:Attribute n_classes_ was deprecated")
+@pytest.mark.filterwarnings("ignore:Attribute `n_classes_` was deprecated")
 def test_attr_error_raised_if_not_fitted():
     # check that accessing n_classes_ in not fitted GradientBoostingRegressor
     # raises an AttributeError

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1374,7 +1374,7 @@ def test_gbr_deprecated_attr():
     X = np.zeros((10, 10))
     y = np.ones((10,))
     gbr = GradientBoostingRegressor().fit(X, y)
-    msg = "Attribute n_classes_ was deprecated"
+    msg = "Attribute `n_classes_` was deprecated"
     with pytest.warns(FutureWarning, match=msg):
         gbr.n_classes_
 
@@ -1423,7 +1423,7 @@ def test_n_features_deprecation(Estimator):
     y = np.array([1, 0])
     est = Estimator().fit(X, y)
 
-    with pytest.warns(FutureWarning, match="n_features_ was deprecated"):
+    with pytest.warns(FutureWarning, match="`n_features_` was deprecated"):
         est.n_features_
 
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -349,5 +349,5 @@ def test_n_features_deprecation():
     y = np.array([1, 0])
     est = IsolationForest().fit(X, y)
 
-    with pytest.warns(FutureWarning, match="n_features_ was deprecated"):
+    with pytest.warns(FutureWarning, match="`n_features_` was deprecated"):
         est.n_features_

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -148,7 +148,7 @@ class KernelRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -437,7 +437,7 @@ class MDS(BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -522,7 +522,7 @@ class SpectralEmbedding(BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -48,7 +48,7 @@ def test_MDS():
 # TODO: Remove in 1.1
 def test_MDS_pairwise_deprecated():
     mds_clf = mds.MDS(metric="precomputed")
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         mds_clf._pairwise
 

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -403,6 +403,6 @@ def test_spectral_embedding_first_eigen_vector():
 @pytest.mark.parametrize("affinity", ["precomputed", "precomputed_nearest_neighbors"])
 def test_spectral_embedding_pairwise_deprecated(affinity):
     se = SpectralEmbedding(affinity=affinity)
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         se._pairwise

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -439,7 +439,7 @@ class ConfusionMatrixDisplay:
 
 
 @deprecated(
-    "Function plot_confusion_matrix is deprecated in 1.0 and will be "
+    "Function `plot_confusion_matrix` is deprecated in 1.0 and will be "
     "removed in 1.2. Use one of the class methods: "
     "ConfusionMatrixDisplay.from_predictions or "
     "ConfusionMatrixDisplay.from_estimator."

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -387,7 +387,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -517,7 +517,7 @@ class OneVsRestClassifier(
     # TODO: Remove coef_ attribute in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute coef_ was deprecated in "
+        "Attribute `coef_` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26). "
         "If you observe this warning while using RFE "
         "or SelectFromModel, use the importance_getter "
@@ -536,7 +536,7 @@ class OneVsRestClassifier(
     # TODO: Remove intercept_ attribute in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute intercept_ was deprecated in "
+        "Attribute `intercept_` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26). "
         "If you observe this warning while using RFE "
         "or SelectFromModel, use the importance_getter "
@@ -552,7 +552,7 @@ class OneVsRestClassifier(
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -858,7 +858,7 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -478,8 +478,8 @@ class GaussianNB(_BaseNB):
         return joint_log_likelihood
 
     @deprecated(  # type: ignore
-        "Attribute sigma_ was deprecated in 1.0 and will be removed in"
-        "1.2. Use var_ instead."
+        "Attribute `sigma_` was deprecated in 1.0 and will be removed in"
+        "1.2. Use `var_` instead."
     )
     @property
     def sigma_(self):
@@ -682,7 +682,7 @@ class _BaseDiscreteNB(_BaseNB):
 
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute coef_ was deprecated in "
+        "Attribute `coef_` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -695,7 +695,7 @@ class _BaseDiscreteNB(_BaseNB):
 
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute intercept_ was deprecated in "
+        "Attribute `intercept_` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property
@@ -712,8 +712,8 @@ class _BaseDiscreteNB(_BaseNB):
     # TODO: Remove in 1.2
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute n_features_ was deprecated in version 1.0 and will be "
-        "removed in 1.2. Use 'n_features_in_' instead."
+        "Attribute `n_features_` was deprecated in version 1.0 and will be "
+        "removed in 1.2. Use `n_features_in_` instead."
     )
     @property
     def n_features_(self):

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -580,7 +580,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -175,7 +175,7 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1785,6 +1785,6 @@ def test_auto_algorithm(X, metric, metric_params, expected_algo):
 )
 def test_pairwise_deprecated(NearestNeighbors):
     nn = NearestNeighbors(metric="precomputed")
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         nn._pairwise

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -651,7 +651,7 @@ class Pipeline(_BaseComposition):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2231,7 +2231,7 @@ class KernelCenterer(TransformerMixin, BaseEstimator):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1."
     )
     @property

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -440,7 +440,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
     # TODO: Remove in 1.2
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "The attribute n_input_features_ was "
+        "The attribute `n_input_features_` was "
         "deprecated in version 1.0 and will be removed in 1.2."
     )
     @property

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2245,7 +2245,7 @@ def test_cv_pipeline_precomputed():
 # TODO: Remove in 1.1
 def test_pairwise_deprecated():
     kcent = KernelCenterer()
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         kcent._pairwise
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2231,7 +2231,7 @@ def test_cv_pipeline_precomputed():
     assert pipeline._get_tags()["pairwise"]
 
     # TODO: Remove in 1.1
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         assert pipeline._pairwise
 

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -848,7 +848,7 @@ def test_polynomial_features_deprecated_n_input_features():
     # check that we raise a deprecation warning when accessing
     # `n_input_features_`. FIXME: remove in 1.2
     depr_msg = (
-        "The attribute n_input_features_ was deprecated in version "
+        "The attribute `n_input_features_` was deprecated in version "
         "1.0 and will be removed in 1.2."
     )
     X = np.arange(10).reshape(5, 2)

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -127,7 +127,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
     # TODO: Remove in 1.1
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "Attribute _pairwise was deprecated in "
+        "Attribute `_pairwise` was deprecated in "
         "version 0.24 and will be removed in 1.1 (renaming of 0.26)."
     )
     @property

--- a/sklearn/tests/test_kernel_ridge.py
+++ b/sklearn/tests/test_kernel_ridge.py
@@ -97,6 +97,6 @@ def test_kernel_ridge_multi_output():
 # TODO: Remove in 1.1
 def test_kernel_ridge_pairwise_is_deprecated():
     k_ridge = KernelRidge(kernel="precomputed")
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         k_ridge._pairwise

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -519,7 +519,7 @@ def test_ovr_deprecated_coef_intercept():
     ovr = ovr.fit(iris.data, iris.target)
 
     msg = (
-        r"Attribute {0} was deprecated in version 0.24 "
+        r"Attribute `{0}` was deprecated in version 0.24 "
         r"and will be removed in 1.1 \(renaming of 0.26\). If you observe "
         r"this warning while using RFE or SelectFromModel, "
         r"use the importance_getter parameter instead."
@@ -857,7 +857,7 @@ def test_pairwise_tag(MultiClassClassifier):
 def test_pairwise_deprecated(MultiClassClassifier):
     clf_precomputed = svm.SVC(kernel="precomputed")
     ov_clf = MultiClassClassifier(clf_precomputed)
-    msg = r"Attribute _pairwise was deprecated in version 0\.24"
+    msg = r"Attribute `_pairwise` was deprecated in version 0\.24"
     with pytest.warns(FutureWarning, match=msg):
         ov_clf._pairwise
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -981,5 +981,5 @@ def test_n_features_deprecation(Estimator):
     y = np.array([1, 0])
     est = Estimator().fit(X, y)
 
-    with pytest.warns(FutureWarning, match="n_features_ was deprecated"):
+    with pytest.warns(FutureWarning, match="`n_features_` was deprecated"):
         est.n_features_

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -64,7 +64,7 @@ def test_gnb_var():
     clf = GaussianNB()
     clf.fit(X, y)
 
-    with pytest.warns(FutureWarning, match="Attribute sigma_ was deprecated"):
+    with pytest.warns(FutureWarning, match="Attribute `sigma_` was deprecated"):
         assert_array_equal(clf.sigma_, clf.var_)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to https://github.com/scikit-learn/scikit-learn/pull/20385


#### What does this implement/fix? Explain your changes.
Now that docstrings for properties are exposed, sphinx considers the underscore (`_`) a link. This PR makes sure all the deprecated messages refer to attributes as literals.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
