### PR TITLE
BUG Corrects tag in TfidfTransformer

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1559,7 +1559,12 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
         self : object
             Fitted transformer.
         """
-        X = self._validate_data(X, accept_sparse=("csr", "csc"))
+        # large sparse data is not supported for 32bit platforms because
+        # _document_frequency uses np.bincount which works on arrays of
+        # dtype NPY_INTP which is int32 for 32bit platforms. See #20923
+        X = self._validate_data(
+            X, accept_sparse=("csr", "csc"), accept_large_sparse=not _IS_32BIT
+        )
         if not sp.issparse(X):
             X = sp.csr_matrix(X)
         dtype = X.dtype if X.dtype in FLOAT_DTYPES else np.float64

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1648,7 +1648,7 @@ class TfidfTransformer(TransformerMixin, BaseEstimator):
         )
 
     def _more_tags(self):
-        return {"X_types": "sparse"}
+        return {"X_types": ["2darray", "sparse"]}
 
 
 class TfidfVectorizer(CountVectorizer):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -317,12 +317,11 @@ def test_valid_tag_types(estimator):
     tags = _safe_tags(estimator)
 
     for name, tag in tags.items():
-        default_tag_type = type(_DEFAULT_TAGS[name])
+        correct_tags = type(_DEFAULT_TAGS[name])
         if name == "_xfail_checks":
             # _xfail_checks can be a dictionary
-            assert isinstance(tag, (dict, default_tag_type))
-        else:
-            assert isinstance(tag, default_tag_type)
+            correct_tags = (correct_tags, dict)
+        assert isinstance(tag, correct_tags)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -37,6 +37,7 @@ from sklearn.model_selection import HalvingRandomSearchCV
 from sklearn.pipeline import make_pipeline
 
 from sklearn.utils import IS_PYPY
+from sklearn.utils._tags import _DEFAULT_TAGS, _safe_tags
 from sklearn.utils._testing import (
     SkipTest,
     set_random_state,
@@ -306,6 +307,22 @@ def test_search_cv(estimator, check, request):
         )
     ):
         check(estimator)
+
+
+@pytest.mark.parametrize(
+    "estimator", _tested_estimators(), ids=_get_check_estimator_ids
+)
+def test_valid_tag_types(estimator):
+    """Check that estimator tags are valid."""
+    tags = _safe_tags(estimator)
+
+    for name, tag in tags.items():
+        default_tag_type = type(_DEFAULT_TAGS[name])
+        if name == "_xfail_checks":
+            # _xfail_checks can be a dictionary
+            assert isinstance(tag, (dict, default_tag_type))
+        else:
+            assert isinstance(tag, default_tag_type)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR corrects the tag in `TfidfTransformer` and adds a new common test to check that the tags are the correct dtype.

This is kind of related to https://github.com/scikit-learn/scikit-learn/issues/20804, where  `X_types` is overriding the default `["2darray"]` which skips most of the common test.