### PR TITLE
DOC Ensures that VotingClassifier passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -89,7 +89,6 @@ DOCSTRING_IGNORE_LIST = [
     "TruncatedSVD",
     "TweedieRegressor",
     "VarianceThreshold",
-    "VotingClassifier",
 ]
 
 

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -305,7 +305,6 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         -------
         self : object
             Returns the instance itself.
-
         """
         check_classification_targets(y)
         if isinstance(y, np.ndarray) and len(y.shape) > 1 and y.shape[1] > 1:


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures VotingClassifier is compatible with numpydoc.

- Remove `VotingClassifier` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.