### PR TITLE
DOC - Ensure HashingVectorizer passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -9,7 +9,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 
 # List of modules ignored when checking for numpydoc validation.
 DOCSTRING_IGNORE_LIST = [
-    "HashingVectorizer",
     "HuberRegressor",
     "IterativeImputer",
     "KNNImputer",

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -763,7 +763,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         self.dtype = dtype
 
     def partial_fit(self, X, y=None):
-        """Does nothing: this transformer is stateless.
+        """No-op: this transformer is stateless.
 
         This method is just there to mark the fact that this transformer
         can work in a streaming setup.
@@ -772,6 +772,14 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         ----------
         X : ndarray of shape [n_samples, n_features]
             Training data.
+
+        y : None
+            This parameter is ignored.
+
+        Returns
+        -------
+        self : object
+            HashingVectorizer instance.
         """
         return self
 
@@ -789,7 +797,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         Returns
         -------
         self : object
-            Fitted vectorizer.
+            HashingVectorizer instance.
         """
         # triggers a parameter validation
         if isinstance(X, str):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -555,7 +555,7 @@ class _VectorizerMixin:
 
 
 class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
-    r"""Convert a collection of text documents to a matrix of token occurrences
+    r"""Convert a collection of text documents to a matrix of token occurrences.
 
     It turns a collection of text documents into a scipy.sparse matrix holding
     token occurrence counts (or binary occurrence information), possibly
@@ -568,10 +568,10 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
     This strategy has several advantages:
 
     - it is very low memory scalable to large datasets as there is no need to
-      store a vocabulary dictionary in memory
+      store a vocabulary dictionary in memory.
 
     - it is fast to pickle and un-pickle as it holds no state besides the
-      constructor parameters
+      constructor parameters.
 
     - it can be used in a streaming (partial fit) or parallel pipeline as there
       is no state computed during fit.
@@ -595,7 +595,6 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
 
     Parameters
     ----------
-
     input : {'filename', 'file', 'content'}, default='content'
         - If `'filename'`, the sequence passed as an argument to fit is
           expected to be a list of filenames that need reading to fetch
@@ -607,7 +606,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         - If `'content'`, the input is expected to be a sequence of items that
           can be of type string or byte.
 
-    encoding : string, default='utf-8'
+    encoding : str, default='utf-8'
         If bytes or files are given to analyze, this encoding is used to
         decode.
 
@@ -686,7 +685,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         of features are likely to cause hash collisions, but large numbers
         will cause larger coefficient dimensions in linear learners.
 
-    binary : bool, default=False.
+    binary : bool, default=False
         If True, all non zero counts are set to 1. This is useful for discrete
         probabilistic models that model binary events rather than integer
         counts.
@@ -704,6 +703,13 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
     dtype : type, default=np.float64
         Type of the matrix returned by fit_transform() or transform().
 
+    See Also
+    --------
+    CountVectorizer : Transforms text into a sparse matrix of n-gram counts.
+
+    TfidfVectorizer : Convert a collection of raw documents to a matrix of
+        TF-IDF features.
+
     Examples
     --------
     >>> from sklearn.feature_extraction.text import HashingVectorizer
@@ -717,11 +723,6 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
     >>> X = vectorizer.fit_transform(corpus)
     >>> print(X.shape)
     (4, 16)
-
-    See Also
-    --------
-    CountVectorizer, TfidfVectorizer
-
     """
 
     def __init__(

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -776,12 +776,20 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         return self
 
     def fit(self, X, y=None):
-        """Does nothing: this transformer is stateless.
+        """No-op: this transformer is stateless.
 
         Parameters
         ----------
         X : ndarray of shape [n_samples, n_features]
             Training data.
+
+        y : None
+            This parameter is ignored.
+
+        Returns
+        -------
+        self : object
+            Fitted vectorizer.
         """
         # triggers a parameter validation
         if isinstance(X, str):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -705,8 +705,8 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
 
     See Also
     --------
-    CountVectorizer : Transforms text into a sparse matrix of n-gram counts.
-
+    CountVectorizer : Convert a collection of text documents to a matrix of
+        token counts.
     TfidfVectorizer : Convert a collection of raw documents to a matrix of
         TF-IDF features.
 
@@ -773,8 +773,8 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         X : ndarray of shape [n_samples, n_features]
             Training data.
 
-        y : None
-            This parameter is ignored.
+        y : Ignored
+            Not used, present for API consistency by convention.
 
         Returns
         -------
@@ -791,8 +791,8 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         X : ndarray of shape [n_samples, n_features]
             Training data.
 
-        y : None
-            This parameter is ignored.
+        y : Ignored
+            Not used, present for API consistency by convention.
 
         Returns
         -------


### PR DESCRIPTION

#### Reference Issues/PRs
Reference #20308 


#### What does this implement/fix? Explain your changes.
Changes tosklearn/feature_extraction/text.py:
HashingVectorizer Docstring
HashingVectorizer.fit Docstring
HashingVectorizer.partial_fit Docstring

Removes HashingVectorizer from maint_tools/test_docstrings.py DOCSTRING_IGNORE_LIST

#### Any other comments?


