### PR TITLE
ENH add `only_non_negative` parameter to `_check_sample_weight`

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -821,7 +821,7 @@ Changelog
   unavailable on the basis of state, in a more readable way.
   :pr:`19948` by `Joel Nothman`_.
 
-_ |Enhancement| :func:`utils.validation.check_is_fitted` now uses
+- |Enhancement| :func:`utils.validation.check_is_fitted` now uses
   ``__sklearn_is_fitted__`` if available, instead of checking for attributes ending with
   an underscore. This also makes :class:`Pipeline` and
   :class:`preprocessing.FunctionTransformer` pass
@@ -856,7 +856,7 @@ _ |Enhancement| :func:`utils.validation.check_is_fitted` now uses
   warning was previously raised in resampling utilities and functions using
   those utilities (e.g. :func:`model_selection.train_test_split`,
   :func:`model_selection.cross_validate`,
-  :func:`model_seleection.cross_val_score`,
+  :func:`model_selection.cross_val_score`,
   :func:`model_selection.cross_val_predict`).
   :pr:`20673` by :user:`Joris Van den Bossche  <jorisvandenbossche>`.
 
@@ -864,6 +864,18 @@ _ |Enhancement| :func:`utils.validation.check_is_fitted` now uses
   numbers would raise an error due to overflow in C types (`np.float64` or
   `np.int64`).
   :pr:`20727` by `Guillaume Lemaitre`_.
+
+- |Enhancement| :func:`utils.validation._check_sample_weight` can perform a
+  non-negativity check on the sample weights. It can be turned on
+  using the only_non_negative bool parameter.
+  Estimators that check for non-negative weights are updated:
+  :func:`linear_model.LinearRegression` (here the previous
+  error message was misleading),
+  :func:`ensemble.AdaBoostClassifier`,
+  :func:`ensemble.AdaBoostRegressor`,
+  :func:`neighbors.KernelDensity`.
+  :pr:`20880` by :user:`Guillaume Lemaitre <glemaitre>`
+  and :user:`András Simon <simonandras>`.
 
 :mod:`sklearn.validation`
 .........................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -901,7 +901,7 @@ Changelog
   warning was previously raised in resampling utilities and functions using
   those utilities (e.g. :func:`model_selection.train_test_split`,
   :func:`model_selection.cross_validate`,
-  :func:`model_selection.cross_val_score`,
+  :func:`model_seleection.cross_val_score`,
   :func:`model_selection.cross_val_predict`).
   :pr:`20673` by :user:`Joris Van den Bossche  <jorisvandenbossche>`.
 
@@ -909,18 +909,6 @@ Changelog
   numbers would raise an error due to overflow in C types (`np.float64` or
   `np.int64`).
   :pr:`20727` by `Guillaume Lemaitre`_.
