### PR TITLE
MNT Replace @property with @available_if

### DIFF
--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -403,7 +403,7 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
             samples. The lower, the more abnormal. Negative scores represent
             outliers, positive scores represent inliers.
         """
-        return self._score_samples(X) - self.offset_
+        return self.score_samples(X) - self.offset_
 
     def _check_novelty_score_samples(self):
         if not self.novelty:

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -364,32 +364,7 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
 
         return is_inlier
 
-    @property
-    def decision_function(self):
-        """Shifted opposite of the Local Outlier Factor of X.
-
-        Bigger is better, i.e. large values correspond to inliers.
-
-        **Only available for novelty detection (when novelty is set to True).**
-        The shift offset allows a zero threshold for being an outlier.
-        The argument X is supposed to contain *new data*: if X contains a
-        point from training, it considers the later in its own neighborhood.
-        Also, the samples in X are not considered in the neighborhood of any
-        point.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            The query sample or samples to compute the Local Outlier Factor
-            w.r.t. the training samples.
-
-        Returns
-        -------
-        shifted_opposite_lof_scores : ndarray of shape (n_samples,)
-            The shifted opposite of the Local Outlier Factor of each input
-            samples. The lower, the more abnormal. Negative scores represent
-            outliers, positive scores represent inliers.
-        """
+    def _check_novelty_decision_function(self):
         if not self.novelty:
             msg = (
                 "decision_function is not available when novelty=False. "
@@ -400,10 +375,10 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
                 "negative_outlier_factor_ attribute."
             )
             raise AttributeError(msg)
+        return True
 
-        return self._decision_function
-
-    def _decision_function(self, X):
+    @available_if(_check_novelty_decision_function)
+    def decision_function(self, X):
         """Shifted opposite of the Local Outlier Factor of X.
 
         Bigger is better, i.e. large values correspond to inliers.
@@ -428,36 +403,9 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
             samples. The lower, the more abnormal. Negative scores represent
             outliers, positive scores represent inliers.
         """
-
         return self._score_samples(X) - self.offset_
 
-    @property
-    def score_samples(self):
-        """Opposite of the Local Outlier Factor of X.
-
-        It is the opposite as bigger is better, i.e. large values correspond
-        to inliers.
-
-        **Only available for novelty detection (when novelty is set to True).**
-        The argument X is supposed to contain *new data*: if X contains a
-        point from training, it considers the later in its own neighborhood.
-        Also, the samples in X are not considered in the neighborhood of any
-        point.
-        The score_samples on training data is available by considering the
-        the ``negative_outlier_factor_`` attribute.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            The query sample or samples to compute the Local Outlier Factor
-            w.r.t. the training samples.
-
-        Returns
-        -------
-        opposite_lof_scores : ndarray of shape (n_samples,)
-            The opposite of the Local Outlier Factor of each input samples.
-            The lower, the more abnormal.
-        """
+    def _check_novelty_score_samples(self):
         if not self.novelty:
             msg = (
                 "score_samples is not available when novelty=False. The "
@@ -467,10 +415,10 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
                 "and compute score_samples for new unseen data."
             )
             raise AttributeError(msg)
+        return True
 
-        return self._score_samples
-
-    def _score_samples(self, X):
+    @property
+    def score_samples(self, X):
         """Opposite of the Local Outlier Factor of X.
 
         It is the opposite as bigger is better, i.e. large values correspond

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -417,7 +417,7 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
             raise AttributeError(msg)
         return True
 
-    @property
+    @available_if(_check_novelty_score_samples)
     def score_samples(self, X):
         """Opposite of the Local Outlier Factor of X.
 

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -1195,7 +1195,7 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
             else:
                 self._label_binarizer.fit(classes)
 
-        super()._partial_fit(X, y)
+        super().partial_fit(X, y)
 
         return self
 

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -774,7 +774,8 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
 
         Returns
         -------
-        self : returns a trained MLP model.
+        self : object
+            Trained MLP model.
         """
         return self._fit(X, y, incremental=True)
 
@@ -1186,7 +1187,8 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
 
         Returns
         -------
-        self : returns a trained MLP model.
+        self : object
+            Trained MLP model.
         """
         if _check_partial_fit_first_call(self, classes):
             self._label_binarizer = LabelBinarizer()


### PR DESCRIPTION
Signed-off-by: harupy <hkawamura0130@gmail.com>

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

- https://github.com/scikit-learn/scikit-learn/issues/20630
- https://github.com/scikit-learn/scikit-learn/pull/20667


#### What does this implement/fix? Explain your changes.

Replaces `@property` used to prevent accessing the decorated method when a specified condition is not satisfied with @available_if.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
