### PR TITLE
DOC Typo: remove unecessary 'on' from docstring

### DIFF
--- a/sklearn/datasets/_svmlight_format_io.py
+++ b/sklearn/datasets/_svmlight_format_io.py
@@ -61,8 +61,8 @@ def load_svmlight_file(
     This format is used as the default format for both svmlight and the
     libsvm command line programs.
 
-    Parsing a text based source can be expensive. When working
-    repeatedly on the same dataset, it is recommended to wrap this
+    Parsing a text based source can be expensive. When repeatedly
+    working on the same dataset, it is recommended to wrap this
     loader with joblib.Memory.cache to store a memmapped backup of the
     CSR results of the first call and benefit from the near instantaneous
     loading of memmapped structures for the subsequent calls.

--- a/sklearn/datasets/_svmlight_format_io.py
+++ b/sklearn/datasets/_svmlight_format_io.py
@@ -61,7 +61,7 @@ def load_svmlight_file(
     This format is used as the default format for both svmlight and the
     libsvm command line programs.
 
-    Parsing a text based source can be expensive. When working on
+    Parsing a text based source can be expensive. When working
     repeatedly on the same dataset, it is recommended to wrap this
     loader with joblib.Memory.cache to store a memmapped backup of the
     CSR results of the first call and benefit from the near instantaneous


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
N/A

#### What does this implement/fix? Explain your changes.
This PR only removes unnecessary use of word 'on'  in a docstring. It seems to be grammatically incorrect. 

#### Any other comments?
This is my first PR here. Even though I've read through the guidelines, I'm sorry if something is wrong. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
