### PR TITLE
TST Avoid raising a spurious warning in test_kernel_approximation.py

### DIFF
--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -303,11 +303,11 @@ def test_nystroem_callable():
     ).fit(X)
     assert len(kernel_log) == n_samples * (n_samples - 1) / 2
 
-    # if degree, gamma or coef0 is passed, we raise a warning
+    # if degree, gamma or coef0 is passed, we raise a ValueError
     msg = "Don't pass gamma, coef0 or degree to Nystroem"
     params = ({"gamma": 1}, {"coef0": 1}, {"degree": 2})
     for param in params:
-        ny = Nystroem(kernel=_linear_kernel, **param)
+        ny = Nystroem(kernel=_linear_kernel, n_components=(n_samples - 1), **param)
         with pytest.raises(ValueError, match=msg):
             ny.fit(X)
 


### PR DESCRIPTION
Remove a spurious warning related to the size of `n_components` compared to `n_samples` in `test_nystroem_callable`.