### PR TITLE
DOC Ensures that GradientBoostingClassifier passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -30,7 +30,6 @@ DOCSTRING_IGNORE_LIST = [
     "GaussianMixture",
     "GaussianProcessRegressor",
     "GaussianRandomProjection",
-    "GradientBoostingClassifier",
     "GradientBoostingRegressor",
     "GridSearchCV",
     "HalvingGridSearchCV",

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -460,6 +460,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         Returns
         -------
         self : object
+            Fitted estimator.
         """
         if self.criterion in ("absolute_error", "mae"):
             # TODO: This should raise an error from 1.1
@@ -1319,7 +1320,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             ``dtype=np.float32`` and if a sparse matrix is provided
             to a sparse ``csr_matrix``.
 
-        Returns
+        Yields
         -------
         score : generator of ndarray of shape (n_samples, k)
             The decision function of the input samples, which corresponds to
@@ -1362,7 +1363,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             ``dtype=np.float32`` and if a sparse matrix is provided
             to a sparse ``csr_matrix``.
 
-        Returns
+        Yields
         -------
         y : generator of ndarray of shape (n_samples,)
             The predicted value of the input samples.
@@ -1381,16 +1382,16 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             ``dtype=np.float32`` and if a sparse matrix is provided
             to a sparse ``csr_matrix``.
 
-        Raises
-        ------
-        AttributeError
-            If the ``loss`` does not support probabilities.
-
         Returns
         -------
         p : ndarray of shape (n_samples, n_classes)
             The class probabilities of the input samples. The order of the
             classes corresponds to that in the attribute :term:`classes_`.
+
+        Raises
+        ------
+        AttributeError
+            If the ``loss`` does not support probabilities.
         """
         raw_predictions = self.decision_function(X)
         try:
@@ -1412,16 +1413,16 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             ``dtype=np.float32`` and if a sparse matrix is provided
             to a sparse ``csr_matrix``.
 
-        Raises
-        ------
-        AttributeError
-            If the ``loss`` does not support probabilities.
-
         Returns
         -------
         p : ndarray of shape (n_samples, n_classes)
             The class log-probabilities of the input samples. The order of the
             classes corresponds to that in the attribute :term:`classes_`.
+
+        Raises
+        ------
+        AttributeError
+            If the ``loss`` does not support probabilities.
         """
         proba = self.predict_proba(X)
         return np.log(proba)
@@ -1439,7 +1440,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             ``dtype=np.float32`` and if a sparse matrix is provided
             to a sparse ``csr_matrix``.
 
-        Returns
+        Yields
         -------
         y : generator of ndarray of shape (n_samples,)
             The predicted value of the input samples.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1321,7 +1321,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             to a sparse ``csr_matrix``.
 
         Yields
-        -------
+        ------
         score : generator of ndarray of shape (n_samples, k)
             The decision function of the input samples, which corresponds to
             the raw values predicted from the trees of the ensemble . The
@@ -1441,7 +1441,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             to a sparse ``csr_matrix``.
 
         Yields
-        -------
+        ------
         y : generator of ndarray of shape (n_samples,)
             The predicted value of the input samples.
         """


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308

#### What does this implement/fix? Explain your changes.
This PR ensures GradientBoostingClassifier is compatible with numpydoc.
- Remove `GradientBoostingClassifier` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.

#### Any other comments?
#DataUmbrella Sprint