### PR TITLE
DOC fix hyperlink for permutation test example

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -980,7 +980,7 @@ individual model is very fast.
 
 .. topic:: Examples
 
-    * :ref:`sphx_glr_auto_examples_feature_selection_plot_permutation_test_for_classification.py`
+    * :ref:`sphx_glr_auto_examples_model_selection_plot_permutation_test_for_classification.py`
 
 .. topic:: References:
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -980,7 +980,7 @@ individual model is very fast.
 
 .. topic:: Examples
 
-    * :ref:`sphx_glr_auto_examples_model_selection_plot_permutation_test_for_classification.py`
+    * :ref:`sphx_glr_auto_examples_model_selection_plot_permutation_tests_for_classification.py`
 
 .. topic:: References:
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -437,7 +437,7 @@ In the multilabel case with binary label indicators::
 
 .. topic:: Example:
 
-  * See :ref:`sphx_glr_auto_examples_model_selection_plot_permutation_test_for_classification.py`
+  * See :ref:`sphx_glr_auto_examples_model_selection_plot_permutation_tests_for_classification.py`
     for an example of accuracy score usage using permutations of
     the dataset.
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -437,7 +437,7 @@ In the multilabel case with binary label indicators::
 
 .. topic:: Example:
 
-  * See :ref:`sphx_glr_auto_examples_feature_selection_plot_permutation_test_for_classification.py`
+  * See :ref:`sphx_glr_auto_examples_model_selection_plot_permutation_test_for_classification.py`
     for an example of accuracy score usage using permutations of
     the dataset.
 


### PR DESCRIPTION
I encountered the error while working on: https://github.com/scikit-learn/scikit-learn/pull/20552

We indeed move the example from `feature_selection` to `model_selection`. We forgot to change the hyperlink in the documentation and the warning was not raised by `sphinx` apparently.