### PR TITLE
Add custom_range argument for partial dependence

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -413,9 +413,9 @@ Changelog
 :mod:`sklearn.inspection`
 .........................
 
-- |Feature| Add `custom_grid` parameter in
-  :func:`inspection.partial_dependence`. It enables users to pass their own grid
-  of values at which the partial dependence should be calculated.
+- |Feature| Add `custom_range` parameter in
+  :func:`inspection.partial_dependence`. It enables users to pass their own range
+  of values at which the partial dependence should be calculated for a given feature.
   :pr:`21033` by :user:`Freddy A. Boulton <freddyaboulton>`.
 
 :mod:`sklearn.utils`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -410,6 +410,16 @@ Changelog
 - |API| Adds :meth:`get_feature_names_out` to :class:`impute.SimpleImputer`,
   :class:`impute.KNNImputer`, :class:`impute.IterativeImputer`, and
   :class:`impute.MissingIndicator`. :pr:`21078` by `Thomas Fan`_.
+:mod:`sklearn.inspection`
+.........................
+
+- |Feature| Add `custom_grid` parameter in
+  :func:`inspection.partial_dependence`. It enables users to pass their own grid
+    of values at which the partial dependence should be calculated.
+  :pr:`21033` by :user:`Freddy A. Boulton <freddyaboulton>`.
+
+:mod:`sklearn.utils`
+....................
 
 - |API| The `verbose` parameter was deprecated for :class:`impute.SimpleImputer`.
   A warning will always be raised upon the removal of empty columns.

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -410,10 +410,11 @@ Changelog
 - |API| Adds :meth:`get_feature_names_out` to :class:`impute.SimpleImputer`,
   :class:`impute.KNNImputer`, :class:`impute.IterativeImputer`, and
   :class:`impute.MissingIndicator`. :pr:`21078` by `Thomas Fan`_.
+
 :mod:`sklearn.inspection`
 .........................
 
-- |Feature| Add `custom_range` parameter in
+- |Feature| Add `custom_values` parameter in
   :func:`inspection.partial_dependence`. It enables users to pass their own range
   of values at which the partial dependence should be calculated for a given feature.
   :pr:`21033` by :user:`Freddy A. Boulton <freddyaboulton>`.

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -415,7 +415,7 @@ Changelog
 
 - |Feature| Add `custom_grid` parameter in
   :func:`inspection.partial_dependence`. It enables users to pass their own grid
-    of values at which the partial dependence should be calculated.
+  of values at which the partial dependence should be calculated.
   :pr:`21033` by :user:`Freddy A. Boulton <freddyaboulton>`.
 
 :mod:`sklearn.utils`

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -105,6 +105,54 @@ def _grid_from_X(X, percentiles, grid_resolution):
     return cartesian(values), values
 
 
+def _grid_from_custom_grid(features, custom_grid):
+    """Generate a cartesian product of the 1-d grids in custom_grid.
+
+    Parameters
+    ----------
+    features : scalar, array-like
+        The features for which the partial dependency should be computed.
+
+    custom_grid : dict
+        A dictionary mapping an element of `features` to an array of values where
+        the partial dependence should be calculated for that feature
+
+    Returns
+    -------
+    grid : ndarray, shape (n_points, n_target_features)
+        A value for each feature at each point in the grid. ``n_points`` is
+        the product of the lengths of the arrays in custom_grid.
+
+    values : list of 1d ndarrays
+        The values with which the grid has been created. The size of each
+        array ``values[j]`` is the size of the grid in custom_grid.
+    """
+
+    if isinstance(features, (str, int, float, bool)):
+        features = [features]
+    if set(features) != custom_grid.keys():
+        raise ValueError(
+            "If custom_grid is specified, its keys must equal the values in features!"
+        )
+    values = []
+    for feature in features:
+        value = custom_grid[feature]
+        if not isinstance(value, np.ndarray):
+            value = np.array(value)
+        if value.ndim != 1:
+            raise ValueError(
+                "Grid for feature {} is not a one-dimensional array. Got {} dimensions"
+                .format(feature, value.ndim)
+            )
+        values.append(value)
+    shape = (len(v) for v in values)
+    ix = np.indices(shape)
+    ix = ix.reshape(len(values), -1).T
+    out = np.empty_like(ix, dtype=object)
+    grid = cartesian(values, out)
+    return grid, values
+
+
 def _partial_dependence_recursion(est, grid, features):
     averaged_predictions = est._compute_partial_dependence_recursion(grid, features)
     if averaged_predictions.ndim == 1:
