### PR TITLE
Warn in the main process when a fit fails during a cross-validation

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -487,6 +487,7 @@ Changelog
   group within a single split.
   :pr:`18649` by :user:`Leandro Hermida <hermidalc>` and
   :user:`Rodion Martynov <marrodion>`.
+
 - |Enhancement| warn only once in the main process for per-split fit failures
   in cross-validation. :pr:`20619` by :user:`Loïc Estève <lesteve>`
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -488,7 +488,7 @@ Changelog
   :pr:`18649` by :user:`Leandro Hermida <hermidalc>` and
   :user:`Rodion Martynov <marrodion>`.
 - |Enhancement| warn only once in the main process for per-split fit failures
-  in cross-validations. :pr:`20619` by :user:`Loïc Estève <lesteve>`
+  in cross-validation. :pr:`20619` by :user:`Loïc Estève <lesteve>`
 
 :mod:`sklearn.naive_bayes`
 ..........................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -487,6 +487,8 @@ Changelog
   group within a single split.
   :pr:`18649` by :user:`Leandro Hermida <hermidalc>` and
   :user:`Rodion Martynov <marrodion>`.
+- |Enhancement| warn only once in the main process for per-split fit failures
+  in cross-validations. :pr:`20619` by :user:`Loïc Estève <lesteve>`
 
 :mod:`sklearn.naive_bayes`
 ..........................

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -794,16 +794,18 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                         "splits, got {}".format(n_splits, len(out) // n_candidates)
                     )
 
-                all_candidate_params.extend(candidate_params)
-                all_out.extend(out)
-                _warn_about_fit_failures(all_out, self.error_score)
+                _warn_about_fit_failures(out, self.error_score)
 
                 # For callable self.scoring, the return type is only know after
                 # calling. If the return type is a dictionary, the error scores
                 # can now be inserted with the correct key. The type checking
                 # of out will be done in `_insert_error_scores`.
+
                 if callable(self.scoring):
-                    _insert_error_scores(all_out, self.error_score)
+                    _insert_error_scores(out, self.error_score)
+
+                all_candidate_params.extend(candidate_params)
+                all_out.extend(out)
 
                 if more_results is not None:
                     for key, value in more_results.items():

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -31,6 +31,7 @@ from ._validation import _fit_and_score
 from ._validation import _aggregate_score_dicts
 from ._validation import _insert_error_scores
 from ._validation import _normalize_score_results
+from ._validation import _warn_about_fit_failures
 from ..exceptions import NotFittedError
 from joblib import Parallel
 from ..utils import check_random_state
@@ -801,6 +802,8 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                     _insert_error_scores(out, self.error_score)
                 all_candidate_params.extend(candidate_params)
                 all_out.extend(out)
+                _warn_about_fit_failures(all_out, self.error_score)
+
                 if more_results is not None:
                     for key, value in more_results.items():
                         all_more_results[key].extend(value)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -800,7 +800,6 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                 # calling. If the return type is a dictionary, the error scores
                 # can now be inserted with the correct key. The type checking
                 # of out will be done in `_insert_error_scores`.
-
                 if callable(self.scoring):
                     _insert_error_scores(out, self.error_score)
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -794,15 +794,16 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                         "splits, got {}".format(n_splits, len(out) // n_candidates)
                     )
 
+                all_candidate_params.extend(candidate_params)
+                all_out.extend(out)
+                _warn_about_fit_failures(all_out, self.error_score)
+
                 # For callable self.scoring, the return type is only know after
                 # calling. If the return type is a dictionary, the error scores
                 # can now be inserted with the correct key. The type checking
                 # of out will be done in `_insert_error_scores`.
                 if callable(self.scoring):
