### PR TITLE
Check feature_names_in_ for sklearn.model_selection

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1251,16 +1251,16 @@ class GridSearchCV(BaseSearchCV):
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes such an
-        attribute when fit.
+        parameter for more details) and that `best_estimator_` exposes
+        `n_features_in_` when fit.
 
         .. versionadded:: 0.24
 
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes such an
-        attribute when fit.
+        parameter for more details) and that `best_estimator_` exposes
+        `feature_names_in_` when fit.
 
         .. versionadded:: 1.0
 
@@ -1610,16 +1610,16 @@ class RandomizedSearchCV(BaseSearchCV):
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes such an
-        attribute when fit.
+        parameter for more details) and that `best_estimator_` exposes
+        `n_features_in_` when fit.
 
         .. versionadded:: 0.24
 
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes such an
-        attribute when fit.
+        parameter for more details) and that `best_estimator_` exposes
+        `feature_names_in_` when fit.
 
         .. versionadded:: 1.0
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -858,6 +858,9 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             refit_end_time = time.time()
             self.refit_time_ = refit_end_time - refit_start_time
 
+            if hasattr(self.best_estimator_, "feature_names_in_"):
+                self.feature_names_in_ = self.best_estimator_.feature_names_in_
+
         # Store the only scorer not as a dict for single metric evaluation
         self.scorer_ = scorers
 
@@ -1246,10 +1249,20 @@ class GridSearchCV(BaseSearchCV):
         the underlying estimator is a classifier.
 
     n_features_in_ : int
-        Number of features seen during :term:`fit`. Only defined if the
-        underlying estimator exposes such an attribute when fit.
+        Number of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes such an
+        attribute when fit.
 
         .. versionadded:: 0.24
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes such an
+        attribute when fit.
+
+        .. versionadded:: 1.0
 
     Notes
     -----
@@ -1595,10 +1608,20 @@ class RandomizedSearchCV(BaseSearchCV):
         the underlying estimator is a classifier.
 
     n_features_in_ : int
-        Number of features seen during :term:`fit`. Only defined if the
-        underlying estimator exposes such an attribute when fit.
+        Number of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes such an
+        attribute when fit.
 
         .. versionadded:: 0.24
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes such an
+        attribute when fit.
+
+        .. versionadded:: 1.0
 
     Notes
     -----

--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -626,10 +626,20 @@ class HalvingGridSearchCV(BaseSuccessiveHalving):
         the underlying estimator is a classifier.
 
     n_features_in_ : int
-        Number of features seen during :term:`fit`. Only defined if the
-        underlying estimator exposes such an attribute when fit.
+        Number of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes such an
+        attribute when fit.
 
         .. versionadded:: 0.24
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes such an
+        attribute when fit.
+
+        .. versionadded:: 1.0
 
     See Also
     --------
@@ -954,10 +964,20 @@ class HalvingRandomSearchCV(BaseSuccessiveHalving):
         the underlying estimator is a classifier.
 
     n_features_in_ : int
-        Number of features seen during :term:`fit`. Only defined if the
-        underlying estimator exposes such an attribute when fit.
+        Number of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes such an
+        attribute when fit.
 
         .. versionadded:: 0.24
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes such an
+        attribute when fit.
+
+        .. versionadded:: 1.0
 
     See Also
     --------

--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -628,16 +628,14 @@ class HalvingGridSearchCV(BaseSuccessiveHalving):
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes such an
-        attribute when fit.
+        parameter for more details) and exposes such an attribute when fit.
 
         .. versionadded:: 0.24
 
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes such an
-        attribute when fit.
+        parameter for more details) and exposes such an attribute when fit.
 
         .. versionadded:: 1.0
 
@@ -966,16 +964,14 @@ class HalvingRandomSearchCV(BaseSuccessiveHalving):
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes such an
-        attribute when fit.
+        parameter for more details) and exposes such an attribute when fit.
 
         .. versionadded:: 0.24
 
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes such an
-        attribute when fit.
+        parameter for more details) and exposes such an attribute when fit.
 
         .. versionadded:: 1.0
 

--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -628,14 +628,16 @@ class HalvingGridSearchCV(BaseSuccessiveHalving):
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and exposes such an attribute when fit.
+        parameter for more details) and that `best_estimator_` exposes
+        `n_features_in_` when fit.
 
         .. versionadded:: 0.24
 
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and exposes such an attribute when fit.
+        parameter for more details) and that `best_estimator_` exposes
+        `feature_names_in_` when fit.
 
         .. versionadded:: 1.0
 
@@ -964,14 +966,16 @@ class HalvingRandomSearchCV(BaseSuccessiveHalving):
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and exposes such an attribute when fit.
+        parameter for more details) and that `best_estimator_` exposes
+        `n_features_in_` when fit.
 
         .. versionadded:: 0.24
 
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and exposes such an attribute when fit.
+        parameter for more details) and that `best_estimator_` exposes
+        `feature_names_in_` when fit.
 
         .. versionadded:: 1.0
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -327,12 +327,15 @@ COLUMN_NAME_MODULES_TO_IGNORE = {
     "compose",
     "feature_extraction",
     "kernel_approximation",
-    "model_selection",
     "multioutput",
 }
 
 _estimators_to_test = list(
-    chain(_tested_estimators(), [make_pipeline(LogisticRegression(C=1))])
+    chain(
+        _tested_estimators(),
+        [make_pipeline(LogisticRegression(C=1))],
+        list(_generate_search_cv_instances()),
+    )
 )
 
 


### PR DESCRIPTION
## Reference Issues/PRs

Follow up to #18010

## What does this implement/fix? Explain your changes.

Always delegate to the underlying `best_estimator_` when defined. Depends on the value of `refit` in a complex way.