### PR TITLE
DOC Ensures that HistGradientBoostingClassifier passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -33,7 +33,6 @@ DOCSTRING_IGNORE_LIST = [
     "HalvingGridSearchCV",
     "HalvingRandomSearchCV",
     "HashingVectorizer",
-    "HistGradientBoostingClassifier",
     "HistGradientBoostingRegressor",
     "HuberRegressor",
     "IncrementalPCA",

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1461,8 +1461,8 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
 
     See Also
     --------
-    GradientBoostingClassifier : Implementation of Gradient Boosting for
-        classification with poor performance in big datasets.
+    GradientBoostingClassifier : Exact gradient boosting method that does not
+        scale as good on datasets with a large number of samples.
     DecisionTreeClassifier : A decision tree classifier.
     RandomForestClassifier : A meta-estimator that fits a number of decision
         tree classifiers on various sub-samples of the dataset and uses

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1461,7 +1461,8 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
 
     See Also
     --------
-    GradientBoostingClassifier : Gradient Boosting for classification.
+    GradientBoostingClassifier : Implementation of Gradient Boosting for
+        classification with poor performance in big datasets.
     DecisionTreeClassifier : A decision tree classifier.
     RandomForestClassifier : A meta-estimator that fits a number of decision
         tree classifiers on various sub-samples of the dataset and uses

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -222,6 +222,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         Returns
         -------
         self : object
+            Fitted estimator.
         """
         fit_start_time = time()
         acc_find_split_time = 0.0  # time spent finding the best splits
@@ -991,6 +992,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
 
     @property
     def n_iter_(self):
+        """Number of iterations of the boosting process."""
         check_is_fitted(self)
         return len(self._predictors)
 
@@ -1360,7 +1362,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         ``max_bins`` bins. In addition to the ``max_bins`` bins, one more bin
         is always reserved for missing values. Must be no larger than 255.
     categorical_features : array-like of {bool, int} of shape (n_features) \
-            or shape (n_categorical_features,), default=None.
+            or shape (n_categorical_features,), default=None
         Indicates the categorical features.
 
         - None : no feature will be considered categorical.
@@ -1456,6 +1458,19 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         Number of features seen during :term:`fit`.
 
         .. versionadded:: 0.24
+
+    See Also
+    --------
+    GradientBoostingClassifier : Gradient Boosting for classification.
+    DecisionTreeClassifier : A decision tree classifier.
+    RandomForestClassifier : A meta-estimator that fits a number of decision
+        tree classifiers on various sub-samples of the dataset and uses
+        averaging to improve the predictive accuracy and control over-fitting.
+    AdaBoostClassifier : A meta-estimator that begins by fitting a classifier
+        on the original dataset and then fits additional copies of the
+        classifier on the same dataset where the weights of incorrectly
+        classified instances are adjusted such that subsequent classifiers
+        focus more on difficult cases.
 
     Examples
     --------


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures `HistGradientBoostingClassifier` is compatible with numpydoc.

- Remove `HistGradientBoostingClassifier` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.

#### Any other comments?
#DataUmbrella Sprint