### PR TITLE
DOC Update link for Yen-Chen Lin in about page

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -556,7 +556,7 @@ program.
 - 2013 - Kemal Eren, Nicolas Trésegnie
 - 2014 - Hamzeh Alsalhi, Issam Laradji, Maheshakya Wijewardena, Manoj Kumar.
 - 2015 - `Raghav RV <https://github.com/raghavrv>`_, Wei Xue
-- 2016 - `Nelson Liu <http://nelsonliu.me>`_, `YenChen Lin <https://yclin.me/>`_
+- 2016 - `Nelson Liu <http://nelsonliu.me>`_, `YenChen Lin <https://yenchenlin.me/>`_
 
 .. _Vlad Niculae: https://vene.ro/
 


### PR DESCRIPTION
Updates the link to @yenchenlin's webpage in sklearn's about page.