### PR TITLE
[WIP] FIX index overflow error in sparse matrix polynomial expansion …

### DIFF
--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -9,17 +9,18 @@ from numpy cimport ndarray
 cimport numpy as np
 
 np.import_array()
-ctypedef np.int32_t INDEX_T
+ctypedef np.int32_t INDEX_A
+ctypedef fused INDEX_B:
+    np.int32_t
+    np.int64_t
+ctypedef np.int8_t FLAG_T
 
 ctypedef fused DATA_T:
     np.float32_t
     np.float64_t
-    np.int32_t
-    np.int64_t
 
-
-cdef inline INDEX_T _deg2_column(INDEX_T d, INDEX_T i, INDEX_T j,
-                                 INDEX_T interaction_only) nogil:
+cdef inline INDEX_B _deg2_column(INDEX_B d, INDEX_B i, INDEX_B j,
+                                 FLAG_T interaction_only) nogil:
     """Compute the index of the column for a degree 2 expansion
 
     d is the dimensionality of the input data, i and j are the indices
@@ -31,8 +32,8 @@ cdef inline INDEX_T _deg2_column(INDEX_T d, INDEX_T i, INDEX_T j,
         return d * i - (i**2 + i) / 2 + j
 
 
-cdef inline INDEX_T _deg3_column(INDEX_T d, INDEX_T i, INDEX_T j, INDEX_T k,
-                                 INDEX_T interaction_only) nogil:
+cdef inline INDEX_B _deg3_column(INDEX_B d, INDEX_B i, INDEX_B j, INDEX_B k,
+                                 FLAG_T interaction_only) nogil:
     """Compute the index of the column for a degree 3 expansion
 
     d is the dimensionality of the input data, i, j and k are the indices
@@ -49,10 +50,14 @@ cdef inline INDEX_T _deg3_column(INDEX_T d, INDEX_T i, INDEX_T j, INDEX_T k,
 
 
 def _csr_polynomial_expansion(ndarray[DATA_T, ndim=1] data,
-                              ndarray[INDEX_T, ndim=1] indices,
-                              ndarray[INDEX_T, ndim=1] indptr,
-                              INDEX_T d, INDEX_T interaction_only,
-                              INDEX_T degree):
+                              ndarray[INDEX_A, ndim=1] indices,
+                              ndarray[INDEX_A, ndim=1] indptr,
+                              INDEX_A d,
+                              ndarray[DATA_T, ndim=1] result_data,
+                              ndarray[INDEX_B, ndim=1] result_indices,
+                              ndarray[INDEX_B, ndim=1] result_indptr,
+                              FLAG_T interaction_only,
+                              FLAG_T degree):
     """
     Perform a second-degree polynomial or interaction expansion on a scipy
     compressed sparse row (CSR) matrix. The method used only takes products of
@@ -74,6 +79,15 @@ def _csr_polynomial_expansion(ndarray[DATA_T, ndim=1] data,
     d : int
         The dimensionality of the input CSR matrix.
 
+    result_data : nd-array
+         The output CSR matrix's "data" attribute
+
+    result_indices : nd-array
+         The output CSR matrix's "indices" attribute
+
+    result_indptr : nd-array
+        The output CSR matrix's "indptr" attribute
+
     interaction_only : int
         0 for a polynomial expansion, 1 for an interaction expansion.
 
@@ -86,44 +100,13 @@ def _csr_polynomial_expansion(ndarray[DATA_T, ndim=1] data,
     Matrices Using K-Simplex Numbers" by Andrew Nystrom and John Hughes.
     """
 
