### PR TITLE
Perform attribute check when function decorated by `availabel_if` is used as unbound method

### DIFF
--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.metaestimators import available_if
 
@@ -105,9 +107,18 @@ def test_available_if():
     assert hasattr(AvailableParameterEstimator(), "available_func")
     assert not hasattr(AvailableParameterEstimator(available=False), "available_func")
 
+
+def test_available_if_unbound_method():
     # This is a non regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/20614
     # to make sure that decorated functions can be used as an unbound method,
     # for instance when monkeypatching.
     est = AvailableParameterEstimator()
     AvailableParameterEstimator.available_func(est)
+
+    est = AvailableParameterEstimator(available=False)
+    with pytest.raises(
+        AttributeError,
+        match="This 'AvailableParameterEstimator' has no attribute 'available_func'",
+    ):
+        AvailableParameterEstimator.available_func(est)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

- A follow-up for #20623 
- Perform an attribute check when a function decorated by `availabel_if` is used as an unbound method

#### What does this implement/fix? Explain your changes.

```python
# Base code

class AvailableParameterEstimator:

    def __init__(self, available=True):
        self.available = available

    @available_if(lambda est: est.available)
    def available_func(self):
        print("available")

# Before:
>>> est = AvailableParameterEstimator(available=False)
>>> AvailableParameterEstimator.available_func(est)  # no exception is thrown
available

# After:
>>> est = AvailableParameterEstimator(available=False)
>>> AvailableParameterEstimator.available_func(est)
Traceback (most recent call last):
    ...
AttributeError: This 'AvailableParameterEstimator' has no attribute 'available_func'
```


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
