### PR TITLE
DOC: add sphinxext-opengraph

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
       - SPHINX_GALLERY_VERSION: 'min'
       - NUMPYDOC_VERSION: 'min'
       - SPHINX_PROMPT_VERSION: 'min'
+      - SPHINXEXT_OPENGRAPH_VERSION: 'min'
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
@@ -63,6 +64,7 @@ jobs:
       - SPHINX_GALLERY_VERSION: 'latest'
       - NUMPYDOC_VERSION: 'latest'
       - SPHINX_PROMPT_VERSION: 'latest'
+      - SPHINXEXT_OPENGRAPH_VERSION: 'latest'
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -180,6 +180,7 @@ pip install "$(get_dep scikit-image $SCIKIT_IMAGE_VERSION)"
 pip install "$(get_dep sphinx-gallery $SPHINX_GALLERY_VERSION)"
 pip install "$(get_dep numpydoc $NUMPYDOC_VERSION)"
 pip install "$(get_dep sphinx-prompt $SPHINX_PROMPT_VERSION)"
+pip install "$(get_dep sphinxext-opengraph $SPHINXEXT_OPENGRAPH_VERSION)"
 
 # Set parallelism to 3 to overlap IO bound tasks with CPU bound tasks on CI
 # workers with 2 cores when building the compiled extensions of scikit-learn.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinx_issues",
     "add_toctree_functions",
     "sphinx-prompt",
+    "sphinxext.opengraph",
 ]
 
 # this is needed for some reason...
@@ -506,3 +507,11 @@ autosummary_filename_map = {
     "sklearn.covariance.oas": "oas-function",
     "sklearn.decomposition.fastica": "fastica-function",
 }
+
+
+# Config for sphinxext.opengraph
+
+ogp_site_url = "https://scikit-learn/stable/"
+ogp_image = "https://scikit-learn.org/stable/_static/scikit-learn-logo-small.png"
+ogp_use_first_image = True
+ogp_site_name = "scikit-learn"

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -703,7 +703,8 @@ Building the documentation requires installing some additional packages:
 .. prompt:: bash $
 
     pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas \
-                scikit-image packaging seaborn sphinx-prompt
+                scikit-image packaging seaborn sphinx-prompt \
+                sphinxext-opengraph
 
 To build the documentation, you need to be in the ``doc`` folder:
 

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -41,6 +41,7 @@ dependent_packages = {
     "numpydoc": ("1.0.0", "docs"),
     "Pillow": ("7.1.2", "docs"),
     "sphinx-prompt": ("1.3.0", "docs"),
+    "sphinxext-opengraph": ("0.4.2", "docs"),
 }
 
 


### PR DESCRIPTION
sphinxext-opengraph creates social-network thumbnails and summaries.
Hence it makes scikit-learn online presence more visible and readable.

The drawback is an added dependency (sphinxext-opengraph) to build the doc.

This PR is just a test to demo the functionality and see if we like it.

Under mattermost (and slack, and other social networks) it produces previews as such:
![image](https://user-images.githubusercontent.com/208217/124400192-f7bd4380-dd20-11eb-924a-61deeb1b204c.png)
