### PR TITLE
Adjust comment to reflect the move away from the binder-examples repo

### DIFF
--- a/doc/binder/requirements.txt
+++ b/doc/binder/requirements.txt
@@ -1,5 +1,5 @@
-# A binder requirement file is required by sphinx-gallery. We don't really need
-# one since the binder requirement files live in the
-# scikit-learn/binder-examples repo and not in the scikit-learn.github.io repo
-# that comes from the scikit-learn doc build. This file can be removed if
-# 'dependencies' is made an optional key for binder in sphinx-gallery.
+# A binder requirement file is required by sphinx-gallery.
+# We don't really need one since our binder requirement file lives in the
+# .binder directory.
+# This file can be removed if 'dependencies' is made an optional key for
+# binder in sphinx-gallery.


### PR DESCRIPTION

#### Reference Issues/PRs
See also #14719

#### What does this implement/fix? Explain your changes.
#14719 moved the binder setup from the former `binder-examples` repo to the `scikit-learn` repo. The corresponding comment in the `doc/binder/requirements.txt` file was never updated to reflect that, though, which can lead to confusion.

