### PR TITLE
DOC Ensures that RidgeClassifierCV passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -89,7 +89,6 @@ DOCSTRING_IGNORE_LIST = [
     "RandomizedSearchCV",
     "RegressorChain",
     "RidgeClassifier",
-    "RidgeClassifierCV",
     "RobustScaler",
     "SGDOneClassSVM",
     "SGDRegressor",

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2165,7 +2165,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
             ``normalize`` was deprecated in version 1.0 and
             will be removed in 1.2.
 
-    scoring : string, callable, default=None
+    scoring : str, callable, default=None
         A string (see model evaluation documentation) or
         a scorer callable object / function with signature
         ``scorer(estimator, X, y)``.
@@ -2188,7 +2188,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
         The "balanced" mode uses the values of y to automatically adjust
         weights inversely proportional to class frequencies in the input data
-        as ``n_samples / (n_classes * np.bincount(y))``
+        as ``n_samples / (n_classes * np.bincount(y))``.
 
     store_cv_values : bool, default=False
         Flag indicating if the cross-validation values corresponding to
@@ -2229,15 +2229,6 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
         .. versionadded:: 0.24
 
-    Examples
-    --------
-    >>> from sklearn.datasets import load_breast_cancer
-    >>> from sklearn.linear_model import RidgeClassifierCV
-    >>> X, y = load_breast_cancer(return_X_y=True)
-    >>> clf = RidgeClassifierCV(alphas=[1e-3, 1e-2, 1e-1, 1]).fit(X, y)
-    >>> clf.score(X, y)
-    0.9630...
-
     See Also
     --------
     Ridge : Ridge regression.
@@ -2249,6 +2240,15 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
     For multi-class classification, n_class classifiers are trained in
     a one-versus-all approach. Concretely, this is implemented by taking
     advantage of the multi-variate response support in Ridge.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import load_breast_cancer
+    >>> from sklearn.linear_model import RidgeClassifierCV
+    >>> X, y = load_breast_cancer(return_X_y=True)
+    >>> clf = RidgeClassifierCV(alphas=[1e-3, 1e-2, 1e-1, 1]).fit(X, y)
+    >>> clf.score(X, y)
+    0.9630...
     """
 
     def __init__(
@@ -2292,6 +2292,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
         Returns
         -------
         self : object
+            Fitted estimator.
         """
         X, y = self._validate_data(
             X,
@@ -2317,6 +2318,7 @@ class RidgeClassifierCV(LinearClassifierMixin, _BaseRidgeCV):
 
     @property
     def classes_(self):
+        """Classes labels."""
         return self._label_binarizer.classes_
 
     def _more_tags(self):


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures RidgeClassifierCV is compatible with numpydoc.

- Remove `RidgeClassifierCV` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.


#### Any other comments?
#DataUmbrella Sprint