### PR TITLE
MAINT Removes UserWarning when calling all_estimators

### DIFF
--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -1158,7 +1158,13 @@ def all_estimators(type_filter=None):
         return True
 
     all_classes = []
-    modules_to_ignore = {"tests", "externals", "setup", "conftest"}
+    modules_to_ignore = {
+        "tests",
+        "externals",
+        "setup",
+        "conftest",
+        "enable_hist_gradient_boosting",
+    }
     root = str(Path(__file__).parent.parent)  # sklearn package
     # Ignore deprecation warnings triggered at import time and from walking
     # packages

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -4,6 +4,7 @@
 
 import unittest
 import sys
+import warnings
 
 import numpy as np
 import scipy.sparse as sp
@@ -713,7 +714,10 @@ def test_check_class_weight_balanced_linear_classifier():
 def test_all_estimators_all_public():
     # all_estimator should not fail when pytest is not installed and return
     # only public estimators
-    estimators = all_estimators()
+    with warnings.catch_warnings(record=True) as record:
+        estimators = all_estimators()
+    # no warnings are raised
+    assert not record
     for est in estimators:
         assert not est.__class__.__name__.startswith("_")
 


### PR DESCRIPTION
This PR makes sure that `all_estimators` does not raise a `UserWarning` anymore.