### PR TITLE
FIX support both instance and class level methods in `_AvailableIfDescriptor.__get__`

### DIFF
--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -111,7 +111,10 @@ class _AvailableIfDescriptor:
                 )
 
         # lambda, but not partial, allows help() to work with update_wrapper
-        out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)  # noqa
+        if obj is None:
+            out = lambda *args, **kwargs: self.fn(*args, **kwargs)  # noqa
+        else:
+            out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)  # noqa
         # update the docstring of the returned function
         update_wrapper(out, self.fn)
         return out

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -110,8 +110,7 @@ class _AvailableIfDescriptor:
                     f" {repr(self.attribute_name)}"
                 )
 
-        # lambda, but not partial, allows help() to work with update_wrapper
-        if obj:
+            # lambda, but not partial, allows help() to work with update_wrapper
             out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)  # noqa
         else:
             # This makes it possible to use the decorated method as an unbound method,

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -111,10 +111,12 @@ class _AvailableIfDescriptor:
                 )
 
         # lambda, but not partial, allows help() to work with update_wrapper
-        if obj is None:
-            out = lambda *args, **kwargs: self.fn(*args, **kwargs)  # noqa
-        else:
+        if obj:
             out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)  # noqa
+        else:
+            # This makes it possible to use the decorated method as an unbound method,
+            # for instance when monkeypatching.
+            out = lambda *args, **kwargs: self.fn(*args, **kwargs)  # noqa
         # update the docstring of the returned function
         update_wrapper(out, self.fn)
         return out

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -1,3 +1,5 @@
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.metaestimators import available_if
 
@@ -104,3 +106,8 @@ def test_available_if_docstring():
 def test_available_if():
     assert hasattr(AvailableParameterEstimator(), "available_func")
     assert not hasattr(AvailableParameterEstimator(available=False), "available_func")
+
+    X = [[0, 0], [0, 0], [1, 1], [1, 1]]
+    pipe = Pipeline([("scaler", StandardScaler())])
+    pipe.fit(X)
+    Pipeline.transform(pipe, X)

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -105,5 +105,9 @@ def test_available_if():
     assert hasattr(AvailableParameterEstimator(), "available_func")
     assert not hasattr(AvailableParameterEstimator(available=False), "available_func")
 
+    # This is a non regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/20614
+    # to make sure that decorated functions can be used as an unbound method,
+    # for instance when monkeypatching.
     est = AvailableParameterEstimator()
     AvailableParameterEstimator.available_func(est)

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -1,5 +1,3 @@
-from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import StandardScaler
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.metaestimators import available_if
 
@@ -107,7 +105,5 @@ def test_available_if():
     assert hasattr(AvailableParameterEstimator(), "available_func")
     assert not hasattr(AvailableParameterEstimator(available=False), "available_func")
 
-    X = [[0, 0], [0, 0], [1, 1], [1, 1]]
-    pipe = Pipeline([("scaler", StandardScaler())])
-    pipe.fit(X)
-    Pipeline.transform(pipe, X)
+    est = AvailableParameterEstimator()
+    AvailableParameterEstimator.available_func(est)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes https://github.com/scikit-learn/scikit-learn/issues/20614


#### What does this implement/fix? Explain your changes.

Fix this line:

https://github.com/scikit-learn/scikit-learn/blob/5d88f9aff9ca1b672e0d10e1a2a7afa1e286b31b/sklearn/utils/metaestimators.py#L114

to:

```python
if obj is None:
    # descriptor is accessed through class (e.g. `Pipeline.score`)
    out = lambda *args, **kwargs: self.fn(*args, **kwargs)
else:
    # descriptor is accessed through instance. (e.g. `Pipline([...]).score`)
    out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
