### PR TITLE
DOC Ensures that FeatureHasher passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -10,7 +10,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 # List of modules ignored when checking for numpydoc validation.
 DOCSTRING_IGNORE_LIST = [
     "Birch",
-    "FeatureHasher",
     "FeatureUnion",
     "FunctionTransformer",
     "GammaRegressor",

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -53,11 +53,7 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-<<<<<<< HEAD
     input_type : str, {"dict", "pair", "string"}, default="dict"
-=======
-    input_type : {"dict", "pair", "string"}, default="dict"
->>>>>>> 31a7cc17564047c61e3fdc72e6fa621a84967c7a
         Either "dict" (the default) to accept dictionaries over
         (feature_name, value); "pair" to accept pairs of (feature_name, value);
         or "string" to accept single strings.

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -53,7 +53,7 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-    input_type : {"dict", "pair", "str"}, default="dict"
+    input_type : {"dict", "pair", "string"}, default="dict"
         Either "dict" (the default) to accept dictionaries over
         (feature_name, value); "pair" to accept pairs of (feature_name, value);
         or "string" to accept single strings.
@@ -131,11 +131,11 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Input samples.
+        X : Ignored
+            Not used, present here for API consistency by convention.
 
-        y : array-like of shape (n_samples,) or (n_samples, n_outputs)
-            Target values.
+        y : Ignored
+            Not used, present here for API consistency by convention.
 
         Returns
         -------

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -53,7 +53,7 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-    input_type : {"dict", "pair", "string"}, default="dict"
+    input_type : str, {"dict", "pair", "string"}, default="dict"
         Either "dict" (the default) to accept dictionaries over
         (feature_name, value); "pair" to accept pairs of (feature_name, value);
         or "string" to accept single strings.

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -162,7 +162,6 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         -------
         X : sparse matrix of shape (n_samples, n_features)
             Feature matrix, for use with estimators or further transformers.
-
         """
         raw_X = iter(raw_X)
         if self.input_type == "dict":

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -131,12 +131,16 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : ndarray
+        X : array-like of shape (n_samples, n_features)
+            Input samples.
+
+        y : array-like of shape (n_samples,) or (n_samples, n_outputs)
+            Target values.
 
         Returns
         -------
-        self : FeatureHasher
-
+        self : object
+            FeatureHasher class instance.
         """
         # repeat input validation for grid search (which calls set_params)
         self._validate_params(self.n_features, self.input_type)

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -53,7 +53,7 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-    input_type : str, {"dict", "pair", "string"}, default="dict"
+    input_type : str, {'dict', 'pair', 'string'}, default='dict'
         Either "dict" (the default) to accept dictionaries over
         (feature_name, value); "pair" to accept pairs of (feature_name, value);
         or "string" to accept single strings.

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -53,7 +53,8 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-    input_type : str, {'dict', 'pair', 'string'}, default='dict'
+    input_type : str, default='dict'
+        Choose a string from {'dict', 'pair', 'string'}.
         Either "dict" (the default) to accept dictionaries over
         (feature_name, value); "pair" to accept pairs of (feature_name, value);
         or "string" to accept single strings.

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -53,7 +53,7 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         The number of features (columns) in the output matrices. Small numbers
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
-    input_type : {"dict", "pair", "string"}, default="dict"
+    input_type : {"dict", "pair", "str"}, default="dict"
         Either "dict" (the default) to accept dictionaries over
         (feature_name, value); "pair" to accept pairs of (feature_name, value);
         or "string" to accept single strings.
@@ -75,6 +75,11 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
             ``alternate_sign`` replaces the now deprecated ``non_negative``
             parameter.
 
+    See Also
+    --------
+    DictVectorizer : Vectorizes string-valued features using a hash table.
+    sklearn.preprocessing.OneHotEncoder : Handles nominal/categorical features.
+
     Examples
     --------
     >>> from sklearn.feature_extraction import FeatureHasher
@@ -84,11 +89,6 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
     >>> f.toarray()
     array([[ 0.,  0., -4., -1.,  0.,  0.,  0.,  0.,  0.,  2.],
            [ 0.,  0.,  0., -2., -5.,  0.,  0.,  0.,  0.,  0.]])
-
-    See Also
-    --------
-    DictVectorizer : Vectorizes string-valued features using a hash table.
-    sklearn.preprocessing.OneHotEncoder : Handles nominal/categorical features.
     """
 
     def __init__(


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #20308 

#### What does this implement/fix? Explain your changes.

- `FeatureHascher` removed from DOCSTRING_IGNORE_LIST in test_docstrings.py
- In `FeatureHasher`: "See Also" position changed.
- In `FeatureHash.fit`: add `X`, `y` and self description.
- In `FeatureHasher.transform`: blank line removed.