### PR TITLE
DOC Ensures that ExtraTreesClassifier passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -21,7 +21,6 @@ DOCSTRING_IGNORE_LIST = [
     "DummyClassifier",
     "ElasticNetCV",
     "ExtraTreeRegressor",
-    "ExtraTreesClassifier",
     "ExtraTreesRegressor",
     "FactorAnalysis",
     "FeatureAgglomeration",

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -2233,10 +2233,6 @@ class ExtraTreesRegressor(ForestRegressor):
     ExtraTreesRegressor : An extra-trees regressor.
     RandomForestClassifier : A random forest classifier.
     RandomForestRegressor : Ensemble regressor using trees with optimal splits.
-    sklearn.tree.ExtraTreeClassifier: An extremely randomized
-        tree classifier.
-    sklearn.tree.ExtraTreeRegressor : An extremely randomized
-        tree regressor.
 
     Notes
     -----

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -2229,8 +2229,14 @@ class ExtraTreesRegressor(ForestRegressor):
 
     See Also
     --------
-    sklearn.tree.ExtraTreeRegressor : Base estimator for this ensemble.
+    ExtraTreesClassifier : An extra-trees classifier.
+    ExtraTreesRegressor : An extra-trees regressor.
+    RandomForestClassifier : A random forest classifier.
     RandomForestRegressor : Ensemble regressor using trees with optimal splits.
+    sklearn.tree.ExtraTreeClassifier: An extremely randomized
+        tree classifier.
+    sklearn.tree.ExtraTreeRegressor : An extremely randomized
+        tree regressor.
 
     Notes
     -----


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #20308

#### What does this implement/fix? Explain your changes.
This class was already passing the numpydoc validation. I added a few more options to the ``See Also`` section.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
