### PR TITLE
Check features_names_in_ in sklearn.multioutput

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -145,6 +145,8 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
 
         if first_time and hasattr(self.estimators_[0], "n_features_in_"):
             self.n_features_in_ = self.estimators_[0].n_features_in_
+        if first_time and hasattr(self.estimators_[0], "feature_names_in_"):
+            self.feature_names_in_ = self.estimators_[0].feature_names_in_
 
         return self
 
@@ -206,6 +208,8 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
 
         if hasattr(self.estimators_[0], "n_features_in_"):
             self.n_features_in_ = self.estimators_[0].n_features_in_
+        if hasattr(self.estimators_[0], "feature_names_in_"):
+            self.feature_names_in_ = self.estimators_[0].feature_names_in_
 
         return self
 
@@ -278,6 +282,12 @@ class MultiOutputRegressor(RegressorMixin, _MultiOutputEstimator):
         underlying `estimator` exposes such an attribute when fit.
 
         .. versionadded:: 0.24
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Only defined if the
+        underlying estimators expose such an attribute when fit.
+
+        .. versionadded:: 1.0
 
     Examples
     --------
@@ -361,6 +371,12 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
         underlying `estimator` exposes such an attribute when fit.
 
         .. versionadded:: 0.24
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Only defined if the
+        underlying estimators expose such an attribute when fit.
+
+        .. versionadded:: 1.0
 
     Examples
     --------
@@ -675,6 +691,12 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         .. versionadded:: 0.24
 
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Defined only when `X`
+        has feature names that are all strings.
+
+        .. versionadded:: 1.0
+
     Examples
     --------
     >>> from sklearn.datasets import make_multilabel_classification
@@ -773,6 +795,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
             Returns the decision function of the sample for each model
             in the chain.
         """
+        X = self._validate_data(X, accept_sparse=True, reset=False)
         Y_decision_chain = np.zeros((X.shape[0], len(self.estimators_)))
         Y_pred_chain = np.zeros((X.shape[0], len(self.estimators_)))
         for chain_idx, estimator in enumerate(self.estimators_):
@@ -859,6 +882,12 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
         underlying `base_estimator` exposes such an attribute when fit.
 
         .. versionadded:: 0.24
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Defined only when `X`
+        has feature names that are all strings.
+
+        .. versionadded:: 1.0
 
     Examples
     --------

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -328,7 +328,6 @@ COLUMN_NAME_MODULES_TO_IGNORE = {
     "feature_extraction",
     "kernel_approximation",
     "model_selection",
-    "multioutput",
 }
 
 _estimators_to_test = list(


### PR DESCRIPTION
## Reference Issues/PRs

Follow up to #18010

## What does this implement/fix? Explain your changes.

- Make `ClassifierChain` validate data in `decision_function` to be consistent  with `predict`.
- Multioutput meta estimators delegate to their first base estimator.