### PR TITLE
Fixed Bug : AdaBoost's training error can increase with a larger number of trees #20443

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -1159,7 +1159,6 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
             if len(self.estimators_) > 1:
                 self.estimators_.pop(-1)
             return None, None, None
-        
         beta = estimator_error / (1.0 - estimator_error)
 
         # Boost weight using AdaBoost.R2 alg

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -1159,6 +1159,7 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
             if len(self.estimators_) > 1:
                 self.estimators_.pop(-1)
             return None, None, None
+        
         beta = estimator_error / (1.0 - estimator_error)
 
         # Boost weight using AdaBoost.R2 alg

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -1173,15 +1173,15 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
                     # improved
 
                     sample_weight[sample_mask] *= np.power(beta, (1.0
-                             - masked_error_vector) * self.learning_rate)
+                                 - masked_error_vector) * self.learning_rate)
                 else:
 
-                        # reset if not improved
+                    # reset if not improved
 
                     sample_weight[sample_mask] = 1 / len(sample_weight)
             else:
                 sample_weight[sample_mask] *= np.power(beta, (1.0
-                        - masked_error_vector) * self.learning_rate)
+                             - masked_error_vector) * self.learning_rate)
 
         self.previous_beta = beta
 

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -1167,7 +1167,7 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
         estimator_weight = self.learning_rate * np.log(1.0 / beta)
 
         if not iboost == self.n_estimators - 1:
-            if hasattr(self, 'previous_beta'):
+            if hasattr(self, "previous_beta"):
                 if self.previous_beta > beta:
 
                     # improved

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -1159,26 +1159,30 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
             if len(self.estimators_) > 1:
                 self.estimators_.pop(-1)
             return None, None, None
+        
         beta = estimator_error / (1.0 - estimator_error)
 
         # Boost weight using AdaBoost.R2 alg
+
         estimator_weight = self.learning_rate * np.log(1.0 / beta)
 
         if not iboost == self.n_estimators - 1:
-            if hasattr(self, "previous_beta"):
+            if hasattr(self, 'previous_beta'):
                 if self.previous_beta > beta:
+
                     # improved
-                    sample_weight[sample_mask] *= np.power(
-                            beta, (1.0 - masked_error_vector) * self.learning_rate
-                    )
+
+                    sample_weight[sample_mask] *= np.power(beta, (1.0
+                             - masked_error_vector) * self.learning_rate)
                 else:
-                    # reset if not improved
+
+                        # reset if not improved
+
                     sample_weight[sample_mask] = 1 / len(sample_weight)
             else:
-                sample_weight[sample_mask] *= np.power(
-                        beta, (1.0 - masked_error_vector) * self.learning_rate
-                )
-                
+                sample_weight[sample_mask] *= np.power(beta, (1.0
+                        - masked_error_vector) * self.learning_rate)
+
         self.previous_beta = beta
 
         return sample_weight, estimator_weight, estimator_error

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -1159,16 +1159,28 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
             if len(self.estimators_) > 1:
                 self.estimators_.pop(-1)
             return None, None, None
-
+        
         beta = estimator_error / (1.0 - estimator_error)
 
         # Boost weight using AdaBoost.R2 alg
         estimator_weight = self.learning_rate * np.log(1.0 / beta)
 
         if not iboost == self.n_estimators - 1:
-            sample_weight[sample_mask] *= np.power(
-                beta, (1.0 - masked_error_vector) * self.learning_rate
-            )
+            if hasattr(self, "previous_beta"):
+                if self.previous_beta > beta:
+                    # improved
+                    sample_weight[sample_mask] *= np.power(
+                            beta, (1.0 - masked_error_vector) * self.learning_rate
+                    )
+                else:
+                    # reset if not improved
+                    sample_weight[sample_mask] = 1 / len(sample_weight)
+            else:
+                sample_weight[sample_mask] *= np.power(
+                        beta, (1.0 - masked_error_vector) * self.learning_rate
+                )
+                
+        self.previous_beta = beta
 
         return sample_weight, estimator_weight, estimator_error
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
fixes #20443

#### What does this implement/fix? Explain your changes.
Problem:

For 500 leaves we get the expected behavior: both the training and validation errors decrease when increasing the number of trees. At some point we reach a plateau of diminishing returns. However for lower number of leaves , the training set is growing with more trees!

Solution:

The code I changed, I hope will solve the problem so the reviewers can look into it and merge it with the master branch.


#### Any other comments?

Credits for code contribution : @europeanplaice