### PR TITLE
Add `err_msg` to `available_if` to allow specifying `AttributeError` message

### DIFF
--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -91,11 +91,15 @@ class _AvailableIfDescriptor:
     descriptors.
     """
 
-    def __init__(self, fn, check, attribute_name, err_msg_template):
+    def __init__(self, fn, check, attribute_name, err_msg_template=None):
         self.fn = fn
         self.check = check
         self.attribute_name = attribute_name
-        self.err_msg_template = err_msg_template
+        self.err_msg_template = (
+            "This {owner} has no attribute {attribute_name}"
+            if err_msg_template is None
+            else err_msg_template
+        )
 
         # update the docstring of the descriptor
         update_wrapper(self, fn)
@@ -171,8 +175,6 @@ def available_if(check, err_msg_template=None):
     >>> obj.say_hello()
     Hello
     """
-    if err_msg_template is None:
-        err_msg_template = "This {owner} has no attribute {attribute_name}"
     return lambda fn: _AvailableIfDescriptor(
         fn,
         check,

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -136,7 +136,7 @@ def available_if(check, *, err_msg=None):
 
     err_msg : str, default=None
         An error message for an `AttributeError` raised if `check` returns `False`.
-        If not passed, defaults to `"This {owner} has no attribute {attribute_name}"`
+        If `None` (default), it defaults to `"This {owner} has no attribute {attribute_name}"`
         where `owner` represents the name of the class that owns the decorated method
         and `attribute_name` represents the name of the decorated method.
 

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -158,10 +158,7 @@ def available_if(check, err_msg_template=None):
     ...
     ...    @available_if(
     ...        _x_is_even,
-    ...        err_msg_template=(
-    ...            "{attribute_name} is not available for this {owner} because"
-    ...            " self.x is not an even number"
-    ...        ),
+    ...        err_msg_template="{attribute_name} is not available for this {owner}",
     ...    )
     ...    def say_hello(self):
     ...        print("Hello")
@@ -172,7 +169,7 @@ def available_if(check, err_msg_template=None):
     >>> obj.say_hello()
     Traceback (most recent call last):
         ...
-    AttributeError: 'say_hello' is not available for this 'HelloIfEven' because self.x is not an even number
+    AttributeError: 'say_hello' is not available for this 'HelloIfEven'
     >>> obj.x = 2
     >>> hasattr(obj, "say_hello")
     True

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -135,7 +135,7 @@ def available_if(check, *, err_msg=None):
         or raise an AttributeError if not available.
 
     err_msg : str, default=None
-        An error message for an AttributeError raised if `check` returns a falsy value.
+        An error message for an `AttributeError` raised if `check` returns `False`.
         If not passed, defaults to `"This {owner} has no attribute {attribute_name}"`
         where `owner` represents the name of the class that owns the decorated method
         and `attribute_name` represents the name of the decorated method.

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -158,7 +158,10 @@ def available_if(check, err_msg_template=None):
     ...
     ...    @available_if(
     ...        _x_is_even,
-    ...        "{attribute_name} is only available when self.x is an even number",
+    ...        err_msg_template=(
+    ...            "{attribute_name} is not available for this {owner} because"
+    ...            " self.x is not an even number"
+    ...        ),
     ...    )
     ...    def say_hello(self):
     ...        print("Hello")
@@ -167,8 +170,9 @@ def available_if(check, err_msg_template=None):
     >>> hasattr(obj, "say_hello")
     False
     >>> obj.say_hello()
-    ...
-    AttributeError: say_hello is only available when self.x is an even number
+    Traceback (most recent call last):
+        ...
+    AttributeError: 'say_hello' is not available for this 'HelloIfEven' because self.x is not an even number
     >>> obj.x = 2
     >>> hasattr(obj, "say_hello")
     True

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -136,9 +136,10 @@ def available_if(check, *, err_msg=None):
 
     err_msg : str, default=None
         An error message for an `AttributeError` raised if `check` returns `False`.
-        If `None` (default), it defaults to `"This {owner} has no attribute {attribute_name}"`
-        where `owner` represents the name of the class that owns the decorated method
-        and `attribute_name` represents the name of the decorated method.
+        If `None` (default), it defaults to
+        `"This {owner} has no attribute {attribute_name}"` where `owner` represents
+        the name of the class that owns the decorated method and `attribute_name`
+        represents the name of the decorated method.
 
     Examples
     --------

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -92,13 +92,10 @@ class AvailableParameterEstimator:
 
     @available_if(
         lambda est: est.available,
-        err_msg_template=(
-            "{attribute_name} is not available for this {owner} because self.available"
-            " is False"
-        ),
+        err_msg="self.available must be True",
     )
-    def available_func_helpful(self):
-        """This is a mock available_if function with a helpful error message"""
+    def available_func_err_msg(self):
+        """This is a mock available_if function to test err_msg"""
         pass
 
 
@@ -125,14 +122,8 @@ def test_available_if():
     ):
         est.available_func
 
-    with pytest.raises(
-        AttributeError,
-        match=(
-            "'available_func_helpful' is not available for this"
-            " 'AvailableParameterEstimator' because self.available is False"
-        ),
-    ):
-        est.available_func_helpful
+    with pytest.raises(AttributeError, match="self.available must be True"):
+        est.available_func_err_msg
 
     # This is a non regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/20614

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -95,7 +95,7 @@ class AvailableParameterEstimator:
         err_msg="self.available must be True",
     )
     def available_func_err_msg(self):
-        """This is a mock available_if function to test err_msg"""
+        """This is a mock `available_if` function to test `err_msg`."""
         pass
 
 

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.metaestimators import available_if
 
@@ -88,6 +90,17 @@ class AvailableParameterEstimator:
         """This is a mock available_if function"""
         pass
 
+    @available_if(
+        lambda est: est.available,
+        err_msg_template=(
+            "{attribute_name} is not available for this {owner} because self.available"
+            " is False"
+        ),
+    )
+    def available_func_helpful(self):
+        """This is a mock available_if function with a helpful error message"""
+        pass
+
 
 def test_available_if_docstring():
     assert "This is a mock available_if function" in str(
@@ -104,6 +117,22 @@ def test_available_if_docstring():
 def test_available_if():
     assert hasattr(AvailableParameterEstimator(), "available_func")
     assert not hasattr(AvailableParameterEstimator(available=False), "available_func")
+
+    est = AvailableParameterEstimator(available=False)
+    with pytest.raises(
+        AttributeError,
+        match="This 'AvailableParameterEstimator' has no attribute 'available_func'",
+    ):
+        est.available_func
+
+    with pytest.raises(
+        AttributeError,
+        match=(
+            "'available_func_helpful' is not available for this"
+            " 'AvailableParameterEstimator' because self.available is False"
+        ),
+    ):
+        est.available_func_helpful
 
     # This is a non regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/20614


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Related to: https://github.com/scikit-learn/scikit-learn/issues/20630.

#### What does this implement/fix? Explain your changes.

Once this PR is merged, we can replace `@property` applied on predict methods with `@available_if` and raise an `AttributeError` with a helpful message when the available condition is not satisfied.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
