### PR TITLE
DOC Ensures that HistGradientBoostingRegressor passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -33,7 +33,6 @@ DOCSTRING_IGNORE_LIST = [
     "HalvingGridSearchCV",
     "HalvingRandomSearchCV",
     "HashingVectorizer",
-    "HistGradientBoostingRegressor",
     "HuberRegressor",
     "IncrementalPCA",
     "Isomap",

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1027,7 +1027,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         "least squares" and "poisson" losses actually implement
         "half least squares loss" and "half poisson deviance" to simplify the
         computation of the gradient. Furthermore, "poisson" loss internally
-        uses a log-link and requires ``y >= 0``
+        uses a log-link and requires ``y >= 0``.
 
         .. versionchanged:: 0.23
            Added option 'poisson'.
@@ -1070,7 +1070,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         ``max_bins`` bins. In addition to the ``max_bins`` bins, one more bin
         is always reserved for missing values. Must be no larger than 255.
     categorical_features : array-like of {bool, int} of shape (n_features) \
-            or shape (n_categorical_features,), default=None.
+            or shape (n_categorical_features,), default=None
         Indicates the categorical features.
 
         - None : no feature will be considered categorical.
@@ -1164,6 +1164,18 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
         .. versionadded:: 0.24
 
+    See Also
+    --------
+    GradientBoostingRegressor : Exact gradient boosting method that does not
+        scale as good on datasets with a large number of samples.
+    DecisionTreeRegressor : A decision tree regressor.
+    RandomForestRegressor : A random forest regressor.
+    AdaBoostRegressor : A meta-estimator that begins by fitting a regressor
+        on the original dataset and then fits additional copies of the
+        regressor on the same dataset but where the weights of instances are
+        adjusted according to the error of the current prediction. As such,
+        subsequent regressors focus more on difficult cases.
+
     Examples
     --------
     >>> from sklearn.ensemble import HistGradientBoostingRegressor
@@ -1244,7 +1256,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         return self._loss.inverse_link_function(self._raw_predict(X).ravel())
 
     def staged_predict(self, X):
-        """Predict regression target for each iteration
+        """Predict regression target for each iteration.
 
         This method allows monitoring (i.e. determine error on testing set)
         after each stage.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1169,7 +1169,10 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     GradientBoostingRegressor : Exact gradient boosting method that does not
         scale as good on datasets with a large number of samples.
     sklearn.tree.DecisionTreeRegressor : A decision tree regressor.
-    RandomForestRegressor : A random forest regressor.
+    RandomForestRegressor : A meta-estimator that fits a number of decision
+        tree regressors on various sub-samples of the dataset and uses
+        averaging to improve the statistical performance and control
+        over-fitting.
     AdaBoostRegressor : A meta-estimator that begins by fitting a regressor
         on the original dataset and then fits additional copies of the
         regressor on the same dataset but where the weights of instances are

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1168,7 +1168,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     --------
     GradientBoostingRegressor : Exact gradient boosting method that does not
         scale as good on datasets with a large number of samples.
-    DecisionTreeRegressor : A decision tree regressor.
+    sklearn.tree.DecisionTreeRegressor : A decision tree regressor.
     RandomForestRegressor : A random forest regressor.
     AdaBoostRegressor : A meta-estimator that begins by fitting a regressor
         on the original dataset and then fits additional copies of the


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures HistGradientBoostingRegressor is compatible with numpydoc.

- Remove `HistGradientBoostingRegressor` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.


#### Any other comments?
#DataUmbrella Sprint