-                    _insert_error_scores(out, self.error_score)
-                all_candidate_params.extend(candidate_params)
-                all_out.extend(out)
-                _warn_about_fit_failures(all_out, self.error_score)
+                    _insert_error_scores(all_out, self.error_score)
 
                 if more_results is not None:
                     for key, value in more_results.items():

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -362,12 +362,12 @@ def _warn_about_fit_failures(results, error_score):
         )
 
         some_fits_failed_message = (
-            f"\n{num_failed_fits} fits failed on the training sets over a total of"
-            f" {num_fits} fits.\nThe score on these train-test partitions for these"
-            f" parameters will be set to {error_score}.\nIf these failures are"
-            " not expected, you can try to debug them by setting"
-            " error_score='raise'.\n\nBelow are more details about the"
-            f" failures:\n{fit_errors_summary}"
+            f"\n{num_failed_fits} fits failed out of a total of {num_fits}.\n"
+            "The score on these train-test partitions for these parameters"
+            f" will be set to {error_score}.\n"
+            "If these failures are not expected, you can try to debug them "
+            "by setting error_score='raise'.\n\n"
+            f"Below are more details about the failures:\n{fit_errors_summary}"
         )
         warnings.warn(some_fits_failed_message, FitFailedWarning)
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -289,6 +289,15 @@ def cross_validate(
 
     results = _aggregate_score_dicts(results)
 
+    # If all the fits failed raise an informative warning in the main process
+    # if results["fit_failed"].all():
+    #     all_fits_failed_message = (
+    #         "All the fit on the training sets failed. Something seems wrong in the"
+    #         f" configuration of {estimator}\n.You can try to debug this further by"
+    #         " setting 'error_score='raise'."
+    #     )
+    #     warnings.warn(all_fits_failed_message)
+
     ret = {}
     ret["fit_time"] = results["fit_time"]
     ret["score_time"] = results["score_time"]

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -355,10 +355,11 @@ def _warn_about_fit_failures(results, error_score):
         ]
 
         some_fits_failed_message = (
-            f"\n{num_failed_fits}/{num_fits} fits on the training sets failed. The"
-            f" score on this train-test partition has been set to {error_score}.\nIn"
-            " case these failures are not expected, you can try to debug these failures"
-            " by setting error_score='raise'.\n\nHere are more details about the"
+            f"\n{num_failed_fits} fits failed on the training sets over a total of"
+            f" {num_fits} fits. The score on these train-test partitions for these"
+            f" parameters will be set to {error_score}.\nIn case these failures are"
+            " not expected, you can try to debug these failures by setting"
+            " error_score='raise'.\n\nHere are more details about the"
             " failures:\n----------\n"
             + "----------\n".join(fit_errors)
         )

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -350,7 +350,6 @@ def _warn_about_fit_failures(results, error_score):
     fit_errors = [
         result["fit_error"] for result in results if result["fit_error"] is not None
     ]
-    
     if fit_errors:
         num_failed_fits = len(fit_errors)
         num_fits = len(results)

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -352,7 +352,7 @@ def _warn_about_fit_failures(results, error_score):
     ]
     num_fits = len(results)
 
-    if len(fit_errors) > 0:
+    if fit_errors:
         num_failed_fits = len(fit_errors)
         fit_errors_counter = Counter(fit_errors)
         delimiter = "-" * 80 + "\n"

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1454,7 +1454,6 @@ def learning_curve(
     error_score : 'raise' or numeric, default=np.nan
         Value to assign to the score if an error occurs in estimator fitting.
         If set to 'raise', the error is raised.
-        # TODO is someone relying on this behaviour (that the warning is raised at the point where the fit failed)
         If a numeric value is given, FitFailedWarning is raised.
 
         .. versionadded:: 0.20

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -281,13 +281,13 @@ def cross_validate(
         for train, test in cv.split(X, y, groups)
     )
 
+    _warn_about_fit_failures(results, error_score)
+
     # For callabe scoring, the return type is only know after calling. If the
     # return type is a dictionary, the error scores can now be inserted with
     # the correct key.
     if callable(scoring):
         _insert_error_scores(results, error_score)
-
-    _warn_about_fit_failures(results, error_score)
 
     results = _aggregate_score_dicts(results)
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -350,10 +350,10 @@ def _warn_about_fit_failures(results, error_score):
     fit_errors = [
         result["fit_error"] for result in results if result["fit_error"] is not None
     ]
-    num_fits = len(results)
-
+    
     if fit_errors:
         num_failed_fits = len(fit_errors)
+        num_fits = len(results)
         fit_errors_counter = Counter(fit_errors)
         delimiter = "-" * 80 + "\n"
         fit_errors_summary = "\n".join(

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1566,8 +1566,8 @@ def test_grid_search_failing_classifier():
         error_score=0.0,
     )
     warning_message = (
-        "Estimator fit failed. The score on this train-test partition "
-        "for these parameters will be set to 0.0.*."
+        "5 fits failed on the training sets over a total of 15 fits. The score on these"
+        r" train-test partitions for these parameters will be set to 0\.0"
     )
     with pytest.warns(FitFailedWarning, match=warning_message):
         gs.fit(X, y)
@@ -1599,8 +1599,8 @@ def test_grid_search_failing_classifier():
         error_score=float("nan"),
     )
     warning_message = (
-        "Estimator fit failed. The score on this train-test partition "
-        "for these parameters will be set to nan."
+        "5 fits failed on the training sets over a total of 15 fits. The score on these"
+        r" train-test partitions for these parameters will be set to nan"
     )
     with pytest.warns(FitFailedWarning, match=warning_message):
         gs.fit(X, y)
