### PR TITLE
FIX Fixes test for checking gitignore and Cython templates

### DIFF
--- a/sklearn/utils/tests/test_cython_templating.py
+++ b/sklearn/utils/tests/test_cython_templating.py
@@ -10,11 +10,11 @@ def test_files_generated_by_templates_are_git_ignored():
         pytest.skip("Tests are not run from the source folder")
 
     base_dir = pathlib.Path(sklearn.__file__).parent
-    ignored_files = open(gitignore_file, "r").readlines()
-    ignored_files = list(map(lambda line: line.strip("\n"), ignored_files))
+    ignored_files = gitignore_file.read_text().split("\n")
+    ignored_files = [pathlib.Path(line) for line in ignored_files]
 
     for filename in base_dir.glob("**/*.tp"):
         filename = filename.relative_to(base_dir.parent)
         # From "path/to/template.p??.tp" to "path/to/template.p??"
         filename_wo_tempita_suffix = filename.with_suffix("")
-        assert str(filename_wo_tempita_suffix) in ignored_files
+        assert filename_wo_tempita_suffix in ignored_files


### PR DESCRIPTION
Converting to string removed the windows compatible path.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #20996 20996
<!--
Fixes #20996 
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Removing string conversion and comparing objects by assert.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
