### PR TITLE
[MRG] FIX missing OrdinaryEncorder.get_feature_names

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -564,6 +564,9 @@ Changelog
   `n_features_in_` and will be removed in 1.2. :pr:`20240` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |Feature| :class:`preprocessing.OrdinalEncoder` now supports
+  `get_feature_names` method. :pr:`20423` by :user:`tsuga <tsuga>`.
+
 :mod:`sklearn.tree`
 ...................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -564,8 +564,8 @@ Changelog
   `n_features_in_` and will be removed in 1.2. :pr:`20240` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
-- |Feature| :class:`preprocessing.OrdinalEncoder` now supports
-  `get_feature_names` method. :pr:`20423` by :user:`tsuga <tsuga>`.
+- |Feature| :class:`preprocessing.OrdinalEncoder` now provides
+  the `get_feature_names` method. :pr:`20423` by :user:`tsuga <tsuga>`.
 
 :mod:`sklearn.tree`
 ...................

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -945,3 +945,34 @@ class OrdinalEncoder(_BaseEncoder):
                 X_tr[mask, idx] = None
 
         return X_tr
+
+    def get_feature_names(self, input_features=None):
+        """
+        Return feature names for output features.
+
+        Parameters
+        ----------
+        input_features : list of str of shape (n_features,)
+            String names for input features if available. By default,
+            "x0", "x1", ... "xn" is used.
+
+        Returns
+        -------
+        output_feature_names : ndarray of shape (n_output_features,)
+            Array of feature names.
+
+        .. versionadded:: 1.0.dev0
+        """
+        check_is_fitted(self)
+        cats = self.categories_
+        if input_features is None:
+            input_features = ["x%d" % i for i in range(len(cats))]
+        elif len(input_features) != len(self.categories_):
+            raise ValueError(
+                "input_features should have length equal to number of "
+                "features ({}), got {}".format(
+                    len(self.categories_), len(input_features)
+                )
+            )
+
+        return np.array(input_features, dtype=object)

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -961,7 +961,7 @@ class OrdinalEncoder(_BaseEncoder):
         output_feature_names : ndarray of shape (n_output_features,)
             Array of feature names.
 
-        .. versionadded:: 1.0.dev0
+        .. versionadded:: 1.0
         """
         check_is_fitted(self)
         cats = self.categories_

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1332,3 +1332,37 @@ def test_ordinal_encoder_handle_unknown_string_dtypes(X_train, X_test):
 
     X_trans = enc.transform(X_test)
     assert_allclose(X_trans, [[-9, 0]])
+
+
+def test_ordinal_encorder_feature_names():
+    enc = OrdinalEncoder()
+    X = [
+        ["Male", 1, "girl", 2, 3],
+        ["Female", 41, "girl", 1, 10],
+        ["Male", 51, "boy", 12, 3],
+        ["Male", 91, "girl", 21, 30],
+    ]
+
+    enc.fit(X)
+    feature_names = enc.get_feature_names()
+    assert isinstance(feature_names, np.ndarray)
+
+    assert_array_equal(
+        ["x0", "x1", "x2", "x3", "x4"],
+        feature_names,
+    )
+
+    feature_names2 = enc.get_feature_names(["one", "two", "three", "four", "five"])
+
+    assert_array_equal(["one", "two", "three", "four", "five"], feature_names2)
+
+    with pytest.raises(ValueError, match="input_features should have length"):
+        enc.get_feature_names(["one", "two"])
+
+
+def test_ordinal_encoder_feature_names_unicode():
+    enc = OrdinalEncoder()
+    X = np.array([["c❤t1", "dat2"]], dtype=object).T
+    enc.fit(X)
+    feature_names = enc.get_feature_names(input_features=["n👍me"])
+    assert_array_equal(["n👍me"], feature_names)


### PR DESCRIPTION
#### Reference Issues/PRs
N/A


#### What does this implement/fix? Explain your changes.

Currently, `OrdinaryEncorder` does not support `get_feature_names` method.
However, `ColumnTransformer`, which is often used together with `OrdinaryEncorder`, expects transformers have their  `get_feature_names` method.

This PR adds a `get_feature_names` method to `OrdinaryEncorder`

#### Any other comments?
N/A

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
