### PR TITLE
ENH improve error message in _get_response function

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -134,6 +134,7 @@ Changelog
 ...................
 
 - |Fix| :func:`config_context` is now threadsafe. :pr:`18736` by `Thomas Fan`_.
+- |Fix| :func:`_get_response` make error message clear. :pr:`20618` by `shinehide`_.
 
 :mod:`sklearn.calibration`
 ..........................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -134,7 +134,6 @@ Changelog
 ...................
 
 - |Fix| :func:`config_context` is now threadsafe. :pr:`18736` by `Thomas Fan`_.
-- |Fix| :func:`_get_response` make error message clear. :pr:`20618` by `shinehide`_.
 
 :mod:`sklearn.calibration`
 ..........................

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -82,9 +82,7 @@ def _get_response(X, estimator, response_method, pos_label=None):
         The class considered as the positive class when computing
         the metrics.
     """
-    classification_error = "Expected a binary classifier, but got {}".format(
-        estimator.__class__.__name__
-    )
+    classification_error = f"Expected 'estimator' to be a binary classifier, but got {estimator.__class__.__name__}"
 
     if not is_classifier(estimator):
         raise ValueError(classification_error)

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -82,8 +82,10 @@ def _get_response(X, estimator, response_method, pos_label=None):
         The class considered as the positive class when computing
         the metrics.
     """
-    classification_error = "Expected 'estimator' to be a binary classifier,"\
-                           f" but got {estimator.__class__.__name__}"
+    classification_error = (
+        "Expected 'estimator' to be a binary classifier, but got"
+        f" {estimator.__class__.__name__}"
+    )
 
     if not is_classifier(estimator):
         raise ValueError(classification_error)

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -82,7 +82,8 @@ def _get_response(X, estimator, response_method, pos_label=None):
         The class considered as the positive class when computing
         the metrics.
     """
-    classification_error = f"Expected 'estimator' to be a binary classifier, but got {estimator.__class__.__name__}"
+    classification_error = "Expected 'estimator' to be a binary classifier,"\
+                           f" but got {estimator.__class__.__name__}"
 
     if not is_classifier(estimator):
         raise ValueError(classification_error)

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -82,7 +82,7 @@ def _get_response(X, estimator, response_method, pos_label=None):
         The class considered as the positive class when computing
         the metrics.
     """