@@ -2112,7 +2112,11 @@ def test_callable_multimetric_error_failing_clf():
         error_score=0.1,
     )
 
-    with pytest.warns(FitFailedWarning, match="Estimator fit failed"):
+    warning_message = (
+        "5 fits failed on the training sets over a total of 15 fits. The score on these"
+        r" train-test partitions for these parameters will be set to 0\.1"
+    )
+    with pytest.warns(FitFailedWarning, match=warning_message):
         gs.fit(X, y)
 
     assert_allclose(gs.cv_results_["mean_test_acc"], [1, 1, 0.1])

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2139,9 +2139,10 @@ def test_callable_multimetric_clf_all_fails():
         error_score=0.1,
     )
 
-    with pytest.warns(FitFailedWarning, match="Estimator fit failed"), pytest.raises(
-        NotFittedError, match="All estimators failed to fit"
-    ):
+    with pytest.warns(
+        FitFailedWarning,
+        match="15 fits failed on the training sets over a total of 15 fits",
+    ), pytest.raises(NotFittedError, match="All estimators failed to fit"):
         gs.fit(X, y)
 
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1567,7 +1567,7 @@ def test_grid_search_failing_classifier():
     )
 
     warning_message = re.compile(
-        "5 fits failed on the training sets over a total of 15 fits.+The score on these"
+        "5 fits failed.+total of 15.+The score on these"
         r" train-test partitions for these parameters will be set to 0\.0.+"
         "5 fits failed with the following error.+ValueError.+Failing classifier failed"
         " as required",
@@ -1603,7 +1603,7 @@ def test_grid_search_failing_classifier():
         error_score=float("nan"),
     )
     warning_message = re.compile(
-        "5 fits failed on the training sets over a total of 15 fits.+The score on these"
+        "5 fits failed.+total of 15.+The score on these"
         r" train-test partitions for these parameters will be set to nan.+"
         "5 fits failed with the following error.+ValueError.+Failing classifier failed"
         " as required",
@@ -2120,7 +2120,7 @@ def test_callable_multimetric_error_failing_clf():
     )
 
     warning_message = re.compile(
-        "5 fits failed on the training sets over a total of 15 fits.+The score on these"
+        "5 fits failed.+total of 15.+The score on these"
         r" train-test partitions for these parameters will be set to 0\.1",
         flags=re.DOTALL,
     )
@@ -2149,7 +2149,7 @@ def test_callable_multimetric_clf_all_fails():
 
     with pytest.warns(
         FitFailedWarning,
-        match="15 fits failed on the training sets over a total of 15 fits",
+        match="15 fits failed.+total of 15",
     ), pytest.raises(NotFittedError, match="All estimators failed to fit"):
         gs.fit(X, y)
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1565,9 +1565,13 @@ def test_grid_search_failing_classifier():
         refit=False,
         error_score=0.0,
     )
-    warning_message = (
-        "5 fits failed on the training sets over a total of 15 fits. The score on these"
-        r" train-test partitions for these parameters will be set to 0\.0"
+
+    warning_message = re.compile(
+        "5 fits failed on the training sets over a total of 15 fits.+The score on these"
+        r" train-test partitions for these parameters will be set to 0\.0.+"
+        "5 fits failed with the following error.+ValueError.+Failing classifier failed"
+        " as required",
+        flags=re.DOTALL,
     )
     with pytest.warns(FitFailedWarning, match=warning_message):
         gs.fit(X, y)
@@ -1598,9 +1602,12 @@ def test_grid_search_failing_classifier():
         refit=False,
         error_score=float("nan"),
     )
