### PR TITLE
[MRG] BaseEstimator added url with info about problems to load with pickle models from differents sklearn versions

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -210,7 +210,7 @@ class BaseEstimator:
     def set_params(self, **params):
         """
         Set the parameters of this estimator.
-        
+
         The method works on simple estimators as well as on nested objects
         (such as :class:`~sklearn.pipeline.Pipeline`). The latter have
         parameters of the form ``<component>__<parameter>`` so that it's

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -210,7 +210,9 @@ class BaseEstimator:
     def set_params(self, **params):
         """
         Set the parameters of this estimator.
-BaseEstimatorpipeline.Pipeline`). The latter have
+        
+        The method works on simple estimators as well as on nested objects
+        (such as :class:`~sklearn.pipeline.Pipeline`). The latter have
         parameters of the form ``<component>__<parameter>`` so that it's
         possible to update each component of a nested object.
 
@@ -321,9 +323,9 @@ BaseEstimatorpipeline.Pipeline`). The latter have
                     "Trying to unpickle estimator {0} from version {1} when "
                     "using version {2}. This might lead to breaking code or "
                     "invalid results. Use at your own risk. "
-                    "For more info please refer to:\n\n"
+                    "For more info please refer to:\n"
                     "https://scikit-learn.org/stable/modules/model_persistence"
-                    ".html#security-maintainability-limitations \n".format(
+                    ".html#security-maintainability-limitations".format(
                         self.__class__.__name__, pickle_version, __version__
                     ),
                     UserWarning,

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -322,7 +322,8 @@ class BaseEstimator:
                 warnings.warn(
                     "Trying to unpickle estimator {0} from version {1} when "
                     "using version {2}. This might lead to breaking code or "
-                    "invalid results. Use at your own risk.".format(
+                    "invalid results. Use at your own risk. For more info please refer to:\n\n"
+                    "https://scikit-learn.org/stable/modules/model_persistence.html#security-maintainability-limitations \n".format(
                         self.__class__.__name__, pickle_version, __version__
                     ),
                     UserWarning,

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -210,9 +210,7 @@ class BaseEstimator:
     def set_params(self, **params):
         """
         Set the parameters of this estimator.
-
-        The method works on simple estimators as well as on nested objects
-        (such as :class:`~sklearn.pipeline.Pipeline`). The latter have
+BaseEstimatorpipeline.Pipeline`). The latter have
         parameters of the form ``<component>__<parameter>`` so that it's
         possible to update each component of a nested object.
 
@@ -322,8 +320,10 @@ class BaseEstimator:
                 warnings.warn(
                     "Trying to unpickle estimator {0} from version {1} when "
                     "using version {2}. This might lead to breaking code or "
-                    "invalid results. Use at your own risk. For more info please refer to:\n\n"
-                    "https://scikit-learn.org/stable/modules/model_persistence.html#security-maintainability-limitations \n".format(
+                    "invalid results. Use at your own risk. "
+                    "For more info please refer to:\n\n"
+                    "https://scikit-learn.org/stable/modules/model_persistence"
+                    ".html#security-maintainability-limitations \n".format(
                         self.__class__.__name__, pickle_version, __version__
                     ),
                     UserWarning,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #20306
See also #7248

#### What does this implement/fix? Explain your changes.

When try to unpickle a model estimator with different version of Scikit-Learn, now  in the warning refer to the page https://scikit-learn.org/stable/modules/model_persistence.html#security-maintainability-limitations that give more info about the warning.

#### Any other comments?
This is how the warning shown in terminal:

![terminal](https://user-images.githubusercontent.com/39212747/124035551-f7f5d000-d9fc-11eb-9d30-6a4ad055db46.png)

And here in Jupyter:
![jupyter](https://user-images.githubusercontent.com/39212747/124035590-0a700980-d9fd-11eb-8dd8-94d0e8cdc365.png)



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
