### PR TITLE
DOC Ensures that FunctionTransformer passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -12,7 +12,6 @@ DOCSTRING_IGNORE_LIST = [
     "Birch",
     "FeatureHasher",
     "FeatureUnion",
-    "FunctionTransformer",
     "GammaRegressor",
     "GaussianMixture",
     "GaussianProcessRegressor",

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -140,9 +140,13 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         X : array-like, shape (n_samples, n_features)
             Input array.
 
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
         Returns
         -------
-        self
+        self : object
+            FunctionTransformer class instance.
         """
         X = self._check_input(X)
         if self.check_inverse and not (self.func is None or self.inverse_func is None):

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -74,7 +74,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
     See Also
     --------
     MaxAbsScaler : Scale each feature by its maximum absolute value.
-    StandardScaler : Standardize features by removing the mean and 
+    StandardScaler : Standardize features by removing the mean and
         scaling to unit variance.
     LabelBinarizer : Binarize labels in a one-vs-all fashion.
     MultilabelBinarizer : Transform between iterable of iterables

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -71,6 +71,17 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
 
         .. versionadded:: 0.18
 
+    See Also
+    --------
+    MaxAbsScaler : Scale each feature by its maximum absolute value.
+    MinMaxScaler : Transform features by scaling each feature to a given range.
+    QuantileTransformers : Transform features using quantiles information.
+    PowerTransformer : Apply a power transform featurewise to make data
+        more Gaussian-like.
+    LabelBinarizer : Binarize labels in a one-vs-all fashion.
+    MultilabelBinarizer : Transform between iterable of iterables
+        and a multilabel format.
+
     Examples
     --------
     >>> import numpy as np

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -74,10 +74,8 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
     See Also
     --------
     MaxAbsScaler : Scale each feature by its maximum absolute value.
-    MinMaxScaler : Transform features by scaling each feature to a given range.
-    QuantileTransformers : Transform features using quantiles information.
-    PowerTransformer : Apply a power transform featurewise to make data
-        more Gaussian-like.
+    StandardScaler : Standardize features by removing the mean and 
+        scaling to unit variance.
     LabelBinarizer : Binarize labels in a one-vs-all fashion.
     MultilabelBinarizer : Transform between iterable of iterables
         and a multilabel format.


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #20308 


#### What does this implement/fix? Explain your changes.

- `FunctionTransformer` removed from `DOCSTRING_IGNORE_LIST` in test_dcstrings.py
- In `FunctionTransformer` : "See Also" section added - REVIEW REQUIRED.
- In `FunctonTansformer.fit`: `y` and `self` descriptions added.



#### Any other comments?

"See Also" section requires a review.