-    warning_message = (
-        "5 fits failed on the training sets over a total of 15 fits. The score on these"
-        r" train-test partitions for these parameters will be set to nan"
+    warning_message = re.compile(
+        "5 fits failed on the training sets over a total of 15 fits.+The score on these"
+        r" train-test partitions for these parameters will be set to nan.+"
+        "5 fits failed with the following error.+ValueError.+Failing classifier failed"
+        " as required",
+        flags=re.DOTALL,
     )
     with pytest.warns(FitFailedWarning, match=warning_message):
         gs.fit(X, y)
@@ -2112,9 +2119,10 @@ def test_callable_multimetric_error_failing_clf():
         error_score=0.1,
     )
 
-    warning_message = (
-        "5 fits failed on the training sets over a total of 15 fits. The score on these"
-        r" train-test partitions for these parameters will be set to 0\.1"
+    warning_message = re.compile(
+        "5 fits failed on the training sets over a total of 15 fits.+The score on these"
+        r" train-test partitions for these parameters will be set to 0\.1",
+        flags=re.DOTALL,
     )
     with pytest.warns(FitFailedWarning, match=warning_message):
         gs.fit(X, y)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2146,7 +2146,7 @@ def test_cross_validate_failing_fits_warnings(error_score):
         "7 fits failed on the training sets over a total of 7 fits.+The score on these"
         " train-test partitions for these parameters will be set to"
         f" {cross_validate_kwargs['error_score']}.",
-        flags=re.DOTALL
+        flags=re.DOTALL,
     )
 
     with pytest.warns(FitFailedWarning, match=warning_message):

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2153,17 +2153,11 @@ def test_cross_validate_failing_fits_warnings(error_score):
 
     # since we're using FailingClassfier, our error will be the following
     error_message = "ValueError: Failing classifier failed as required"
-    # the warning message we're expecting to see
-    warning_message = (
-        "7 fits failed on the training sets over a total of 7 fits. The score on these"
-        " train-test partitions for these parameters will be set to %f. .+Details%s"
-        f" {cross_validate_kwargs['error_score']} {error_message}"
-    )
 
     # check traceback is included
