### PR TITLE
MNT Removing Cython compilation warnings in WeightVector template

### DIFF
--- a/sklearn/utils/_weight_vector.pxd.tp
+++ b/sklearn/utils/_weight_vector.pxd.tp
@@ -20,7 +20,6 @@ dtypes = [('64', 'double'),
 
 # WARNING: Do not edit this .pyx file directly, it is generated from its .pyx.tp
 cimport numpy as np
-from libc.math cimport sqrt
 
 {{for name_suffix, c_type in dtypes}}
 

--- a/sklearn/utils/_weight_vector.pxd.tp
+++ b/sklearn/utils/_weight_vector.pxd.tp
@@ -24,7 +24,6 @@ from libc.math cimport sqrt
 
 {{for name_suffix, c_type in dtypes}}
 
-
 cdef class WeightVector{{name_suffix}}(object):
     cdef readonly {{c_type}}[::1] w
     cdef readonly {{c_type}}[::1] aw

--- a/sklearn/utils/_weight_vector.pxd.tp
+++ b/sklearn/utils/_weight_vector.pxd.tp
@@ -18,12 +18,11 @@ dtypes = [('64', 'double'),
 
 }}
 
+# WARNING: Do not edit this .pyx file directly, it is generated from its .pyx.tp
 cimport numpy as np
+from libc.math cimport sqrt
 
 {{for name_suffix, c_type in dtypes}}
-
-cdef extern from "math.h":
-    cdef extern {{c_type}} sqrt({{c_type}} x)
 
 
 cdef class WeightVector{{name_suffix}}(object):

--- a/sklearn/utils/_weight_vector.pyx.tp
+++ b/sklearn/utils/_weight_vector.pyx.tp
@@ -18,9 +18,15 @@ dtypes = [('64', 'double', 1e-9),
 
 }}
 
+# cython: language_level=3
 # cython: cdivision=True
 # cython: boundscheck=False
 # cython: wraparound=False
+# cython: profile=False
+# cython: linetrace=False
+# cython: initializedcheck=False
+# cython: binding=False
+# distutils: define_macros=CYTHON_TRACE_NOGIL=0
 #
 # Author: Peter Prettenhofer <peter.prettenhofer@gmail.com>
 #         Lars Buitinck

--- a/sklearn/utils/_weight_vector.pyx.tp
+++ b/sklearn/utils/_weight_vector.pyx.tp
@@ -28,6 +28,8 @@ dtypes = [('64', 'double', 1e-9),
 #
 # License: BSD 3 clause
 
+# WARNING: Do not edit this .pyx file directly, it is generated from its .pyx.tp
+
 cimport cython
 from libc.limits cimport INT_MAX
 from libc.math cimport sqrt


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixup for #20481 

#### What does this implement/fix? Explain your changes.

Cython raises a warning at compile time because the `WeightVector` template imports `sqrt` from `libc.math` twice with different signatures.

This import `sqrt` once, removing the warning.

#### Any other comments?

Shouldn't we be stricter and we make the CI fail on Cython (but not on C or C++) compilation warnings?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
