### PR TITLE
FIX removes duplicate 'min_data_in_bin' in lightgbm parameters

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/utils.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/utils.pyx
@@ -64,7 +64,6 @@ def get_equivalent_estimator(estimator, lib='lightgbm'):
         'verbosity': 10 if sklearn_params['verbose'] else -10,
         'boost_from_average': True,
         'enable_bundle': False,  # also makes feature order consistent
-        'min_data_in_bin': 1,
         'subsample_for_bin': _BinMapper().subsample,
     }
 


### PR DESCRIPTION
#### Reference Issues/PRs

Noticed this issue while looking at https://github.com/microsoft/LightGBM/issues/4583#issuecomment-910371960.

#### What does this implement/fix? Explain your changes.

The default `lightgbm_params` in `ensemble/_hist_gradient_boosting` currently specifies `min_data_in_bin` twice.

https://github.com/scikit-learn/scikit-learn/blob/907c093977a7f7f5fd6b4ce78e8976ea10a27f42/sklearn/ensemble/_hist_gradient_boosting/utils.pyx#L60

https://github.com/scikit-learn/scikit-learn/blob/907c093977a7f7f5fd6b4ce78e8976ea10a27f42/sklearn/ensemble/_hist_gradient_boosting/utils.pyx#L67

This isn't causing any issues right now since both are set to the same value, but might lead to inconsistencies in the future if one is updated and the other isn't (since keys must be unique in a Python dictionary).

#### Any other comments?

Thanks for your time and consideration.
