### PR TITLE
Fix OvOClassifier.n_features_in_ and other unexpected warning at prediction time when checking feature_names_in_

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -646,6 +646,15 @@ Changelog
 - |Enhancement| warn only once in the main process for per-split fit failures
   in cross-validation. :pr:`20619` by :user:`Loïc Estève <lesteve>`
 
+
+:mod:`sklearn.multiclass`
+.........................
+
+- |Fix| The `n_features_in_` attribute of :class:`multiclass.OneVsOneClassifier`
+  was incorrect when fit with a base estimator that expects a precomputed
+  kernel matrix.
+  :pr:`20853` by :user:`Olivier Grisel <ogrisel>`.
+
 :mod:`sklearn.naive_bayes`
 ..........................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -646,15 +646,6 @@ Changelog
 - |Enhancement| warn only once in the main process for per-split fit failures
   in cross-validation. :pr:`20619` by :user:`Loïc Estève <lesteve>`
 
-
-:mod:`sklearn.multiclass`
-.........................
-
-- |Fix| The `n_features_in_` attribute of :class:`multiclass.OneVsOneClassifier`
-  was incorrect when fit with a base estimator that expects a precomputed
-  kernel matrix.
-  :pr:`20853` by :user:`Olivier Grisel <ogrisel>`.
-
 :mod:`sklearn.naive_bayes`
 ..........................
 

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -565,8 +565,10 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         """
         Validate X whenever one tries to predict, apply, predict_proba."""
         check_is_fitted(self)
