### PR TITLE
DOC Reword score_sample's and similar interfaces' docstrings

### DIFF
--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -235,7 +235,8 @@ class EmpiricalCovariance(BaseEstimator):
         return self
 
     def score(self, X_test, y=None):
-        """Compute the log-likelihood of a Gaussian data set with `self.covariance_`.
+        """Compute the log-likelihood of X_test under the Gaussian model
+         using `self.covariance_`.
 
         Parameters
         ----------
@@ -251,8 +252,8 @@ class EmpiricalCovariance(BaseEstimator):
         Returns
         -------
         res : float
-            The likelihood of the data set with `self.covariance_` as an
-            estimator of its covariance matrix.
+            The log-likelihood of X_test with `self.covariance_` as an
+            estimator of the Gaussian model covariance matrix.
         """
         X_test = self._validate_data(X_test, reset=False)
         # compute empirical covariance of the test set

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -235,8 +235,7 @@ class EmpiricalCovariance(BaseEstimator):
         return self
 
     def score(self, X_test, y=None):
-        """Compute the log-likelihood of X_test under the Gaussian model
-         using `self.covariance_`.
+        """Compute the log-likelihood of `X_test` under the Gaussian model using `self.covariance_`.
 
         Parameters
         ----------
@@ -252,7 +251,7 @@ class EmpiricalCovariance(BaseEstimator):
         Returns
         -------
         res : float
-            The log-likelihood of X_test with `self.covariance_` as an
+            The log-likelihood of `X_test` with `self.covariance_` as an
             estimator of the Gaussian model covariance matrix.
         """
         X_test = self._validate_data(X_test, reset=False)

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -235,7 +235,10 @@ class EmpiricalCovariance(BaseEstimator):
         return self
 
     def score(self, X_test, y=None):
-        """Compute the log-likelihood of `X_test` under the Gaussian model using `self.covariance_`.
+        """Compute the log-likelihood of `X_test` under the estimated Gaussian model.
+
+        The Gaussian model is defined by its mean and covariance matrix which are
+        represented respectively by `self.location_` and `self.covariance_`.
 
         Parameters
         ----------
@@ -251,8 +254,8 @@ class EmpiricalCovariance(BaseEstimator):
         Returns
         -------
         res : float
-            The log-likelihood of `X_test` with `self.covariance_` as an
-            estimator of the Gaussian model covariance matrix.
+            The log-likelihood of `X_test` with `self.location_` and `self.covariance_`
+            as estimators of the Gaussian model mean and covariance matrix respectively.
         """
         X_test = self._validate_data(X_test, reset=False)
         # compute empirical covariance of the test set

--- a/sklearn/mixture/_base.py
+++ b/sklearn/mixture/_base.py
@@ -335,7 +335,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         pass
 
     def score_samples(self, X):
-        """Compute the weighted log probabilities for each sample.
+        """Compute the log-likelihood of each sample.
 
         Parameters
         ----------
@@ -346,7 +346,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         log_prob : array, shape (n_samples,)
-            Log probabilities of each data point in X.
+            Log-likelihood of each sample in X under the current model.
         """
         check_is_fitted(self)
         X = self._validate_data(X, reset=False)
@@ -368,7 +368,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         log_likelihood : float
-            Log likelihood of the Gaussian mixture given X.
+            Log-likelihood of X under the Gaussian mixture model.
         """
         return self.score_samples(X).mean()
 
@@ -391,7 +391,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         return self._estimate_weighted_log_prob(X).argmax(axis=1)
 
     def predict_proba(self, X):
-        """Predict posterior probability of each component given the data.
+        """Evaluate the components' density for each sample.
 
         Parameters
         ----------
@@ -402,8 +402,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         resp : array, shape (n_samples, n_components)
-            Returns the probability each Gaussian (state) in
-            the model given each sample.
+            Density of each Gaussian component for each sample in X.
         """
         check_is_fitted(self)
         X = self._validate_data(X, reset=False)

--- a/sklearn/mixture/_base.py
+++ b/sklearn/mixture/_base.py
@@ -346,7 +346,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         log_prob : array, shape (n_samples,)
-            Log-likelihood of each sample in X under the current model.
+            Log-likelihood of each sample in `X` under the current model.
         """
         check_is_fitted(self)
         X = self._validate_data(X, reset=False)
@@ -368,7 +368,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         log_likelihood : float
-            Log-likelihood of X under the Gaussian mixture model.
+            Log-likelihood of `X` under the Gaussian mixture model.
         """
         return self.score_samples(X).mean()
 

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -208,7 +208,7 @@ class KernelDensity(BaseEstimator):
         return self
 
     def score_samples(self, X):
-        """Evaluate the log density model on the data.
+        """Compute the log-likelihood of each sample under the model.
 
         Parameters
         ----------
@@ -219,7 +219,7 @@ class KernelDensity(BaseEstimator):
         Returns
         -------
         density : ndarray of shape (n_samples,)
-            The array of log(density) evaluations. These are normalized to be
+            Log-likelihood of each sample in X. These are normalized to be
             probability densities, so values will be low for high-dimensional
             data.
         """
@@ -246,7 +246,7 @@ class KernelDensity(BaseEstimator):
         return log_density
 
     def score(self, X, y=None):
-        """Compute the total log probability density under the model.
+        """Compute the total log-likelihood under the model.
 
         Parameters
         ----------

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -219,7 +219,7 @@ class KernelDensity(BaseEstimator):
         Returns
         -------
         density : ndarray of shape (n_samples,)
-            Log-likelihood of each sample in X. These are normalized to be
+            Log-likelihood of each sample in `X`. These are normalized to be
             probability densities, so values will be low for high-dimensional
             data.
         """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

https://github.com/scikit-learn/scikit-learn/discussions/20957 request showed a mismatch between some of `GaussianMixture`'s interfaces' docstrings and the actual behavior and returned values: log-likelihoods are currently confused with log-probabilities.

#### What does this implement/fix? Explain your changes.

This reword doc-strings to use 'log-likelihood' where needed.
Also, this clarify some other doc-strings' wording.

#### Any other comments?

We potentially want to adapt this new wording, especially the use of "of" and "for" for the log-likelihood, to match with the most common one shall it exist.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
