### PR TITLE
Initialize n_samples in classification criteria

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -350,7 +350,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         if not isinstance(criterion, Criterion):
             if is_classification:
                 criterion = CRITERIA_CLF[self.criterion](
-                    self.n_outputs_, self.n_classes_
+                    self.n_outputs_, n_samples, self.n_classes_
                 )
             else:
                 criterion = CRITERIA_REG[self.criterion](self.n_outputs_, n_samples)

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -211,7 +211,7 @@ cdef class Criterion:
 cdef class ClassificationCriterion(Criterion):
     """Abstract criterion for classification."""
 
-    def __cinit__(self, SIZE_t n_outputs,
+    def __cinit__(self, SIZE_t n_outputs, SIZE_t n_samples,
                   np.ndarray[SIZE_t, ndim=1] n_classes):
         """Initialize attributes for this criterion.
 
@@ -230,7 +230,7 @@ cdef class ClassificationCriterion(Criterion):
         self.end = 0
 
         self.n_outputs = n_outputs
-        self.n_samples = 0
+        self.n_samples = n_samples
         self.n_node_samples = 0
         self.weighted_n_node_samples = 0.0
         self.weighted_n_left = 0.0
@@ -273,7 +273,7 @@ cdef class ClassificationCriterion(Criterion):
 
     def __reduce__(self):
         return (type(self),
-                (self.n_outputs,
+                (self.n_outputs, self.n_samples,
                  sizet_ptr_to_ndarray(self.n_classes, self.n_outputs)),
                 self.__getstate__())
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2178,11 +2178,12 @@ def test_criterion_copy():
 
     for copy_func in [copy.copy, copy.deepcopy, _pickle_copy]:
         for _, typename in CRITERIA_CLF.items():
-            criteria = typename(n_outputs, n_classes)
+            criteria = typename(n_outputs, n_samples, n_classes)
             result = copy_func(criteria).__reduce__()
-            typename_, (n_outputs_, n_classes_), _ = result
+            typename_, (n_outputs_, n_samples_, n_classes_), _ = result
             assert typename == typename_
             assert n_outputs == n_outputs_
+            assert n_samples == n_samples_
             assert_array_equal(n_classes, n_classes_)
 
         for _, typename in CRITERIA_REG.items():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

N/A

#### What does this implement/fix? Explain your changes.

This PR correctly initializes the `n_samples` attribute of `ClassificationCriterion` class with the actual number of samples instead of a zero.

#### Any other comments?

This will enable use of criteria that require the total number of samples.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