-        self._check_feature_names(X, reset=False)
-        return self.estimators_[0]._validate_X_predict(X, check_input=True)
+        X = self._validate_data(X, dtype=DTYPE, accept_sparse="csr", reset=False)
+        if issparse(X) and (X.indices.dtype != np.intc or X.indptr.dtype != np.intc):
+            raise ValueError("No support for np.int64 index based sparse matrices")
+        return X
 
     @property
     def feature_importances_(self):

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -289,8 +289,9 @@ class RANSACRegressor(
             `max_trials` randomly chosen sub-samples.
 
         """
-        # Need to validate separately here.
-        # We can't pass multi_ouput=True because that would allow y to be csr.
+        # Need to validate separately here. We can't pass multi_ouput=True
+        # because that would allow y to be csr. Delay expensive finiteness
+        # check to the base estimator's own input validation.
         check_X_params = dict(accept_sparse="csr", force_all_finite=False)
         check_y_params = dict(ensure_2d=False)
         X, y = self._validate_data(

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -291,7 +291,7 @@ class RANSACRegressor(
         """
         # Need to validate separately here.
         # We can't pass multi_ouput=True because that would allow y to be csr.
-        check_X_params = dict(accept_sparse="csr")
+        check_X_params = dict(accept_sparse="csr", force_all_finite=False)
         check_y_params = dict(ensure_2d=False)
         X, y = self._validate_data(
             X, y, validate_separately=(check_X_params, check_y_params)
@@ -562,8 +562,12 @@ class RANSACRegressor(
             Returns predicted values.
         """
         check_is_fitted(self)
-        self._check_feature_names(X, reset=False)
-
+        X = self._validate_data(
+            X,
+            force_all_finite=False,
+            accept_sparse=True,
+            reset=False,
+        )
         return self.estimator_.predict(X)
 
     def score(self, X, y):
@@ -585,8 +589,12 @@ class RANSACRegressor(
             Score of the prediction.
         """
         check_is_fitted(self)
-        self._check_feature_names(X, reset=False)
-
+        X = self._validate_data(
+            X,
+            force_all_finite=False,
+            accept_sparse=True,
+            reset=False,
+        )
         return self.estimator_.score(X, y)
 
     def _more_tags(self):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -667,8 +667,7 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
             pairwise estimator tag instead.
 
     n_features_in_ : int
-        Number of features seen during :term:`fit`. Only defined if the
-        underlying estimator exposes such an attribute when fit.
+        Number of features seen during :term:`fit`.
 
         .. versionadded:: 0.24
 
@@ -739,9 +738,6 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         )
 
         self.estimators_ = estimators_indices[0]
-
-        if hasattr(self.estimators_[0], "n_features_in_"):
-            self.n_features_in_ = self.estimators_[0].n_features_in_
 
         pairwise = _is_pairwise(self)
         self.pairwise_indices_ = estimators_indices[1] if pairwise else None

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -859,7 +859,7 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         check_is_fitted(self)
         X = self._validate_data(
             X,
-            accept_sparse=["csr", "csc"],
+            accept_sparse=True,
             force_all_finite=False,
             reset=False,
         )

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -857,7 +857,12 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
                 scikit-learn conventions for binary classification.
         """
         check_is_fitted(self)
-        self._check_feature_names(X, reset=False)
+        X = self._validate_data(
+            X,
+            accept_sparse=["csr", "csc"],
+            force_all_finite=False,
+            reset=False,
+        )
 
         indices = self.pairwise_indices_
         if indices is None:

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -169,8 +169,11 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
         self : object
             Returns an instance of self.
         """
-        # we need row slicing support for sparce matrices
-        X, y = self._validate_data(X, y, accept_sparse=["csr", "csc", "lil", "dok"])
+        # we need row slicing support for sparce matrices, but costly finiteness check
+        # can be delegated to the base estimator.
+        X, y = self._validate_data(
+            X, y, accept_sparse=["csr", "csc", "lil", "dok"], force_all_finite=False
+        )
 
         if self.base_estimator is None:
             raise ValueError("base_estimator cannot be None!")
@@ -291,7 +294,12 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
             Array with predicted labels.
         """
         check_is_fitted(self)
-        self._check_feature_names(X, reset=False)
+        X = self._validate_data(
+            X,
+            accept_sparse=True,
+            force_all_finite=False,
+            reset=False,
+        )
         return self.base_estimator_.predict(X)
 
     def predict_proba(self, X):
@@ -308,7 +316,12 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
             Array with prediction probabilities.
         """
         check_is_fitted(self)
-        self._check_feature_names(X, reset=False)
+        X = self._validate_data(
+            X,
+            accept_sparse=True,
+            force_all_finite=False,
+            reset=False,
+        )
         return self.base_estimator_.predict_proba(X)
 
     @if_delegate_has_method(delegate="base_estimator")
@@ -326,7 +339,12 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
             Result of the decision function of the `base_estimator`.
         """
         check_is_fitted(self)
-        self._check_feature_names(X, reset=False)
+        X = self._validate_data(
+            X,
+            accept_sparse=True,
+            force_all_finite=False,
+            reset=False,
+        )
         return self.base_estimator_.decision_function(X)
 
     @if_delegate_has_method(delegate="base_estimator")
@@ -344,7 +362,12 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
             Array with log prediction probabilities.
         """
         check_is_fitted(self)
-        self._check_feature_names(X, reset=False)
+        X = self._validate_data(
+            X,
+            accept_sparse=True,
+            force_all_finite=False,
+            reset=False,
+        )
         return self.base_estimator_.predict_log_proba(X)
 
     @if_delegate_has_method(delegate="base_estimator")
@@ -365,5 +388,10 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
             Result of calling score on the `base_estimator`.
         """
         check_is_fitted(self)
-        self._check_feature_names(X, reset=False)
+        X = self._validate_data(
+            X,
+            accept_sparse=True,
+            force_all_finite=False,
+            reset=False,
+        )
         return self.base_estimator_.score(X, y)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -328,6 +328,7 @@ column_name_estimators = list(
     )
 )
 
+
 @pytest.mark.parametrize(
     "estimator", column_name_estimators, ids=_get_check_estimator_ids
 )

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -324,7 +324,6 @@ def test_check_n_features_in_after_fitting(estimator):
 # is checking for column name consistency.
 
 COLUMN_NAME_MODULES_TO_IGNORE = {
-    "compose",
     "model_selection",
 }
 
@@ -346,6 +345,9 @@ column_name_estimators = [
 def test_pandas_column_name_consistency(estimator):
     _set_checking_parameters(estimator)
     with ignore_warnings(category=(FutureWarning)):
-        check_dataframe_column_names_consistency(
-            estimator.__class__.__name__, estimator
-        )
+        with pytest.warns(None) as record:
+            check_dataframe_column_names_consistency(
+                estimator.__class__.__name__, estimator
+            )
+        for warning in record:
+            assert "was fitted without feature names" not in str(warning.message)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -863,20 +863,22 @@ def test_pairwise_deprecated(MultiClassClassifier):
         ov_clf._pairwise
 
 
-def test_pairwise_cross_val_score():
+@pytest.mark.parametrize(
+    "MultiClassClassifier", [OneVsRestClassifier, OneVsOneClassifier]
+)
+def test_pairwise_cross_val_score(MultiClassClassifier):
     clf_precomputed = svm.SVC(kernel="precomputed")
     clf_notprecomputed = svm.SVC(kernel="linear")
 
     X, y = iris.data, iris.target
 
-    for MultiClassClassifier in [OneVsRestClassifier, OneVsOneClassifier]:
-        ovr_false = MultiClassClassifier(clf_notprecomputed)
-        ovr_true = MultiClassClassifier(clf_precomputed)
+    ovr_false = MultiClassClassifier(clf_notprecomputed)
+    ovr_true = MultiClassClassifier(clf_precomputed)
 
-        linear_kernel = np.dot(X, X.T)
-        score_precomputed = cross_val_score(ovr_true, linear_kernel, y)
-        score_linear = cross_val_score(ovr_false, X, y)
-        assert_array_equal(score_precomputed, score_linear)
+    linear_kernel = np.dot(X, X.T)
+    score_precomputed = cross_val_score(ovr_true, linear_kernel, y, error_score="raise")
+    score_linear = cross_val_score(ovr_false, X, y, error_score="raise")
+    assert_array_equal(score_precomputed, score_linear)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -872,13 +872,17 @@ def test_pairwise_cross_val_score(MultiClassClassifier):
 
     X, y = iris.data, iris.target
 
-    ovr_false = MultiClassClassifier(clf_notprecomputed)
-    ovr_true = MultiClassClassifier(clf_precomputed)
+    multiclass_clf_notprecomputed = MultiClassClassifier(clf_notprecomputed)
+    multiclass_clf_precomputed = MultiClassClassifier(clf_precomputed)
 
     linear_kernel = np.dot(X, X.T)
-    score_precomputed = cross_val_score(ovr_true, linear_kernel, y, error_score="raise")
-    score_linear = cross_val_score(ovr_false, X, y, error_score="raise")
-    assert_array_equal(score_precomputed, score_linear)
+    score_not_precomputed = cross_val_score(
+        multiclass_clf_notprecomputed, X, y, error_score="raise"
+    )
+    score_precomputed = cross_val_score(
+        multiclass_clf_precomputed, linear_kernel, y, error_score="raise"
+    )
+    assert_array_equal(score_precomputed, score_not_precomputed)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -824,7 +824,7 @@ def test_pairwise_indices():
         )
 
 
-def test_pairwise_indices_n_features_in():
+def test_pairwise_n_features_in():
     X, y = iris.data, iris.target
     assert X.shape == (150, 4)
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -853,9 +853,6 @@ def test_pairwise_n_features_in():
     for est in ovr_notprecomputed.estimators_:
         assert est.n_features_in_ == 4
 
-    # Fitting the same models with a precomputed kernel:
-    K = X @ X.T
-
     ovo_notprecomputed = OneVsOneClassifier(clf_notprecomputed).fit(X, y)
     assert ovo_notprecomputed.n_features_in_ == 4
     assert ovo_notprecomputed.n_classes_ == 3
@@ -865,8 +862,10 @@ def test_pairwise_n_features_in():
 
     # When working with precomputed kernels we have one "feature" per training
     # sample:
-    clf_precomputed = svm.SVC(kernel="precomputed").fit(K, y)
+    K = X @ X.T
     assert K.shape == (149, 149)
+
+    clf_precomputed = svm.SVC(kernel="precomputed").fit(K, y)
     assert clf_precomputed.n_features_in_ == 149
 
     ovr_precomputed = OneVsRestClassifier(clf_precomputed).fit(K, y)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -836,7 +836,8 @@ def test_pairwise_n_features_in():
     """
     X, y = iris.data, iris.target
 
-    # remove the last sample to make the class not exactly balanced
+    # Remove the last sample to make the classes not exactly balanced and make
+    # the test more interesting.
     assert y[-1] == 0
     X = X[:-1]
     y = y[:-1]
@@ -879,9 +880,11 @@ def test_pairwise_n_features_in():
     # internally, OvO will drop the samples of the classes not part of the pair
     # of classes under consideration for a given binary classifier. Since we
     # use a precomputed kernel, it will also drop the matching columns of the
-    # kernel matrix, and therefore we have fewer "features" as result. Since
-    # each class has 50 samples, a single OvO binary classifier works with a
-    # subkernel matrix of shape (100, 100).
+    # kernel matrix, and therefore we have fewer "features" as result.
+    #
+    # Since class 0 has 49 samples, and class 1 and 2 have 50 samples each, a
+    # single OvO binary classifier works with a sub-kernel matrix of shape
+    # either (99, 99) or (100, 100).
     ovo_precomputed = OneVsOneClassifier(clf_precomputed).fit(K, y)
     assert ovo_precomputed.n_features_in_ == 149
     assert ovr_precomputed.n_classes_ == 3

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -855,7 +855,6 @@ def test_pairwise_n_features_in():
 
     # Fitting the same models with a precomputed kernel:
     K = X @ X.T
-    assert K.shape == (149, 149)
 
     ovo_notprecomputed = OneVsOneClassifier(clf_notprecomputed).fit(X, y)
     assert ovo_notprecomputed.n_features_in_ == 4
@@ -867,6 +866,7 @@ def test_pairwise_n_features_in():
     # When working with precomputed kernels we have one "feature" per training
     # sample:
     clf_precomputed = svm.SVC(kernel="precomputed").fit(K, y)
+    assert K.shape == (149, 149)
     assert clf_precomputed.n_features_in_ == 149
 
     ovr_precomputed = OneVsRestClassifier(clf_precomputed).fit(K, y)


### PR DESCRIPTION
## Reference Issues/PRs

Follow up to #18010

## What does this implement/fix? Explain your changes.

Add a new test to make sure that we do not raise an expected warning when checking the input data at prediction time, notably in meta-estimators: if the data is validated by the meta estimator at fit time, it should also be validated by the meta-estimator at predict time. The base estimator should therefore not receive a dataframe with column names at predict time.