### PR TITLE
MNT bumb version number to 1.1

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -12,6 +12,7 @@ on libraries.io to be notified when new versions are released.
 .. toctree::
     :maxdepth: 1
 
+    Version 1.1 <whats_new/v1.1.rst>
     Version 1.0 <whats_new/v1.0.rst>
     Version 0.24 <whats_new/v0.24.rst>
     Version 0.23 <whats_new/v0.23.rst>

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -7,7 +7,7 @@
 Version 1.0.0
 =============
 
-**In Development**
+**September 2021**
 
 
 .. include:: changelog_legend.inc

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -47,6 +47,6 @@ Code and Documentation Contributors
 -----------------------------------
 
 Thanks to everyone who has contributed to the maintenance and improvement of
-the project since version 0.24, including:
+the project since version 1.0, including:
 
 TODO: update at the time of the release.

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -1,0 +1,52 @@
+.. include:: _contributors.rst
+
+.. currentmodule:: sklearn
+
+.. _changes_1_1:
+
+Version 1.1.0
+=============
+
+**In Development**
+
+
+.. include:: changelog_legend.inc
+
+Minimal dependencies
+--------------------
+
+Version 1.1.0 of scikit-learn requires python 3.7+, numpy 1.14.6+ and
+scipy 1.1.0+. Optional minimal dependency is matplotlib 2.2.2+.
+
+Put the changes in their relevant module.
+
+Changed models
+--------------
+
+
+Changelog
+---------
+
+..
+    Entries should be grouped by module (in alphabetic order) and prefixed with
+    one of the labels: |MajorFeature|, |Feature|, |Efficiency|, |Enhancement|,
+    |Fix| or |API| (see whats_new.rst for descriptions).
+    Entries should be ordered by those labels (e.g. |Fix| after |Efficiency|).
+    Changes not specific to a module should be listed under *Multiple Modules*
+    or *Miscellaneous*.
+    Entries should end with:
+    :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
+    where 123456 is the *pull request* number, not the issue number.
+
+
+:mod:`sklearn.decomposition`
+............................
+
+
+Code and Documentation Contributors
+-----------------------------------
+
+Thanks to everyone who has contributed to the maintenance and improvement of
+the project since version 0.24, including:
+
+TODO: update at the time of the release.

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "1.0.dev0"
+__version__ = "1.1.dev0"
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded


### PR DESCRIPTION
Bumps the version number in `main` to 1.1, and adds a new what's new file.