### PR TITLE
DOC Remove `graph_shortest_path` references

### DIFF
--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -165,13 +165,6 @@ Graph Routines
   If this is ever needed again, it would be far faster to use a single
   iteration of Dijkstra's algorithm from ``graph_shortest_path``.
 
-- :func:`graph.graph_shortest_path`:
-  (used in :class:`~sklearn.manifold.Isomap`)
-  Return the shortest path between all pairs of connected points on a directed
-  or undirected graph.  Both the Floyd-Warshall algorithm and Dijkstra's
-  algorithm are available.  The algorithm is most efficient when the
-  connectivity matrix is a ``scipy.sparse.csr_matrix``.
-
 
 Testing Functions
 =================

--- a/doc/developers/utilities.rst
+++ b/doc/developers/utilities.rst
@@ -165,7 +165,7 @@ Graph Routines
   If this is ever needed again, it would be far faster to use a single
   iteration of Dijkstra's algorithm from ``graph_shortest_path``.
 
-- :func:`graph_shortest_path.graph_shortest_path`:
+- :func:`graph.graph_shortest_path`:
   (used in :class:`~sklearn.manifold.Isomap`)
   Return the shortest path between all pairs of connected points on a directed
   or undirected graph.  Both the Floyd-Warshall algorithm and Dijkstra's

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1602,7 +1602,6 @@ Plotting
    utils.gen_batches
    utils.gen_even_slices
    utils.graph.single_source_shortest_path_length
-   utils.graph.graph_shortest_path
    utils.indexable
    utils.metaestimators.if_delegate_has_method
    utils.metaestimators.available_if

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1602,7 +1602,7 @@ Plotting
    utils.gen_batches
    utils.gen_even_slices
    utils.graph.single_source_shortest_path_length
-   utils.graph_shortest_path.graph_shortest_path
+   utils.graph.graph_shortest_path
    utils.indexable
    utils.metaestimators.if_delegate_has_method
    utils.metaestimators.available_if


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixup for #20531

#### What does this implement/fix? Explain your changes.

#20531 removed `utils.graph_shortest_path`.

However, references to `utils.graph_shortest_path.graph_shortest_path` are left in documentation, making building the docs fail.

This removes references to `graph_shortest_path`.

#### Any other comments?

Should we remove part of the docs mentioning `graph_shortest_path` as it is being deprecated?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
