### PR TITLE
DOC Ensures that ExtraTreeRegressor passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -19,7 +19,6 @@ DOCSTRING_IGNORE_LIST = [
     "DictVectorizer",
     "DictionaryLearning",
     "ElasticNetCV",
-    "ExtraTreeRegressor",
     "FactorAnalysis",
     "FeatureAgglomeration",
     "FeatureHasher",

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1292,7 +1292,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
             This parameter is deprecated and has no effect.
             It will be removed in 1.1 (renaming of 0.26).
 
-            .. deprecated :: 0.24
+            .. deprecated:: 0.24
 
         Returns
         -------


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308

#### What does this implement/fix? Explain your changes.
This PR ensures ExtraTreeRegressor is compatible with numpydoc.

- Remove `ExtraTreeRegressor` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.


#### Any other comments?
#DataUmbrella Sprint

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
