### PR TITLE
DOC Ensures that RidgeCV passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -128,7 +128,6 @@ DOCSTRING_IGNORE_LIST = [
     "RandomTreesEmbedding",
     "RandomizedSearchCV",
     "RegressorChain",
-    "RidgeCV",
     "RidgeClassifier",
     "RidgeClassifierCV",
     "RobustScaler",

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2025,7 +2025,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
             ``normalize`` was deprecated in version 1.0 and will be removed in
             1.2.
 
-    scoring : string, callable, default=None
+    scoring : str, callable, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2111,7 +2111,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     See Also
     --------
     Ridge : Ridge regression.
-    RidgeClassifier : Ridge classifier.
+    RidgeClassifier : classifier based on ridge regression on {-1, 1} labels.
     RidgeClassifierCV : Ridge classifier with built-in cross validation.
 
     Examples

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1930,6 +1930,7 @@ class _BaseRidgeCV(LinearModel):
         Returns
         -------
         self : object
+            Fitted estimator.
 
         Notes
         -----

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2108,6 +2108,12 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
         .. versionadded:: 0.24
 
+    See Also
+    --------
+    Ridge : Ridge regression.
+    RidgeClassifier : Ridge classifier.
+    RidgeClassifierCV : Ridge classifier with built-in cross validation.
+
     Examples
     --------
     >>> from sklearn.datasets import load_diabetes
@@ -2116,12 +2122,6 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     >>> clf = RidgeCV(alphas=[1e-3, 1e-2, 1e-1, 1]).fit(X, y)
     >>> clf.score(X, y)
     0.5166...
-
-    See Also
-    --------
-    Ridge : Ridge regression.
-    RidgeClassifier : Ridge classifier.
-    RidgeClassifierCV : Ridge classifier with built-in cross validation.
     """
 
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2111,7 +2111,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     See Also
     --------
     Ridge : Ridge regression.
-    RidgeClassifier : classifier based on ridge regression on {-1, 1} labels.
+    RidgeClassifier : Classifier based on ridge regression on {-1, 1} labels.
     RidgeClassifierCV : Ridge classifier with built-in cross validation.
 
     Examples


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308

#### What does this implement/fix? Explain your changes.
Update RidgeCV to pass numpydoc validations RT03, PR06 and GL07.

#### Any other comments?
#DataUmbrella sprint