### PR TITLE
MRG Remove the use of assert_warns and assert_warns_message from the tests 

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -20,7 +20,6 @@ from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_no_warnings
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._mocking import MockDataFrame
 
@@ -406,18 +405,15 @@ def test_precision_recall_fscore_support_errors():
 def test_precision_recall_f_unused_pos_label():
     # Check warning that pos_label unused when set to non-default value
     # but average != 'binary'; even if data is binary.
-    assert_warns_message(
-        UserWarning,
-        "Note that pos_label (set to 2) is "
-        "ignored when average != 'binary' (got 'macro'). You "
-        "may use labels=[pos_label] to specify a single "
-        "positive class.",
-        precision_recall_fscore_support,
-        [1, 2, 1],
-        [1, 2, 2],
-        pos_label=2,
-        average="macro",
-    )
+
+    msg = (
+        r"Note that pos_label \(set to 2\) is "
+        r"ignored when average != 'binary' \(got 'macro'\). You "
+        r"may use labels=\[pos_label\] to specify a single "
+        "positive class.")
+    with pytest.warns(UserWarning, match=msg):
+        precision_recall_fscore_support(
+            [1, 2, 1], [1, 2, 2], pos_label=2, average="macro")
 
 
 def test_confusion_matrix_binary():
@@ -1164,15 +1160,9 @@ def test_classification_report_labels_target_names_unequal_length():
     y_pred = [0, 2, 2, 0, 0]
     target_names = ["class 0", "class 1", "class 2"]
 
-    assert_warns_message(
-        UserWarning,
-        "labels size, 2, does not " "match size of target_names, 3",
-        classification_report,
-        y_true,
-        y_pred,
-        labels=[0, 2],
-        target_names=target_names,
-    )
+    msg = "labels size, 2, does not " "match size of target_names, 3"
+    with pytest.warns(UserWarning, match=msg):
+        classification_report(y_true, y_pred, labels=[0, 2], target_names=target_names)
 
 
 def test_classification_report_no_labels_target_names_unequal_length():
@@ -1286,18 +1276,17 @@ def test_jaccard_score_validation():
     with pytest.raises(ValueError, match=msg3):
         jaccard_score(y_true, y_pred, average="samples")
 
-    assert_warns_message(
-        UserWarning,
-        "Note that pos_label (set to 3) is ignored when "
-        "average != 'binary' (got 'micro'). You may use "
-        "labels=[pos_label] to specify a single positive "
-        "class.",
-        jaccard_score,
-        y_true,
-        y_pred,
-        average="micro",
-        pos_label=3,
-    )
+    msg = (
+        r"Note that pos_label \(set to 3\) is ignored when "
+        r"average != 'binary' \(got 'micro'\). You may use "
+        r"labels=\[pos_label\] to specify a single positive "
+        "class.")
+    with pytest.warns(UserWarning, match=msg):
+        jaccard_score(
+            y_true,
+            y_pred,
+            average="micro",
+            pos_label=3,)
 
 
 def test_multilabel_jaccard_score(recwarn):
@@ -1352,33 +1341,23 @@ def test_multilabel_jaccard_score(recwarn):
         "Jaccard is ill-defined and being set to 0.0 in labels "
         "with no true or predicted samples."
     )
-    assert (
-        assert_warns_message(
-            UndefinedMetricWarning,
-            msg,
-            jaccard_score,
+
+    with pytest.warns(UndefinedMetricWarning, match=msg):
+        assert(jaccard_score(
             np.array([[0, 1]]),
             np.array([[0, 1]]),
-            average="macro",
-        )
-        == 0.5
-    )
+            average="macro") == 0.5)
 
     msg = (
         "Jaccard is ill-defined and being set to 0.0 in samples "
         "with no true or predicted labels."
     )
-    assert (
-        assert_warns_message(
-            UndefinedMetricWarning,
-            msg,
-            jaccard_score,
+
+    with pytest.warns(UndefinedMetricWarning, match=msg):
+        assert(jaccard_score(
             np.array([[0, 0], [1, 1]]),
             np.array([[0, 0], [1, 1]]),
-            average="samples",
-        )
-        == 0.5
-    )
+            average="samples") == 0.5)
 
     assert not list(recwarn)
 