@@ -214,6 +262,7 @@ def partial_dependence(
     grid_resolution=100,
     method="auto",
     kind="average",
+    custom_grid=None,
 ):
     """Partial dependence of ``features``.
 
@@ -314,6 +363,12 @@ def partial_dependence(
         slower `method='brute'` option.
 
         .. versionadded:: 0.24
+
+    custom_grid: dict
+        A dictionary mapping an element of `features` to an array of values where
+        the partial dependence should be calculated for that feature. The length
+        of `custom_grid` must match the length of `features`.
+
 
     Returns
     -------
@@ -457,9 +512,13 @@ def partial_dependence(
         _get_column_indices(X, features), dtype=np.int32, order="C"
     ).ravel()
 
-    grid, values = _grid_from_X(
-        _safe_indexing(X, features_indices, axis=1), percentiles, grid_resolution
-    )
+    custom_grid = custom_grid or {}
+    if custom_grid:
+        grid, values = _grid_from_custom_grid(features, custom_grid)
+    else:
+        grid, values = _grid_from_X(
+            _safe_indexing(X, features_indices, axis=1), percentiles, grid_resolution
+        )
 
     if method == "brute":
         averaged_predictions, predictions = _partial_dependence_brute(

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -312,6 +312,7 @@ def partial_dependence(
 
     method : {'auto', 'recursion', 'brute'}, default='auto'
         The method used to calculate the averaged predictions:
+
         - `'recursion'` is only supported for some tree-based estimators
           (namely
           :class:`~sklearn.ensemble.GradientBoostingClassifier`,
@@ -328,10 +329,13 @@ def partial_dependence(
           the average of the Individual Conditional Expectation (ICE) by
           design, it is not compatible with ICE and thus `kind` must be
           `'average'`.
+
         - `'brute'` is supported for any estimator, but is more
           computationally intensive.
+
         - `'auto'`: the `'recursion'` is used for estimators that support it,
           and `'brute'` is used otherwise.
+
         Please see :ref:`this note <pdp_method_differences>` for
         differences between the `'brute'` and `'recursion'` method.
 
@@ -339,9 +343,11 @@ def partial_dependence(
         Whether to return the partial dependence averaged across all the
         samples in the dataset or one line per sample or both.
         See Returns below.
+
         Note that the fast `method='recursion'` option is only available for
         `kind='average'`. Plotting individual dependencies requires using the
         slower `method='brute'` option.
+
         .. versionadded:: 0.24
 
     custom_values: dict

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -36,29 +36,36 @@ __all__ = [
 
 def _grid_from_X(X, percentiles, grid_resolution, custom_values):
     """Generate a grid of points based on the percentiles of X.
+
     The grid is a cartesian product between the columns of ``values``. The
     ith column of ``values`` consists in ``grid_resolution`` equally-spaced
     points between the percentiles of the jth column of X.
     If ``grid_resolution`` is bigger than the number of unique values in the
     jth column of X, then those unique values will be used instead.
+
     Parameters
     ----------
     X : ndarray, shape (n_samples, n_target_features)
         The data.
+
     percentiles : tuple of floats
         The percentiles which are used to construct the extreme values of
         the grid. Must be in [0, 1].
+
     grid_resolution : int
         The number of equally spaced points to be placed on the grid for each
         feature.
+
     custom_values: dict
         Mapping from column index of X to an array-like of values where
         the partial dependence should be calculated for that feature
+
     Returns
     -------
     grid : ndarray, shape (n_points, n_target_features)
         A value for each feature at each point in the grid. ``n_points`` is
         always ``<= grid_resolution ** X.shape[1]``.
+
     values : list of 1d ndarrays
         The values with which the grid has been created. The size of each
         array ``values[j]`` is either ``grid_resolution``, the number of

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -119,17 +119,22 @@ def _grid_from_X(X, percentiles, grid_resolution, custom_values):
                 )
         values.append(axis)
 
-    # Store cartesian in grid of dtype=object to support grids of str/numeric values
+    # Create a place holder for the cartesian product of the individual grids.
     shape = (len(v) for v in values)
     ix = np.indices(shape)
     ix = ix.reshape(len(values), -1).T
 
+    # If the user is computing partial dependence for a mix of
+    # numeric/non-numeric features we use object dtype.
+    # Else, we use the first dtype in values,
+    # which is the default behavior of the cartesian function.
     dtypes = [arr.dtype for arr in values]
     out_dtype = (
         object
         if any(not np.issubdtype(dtype, np.number) for dtype in dtypes)
         else dtypes[0]
     )
