### PR TITLE
Fixing integer overflow on 32-bit architectures.

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -658,7 +658,7 @@ Changelog
 - |Enhancement| warn only once in the main process for per-split fit failures
   in cross-validation. :pr:`20619` by :user:`Loïc Estève <lesteve>`
 
-- |Fix| Avoid premature overflow in :class:`model_selection.train_test_split`.
+- |Fix| Avoid premature overflow in :func:`model_selection.train_test_split`.
   :pr:`20904` by :user:`Tomasz Jakubek <t-jakubek>`.
 
 :mod:`sklearn.naive_bayes`

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -658,6 +658,9 @@ Changelog
 - |Enhancement| warn only once in the main process for per-split fit failures
   in cross-validation. :pr:`20619` by :user:`Loïc Estève <lesteve>`
 
+- |Fix| Avoid premature overflow in :class:`model_selection.train_test_split`.
+  :pr:`20904` by :user:`Tomasz Jakubek <t-jakubek>`.
+
 :mod:`sklearn.naive_bayes`
 ..........................
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1284,14 +1284,21 @@ def test_train_test_split():
         assert_array_equal(test, [8, 9])
         assert_array_equal(train, [0, 1, 2, 3, 4, 5, 6, 7])
 
+
 def test_train_test_split_32bit_overflow():
     # Based on issue #20774 - check for integer overflow on 32-bit platforms
-    big_number = 100000     # A number 'n' big enough for expression 'n * n * train_size'
-                            # to cause overflow for signed 32-bit integer
+
+    # A number 'n' big enough for expression 'n * n * train_size' to cause
+    # an overflow for signed 32-bit integer
+    big_number = 100000
+
+    # Definition of 'y' is a part of reproduction - population for at least
+    # one class should be in the same order of magnitude as size of X
     X = np.arange(big_number)
-    y = X > (0.99 * big_number) # Part of reproduction - population for at least one class 
-                                # should be in the same order of magnitude as size of X
-    X_train, X_test, y_train, y_test = train_test_split(X, y, stratify=y, train_size=0.25)
+    y = X > (0.99 * big_number)
+
+    split = train_test_split(X, y, stratify=y, train_size=0.25)
+    X_train, X_test, y_train, y_test = split
 
     assert X_train.size + X_test.size == big_number
     assert y_train.size + y_test.size == big_number

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1283,7 +1283,8 @@ def test_train_test_split():
         train, test = train_test_split(y, shuffle=False, test_size=test_size)
         assert_array_equal(test, [8, 9])
         assert_array_equal(train, [0, 1, 2, 3, 4, 5, 6, 7])
-    
+
+def test_train_test_split_32bit_overflow():
     # Based on issue #20774 - check for integer overflow on 32-bit platforms
     big_number = 100000     # A number 'n' big enough for expression 'n * n * train_size'
                             # to cause overflow for signed 32-bit integer

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1283,6 +1283,17 @@ def test_train_test_split():
         train, test = train_test_split(y, shuffle=False, test_size=test_size)
         assert_array_equal(test, [8, 9])
         assert_array_equal(train, [0, 1, 2, 3, 4, 5, 6, 7])
+    
+    # Based on issue #20774 - check for integer overflow on 32-bit platforms
+    big_number = 100000     # A number 'n' big enough for expression 'n * n * train_size'
+                            # to cause overflow for signed 32-bit integer
+    X = np.arange(big_number)
+    y = X > (0.99 * big_number) # Part of reproduction - population for at least one class 
+                                # should be in the same order of magnitude as size of X
+    X_train, X_test, y_train, y_test = train_test_split(X, y, stratify=y, train_size=0.25)
+
+    assert X_train.size + X_test.size == big_number
+    assert y_train.size + y_test.size == big_number
 
 
 @ignore_warnings

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1286,7 +1286,11 @@ def test_train_test_split():
 
 
 def test_train_test_split_32bit_overflow():
