### PR TITLE
DOC Ensures that RidgeClassifier passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -88,7 +88,6 @@ DOCSTRING_IGNORE_LIST = [
     "RadiusNeighborsTransformer",
     "RandomizedSearchCV",
     "RegressorChain",
-    "RidgeClassifier",
     "RidgeClassifierCV",
     "RobustScaler",
     "SGDOneClassSVM",

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1225,6 +1225,12 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
     @property
     def classes_(self):
+        """Classes labels.
+
+        Returns
+        -------
+        ndarray of shape (n_classes,)
+        """
         return self._label_binarizer.classes_
 
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1225,12 +1225,7 @@ class RidgeClassifier(LinearClassifierMixin, _BaseRidge):
 
     @property
     def classes_(self):
-        """Classes labels.
-
-        Returns
-        -------
-        ndarray of shape (n_classes,)
-        """
+        """Classes labels."""
         return self._label_binarizer.classes_
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures RidgeClassifier is compatible with numpydoc.

- Remove `RidgeClassifier` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.


#### Any other comments?
#DataUmbrella Sprint