### PR TITLE
Use `--color=yes` for pytest to color pytest logs and make it easier to identify errors on CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ addopts =
     --ignore asv_benchmarks
     --doctest-modules
     --disable-pytest-warnings
+    --color=yes
     -rxXs
 
 filterwarnings =


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Use `--color=yes` for pytest to color pytest logs and make it easier to identify errors.

# Before:
![image](https://user-images.githubusercontent.com/17039389/128621712-403141ec-f72c-4c11-bfc6-0dbcb9295442.png)

# After:
![image](https://user-images.githubusercontent.com/17039389/128621679-4037c169-dcab-4016-962d-faa9a353a6a8.png)


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
