### PR TITLE
FIX change the meaning of include_boundaries in check_scalar

### DIFF
--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -469,7 +469,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
             target_type=numbers.Real,
             min_val=0.5,
             max_val=1,
-            closed="left",
+            include_boundaries="left",
         )
         check_scalar(self.max_iter, "max_iter", target_type=numbers.Integral, min_val=1)
         check_scalar(

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -469,7 +469,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
             target_type=numbers.Real,
             min_val=0.5,
             max_val=1,
-            closed="right",
+            closed="left",
         )
         check_scalar(self.max_iter, "max_iter", target_type=numbers.Integral, min_val=1)
         check_scalar(

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -272,7 +272,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
     Parameters
     ----------
     damping : float, default=0.5
-        Damping factor (between 0.5 and 1) is the extent to
+        Damping factor in the range `[0.5, 1.0)` is the extent to
         which the current value is maintained relative to
         incoming values (weighted 1 - damping). This in order
         to avoid numerical oscillations when updating these

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1075,7 +1075,7 @@ def test_check_scalar_valid(x):
             int,
             2,
             4,
-            "neither",
+            "right",
             ValueError("test_name4 == 2, must be > 2."),
         ),
         (
@@ -1084,7 +1084,7 @@ def test_check_scalar_valid(x):
             int,
             2,
             4,
-            "neither",
+            "left",
             ValueError("test_name5 == 4, must be < 4."),
         ),
     ],

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1087,6 +1087,18 @@ def test_check_scalar_valid(x):
             "left",
             ValueError("test_name5 == 4, must be < 4."),
         ),
+        (
+            4,
+            "test_name6",
+            int,
+            2,
+            4,
+            "bad parameter value",
+            ValueError(
+                "Unknown value for `include_boundaries`: bad parameter value. "
+                "Possible values are: ('left', 'right', 'both', 'neither')."
+            ),
+        ),
     ],
 )
 def test_check_scalar_invalid(

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1031,14 +1031,14 @@ def test_check_scalar_valid(x):
             target_type=numbers.Real,
             min_val=2,
             max_val=5,
-            closed="both",
+            include_boundaries="both",
         )
     assert len(record) == 0
     assert scalar == x
 
 
 @pytest.mark.parametrize(
-    "x, target_name, target_type, min_val, max_val, closed, err_msg",
+    "x, target_name, target_type, min_val, max_val, include_boundaries, err_msg",
     [
         (
             1,
@@ -1090,7 +1090,7 @@ def test_check_scalar_valid(x):
     ],
 )
 def test_check_scalar_invalid(
-    x, target_name, target_type, min_val, max_val, closed, err_msg
+    x, target_name, target_type, min_val, max_val, include_boundaries, err_msg
 ):
     """Test that check_scalar returns the right error if a wrong input is
     given"""
@@ -1101,7 +1101,7 @@ def test_check_scalar_invalid(
             target_type=target_type,
             min_val=min_val,
             max_val=max_val,
-            closed=closed,
+            include_boundaries=include_boundaries,
         )
     assert str(raised_error.value) == str(err_msg)
     assert type(raised_error.value) == type(err_msg)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1031,7 +1031,7 @@ def test_check_scalar_valid(x):
             target_type=numbers.Real,
             min_val=2,
             max_val=5,
-            closed="neither",
+            closed="both",
         )
     assert len(record) == 0
     assert scalar == x
@@ -1058,7 +1058,7 @@ def test_check_scalar_valid(x):
             2,
             4,
             "neither",
