### PR TITLE
MNT black to ignore .vscode folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ exclude = '''
     \.eggs         # exclude a few common directories in the
   | \.git          # root of the project
   | \.mypy_cache
+  | \.vscode
   | examples
   | build
   | dist


### PR DESCRIPTION
`black` ended up "fixing" files in my `.vscode` folder, `black` should ignore that folder.

cc @thomasjpfan @rth 