-    # Based on issue #20774 - check for integer overflow on 32-bit platforms
+    """Check for integer overflow on 32-bit platforms.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/20774
+    """
 
     # A number 'n' big enough for expression 'n * n * train_size' to cause
     # an overflow for signed 32-bit integer

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -1056,7 +1056,7 @@ def _approximate_mode(class_counts, n_draws, rng):
     rng = check_random_state(rng)
     # this computes a bad approximation to the mode of the
     # multivariate hypergeometric given by class_counts and n_draws
-    continuous = n_draws * class_counts / class_counts.sum()
+    continuous = class_counts / class_counts.sum() * n_draws
     # floored means we don't overshoot n_samples, but probably undershoot
     floored = np.floor(continuous)
     # we add samples according to how much "left over" probability

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -684,13 +684,16 @@ def test_is_scalar_nan(value, result):
     assert isinstance(is_scalar_nan(value), bool)
 
 
-def test_approximate_mode(value, result):
+def test_approximate_mode():
     # Per issue #20774 - make sure _approximate_mode() returns valid results for
     # cases where "class_counts * n_draws" is enough to overflow 32-bit signed integer
-    ret = _approximate_mode(class_counts=np.array([99000, 1000], dtype=np.int32), n_draws=25000, rng=0)
-    assert_array_equal(ret, [24750, 250])   # Draws 25% of the total population, so in this case fair draw means:
-                                            # 25% * 99.000 = 24.750
-                                            # 25% *  1.000 =    250
+    X = np.array([99000, 1000], dtype=np.int32)
+    ret = _approximate_mode(class_counts=X, n_draws=25000, rng=0)
+
+    # Draws 25% of the total population, so in this case a fair draw means:
+    # 25% * 99.000 = 24.750
+    # 25% *  1.000 =    250
+    assert_array_equal(ret, [24750, 250])
 
 
 def dummy_func():

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -685,8 +685,13 @@ def test_is_scalar_nan(value, result):
 
 
 def test_approximate_mode():
-    # Per issue #20774 - make sure _approximate_mode() returns valid results for
-    # cases where "class_counts * n_draws" is enough to overflow 32-bit signed integer
+    """Make sure sklearn.utils._approximate_mode returns valid
+    results for cases where "class_counts * n_draws" is enough
+    to overflow 32-bit signed integer.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/20774
+    """
     X = np.array([99000, 1000], dtype=np.int32)
     ret = _approximate_mode(class_counts=X, n_draws=25000, rng=0)
 

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -29,6 +29,7 @@ from sklearn.utils import _message_with_time, _print_elapsed_time
 from sklearn.utils import get_chunk_n_rows
 from sklearn.utils import is_scalar_nan
 from sklearn.utils import _to_object_array
+from sklearn.utils import _approximate_mode
 from sklearn.utils.fixes import parse_version
 from sklearn.utils._mocking import MockDataFrame
 from sklearn.utils._testing import SkipTest
@@ -681,6 +682,15 @@ def test_is_scalar_nan(value, result):
     assert is_scalar_nan(value) is result
     # make sure that we are returning a Python bool
     assert isinstance(is_scalar_nan(value), bool)
+
+
+def test_approximate_mode(value, result):
+    # Per issue #20774 - make sure _approximate_mode() returns valid results for
+    # cases where "class_counts * n_draws" is enough to overflow 32-bit signed integer
+    ret = _approximate_mode(class_counts=np.array([99000, 1000], dtype=np.int32), n_draws=25000, rng=0)
+    assert_array_equal(ret, [24750, 250])   # Draws 25% of the total population, so in this case fair draw means:
+                                            # 25% * 99.000 = 24.750
+                                            # 25% *  1.000 =    250
 
 
 def dummy_func():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #20774

#### What does this implement/fix? Explain your changes.
Changing order of operations, so there is no integer overflow and train_test_split() returns valid data.