+
     out = np.empty_like(ix, dtype=out_dtype)
     return cartesian(values, out), values
 

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -244,11 +244,15 @@ def partial_dependence(
     custom_values=None,
 ):
     """Partial dependence of ``features``.
+
     Partial dependence of a feature (or a set of features) corresponds to
     the average response of an estimator for each possible value of the
     feature.
+
     Read more in the :ref:`User Guide <partial_dependence>`.
+
     .. warning::
+
         For :class:`~sklearn.ensemble.GradientBoostingClassifier` and
         :class:`~sklearn.ensemble.GradientBoostingRegressor`, the
         `'recursion'` method (used by default) will not account for the `init`
@@ -263,20 +267,24 @@ def partial_dependence(
         :class:`~sklearn.ensemble.GradientBoostingRegressor`, not to
         :class:`~sklearn.ensemble.HistGradientBoostingClassifier` and
         :class:`~sklearn.ensemble.HistGradientBoostingRegressor`.
+
     Parameters
     ----------
     estimator : BaseEstimator
         A fitted estimator object implementing :term:`predict`,
         :term:`predict_proba`, or :term:`decision_function`.
         Multioutput-multiclass classifiers are not supported.
+
     X : {array-like or dataframe} of shape (n_samples, n_features)
         ``X`` is used to generate a grid of values for the target
         ``features`` (where the partial dependence will be evaluated), and
         also to generate values for the complement features when the
         `method` is 'brute'.
+
     features : array-like of {int, str}
         The feature (e.g. `[0]`) or pair of interacting features
         (e.g. `[(0, 1)]`) for which the partial dependency should be computed.
+
     response_method : {'auto', 'predict_proba', 'decision_function'}, \
             default='auto'
         Specifies whether to use :term:`predict_proba` or
@@ -286,12 +294,15 @@ def partial_dependence(
         and we revert to :term:`decision_function` if it doesn't exist. If
         ``method`` is 'recursion', the response is always the output of
         :term:`decision_function`.
+
     percentiles : tuple of float, default=(0.05, 0.95)
         The lower and upper percentile used to create the extreme values
         for the grid. Must be in [0, 1].
+
     grid_resolution : int, default=100
         The number of equally spaced points on the grid, for each target
         feature.
+
     method : {'auto', 'recursion', 'brute'}, default='auto'
         The method used to calculate the averaged predictions:
         - `'recursion'` is only supported for some tree-based estimators

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -36,36 +36,29 @@ __all__ = [
 
 def _grid_from_X(X, percentiles, grid_resolution, custom_values):
     """Generate a grid of points based on the percentiles of X.
-
     The grid is a cartesian product between the columns of ``values``. The
     ith column of ``values`` consists in ``grid_resolution`` equally-spaced
     points between the percentiles of the jth column of X.
     If ``grid_resolution`` is bigger than the number of unique values in the
     jth column of X, then those unique values will be used instead.
-
     Parameters
     ----------
     X : ndarray, shape (n_samples, n_target_features)
         The data.
-
     percentiles : tuple of floats
         The percentiles which are used to construct the extreme values of
         the grid. Must be in [0, 1].
-
     grid_resolution : int
         The number of equally spaced points to be placed on the grid for each
         feature.
-
     custom_values: dict
         Mapping from column index of X to an array-like of values where
         the partial dependence should be calculated for that feature
-
     Returns
     -------
     grid : ndarray, shape (n_points, n_target_features)
         A value for each feature at each point in the grid. ``n_points`` is
         always ``<= grid_resolution ** X.shape[1]``.
-
     values : list of 1d ndarrays
         The values with which the grid has been created. The size of each
         array ``values[j]`` is either ``grid_resolution``, the number of
@@ -251,15 +244,11 @@ def partial_dependence(
     custom_values=None,
 ):
     """Partial dependence of ``features``.
-
     Partial dependence of a feature (or a set of features) corresponds to
     the average response of an estimator for each possible value of the
     feature.
-
     Read more in the :ref:`User Guide <partial_dependence>`.
-
     .. warning::
-
         For :class:`~sklearn.ensemble.GradientBoostingClassifier` and
         :class:`~sklearn.ensemble.GradientBoostingRegressor`, the
         `'recursion'` method (used by default) will not account for the `init`
@@ -274,24 +263,20 @@ def partial_dependence(
         :class:`~sklearn.ensemble.GradientBoostingRegressor`, not to
         :class:`~sklearn.ensemble.HistGradientBoostingClassifier` and
         :class:`~sklearn.ensemble.HistGradientBoostingRegressor`.
-
     Parameters
     ----------
     estimator : BaseEstimator
         A fitted estimator object implementing :term:`predict`,
         :term:`predict_proba`, or :term:`decision_function`.
         Multioutput-multiclass classifiers are not supported.
-
     X : {array-like or dataframe} of shape (n_samples, n_features)
         ``X`` is used to generate a grid of values for the target
         ``features`` (where the partial dependence will be evaluated), and
         also to generate values for the complement features when the
         `method` is 'brute'.
-
     features : array-like of {int, str}
         The feature (e.g. `[0]`) or pair of interacting features
         (e.g. `[(0, 1)]`) for which the partial dependency should be computed.
-
     response_method : {'auto', 'predict_proba', 'decision_function'}, \
             default='auto'
         Specifies whether to use :term:`predict_proba` or
@@ -301,18 +286,14 @@ def partial_dependence(
         and we revert to :term:`decision_function` if it doesn't exist. If
         ``method`` is 'recursion', the response is always the output of
         :term:`decision_function`.
-
     percentiles : tuple of float, default=(0.05, 0.95)
         The lower and upper percentile used to create the extreme values
         for the grid. Must be in [0, 1].
-
     grid_resolution : int, default=100
         The number of equally spaced points on the grid, for each target
         feature.
-
     method : {'auto', 'recursion', 'brute'}, default='auto'
         The method used to calculate the averaged predictions:
-
         - `'recursion'` is only supported for some tree-based estimators
           (namely
           :class:`~sklearn.ensemble.GradientBoostingClassifier`,
@@ -329,13 +310,10 @@ def partial_dependence(
           the average of the Individual Conditional Expectation (ICE) by
           design, it is not compatible with ICE and thus `kind` must be
           `'average'`.
-
         - `'brute'` is supported for any estimator, but is more
           computationally intensive.
-
         - `'auto'`: the `'recursion'` is used for estimators that support it,
           and `'brute'` is used otherwise.
-
         Please see :ref:`this note <pdp_method_differences>` for
         differences between the `'brute'` and `'recursion'` method.
 
@@ -343,19 +321,15 @@ def partial_dependence(
         Whether to return the partial dependence averaged across all the
         samples in the dataset or one line per sample or both.
         See Returns below.
-
         Note that the fast `method='recursion'` option is only available for
         `kind='average'`. Plotting individual dependencies requires using the
         slower `method='brute'` option.
-
         .. versionadded:: 0.24
 
     custom_values: dict
-        A dictionary mapping an element of `features` to an array of values where
+        A dictionary mapping the index of an element of `features` to an array of values where
         the partial dependence should be calculated for that feature. Setting a range
         of values for a feature overrides `grid_resolution` and `percentiles`.
-
-
     Returns
     -------
     predictions : :class:`~sklearn.utils.Bunch`
@@ -390,7 +364,6 @@ def partial_dependence(
     --------
     PartialDependenceDisplay.from_estimator : Plot Partial Dependence.
     PartialDependenceDisplay : Partial Dependence visualization.
-
     Examples
     --------
     >>> X = [[0, 0, 2], [1, 0, 0]]

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -366,6 +366,7 @@ def partial_dependence(
     --------
     PartialDependenceDisplay.from_estimator : Plot Partial Dependence.
     PartialDependenceDisplay : Partial Dependence visualization.
+
     Examples
     --------
     >>> X = [[0, 0, 2], [1, 0, 0]]

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -327,9 +327,11 @@ def partial_dependence(
         .. versionadded:: 0.24
 
     custom_values: dict
-        A dictionary mapping the index of an element of `features` to an array of values where
-        the partial dependence should be calculated for that feature. Setting a range
-        of values for a feature overrides `grid_resolution` and `percentiles`.
+        A dictionary mapping the index of an element of `features` to an array
+        of values where the partial dependence should be calculated
+        for that feature. Setting a range of values for a feature overrides
+        `grid_resolution` and `percentiles`.
+
     Returns
     -------
     predictions : :class:`~sklearn.utils.Bunch`

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -44,6 +44,7 @@ def plot_partial_dependence(
     kind="average",
     subsample=1000,
     random_state=None,
+    custom_values=None,
 ):
     """Partial dependence (PD) and individual conditional expectation (ICE)
     plots.
