### PR TITLE
MAINT Remove redundant checks in `neighbors` Binary Tree's

### DIFF
--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -570,7 +570,7 @@ cdef class NeighborsHeap:
         cdef ITYPE_t* ind_arr = &self.indices[row, 0]
 
         # check if val should be in heap
-        if val > dist_arr[0]:
+        if val >= dist_arr[0]:
             return 0
 
         # insert val at position zero
@@ -1722,8 +1722,7 @@ cdef class BinaryTree:
                 dist_pt = self.rdist(pt,
                                      &self.data[self.idx_array[i], 0],
                                      self.data.shape[1])
-                if dist_pt < heap.largest(i_pt):
-                    heap._push(i_pt, dist_pt, self.idx_array[i])
+                heap._push(i_pt, dist_pt, self.idx_array[i])
 
         #------------------------------------------------------------
         # Case 3: Node is not a leaf.  Recursively query subnodes
@@ -1785,8 +1784,7 @@ cdef class BinaryTree:
                     dist_pt = self.rdist(pt,
                                          &self.data[self.idx_array[i], 0],
                                          self.data.shape[1])
-                    if dist_pt < heap.largest(i_pt):
-                        heap._push(i_pt, dist_pt, self.idx_array[i])
+                    heap._push(i_pt, dist_pt, self.idx_array[i])
 
             #------------------------------------------------------------
             # Case 3: Node is not a leaf.  Add subnodes to the node heap
@@ -1840,8 +1838,7 @@ cdef class BinaryTree:
                         data1 + n_features * self.idx_array[i1],
                         data2 + n_features * i_pt,
                         n_features)
-                    if dist_pt < heap.largest(i_pt):
-                        heap._push(i_pt, dist_pt, self.idx_array[i1])
+                    heap._push(i_pt, dist_pt, self.idx_array[i1])
 
                 # keep track of node bound
                 bounds[i_node2] = fmax(bounds[i_node2],
@@ -1953,8 +1950,7 @@ cdef class BinaryTree:
                             data1 + n_features * self.idx_array[i1],
                             data2 + n_features * i_pt,
                             n_features)
-                        if dist_pt < heap.largest(i_pt):
-                            heap._push(i_pt, dist_pt, self.idx_array[i1])
+                        heap._push(i_pt, dist_pt, self.idx_array[i1])
 
                     # keep track of node bound
                     bounds[i_node2] = fmax(bounds[i_node2],

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -729,6 +729,21 @@ def test_radius_neighbors_returns_array_of_objects():
     assert_array_equal(neigh_ind, expected_ind)
 
 
+@pytest.mark.parametrize("algorithm", ["ball_tree", "kd_tree", "brute"])
+def test_query_equidistant_kth_nn(algorithm):
+    # For several candidates for the k-th nearest neighbor position,
+    # the first candidate should be chosen
+    query_point = np.array([[0, 0]])
+    equidistant_points = np.array([[1, 0], [0, 1], [-1, 0], [0, -1]])
+    # The 3rd and 4th points should not replace the 2nd point
+    # for the 2th nearest neighbor position
+    k = 2
+    knn_indices = np.array([[0, 1]])
+    nn = neighbors.NearestNeighbors(algorithm=algorithm).fit(equidistant_points)
+    indices = np.sort(nn.kneighbors(query_point, n_neighbors=k, return_distance=False))
+    assert_array_equal(indices, knn_indices)
+
+
 @pytest.mark.parametrize(
     ["algorithm", "metric"],
     [


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

A check is also done at the level of the heap
so there's no need to test prior to insertion.

The test in `NeighborsHeap._push` is relaxed to
keep the current behavior.

### Comments

Probably, more tests could be added for `KDTree` and `BallTree` regarding this change?