@@ -1428,12 +1407,15 @@ def test_average_binary_jaccard_score(recwarn):
         "Jaccard is ill-defined and being set to 0.0 due to "
         "no true or predicted samples"
     )
-    assert (
-        assert_warns_message(
-            UndefinedMetricWarning, msg, jaccard_score, [0, 0], [0, 0], average="binary"
+    with pytest.warns(UndefinedMetricWarning, match=msg):
+        assert(
+            jaccard_score(
+                [0, 0],
+                [0, 0],
+                average="binary"
+            ) == 0.0
         )
-        == 0.0
-    )
+
     # tp=1, fp=0, fn=0, tn=0 (pos_label=0)
     assert jaccard_score([0], [0], pos_label=0, average="binary") == 1.0
     y_true = np.array([1, 0, 1, 1, 0])
@@ -1810,7 +1792,12 @@ def test_prf_warnings():
             " Use `zero_division` parameter to control"
             " this behavior."
         )
-        assert_warns_message(w, msg, f, [0, 1, 2], [1, 1, 2], average=average)
+        with pytest.warns(w, match=msg):
+            f(
+                [0, 1, 2],
+                [1, 1, 2],
+                average=average
+            )
 
         msg = (
             "Recall and F-score are ill-defined and "
@@ -1818,7 +1805,12 @@ def test_prf_warnings():
             " Use `zero_division` parameter to control"
             " this behavior."
         )
-        assert_warns_message(w, msg, f, [1, 1, 2], [0, 1, 2], average=average)
+        with pytest.warns(w, match=msg):
+            f(
+                [1, 1, 2],
+                [0, 1, 2],
+                average=average
+            )
 
     # average of per-sample scores
     msg = (
@@ -1827,14 +1819,12 @@ def test_prf_warnings():
         " Use `zero_division` parameter to control"
         " this behavior."
     )
-    assert_warns_message(
-        w,
-        msg,
-        f,
-        np.array([[1, 0], [1, 0]]),
-        np.array([[1, 0], [0, 0]]),
-        average="samples",
-    )
+    with pytest.warns(w, match=msg):
+        f(
+            np.array([[1, 0], [1, 0]]),
+            np.array([[1, 0], [0, 0]]),
+            average="samples",
+        )
 
     msg = (
         "Recall and F-score are ill-defined and "
@@ -1842,14 +1832,12 @@ def test_prf_warnings():
         " Use `zero_division` parameter to control"
         " this behavior."
     )
-    assert_warns_message(
-        w,
-        msg,
-        f,
-        np.array([[1, 0], [0, 0]]),
-        np.array([[1, 0], [1, 0]]),
-        average="samples",
-    )
+    with pytest.warns(w, match=msg):
+        f(
+            np.array([[1, 0], [0, 0]]),
+            np.array([[1, 0], [1, 0]]),
+            average="samples",
+        )
 
     # single score: micro-average
     msg = (
@@ -1858,14 +1846,12 @@ def test_prf_warnings():
         " Use `zero_division` parameter to control"
         " this behavior."
     )
-    assert_warns_message(
-        w,
-        msg,
-        f,
-        np.array([[1, 1], [1, 1]]),
-        np.array([[0, 0], [0, 0]]),
-        average="micro",
-    )
+    with pytest.warns(w, match=msg):
+        f(
+            np.array([[1, 1], [1, 1]]),
+            np.array([[0, 0], [0, 0]]),
+            average="micro",
+        )
 
     msg = (
         "Recall and F-score are ill-defined and "
@@ -1873,14 +1859,12 @@ def test_prf_warnings():
         " Use `zero_division` parameter to control"
         " this behavior."
     )
-    assert_warns_message(
-        w,
-        msg,
-        f,
-        np.array([[0, 0], [0, 0]]),
-        np.array([[1, 1], [1, 1]]),
-        average="micro",
-    )
+    with pytest.warns(w, match=msg):
+        f(
+            np.array([[0, 0], [0, 0]]),
+            np.array([[1, 1], [1, 1]]),
+            average="micro",
+        )
 
     # single positive label
     msg = (
@@ -1889,7 +1873,12 @@ def test_prf_warnings():
         " Use `zero_division` parameter to control"
         " this behavior."
     )
