### PR TITLE
Add changelog entry about removed function

### DIFF
--- a/doc/whats_new/v0.24.rst
+++ b/doc/whats_new/v0.24.rst
@@ -490,6 +490,8 @@ Changelog
   custom token pattern which capture more than one group is provided.
   :pr:`15427` by :user:`Gangesh Gudmalwar <ggangesh>` and
   :user:`Erin R Hoffman <hoffm386>`.
+  
+- [API] removed :func:`feature_extraction.extract_patches`.
 
 :mod:`sklearn.feature_selection`
 ................................


### PR DESCRIPTION
The function `feature_extraction.extract_patches` was marked as deprecated in 0.22 and removed in 0.24 as part of commit https://github.com/scikit-learn/scikit-learn/commit/ac8cbb3799bdfa31360c87bf1097410326dba0bd
I had a difficult time tracking down what happened to this function when it stopped working, so this change belongs in the changelog.
There may be other removed deprecated functions that are not documented, but I only followed this one.
