### PR TITLE
ENH Adds feature_names_in_ and n_features_in_ to Encoders

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -125,18 +125,6 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
         X_int = np.zeros((n_samples, n_features), dtype=int)
         X_mask = np.ones((n_samples, n_features), dtype=bool)
 
-        if n_features != len(self.categories_):
-            raise ValueError(
-                "The number of features in X is different to the number of "
-                "features of the fitted data. The fitted data had {} features "
-                "and the X has {} features.".format(
-                    len(
-                        self.categories_,
-                    ),
-                    n_features,
-                )
-            )
-
         columns_with_unknown = []
         for i in range(n_features):
             Xi = X_list[i]

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -70,6 +70,8 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
         return X[:, feature_idx]
 
     def _fit(self, X, handle_unknown="error", force_all_finite=True):
+        self._check_n_features(X, reset=True)
+        self._check_feature_names(X, reset=True)
         X_list, n_samples, n_features = self._check_X(
             X, force_all_finite=force_all_finite
         )
@@ -114,6 +116,8 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
     def _transform(
         self, X, handle_unknown="error", force_all_finite=True, warn_on_unknown=False
     ):
+        self._check_feature_names(X, reset=False)
+        self._check_n_features(X, reset=False)
         X_list, n_samples, n_features = self._check_X(
             X, force_all_finite=force_all_finite
         )
@@ -282,6 +286,11 @@ class OneHotEncoder(_BaseEncoder):
 
         .. versionchanged:: 0.23
            Added the possibility to contain `None` values.
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
+        .. versionadded:: 1.0
 
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Defined only when `X`
@@ -750,6 +759,11 @@ class OrdinalEncoder(_BaseEncoder):
         The categories of each feature determined during ``fit`` (in order of
         the features in X and corresponding with the output of ``transform``).
         This does not include categories that weren't seen during ``fit``.
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
+        .. versionadded:: 1.0
 
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Defined only when `X`

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -39,19 +39,6 @@ def test_one_hot_encoder_sparse_dense():
     assert_array_equal(X_trans_sparse.toarray(), X_trans_dense)
 
 
-def test_one_hot_encoder_diff_n_features():
-    X = np.array([[0, 2, 1], [1, 0, 3], [1, 0, 2]])
-    X2 = np.array([[1, 0]])
-    enc = OneHotEncoder()
-    enc.fit(X)
-    err_msg = (
-        "The number of features in X is different to the number of "
-        "features of the fitted data."
-    )
-    with pytest.raises(ValueError, match=err_msg):
-        enc.transform(X2)
-
-
 def test_one_hot_encoder_handle_unknown():
     X = np.array([[0, 2, 1], [1, 0, 3], [1, 0, 2]])
     X2 = np.array([[4, 1, 1]])

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3192,6 +3192,8 @@ def _enforce_estimator_tags_x(estimator, X):
     # strictly positive data
     if _safe_tags(estimator, key="requires_positive_X"):
         X -= X.min()
+    if "categorical" in _safe_tags(estimator, key="X_types"):
+        X = (X - X.min()).astype(np.int32)
     return X
 
 
@@ -3619,11 +3621,11 @@ def check_n_features_in_after_fitting(name, estimator_orig):
     # Make sure that n_features_in are checked after fitting
     tags = _safe_tags(estimator_orig)
 
-    if (
-        "2darray" not in tags["X_types"]
-        and "sparse" not in tags["X_types"]
-        or tags["no_validation"]
-    ):
+    is_supported_X_types = (
+        "2darray" in tags["X_types"] or "categorical" in tags["X_types"]
+    )
+
+    if not is_supported_X_types or tags["no_validation"]:
         return
 
     rng = np.random.RandomState(0)
@@ -3708,12 +3710,11 @@ def check_dataframe_column_names_consistency(name, estimator_orig):
         )
 
     tags = _safe_tags(estimator_orig)
+    is_supported_X_types = (
+        "2darray" in tags["X_types"] or "categorical" in tags["X_types"]
+    )
 
-    if (
-        "2darray" not in tags["X_types"]
-        and "sparse" not in tags["X_types"]
-        or tags["no_validation"]
-    ):
+    if not is_supported_X_types or tags["no_validation"]:
         return
 
     rng = np.random.RandomState(0)


### PR DESCRIPTION
This PR:

1. Adds `feature_names_in_` and `n_features_in_` to `OneHotEncoder` and `OrdinalEncoder`.
2. Updates the tests to support categorical `X_types`.