### PR TITLE
ENH RFE passes metadata to the underlying fit and score methods

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -310,7 +310,12 @@ Changelog
   :pr:`17169` by :user:`Dmytro Lituiev <DSLituiev>`
   and :user:`Julien Jerphanion <jjerphan>`.
 
-- |API| Raises an error in :class:`feature_selection.VarianceThreshold`
+  - |Enhancement| :class:`feature_selection.RFE` now accepts extra input as
+    ``**metadata`` during ``fit`` and ``score`` which are passed to the
+    corresponding scores of the underlying estimator. :pr:`20491` by
+    `Adrin Jalali`_.
+
+  - |API| Raises an error in :class:`feature_selection.VarianceThreshold`
   when the variance threshold is negative.
   :pr:`20207` by :user:`Tomohiro Endo <europeanplaice>`
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -310,12 +310,12 @@ Changelog
   :pr:`17169` by :user:`Dmytro Lituiev <DSLituiev>`
   and :user:`Julien Jerphanion <jjerphan>`.
 
-  - |Enhancement| :class:`feature_selection.RFE` now accepts extra input as
-    ``**metadata`` during ``fit`` and ``score`` which are passed to the
-    corresponding scores of the underlying estimator. :pr:`20491` by
-    `Adrin Jalali`_.
+- |Enhancement| :class:`feature_selection.RFE` now accepts extra input as
+  ``**metadata`` during ``fit`` and ``score`` which are passed to the
+  corresponding scores of the underlying estimator. :pr:`20491` by
+  `Adrin Jalali`_.
 
-  - |API| Raises an error in :class:`feature_selection.VarianceThreshold`
+- |API| Raises an error in :class:`feature_selection.VarianceThreshold`
   when the variance threshold is negative.
   :pr:`20207` by :user:`Tomohiro Endo <europeanplaice>`
 

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -192,7 +192,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         """
         return self.estimator_.classes_
 
-    def fit(self, X, y):
+    def fit(self, X, y, **metadata):
         """Fit the RFE model and then the underlying estimator on the selected features.
 
         Parameters
@@ -203,14 +203,19 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         y : array-like of shape (n_samples,)
             The target values.
 
+        **metadata : dict, default=None
+            Parameters to be passed to the underlying estimator's fit.
+
+            .. versionadded:: 1.0
+
         Returns
         -------
         self : object
             Fitted estimator.
         """
-        return self._fit(X, y)
+        return self._fit(X, y, **metadata)
 
-    def _fit(self, X, y, step_score=None):
+    def _fit(self, X, y, step_score=None, **metadata):
         # Parameter step_score controls the calculation of self.scores_
         # step_score is not exposed to users
         # and is used when implementing RFECV
@@ -269,7 +274,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             if self.verbose > 0:
                 print("Fitting estimator with %d features." % np.sum(support_))
 
-            estimator.fit(X[:, features], y)
+            estimator.fit(X[:, features], y, **metadata)
 
             # Get importance and rank them
             importances = _get_feature_importances(
@@ -296,7 +301,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         # Set final attributes
         features = np.arange(n_features)[support_]
         self.estimator_ = clone(self.estimator)
-        self.estimator_.fit(X[:, features], y)
+        self.estimator_.fit(X[:, features], y, **metadata)
 
         # Compute step score when only n_features_to_select features left
         if step_score:
@@ -325,7 +330,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         return self.estimator_.predict(self.transform(X))
 
     @if_delegate_has_method(delegate="estimator")
-    def score(self, X, y):
+    def score(self, X, y, **metadata):
         """Reduce X to the selected features and return the score of the underlying estimator.
 
         Parameters
@@ -336,6 +341,11 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         y : array of shape [n_samples]
             The target values.
 
+        **metadata : dict, default=None
+            Parameters to be passed to the underlying estimator's score.
+
+            .. versionadded:: 1.0
+
         Returns
         -------
         score : float
@@ -343,7 +353,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             features returned by `rfe.transform(X)` and `y`.
         """
         check_is_fitted(self)
-        return self.estimator_.score(self.transform(X), y)
+        return self.estimator_.score(self.transform(X), y, **metadata)
 
     def _get_support_mask(self):
         check_is_fitted(self)

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -502,20 +502,20 @@ def test_RFE_fit_score_params():
     class TestEstimator(BaseEstimator, ClassifierMixin):
         def fit(self, X, y, prop=None):
             if prop is None:
-                raise ValueError("prop cannot be None")
+                raise ValueError("fit: prop cannot be None")
             self.svc_ = SVC(kernel="linear").fit(X, y)
             self.coef_ = self.svc_.coef_
             return self
 
         def score(self, X, y, prop=None):
             if prop is None:
-                raise ValueError("prop cannot be None")
+                raise ValueError("score: prop cannot be None")
             return self.svc_.score(X, y)
 
     X, y = load_iris(return_X_y=True)
-    with pytest.raises(ValueError, match="prop cannot be None"):
+    with pytest.raises(ValueError, match="fit: prop cannot be None"):
         RFE(estimator=TestEstimator()).fit(X, y)
-    with pytest.raises(ValueError, match="prop cannot be None"):
-        RFE(estimator=TestEstimator()).fit(X, y)
+    with pytest.raises(ValueError, match="score: prop cannot be None"):
+        RFE(estimator=TestEstimator()).fit(X, y, prop="foo").score(X, y)
 
     RFE(estimator=TestEstimator()).fit(X, y, prop="foo").score(X, y, prop="foo")


### PR DESCRIPTION
During https://github.com/scikit-learn/scikit-learn/pull/20350 I realized RFE doesn't accept metadata (e.g sample_weight) to be passed to the underlying estimator. This PR fixes that part, the rest need to stay in the other PR.

cc @jnothman @thomasjpfan 