### PR TITLE
DOC Ensures that Ridge passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -129,7 +129,6 @@ DOCSTRING_IGNORE_LIST = [
     "RandomTreesEmbedding",
     "RandomizedSearchCV",
     "RegressorChain",
-    "Ridge",
     "RidgeCV",
     "RidgeClassifier",
     "RidgeClassifierCV",

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -999,7 +999,8 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
 
         Returns
         -------
-        self : returns an instance of self.
+        self : object
+            Fitted estimator.
         """
         return super().fit(X, y, sample_weight=sample_weight)
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -988,10 +988,10 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         Parameters
         ----------
         X : {ndarray, sparse matrix} of shape (n_samples, n_features)
-            Training data
+            Training data.
 
         y : ndarray of shape (n_samples,) or (n_samples, n_targets)
-            Target values
+            Target values.
 
         sample_weight : float or ndarray of shape (n_samples,), default=None
             Individual weights for each sample. If given a float, every sample


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308

#### What does this implement/fix? Explain your changes.
Update Ridge to pass numpydoc validations RT03 and PR09.

#### Any other comments?
#DataUmbrella sprint
