### PR TITLE
MNT add --allow-releaseinfo-change for circleci

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -134,7 +134,7 @@ make_args="SPHINXOPTS=-T $make_args"  # show full traceback on exception
 
 # Installing required system packages to support the rendering of math
 # notation in the HTML documentation and to optimize the image files
-sudo -E apt-get -yq update
+sudo -E apt-get -yq update --allow-releaseinfo-change
 sudo -E apt-get -yq --no-install-suggests --no-install-recommends \
     install dvipng gsfonts ccache zip optipng
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This fixes cicleci failures that popped recently up, e.g. in #20567 and #18686.
ci/circleci: doc got the following error in `build_doc.sh`:
```
+ sudo -E apt-get -yq update
Get:1 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:2 http://deb.debian.org/debian buster InRelease [122 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
Reading package lists...
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
```

It adds the option `--allow-releaseinfo-change` to `apt-get -yq update ` in `build_doc.sh` for circleci. I'm not 100% sure that this is the right way to fix it, at least it worked.