-    assert_warns_message(w, msg, f, [1, 1], [-1, -1], average="binary")
+    with pytest.warns(w, match=msg):
+        f(
+            [1, 1],
+            [-1, -1],
+            average="binary",
+        )
 
     msg = (
         "Recall and F-score are ill-defined and "
@@ -1897,7 +1886,12 @@ def test_prf_warnings():
         " Use `zero_division` parameter to control"
         " this behavior."
     )
-    assert_warns_message(w, msg, f, [-1, -1], [1, 1], average="binary")
+    with pytest.warns(w, match=msg):
+        f(
+            [-1, -1],
+            [1, 1],
+            average="binary",
+        )
 
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
@@ -2536,13 +2530,12 @@ def test_brier_score_loss():
 
 
 def test_balanced_accuracy_score_unseen():
-    assert_warns_message(
-        UserWarning,
-        "y_pred contains classes not in y_true",
-        balanced_accuracy_score,
-        [0, 0, 0],
-        [0, 0, 1],
-    )
+    msg = "y_pred contains classes not in y_true"
+    with pytest.warns(UserWarning, match=msg):
+        balanced_accuracy_score(
+            [0, 0, 0],
+            [0, 0, 1]
+        )
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -410,10 +410,12 @@ def test_precision_recall_f_unused_pos_label():
         r"Note that pos_label \(set to 2\) is "
         r"ignored when average != 'binary' \(got 'macro'\). You "
         r"may use labels=\[pos_label\] to specify a single "
-        "positive class.")
+        "positive class."
+    )
     with pytest.warns(UserWarning, match=msg):
         precision_recall_fscore_support(
-            [1, 2, 1], [1, 2, 2], pos_label=2, average="macro")
+            [1, 2, 1], [1, 2, 2], pos_label=2, average="macro"
+        )
 
 
 def test_confusion_matrix_binary():
@@ -1280,13 +1282,10 @@ def test_jaccard_score_validation():
         r"Note that pos_label \(set to 3\) is ignored when "
         r"average != 'binary' \(got 'micro'\). You may use "
         r"labels=\[pos_label\] to specify a single positive "
-        "class.")
+        "class."
+    )
     with pytest.warns(UserWarning, match=msg):
-        jaccard_score(
-            y_true,
-            y_pred,
-            average="micro",
-            pos_label=3,)
+        jaccard_score(y_true, y_pred, average="micro", pos_label=3)
 
 
 def test_multilabel_jaccard_score(recwarn):
@@ -1343,10 +1342,10 @@ def test_multilabel_jaccard_score(recwarn):
     )
 
     with pytest.warns(UndefinedMetricWarning, match=msg):
-        assert(jaccard_score(
-            np.array([[0, 1]]),
-            np.array([[0, 1]]),
-            average="macro") == 0.5)
+        assert (
+            jaccard_score(np.array([[0, 1]]), np.array([[0, 1]]), average="macro")
+            == 0.5
+        )
 
     msg = (
         "Jaccard is ill-defined and being set to 0.0 in samples "
@@ -1354,10 +1353,14 @@ def test_multilabel_jaccard_score(recwarn):
     )
 
     with pytest.warns(UndefinedMetricWarning, match=msg):
-        assert(jaccard_score(
-            np.array([[0, 0], [1, 1]]),
-            np.array([[0, 0], [1, 1]]),
-            average="samples") == 0.5)
+        assert (
+            jaccard_score(
+                np.array([[0, 0], [1, 1]]),
+                np.array([[0, 0], [1, 1]]),
+                average="samples",
+            )
+            == 0.5
+        )
 
     assert not list(recwarn)
 
@@ -1408,13 +1411,7 @@ def test_average_binary_jaccard_score(recwarn):
         "no true or predicted samples"
     )
     with pytest.warns(UndefinedMetricWarning, match=msg):
