### PR TITLE
FIX avoid `isotonic_regression` to modify `sample_weight` in-place

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -315,7 +315,7 @@ Changelog
   :pr:`20207` by :user:`Tomohiro Endo <europeanplaice>`
 
 - |FIX| Fix a bug in :func:`isotonic.isotonic_regression` where the
-  `sample_weight` passed by a user were overwritten during `fit`.
+  `sample_weight` passed by a user were overwritten during the fit.
   :pr:`20515` by :user:`Carsten Allefeld <allefeld>`.
 
 :mod:`sklearn.inspection`

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -314,6 +314,10 @@ Changelog
   when the variance threshold is negative.
   :pr:`20207` by :user:`Tomohiro Endo <europeanplaice>`
 
+- |FIX| Fix a bug in :func:`isotonic.isotonic_regression` where the
+  `sample_weight` passed by a user were overwritten during `fit`.
+  :pr:`20515` by :user:`Carsten Allefeld <allefeld>`.
+
 :mod:`sklearn.inspection`
 .........................
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -118,7 +118,7 @@ def isotonic_regression(
     order = np.s_[:] if increasing else np.s_[::-1]
     y = check_array(y, ensure_2d=False, dtype=[np.float64, np.float32])
     y = np.array(y[order], dtype=y.dtype)
-    sample_weight = _check_sample_weight(sample_weight, y, dtype=y.dtype)
+    sample_weight = _check_sample_weight(sample_weight, y, dtype=y.dtype, copy=True)
     sample_weight = np.ascontiguousarray(sample_weight[order])
 
     _inplace_contiguous_isotonic_regression(y, sample_weight)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -676,3 +676,21 @@ def test_isotonic_2darray_more_than_1_feature():
 
     with pytest.raises(ValueError, match=msg):
         iso_reg.transform(X_2d)
+
+
+def test_isotonic_regression_sample_weight_not_overwritten():
+    """Check that calling `fit` will not overwrite `sample_weight`.
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/20508
+    """
+    from sklearn.datasets import make_regression
+
+    X, y = make_regression(n_samples=10, n_features=1, random_state=41)
+    sample_weight_original = np.ones(shape=y.shape)
+    sample_weight_fit = sample_weight_original.copy()
+
+    isotonic_regression(y, sample_weight=sample_weight_fit)
+    assert_allclose(sample_weight_fit, sample_weight_original)
+
+    IsotonicRegression().fit(X, y, sample_weight=sample_weight_fit)
+    assert_allclose(sample_weight_fit, sample_weight_original)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -5,6 +5,7 @@ import copy
 
 import pytest
 
+from sklearn.datasets import make_regression
 from sklearn.isotonic import (
     check_increasing,
     isotonic_regression,
@@ -684,10 +685,9 @@ def test_isotonic_regression_sample_weight_not_overwritten():
     Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/20508
     """
-    from sklearn.datasets import make_regression
-
     X, y = make_regression(n_samples=10, n_features=1, random_state=41)
-    sample_weight_original = np.ones(shape=y.shape)
+    sample_weight_original = np.ones_like(y)
+    sample_weight_original[0] = 10
     sample_weight_fit = sample_weight_original.copy()
 
     isotonic_regression(y, sample_weight=sample_weight_fit)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -679,7 +679,8 @@ def test_isotonic_2darray_more_than_1_feature():
 
 
 def test_isotonic_regression_sample_weight_not_overwritten():
-    """Check that calling `fit` will not overwrite `sample_weight`.
+    """Check that calling fitting function of isotonic regression will not
+    overwrite `sample_weight`.
     Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/20508
     """


### PR DESCRIPTION
closes #20508 

This should fix #20508, by copying the passed `sample_weight` parameter before it is passed in turn to the core algorithm.
