### PR TITLE
ENH Adds feature_names_in_ to TransformedTargetRegressor

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -316,17 +316,6 @@ def test_check_n_features_in_after_fitting(estimator):
     check_n_features_in_after_fitting(estimator.__class__.__name__, estimator)
 
 
-# TODO: When more modules get added, we can remove it from this list to make
-# sure it gets tested. After we finish each module we can move the checks
-# into check_estimator.
-# NOTE: When running `check_dataframe_column_names_consistency` on a meta-estimator that
-# delegates validation to a base estimator, the check is testing that the base estimator
-# is checking for column name consistency.
-
-COLUMN_NAME_MODULES_TO_IGNORE = {
-    "compose",
-}
-
 _estimators_to_test = list(
     chain(
         _tested_estimators(),
@@ -336,16 +325,7 @@ _estimators_to_test = list(
 )
 
 
-column_name_estimators = [
-    est
-    for est in _estimators_to_test
-    if est.__module__.split(".")[1] not in COLUMN_NAME_MODULES_TO_IGNORE
-]
-
-
-@pytest.mark.parametrize(
-    "estimator", column_name_estimators, ids=_get_check_estimator_ids
-)
+@pytest.mark.parametrize("estimator", _estimators_to_test, ids=_get_check_estimator_ids)
 def test_pandas_column_name_consistency(estimator):
     _set_checking_parameters(estimator)
     with ignore_warnings(category=(FutureWarning)):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #18010


#### What does this implement/fix? Explain your changes.
This PR:

1. Adds `feature_names_in_` to `TransformedTargetRegressor`. 
2. Updates the tags to remove  "no_validation", since the estimator delegates validation to the inner estimator.
3. Adds `multioutput` tag based on the inner estimator.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
