### PR TITLE
Update_scorer.py

### DIFF
--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -58,6 +58,10 @@ from .cluster import adjusted_mutual_info_score
 from .cluster import normalized_mutual_info_score
 from .cluster import fowlkes_mallows_score
 
+from .cluster import silhouette_score
+from .cluster import calinski_harabasz_score
+from .cluster import davies_bouldin_score
+
 from ..utils.multiclass import type_of_target
 from ..base import is_regressor
 
@@ -733,7 +737,7 @@ brier_score_loss_scorer = make_scorer(
 )
 
 
-# Clustering scores
+# Clustering supervised scores
 adjusted_rand_scorer = make_scorer(adjusted_rand_score)
 rand_scorer = make_scorer(rand_score)
 homogeneity_scorer = make_scorer(homogeneity_score)
@@ -743,6 +747,10 @@ mutual_info_scorer = make_scorer(mutual_info_score)
 adjusted_mutual_info_scorer = make_scorer(adjusted_mutual_info_score)
 normalized_mutual_info_scorer = make_scorer(normalized_mutual_info_score)
 fowlkes_mallows_scorer = make_scorer(fowlkes_mallows_score)
+# Clustering unsupervised scores
+silhouette_score = make_scorer(silhouette_score)
+calinski_harabasz_score = make_scorer(calinski_harabasz_score)
+davies_bouldin_score = make_scorer(davies_bouldin_score)
 
 
 SCORERS = dict(
@@ -778,6 +786,10 @@ SCORERS = dict(
     adjusted_mutual_info_score=adjusted_mutual_info_scorer,
     normalized_mutual_info_score=normalized_mutual_info_scorer,
     fowlkes_mallows_score=fowlkes_mallows_scorer,
+    # Cluster metrics that use unsupervised evaluation
+    silhouette_score = silhouette_score,
+    calinski_harabasz_score = calinski_harabasz_score,
+    davies_bouldin_score = davies_bouldin_score,
 )
 
 


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
While using scoring parameter in GridSearchCV to find the best parameters for clustering algorithm with the unsupervised data(With NO Labels) , already existing supervised clustering scores throws an error that the exsiting supervised scoring methods are not a valid scoring value
Example :
 ValueError: 'rand_score' is not a valid scoring value. Use sorted(sklearn.metrics.SCORERS.keys()) to get valid options.


#### What does this implement/fix? Explain your changes.
Imported unsupervised scores from cluster and made changes in scorer.py , inorder to make unsupervised scores such as silhouette_score , calinski_harabasz_score , davies_bouldin_score should be available in scorer.py which would be helpful while performing GridSearchCV. We can also consider unsupervised scores in scoring parameter , while performing GridSearchCV for finding the parameters of the best model.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
