### PR TITLE
MAINT Make multioutput tests deterministic

### DIFF
--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -34,7 +34,7 @@ from sklearn.ensemble import StackingRegressor
 
 
 def test_multi_target_regression():
-    X, y = datasets.make_regression(n_targets=3)
+    X, y = datasets.make_regression(n_targets=3, random_state=0)
     X_train, y_train = X[:50], y[:50]
     X_test, y_test = X[50:], y[50:]
 
@@ -52,7 +52,7 @@ def test_multi_target_regression():
 
 
 def test_multi_target_regression_partial_fit():
-    X, y = datasets.make_regression(n_targets=3)
+    X, y = datasets.make_regression(n_targets=3, random_state=0)
     X_train, y_train = X[:50], y[:50]
     X_test, y_test = X[50:], y[50:]
 
@@ -76,7 +76,7 @@ def test_multi_target_regression_partial_fit():
 
 def test_multi_target_regression_one_target():
     # Test multi target regression raises
-    X, y = datasets.make_regression(n_targets=1)
+    X, y = datasets.make_regression(n_targets=1, random_state=0)
     rgr = MultiOutputRegressor(GradientBoostingRegressor(random_state=0))
     msg = "at least two dimensions"
     with pytest.raises(ValueError, match=msg):
@@ -84,7 +84,7 @@ def test_multi_target_regression_one_target():
 
 
 def test_multi_target_sparse_regression():
-    X, y = datasets.make_regression(n_targets=3)
+    X, y = datasets.make_regression(n_targets=3, random_state=0)
     X_train, y_train = X[:50], y[:50]
     X_test = X[50:]
 
@@ -601,7 +601,7 @@ class DummyClassifierWithFitParams(DummyClassifier):
         ),
         (
             MultiOutputRegressor(DummyRegressorWithFitParams()),
-            datasets.make_regression(n_targets=3),
+            datasets.make_regression(n_targets=3, random_state=0),
         ),
     ],
 )
@@ -616,7 +616,7 @@ def test_multioutput_estimator_with_fit_params(estimator, dataset):
 def test_regressor_chain_w_fit_params():
     # Make sure fit_params are properly propagated to the sub-estimators
     rng = np.random.RandomState(0)
-    X, y = datasets.make_regression(n_targets=3)
+    X, y = datasets.make_regression(n_targets=3, random_state=0)
     weight = rng.rand(y.shape[0])
 
     class MySGD(SGDRegressor):

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -33,10 +33,8 @@ from sklearn.impute import SimpleImputer
 from sklearn.ensemble import StackingRegressor
 
 
-# XXX: DEBUG only, do no merge with `range(1000)`
-@pytest.mark.parametrize("seed", range(1000))
-def test_multi_target_regression(seed):
-    X, y = datasets.make_regression(n_targets=3, random_state=seed)
+def test_multi_target_regression():
+    X, y = datasets.make_regression(n_targets=3, random_state=0)
     X_train, y_train = X[:50], y[:50]
     X_test, y_test = X[50:], y[50:]
 

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -33,8 +33,10 @@ from sklearn.impute import SimpleImputer
 from sklearn.ensemble import StackingRegressor
 
 
-def test_multi_target_regression():
-    X, y = datasets.make_regression(n_targets=3, random_state=0)
+# XXX: DEBUG only, do no merge with `range(1000)`
+@pytest.mark.parametrize("seed", range(1000))
+def test_multi_target_regression(seed):
+    X, y = datasets.make_regression(n_targets=3, random_state=seed)
     X_train, y_train = X[:50], y[:50]
     X_test, y_test = X[50:], y[50:]
 


### PR DESCRIPTION
To avoid rare random failures such as the one that occurred when running the last nightly builds:

https://github.com/scikit-learn/scikit-learn/runs/2986642144?check_suite_focus=true

Note however that the failure observed in this test run is weird:

```python
      def test_multi_target_regression():
          X, y = datasets.make_regression(n_targets=3)
          X_train, y_train = X[:50], y[:50]
          X_test, y_test = X[50:], y[50:]
      
          references = np.zeros_like(y_test)
          for n in range(3):
              rgr = GradientBoostingRegressor(random_state=0)
              rgr.fit(X_train, y_train[:, n])
              references[:, n] = rgr.predict(X_test)
      
          rgr = MultiOutputRegressor(GradientBoostingRegressor(random_state=0))
          rgr.fit(X_train, y_train)
          y_pred = rgr.predict(X_test)
      
  >       assert_almost_equal(references, y_pred)
  E       AssertionError: 
  E       Arrays are not almost equal to 7 decimals
  E       
  E       Mismatched elements: 25 / 150 (16.7%)
  E       Max absolute difference: 0.18403063
  E       Max relative difference: 0.06804465
  E        x: array([[-146.7381045,   54.9331913,  -68.1286592],
  E              [ -70.7373213,   19.757404 , -188.343298 ],
  E              [ -50.9623975,  102.3977605,   29.7333162],...
  E        y: array([[-146.793342 ,   54.9331913,  -68.1286592],
  E              [ -70.7902073,   19.757404 , -188.343298 ],
  E              [ -50.9623975,  102.3977605,   29.7333162],...
```

It might be caused a numerical stability problem that only appears with very specific data. However I could not reproduce it locally by scanning the `random_state` of the `make_regression` function in `range(500)`...

Still the magnitude of the failure is worrying...