### PR TITLE
[WIP] DOC Ensures that FeatureAgglomeration passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -20,7 +20,6 @@ DOCSTRING_IGNORE_LIST = [
     "DictionaryLearning",
     "ElasticNetCV",
     "FactorAnalysis",
-    "FeatureAgglomeration",
     "FeatureHasher",
     "FeatureUnion",
     "FunctionTransformer",

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -1169,18 +1169,23 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         self.pooling_func = pooling_func
 
     def fit(self, X, y=None, **params):
-        """Fit the hierarchical clustering on the data
+        """Fit the hierarchical clustering on the data.
 
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
-            The data
+            The data.
 
         y : Ignored
+            Ignored parameter.
+
+        **params : dict
+            Additional fit parameters.
 
         Returns
         -------
-        self
+        self : object
+            FeatureAgglomeration class instance.
         """
         X = self._validate_data(
             X,

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -983,8 +983,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         return self
 
     def fit_predict(self, X, y=None):
-        """Fit the hierarchical clustering from features or distance matrix,
-        and return cluster labels.
+        """Fit the hierarchical clustering from features or distance matrix.
 
         Parameters
         ----------

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -1123,6 +1123,11 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         Only computed if `distance_threshold` is used or `compute_distances`
         is set to `True`.
 
+    See Also
+    --------
+    AgglomerativeClustering : It performs a hierarchical clustering using
+        a bottom up approach.
+
     Examples
     --------
     >>> import numpy as np

--- a/sklearn/cluster/_feature_agglomeration.py
+++ b/sklearn/cluster/_feature_agglomeration.py
@@ -22,7 +22,7 @@ class AgglomerationTransform(TransformerMixin):
 
     def transform(self, X):
         """
-        Transform a new matrix using the built clustering
+        Transform a new matrix using the built clustering.
 
         Parameters
         ----------

--- a/sklearn/cluster/_feature_agglomeration.py
+++ b/sklearn/cluster/_feature_agglomeration.py
@@ -54,15 +54,15 @@ class AgglomerationTransform(TransformerMixin):
         return nX
 
     def inverse_transform(self, Xred):
-        """
-        Inverse the transformation.
+        """Inverse the transformation.
+
         Return a vector of size nb_features with the values of Xred assigned
-        to each group of features
+        to each group of features.
 
         Parameters
         ----------
         Xred : array-like of shape (n_samples, n_clusters) or (n_clusters,)
-            The values to be assigned to each cluster of samples
+            The values to be assigned to each cluster of samples.
 
         Returns
         -------


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #20308 


#### What does this implement/fix? Explain your changes.

- `FeatureAgglomeration` removed from `DOCSTRING_IGNORE_LIST` in test_docstrings.py
- In `FeatureAgglomeration` : "See Also" section added.
- In `FeatureAgglomeration.fit` : `**params` parameter description added, self description added.
- In `AgglomerationTransform.inverse_transform` : summary modified.
- In `AgglomerationTransform`.transform : summary modified.


#### Any other comments?

Running `pytest maint_tools/test_docstrings.py -k FeatureAgglomeration-` in this branch I obtain:

```
====================================== test session starts ======================================
platform linux -- Python 3.8.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /.../.../scikit-learn, configfile: setup.cfg
plugins: cov-2.12.1, anyio-2.2.0
collected 1760 items / 1752 deselected / 8 selected                                             

maint_tools/test_docstrings.py ..F.....                                                   [100%]

=========================================== FAILURES ============================================
_______________________ test_docstring[FeatureAgglomeration-fit_predict] ________________________

Estimator = <class 'sklearn.cluster._agglomerative.FeatureAgglomeration'>, method = 'fit_predict'
request = <FixtureRequest for <Function test_docstring[FeatureAgglomeration-fit_predict]>>

    @pytest.mark.parametrize("Estimator, method", get_all_methods())
    def test_docstring(Estimator, method, request):
        base_import_path = Estimator.__module__
        import_path = [base_import_path, Estimator.__name__]
        if method is not None:
            import_path.append(method)
    
        import_path = ".".join(import_path)
    
        if Estimator.__name__ in DOCSTRING_IGNORE_LIST:
            request.applymarker(
                pytest.mark.xfail(run=False, reason="TODO pass numpydoc validation")
            )
    
        res = numpydoc_validation.validate(import_path)
    
        res["errors"] = list(filter_errors(res["errors"], method, Estimator=Estimator))
    
        if res["errors"]:
            msg = repr_errors(res, Estimator, method)
    
>           raise ValueError(msg)
E           ValueError: 
E           
E           None
E           
E           FeatureAgglomeration.fit_predict
E           Parsing of the method signature failed, possibly because this is a property.
E           
E           Fit the hierarchical clustering from features or distance matrix,
E           and return cluster labels.
E           
E           Parameters
E           ----------
E           X : array-like of shape (n_samples, n_features) or                 (n_samples, n_samples)
E               Training instances to cluster, or distances between instances if
E               ``affinity='precomputed'``.
E           
E           y : Ignored
E               Not used, present here for API consistency by convention.
E           
E           Returns
E           -------
E           labels : ndarray of shape (n_samples,)
E               Cluster labels.
E           
E           # Errors
E           
E            - GL08: The object does not have a docstring

maint_tools/test_docstrings.py:252: ValueError
========================= 1 failed, 7 passed, 1752 deselected in 1.03s ==========================

```

which I was not able to solve. Any suggestions?

Thank you!
