### PR TITLE
DOC Add Neptune link to "Experimentation frameworks"

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -66,7 +66,7 @@ enhance the functionality of scikit-learn's estimators.
 
 **Experimentation frameworks**
 
-- `Neptune <https://neptune.ai/>`_ is a metadata store for MLOps, 
+- `Neptune <https://neptune.ai/>`_ Metadata store for MLOps, 
   built for teams that run a lot of experiments.‌ It gives you a single 
   place to log, store, display, organize, compare, and query all your 
   model building metadata.

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -66,6 +66,11 @@ enhance the functionality of scikit-learn's estimators.
 
 **Experimentation frameworks**
 
+- `Neptune <https://neptune.ai/>`_ is a metadata store for MLOps, 
+  built for teams that run a lot of experiments.‌ It gives you a single 
+  place to log, store, display, organize, compare, and query all your 
+  model building metadata.
+
 - `Sacred <https://github.com/IDSIA/Sacred>`_ Tool to help you configure,
   organize, log and reproduce experiments
 


### PR DESCRIPTION

My name is Prince Canuma and I am Data Scientist at Neptune.ai

#### What does this implement/fix? Explain your changes.
Adds link the link to the Neptune to the Experimentation frameworks.


#### Any other comments?
I added a link to our website but we have created an integration between [Neptune + Sklearn integration](https://docs.neptune.ai/integrations-and-supported-tools/model-training/sklearn) that allow Sklearn users to log metadata to Neptune. So, I would like to know if the link to the **Neptune + Skearn integration** docs page is valid a link for this page? Instead of the link to the website.