-        assert(
-            jaccard_score(
-                [0, 0],
-                [0, 0],
-                average="binary"
-            ) == 0.0
-        )
+        assert jaccard_score([0, 0], [0, 0], average="binary") == 0.0
 
     # tp=1, fp=0, fn=0, tn=0 (pos_label=0)
     assert jaccard_score([0], [0], pos_label=0, average="binary") == 1.0
@@ -1793,11 +1790,7 @@ def test_prf_warnings():
             " this behavior."
         )
         with pytest.warns(w, match=msg):
-            f(
-                [0, 1, 2],
-                [1, 1, 2],
-                average=average
-            )
+            f([0, 1, 2], [1, 1, 2], average=average)
 
         msg = (
             "Recall and F-score are ill-defined and "
@@ -1806,11 +1799,7 @@ def test_prf_warnings():
             " this behavior."
         )
         with pytest.warns(w, match=msg):
-            f(
-                [1, 1, 2],
-                [0, 1, 2],
-                average=average
-            )
+            f([1, 1, 2], [0, 1, 2], average=average)
 
     # average of per-sample scores
     msg = (
@@ -1820,11 +1809,7 @@ def test_prf_warnings():
         " this behavior."
     )
     with pytest.warns(w, match=msg):
-        f(
-            np.array([[1, 0], [1, 0]]),
-            np.array([[1, 0], [0, 0]]),
-            average="samples",
-        )
+        f(np.array([[1, 0], [1, 0]]), np.array([[1, 0], [0, 0]]), average="samples")
 
     msg = (
         "Recall and F-score are ill-defined and "
@@ -1833,11 +1818,7 @@ def test_prf_warnings():
         " this behavior."
     )
     with pytest.warns(w, match=msg):
-        f(
-            np.array([[1, 0], [0, 0]]),
-            np.array([[1, 0], [1, 0]]),
-            average="samples",
-        )
+        f(np.array([[1, 0], [0, 0]]), np.array([[1, 0], [1, 0]]), average="samples")
 
     # single score: micro-average
     msg = (
@@ -1847,11 +1828,7 @@ def test_prf_warnings():
         " this behavior."
     )
     with pytest.warns(w, match=msg):
-        f(
-            np.array([[1, 1], [1, 1]]),
-            np.array([[0, 0], [0, 0]]),
-            average="micro",
-        )
+        f(np.array([[1, 1], [1, 1]]), np.array([[0, 0], [0, 0]]), average="micro")
 
     msg = (
         "Recall and F-score are ill-defined and "
@@ -1860,11 +1837,7 @@ def test_prf_warnings():
         " this behavior."
     )
     with pytest.warns(w, match=msg):
-        f(
-            np.array([[0, 0], [0, 0]]),
-            np.array([[1, 1], [1, 1]]),
-            average="micro",
-        )
+        f(np.array([[0, 0], [0, 0]]), np.array([[1, 1], [1, 1]]), average="micro")
 
     # single positive label
     msg = (
@@ -1874,11 +1847,7 @@ def test_prf_warnings():
         " this behavior."
     )
     with pytest.warns(w, match=msg):
-        f(
-            [1, 1],
-            [-1, -1],
-            average="binary",
-        )
+        f([1, 1], [-1, -1], average="binary")
 
     msg = (
         "Recall and F-score are ill-defined and "
@@ -1887,11 +1856,7 @@ def test_prf_warnings():
         " this behavior."
     )
     with pytest.warns(w, match=msg):
-        f(
-            [-1, -1],
-            [1, 1],
-            average="binary",
-        )
+        f([-1, -1], [1, 1], average="binary")
 
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
@@ -2208,20 +2173,8 @@ def test__check_targets():
                 _check_targets(y1[:-1], y2)
 
     # Make sure seq of seq is not supported
