### PR TITLE
DOC Ensures that SelectPercentile passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -94,7 +94,6 @@ DOCSTRING_IGNORE_LIST = [
     "SelectFromModel",
     "SelectFwe",
     "SelectKBest",
-    "SelectPercentile",
     "SelfTrainingClassifier",
     "SequentialFeatureSelector",
     "SimpleImputer",

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -458,22 +458,6 @@ class SelectPercentile(_BaseFilter):
 
         .. versionadded:: 0.24
 
-    Examples
-    --------
-    >>> from sklearn.datasets import load_digits
-    >>> from sklearn.feature_selection import SelectPercentile, chi2
-    >>> X, y = load_digits(return_X_y=True)
-    >>> X.shape
-    (1797, 64)
-    >>> X_new = SelectPercentile(chi2, percentile=10).fit_transform(X, y)
-    >>> X_new.shape
-    (1797, 7)
-
-    Notes
-    -----
-    Ties between features with equal scores will be broken in an unspecified
-    way.
-
     See Also
     --------
     f_classif : ANOVA F-value between label/feature for classification tasks.
@@ -487,6 +471,22 @@ class SelectPercentile(_BaseFilter):
     SelectFwe : Select features based on family-wise error rate.
     GenericUnivariateSelect : Univariate feature selector with configurable
         mode.
+
+    Notes
+    -----
+    Ties between features with equal scores will be broken in an unspecified
+    way.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import load_digits
+    >>> from sklearn.feature_selection import SelectPercentile, chi2
+    >>> X, y = load_digits(return_X_y=True)
+    >>> X.shape
+    (1797, 64)
+    >>> X_new = SelectPercentile(chi2, percentile=10).fit_transform(X, y)
+    >>> X_new.shape
+    (1797, 7)
     """
 
     def __init__(self, score_func=f_classif, *, percentile=10):


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures SelectPercentile is compatible with numpydoc.

- Remove `SelectPercentile` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.


#### Any other comments?
