### PR TITLE
TST Replace assert_warns with pytest context manager in sklearn/utilst/tests/test_testing.py

### DIFF
--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -119,16 +119,12 @@ def test_ignore_warning():
     # Check the function directly
     assert_no_warnings(ignore_warnings(_warning_function))
     assert_no_warnings(ignore_warnings(_warning_function, category=DeprecationWarning))
-    assert_warns(
-        DeprecationWarning, ignore_warnings(_warning_function, category=UserWarning)
-    )
-    assert_warns(
-        UserWarning, ignore_warnings(_multiple_warning_function, category=FutureWarning)
-    )
-    assert_warns(
-        DeprecationWarning,
-        ignore_warnings(_multiple_warning_function, category=UserWarning),
-    )
+    with pytest.warns(DeprecationWarning):
+        ignore_warnings(_warning_function, category=UserWarning)()
+    with pytest.warns(UserWarning):
+        ignore_warnings(_multiple_warning_function, category=FutureWarning)()
+    with pytest.warns(DeprecationWarning):
+        ignore_warnings(_multiple_warning_function, category=UserWarning)()
     assert_no_warnings(
         ignore_warnings(_warning_function, category=(DeprecationWarning, UserWarning))
     )


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #19414

#### What does this implement/fix? Explain your changes.
This PR replaces `assert_warns` with pytest context manager in sklearn/utilst/tests/test_testing.py.

It fixes the failing tests for this [PR](https://github.com/scikit-learn/scikit-learn/pull/20421) which were reverted to merge it.
The problem was that to call the function [`ignore_warnings`](https://github.com/scikit-learn/scikit-learn/blob/e4ef854d031854932b7165d55bfd04a400af6b85/sklearn/utils/_testing.py#L224) we should use `ignore_warnings(_warning_function, category=UserWarning)()` for example, instead of `ignore_warnings(_warning_function, category=UserWarning)` (which was what I tried in the beginning).
Otherwise the wrapped function is never executed.

#### Any other comments?
#DataUmbrella Sprint