-
-- |Enhancement| :func:`utils.validation._check_sample_weight` can perform a
-  non-negativity check on the sample weights. It can be turned on
-  using the only_non_negative bool parameter.
-  Estimators that check for non-negative weights are updated:
-  :func:`linear_model.LinearRegression` (here the previous
-  error message was misleading),
-  :func:`ensemble.AdaBoostClassifier`,
-  :func:`ensemble.AdaBoostRegressor`,
-  :func:`neighbors.KernelDensity`.
-  :pr:`20880` by :user:`Guillaume Lemaitre <glemaitre>`
-  and :user:`András Simon <simonandras>`.
 
 - |API| :func:`utils._testing.assert_warns` and
   :func:`utils._testing.assert_warns_message` are deprecated in 1.0 and will

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -38,9 +38,20 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.utils`
+....................
 
-:mod:`sklearn.decomposition`
-............................
+- |Enhancement| :func:`utils.validation._check_sample_weight` can perform a
+  non-negativity check on the sample weights. It can be turned on
+  using the only_non_negative bool parameter.
+  Estimators that check for non-negative weights are updated:
+  :func:`linear_model.LinearRegression` (here the previous
+  error message was misleading),
+  :func:`ensemble.AdaBoostClassifier`,
+  :func:`ensemble.AdaBoostRegressor`,
+  :func:`neighbors.KernelDensity`.
+  :pr:`20880` by :user:`Guillaume Lemaitre <glemaitre>`
+  and :user:`András Simon <simonandras>`.
 
 
 Code and Documentation Contributors

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -123,10 +123,10 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
             y_numeric=is_regressor(self),
         )
 
-        sample_weight = _check_sample_weight(sample_weight, X, np.float64, copy=True)
+        sample_weight = _check_sample_weight(
+            sample_weight, X, np.float64, copy=True, only_non_negative=True
+        )
         sample_weight /= sample_weight.sum()
-        if np.any(sample_weight < 0):
-            raise ValueError("sample_weight cannot contain negative weights")
 
         # Check parameters
         self._validate_estimator()
@@ -136,7 +136,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         self.estimator_weights_ = np.zeros(self.n_estimators, dtype=np.float64)
         self.estimator_errors_ = np.ones(self.n_estimators, dtype=np.float64)
 
-        # Initializion of the random number instance that will be used to
+        # Initialization of the random number instance that will be used to
         # generate a seed at each iteration
         random_state = check_random_state(self.random_state)
 

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -576,6 +576,6 @@ def test_adaboost_negative_weight_error(model, X, y):
     sample_weight = np.ones_like(y)
     sample_weight[-1] = -10
 
-    err_msg = "sample_weight cannot contain negative weight"
+    err_msg = "Negative values in data passed to `sample_weight`"
     with pytest.raises(ValueError, match=err_msg):
         model.fit(X, y, sample_weight=sample_weight)

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -664,7 +664,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(
-                sample_weight, X, only_non_negative=True, dtype=X.dtype
+                sample_weight, X, dtype=X.dtype, only_non_negative=True
             )
 
         X, y, X_offset, y_offset, X_scale = self._preprocess_data(

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -663,7 +663,9 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         )
 
         if sample_weight is not None:  # the weights should be non-negative
-            sample_weight = _check_sample_weight(sample_weight, X, only_non_negative=True, dtype=X.dtype)
+            sample_weight = _check_sample_weight(
+                sample_weight, X, only_non_negative=True, dtype=X.dtype
+            )
 
         X, y, X_offset, y_offset, X_scale = self._preprocess_data(
             X,

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -663,7 +663,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         )
 
         if sample_weight is not None:  # the weights should be non-negative
-            sample_weight = _check_sample_weight(sample_weight, X, only_positive=True, dtype=X.dtype)
+            sample_weight = _check_sample_weight(sample_weight, X, only_non_negative=True, dtype=X.dtype)
 
         X, y, X_offset, y_offset, X_scale = self._preprocess_data(
             X,

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -662,10 +662,8 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
             X, y, accept_sparse=accept_sparse, y_numeric=True, multi_output=True
         )
 
-        if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
-            if np.any(sample_weight < 0):
-                raise ValueError("The weights of the samples cannot be negative")
+        if sample_weight is not None:  # the weights should be non-negative
+            sample_weight = _check_sample_weight(sample_weight, X, only_positive=True, dtype=X.dtype)
 
         X, y, X_offset, y_offset, X_scale = self._preprocess_data(
             X,

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -662,7 +662,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
             X, y, accept_sparse=accept_sparse, y_numeric=True, multi_output=True
         )
 
-        if sample_weight is not None:  # the weights should be non-negative
+        if sample_weight is not None:
             sample_weight = _check_sample_weight(
                 sample_weight, X, only_non_negative=True, dtype=X.dtype
             )

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -664,6 +664,8 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
+            if np.any(sample_weight < 0):
+                raise ValueError("The weights of the samples cannot be negative")
 
         X, y, X_offset, y_offset, X_scale = self._preprocess_data(
             X,

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -191,7 +191,9 @@ class KernelDensity(BaseEstimator):
         X = self._validate_data(X, order="C", dtype=DTYPE)
 
         if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X, DTYPE, only_non_negative=True)
+            sample_weight = _check_sample_weight(
+                sample_weight, X, DTYPE, only_non_negative=True
+            )
 
         kwargs = self.metric_params
         if kwargs is None:

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -191,9 +191,7 @@ class KernelDensity(BaseEstimator):
         X = self._validate_data(X, order="C", dtype=DTYPE)
 
         if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X, DTYPE)
-            if sample_weight.min() <= 0:
-                raise ValueError("sample_weight must have positive values")
+            sample_weight = _check_sample_weight(sample_weight, X, DTYPE, only_non_negative=True)
 
         kwargs = self.metric_params
         if kwargs is None:

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -209,7 +209,7 @@ def test_sample_weight_invalid():
     data = np.reshape([1.0, 2.0, 3.0], (-1, 1))
 
     sample_weight = [0.1, -0.2, 0.3]
-    expected_err = "sample_weight must have positive values"
+    expected_err = "Negative values in data passed to `sample_weight`"
     with pytest.raises(ValueError, match=expected_err):
         kde.fit(data, sample_weight=sample_weight)
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -51,8 +51,8 @@ from sklearn.utils.validation import (
     _num_features,
     FLOAT_DTYPES,
     _get_feature_names,
+    _check_fit_params
 )
-from sklearn.utils.validation import _check_fit_params
 from sklearn.base import BaseEstimator
 import sklearn
 
@@ -1239,6 +1239,14 @@ def test_check_sample_weight():
     X = np.ones((5, 2), dtype=int)
     sample_weight = _check_sample_weight(None, X, dtype=X.dtype)
     assert sample_weight.dtype == np.float64
+
+    # check negative weight when only_non_negative=True
+    X = np.ones((5, 2))
+    sample_weight = np.ones(_num_samples(X))
+    sample_weight[-1] = -10
+    err_msg = "Negative values in data passed to `sample_weight`"
+    with pytest.raises(ValueError, match=err_msg):
+        _check_sample_weight(sample_weight, X, only_non_negative=True)
 
 
 @pytest.mark.parametrize("toarray", [np.array, sp.csr_matrix, sp.csc_matrix])

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -51,7 +51,7 @@ from sklearn.utils.validation import (
     _num_features,
     FLOAT_DTYPES,
     _get_feature_names,
-    _check_fit_params
+    _check_fit_params,
 )
 from sklearn.base import BaseEstimator
 import sklearn

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1480,11 +1480,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
 
 
 def _check_sample_weight(
-    sample_weight,
-    X,
-    dtype=None,
-    copy=False,
-    only_non_negative=False
+    sample_weight, X, dtype=None, copy=False, only_non_negative=False
 ):
     """Validate sample weights.
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1496,7 +1496,8 @@ def _check_sample_weight(sample_weight, X, only_non_negative=False, dtype=None,
     X : {ndarray, list, sparse matrix}
         Input data.
         
-    only_non_negative : if True then a non negativity check for the sample_weight will be done
+    only_non_negative : if True then a non negativity check for the sample_weight
+        will be done
 
     dtype : dtype, default=None
        dtype of the validated `sample_weight`.

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1548,7 +1548,7 @@ def _check_sample_weight(
             )
 
     if only_non_negative:
-        check_non_negative(sample_weight, "sample weight")
+        check_non_negative(sample_weight, "`sample_weight`")
 
     return sample_weight
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1492,7 +1492,7 @@ def _check_sample_weight(
     Parameters
     ----------
     sample_weight : {ndarray, Number or None}, shape (n_samples,)
-       Input sample weights.
+        Input sample weights.
 
     X : {ndarray, list, sparse matrix}
         Input data.
@@ -1503,11 +1503,11 @@ def _check_sample_weight(
         .. versionadded:: 1.0
 
     dtype : dtype, default=None
-       dtype of the validated `sample_weight`.
-       If None, and the input `sample_weight` is an array, the dtype of the
-       input is preserved; otherwise an array with the default numpy dtype
-       is be allocated.  If `dtype` is not one of `float32`, `float64`,
-       `None`, the output will be of dtype `float64`.
+        dtype of the validated `sample_weight`.
+        If None, and the input `sample_weight` is an array, the dtype of the
+        input is preserved; otherwise an array with the default numpy dtype
+        is be allocated.  If `dtype` is not one of `float32`, `float64`,
+        `None`, the output will be of dtype `float64`.
 
     copy : bool, default=False
         If True, a copy of sample_weight will be created.
@@ -1515,7 +1515,7 @@ def _check_sample_weight(
     Returns
     -------
     sample_weight : ndarray of shape (n_samples,)
-       Validated sample weight. It is guaranteed to be "C" contiguous.
+        Validated sample weight. It is guaranteed to be "C" contiguous.
     """
     n_samples = _num_samples(X)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1479,7 +1479,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
     return lambdas
 
 
-def _check_sample_weight(sample_weight, X, only_positive=False, dtype=None, copy=False):
+def _check_sample_weight(sample_weight, X, only_non_negative=False, dtype=None, copy=False):
     """Validate sample weights.
 
     Note that passing sample_weight=None will output an array of ones.
@@ -1494,6 +1494,8 @@ def _check_sample_weight(sample_weight, X, only_positive=False, dtype=None, copy
 
     X : {ndarray, list, sparse matrix}
         Input data.
+        
+    only_non_negative : if True then a non negativity check for the sample_weight will be done
 
     dtype : dtype, default=None
        dtype of the validated `sample_weight`.
@@ -1540,7 +1542,7 @@ def _check_sample_weight(sample_weight, X, only_positive=False, dtype=None, copy
                 )
             )
 
-    if only_positive:
+    if only_non_negative:
         check_non_negative(sample_weight, "sample weight")
 
     return sample_weight

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1479,7 +1479,8 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
     return lambdas
 
 
-def _check_sample_weight(sample_weight, X, only_non_negative=False, dtype=None, copy=False):
+def _check_sample_weight(sample_weight, X, only_non_negative=False, dtype=None,
+                         copy=False):
     """Validate sample weights.
 
     Note that passing sample_weight=None will output an array of ones.

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1497,8 +1497,10 @@ def _check_sample_weight(
     X : {ndarray, list, sparse matrix}
         Input data.
 
-    only_non_negative : if True then a non negativity check for the sample_weight
-        will be done.
+    only_non_negative : bool, default=False,
+        Whether or not the weights are expected to be non-negative.
+        
+        .. versionadded:: 1.0
 
     dtype : dtype, default=None
        dtype of the validated `sample_weight`.

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1495,7 +1495,7 @@ def _check_sample_weight(sample_weight, X, only_non_negative=False, dtype=None,
 
     X : {ndarray, list, sparse matrix}
         Input data.
-        
+
     only_non_negative : if True then a non negativity check for the sample_weight
         will be done
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1497,7 +1497,7 @@ def _check_sample_weight(sample_weight, X, only_non_negative=False, dtype=None,
         Input data.
 
     only_non_negative : if True then a non negativity check for the sample_weight
-        will be done
+        will be done.
 
     dtype : dtype, default=None
        dtype of the validated `sample_weight`.

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1479,7 +1479,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
     return lambdas
 
 
-def _check_sample_weight(sample_weight, X, dtype=None, copy=False):
+def _check_sample_weight(sample_weight, X, only_positive=False, dtype=None, copy=False):
     """Validate sample weights.
 
     Note that passing sample_weight=None will output an array of ones.
@@ -1539,6 +1539,9 @@ def _check_sample_weight(sample_weight, X, dtype=None, copy=False):
                     sample_weight.shape, (n_samples,)
                 )
             )
+
+    if only_positive:
+        check_non_negative(sample_weight, "sample weight")
 
     return sample_weight
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1480,7 +1480,11 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
 
 
 def _check_sample_weight(
-    sample_weight, X, only_non_negative=False, dtype=None, copy=False
+    sample_weight,
+    X,
+    dtype=None,
+    copy=False,
+    only_non_negative=False
 ):
     """Validate sample weights.
 
@@ -1499,7 +1503,7 @@ def _check_sample_weight(
 
     only_non_negative : bool, default=False,
         Whether or not the weights are expected to be non-negative.
-        
+
         .. versionadded:: 1.0
 
     dtype : dtype, default=None

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1479,8 +1479,9 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
     return lambdas
 
 
-def _check_sample_weight(sample_weight, X, only_non_negative=False, dtype=None,
-                         copy=False):
+def _check_sample_weight(
+    sample_weight, X, only_non_negative=False, dtype=None, copy=False
+):
     """Validate sample weights.
 
     Note that passing sample_weight=None will output an array of ones.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #20036. 
Partially addressed https://github.com/scikit-learn/scikit-learn/issues/15531

#### What does this implement/fix? Explain your changes.
The LinearRegression() objects .fit() method gives unclear error message if the sample_weight parameter of the fit() method has negative value. The exception occured only at the call of linalg.lstsq(X, y). I think its better if the negative value check is done at the beginning of the .fit() method. The new message is: "The weights of the samples cannot be negative".

#### Any other comments?
I think the check for negative values should not be done inside the _check_sample_weight() function but inside the given .fit() method. Maybe there are other cases too where this exception message and the negative weight value check can be useful.

This is my first PR to the open source community and i wellcome any comment or advice related to this PR!


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
