### PR TITLE
TST avoid FutureWarning due to n_features_in_ deprecation in Dummy*

### DIFF
--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -613,7 +613,7 @@ def test_calibration_votingclassifier():
     # defined via a property that only works when voting="soft".
     X, y = make_classification(n_samples=10, n_features=5, n_classes=2, random_state=7)
     vote = VotingClassifier(
-        estimators=[("dummy" + str(i), DummyClassifier()) for i in range(3)],
+        estimators=[("lr" + str(i), LogisticRegression()) for i in range(3)],
         voting="soft",
     )
     vote.fit(X, y)

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -726,6 +726,8 @@ def test_dtype_of_classifier_probas(strategy):
     assert probas.dtype == np.float64
 
 
+# TODO: remove in 1.2
+@pytest.mark.filterwarnings("ignore:`n_features_in_` is deprecated")
 @pytest.mark.parametrize("Dummy", (DummyRegressor, DummyClassifier))
 def test_n_features_in_(Dummy):
     X = [[1, 2]]

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -615,6 +615,7 @@ class DummyClassifierWithFitParams(DummyClassifier):
         return super().fit(X, y, sample_weight)
 
 
+@pytest.mark.filterwarnings("ignore:`n_features_in_` is deprecated")
 @pytest.mark.parametrize(
     "estimator, dataset",
     [


### PR DESCRIPTION
follow-up #20960

Removing the warning issued due to the deprecation of `n_features_in_` in `Dummy*`.