### PR TITLE
DOC Ensures that LinearSVC passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -83,7 +83,6 @@ DOCSTRING_IGNORE_LIST = [
     "LassoLarsIC",
     "LatentDirichletAllocation",
     "LedoitWolf",
-    "LinearSVC",
     "LinearSVR",
     "LocalOutlierFactor",
     "LocallyLinearEmbedding",


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308

#### What does this implement/fix? Explain your changes.
LinearSVC was already compatible with numpydoc. I only removed `LinearSVC` from `DOCSTRING_IGNORE_LIST`.

#### Any other comments?
#DataUmbrella Sprint
