### PR TITLE
Fix `_weighted_percentile` for `percentile=0`

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -616,6 +616,13 @@ Changelog
 - |Fix| Propreties that are decorated with :func:`utils.deprecated` correctly
   wraps the property's docstring. :pr:`20385` by `Thomas Fan`_.
 
+- |Fix| :func:`utils.stats._weighted_percentile` now correctly ignores
+  zero-weighted observations smaller than the smallest observation with
+  positive weight for ``percentile=0``. Affected classes are
+  :class:`dummy.DummyRegressor` for ``quantile=0`` and
+  :class:`ensemble.HuberLossFunction` and :class:`ensemble.HuberLossFunction`
+  for ``alpha=0``. :pr:`20528` by :user:`Malte Londschien <mlondschien>`.
+
 :mod:`sklearn.validation`
 .........................
 

--- a/sklearn/utils/stats.py
+++ b/sklearn/utils/stats.py
@@ -45,6 +45,7 @@ def _weighted_percentile(array, sample_weight, percentile=50):
     weight_cdf = stable_cumsum(sorted_weights, axis=0)
     adjusted_percentile = percentile / 100 * weight_cdf[-1]
 
+    # For percentile=0, ignore leading observations with sample_weight=0. GH20528
     mask = adjusted_percentile == 0
     adjusted_percentile[mask] = np.nextafter(
         adjusted_percentile[mask], adjusted_percentile[mask] + 1

--- a/sklearn/utils/stats.py
+++ b/sklearn/utils/stats.py
@@ -44,6 +44,12 @@ def _weighted_percentile(array, sample_weight, percentile=50):
     # Find index of median prediction for each sample
     weight_cdf = stable_cumsum(sorted_weights, axis=0)
     adjusted_percentile = percentile / 100 * weight_cdf[-1]
+
+    mask = adjusted_percentile == 0
+    adjusted_percentile[mask] = np.nextafter(
+        adjusted_percentile[mask], adjusted_percentile[mask] + 1
+    )
+
     percentile_idx = np.array(
         [
             np.searchsorted(weight_cdf[:, i], adjusted_percentile[i])

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -35,6 +35,19 @@ def test_weighted_percentile_zero_weight():
     assert approx(score) == 1.0
 
 
+def test_weighted_percentile_zero_weight_zero_percentile():
+    y = np.array([0, 1, 2, 3, 4, 5])
+    sw = np.array([0, 0, 1, 1, 1, 0])
+    score = _weighted_percentile(y, sw, 0)
+    assert approx(score) == 2
+
+    score = _weighted_percentile(y, sw, 50)
+    assert approx(score) == 3
+
+    score = _weighted_percentile(y, sw, 100)
+    assert approx(score) == 4
+
+
 def test_weighted_median_equal_weights():
     # Checks weighted percentile=0.5 is same as median when weights equal
     rng = np.random.RandomState(0)


### PR DESCRIPTION
Related: https://github.com/scikit-learn/scikit-learn/pull/20526

On master:
```python
In [3]: _weighted_percentile(
    ...:     np.array(range(6)),
    ...:     np.array([0, 0, 1, 1, 1, 0]),
    ...:     0
    ...:  )
Out[3]: 0

In [4]: _weighted_percentile(
    ...:     np.array(range(6)),
    ...:     np.array([0, 0, 1, 1, 1, 0]),
    ...:     100
    ...:  )
Out[4]: 4
```

The issue here is that
```python
In [5]: np.searchsorted([0, 0, 1, 2, 3, 4, 4], 0)
Out[5]: 0

In [6]: np.searchsorted([0, 0, 1, 2, 3, 4, 4], 4)
Out[6]: 5
```

This fixes this behaviour.