### PR TITLE
API Deprecate `n_features_in_` from `Dummy*` 

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -335,6 +335,13 @@ Changelog
   in 1.2. Use the new parameters `alpha_W` and `alpha_H` instead. :pr:`20512` by
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+:mod:`sklearn.dummy`
+....................
+
+- |API| Attribute `n_features_in_` in :class:`dummy.DummyRegressor` and
+  :class:`dummy.DummyRegressor` is deprecated and will be removed in 1.2.
+  :pr:`20960` by `Thomas Fan`_.
+
 :mod:`sklearn.ensemble`
 .......................
 

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -10,6 +10,7 @@ import scipy.sparse as sp
 from .base import BaseEstimator, ClassifierMixin, RegressorMixin
 from .base import MultiOutputMixin
 from .utils import check_random_state
+from .utils import deprecated
 from .utils.validation import _num_samples
 from .utils.validation import check_array
 from .utils.validation import check_consistent_length
@@ -75,10 +76,12 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
     n_outputs_ : int
         Number of outputs.
 
-    n_features_in_ : int
-        Number of features seen during :term:`fit`.
+    n_features_in_ : `None`
+        Always set to `None`.
 
         .. versionadded:: 0.24
+        .. deprecated:: 1.0
+            Will be removed in 1.0
 
     sparse_output_ : bool
         True if the array returned from predict is to be in sparse CSC format.
@@ -163,8 +166,6 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
             y = np.reshape(y, (-1, 1))
 
         self.n_outputs_ = y.shape[1]
-
-        self.n_features_in_ = None  # No input validation is done for X
 
         check_consistent_length(X, y)
 
@@ -421,6 +422,16 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
             X = np.zeros(shape=(len(y), 1))
         return super().score(X, y, sample_weight)
 
+    # TODO: Remove in 1.2
+    # mypy error: Decorated property not supported
+    @deprecated(  # type: ignore
+        "`n_features_in_` is deprecated in 1.0 and will be removed in 1.2."
+    )
+    @property
+    def n_features_in_(self):
+        check_is_fitted(self)
+        return None
+
 
 class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     """Regressor that makes predictions using simple rules.
@@ -459,10 +470,12 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         Mean or median or quantile of the training targets or constant value
         given by the user.
 
-    n_features_in_ : int
-        Number of features seen during :term:`fit`.
+    n_features_in_ : `None`
+        Always set to `None`.
 
         .. versionadded:: 0.24
+        .. deprecated:: 1.0
+            Will be removed in 1.0
 
     n_outputs_ : int
         Number of outputs.
@@ -518,7 +531,6 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             )
 
         y = check_array(y, ensure_2d=False)
-        self.n_features_in_ = None  # No input validation is done for X
         if len(y) == 0:
             raise ValueError("y must not be empty.")
 
@@ -656,3 +668,13 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         if X is None:
             X = np.zeros(shape=(len(y), 1))
         return super().score(X, y, sample_weight)
+
+    # TODO: Remove in 1.2
+    # mypy error: Decorated property not supported
+    @deprecated(  # type: ignore
+        "`n_features_in_` is deprecated in 1.0 and will be removed in 1.2."
+    )
+    @property
+    def n_features_in_(self):
+        check_is_fitted(self)
+        return None

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -733,4 +733,7 @@ def test_n_features_in_(Dummy):
     d = Dummy()
     assert not hasattr(d, "n_features_in_")
     d.fit(X, y)
-    assert d.n_features_in_ is None
+
+    with pytest.warns(FutureWarning, match="`n_features_in_` is deprecated"):
+        n_features_in = d.n_features_in_
+    assert n_features_in is None


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/20874


#### What does this implement/fix? Explain your changes.
An alternative is to define `n_features_in_` and `feature_names_in_` and not validate.

CC @NicolasHug 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
