### PR TITLE
DOC fix y-axis name in preprocessor comparison example

### DIFF
--- a/examples/preprocessing/plot_all_scaling.py
+++ b/examples/preprocessing/plot_all_scaling.py
@@ -67,8 +67,9 @@ from sklearn.datasets import fetch_california_housing
 
 print(__doc__)
 
-dataset = fetch_california_housing(as_frame=True)
+dataset = fetch_california_housing()
 X_full, y_full = dataset.data, dataset.target
+feature_names = dataset.feature_names
 
 feature_mapping = {
     'MedInc': 'Median income in block',
@@ -85,7 +86,8 @@ feature_mapping = {
 # Feature MedInc has a long tail distribution.
 # Feature AveOccup has a few but very large outliers.
 features = ['MedInc', 'AveOccup']
-X = X_full[features].values
+features_idx = [feature_names.index(feature) for feature in features]
+X = X_full[:, features_idx]
 distributions = [
     ('Unscaled data', X),
     ('Data after standard scaling',

--- a/examples/preprocessing/plot_all_scaling.py
+++ b/examples/preprocessing/plot_all_scaling.py
@@ -6,7 +6,7 @@
 Compare the effect of different scalers on data with outliers
 =============================================================
 
-Feature 0 (median income in a block) and feature 5 (number of households) of
+Feature 0 (median income in a block) and feature 5 (average house occupancy) of
 the :ref:`california_housing_dataset` have very
 different scales and contain some very large outliers. These two
 characteristics lead to difficulties to visualize the data and, more
@@ -67,15 +67,25 @@ from sklearn.datasets import fetch_california_housing
 
 print(__doc__)
 
-dataset = fetch_california_housing()
+dataset = fetch_california_housing(as_frame=True)
 X_full, y_full = dataset.data, dataset.target
 
+feature_mapping = {
+    'MedInc': 'Median income in block',
+    'HousAge': 'Median house age in block',
+    'AveRooms': 'Average number of rooms',
+    'AveBedrms': 'Average number of bedrooms',
+    'Population': 'Block population',
+    'AveOccup': 'Average house occupancy',
+    'Latitude': 'House block latitude',
+    'Longitude': 'House block longitude'
+}
+
 # Take only 2 features to make visualization easier
-# Feature of 0 has a long tail distribution.
-# Feature 5 has a few but very large outliers.
-
-X = X_full[:, [0, 5]]
-
+# Feature MedInc has a long tail distribution.
+# Feature AveOccup has a few but very large outliers.
+features = ['MedInc', 'AveOccup']
+X = X_full[features].values
 distributions = [
     ('Unscaled data', X),
     ('Data after standard scaling',
@@ -194,8 +204,8 @@ def make_plot(item_idx):
     ax_zoom_out, ax_zoom_in, ax_colorbar = create_axes(title)
     axarr = (ax_zoom_out, ax_zoom_in)
     plot_distribution(axarr[0], X, y, hist_nbins=200,
-                      x0_label="Median Income",
-                      x1_label="Number of households",
+                      x0_label=feature_mapping[features[0]],
+                      x1_label=feature_mapping[features[1]],
                       title="Full data")
 
     # zoom-in
@@ -208,8 +218,8 @@ def make_plot(item_idx):
         np.all(X < [cutoffs_X0[1], cutoffs_X1[1]], axis=1))
     plot_distribution(axarr[1], X[non_outliers_mask], y[non_outliers_mask],
                       hist_nbins=50,
-                      x0_label="Median Income",
-                      x1_label="Number of households",
+                      x0_label=feature_mapping[features[0]],
+                      x1_label=feature_mapping[features[1]],
                       title="Zoom-in")
 
     norm = mpl.colors.Normalize(y_full.min(), y_full.max())
@@ -228,11 +238,11 @@ def make_plot(item_idx):
 # left plot showing the entire dataset, and the right zoomed-in to show the
 # dataset without the marginal outliers. A large majority of the samples are
 # compacted to a specific range, [0, 10] for the median income and [0, 6] for
-# the number of households. Note that there are some marginal outliers (some
-# blocks have more than 1200 households). Therefore, a specific pre-processing
-# can be very beneficial depending of the application. In the following, we
-# present some insights and behaviors of those pre-processing methods in the
-# presence of marginal outliers.
+# the average house occupancy. Note that there are some marginal outliers (some
+# blocks have average occupancy of more than 1200). Therefore, a specific
+# pre-processing can be very beneficial depending of the application. In the
+# following, we present some insights and behaviors of those pre-processing
+# methods in the presence of marginal outliers.
 
 make_plot(0)
 
@@ -248,7 +258,7 @@ make_plot(0)
 # feature have different magnitudes, the spread of the transformed data on
 # each feature is very different: most of the data lie in the [-2, 4] range for
 # the transformed median income feature while the same data is squeezed in the
-# smaller [-0.2, 0.2] range for the transformed number of households.
+# smaller [-0.2, 0.2] range for the transformed average house occupancy.
 #
 # :class:`~sklearn.preprocessing.StandardScaler` therefore cannot guarantee
 # balanced feature scales in the
@@ -264,7 +274,7 @@ make_plot(1)
 # all feature values are in
 # the range [0, 1] as shown in the right panel below. However, this scaling
 # compresses all inliers into the narrow range [0, 0.005] for the transformed
-# number of households.
+# average house occupancy.
 #
 # Both :class:`~sklearn.preprocessing.StandardScaler` and
 # :class:`~sklearn.preprocessing.MinMaxScaler` are very sensitive to the
@@ -313,9 +323,9 @@ make_plot(4)
 # scaling factor is determined via maximum likelihood estimation in both
 # methods. By default, :class:`~sklearn.preprocessing.PowerTransformer` applies
 # zero-mean, unit variance normalization. Note that
-# Box-Cox can only be applied to strictly positive data. Income and number of
-# households happen to be strictly positive, but if negative values are present
-# the Yeo-Johnson transformed is preferred.
+# Box-Cox can only be applied to strictly positive data. Income and average
+# house occupancy happen to be strictly positive, but if negative values are
+# present the Yeo-Johnson transformed is preferred.
 
 make_plot(5)
 make_plot(6)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Resolves #20720 


#### What does this implement/fix? Explain your changes.
Fixes wrong y-axis label in all scaler comparison plots (changed from `Number of households` to `Average house occupancy`).
Appearances of wrong label in comments are also fixed.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
