### PR TITLE
DOC Ensures that GaussianMixture passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -14,7 +14,6 @@ DOCSTRING_IGNORE_LIST = [
     "FeatureUnion",
     "FunctionTransformer",
     "GammaRegressor",
-    "GaussianMixture",
     "GaussianProcessRegressor",
     "GaussianRandomProjection",
     "GridSearchCV",

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -610,6 +610,11 @@ class GaussianMixture(BaseMixture):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    BayesianGaussianMixture : Gaussian mixture model fit with a variational
+        inference.
+
     Examples
     --------
     >>> import numpy as np
@@ -621,11 +626,6 @@ class GaussianMixture(BaseMixture):
            [ 1.,  2.]])
     >>> gm.predict([[0, 0], [12, 3]])
     array([1, 0])
-
-    See Also
-    --------
-    BayesianGaussianMixture : Gaussian mixture model fit with a variational
-        inference.
     """
 
     def __init__(
@@ -811,6 +811,7 @@ class GaussianMixture(BaseMixture):
         Parameters
         ----------
         X : array of shape (n_samples, n_dimensions)
+            The input samples.
 
         Returns
         -------
@@ -827,6 +828,7 @@ class GaussianMixture(BaseMixture):
         Parameters
         ----------
         X : array of shape (n_samples, n_dimensions)
+            The input samples.
 
         Returns
         -------


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures GaussianMixture is compatible with numpydoc.

- Remove `GaussianMixture` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.