### PR TITLE
Check feature_names_in_ for sklearn.feature_extraction

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1486,6 +1486,12 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
 
         .. versionadded:: 1.0
 
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Defined only when `X`
+        has feature names that are all strings.
+
+        .. versionadded:: 1.0
+
     See Also
     --------
     CountVectorizer : Transforms text into a sparse matrix of n-gram counts.

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -325,7 +325,6 @@ def test_check_n_features_in_after_fitting(estimator):
 
 COLUMN_NAME_MODULES_TO_IGNORE = {
     "compose",
-    "feature_extraction",
     "kernel_approximation",
     "model_selection",
     "multioutput",


### PR DESCRIPTION
## Reference Issues/PRs

Follow up to #18010

## What does this implement/fix? Explain your changes.

Feature extraction estimators are already mostly ignored by the test because most of them do not accept 2d arrays/dataframes as input except `TfIdfTransformer` which was already working but just lacked an update in its docstring.