-    warning_message = (
+    warning_message = re.compile(
         "The score on these train-test partitions for these parameters will be set"
-        f" to {cross_validate_kwargs['error_score']}"
+        f" to {cross_validate_kwargs['error_score']}.+{error_message}", re.DOTALL
     )
     with pytest.warns(FitFailedWarning, match=warning_message):
         cross_validate(*cross_validate_args, **cross_validate_kwargs)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2143,7 +2143,7 @@ def test_cross_validate_failing_fits_warnings(error_score):
     cross_validate_kwargs = {"cv": 7, "error_score": error_score}
     # check if the warning message type is as expected
     warning_message = re.compile(
-        "7 fits failed on the training sets over a total of 7 fits.+The score on these"
+        "7 fits failed.+total of 7.+The score on these"
         " train-test partitions for these parameters will be set to"
         f" {cross_validate_kwargs['error_score']}.",
         flags=re.DOTALL,

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2157,7 +2157,8 @@ def test_cross_validate_failing_fits_warnings(error_score):
     # check traceback is included
     warning_message = re.compile(
         "The score on these train-test partitions for these parameters will be set"
-        f" to {cross_validate_kwargs['error_score']}.+{error_message}", re.DOTALL
+        f" to {cross_validate_kwargs['error_score']}.+{error_message}",
+        re.DOTALL,
     )
     with pytest.warns(FitFailedWarning, match=warning_message):
         cross_validate(*cross_validate_args, **cross_validate_kwargs)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2142,10 +2142,11 @@ def test_cross_validate_failing_fits_warnings(error_score):
     cross_validate_args = [failing_clf, X, y]
     cross_validate_kwargs = {"cv": 7, "error_score": error_score}
     # check if the warning message type is as expected
-    warning_message = (
-        "7 fits failed on the training sets over a total of 7 fits. The score on these"
+    warning_message = re.compile(
+        "7 fits failed on the training sets over a total of 7 fits.+The score on these"
         " train-test partitions for these parameters will be set to"
-        f" {cross_validate_kwargs['error_score']}."
+        f" {cross_validate_kwargs['error_score']}.",
+        flags=re.DOTALL
     )
 
     with pytest.warns(FitFailedWarning, match=warning_message):

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2082,37 +2082,6 @@ def test_fit_and_score_failing():
     y = np.ones(9)
     fit_and_score_args = [failing_clf, X, None, dict(), None, None, 0, None, None]
     # passing error score to trigger the warning message
-    fit_and_score_kwargs = {"error_score": 0}
-    # check if the warning message type is as expected
-    warning_message = (
-        "Estimator fit failed. The score on this train-test partition for "
-        "these parameters will be set to %f." % (fit_and_score_kwargs["error_score"])
-    )
-    with pytest.warns(FitFailedWarning, match=warning_message):
-        _fit_and_score(*fit_and_score_args, **fit_and_score_kwargs)
-    # since we're using FailingClassfier, our error will be the following
-    error_message = "ValueError: Failing classifier failed as required"
-    # the warning message we're expecting to see
-    warning_message = (
-        "Estimator fit failed. The score on this train-test "
-        "partition for these parameters will be set to %f. "
-        "Details: \n%s" % (fit_and_score_kwargs["error_score"], error_message)
-    )
-
-    def test_warn_trace(msg):
-        assert "Traceback (most recent call last):\n" in msg
-        split = msg.splitlines()  # note: handles more than '\n'
-        mtb = split[0] + "\n" + split[-1]
-        return warning_message in mtb
-
-    # check traceback is included
-    warning_message = (
-        "Estimator fit failed. The score on this train-test partition for "
-        "these parameters will be set to %f." % (fit_and_score_kwargs["error_score"])
-    )
-    with pytest.warns(FitFailedWarning, match=warning_message):
-        _fit_and_score(*fit_and_score_args, **fit_and_score_kwargs)
-
     fit_and_score_kwargs = {"error_score": "raise"}
     # check if exception was raised, with default error_score='raise'
     with pytest.raises(ValueError, match="Failing classifier failed as required"):
@@ -2159,6 +2128,45 @@ def test_fit_and_score_working():
     }
     result = _fit_and_score(*fit_and_score_args, **fit_and_score_kwargs)
     assert result["parameters"] == fit_and_score_kwargs["parameters"]
+
+
+@pytest.mark.parametrize("error_score", [np.nan, 0])
+def test_cross_validate_failing_fits_warnings(error_score):
+    # Create a failing classifier to deliberately fail
+    failing_clf = FailingClassifier(FailingClassifier.FAILING_PARAMETER)
+    # dummy X data
+    X = np.arange(1, 10)
+    y = np.ones(9)
+    # fit_and_score_args = [failing_clf, X, None, dict(), None, None, 0, None, None]
+    # passing error score to trigger the warning message
+    cross_validate_args = [failing_clf, X, y]
+    cross_validate_kwargs = {"cv": 7, "error_score": error_score}
+    # check if the warning message type is as expected
+    warning_message = (
+        "7 fits failed on the training sets over a total of 7 fits. The score on these"
+        " train-test partitions for these parameters will be set to"
+        f" {cross_validate_kwargs['error_score']}."
+    )
+
+    with pytest.warns(FitFailedWarning, match=warning_message):
+        cross_validate(*cross_validate_args, **cross_validate_kwargs)
+
+    # since we're using FailingClassfier, our error will be the following
+    error_message = "ValueError: Failing classifier failed as required"
+    # the warning message we're expecting to see
+    warning_message = (
+        "7 fits failed on the training sets over a total of 7 fits. The score on these"
+        " train-test partitions for these parameters will be set to %f. .+Details%s"
+        f" {cross_validate_kwargs['error_score']} {error_message}"
+    )
+
+    # check traceback is included
+    warning_message = (
+        "The score on these train-test partitions for these parameters will be set"
+        f" to {cross_validate_kwargs['error_score']}"
+    )
+    with pytest.warns(FitFailedWarning, match=warning_message):
+        cross_validate(*cross_validate_args, **cross_validate_kwargs)
 
 
 def _failing_scorer(estimator, X, y, error_msg):

--- a/test.py
+++ b/test.py
@@ -1,0 +1,8 @@
+from sklearn.datasets import make_classification
+X, y = make_classification()
+
+from sklearn.linear_model import LogisticRegression
+lr = LogisticRegression(C='wrong-value')
+
+from sklearn.model_selection import cross_val_score
+cross_val_score(lr, X, y, n_jobs=2)

--- a/test.py
+++ b/test.py
@@ -1,8 +1,0 @@
-from sklearn.datasets import make_classification
-X, y = make_classification()
-
-from sklearn.linear_model import LogisticRegression
-lr = LogisticRegression(C='wrong-value')
-
-from sklearn.model_selection import cross_val_score
-cross_val_score(lr, X, y, n_jobs=2)


### PR DESCRIPTION
#### Reference Issues/PRs
Fix #20475

#### What does this implement/fix? Explain your changes.

Removes a per-split warning and do a summary warning in the main process.

#### Any other comments?

Still polishing it for now, some test failures expected.

Some remaining things to discuss/do:
- [x] removing the per-split warning may affect `BaseSearchCV` derived classes outside scikit-learn. There will be no warnings when a fit fails. How acceptable is it?
- [x] agree on the warning message. This is how it looks right now. I could potentially shorten it when some of the errors are exactly the same:
```
/home/local/lesteve/dev/scikit-learn/sklearn/model_selection/_validation.py:366: FitFailedWarning: 
5 fits failed on the training sets over a total of 5 fits. The score on these train-test partitions for these parameters will be set to nan.
In case these failures are not expected, you can try to debug these failures by setting error_score='raise'.

Here are more details about the failures:
----------
Traceback (most recent call last):
  File "/home/local/lesteve/dev/scikit-learn/sklearn/model_selection/_validation.py", line 675, in _fit_and_score
    estimator.fit(X_train, y_train, **fit_params)
  File "/home/local/lesteve/dev/scikit-learn/sklearn/linear_model/_logistic.py", line 1458, in fit
    raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
ValueError: Penalty term must be positive; got (C='wrong-value')
----------
Traceback (most recent call last):
  File "/home/local/lesteve/dev/scikit-learn/sklearn/model_selection/_validation.py", line 675, in _fit_and_score
    estimator.fit(X_train, y_train, **fit_params)
  File "/home/local/lesteve/dev/scikit-learn/sklearn/linear_model/_logistic.py", line 1458, in fit
    raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
ValueError: Penalty term must be positive; got (C='wrong-value')
----------
Traceback (most recent call last):
  File "/home/local/lesteve/dev/scikit-learn/sklearn/model_selection/_validation.py", line 675, in _fit_and_score
    estimator.fit(X_train, y_train, **fit_params)
  File "/home/local/lesteve/dev/scikit-learn/sklearn/linear_model/_logistic.py", line 1458, in fit
    raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
ValueError: Penalty term must be positive; got (C='wrong-value')
----------
Traceback (most recent call last):
  File "/home/local/lesteve/dev/scikit-learn/sklearn/model_selection/_validation.py", line 675, in _fit_and_score
    estimator.fit(X_train, y_train, **fit_params)
  File "/home/local/lesteve/dev/scikit-learn/sklearn/linear_model/_logistic.py", line 1458, in fit
    raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
ValueError: Penalty term must be positive; got (C='wrong-value')
----------
Traceback (most recent call last):
  File "/home/local/lesteve/dev/scikit-learn/sklearn/model_selection/_validation.py", line 675, in _fit_and_score
    estimator.fit(X_train, y_train, **fit_params)
  File "/home/local/lesteve/dev/scikit-learn/sklearn/linear_model/_logistic.py", line 1458, in fit
    raise ValueError("Penalty term must be positive; got (C=%r)" % self.C)
ValueError: Penalty term must be positive; got (C='wrong-value')

  warnings.warn(some_fits_failed_message, FitFailedWarning)
```

- [x] add changelog
- [x] `test_callable_multimetric_clf_all_fails` failure: quirk that for multimetric you get an error if all the test fails (but not for single metric). Is there a good reason for this behaviour? I changed my PR to make this test pass, basically the warnings on fit failures happens before the insertion of error scores for the multimetric case.