### PR TITLE
Replace assert_warns* with pytest context manager in sklearn/utilst/tests/*

### DIFF
--- a/sklearn/utils/tests/test_deprecation.py
+++ b/sklearn/utils/tests/test_deprecation.py
@@ -6,7 +6,7 @@ import pickle
 
 from sklearn.utils.deprecation import _is_deprecated
 from sklearn.utils.deprecation import deprecated
-from sklearn.utils._testing import assert_warns_message
+import pytest
 
 
 @deprecated("qwerty")
@@ -42,10 +42,14 @@ def mock_function():
 
 
 def test_deprecated():
-    assert_warns_message(FutureWarning, "qwerty", MockClass1)
-    assert_warns_message(FutureWarning, "mockclass2_method", MockClass2().method)
-    assert_warns_message(FutureWarning, "deprecated", MockClass3)
-    val = assert_warns_message(FutureWarning, "deprecated", mock_function)
+    with pytest.warns(FutureWarning, match="qwerty"):
+        MockClass1()
+    with pytest.warns(FutureWarning, match="mockclass2_method"):
+        MockClass2().method()
+    with pytest.warns(FutureWarning, match="deprecated"):
+        MockClass3()
+    with pytest.warns(FutureWarning, match="deprecated"):
+        val = mock_function()
     assert val == 10
 
 

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -19,8 +19,6 @@ from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_allclose_dense_sparse
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import assert_warns
-from sklearn.utils._testing import assert_warns_message
 from sklearn.utils._testing import skip_if_32bit
 
 from sklearn.utils.extmath import density, _safe_accumulator_op
@@ -492,16 +490,12 @@ def test_randomized_svd_sparse_warnings():
     n_components = 5
     for cls in (sparse.lil_matrix, sparse.dok_matrix):
         X = cls(X)
-        assert_warns_message(
-            sparse.SparseEfficiencyWarning,
+        warn_msg = (
             "Calculating SVD of a {} is expensive. "
-            "csr_matrix is more efficient.".format(cls.__name__),
-            randomized_svd,
-            X,
-            n_components,
-            n_iter=1,
-            power_iteration_normalizer="none",
+            "csr_matrix is more efficient.".format(cls.__name__)
         )
+        with pytest.warns(sparse.SparseEfficiencyWarning, match=warn_msg):
+            randomized_svd(X, n_components, n_iter=1, power_iteration_normalizer="none")
 
 
 def test_svd_flip():
@@ -898,7 +892,8 @@ def test_softmax():
 def test_stable_cumsum():
     assert_array_equal(stable_cumsum([1, 2, 3]), np.cumsum([1, 2, 3]))
     r = np.random.RandomState(0).rand(100000)
-    assert_warns(RuntimeWarning, stable_cumsum, r, rtol=0, atol=0)
+    with pytest.warns(RuntimeWarning):
+        stable_cumsum(r, rtol=0, atol=0)
 
     # test axis parameter
     A = np.random.RandomState(36).randint(1000, size=(5, 5, 5))

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -119,12 +119,16 @@ def test_ignore_warning():
     # Check the function directly
     assert_no_warnings(ignore_warnings(_warning_function))
     assert_no_warnings(ignore_warnings(_warning_function, category=DeprecationWarning))
-    with pytest.warns(DeprecationWarning):
-        ignore_warnings(_warning_function, category=UserWarning)
-    with pytest.warns(UserWarning):
-        ignore_warnings(_multiple_warning_function, category=FutureWarning)
-    with pytest.warns(DeprecationWarning):
-        ignore_warnings(_multiple_warning_function, category=UserWarning)
+    assert_warns(
+        DeprecationWarning, ignore_warnings(_warning_function, category=UserWarning)
+    )
+    assert_warns(
+        UserWarning, ignore_warnings(_multiple_warning_function, category=FutureWarning)
+    )
+    assert_warns(
+        DeprecationWarning,
+        ignore_warnings(_multiple_warning_function, category=UserWarning),
+    )
     assert_no_warnings(
         ignore_warnings(_warning_function, category=(DeprecationWarning, UserWarning))
     )

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -107,7 +107,7 @@ def test_assert_raise_message():
 
 
 def test_ignore_warning():
-    # This check that ignore_warning decorateur and context manager are working
+    # This check that ignore_warning decorator and context manager are working
     # as expected
     def _warning_function():
         warnings.warn("deprecation warning", DeprecationWarning)
@@ -119,16 +119,12 @@ def test_ignore_warning():
     # Check the function directly
     assert_no_warnings(ignore_warnings(_warning_function))
     assert_no_warnings(ignore_warnings(_warning_function, category=DeprecationWarning))
-    assert_warns(
-        DeprecationWarning, ignore_warnings(_warning_function, category=UserWarning)
-    )
-    assert_warns(
-        UserWarning, ignore_warnings(_multiple_warning_function, category=FutureWarning)
-    )
-    assert_warns(
-        DeprecationWarning,
-        ignore_warnings(_multiple_warning_function, category=UserWarning),
-    )
+    with pytest.warns(DeprecationWarning):
+        ignore_warnings(_warning_function, category=UserWarning)
+    with pytest.warns(UserWarning):
+        ignore_warnings(_multiple_warning_function, category=FutureWarning)
+    with pytest.warns(DeprecationWarning):
+        ignore_warnings(_multiple_warning_function, category=UserWarning)
     assert_no_warnings(
         ignore_warnings(_warning_function, category=(DeprecationWarning, UserWarning))
     )
@@ -162,9 +158,12 @@ def test_ignore_warning():
     assert_no_warnings(decorator_no_warning)
     assert_no_warnings(decorator_no_warning_multiple)
     assert_no_warnings(decorator_no_deprecation_warning)
-    assert_warns(DeprecationWarning, decorator_no_user_warning)
-    assert_warns(UserWarning, decorator_no_deprecation_multiple_warning)
-    assert_warns(DeprecationWarning, decorator_no_user_multiple_warning)
+    with pytest.warns(DeprecationWarning):
+        decorator_no_user_warning()
+    with pytest.warns(UserWarning):
+        decorator_no_deprecation_multiple_warning()
+    with pytest.warns(DeprecationWarning):
+        decorator_no_user_multiple_warning()
 
     # Check the context manager
     def context_manager_no_warning():
@@ -194,9 +193,12 @@ def test_ignore_warning():
     assert_no_warnings(context_manager_no_warning)
     assert_no_warnings(context_manager_no_warning_multiple)
     assert_no_warnings(context_manager_no_deprecation_warning)
-    assert_warns(DeprecationWarning, context_manager_no_user_warning)
-    assert_warns(UserWarning, context_manager_no_deprecation_multiple_warning)
-    assert_warns(DeprecationWarning, context_manager_no_user_multiple_warning)
+    with pytest.warns(DeprecationWarning):
+        context_manager_no_user_warning()
+    with pytest.warns(UserWarning):
+        context_manager_no_deprecation_multiple_warning()
+    with pytest.warns(DeprecationWarning):
+        context_manager_no_user_multiple_warning()
 
     # Check that passing warning class as first positional argument
     warning_class = UserWarning

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -11,7 +11,6 @@ import scipy.sparse as sp
 from sklearn.utils._testing import (
     assert_array_equal,
     assert_allclose_dense_sparse,
-    assert_warns_message,
     assert_no_warnings,
     _convert_container,
 )
@@ -545,7 +544,7 @@ def test_gen_even_slices():
 
 
 @pytest.mark.parametrize(
-    ("row_bytes", "max_n_rows", "working_memory", "expected", "warning"),
+    ("row_bytes", "max_n_rows", "working_memory", "expected", "warn_msg"),
     [
         (1024, None, 1, 1024, None),
         (1024, None, 0.99999999, 1023, None),
@@ -564,30 +563,26 @@ def test_gen_even_slices():
         ),
     ],
 )
-def test_get_chunk_n_rows(row_bytes, max_n_rows, working_memory, expected, warning):
-    if warning is not None:
-
-        def check_warning(*args, **kw):
-            return assert_warns_message(UserWarning, warning, *args, **kw)
-
-    else:
-        check_warning = assert_no_warnings
-
-    actual = check_warning(
-        get_chunk_n_rows,
-        row_bytes=row_bytes,
-        max_n_rows=max_n_rows,
-        working_memory=working_memory,
-    )
+def test_get_chunk_n_rows(row_bytes, max_n_rows, working_memory, expected, warn_msg):
+    warning = None if warn_msg is None else UserWarning
+    with pytest.warns(warning, match=warn_msg) as w:
+        actual = get_chunk_n_rows(
+            row_bytes=row_bytes,
+            max_n_rows=max_n_rows,
+            working_memory=working_memory,
+        )
 
     assert actual == expected
     assert type(actual) is type(expected)
+    if warn_msg is None:
+        assert len(w) == 0
     with config_context(working_memory=working_memory):
-        actual = check_warning(
-            get_chunk_n_rows, row_bytes=row_bytes, max_n_rows=max_n_rows
-        )
+        with pytest.warns(warning, match=warn_msg) as w:
+            actual = get_chunk_n_rows(row_bytes=row_bytes, max_n_rows=max_n_rows)
         assert actual == expected
         assert type(actual) is type(expected)
+        if warn_msg is None:
+            assert len(w) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #19414


#### What does this implement/fix? Explain your changes.
This PR replaces `assert_warns` and `assert_warns_message` with pytest context manager for the module sklearn/utilst/tests


#### Any other comments?
I don't know why (the logic was the same for every replacement) but the test `test_ignore_warning` from [sklearn/utils/tests/test_testing.py](https://github.com/scikit-learn/scikit-learn/blob/daae053f7e9afc1dac24ce9ecce87f1356b96b03/sklearn/utils/tests/test_testing.py#L122-L131) fails locally. I was not able to fix it, that is why this is Work In Progress. I would like to see if they pass in the CI or not. This test only fails when `ignore_warnings` is used as a function.


It should be noted that [sklearn/utils/tests/test_estimator_checks.py ](https://github.com/scikit-learn/scikit-learn/blob/daae053f7e9afc1dac24ce9ecce87f1356b96b03/sklearn/utils/tests/test_estimator_checks.py) still uses `assert_warns` . In this file, in a [comment](https://github.com/scikit-learn/scikit-learn/blob/daae053f7e9afc1dac24ce9ecce87f1356b96b03/sklearn/utils/tests/test_estimator_checks.py#L1-L3), it is mentioned that pytest can not be used.
For that reason, the tests for `assert_warns` were not replaced in [sklearn/utils/tests/test_testing.py](https://github.com/scikit-learn/scikit-learn/blob/daae053f7e9afc1dac24ce9ecce87f1356b96b03/sklearn/utils/tests/test_testing.py#L216-L253) and neither was the definition of the function in [sklearn/utils/_testing.py](https://github.com/scikit-learn/scikit-learn/blob/daae053f7e9afc1dac24ce9ecce87f1356b96b03/sklearn/utils/_testing.py#L85).

On the other hand, we could probably do something similar with `assert_no_warnings` using the pytest context manager and checking the number of warnings. Although we should filter those from `np.VisibleDeprecationWarning` to replicate the behavior from `assert_no_warnings`.

Let me know what you think about the pull request. Any suggestion is more than welcome 🤓 


Thanks #DataUmbrella
cc: @tomasmoreyra
