### PR TITLE
ENH allow extra params to be copied in clone

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -618,6 +618,11 @@ X_types (default=['2darray'])
     ``'categorical'`` data. For now, the test for sparse data do not make use
     of the ``'sparse'`` tag.
 
+extra_params (default=[])
+    This includes the list of names of the parameters which need to be copied in
+    ``clone``, but are not included in the output of ``get_params`` and are not
+    an ``__init__`` parameter.
+
 It is unlikely that the default values for each tag will suit the needs of your
 specific estimator. Additional tags can be created or default tags can be
 overridden by defining a `_more_tags()` method which returns a dict with the

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -618,7 +618,7 @@ X_types (default=['2darray'])
     ``'categorical'`` data. For now, the test for sparse data do not make use
     of the ``'sparse'`` tag.
 
-extra_params (default=[])
+non_init_params (default=[])
     This includes the list of names of the parameters which need to be copied in
     ``clone``, but are not included in the output of ``get_params`` and are not
     an ``__init__`` parameter.

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -137,6 +137,10 @@ Changelog
 :mod:`sklearn.base`
 ...................
 
+- |Enhancement| :func:`clone` now copies extra parameters which are listed in
+  ``tags["extra_params"]``, and ``check_no_attributes_set_in_init`` tolerates
+  them being copied. :pr:`20681` by `Adrin Jalali`_.
+
 - |Fix| :func:`config_context` is now threadsafe. :pr:`18736` by `Thomas Fan`_.
 
 :mod:`sklearn.calibration`

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -138,7 +138,7 @@ Changelog
 ...................
 
 - |Enhancement| :func:`clone` now copies extra parameters which are listed in
-  ``tags["extra_params"]``, and ``check_no_attributes_set_in_init`` tolerates
+  ``tags["non_init_params"]``, and ``check_no_attributes_set_in_init`` tolerates
   them being copied. :pr:`20681` by `Adrin Jalali`_.
 
 - |Fix| :func:`config_context` is now threadsafe. :pr:`18736` by `Thomas Fan`_.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -35,7 +35,7 @@ def clone(estimator, *, safe=True):
 
     If there are parameters which need to be copied but are not returned as the
     output of ``get_params``, they can be included in
-    ``estimator_tags["extra_params"]`` as an iterable of their names.
+    ``estimator_tags["non_init_params"]`` as an iterable of their names.
 
     If the estimator's `random_state` parameter is an integer (or if the
     estimator doesn't have a `random_state` parameter), an *exact clone* is
@@ -85,8 +85,8 @@ def clone(estimator, *, safe=True):
     params_set = new_object.get_params(deep=False)
 
     # we then copy parameters which are requested to be copied in the
-    # "extra_params" tag.
-    extra_params = _safe_tags(estimator).get("extra_params", [])
+    # "non_init_params" tag.
+    extra_params = _safe_tags(estimator).get("non_init_params", [])
     for param in extra_params:
         try:
             setattr(new_object, param, clone(getattr(estimator, param), safe=False))

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -141,6 +141,21 @@ def test_clone_2():
     assert not hasattr(new_selector, "own_attribute")
 
 
+def test_clone_extra_params():
+    # Test that clone copies the parameters provided in tags["extra_params"]
+    class Estimator(BaseEstimator):
+        def _more_tags(self):
+            return {"extra_params": ["param1"]}
+
+    est = Estimator()
+    # test that clone works when "param1" is not present
+    est_copy = clone(est)
+    assert not hasattr(est_copy, "param1")
+    est.param1 = 42
+    est_copy = clone(est)
+    assert est_copy.param1 == 42
+
+
 def test_clone_buggy():
     # Check that clone raises an error on buggy estimators.
     buggy = Buggy()

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -142,10 +142,10 @@ def test_clone_2():
 
 
 def test_clone_extra_params():
-    # Test that clone copies the parameters provided in tags["extra_params"]
+    # Test that clone copies the parameters provided in tags["non_init_params"]
     class Estimator(BaseEstimator):
         def _more_tags(self):
-            return {"extra_params": ["param1"]}
+            return {"non_init_params": ["param1"]}
 
     est = Estimator()
     # test that clone works when "param1" is not present

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -19,6 +19,7 @@ _DEFAULT_TAGS = {
     "preserves_dtype": [np.float64],
     "requires_y": False,
     "pairwise": False,
+    "extra_params": [],
 }
 
 

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -19,7 +19,7 @@ _DEFAULT_TAGS = {
     "preserves_dtype": [np.float64],
     "requires_y": False,
     "pairwise": False,
-    "extra_params": [],
+    "non_init_params": [],
 }
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2750,8 +2750,13 @@ def check_no_attributes_set_in_init(name, estimator_orig):
         for param in params_parent
     ]
 
-    # Test for no setting apart from parameters during init
-    invalid_attr = set(vars(estimator)) - set(init_params) - set(parents_init_params)
+    # Test for no setting apart from parameters and "extra_params" during init
+    invalid_attr = (
+        set(vars(estimator))
+        - set(init_params)
+        - set(parents_init_params)
+        - set(_safe_tags(estimator).get("extra_params", []))
+    )
     assert not invalid_attr, (
         "Estimator %s should not set any attribute apart"
         " from parameters during init. Found attributes %s."

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2750,12 +2750,12 @@ def check_no_attributes_set_in_init(name, estimator_orig):
         for param in params_parent
     ]
 
-    # Test for no setting apart from parameters and "extra_params" during init
+    # Test for no setting apart from parameters and "non_init_params" during init
     invalid_attr = (
         set(vars(estimator))
         - set(init_params)
         - set(parents_init_params)
-        - set(_safe_tags(estimator).get("extra_params", []))
+        - set(_safe_tags(estimator).get("non_init_params", []))
     )
     assert not invalid_attr, (
         "Estimator %s should not set any attribute apart"

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -630,7 +630,7 @@ def test_check_no_attributes_set_in_init():
 
     class ConformantEstimatorWithExtraParams(BaseEstimator):
         def _more_tags(self):
-            return {"extra_params": ["param1"]}
+            return {"non_init_params": ["param1"]}
 
         def __init__(self):
             self.param1 = 42

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -628,6 +628,13 @@ def test_check_no_attributes_set_in_init():
         def __init__(self, you_should_set_this_=None):
             pass
 
+    class ConformantEstimatorWithExtraParams(BaseEstimator):
+        def _more_tags(self):
+            return {"extra_params": ["param1"]}
+
+        def __init__(self):
+            self.param1 = 42
+
     msg = (
         "Estimator estimator_name should not set any"
         " attribute apart from parameters during init."
@@ -646,6 +653,11 @@ def test_check_no_attributes_set_in_init():
         check_no_attributes_set_in_init(
             "estimator_name", NonConformantEstimatorNoParamSet()
         )
+
+    # this shouldn't raise any errors
+    check_no_attributes_set_in_init(
+        "conformant_estimator", ConformantEstimatorWithExtraParams()
+    )
 
 
 def test_check_estimator_pairwise():


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/20585

This PR proposes a new tag: `"extra_params"` (open to better names), which would indicate which non `__init__` parameters should be copied in `clone`.