### PR TITLE
TST Adds dtype check for feature_names_in_

### DIFF
--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1613,3 +1613,5 @@ def test_feature_names_in_():
 
     ct.fit(df)
     assert_array_equal(ct.feature_names_in_, feature_names)
+    assert isinstance(ct.feature_names_in_, np.ndarray)
+    assert ct.feature_names_in_.dtype == object

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3744,6 +3744,8 @@ def check_dataframe_column_names_consistency(name, estimator_orig):
             "Estimator does not have a feature_names_in_ "
             "attribute after fitting with a dataframe"
         )
+    assert isinstance(estimator.feature_names_in_, np.ndarray)
+    assert estimator.feature_names_in_.dtype == object
     assert_array_equal(estimator.feature_names_in_, names)
 
     # Only check sklearn estimators for feature_names_in_ in docstring

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1616,7 +1616,7 @@ def _get_feature_names(X):
 
     # extract feature names for support array containers
     if hasattr(X, "columns"):
-        feature_names = np.asarray(X.columns)
+        feature_names = np.asarray(X.columns, dtype=object)
 
     if feature_names is None or len(feature_names) == 0:
         return


### PR DESCRIPTION
As a follow up to the dev meeting, this PR adds an explicit check to make sure that `feature_names_in_` is an ndarray of object dtype.