-    classification_error = "{} should be a binary classifier".format(
+    classification_error = "Expected a binary classifier, but got {}".format(
         estimator.__class__.__name__
     )
 

--- a/sklearn/metrics/_plot/tests/test_plot_curve_common.py
+++ b/sklearn/metrics/_plot/tests/test_plot_curve_common.py
@@ -31,7 +31,7 @@ def test_plot_curve_error_non_binary(pyplot, data, plot_func):
     clf = DecisionTreeClassifier()
     clf.fit(X, y)
 
-    msg = "Expected a binary classifier, but got DecisionTreeClassifier"
+    msg = "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
     with pytest.raises(ValueError, match=msg):
         plot_func(clf, X, y)
 

--- a/sklearn/metrics/_plot/tests/test_plot_curve_common.py
+++ b/sklearn/metrics/_plot/tests/test_plot_curve_common.py
@@ -31,8 +31,9 @@ def test_plot_curve_error_non_binary(pyplot, data, plot_func):
     clf = DecisionTreeClassifier()
     clf.fit(X, y)
 
-    msg = "Expected 'estimator' to be a binary classifier," \
-          " but got DecisionTreeClassifier"
+    msg = (
+        "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
+    )
     with pytest.raises(ValueError, match=msg):
         plot_func(clf, X, y)
 

--- a/sklearn/metrics/_plot/tests/test_plot_curve_common.py
+++ b/sklearn/metrics/_plot/tests/test_plot_curve_common.py
@@ -31,7 +31,7 @@ def test_plot_curve_error_non_binary(pyplot, data, plot_func):
     clf = DecisionTreeClassifier()
     clf.fit(X, y)
 
-    msg = "DecisionTreeClassifier should be a binary classifier"
+    msg = "Expected a binary classifier, but got DecisionTreeClassifier"
     with pytest.raises(ValueError, match=msg):
         plot_func(clf, X, y)
 

--- a/sklearn/metrics/_plot/tests/test_plot_curve_common.py
+++ b/sklearn/metrics/_plot/tests/test_plot_curve_common.py
@@ -31,7 +31,8 @@ def test_plot_curve_error_non_binary(pyplot, data, plot_func):
     clf = DecisionTreeClassifier()
     clf.fit(X, y)
 
-    msg = "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
+    msg = "Expected 'estimator' to be a binary classifier," \
+          " but got DecisionTreeClassifier"
     with pytest.raises(ValueError, match=msg):
         plot_func(clf, X, y)
 

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -40,12 +40,14 @@ def test_errors(pyplot):
     multi_clf = DecisionTreeClassifier().fit(X, y_multiclass)
 
     # Fitted multiclass classifier with binary data
-    msg = "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
+    msg = "Expected 'estimator' to be a binary classifier," \
+          " but got DecisionTreeClassifier"
     with pytest.raises(ValueError, match=msg):
         plot_precision_recall_curve(multi_clf, X, y_binary)
 
     reg = DecisionTreeRegressor().fit(X, y_multiclass)
-    msg = "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
+    msg = "Expected 'estimator' to be a binary classifier," \
+          " but got DecisionTreeClassifier"
     with pytest.raises(ValueError, match=msg):
         plot_precision_recall_curve(reg, X, y_binary)
 

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -48,7 +48,7 @@ def test_errors(pyplot):
 
     reg = DecisionTreeRegressor().fit(X, y_multiclass)
     msg = (
-        "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
+        "Expected 'estimator' to be a binary classifier, but got DecisionTreeRegressor"
     )
     with pytest.raises(ValueError, match=msg):
         plot_precision_recall_curve(reg, X, y_binary)

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -40,12 +40,12 @@ def test_errors(pyplot):
     multi_clf = DecisionTreeClassifier().fit(X, y_multiclass)
 
     # Fitted multiclass classifier with binary data
-    msg = "Expected a binary classifier, but got DecisionTreeClassifier"
+    msg = "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
     with pytest.raises(ValueError, match=msg):
         plot_precision_recall_curve(multi_clf, X, y_binary)
 
     reg = DecisionTreeRegressor().fit(X, y_multiclass)
-    msg = "Expected a binary classifier, but got DecisionTreeClassifier"
+    msg = "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
     with pytest.raises(ValueError, match=msg):
         plot_precision_recall_curve(reg, X, y_binary)
 

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -40,14 +40,16 @@ def test_errors(pyplot):
     multi_clf = DecisionTreeClassifier().fit(X, y_multiclass)
 
     # Fitted multiclass classifier with binary data
-    msg = "Expected 'estimator' to be a binary classifier," \
-          " but got DecisionTreeClassifier"
+    msg = (
+        "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
+    )
     with pytest.raises(ValueError, match=msg):
         plot_precision_recall_curve(multi_clf, X, y_binary)
 
     reg = DecisionTreeRegressor().fit(X, y_multiclass)
-    msg = "Expected 'estimator' to be a binary classifier," \
-          " but got DecisionTreeClassifier"
+    msg = (
+        "Expected 'estimator' to be a binary classifier, but got DecisionTreeClassifier"
+    )
     with pytest.raises(ValueError, match=msg):
         plot_precision_recall_curve(reg, X, y_binary)
 

--- a/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
+++ b/sklearn/metrics/_plot/tests/test_plot_precision_recall.py
@@ -40,12 +40,12 @@ def test_errors(pyplot):
     multi_clf = DecisionTreeClassifier().fit(X, y_multiclass)
 
     # Fitted multiclass classifier with binary data
-    msg = "DecisionTreeClassifier should be a binary classifier"
+    msg = "Expected a binary classifier, but got DecisionTreeClassifier"
     with pytest.raises(ValueError, match=msg):
         plot_precision_recall_curve(multi_clf, X, y_binary)
 
     reg = DecisionTreeRegressor().fit(X, y_multiclass)
-    msg = "DecisionTreeRegressor should be a binary classifier"
+    msg = "Expected a binary classifier, but got DecisionTreeClassifier"
     with pytest.raises(ValueError, match=msg):
         plot_precision_recall_curve(reg, X, y_binary)
 


### PR DESCRIPTION
Closes #20577

Improve error message raised in `_get_response` when an estimator other than a binary classifier is given.
