### PR TITLE
DOC minor fixes to examples for neighbors transformers

### DIFF
--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -567,7 +567,7 @@ using the caching properties of the scikit-learn pipeline:
     >>> from sklearn.neighbors import KNeighborsTransformer
     >>> from sklearn.pipeline import make_pipeline
     >>> from sklearn.datasets import make_regression
-    >>> cache_path = tempfile.gettempdir()
+    >>> cache_path = tempfile.gettempdir()  # we use a temporary folder here
     >>> X, _ = make_regression(n_samples=50, n_features=25, random_state=0)
     >>> estimator = make_pipeline(
     ...     KNeighborsTransformer(mode='distance'),

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -562,13 +562,18 @@ First, the precomputed graph can be re-used multiple times, for instance while
 varying a parameter of the estimator. This can be done manually by the user, or
 using the caching properties of the scikit-learn pipeline:
 
-    >>> from sklearn.manifold import Isomap
     >>> from sklearn.neighbors import KNeighborsTransformer
+    >>> from sklearn.manifold import Isomap
     >>> from sklearn.pipeline import make_pipeline
+    >>> from sklearn.datasets import make_regression
+    >>> X, _ = make_regression(n_samples=50, n_features=25, random_state=0)
     >>> estimator = make_pipeline(
-    ...     KNeighborsTransformer(n_neighbors=5, mode='distance'),
-    ...     Isomap(metric='precomputed'),
+    ...     KNeighborsTransformer(mode='distance'),
+    ...     Isomap(n_components=3, metric='precomputed'),
     ...     memory='/path/to/cache')
+    >>> X_embedded = estimator.fit_transform(X)
+    >>> X_embedded.shape
+    (50, 3)
 
 Second, precomputing the graph can give finer control on the nearest neighbors
 estimation, for instance enabling multiprocessing though the parameter

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -562,15 +562,17 @@ First, the precomputed graph can be re-used multiple times, for instance while
 varying a parameter of the estimator. This can be done manually by the user, or
 using the caching properties of the scikit-learn pipeline:
 
-    >>> from sklearn.neighbors import KNeighborsTransformer
+    >>> import tempfile
     >>> from sklearn.manifold import Isomap
+    >>> from sklearn.neighbors import KNeighborsTransformer
     >>> from sklearn.pipeline import make_pipeline
     >>> from sklearn.datasets import make_regression
+    >>> cache_path = tempfile.gettempdir()
     >>> X, _ = make_regression(n_samples=50, n_features=25, random_state=0)
     >>> estimator = make_pipeline(
     ...     KNeighborsTransformer(mode='distance'),
     ...     Isomap(n_components=3, metric='precomputed'),
-    ...     memory='/path/to/cache')
+    ...     memory=cache_path)
     >>> X_embedded = estimator.fit_transform(X)
     >>> X_embedded.shape
     (50, 3)

--- a/sklearn/neighbors/_graph.py
+++ b/sklearn/neighbors/_graph.py
@@ -332,12 +332,15 @@ class KNeighborsTransformer(KNeighborsMixin, TransformerMixin, NeighborsBase):
 
     Examples
     --------
-    >>> from sklearn.manifold import Isomap
+    >>> from sklearn.datasets import load_wine
     >>> from sklearn.neighbors import KNeighborsTransformer
-    >>> from sklearn.pipeline import make_pipeline
-    >>> estimator = make_pipeline(
-    ...     KNeighborsTransformer(n_neighbors=5, mode='distance'),
-    ...     Isomap(metric='precomputed'))
+    >>> X, _ = load_wine(return_X_y = True)
+    >>> X.shape
+    (178, 13)
+    >>> transformer = KNeighborsTransformer(n_neighbors=5, mode='distance')
+    >>> X_dist_graph = transformer.fit_transform(X)
+    >>> X_dist_graph.shape
+    (178, 178)
     """
 
     def __init__(
@@ -549,12 +552,19 @@ class RadiusNeighborsTransformer(RadiusNeighborsMixin, TransformerMixin, Neighbo
 
     Examples
     --------
+    >>> import numpy as np
+    >>> from sklearn.datasets import load_wine
     >>> from sklearn.cluster import DBSCAN
     >>> from sklearn.neighbors import RadiusNeighborsTransformer
     >>> from sklearn.pipeline import make_pipeline
+    >>> X, _ = load_wine(return_X_y = True)
     >>> estimator = make_pipeline(
     ...     RadiusNeighborsTransformer(radius=42.0, mode='distance'),
-    ...     DBSCAN(min_samples=30, metric='precomputed'))
+    ...     DBSCAN(eps=25.0, metric='precomputed'))
+    >>> X_clustered = estimator.fit_predict(X)
+    >>> clusters, counts = np.unique(X_clustered, return_counts=True)
+    >>> print(counts)
+    [ 29  15 111  11  12]
     """
 
     def __init__(

--- a/sklearn/neighbors/_graph.py
+++ b/sklearn/neighbors/_graph.py
@@ -334,7 +334,7 @@ class KNeighborsTransformer(KNeighborsMixin, TransformerMixin, NeighborsBase):
     --------
     >>> from sklearn.datasets import load_wine
     >>> from sklearn.neighbors import KNeighborsTransformer
-    >>> X, _ = load_wine(return_X_y = True)
+    >>> X, _ = load_wine(return_X_y=True)
     >>> X.shape
     (178, 13)
     >>> transformer = KNeighborsTransformer(n_neighbors=5, mode='distance')
@@ -557,7 +557,7 @@ class RadiusNeighborsTransformer(RadiusNeighborsMixin, TransformerMixin, Neighbo
     >>> from sklearn.cluster import DBSCAN
     >>> from sklearn.neighbors import RadiusNeighborsTransformer
     >>> from sklearn.pipeline import make_pipeline
-    >>> X, _ = load_wine(return_X_y = True)
+    >>> X, _ = load_wine(return_X_y=True)
     >>> estimator = make_pipeline(
     ...     RadiusNeighborsTransformer(radius=42.0, mode='distance'),
     ...     DBSCAN(eps=25.0, metric='precomputed'))


### PR DESCRIPTION
#### Reference Issues/PRs
Follow-up to discussion in #21011 (already closed)


#### What does this implement/fix? Explain your changes.
Minor doc fixes to add fit and transform/predict to different neighbors transformer examples: 
- `KNeighborsTransformer` example has pipeline removed to highlight shape of resulting distance matrix/graph 
- `KNeighborsTransformer` pipeline to `Isomap` is left in general neighbors documentation but now includes `fit_transform` and replaces fake directory`'/path/to/cache'` that caused tests to fail 
- `RadiusNeighborsTransformer` pipeline now includes `fit_predict` 


#### Any other comments?
None