### PR TITLE
Improve error message for checking estimators on empty data value error

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1687,7 +1687,7 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     # The precise message can change depending on whether X or y is
     # validated first. Let us test the type of exception only:
     err_msg = (
-        f"The estimator {name} does not raise an error when an "
+        f"The estimator {name} does not raise a ValueError when an "
         "empty data is used to train. Perhaps use check_array in train."
     )
     with raises(ValueError, err_msg=err_msg):


### PR DESCRIPTION
Small improvement to an error message of `sklearn.utils.estimator_checks.check_estimator`.  My custom estimator raised an AssertionError on empty training data, and it took me some time to figure it out needed to be a ValueError instead:

https://github.com/scikit-learn/scikit-learn/blob/3e7c04fe2cb7deb72d44c042f6a502829fbb164d/sklearn/utils/estimator_checks.py#L1693-L1694


 Hope this small improvement will help out somebody in the future!