### PR TITLE
FIX check linear kernel property in SpectralClustering

### DIFF
--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -598,7 +598,8 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
 
             if (self.affinity == 'linear') and (np.any(self.affinity_matrix_ < 0)):
                 raise ValueError(
-                    f"The affinity matrix generated for your input ndarray contains negative values, which is not compatible with affinity = {self.affinity}")
+                    f"The affinity matrix generated for your input ndarray contains negative values,"
+                    f" which is not compatible with affinity = {self.affinity}")
 
         random_state = check_random_state(self.random_state)
         self.labels_ = spectral_clustering(

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -596,11 +596,16 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
                 X, metric=self.affinity, filter_params=True, **params
             )
 
-            if (self.affinity == 'linear') and (np.any(self.affinity_matrix_ < 0)):
-                raise ValueError(
+            unacceptable_kernels = ["linear"]
+            if (self.affinity in unacceptable_kernels) and (
+                np.any(self.affinity_matrix_ < 0)
+            ):
+                self.affinity_matrix_ += abs(self.affinity_matrix_.min())
+                warnings.warn(
                     f"The affinity matrix generated "
                     f"for your input ndarray contains negative values,"
-                    f" which is not compatible with affinity = {self.affinity}")
+                    f" which is not compatible with affinity = {self.affinity}"
+                )
 
         random_state = check_random_state(self.random_state)
         self.labels_ = spectral_clustering(

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -598,7 +598,8 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
 
             if (self.affinity == 'linear') and (np.any(self.affinity_matrix_ < 0)):
                 raise ValueError(
-                    f"The affinity matrix generated for your input ndarray contains negative values,"
+                    f"The affinity matrix generated "
+                    f"for your input ndarray contains negative values,"
                     f" which is not compatible with affinity = {self.affinity}")
 
         random_state = check_random_state(self.random_state)

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -596,6 +596,10 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
                 X, metric=self.affinity, filter_params=True, **params
             )
 
+            if (self.affinity == 'linear') and (np.any(self.affinity_matrix_ < 0)):
+                raise ValueError(
+                    f"The affinity matrix generated for your input ndarray contains negative values, which is not compatible with affinity = {self.affinity}")
+
         random_state = check_random_state(self.random_state)
         self.labels_ = spectral_clustering(
             self.affinity_matrix_,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #20754

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR fixes the issue with SpectralClustering which fails on particular inputs when our affinity is linear.





<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
