### PR TITLE
TST add unit tests for current _get_response

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ addopts =
     --ignore maint_tools
     --ignore asv_benchmarks
     --doctest-modules
-    --disable-pytest-warnings
+    # --disable-pytest-warnings
     --color=yes
     -rxXs
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ addopts =
     --ignore maint_tools
     --ignore asv_benchmarks
     --doctest-modules
-    # --disable-pytest-warnings
+    --disable-pytest-warnings
     --color=yes
     -rxXs
 

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -94,7 +94,9 @@ def _get_response(X, estimator, response_method, pos_label=None):
 
     y_pred = prediction_method(X)
 
-    if pos_label is not None and pos_label not in estimator.classes_:
+    # Checking that a scalar is contained in a NumPy array will raise a FutureWarning.
+    # We need to convert it into a list.
+    if pos_label is not None and pos_label not in list(estimator.classes_):
         raise ValueError(
             "The class provided by 'pos_label' is unknown. Got "
             f"{pos_label} instead of one of {estimator.classes_}"
@@ -111,7 +113,7 @@ def _get_response(X, estimator, response_method, pos_label=None):
             pos_label = estimator.classes_[1]
             y_pred = y_pred[:, 1]
         else:
-            class_idx = np.flatnonzero(estimator.classes_ == pos_label)
+            class_idx = np.flatnonzero(estimator.classes_ == pos_label)[0]
             y_pred = y_pred[:, class_idx]
     else:
         if pos_label is None:

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -94,8 +94,8 @@ def _get_response(X, estimator, response_method, pos_label=None):
 
     y_pred = prediction_method(X)
 
-    # Checking that a scalar is contained in a NumPy array will raise a FutureWarning.
-    # We need to convert it into a list.
+    # `not in` between a `str` and a NumPy array will raise a FutureWarning;
+    # thus we convert the array of classes into a Python list.
     if pos_label is not None and pos_label not in list(estimator.classes_):
         raise ValueError(
             "The class provided by 'pos_label' is unknown. Got "

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -96,7 +96,7 @@ def _get_response(X, estimator, response_method, pos_label=None):
         except ValueError as e:
             raise ValueError(
                 "The class provided by 'pos_label' is unknown. Got "
-                f"{pos_label} instead of one of {estimator.classes_}"
+                f"{pos_label} instead of one of {set(estimator.classes_)}"
             ) from e
     else:
         class_idx = 1

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -99,8 +99,8 @@ def _get_response(X, estimator, response_method, pos_label=None):
                 f"{pos_label} instead of one of {estimator.classes_}"
             ) from e
     else:
-        pos_label = estimator.classes_[1]
         class_idx = 1
+        pos_label = estimator.classes_[class_idx]
 
     if y_pred.ndim != 1:  # `predict_proba`
         y_pred_shape = y_pred.shape[1]

--- a/sklearn/metrics/_plot/base.py
+++ b/sklearn/metrics/_plot/base.py
@@ -89,16 +89,7 @@ def _get_response(X, estimator, response_method, pos_label=None):
         raise ValueError(classification_error)
 
     prediction_method = _check_classifier_response_method(estimator, response_method)
-
     y_pred = prediction_method(X)
-
-    # `not in` between a `str` and a NumPy array will raise a FutureWarning;
-    # thus we convert the array of classes into a Python list.
-    if pos_label is not None and pos_label not in list(estimator.classes_):
-        raise ValueError(
-            "The class provided by 'pos_label' is unknown. Got "
-            f"{pos_label} instead of one of {estimator.classes_}"
-        )
     if pos_label is not None:
         try:
             class_idx = estimator.classes_.tolist().index(pos_label)

--- a/sklearn/metrics/_plot/tests/test_base.py
+++ b/sklearn/metrics/_plot/tests/test_base.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+from sklearn.metrics._plot.base import _get_response
+
+
+@pytest.mark.parametrize(
+    "estimator, err_msg, params",
+    [
+        (
+            DecisionTreeRegressor(),
+            "Expected 'estimator' to be a binary classifier",
+            {"response_method": "auto"},
+        ),
+        (
+            DecisionTreeClassifier(),
+            "The class provided by 'pos_label' is unknown.",
+            {"response_method": "auto", "pos_label": "unknown"},
+        ),
+        (
+            DecisionTreeClassifier(),
+            "fit on multiclass",
+            {"response_method": "predict_proba"},
+        ),
+    ],
+)
+def test_get_response_error(estimator, err_msg, params):
+    """Check that we raise the proper error messages in `_get_response`."""
+    X, y = load_iris(return_X_y=True)
+
+    estimator.fit(X, y)
+    with pytest.raises(ValueError, match=err_msg):
+        _get_response(X, estimator, **params)
+
+
+def test_get_response_predict_proba():
+    """Check the behaviour of `_get_response` using `predict_proba`."""
+    X, y = load_iris(return_X_y=True)
+    X_binary, y_binary = X[:100], y[:100]
+
+    classifier = DecisionTreeClassifier().fit(X_binary, y_binary)
+    y_proba, pos_label = _get_response(
+        X_binary, classifier, response_method="predict_proba"
+    )
+    np.testing.assert_allclose(y_proba, classifier.predict_proba(X_binary)[:, 1])
+    assert pos_label == 1
+
+    y_proba, pos_label = _get_response(
+        X_binary, classifier, response_method="predict_proba", pos_label=0
+    )
+    np.testing.assert_allclose(y_proba, classifier.predict_proba(X_binary)[:, 0])
+    assert pos_label == 0
+
+
+def test_get_response_decision_function():
+    """Check the behaviour of `get_response` using `decision_function`."""
+    X, y = load_iris(return_X_y=True)
+    X_binary, y_binary = X[:100], y[:100]
+
+    classifier = LogisticRegression().fit(X_binary, y_binary)
+    y_score, pos_label = _get_response(
+        X_binary, classifier, response_method="decision_function"
+    )
+    np.testing.assert_allclose(y_score, classifier.decision_function(X_binary))
+    assert pos_label == 1
+
+    y_score, pos_label = _get_response(
+        X_binary, classifier, response_method="decision_function", pos_label=0
+    )
+    np.testing.assert_allclose(y_score, classifier.decision_function(X_binary) * -1)
+    assert pos_label == 0

--- a/sklearn/metrics/_plot/tests/test_base.py
+++ b/sklearn/metrics/_plot/tests/test_base.py
@@ -56,6 +56,25 @@ def test_get_response_predict_proba():
     assert pos_label == 0
 
 
+def test_get_response_warning():
+    """Check that we don't raise a FutureWarning issued by NumPy."""
+    X, y = load_iris(return_X_y=True)
+    X_binary, y_binary = X[:100], y[:100]
+
+    classifier = DecisionTreeClassifier().fit(X_binary, y_binary)
+    with pytest.warns(None) as record:
+        try:
+            _get_response(
+                X_binary,
+                classifier,
+                response_method="predict_proba",
+                pos_label="unknown",
+            )
+        except ValueError:
+            pass
+    assert len(record) == 0
+
+
 def test_get_response_decision_function():
     """Check the behaviour of `get_response` using `decision_function`."""
     X, y = load_iris(return_X_y=True)

--- a/sklearn/metrics/_plot/tests/test_base.py
+++ b/sklearn/metrics/_plot/tests/test_base.py
@@ -56,25 +56,6 @@ def test_get_response_predict_proba():
     assert pos_label == 0
 
 
-def test_get_response_warning():
-    """Check that we don't raise a FutureWarning issued by NumPy."""
-    X, y = load_iris(return_X_y=True)
-    X_binary, y_binary = X[:100], y[:100]
-
-    classifier = DecisionTreeClassifier().fit(X_binary, y_binary)
-    with pytest.warns(None) as record:
-        try:
-            _get_response(
-                X_binary,
-                classifier,
-                response_method="predict_proba",
-                pos_label="unknown",
-            )
-        except ValueError:
-            pass
-    assert len(record) == 0
-
-
 def test_get_response_decision_function():
     """Check the behaviour of `get_response` using `decision_function`."""
     X, y = load_iris(return_X_y=True)


### PR DESCRIPTION
Working on #21038, I could catch an inconsistency regarding the shape of `y_pred` when `pos_label` is set to a value.
We were also raising a `FutureWarning` with a scalar/NumPy array `in` operation.

This PR adds minimum tests. They will be probably adapted later on in #20999 but this is safer to have them now.