### PR TITLE
FIX attribute component_indices_ was not assigned to the write values in sklearn.kernel_approximation.Nystroem

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -840,7 +840,7 @@ Changelog
 - |Fix| Fix a bug in :class:`sklearn.kernel_approximation.Nystroem`
   where the attribute ``component_indices_`` has a incorrect dimension.
   It should have a dimension of ``n_components``.
-  :pr: `20798` by :user:`Ayan Bag <ayanbag>`.
+  :pr:`20798` by :user:`Ayan Bag <ayanbag>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -834,6 +834,14 @@ Changelog
   :func:`~sklearn.utils.check_array` in 1.0 and will raise a `TypeError` in
   1.2. :pr:`20165` by `Thomas Fan`_.
 
+:mod:`sklearn.kernel_approximation`
+...................................
+
+- |Fix| Fix a bug in :class:`sklearn.kernel_approximation.Nystroem`
+  where the attribute ``component_indices_`` has a incorrect dimension.
+  It should have a dimension of ``n_components``.
+  :pr: by :user:`Ayan Bag <ayanbag>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -840,7 +840,7 @@ Changelog
 - |Fix| Fix a bug in :class:`sklearn.kernel_approximation.Nystroem`
   where the attribute ``component_indices_`` has a incorrect dimension.
   It should have a dimension of ``n_components``.
-  :pr: by :user:`Ayan Bag <ayanbag>`.
+  :pr: `20798` by :user:`Ayan Bag <ayanbag>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -878,7 +878,7 @@ class Nystroem(TransformerMixin, BaseEstimator):
         S = np.maximum(S, 1e-12)
         self.normalization_ = np.dot(U / np.sqrt(S), V)
         self.components_ = basis
-        self.component_indices_ = inds
+        self.component_indices_ = basis_inds
         return self
 
     def transform(self, X):

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -14,6 +14,7 @@ from sklearn.kernel_approximation import SkewedChi2Sampler
 from sklearn.kernel_approximation import Nystroem
 from sklearn.kernel_approximation import PolynomialCountSketch
 from sklearn.metrics.pairwise import polynomial_kernel, rbf_kernel, chi2_kernel
+from sklearn.datasets import make_classification
 
 # generate data
 rng = np.random.RandomState(0)
@@ -330,3 +331,13 @@ def test_nystroem_precomputed_kernel():
         ny = Nystroem(kernel="precomputed", n_components=X.shape[0], **param)
         with pytest.raises(ValueError, match=msg):
             ny.fit(K)
+
+def test_nystroem_component_indices():
+    """Check that `component_indices_` corresponds to the subset of data point.
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/20474
+    """
+    X, _ = make_classification(n_samples=100)
+    feature_map_nystroem = Nystroem(n_components=10,random_state=0,)
+    feature_map_nystroem.fit(X)
+    assert feature_map_nystroem.component_indices_.shape == (10,)

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -332,12 +332,13 @@ def test_nystroem_precomputed_kernel():
         with pytest.raises(ValueError, match=msg):
             ny.fit(K)
 
+
 def test_nystroem_component_indices():
     """Check that `component_indices_` corresponds to the subset of data point.
     Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/20474
     """
     X, _ = make_classification(n_samples=100)
-    feature_map_nystroem = Nystroem(n_components=10,random_state=0,)
+    feature_map_nystroem = Nystroem(n_components=10, random_state=0,)
     feature_map_nystroem.fit(X)
     assert feature_map_nystroem.component_indices_.shape == (10,)


### PR DESCRIPTION

#### Reference Issues/PRs

Fixes  #20474 

#### What does this implement/fix? Explain your changes.

The attribute ``component_indices_`` of  ``sklearn.kernel_approximation.Nystroem`` is incorrect.  The attribute ``component_indices_`` has a wrong dimension, it should have a dimension of ``n_components`` i.e ``self.component_indices_ = basis_inds`` instead of ``self.component_indices_ = inds``.
