### PR TITLE
FIX Remove **params from fit function for FeatureAgglomeration to get more concise error message

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -214,6 +214,10 @@ Changelog
   of connected components is greater than 1. :pr:`20597` by
   `Thomas Fan`_.
 
+- |Fix| :class:`cluster.FeatureAgglomeration` now does not take a ``**params``
+  kwarg in the ``fit`` function, resulting in a more concise error. :pr:`` by
+  :user:`Adam Li <adam2392>`.
+
 :mod:`sklearn.compose`
 ......................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -214,8 +214,8 @@ Changelog
   of connected components is greater than 1. :pr:`20597` by
   `Thomas Fan`_.
 
-- |Fix| :class:`cluster.FeatureAgglomeration` now does not take a ``**params``
-  kwarg in the ``fit`` function, resulting in a more concise error. :pr:`20899`
+- |Fix| :class:`cluster.FeatureAgglomeration` does not accept a ``**params`` kwarg in
+  the ``fit`` function anymore, resulting in a more concise error message. :pr:`20899`
   by :user:`Adam Li <adam2392>`.
 
 :mod:`sklearn.compose`

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -215,8 +215,8 @@ Changelog
   `Thomas Fan`_.
 
 - |Fix| :class:`cluster.FeatureAgglomeration` now does not take a ``**params``
-  kwarg in the ``fit`` function, resulting in a more concise error. :pr:`` by
-  :user:`Adam Li <adam2392>`.
+  kwarg in the ``fit`` function, resulting in a more concise error. :pr:`20899`
+  by :user:`Adam Li <adam2392>`.
 
 :mod:`sklearn.compose`
 ......................

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -1202,8 +1202,8 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         )
         self.pooling_func = pooling_func
 
-    def fit(self, X, y=None, **params):
-        """Fit the hierarchical clustering on the data.
+    def fit(self, X, y=None):
+        """Fit the hierarchical clustering on the data
 
         Parameters
         ----------
@@ -1212,9 +1212,6 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
 
         y : Ignored
             Not used, present here for API consistency by convention.
-
-        **params : dictionary of keyword arguments
-            Additional fit parameters.
 
         Returns
         -------
@@ -1230,7 +1227,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         # save n_features_in_ attribute here to reset it after, because it will
         # be overridden in AgglomerativeClustering since we passed it X.T.
         n_features_in_ = self.n_features_in_
-        AgglomerativeClustering.fit(self, X.T, **params)
+        AgglomerativeClustering.fit(self, X.T)
         self.n_features_in_ = n_features_in_
         return self
 

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -1203,7 +1203,7 @@ class FeatureAgglomeration(AgglomerativeClustering, AgglomerationTransform):
         self.pooling_func = pooling_func
 
     def fit(self, X, y=None):
-        """Fit the hierarchical clustering on the data
+        """Fit the hierarchical clustering on the data.
 
         Parameters
         ----------


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes: #20897 


#### What does this implement/fix? Explain your changes.
Removes the **kwargs parameter in `FeatureAgglomeration.fit` to result in a more concise error.

#### Any other comments?