@@ -283,6 +284,11 @@ def plot_partial_dependence(
 
         .. versionadded:: 0.24
 
+    custom_values: dict
+        A dictionary mapping the index of an element of `features` to an array of values where
+        the partial dependence should be calculated for that feature. Setting a range
+        of values for a feature overrides `grid_resolution` and `percentiles`.
+
     Returns
     -------
     display : :class:`~sklearn.inspection.PartialDependenceDisplay`
@@ -327,6 +333,7 @@ def plot_partial_dependence(
         kind=kind,
         subsample=subsample,
         random_state=random_state,
+        custom_values=custom_values,
     )
 
 
@@ -353,6 +360,7 @@ def _plot_partial_dependence(
     kind="average",
     subsample=1000,
     random_state=None,
+    custom_values=None,
 ):
     """See PartialDependenceDisplay.from_estimator for details"""
     import matplotlib.pyplot as plt  # noqa
@@ -486,6 +494,7 @@ def _plot_partial_dependence(
             grid_resolution=grid_resolution,
             percentiles=percentiles,
             kind=kind_plot,
+            custom_values=custom_values,
         )
         for kind_plot, fxs in zip(kind_, features)
     )
@@ -749,6 +758,7 @@ class PartialDependenceDisplay:
         kind="average",
         subsample=1000,
         random_state=None,
