### PR TITLE
DOC Ensures that OPTICS passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -34,7 +34,6 @@ DOCSTRING_IGNORE_LIST = [
     "NearestCentroid",
     "NeighborhoodComponentsAnalysis",
     "Normalizer",
-    "OPTICS",
     "OneVsOneClassifier",
     "OneVsRestClassifier",
     "OrdinalEncoder",

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -268,13 +268,13 @@ class OPTICS(ClusterMixin, BaseEstimator):
             A feature array, or array of distances between samples if
             metric='precomputed'.
 
-        y : ignored
-            Ignored.
+        y : Ignored
+            Not used, present for API consistency by convention.
 
         Returns
         -------
-        self : instance of OPTICS
-            The instance.
+        self : object
+            Returns a fitted instance of self.
         """
         dtype = bool if self.metric in PAIRWISE_BOOLEAN_FUNCTIONS else float
         if dtype == bool and X.dtype != bool:
@@ -360,7 +360,7 @@ def _validate_size(size, n_samples, param_name):
 
 # OPTICS helper functions
 def _compute_core_distances_(X, neighbors, min_samples, working_memory):
-    """Compute the k-th nearest neighbor of each sample
+    """Compute the k-th nearest neighbor of each sample.
 
     Equivalent to neighbors.kneighbors(X, self.min_samples)[0][:, -1]
     but with more memory efficiency.


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures OPTICS is compatible with numpydoc.

- Remove `OPTICS` from `DOCSTRING_IGNORE_LIST`.
- Made some minor changes to the docstrings  from OPTICS.