### PR TITLE
DOC Ensures that ColumnTransformer passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -14,7 +14,6 @@ DOCSTRING_IGNORE_LIST = [
     "Birch",
     "CalibratedClassifierCV",
     "ClassifierChain",
-    "ColumnTransformer",
     "DecisionTreeRegressor",
     "DictVectorizer",
     "DictionaryLearning",

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -147,6 +147,14 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
         .. versionadded:: 0.24
 
+    See Also
+    --------
+    make_column_transformer : Convenience function for
+        combining the outputs of multiple transformer objects applied to
+        column subsets of the original feature space.
+    make_column_selector : Convenience function for selecting
+        columns based on datatype or the columns name with a regex pattern.
+
     Notes
     -----
     The order of the columns in the transformed feature matrix follows the
@@ -155,14 +163,6 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     dropped from the resulting transformed feature matrix, unless specified
     in the `passthrough` keyword. Those columns specified with `passthrough`
     are added at the right to the output of the transformers.
-
-    See Also
-    --------
-    make_column_transformer : Convenience function for
-        combining the outputs of multiple transformer objects applied to
-        column subsets of the original feature space.
-    make_column_selector : Convenience function for selecting
-        columns based on datatype or the columns name with a regex pattern.
 
     Examples
     --------
@@ -180,7 +180,6 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     >>> ct.fit_transform(X)
     array([[0. , 1. , 0.5, 0.5],
            [0.5, 0.5, 0. , 1. ]])
-
     """
 
     _required_parameters = ["transformers"]

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -241,13 +241,17 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     def set_params(self, **kwargs):
         """Set the parameters of this estimator.
 
-        Valid parameter keys can be listed with ``get_params()``. Note that you
-        can directly set the parameters of the estimators contained in
-        `transformers` of `ColumnTransformer`.
+        Parameters
+        ----------
+        **kwargs : dict
+                 Valid parameter keys can be listed with ``get_params()``. Note that you
+                 can directly set the parameters of the estimators contained in
+                 `transformers` of `ColumnTransformer`.
 
         Returns
         -------
-        self
+        self : object
+                 ColumnTransformer class instance.
         """
         self._set_params("_transformers", **kwargs)
         return self

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -590,13 +590,11 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
         Returns
         -------
-        X_t : {array-like, sparse matrix} of \
-                shape (n_samples, sum_n_components)
-            hstack of results of transformers. sum_n_components is the
+        X_t : {array-like, sparse matrix} of shape (n_samples, sum_n_components)
+            The _"hstack" of results of transformers. The "sum_n_components" is the
             sum of n_components (output dimension) over transformers. If
             any result is a sparse matrix, everything will be converted to
             sparse matrices.
-
         """
         check_is_fitted(self)
         X = _check_X(X)

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -511,9 +511,8 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
         Returns
         -------
-        self : ColumnTransformer
-            This estimator
-
+        self : object
+            ColumnTransformer class instance.
         """
         # we use fit_transform to make sure to set sparse_output_ (for which we
         # need the transformed data) to have consistent output type in predict

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -363,7 +363,6 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         Read-only attribute to access any transformer by given name.
         Keys are transformer names and values are the fitted transformer
         objects.
-
         """
         # Use Bunch object to improve autocomplete
         return Bunch(**{name: trans for name, trans, _ in self.transformers_})

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -533,13 +533,11 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
         Returns
         -------
-        X_t : {array-like, sparse matrix} of \
-                shape (n_samples, sum_n_components)
-            hstack of results of transformers. sum_n_components is the
+        X_t : {array-like, sparse matrix} of shape (n_samples, sum_n_components)
+            The "_hstack" of results of transformers. The "sum_n_components" is the
             sum of n_components (output dimension) over transformers. If
             any result is a sparse matrix, everything will be converted to
             sparse matrices.
-
         """
         # TODO: this should be `feature_names_in_` when we start having it
         if hasattr(X, "columns"):


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308 


#### What does this implement/fix? Explain your changes.

- "ColumnTransformer" removed from DOCSTRING_IGNORE_LIST in test_docstring.py
- In "ColumnTransformer.\_\_init\_\_" : "See Also" section moved in the right place
- In "ColumnTransformer.fit" : "self" description modified.
- In "ColumnTransformer.fit_transform" : "X_t" description modified.
- In "ColumnTransformer.transform" : "X_t" description modified.
- In "ColumnTransformer.named_transformers_" : blank line removed
-  In "ColumnTransformer.set_params" : "**kwargs" and "self" descriptions added



