### PR TITLE
DOC - Ensures that GridSearchCV passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -11,7 +11,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 DOCSTRING_IGNORE_LIST = [
     "GaussianProcessRegressor",
     "GaussianRandomProjection",
-    "GridSearchCV",
     "HalvingGridSearchCV",
     "HalvingRandomSearchCV",
     "HashingVectorizer",

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -602,6 +602,12 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             Must fulfill the input assumptions of the
             underlying estimator.
 
+        Returns
+        -------
+        Xt : {array-like, sparse matrix} of shape (n_features,) \
+             or (n_samples, n_features)
+             X transformed in the new space based on the estimator with
+             the best found parameters.
         """
         check_is_fitted(self)
         return self.best_estimator_.transform(X)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -508,6 +508,11 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             Must fulfill the input assumptions of the
             underlying estimator.
 
+        Returns
+        -------
+        y : ndarray of shape (n_samples,)
+            The predicted labels or values for X based on the estimator with the
+            best found parameters.
         """
         check_is_fitted(self)
         return self.best_estimator_.predict(X)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -530,6 +530,12 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             Must fulfill the input assumptions of the
             underlying estimator.
 
+        Returns
+        -------
+        p : ndarray of shape (n_samples,) or (n_samples, n_classes)
+            Predicted class probabilities for X based on the estimator with
+            the best found parameters. The order of the classes corresponds
+            to that in the attribute :term:`classes_`.
         """
         check_is_fitted(self)
         return self.best_estimator_.predict_proba(X)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -614,6 +614,17 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
     @property
     def classes_(self):
+        """The class labels.
+
+        Only available if the underlying estimator implements
+        ``classes_`` and ``refit=True``.
+
+        Returns
+        ----------
+        classes_ : ndarray of shape (n_classes,)
+                   The class labels of the estimator with the best found
+                   paramaters.
+        """
         _estimator_has("classes_")(self)
         return self.best_estimator_.classes_
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -599,6 +599,12 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             Must fulfill the input assumptions of the
             underlying estimator.
 
+        Returns
+        -------
+        X : {ndarray, sparse matrix, list} of shape (n_features,) \
+            or (n_samples, n_features)
+            Result of the inverse_transform function for Xt based on the estimator
+            with the best found parameters.
         """
         check_is_fitted(self)
         return self.best_estimator_.inverse_transform(Xt)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -432,7 +432,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         return getattr(self.estimator, "_pairwise", False)
 
     def score(self, X, y=None):
-        """Returns the score on the given data, if the estimator has been refit.
+        """Return the score on the given data, if the estimator has been refit.
 
         This uses the score defined by ``scoring`` where provided, and the
         ``best_estimator_.score`` method otherwise.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -451,6 +451,8 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         score : float
+                The score defined by ``scoring`` if provided, and the
+                ``best_estimator_.score`` method otherwise.
         """
         _check_refit(self, "score")
         check_is_fitted(self)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -744,7 +744,12 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             instance (e.g., :class:`~sklearn.model_selection.GroupKFold`).
 
         **fit_params : dict of str -> object
-            Parameters passed to the ``fit`` method of the estimator
+            Parameters passed to the ``fit`` method of the estimator.
+
+        Returns
+        -------
+        self : object
+               Instance of fitted estimator.
         """
         estimator = self.estimator
         refit_metric = "score"

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -547,6 +547,12 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             Must fulfill the input assumptions of the
             underlying estimator.
 
+        Returns
+        -------
+        p : ndarray of shape (n_samples,) or (n_samples, n_classes)
+            Predicted class log-probabilities for X based on the estimator with
+            the best found parameters. The order of the classes corresponds
+            to that in the attribute :term:`classes_`.
         """
         check_is_fitted(self)
         return self.best_estimator_.predict_log_proba(X)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -611,6 +611,18 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
     @property
     def n_features_in_(self):
+        """Number of features seen during :term:`fit`.
+
+        Only available if `best_estimator_` is defined
+        (see the documentation for the `refit` parameter for more details)
+        and that `best_estimator_` exposes `feature_names_in_` when fit.
+
+        Returns
+        -------
+        n : int
+            Number of features seen during :term:`fit` based on the estimator
+            with the best found parameters.
+        """
         # For consistency with other estimators we raise a AttributeError so
         # that hasattr() fails if the search estimator isn't fitted.
         try:

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1002,7 +1002,7 @@ class GridSearchCV(BaseSearchCV):
 
     Parameters
     ----------
-    estimator : estimator object.
+    estimator : estimator object
         This is assumed to implement the scikit-learn estimator interface.
         Either estimator needs to provide a ``score`` function,
         or ``scoring`` must be passed.
@@ -1136,25 +1136,6 @@ class GridSearchCV(BaseSearchCV):
 
         .. versionchanged:: 0.21
             Default value was changed from ``True`` to ``False``
-
-
-    Examples
-    --------
-    >>> from sklearn import svm, datasets
-    >>> from sklearn.model_selection import GridSearchCV
-    >>> iris = datasets.load_iris()
-    >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
-    >>> svc = svm.SVC()
-    >>> clf = GridSearchCV(svc, parameters)
-    >>> clf.fit(iris.data, iris.target)
-    GridSearchCV(estimator=SVC(),
-                 param_grid={'C': [1, 10], 'kernel': ('linear', 'rbf')})
-    >>> sorted(clf.cv_results_.keys())
-    ['mean_fit_time', 'mean_score_time', 'mean_test_score',...
-     'param_C', 'param_kernel', 'params',...
-     'rank_test_score', 'split0_test_score',...
-     'split2_test_score', ...
-     'std_fit_time', 'std_score_time', 'std_test_score']
 
     Attributes
     ----------
@@ -1308,6 +1289,23 @@ class GridSearchCV(BaseSearchCV):
     sklearn.metrics.make_scorer : Make a scorer from a performance metric or
         loss function.
 
+    Examples
+    --------
+    >>> from sklearn import svm, datasets
+    >>> from sklearn.model_selection import GridSearchCV
+    >>> iris = datasets.load_iris()
+    >>> parameters = {'kernel':('linear', 'rbf'), 'C':[1, 10]}
+    >>> svc = svm.SVC()
+    >>> clf = GridSearchCV(svc, parameters)
+    >>> clf.fit(iris.data, iris.target)
+    GridSearchCV(estimator=SVC(),
+                 param_grid={'C': [1, 10], 'kernel': ('linear', 'rbf')})
+    >>> sorted(clf.cv_results_.keys())
+    ['mean_fit_time', 'mean_score_time', 'mean_test_score',...
+     'param_C', 'param_kernel', 'params',...
+     'rank_test_score', 'split0_test_score',...
+     'split2_test_score', ...
+     'std_fit_time', 'std_score_time', 'std_test_score']
     """
 
     _required_parameters = ["estimator", "param_grid"]

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -451,8 +451,8 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         score : float
-                The score defined by ``scoring`` if provided, and the
-                ``best_estimator_.score`` method otherwise.
+            The score defined by ``scoring`` if provided, and the
+            ``best_estimator_.score`` method otherwise.
         """
         _check_refit(self, "score")
         check_is_fitted(self)
@@ -493,7 +493,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         y_score : ndarray of shape (n_samples,)
-                  The ``best_estimator_.score_samples`` method.
+            The ``best_estimator_.score_samples`` method.
         """
         check_is_fitted(self)
         return self.best_estimator_.score_samples(X)
@@ -513,9 +513,9 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         Returns
         -------
-        y : ndarray of shape (n_samples,)
-            The predicted labels or values for X based on the estimator with the
-            best found parameters.
+        y_pred : ndarray of shape (n_samples,)
+            The predicted labels or values for `X` based on the estimator with
+            the best found parameters.
         """
         check_is_fitted(self)
         return self.best_estimator_.predict(X)
@@ -535,10 +535,10 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         Returns
         -------
-        p : ndarray of shape (n_samples,) or (n_samples, n_classes)
-            Predicted class probabilities for X based on the estimator with
+        y_pred : ndarray of shape (n_samples,) or (n_samples, n_classes)
+            Predicted class probabilities for `X` based on the estimator with
             the best found parameters. The order of the classes corresponds
-            to that in the attribute :term:`classes_`.
+            to that in the fitted attribute :term:`classes_`.
         """
         check_is_fitted(self)
         return self.best_estimator_.predict_proba(X)
@@ -558,10 +558,10 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         Returns
         -------
-        p : ndarray of shape (n_samples,) or (n_samples, n_classes)
-            Predicted class log-probabilities for X based on the estimator with
-            the best found parameters. The order of the classes corresponds
-            to that in the attribute :term:`classes_`.
+        y_pred : ndarray of shape (n_samples,) or (n_samples, n_classes)
+            Predicted class log-probabilities for `X` based on the estimator
+            with the best found parameters. The order of the classes
+            corresponds to that in the fitted attribute :term:`classes_`.
         """
         check_is_fitted(self)
         return self.best_estimator_.predict_log_proba(X)
@@ -581,10 +581,10 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         Returns
         -------
-        score : ndarray of shape (n_samples,) or (n_samples, n_classes) \
+        y_score : ndarray of shape (n_samples,) or (n_samples, n_classes) \
                 or (n_samples, n_classes * (n_classes-1) / 2)
-                Result of the decision function for X based on the estimator with
-                the best found parameters.
+            Result of the decision function for `X` based on the estimator with
+            the best found parameters.
         """
         check_is_fitted(self)
         return self.best_estimator_.decision_function(X)
@@ -604,10 +604,9 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         Returns
         -------
-        Xt : {array-like, sparse matrix} of shape (n_features,) \
-             or (n_samples, n_features)
-             X transformed in the new space based on the estimator with
-             the best found parameters.
+        Xt : {ndarray, sparse matrix} of shape (n_samples, n_features)
+            `X` transformed in the new space based on the estimator with
+            the best found parameters.
         """
         check_is_fitted(self)
         return self.best_estimator_.transform(X)
@@ -627,10 +626,9 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         Returns
         -------
-        X : {ndarray, sparse matrix, list} of shape (n_features,) \
-            or (n_samples, n_features)
-            Result of the inverse_transform function for Xt based on the estimator
-            with the best found parameters.
+        X : {ndarray, sparse matrix} of shape (n_samples, n_features)
+            Result of the `inverse_transform` function for `Xt` based on the
+            estimator with the best found parameters.
         """
         check_is_fitted(self)
         return self.best_estimator_.inverse_transform(Xt)
@@ -639,15 +637,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
     def n_features_in_(self):
         """Number of features seen during :term:`fit`.
 
-        Only available if `best_estimator_` is defined
-        (see the documentation for the `refit` parameter for more details)
-        and that `best_estimator_` exposes `feature_names_in_` when fit.
-
-        Returns
-        -------
-        n : int
-            Number of features seen during :term:`fit` based on the estimator
-            with the best found parameters.
+        Only available when `refit=True`.
         """
         # For consistency with other estimators we raise a AttributeError so
         # that hasattr() fails if the search estimator isn't fitted.
@@ -664,16 +654,9 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
     @property
     def classes_(self):
-        """The class labels.
+        """Class labels.
 
-        Only available if the underlying estimator implements
-        ``classes_`` and ``refit=True``.
-
-        Returns
-        ----------
-        classes_ : ndarray of shape (n_classes,)
-                   The class labels of the estimator with the best found
-                   paramaters.
+        Only available when `refit=True` and the estimator is a classifier.
         """
         _estimator_has("classes_")(self)
         return self.best_estimator_.classes_
@@ -799,7 +782,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         self : object
-               Instance of fitted estimator.
+            Instance of fitted estimator.
         """
         estimator = self.estimator
         refit_metric = "score"

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -493,6 +493,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         y_score : ndarray of shape (n_samples,)
+                  The ``best_estimator_.score_samples`` method.
         """
         check_is_fitted(self)
         return self.best_estimator_.score_samples(X)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -559,6 +559,12 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             Must fulfill the input assumptions of the
             underlying estimator.
 
+        Returns
+        -------
+        score : ndarray of shape (n_samples,) or (n_samples, n_classes) \
+                or (n_samples, n_classes * (n_classes-1) / 2)
+                Result of the decision function for X based on the estimator with
+                the best found parameters.
         """
         check_is_fitted(self)
         return self.best_estimator_.decision_function(X)


### PR DESCRIPTION

#### Reference Issues/PRs
Addresses #20308 

#### What does this implement/fix? Explain your changes.
Ensure GridSearchCV passes numpydoc validation by making changes to sklearn/model_selection/_search.py:
GridSearchCV
GridSearchCV.classes_
GridSearchCV.decision_function
GridSearchCV.fit
GridSearchCV.inverse_transform
GridSearchCV.n_features_in_
GridSearchCV.predict
GridSearchCV.predict_log_proba
GridSearchCV.predict_proba
GridSearchCV.score
GridSearchCV.score_samples
GridSearchCV.transform

#### Any other comments?