-    y1 = [
-        (
-            1,
-            2,
-        ),
-        (0, 2, 3),
-    ]
-    y2 = [
-        (2,),
-        (
-            0,
-            2,
-        ),
-    ]
+    y1 = [(1, 2), (0, 2, 3)]
+    y2 = [(2,), (0, 2)]
     msg = (
         "You appear to be using a legacy multi-label data representation. "
         "Sequence of sequences are no longer supported; use a binary array"
@@ -2532,10 +2485,7 @@ def test_brier_score_loss():
 def test_balanced_accuracy_score_unseen():
     msg = "y_pred contains classes not in y_true"
     with pytest.warns(UserWarning, match=msg):
-        balanced_accuracy_score(
-            [0, 0, 0],
-            [0, 0, 1]
-        )
+        balanced_accuracy_score([0, 0, 0], [0, 0, 1])
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1871,8 +1871,12 @@ def test_top_k_accuracy_score_warning(y_true, k):
             [0.3, 0.2, 0.1, 0.4],
         ]
     )
-    w = UndefinedMetricWarning
-    score = assert_warns(w, top_k_accuracy_score, y_true, y_score, k=k)
+    expected_message = (
+        r"'k' \(\d+\) greater than or equal to 'n_classes' \(\d+\) will result in a "
+        "perfect score and is therefore meaningless."
+    )
+    with pytest.warns(UndefinedMetricWarning, match=expected_message):
+        score = top_k_accuracy_score(y_true, y_score, k=k)
     assert score == 1
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -353,7 +353,12 @@ def test_roc_curve_toydata():
     y_true = [0, 0]
     y_score = [0.25, 0.75]
     # assert UndefinedMetricWarning because of no positive sample in y_true
-    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve, y_true, y_score)
+    expected_message = (
+        "No positive samples in y_true, true positive value should be meaningless"
+    )
+    with pytest.warns(UndefinedMetricWarning, match=expected_message):
+        tpr, fpr, _ = roc_curve(y_true, y_score)
+
     with pytest.raises(ValueError):
         roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0.0, 0.5, 1.0])
@@ -362,7 +367,12 @@ def test_roc_curve_toydata():
     y_true = [1, 1]
     y_score = [0.25, 0.75]
     # assert UndefinedMetricWarning because of no negative sample in y_true
-    tpr, fpr, _ = assert_warns(UndefinedMetricWarning, roc_curve, y_true, y_score)
+    expected_message = (
+        "No negative samples in y_true, false positive value should be meaningless"
+    )
+    with pytest.warns(UndefinedMetricWarning, match=expected_message):
+        tpr, fpr, _ = roc_curve(y_true, y_score)
+
     with pytest.raises(ValueError):
         roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [np.nan, np.nan, np.nan])

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -285,15 +285,23 @@ def test_roc_curve_one_label():
     y_true = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     y_pred = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
     # assert there are warnings
-    w = UndefinedMetricWarning
-    fpr, tpr, thresholds = assert_warns(w, roc_curve, y_true, y_pred)
+    expected_message = (
+        "No negative samples in y_true, false positive value should be meaningless"
+    )
+    with pytest.warns(UndefinedMetricWarning, match=expected_message):
+        fpr, tpr, thresholds = roc_curve(y_true, y_pred)
+
     # all true labels, all fpr should be nan
     assert_array_equal(fpr, np.full(len(thresholds), np.nan))
     assert fpr.shape == tpr.shape
     assert fpr.shape == thresholds.shape
 
     # assert there are warnings
-    fpr, tpr, thresholds = assert_warns(w, roc_curve, [1 - x for x in y_true], y_pred)
+    expected_message = (
+        "No positive samples in y_true, true positive value should be meaningless"
+    )
+    with pytest.warns(UndefinedMetricWarning, match=expected_message):
+        fpr, tpr, thresholds = roc_curve([1 - x for x in y_true], y_pred)
     # all negative labels, all tpr should be nan
     assert_array_equal(tpr, np.full(len(thresholds), np.nan))
     assert fpr.shape == tpr.shape

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -17,7 +17,6 @@ from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import assert_warns
 
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import auc


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

fixes #19414

#### What does this implement/fix? Explain your changes.
Remove the use of assert_warns and assert_warns_message in the files:
 - sklearn/metrics/tests/test_classification.py 
 - sklearn/metrics/tests/test_ranking.py

#### Any other comments?

#DataUmbrella sprint
This PR was developed by @sofide and myself.
cc: @amueller @g-walsh

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
