### PR TITLE
DOC Ensures that ElasticNetCV passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -18,7 +18,6 @@ DOCSTRING_IGNORE_LIST = [
     "DecisionTreeRegressor",
     "DictVectorizer",
     "DictionaryLearning",
-    "ElasticNetCV",
     "FactorAnalysis",
     "FeatureAgglomeration",
     "FeatureHasher",

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1944,7 +1944,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
     Parameters
     ----------
     l1_ratio : float or list of float, default=0.5
-        float between 0 and 1 passed to ElasticNet (scaling between
+        Float between 0 and 1 passed to ElasticNet (scaling between
         l1 and l2 penalties). For ``l1_ratio = 0``
         the penalty is an L2 penalty. For ``l1_ratio = 1`` it is an L1 penalty.
         For ``0 < l1_ratio < 1``, the penalty is a combination of L1 and L2
@@ -2076,22 +2076,10 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
         .. versionadded:: 0.24
 
-    Examples
+    See Also
     --------
-    >>> from sklearn.linear_model import ElasticNetCV
-    >>> from sklearn.datasets import make_regression
-
-    >>> X, y = make_regression(n_features=2, random_state=0)
-    >>> regr = ElasticNetCV(cv=5, random_state=0)
-    >>> regr.fit(X, y)
-    ElasticNetCV(cv=5, random_state=0)
-    >>> print(regr.alpha_)
-    0.199...
-    >>> print(regr.intercept_)
-    0.398...
-    >>> print(regr.predict([[0, 0]]))
-    [0.398...]
-
+    enet_path : Compute elastic net path with coordinate descent.
+    ElasticNet : Linear regression with combined L1 and L2 priors as regularizer.
 
     Notes
     -----
@@ -2119,10 +2107,21 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
         alpha = a + b and l1_ratio = a / (a + b).
 
-    See Also
+    Examples
     --------
-    enet_path
-    ElasticNet
+    >>> from sklearn.linear_model import ElasticNetCV
+    >>> from sklearn.datasets import make_regression
+
+    >>> X, y = make_regression(n_features=2, random_state=0)
+    >>> regr = ElasticNetCV(cv=5, random_state=0)
+    >>> regr.fit(X, y)
+    ElasticNetCV(cv=5, random_state=0)
+    >>> print(regr.alpha_)
+    0.199...
+    >>> print(regr.intercept_)
+    0.398...
+    >>> print(regr.predict([[0, 0]]))
+    [0.398...]
     """
 
     path = staticmethod(enet_path)


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308 


#### What does this implement/fix? Explain your changes.

- "ElasticNetCV" removed from DOCSTRING_IGNORE_LIST in test_docstrings.py
- In "ElasticNetCV.\_\_init\_\_" : "See Also" and "Notes" sections moved in the right place, `l1_ratio` description modified, `enet_path` and `ElasticNet` desctiptions added in "See Also" section, blank line removed