-            ValueError("test_name2 == 1, must be >= 2."),
+            ValueError("test_name2 == 1, must be > 2."),
         ),
         (
             5,
@@ -1067,7 +1067,7 @@ def test_check_scalar_valid(x):
             2,
             4,
             "neither",
-            ValueError("test_name3 == 5, must be <= 4."),
+            ValueError("test_name3 == 5, must be < 4."),
         ),
         (
             2,
@@ -1075,7 +1075,7 @@ def test_check_scalar_valid(x):
             int,
             2,
             4,
-            "left",
+            "neither",
             ValueError("test_name4 == 2, must be > 2."),
         ),
         (
@@ -1084,7 +1084,7 @@ def test_check_scalar_valid(x):
             int,
             2,
             4,
-            "right",
+            "neither",
             ValueError("test_name5 == 4, must be < 4."),
         ),
     ],

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1095,7 +1095,7 @@ def test_check_scalar_valid(x):
             4,
             "bad parameter value",
             ValueError(
-                "Unknown value for `include_boundaries`: bad parameter value. "
+                "Unknown value for `include_boundaries`: 'bad parameter value'. "
                 "Possible values are: ('left', 'right', 'both', 'neither')."
             ),
         ),

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1295,7 +1295,7 @@ def check_scalar(
     expected_include_boundaries = ("left", "right", "both", "neither")
     if include_boundaries not in expected_include_boundaries:
         raise ValueError(
-            f"Unknown value for `include_boundaries`: {include_boundaries}. "
+            f"Unknown value for `include_boundaries`: {repr(include_boundaries)}. "
             f"Possible values are: {expected_include_boundaries}."
         )
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1292,10 +1292,11 @@ def check_scalar(
     if not isinstance(x, target_type):
         raise TypeError(f"{name} must be an instance of {target_type}, not {type(x)}.")
 
-    expected_include_boundaries = {"left", "right", "both", "neither"}
+    expected_include_boundaries = ("left", "right", "both", "neither")
     if include_boundaries not in expected_include_boundaries:
         raise ValueError(
-            f"Unknown value for `include_boundaries`: {include_boundaries}"
+            f"Unknown value for `include_boundaries`: {include_boundaries}. "
+            f"Possible values are: {expected_include_boundaries}."
         )
 
     comparison_operator = (

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1242,7 +1242,7 @@ def check_scalar(
     *,
     min_val=None,
     max_val=None,
-    closed="both",
+    include_boundaries="both",
 ):
     """Validate scalar parameters type and value.
 
@@ -1265,10 +1265,15 @@ def check_scalar(
         The maximum valid value the parameter can take. If None (default) it
         is implied that the parameter does not have an upper bound.
 
-    closed : {"left", "right", "both", "neither"}, default="both"
-        Whether the interval is closed on the left-side, right-side, both or
-        neither. By default, `"both"` is used and `min_val` and `max_val` are
-        included in the range of accepted values.
+    include_boundaries : {"left", "right", "both", "neither"}, default="both"
+        Whether the interval defined by `min_val` and `max_val` should include
+        the boundaries. Possible choices are:
+
+        - `"left"`: `min_val` is included in the valid interval;
+        - `"right"`: `max_val` is included in the valid interval;
+        - `"both"`: `min_val` and `max_val` are included in the valid interval;
+        - `"neither"`: neither `min_val` nor `max_val` are included in the
+          valid interval.
 
     Returns
     -------
@@ -1287,22 +1292,28 @@ def check_scalar(
     if not isinstance(x, target_type):
         raise TypeError(f"{name} must be an instance of {target_type}, not {type(x)}.")
 
-    expected_closed = {"left", "right", "both", "neither"}
-    if closed not in expected_closed:
-        raise ValueError(f"Unknown value for `closed`: {closed}")
+    expected_include_boundaries = {"left", "right", "both", "neither"}
+    if include_boundaries not in expected_include_boundaries:
+        raise ValueError(
+            f"Unknown value for `include_boundaries`: {include_boundaries}"
+        )
 
-    comparison_operator = operator.lt if closed in ("left", "both") else operator.le
+    comparison_operator = (
+        operator.lt if include_boundaries in ("left", "both") else operator.le
+    )
     if min_val is not None and comparison_operator(x, min_val):
         raise ValueError(
             f"{name} == {x}, must be"
-            f" {'>=' if closed in ('left', 'both') else '>'} {min_val}."
+            f" {'>=' if include_boundaries in ('left', 'both') else '>'} {min_val}."
         )
 
-    comparison_operator = operator.gt if closed in ("right", "both") else operator.ge
+    comparison_operator = (
+        operator.gt if include_boundaries in ("right", "both") else operator.ge
+    )
     if max_val is not None and comparison_operator(x, max_val):
         raise ValueError(
             f"{name} == {x}, must be"
-            f" {'<=' if closed in ('right', 'both') else '<'} {max_val}."
+            f" {'<=' if include_boundaries in ('right', 'both') else '<'} {max_val}."
         )
 
     return x

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1242,7 +1242,7 @@ def check_scalar(
     *,
     min_val=None,
     max_val=None,
-    closed="neither",
+    closed="both",
 ):
     """Validate scalar parameters type and value.
 
@@ -1265,9 +1265,10 @@ def check_scalar(
         The maximum valid value the parameter can take. If None (default) it
         is implied that the parameter does not have an upper bound.
 
-    closed : {"left", "right", "both", "neither"}, default="neither"
+    closed : {"left", "right", "both", "neither"}, default="both"
         Whether the interval is closed on the left-side, right-side, both or
-        neither.
+        neither. By default, `"both"` is used and `min_val` and `max_val` are
+        included in the range of accepted values.
 
     Returns
     -------
@@ -1290,18 +1291,18 @@ def check_scalar(
     if closed not in expected_closed:
         raise ValueError(f"Unknown value for `closed`: {closed}")
 
-    comparison_operator = operator.le if closed in ("left", "both") else operator.lt
+    comparison_operator = operator.lt if closed in ("left", "both") else operator.le
     if min_val is not None and comparison_operator(x, min_val):
         raise ValueError(
             f"{name} == {x}, must be"
-            f" {'>' if closed in ('left', 'both') else '>='} {min_val}."
+            f" {'>=' if closed in ('left', 'both') else '>'} {min_val}."
         )
 
-    comparison_operator = operator.ge if closed in ("right", "both") else operator.gt
+    comparison_operator = operator.gt if closed in ("right", "both") else operator.ge
     if max_val is not None and comparison_operator(x, max_val):
         raise ValueError(
             f"{name} == {x}, must be"
-            f" {'<' if closed in ('right', 'both') else '<='} {max_val}."
+            f" {'<=' if closed in ('right', 'both') else '<'} {max_val}."
         )
 
     return x

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1269,8 +1269,8 @@ def check_scalar(
         Whether the interval defined by `min_val` and `max_val` should include
         the boundaries. Possible choices are:
 
-        - `"left"`: `min_val` is included in the valid interval;
-        - `"right"`: `max_val` is included in the valid interval;
+        - `"left"`: only `min_val` is included in the valid interval;
+        - `"right"`: only `max_val` is included in the valid interval;
         - `"both"`: `min_val` and `max_val` are included in the valid interval;
         - `"neither"`: neither `min_val` nor `max_val` are included in the
           valid interval.


### PR DESCRIPTION
I think that the current definition of the parameter `closed` in `check_scalar` is counterintuitive.
Indeed, `min_val` and `max_val` define the interval of proper value and `closed` will define whether or not to include these values. Thus `left` should include `min_val` in the interval, `right` should include `max_val` in the range of correct values.