### PR TITLE
DOC Fixes typo in plot_permutation_test_for_classification

### DIFF
--- a/examples/feature_selection/plot_permutation_test_for_classification.py
+++ b/examples/feature_selection/plot_permutation_test_for_classification.py
@@ -5,7 +5,7 @@ Test with permutations the significance of a classification score
 
 This example demonstrates the use of
 :func:`~sklearn.model_selection.permutation_test_score` to evaluate the
-significance of a cross-valdiated score using permutations.
+significance of a cross-validated score using permutations.
 """
 
 # Authors:  Alexandre Gramfort <alexandre.gramfort@inria.fr>


### PR DESCRIPTION
This PR fixes a trivial typo.