-    assert degree in (2, 3)
-
-    if degree == 2:
-        expanded_dimensionality = int((d**2 + d) / 2 - interaction_only*d)
-    else:
-        expanded_dimensionality = int((d**3 + 3*d**2 + 2*d) / 6
-                                      - interaction_only*d**2)
-    if expanded_dimensionality == 0:
-        return None
-    assert expanded_dimensionality > 0
-
-    cdef INDEX_T total_nnz = 0, row_i, nnz
-
-    # Count how many nonzero elements the expanded matrix will contain.
-    for row_i in range(indptr.shape[0]-1):
-        # nnz is the number of nonzero elements in this row.
-        nnz = indptr[row_i + 1] - indptr[row_i]
-        if degree == 2:
-            total_nnz += (nnz ** 2 + nnz) / 2 - interaction_only * nnz
-        else:
-            total_nnz += ((nnz ** 3 + 3 * nnz ** 2 + 2 * nnz) / 6
-                          - interaction_only * nnz ** 2)
-
     # Make the arrays that will form the CSR matrix of the expansion.
-    cdef ndarray[DATA_T, ndim=1] expanded_data = ndarray(
-        shape=total_nnz, dtype=data.dtype)
-    cdef ndarray[INDEX_T, ndim=1] expanded_indices = ndarray(
-        shape=total_nnz, dtype=indices.dtype)
-    cdef INDEX_T num_rows = indptr.shape[0] - 1
-    cdef ndarray[INDEX_T, ndim=1] expanded_indptr = ndarray(
-        shape=num_rows + 1, dtype=indptr.dtype)
+    cdef INDEX_A row_i, row_starts, row_ends, i, j, k, i_ptr, j_ptr, k_ptr
 
-    cdef INDEX_T expanded_index = 0, row_starts, row_ends, i, j, k, \
-                 i_ptr, j_ptr, k_ptr, num_cols_in_row,  \
-                 expanded_column
+    cdef INDEX_B expanded_index=0, num_cols_in_row, col
 
     with nogil:
-        expanded_indptr[0] = indptr[0]
+        result_indptr[0] = indptr[0]
         for row_i in range(indptr.shape[0]-1):
             row_starts = indptr[row_i]
             row_ends = indptr[row_i + 1]
@@ -133,9 +116,9 @@ def _csr_polynomial_expansion(ndarray[DATA_T, ndim=1] data,
                 for j_ptr in range(i_ptr + interaction_only, row_ends):
                     j = indices[j_ptr]
                     if degree == 2:
-                        col = _deg2_column(d, i, j, interaction_only)
-                        expanded_indices[expanded_index] = col
-                        expanded_data[expanded_index] = (
+                        col = _deg2_column[INDEX_B](d, i, j, interaction_only)
+                        result_indices[expanded_index] = col
+                        result_data[expanded_index] = (
                             data[i_ptr] * data[j_ptr])
                         expanded_index += 1
                         num_cols_in_row += 1
@@ -144,14 +127,11 @@ def _csr_polynomial_expansion(ndarray[DATA_T, ndim=1] data,
                         for k_ptr in range(j_ptr + interaction_only,
                                             row_ends):
                             k = indices[k_ptr]
-                            col = _deg3_column(d, i, j, k, interaction_only)
-                            expanded_indices[expanded_index] = col
-                            expanded_data[expanded_index] = (
+                            col = _deg3_column[INDEX_B](d, i, j, k, interaction_only)
+                            result_indices[expanded_index] = col
+                            result_data[expanded_index] = (
                                 data[i_ptr] * data[j_ptr] * data[k_ptr])
                             expanded_index += 1
                             num_cols_in_row += 1
 
-            expanded_indptr[row_i+1] = expanded_indptr[row_i] + num_cols_in_row
-
-    return csr_matrix((expanded_data, expanded_indices, expanded_indptr),
-                      shape=(num_rows, expanded_dimensionality))
+            result_indptr[row_i+1] = result_indptr[row_i] + num_cols_in_row


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #19676
Fixes #17554

#### What does this implement/fix? Explain your changes.
The _csr_polynomial_expansion function in sklearn.preprocessing.PolynomialFeatures now can work with int64 index

What was done:
All necessary resulting data arrays now allocated in python part outside of _csr_polynomial_expansion
The type of the resulting data array now depends on expanded_d

cc: (reviewer) @wdevazelhes  , @thomasjpfan 