### PR TITLE
DOC Ensures that SelectFdr passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -62,7 +62,6 @@ DOCSTRING_IGNORE_LIST = [
     "RobustScaler",
     "SGDOneClassSVM",
     "SGDRegressor",
-    "SelectFdr",
     "SelectFpr",
     "SelectFromModel",
     "SelectFwe",

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -699,7 +699,7 @@ class SelectFpr(_BaseFilter):
 
 
 class SelectFdr(_BaseFilter):
-    """Filter: Select the p-values for an estimated false discovery rate
+    """Filter: Select the p-values for an estimated false discovery rate.
 
     This uses the Benjamini-Hochberg procedure. ``alpha`` is an upper bound
     on the expected false discovery rate.
@@ -716,17 +716,6 @@ class SelectFdr(_BaseFilter):
 
     alpha : float, default=5e-2
         The highest uncorrected p-value for features to keep.
-
-    Examples
-    --------
-    >>> from sklearn.datasets import load_breast_cancer
-    >>> from sklearn.feature_selection import SelectFdr, chi2
-    >>> X, y = load_breast_cancer(return_X_y=True)
-    >>> X.shape
-    (569, 30)
-    >>> X_new = SelectFdr(chi2, alpha=0.01).fit_transform(X, y)
-    >>> X_new.shape
-    (569, 16)
 
     Attributes
     ----------
@@ -747,10 +736,6 @@ class SelectFdr(_BaseFilter):
 
         .. versionadded:: 1.0
 
-    References
-    ----------
-    https://en.wikipedia.org/wiki/False_discovery_rate
-
     See Also
     --------
     f_classif : ANOVA F-value between label/feature for classification tasks.
@@ -765,6 +750,21 @@ class SelectFdr(_BaseFilter):
     SelectFwe : Select features based on family-wise error rate.
     GenericUnivariateSelect : Univariate feature selector with configurable
         mode.
+
+    References
+    ----------
+    https://en.wikipedia.org/wiki/False_discovery_rate
+
+    Examples
+    --------
+    >>> from sklearn.datasets import load_breast_cancer
+    >>> from sklearn.feature_selection import SelectFdr, chi2
+    >>> X, y = load_breast_cancer(return_X_y=True)
+    >>> X.shape
+    (569, 30)
+    >>> X_new = SelectFdr(chi2, alpha=0.01).fit_transform(X, y)
+    >>> X_new.shape
+    (569, 16)
     """
 
     def __init__(self, score_func=f_classif, *, alpha=5e-2):


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures SelectFdr is compatible with numpydoc.

- Remove `SelectFdr` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.