+        custom_values=None,
     ):
         """Partial dependence (PD) and individual conditional expectation (ICE) plots.
 
@@ -952,6 +962,11 @@ class PartialDependenceDisplay:
             `None` and `kind` is either `'both'` or `'individual'`.
             See :term:`Glossary <random_state>` for details.
 
+        custom_values : dict
+            A dictionary mapping the index of an element of `features` to an array of values where
+            the partial dependence should be calculated for that feature. Setting a range
+            of values for a feature overrides `grid_resolution` and `percentiles`.
+
         Returns
         -------
         display : :class:`~sklearn.inspection.PartialDependenceDisplay`
@@ -994,6 +1009,7 @@ class PartialDependenceDisplay:
             kind=kind,
             subsample=subsample,
             random_state=random_state,
+            custom_values=custom_values,
         )
 
     def _get_sample_count(self, n_samples):

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -285,9 +285,10 @@ def plot_partial_dependence(
         .. versionadded:: 0.24
 
     custom_values: dict
-        A dictionary mapping the index of an element of `features` to an array of values where
-        the partial dependence should be calculated for that feature. Setting a range
-        of values for a feature overrides `grid_resolution` and `percentiles`.
+        A dictionary mapping the index of an element of `features` to an
+        array of values where the partial dependence should be calculated
+        for that feature. Setting a range of values for a feature overrides
+        `grid_resolution` and `percentiles`.
 
     Returns
     -------
@@ -963,9 +964,10 @@ class PartialDependenceDisplay:
             See :term:`Glossary <random_state>` for details.
 
         custom_values : dict
-            A dictionary mapping the index of an element of `features` to an array of values where
-            the partial dependence should be calculated for that feature. Setting a range
-            of values for a feature overrides `grid_resolution` and `percentiles`.
+            A dictionary mapping the index of an element of `features` to an
+            array of values where the partial dependence should be calculated
+            for that feature. Setting a range of values for a feature overrides
+            `grid_resolution` and `percentiles`.
 
         Returns
         -------

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -177,7 +177,7 @@ def test_grid_from_X():
     assert axes[0].shape == (n_unique_values,)
     assert axes[1].shape == (grid_resolution,)
 
-    # Check that uses custom_grid
+    # Check that uses custom_range
     X = rng.normal(size=(20, 2))
     X[n_unique_values - 1 :, 0] = 12345
     col_1_range = [0, 2, 3]
@@ -189,7 +189,7 @@ def test_grid_from_X():
     assert axes[0].shape == (n_unique_values,)
     assert axes[1].shape == (len(col_1_range),)
 
-    # Check that grid_resolution does not impact custom_grid
+    # Check that grid_resolution does not impact custom_range
     X = rng.normal(size=(20, 2))
     col_0_range = [0, 2, 3, 4, 5, 6]
     grid_resolution = 5

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -8,9 +8,7 @@ import pytest
 import sklearn
 from sklearn.inspection import partial_dependence
 from sklearn.inspection._partial_dependence import (
-    cartesian,
     _grid_from_X,
-    _grid_from_custom_grid,
     _partial_dependence_brute,
     _partial_dependence_recursion,
 )
@@ -88,9 +86,9 @@ iris = load_iris()
 @pytest.mark.parametrize("grid_resolution", (5, 10))
 @pytest.mark.parametrize("features", ([1], [1, 2]))
 @pytest.mark.parametrize("kind", ("average", "individual", "both"))
-@pytest.mark.parametrize("use_custom_grid", [True, False])
+@pytest.mark.parametrize("use_custom_range", [True, False])
 def test_output_shape(
-    Estimator, method, data, grid_resolution, features, kind, use_custom_grid
+    Estimator, method, data, grid_resolution, features, kind, use_custom_range
 ):
     # Check that partial_dependence has consistent output shape for different
     # kinds of estimators:
@@ -106,10 +104,10 @@ def test_output_shape(
     (X, y), n_targets = data
     n_instances = X.shape[0]
 
-    custom_grid = None
-    if use_custom_grid:
+    custom_range = None
+    if use_custom_range:
         grid_resolution = 5
-        custom_grid = {f: X[:grid_resolution, f] for f in features}
+        custom_range = {f: X[:grid_resolution, f] for f in features}
 
     est.fit(X, y)
     result = partial_dependence(
@@ -119,7 +117,7 @@ def test_output_shape(
         method=method,
         kind=kind,
         grid_resolution=grid_resolution,
-        custom_grid=custom_grid,
+        custom_range=custom_range,
     )
     pdp, axes = result, result["values"]
 
@@ -150,7 +148,7 @@ def test_grid_from_X():
     percentiles = (0.05, 0.95)
     grid_resolution = 100
     X = np.asarray([[1, 2], [3, 4]])
-    grid, axes = _grid_from_X(X, percentiles, grid_resolution)
+    grid, axes = _grid_from_X(X, percentiles, grid_resolution, {})
     assert_array_equal(grid, [[1, 2], [1, 4], [3, 2], [3, 4]])
     assert_array_equal(axes, X.T)
 
@@ -161,7 +159,9 @@ def test_grid_from_X():
 
     # n_unique_values > grid_resolution
     X = rng.normal(size=(20, 2))
-    grid, axes = _grid_from_X(X, percentiles, grid_resolution=grid_resolution)
+    grid, axes = _grid_from_X(
+        X, percentiles, grid_resolution=grid_resolution, custom_range={}
+    )
     assert grid.shape == (grid_resolution * grid_resolution, X.shape[1])
     assert np.asarray(axes).shape == (2, grid_resolution)
 
@@ -169,35 +169,37 @@ def test_grid_from_X():
     n_unique_values = 12
     X[n_unique_values - 1 :, 0] = 12345
     rng.shuffle(X)  # just to make sure the order is irrelevant
-    grid, axes = _grid_from_X(X, percentiles, grid_resolution=grid_resolution)
+    grid, axes = _grid_from_X(
+        X, percentiles, grid_resolution=grid_resolution, custom_range={}
+    )
     assert grid.shape == (n_unique_values * grid_resolution, X.shape[1])
     # axes is a list of arrays of different shapes
     assert axes[0].shape == (n_unique_values,)
     assert axes[1].shape == (grid_resolution,)
 
+    # Check that uses custom_grid
+    X = rng.normal(size=(20, 2))
+    X[n_unique_values - 1 :, 0] = 12345
+    col_1_range = [0, 2, 3]
+    grid, axes = _grid_from_X(
+        X, percentiles, grid_resolution=grid_resolution, custom_range={1: col_1_range}
+    )
+    assert grid.shape == (n_unique_values * len(col_1_range), X.shape[1])
+    # axes is a list of arrays of different shapes
+    assert axes[0].shape == (n_unique_values,)
+    assert axes[1].shape == (len(col_1_range),)
 
-@pytest.mark.parametrize(
-    "custom_grid, features",
-    [
-        (
-            {
-                1: np.array([1, 2, 3]),
-                2: np.array([1, 2, 3]),
-                "foo": np.array([4, 5, 6]),
-            },
-            [1, 2, "foo"],
-        ),
-        (
-            {1: [1, 2, 3], 2: np.array([1, 2, 3]), "foo": np.array([4, 5, 6])},
-            [1, "foo", 2],
-        ),
-    ],
-)
-def test_grid_from_custom_grid(custom_grid, features):
-    grid, values = _grid_from_custom_grid(features, custom_grid)
-    np.testing.assert_array_equal(grid, cartesian(values))
-    for val, feature in zip(values, features):
-        np.testing.assert_array_equal(val, custom_grid[feature])
+    # Check that grid_resolution does not impact custom_grid
+    X = rng.normal(size=(20, 2))
+    col_0_range = [0, 2, 3, 4, 5, 6]
+    grid_resolution = 5
+    grid, axes = _grid_from_X(
+        X, percentiles, grid_resolution=grid_resolution, custom_range={0: col_0_range}
+    )
+    assert grid.shape == (grid_resolution * len(col_0_range), X.shape[1])
+    # axes is a list of arrays of different shapes
+    assert axes[0].shape == (len(col_0_range),)
+    assert axes[1].shape == (grid_resolution,)
 
 
 @pytest.mark.parametrize(
@@ -215,7 +217,9 @@ def test_grid_from_custom_grid(custom_grid, features):
 def test_grid_from_X_error(grid_resolution, percentiles, err_msg):
     X = np.asarray([[1, 2], [3, 4]])
     with pytest.raises(ValueError, match=err_msg):
-        _grid_from_X(X, grid_resolution=grid_resolution, percentiles=percentiles)
+        _grid_from_X(
+            X, grid_resolution=grid_resolution, percentiles=percentiles, custom_range={}
+        )
 
 
 @pytest.mark.parametrize("target_feature", range(5))
@@ -529,20 +533,7 @@ class NoPredictProbaNoDecisionFunction(ClassifierMixin, BaseEstimator):
         ),
         (
             LinearRegression(),
-            {"features": [0, 1], "custom_grid": {0: [1, 2, 3]}},
-            "If custom_grid is specified, its keys must equal the values in features!",
-        ),
-        (
-            LinearRegression(),
-            {
-                "features": [0, 1],
-                "custom_grid": {0: [1, 2, 3], 1: [4, 5, 6], 2: [7, 8, 9]},
-            },
-            "If custom_grid is specified, its keys must equal the values in features!",
-        ),
-        (
-            LinearRegression(),
-            {"features": [0, 1], "custom_grid": {0: [1, 2, 3], 1: np.ones((3, 3))}},
+            {"features": [0, 1], "custom_range": {0: [1, 2, 3], 1: np.ones((3, 3))}},
             "Grid for feature 1 is not a one-dimensional array. Got 2 dimensions",
         ),
     ],
@@ -696,15 +687,15 @@ def test_partial_dependence_pipeline():
 
 
 @pytest.mark.parametrize(
-    "features, custom_grid, n_vals_expected",
+    "features, custom_range, n_vals_expected",
     [
         (["b"], {"b": ["a", "b"]}, 2),
         (["b"], {"b": ["a"]}, 1),
         (["a", "b"], {"a": [1, 2], "b": ["a", "b"]}, 4),
     ],
 )
-def test_partial_dependence_pipeline_custom_grid(
-    features, custom_grid, n_vals_expected
+def test_partial_dependence_pipeline_custom_range(
+    features, custom_range, n_vals_expected
 ):
     pd = pytest.importorskip("pandas")
     pl = make_pipeline(
@@ -721,7 +712,7 @@ def test_partial_dependence_pipeline_custom_grid(
         X_holdout,
         features=features,
         grid_resolution=3,
-        custom_grid=custom_grid,
+        custom_range=custom_range,
         kind="average",
     )
     assert part_dep["average"].size == n_vals_expected
@@ -799,35 +790,47 @@ def test_partial_dependence_dataframe(estimator, preprocessor, features):
 
 
 @pytest.mark.parametrize(
-    "features, expected_pd_shape",
+    "features, custom_range, expected_pd_shape",
     [
-        (0, (3, 10)),
-        (iris.feature_names[0], (3, 10)),
-        ([0, 2], (3, 10, 10)),
-        ([iris.feature_names[i] for i in (0, 2)], (3, 10, 10)),
-        ([True, False, True, False], (3, 10, 10)),
+        (0, None, (3, 10)),
+        (0, {0: [1, 2, 3]}, (3, 3)),
+        (iris.feature_names[0], None, (3, 10)),
+        (iris.feature_names[0], {iris.feature_names[0]: np.array([1, 2])}, (3, 2)),
+        ([0, 2], None, (3, 10, 10)),
+        ([0, 2], {2: [7, 8, 9, 10]}, (3, 10, 4)),
+        ([iris.feature_names[i] for i in (0, 2)], None, (3, 10, 10)),
+        (
+            [iris.feature_names[i] for i in (0, 2)],
+            {iris.feature_names[2]: [1, 2, 3, 10]},
+            (3, 10, 4),
+        ),
+        ([iris.feature_names[i] for i in (0, 2)], {2: [1, 2, 3, 10]}, (3, 10, 10)),
+        (
+            [iris.feature_names[i] for i in (0, 2, 3)],
+            {iris.feature_names[2]: [1, 10]},
+            (3, 10, 2, 10),
+        ),
+        ([True, False, True, False], None, (3, 10, 10)),
     ],
-    ids=["scalar-int", "scalar-str", "list-int", "list-str", "mask"],
+    ids=[
+        "scalar-int",
+        "scalar-int-custom-range",
+        "scalar-str",
+        "scalar-str-custom-range",
+        "list-int",
+        "list-int-custom-range",
+        "list-str",
+        "list-str-custom-range",
+        "list-str-custom-range-incorrect",
+        "list-str-three-features",
+        "mask",
+    ],
 )
-@pytest.mark.parametrize("use_custom_grid", [True, False])
-def test_partial_dependence_feature_type(features, expected_pd_shape, use_custom_grid):
+def test_partial_dependence_feature_type(features, custom_range, expected_pd_shape):
     # check all possible features type supported in PDP
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(iris.data, columns=iris.feature_names)
 
-    if use_custom_grid and features == [True, False, True, False]:
-        pytest.mark.xfail(
-            "Custom grid is expected to raise a value error with a feature mask."
-        )
-    elif use_custom_grid and features != [True, False, True, False]:
-        custom_grid = {}
-        if isinstance(features, (str, int)):
-            features = [features]
-        for f in features:
-            col_name = f if isinstance(f, str) else df.columns[f]
-            custom_grid[f] = df.loc[:10, col_name]
-    else:
-        custom_grid = None
     preprocessor = make_column_transformer(
         (StandardScaler(), [iris.feature_names[i] for i in (0, 2)]),
         (RobustScaler(), [iris.feature_names[i] for i in (1, 3)]),
@@ -837,7 +840,12 @@ def test_partial_dependence_feature_type(features, expected_pd_shape, use_custom
     )
     pipe.fit(df, iris.target)
     pdp_pipe = partial_dependence(
-        pipe, df, features=features, grid_resolution=10, kind="average"
+        pipe,
+        df,
+        features=features,
+        grid_resolution=10,
+        kind="average",
+        custom_range=custom_range,
     )
     assert pdp_pipe["average"].shape == expected_pd_shape
     assert len(pdp_pipe["values"]) == len(pdp_pipe["average"].shape) - 1

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -8,7 +8,9 @@ import pytest
 import sklearn
 from sklearn.inspection import partial_dependence
 from sklearn.inspection._partial_dependence import (
+    cartesian,
     _grid_from_X,
+    _grid_from_custom_grid,
     _partial_dependence_brute,
     _partial_dependence_recursion,
 )
@@ -30,6 +32,7 @@ from sklearn.preprocessing import PolynomialFeatures
 from sklearn.preprocessing import StandardScaler
 from sklearn.preprocessing import RobustScaler
 from sklearn.preprocessing import scale
+from sklearn.preprocessing import OneHotEncoder
 from sklearn.pipeline import make_pipeline
 from sklearn.dummy import DummyClassifier
 from sklearn.base import BaseEstimator, ClassifierMixin, clone
@@ -39,6 +42,7 @@ from sklearn.utils._testing import assert_array_equal
 from sklearn.utils import _IS_32BIT
 from sklearn.utils.validation import check_random_state
 from sklearn.tree.tests.test_tree import assert_is_subtree
+from sklearn.impute import SimpleImputer
 
 
 # toy sample
@@ -84,7 +88,10 @@ iris = load_iris()
 @pytest.mark.parametrize("grid_resolution", (5, 10))
 @pytest.mark.parametrize("features", ([1], [1, 2]))
 @pytest.mark.parametrize("kind", ("average", "individual", "both"))
-def test_output_shape(Estimator, method, data, grid_resolution, features, kind):
+@pytest.mark.parametrize("use_custom_grid", [True, False])
+def test_output_shape(
+    Estimator, method, data, grid_resolution, features, kind, use_custom_grid
+):
     # Check that partial_dependence has consistent output shape for different
     # kinds of estimators:
     # - classifiers with binary and multiclass settings
@@ -99,6 +106,11 @@ def test_output_shape(Estimator, method, data, grid_resolution, features, kind):
     (X, y), n_targets = data
     n_instances = X.shape[0]
 
+    custom_grid = None
+    if use_custom_grid:
+        grid_resolution = 5
+        custom_grid = {f: X[:grid_resolution, f] for f in features}
+
     est.fit(X, y)
     result = partial_dependence(
         est,
@@ -107,6 +119,7 @@ def test_output_shape(Estimator, method, data, grid_resolution, features, kind):
         method=method,
         kind=kind,
         grid_resolution=grid_resolution,
+        custom_grid=custom_grid,
     )
     pdp, axes = result, result["values"]
 
@@ -161,6 +174,30 @@ def test_grid_from_X():
     # axes is a list of arrays of different shapes
     assert axes[0].shape == (n_unique_values,)
     assert axes[1].shape == (grid_resolution,)
+
+
+@pytest.mark.parametrize(
+    "custom_grid, features",
+    [
+        (
+            {
+                1: np.array([1, 2, 3]),
+                2: np.array([1, 2, 3]),
+                "foo": np.array([4, 5, 6]),
+            },
+            [1, 2, "foo"],
+        ),
+        (
+            {1: [1, 2, 3], 2: np.array([1, 2, 3]), "foo": np.array([4, 5, 6])},
+            [1, "foo", 2],
+        ),
+    ],
+)
+def test_grid_from_custom_grid(custom_grid, features):
+    grid, values = _grid_from_custom_grid(features, custom_grid)
+    np.testing.assert_array_equal(grid, cartesian(values))
+    for val, feature in zip(values, features):
+        np.testing.assert_array_equal(val, custom_grid[feature])
 
 
 @pytest.mark.parametrize(
@@ -490,6 +527,24 @@ class NoPredictProbaNoDecisionFunction(ClassifierMixin, BaseEstimator):
             {"features": [0], "method": "recursion"},
             "Only the following estimators support the 'recursion' method:",
         ),
+        (
+            LinearRegression(),
+            {"features": [0, 1], "custom_grid": {0: [1, 2, 3]}},
+            "If custom_grid is specified, its keys must equal the values in features!",
+        ),
+        (
+            LinearRegression(),
+            {
+                "features": [0, 1],
+                "custom_grid": {0: [1, 2, 3], 1: [4, 5, 6], 2: [7, 8, 9]},
+            },
+            "If custom_grid is specified, its keys must equal the values in features!",
+        ),
+        (
+            LinearRegression(),
+            {"features": [0, 1], "custom_grid": {0: [1, 2, 3], 1: np.ones((3, 3))}},
+            "Grid for feature 1 is not a one-dimensional array. Got 2 dimensions",
+        ),
     ],
 )
 def test_partial_dependence_error(estimator, params, err_msg):
@@ -641,6 +696,38 @@ def test_partial_dependence_pipeline():
 
 
 @pytest.mark.parametrize(
+    "features, custom_grid, n_vals_expected",
+    [
+        (["b"], {"b": ["a", "b"]}, 2),
+        (["b"], {"b": ["a"]}, 1),
+        (["a", "b"], {"a": [1, 2], "b": ["a", "b"]}, 4),
+    ],
+)
+def test_partial_dependence_pipeline_custom_grid(
+    features, custom_grid, n_vals_expected
+):
+    pd = pytest.importorskip("pandas")
+    pl = make_pipeline(
+        SimpleImputer(strategy="most_frequent"), OneHotEncoder(), DummyClassifier()
+    )
+
+    X = pd.DataFrame({"a": [1, 2, 3, 4], "b": ["a", "b", "a", "b"]})
+    y = pd.Series([0, 1, 0, 1])
+    pl.fit(X, y)
+
+    X_holdout = pd.DataFrame({"a": [1, 2, 3, 4], "b": ["a", "b", "a", None]})
+    part_dep = partial_dependence(
+        pl,
+        X_holdout,
+        features=features,
+        grid_resolution=3,
+        custom_grid=custom_grid,
+        kind="average",
+    )
+    assert part_dep["average"].size == n_vals_expected
+
+
+@pytest.mark.parametrize(
     "estimator",
     [
         LogisticRegression(max_iter=1000, random_state=0),
@@ -722,11 +809,25 @@ def test_partial_dependence_dataframe(estimator, preprocessor, features):
     ],
     ids=["scalar-int", "scalar-str", "list-int", "list-str", "mask"],
 )
-def test_partial_dependence_feature_type(features, expected_pd_shape):
+@pytest.mark.parametrize("use_custom_grid", [True, False])
+def test_partial_dependence_feature_type(features, expected_pd_shape, use_custom_grid):
     # check all possible features type supported in PDP
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(iris.data, columns=iris.feature_names)
 
+    if use_custom_grid and features == [True, False, True, False]:
+        pytest.mark.xfail(
+            "Custom grid is expected to raise a value error with a feature mask."
+        )
+    elif use_custom_grid and features != [True, False, True, False]:
+        custom_grid = {}
+        if isinstance(features, (str, int)):
+            features = [features]
+        for f in features:
+            col_name = f if isinstance(f, str) else df.columns[f]
+            custom_grid[f] = df.loc[:10, col_name]
+    else:
+        custom_grid = None
     preprocessor = make_column_transformer(
         (StandardScaler(), [iris.feature_names[i] for i in (0, 2)]),
         (RobustScaler(), [iris.feature_names[i] for i in (1, 3)]),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #20890 

#### What does this implement/fix? Explain your changes.
This PR allows users to specify a `custom_range` of values to calculate partial depedency for some or all of the `features`.

The api is `custom_range={feature: array-like of grid values}`. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
