### PR TITLE
DOC Ensures that Birch passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -9,7 +9,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 
 # List of modules ignored when checking for numpydoc validation.
 DOCSTRING_IGNORE_LIST = [
-    "Birch",
     "GammaRegressor",
     "GaussianProcessRegressor",
     "GaussianRandomProjection",

--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -480,7 +480,7 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
     # TODO: Remove in 1.2
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "`fit_` is deprecated in 1.0 and will be removed in 1.2"
+        "`fit_` is deprecated in 1.0 and will be removed in 1.2."
     )
     @property
     def fit_(self):
@@ -489,7 +489,7 @@ class Birch(ClusterMixin, TransformerMixin, BaseEstimator):
     # TODO: Remove in 1.2
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
-        "`partial_fit_` is deprecated in 1.0 and will be removed in 1.2"
+        "`partial_fit_` is deprecated in 1.0 and will be removed in 1.2."
     )
     @property
     def partial_fit_(self):


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses to #20308 


#### What does this implement/fix? Explain your changes.

- `Birch` removed from `DOCSTRING_IGNORE_LIST` in test_docstrings.py.
- In `Birch`: period added in deprecated `fit_` and `partial_fit_` summaries.


