### PR TITLE
DOC - Ensure HuberRegressor passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -9,7 +9,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 
 # List of modules ignored when checking for numpydoc validation.
 DOCSTRING_IGNORE_LIST = [
-    "HuberRegressor",
     "IterativeImputer",
     "KNNImputer",
     "LabelPropagation",

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -277,7 +277,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         Returns
         -------
         self : object
-            Fitted 'HuberRegressor' estimator.
+            Fitted `HuberRegressor` estimator.
         """
         X, y = self._validate_data(
             X,

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -209,7 +209,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     --------
     RANSACRegressor : RANSAC (RANdom SAmple Consensus) algorithm.
     TheilSenRegressor : Theil-Sen Estimator robust multivariate regression model.
-    SGDRegressor : Fitted by minimizing a regularized empirical loss with SGD
+    SGDRegressor : Fitted by minimizing a regularized empirical loss with SGD.
 
     References
     ----------

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -276,6 +276,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         Returns
         -------
         self : object
+            Fitted HuberRegressor estimator.
         """
         X, y = self._validate_data(
             X,

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -209,6 +209,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     --------
     RANSACRegressor : RANSAC (RANdom SAmple Consensus) algorithm.
     TheilSenRegressor : Theil-Sen Estimator robust multivariate regression model.
+    SGDRegressor : Fitted by minimizing a regularized empirical loss with SGD
 
     References
     ----------
@@ -276,7 +277,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         Returns
         -------
         self : object
-            Fitted HuberRegressor estimator.
+            Fitted 'HuberRegressor' estimator.
         """
         X, y = self._validate_data(
             X,

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -205,6 +205,13 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         A boolean mask which is set to True where the samples are identified
         as outliers.
 
+    References
+    ----------
+    .. [1] Peter J. Huber, Elvezio M. Ronchetti, Robust Statistics
+           Concomitant scale estimates, pg 172
+    .. [2] Art B. Owen (2006), A robust hybrid of lasso and ridge regression.
+           https://statweb.stanford.edu/~owen/reports/hhu.pdf
+
     Examples
     --------
     >>> import numpy as np
@@ -227,13 +234,6 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     Huber coefficients: [17.7906... 31.0106...]
     >>> print("Linear Regression coefficients:", linear.coef_)
     Linear Regression coefficients: [-1.9221...  7.0226...]
-
-    References
-    ----------
-    .. [1] Peter J. Huber, Elvezio M. Ronchetti, Robust Statistics
-           Concomitant scale estimates, pg 172
-    .. [2] Art B. Owen (2006), A robust hybrid of lasso and ridge regression.
-           https://statweb.stanford.edu/~owen/reports/hhu.pdf
     """
 
     def __init__(

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -205,6 +205,11 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         A boolean mask which is set to True where the samples are identified
         as outliers.
 
+    See Also
+    --------
+    RANSACRegressor : RANSAC (RANdom SAmple Consensus) algorithm.
+    TheilSenRegressor : Theil-Sen Estimator robust multivariate regression model.
+
     References
     ----------
     .. [1] Peter J. Huber, Elvezio M. Ronchetti, Robust Statistics

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -209,6 +209,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     --------
     RANSACRegressor : RANSAC (RANdom SAmple Consensus) algorithm.
     TheilSenRegressor : Theil-Sen Estimator robust multivariate regression model.
+    SGDRegressor : Fitted by minimizing a regularized empirical loss with SGD
 
     References
     ----------

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -276,7 +276,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
         Returns
         -------
         self : object
-            Fitted HuberRegressor estimator.
+            Fitted `HuberRegressor` estimator.
         """
         X, y = self._validate_data(
             X,


### PR DESCRIPTION

#### Reference Issues/PRs
References #20308 

#### What does this implement/fix? Explain your changes.
Changes to file sklearn/linear_model/_huber.py:
Change the ordering of sections in HuberRegressor
Added 'See Also' Section to HuberRegressor
Added description to 'Returns' section

Removed HuberRegressor from maint_tools/test_docstrings.py DOC_IGNORE_LIST

#### Any other comments?
