### PR TITLE
DOC Ensures that NearestNeighbors passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -107,7 +107,6 @@ DOCSTRING_IGNORE_LIST = [
     "MultinomialNB",
     "NMF",
     "NearestCentroid",
-    "NearestNeighbors",
     "NeighborhoodComponentsAnalysis",
     "Normalizer",
     "NuSVC",

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -954,7 +954,7 @@ class RadiusNeighborsMixin:
     def radius_neighbors(
         self, X=None, radius=None, return_distance=True, sort_results=False
     ):
-        """Finds the neighbors within a given radius of a point or points.
+        """Find the neighbors within a given radius of a point or points.
 
         Return the indices and distances of each point from the dataset
         lying in a ball with size ``radius`` around the points of the query
@@ -997,6 +997,14 @@ class RadiusNeighborsMixin:
             from the population matrix that lie within a ball of size
             ``radius`` around the query points.
 
+        Notes
+        -----
+        Because the number of neighbors of each point is not necessarily
+        equal, the results for multiple query points cannot be fit in a
+        standard data array.
+        For efficiency, `radius_neighbors` returns arrays of objects, where
+        each object is a 1D array of indices or distances.
+
         Examples
         --------
         In the following example, we construct a NeighborsClassifier
@@ -1018,14 +1026,6 @@ class RadiusNeighborsMixin:
         The first array returned contains the distances to all points which
         are closer than 1.6, while the second array returned contains their
         indices.  In general, multiple points can be queried at the same time.
-
-        Notes
-        -----
-        Because the number of neighbors of each point is not necessarily
-        equal, the results for multiple query points cannot be fit in a
-        standard data array.
-        For efficiency, `radius_neighbors` returns arrays of objects, where
-        each object is a 1D array of indices or distances.
         """
         check_is_fitted(self)
 
@@ -1146,7 +1146,7 @@ class RadiusNeighborsMixin:
     def radius_neighbors_graph(
         self, X=None, radius=None, mode="connectivity", sort_results=False
     ):
-        """Computes the (weighted) graph of Neighbors for points in X
+        """Compute the (weighted) graph of Neighbors for points in X.
 
         Neighborhoods are restricted the points at a distance lower than
         radius.
@@ -1183,6 +1183,11 @@ class RadiusNeighborsMixin:
             `A[i, j]` gives the weight of the edge connecting `i` to `j`.
             The matrix is of CSR format.
 
+        See Also
+        --------
+        kneighbors_graph :
+            Compute the (weighted) graph of k-Neighbors for points in X.
+
         Examples
         --------
         >>> X = [[0], [3], [1]]
@@ -1195,10 +1200,6 @@ class RadiusNeighborsMixin:
         array([[1., 0., 1.],
                [0., 1., 0.],
                [1., 0., 1.]])
-
-        See Also
-        --------
-        kneighbors_graph
         """
         check_is_fitted(self)
 

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -1185,8 +1185,8 @@ class RadiusNeighborsMixin:
 
         See Also
         --------
-        kneighbors_graph :
-            Compute the (weighted) graph of k-Neighbors for points in X.
+        kneighbors_graph : Compute the (weighted) graph of k-Neighbors for
+            points in X.
 
         Examples
         --------

--- a/sklearn/neighbors/_unsupervised.py
+++ b/sklearn/neighbors/_unsupervised.py
@@ -39,7 +39,7 @@ class NearestNeighbors(KNeighborsMixin, RadiusNeighborsMixin, NeighborsBase):
         nature of the problem.
 
     metric : str or callable, default='minkowski'
-        the distance metric to use for the tree.  The default metric is
+        The distance metric to use for the tree.  The default metric is
         minkowski, and with p=2 is equivalent to the standard Euclidean
         metric. See the documentation of :class:`DistanceMetric` for a
         list of available metrics.
@@ -78,6 +78,28 @@ class NearestNeighbors(KNeighborsMixin, RadiusNeighborsMixin, NeighborsBase):
     n_samples_fit_ : int
         Number of samples in the fitted data.
 
+    See Also
+    --------
+    KNeighborsClassifier :
+        Classifier implementing the k-nearest neighbors vote.
+    RadiusNeighborsClassifier :
+        Classifier implementing a vote among neighbors within a given
+        radius.
+    KNeighborsRegressor :
+        Regression based on k-nearest neighbors.
+    RadiusNeighborsRegressor :
+        Regression based on neighbors within a fixed radius.
+    BallTree :
+        Space partitioning data structure for organizing points in a
+        multi-dimensional space, used for nearest neighbor search.
+
+    Notes
+    -----
+    See :ref:`Nearest Neighbors <neighbors>` in the online documentation
+    for a discussion of the choice of ``algorithm`` and ``leaf_size``.
+
+    https://en.wikipedia.org/wiki/K-nearest_neighbors_algorithm
+
     Examples
     --------
     >>> import numpy as np
@@ -96,21 +118,6 @@ class NearestNeighbors(KNeighborsMixin, RadiusNeighborsMixin, NeighborsBase):
     ... )
     >>> np.asarray(nbrs[0][0])
     array(2)
-
-    See Also
-    --------
-    KNeighborsClassifier
-    RadiusNeighborsClassifier
-    KNeighborsRegressor
-    RadiusNeighborsRegressor
-    BallTree
-
-    Notes
-    -----
-    See :ref:`Nearest Neighbors <neighbors>` in the online documentation
-    for a discussion of the choice of ``algorithm`` and ``leaf_size``.
-
-    https://en.wikipedia.org/wiki/K-nearest_neighbors_algorithm
     """
 
     def __init__(

--- a/sklearn/neighbors/_unsupervised.py
+++ b/sklearn/neighbors/_unsupervised.py
@@ -80,17 +80,14 @@ class NearestNeighbors(KNeighborsMixin, RadiusNeighborsMixin, NeighborsBase):
 
     See Also
     --------
-    KNeighborsClassifier :
-        Classifier implementing the k-nearest neighbors vote.
-    RadiusNeighborsClassifier :
-        Classifier implementing a vote among neighbors within a given
+    KNeighborsClassifier : Classifier implementing the k-nearest neighbors
+        vote.
+    RadiusNeighborsClassifier : Classifier implementing a vote among neighbors
+        within a given radius.
+    KNeighborsRegressor : Regression based on k-nearest neighbors.
+    RadiusNeighborsRegressor : Regression based on neighbors within a fixed
         radius.
-    KNeighborsRegressor :
-        Regression based on k-nearest neighbors.
-    RadiusNeighborsRegressor :
-        Regression based on neighbors within a fixed radius.
-    BallTree :
-        Space partitioning data structure for organizing points in a
+    BallTree : Space partitioning data structure for organizing points in a
         multi-dimensional space, used for nearest neighbor search.
 
     Notes


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures `NearestNeighbors` is compatible with numpydoc.
- Remove `NearestNeighbors` from `DOCSTRING_IGNORE_LIST`.
- Verify all tests passing.


#### Any other comments?
#DataUmbrella Sprint