### PR TITLE
DOC Ensures FeatureUnion passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -11,7 +11,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 DOCSTRING_IGNORE_LIST = [
     "Birch",
     "FeatureHasher",
-    "FeatureUnion",
     "FunctionTransformer",
     "GammaRegressor",
     "GaussianMixture",

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1050,7 +1050,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         X_t : array-like or sparse matrix of \
                 shape (n_samples, sum_n_components)
             The `hstack` of results of transformers. `sum_n_components` is the
-            sum of n_components (output dimension) over transformers.
+            sum of `n_components` (output dimension) over transformers.
         """
         results = self._parallel_func(X, y, fit_params, _fit_transform_one)
         if not results:
@@ -1100,7 +1100,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         X_t : array-like or sparse matrix of \
                 shape (n_samples, sum_n_components)
             The `hstack` of results of transformers. `sum_n_components` is the
-            sum of n_components (output dimension) over transformers.
+            sum of `n_components` (output dimension) over transformers.
         """
         Xs = Parallel(n_jobs=self.n_jobs)(
             delayed(_transform_one)(trans, X, None, weight)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1129,7 +1129,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
     @property
     def n_features_in_(self):
         """Number of features seen during :term:`fit`."""
-        
+
         # X is passed to all transformers so we just delegate to the first one
         return self.transformer_list[0][1].n_features_in_
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -837,10 +837,12 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
 
     Parameters
     ----------
-    transformer_list : list
-        List of (string, transformer) tuples to be applied to the data.
-        The first half of each tuple is the name of the transformer.
-        The tranformer can be 'drop' for it to be ignored.
+    transformer_list : list of tuple
+        List of tuple containing `(str, transformer)`. The first element
+        of the tuple is name affected to the transformer while the
+        second element is a scikit-learn transformer instance.
+        The transformer instance can also be `"drop"` for it to be
+        ignored.
 
         .. versionchanged:: 0.22
            Deprecated `None` as a transformer in favor of 'drop'.
@@ -936,7 +938,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
 
         Returns
         -------
-        self ; object
+        self : object
             FeatureUnion class instance.
         """
         self._set_params("transformer_list", **kwargs)
@@ -1047,7 +1049,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         -------
         X_t : array-like or sparse matrix of \
                 shape (n_samples, sum_n_components)
-            The hstack of results of transformers. sum_n_components is the
+            The `hstack` of results of transformers. `sum_n_components` is the
             sum of n_components (output dimension) over transformers.
         """
         results = self._parallel_func(X, y, fit_params, _fit_transform_one)
@@ -1097,7 +1099,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         -------
         X_t : array-like or sparse matrix of \
                 shape (n_samples, sum_n_components)
-            The hstack of results of transformers. sum_n_components is the
+            The `hstack` of results of transformers. `sum_n_components` is the
             sum of n_components (output dimension) over transformers.
         """
         Xs = Parallel(n_jobs=self.n_jobs)(
@@ -1126,13 +1128,8 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
 
     @property
     def n_features_in_(self):
-        """Number of features seen during :term:`fit`.
-
-        Returns
-        -------
-        self : object
-            FeatureUnion class object.
-        """
+        """Number of features seen during :term:`fit`."""
+        
         # X is passed to all transformers so we just delegate to the first one
         return self.transformer_list[0][1].n_features_in_
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -927,9 +927,17 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         you can directly set the parameters of the estimators contained in
         `tranformer_list`.
 
+        Parameters
+        ----------
+        **kwargs : dict
+            Parameters of this estimator or parameters of estimators contained
+            in `transform_list`. Parameters of the transformers may be set
+            using its name and the parameter name separated by a '__'.
+
         Returns
         -------
-        self
+        self ; object
+            FeatureUnion class instance.
         """
         self._set_params("transformer_list", **kwargs)
         return self

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1118,6 +1118,13 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
 
     @property
     def n_features_in_(self):
+        """Number of features seen during :term:`fit`.
+
+        Returns
+        -------
+        self : object
+            FeatureUnion class object.
+        """
         # X is passed to all transformers so we just delegate to the first one
         return self.transformer_list[0][1].n_features_in_
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -837,10 +837,10 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
 
     Parameters
     ----------
-    transformer_list : list of (string, transformer) tuples
-        List of transformer objects to be applied to the data. The first
-        half of each tuple is the name of the transformer. The tranformer can
-        be 'drop' for it to be ignored.
+    transformer_list : list
+        List of (string, transformer) tuples to be applied to the data.
+        The first half of each tuple is the name of the transformer.
+        The tranformer can be 'drop' for it to be ignored.
 
         .. versionchanged:: 0.22
            Deprecated `None` as a transformer in favor of 'drop'.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1032,11 +1032,14 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         y : array-like of shape (n_samples, n_outputs), default=None
             Targets for supervised learning.
 
+        **fit_params : dict, default=None
+            Parameters to pass to the fit method of the estimator.
+
         Returns
         -------
         X_t : array-like or sparse matrix of \
                 shape (n_samples, sum_n_components)
-            hstack of results of transformers. sum_n_components is the
+            The hstack of results of transformers. sum_n_components is the
             sum of n_components (output dimension) over transformers.
         """
         results = self._parallel_func(X, y, fit_params, _fit_transform_one)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1097,7 +1097,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         -------
         X_t : array-like or sparse matrix of \
                 shape (n_samples, sum_n_components)
-            hstack of results of transformers. sum_n_components is the
+            The hstack of results of transformers. sum_n_components is the
             sum of n_components (output dimension) over transformers.
         """
         Xs = Parallel(n_jobs=self.n_jobs)(

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1005,10 +1005,13 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         y : array-like of shape (n_samples, n_outputs), default=None
             Targets for supervised learning.
 
+        **fit_params : dict, default=None
+            Parameters to pass to the fit method of the estimator.
+
         Returns
         -------
-        self : FeatureUnion
-            This estimator
+        self : object
+            FeatureUnion class instance.
         """
         transformers = self._parallel_func(X, y, fit_params, _fit_one)
         if not transformers:


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #20308 

#### What does this implement/fix? Explain your changes.

- `FeatureUnion` removed from `DOCSTRING_IGNORE_LIST` in test_docstrings.py
- In `FeatureUnion`: solved numpydoc string-warning by moving list content description in `transformer_list` description.
- In `FeatureUnion.fit`: `**fit_params` description added.
- In `FeatureUnion.fit_transform`: `**fit_params` parameter and description added.
- In `FeatureUnion.n_feature_in_` : numpydoc added.
- In `FeatureUnion.set_params`: `**kwargs` and self descriptions added.
- In `FeatureUnion.transform`: `X_t` desctiption fixed.