### PR TITLE
FIX Use take in safe_indexing for pandas to avoid SettingWithCopyWarning

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -735,6 +735,15 @@ Changelog
   now deprecated. Use `scipy.sparse.csgraph.shortest_path` instead. :pr:`20531`
   by `Tom Dupre la Tour`_.
 
+- |Fix| :func:`utils._safe_indexing` explicitly takes a dataframe copy when
+  integer indices are provided avoiding to raise a warning from Pandas. This
+  warning was previously raised in resampling utilities and functions using
+  those utilities (e.g. :func:`model_selection.train_test_split`,
+  :func:`model_selection.cross_validate`,
+  :func:`model_seleection.cross_val_score`,
+  :func:`model_selection.cross_val_predict`).
+  :pr:`20673` by :user:`Joris Van den Bossche  <jorisvandenbossche>`.
+
 :mod:`sklearn.validation`
 .........................
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -209,13 +209,15 @@ def _pandas_indexing(X, key, key_dtype, axis):
         key = key if key.flags.writeable else key.copy()
     elif isinstance(key, tuple):
         key = list(key)
-    # check whether we should index with loc or iloc
-    if key_dtype == "int":
+
+    if key_dtype == "int" and not (isinstance(key, slice) or np.isscalar(key)):
         # using take() instead of iloc[] ensures the return value is a "proper"
         # copy that will not raise SettingWithCopyWarning
         return X.take(key, axis=axis)
     else:
-        return X.loc[:, key] if axis else X.loc[key]
+        # check whether we should index with loc or iloc
+        indexer = X.iloc if key_dtype == "int" else X.loc
+        return indexer[:, key] if axis else indexer[key]
 
 
 def _list_indexing(X, key, key_dtype):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -210,8 +210,12 @@ def _pandas_indexing(X, key, key_dtype, axis):
     elif isinstance(key, tuple):
         key = list(key)
     # check whether we should index with loc or iloc
-    indexer = X.iloc if key_dtype == "int" else X.loc
-    return indexer[:, key] if axis else indexer[key]
+    if key_dtype == "int":
+        # using take() instead of iloc[] ensures the return value is a "proper"
+        # copy that will not raise SettingWithCopyWarning
+        return X.take(key, axis=axis)
+    else:
+        return X.loc[:, key] if axis else X.loc[key]
 
 
 def _list_indexing(X, key, key_dtype):

--- a/sklearn/utils/_mocking.py
+++ b/sklearn/utils/_mocking.py
@@ -50,6 +50,9 @@ class MockDataFrame:
     def __ne__(self, other):
         return not self == other
 
+    def take(self, indices, axis=0):
+        return MockDataFrame(self.array.take(indices, axis=axis))
+
 
 class CheckingClassifier(ClassifierMixin, BaseEstimator):
     """Dummy classifier to test pipelining and meta-estimators.

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -480,7 +480,7 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
         subset.iloc[0, 0] = 10
     assert len(record) == 0, f"{[str(rec.message) for rec in record]}"
     # The original dataframe is unaffected by the assignment on the subset:
-    assert X.iloc[0, 0] = 1
+    assert X.iloc[0, 0] == 1
 
 @pytest.mark.parametrize(
     "key, err_msg",

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -468,7 +468,7 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
     # Using safe_indexing with an array-like indexer gives a copy of the
     # DataFrame -> ensure it doesn't raise a warning if modified
     pd = pytest.importorskip("pandas")
-    X = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
+    X = pd.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
     subset = _safe_indexing(X, [0, 1], axis=0)
     with pytest.warns(None) as record:
         subset.iloc[0, 0] = 10

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -472,8 +472,7 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
     pd = pytest.importorskip("pandas")
     if parse_version(pd.__version__) < parse_version("0.25.0"):
         raise SkipTest(
-            "Older pandas version will raise a different warning than "
-            "SettingWithCopyWarning"
+            "Older pandas version still raise a SettingWithCopyWarning warning"
         )
     X = pd.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
     subset = _safe_indexing(X, [0, 1], axis=0)

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -482,6 +482,7 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
     # The original dataframe is unaffected by the assignment on the subset:
     assert X.iloc[0, 0] == 1
 
+
 @pytest.mark.parametrize(
     "key, err_msg",
     [

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -472,7 +472,7 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
     subset = _safe_indexing(X, [0, 1], axis=0)
     with pytest.warns(None) as record:
         subset.iloc[0, 0] = 10
-    assert len(record) == 0
+    assert len(record) == 0, f"{[str(rec.message) for rec in record]}"
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -464,6 +464,17 @@ def test_safe_indexing_container_axis_0_unsupported_type():
         _safe_indexing(array, indices, axis=0)
 
 
+def test_safe_indexing_pandas_no_settingwithcopy_warning():
+    # Using safe_indexing with an array-like indexer gives a copy of the
+    # DataFrame -> ensure it doesn't raise a warning if modified
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame({'a': [1, 2, 3], 'b': [3, 4, 5]})
+    subset = _safe_indexing(X, [0, 1], axis=0)
+    with pytest.warns(None) as record:
+        subset.iloc[0, 0] = 10
+    assert len(record) == 0
+
+
 @pytest.mark.parametrize(
     "key, err_msg",
     [

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -29,7 +29,9 @@ from sklearn.utils import _message_with_time, _print_elapsed_time
 from sklearn.utils import get_chunk_n_rows
 from sklearn.utils import is_scalar_nan
 from sklearn.utils import _to_object_array
+from sklearn.utils.fixes import parse_version
 from sklearn.utils._mocking import MockDataFrame
+from sklearn.utils._testing import SkipTest
 from sklearn import config_context
 
 # toy array
@@ -468,6 +470,11 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
     # Using safe_indexing with an array-like indexer gives a copy of the
     # DataFrame -> ensure it doesn't raise a warning if modified
     pd = pytest.importorskip("pandas")
+    if parse_version(pd.__version__) < parse_version("0.25.0"):
+        raise SkipTest(
+            "Older pandas version will raise a different warning than "
+            "SettingWithCopyWarning"
+        )
     X = pd.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
     subset = _safe_indexing(X, [0, 1], axis=0)
     with pytest.warns(None) as record:

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -479,7 +479,8 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
     with pytest.warns(None) as record:
         subset.iloc[0, 0] = 10
     assert len(record) == 0, f"{[str(rec.message) for rec in record]}"
-
+    # The original dataframe is unaffected by the assignment on the subset:
+    assert X.iloc[0, 0] = 1
 
 @pytest.mark.parametrize(
     "key, err_msg",


### PR DESCRIPTION
#### Reference Issues/PRs

closes #16191 #8723
Triggered by https://github.com/scikit-learn/scikit-learn/pull/20431#pullrequestreview-721556178

#### What does this implement/fix? Explain your changes.

`_safe_indexing` on the rows for a DataFrame with integer indices always uses an array-like of indices (I think?) and is thus always a copy already. However, doing that with `iloc` can then later give SettingWithCopyWarning when modifying the subset. By using `take()`, which I think should have the same behaviour for this specific use case, avoids those warnings.