### PR TITLE
[WIP] SequentialFeatureSelector stores the intermediate scores and the history of the support masks

### DIFF
--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -213,9 +213,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
             self.support_history_[i, :] = current_mask
 
         if self.direction == "backward":
-            current_mask = ~current_mask
             self.support_history_ = ~self.support_history_
-        self.support_ = current_mask
 
         return self
 
@@ -243,7 +241,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
 
     def _get_support_mask(self):
         check_is_fitted(self)
-        return self.support_
+        return self.support_history_[-1, :]
 
     def _get_support_history(self):
         check_is_fitted(self)

--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -239,7 +239,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
                 scoring=self.scoring,
                 n_jobs=self.n_jobs,
             ).mean()
-        return np.argmax(self.scores_[i, :])
+        return np.nanargmax(self.scores_[i, :])
 
     def _get_support_mask(self):
         check_is_fitted(self)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Currently `SequentialFeatureSelector` returns only the final mask, but discards the results of all the intermediate computations. 
Those results are often of interest, so it would be worthwhile to store them and allow users to access them.
This PR stores the intermediate scores (results of various tested model evaluations), and the history of the support masks.

I would like to ask for a review of the idea and the current implementation!
If I get a green light, I will complete the task list below before the final review.

The naming of the variables is provisional, I was trying to adhere to the standard I've found in this file, but I'm very open to suggestions!

Suggested reviewers (is it a good habit to do this?): @NicolasHug, @rasbt, @thomasjpfan, @glemaitre

#### Task list 
- [ ]  Review of the concept & current implementation
- [ ]  Add public functions to access the variables created
- [ ]  Add docs
- [ ]  Add this feature to one of the user guide examples
- [ ]  Add `scoring` argument to one of the user guide examples (oddly enough I had a difficult time finding this argument, would be useful to include it in an example!)