### PR TITLE
DOC - Ensure that RANSACRegressor passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -35,7 +35,6 @@ DOCSTRING_IGNORE_LIST = [
     "PatchExtractor",
     "PolynomialFeatures",
     "QuadraticDiscriminantAnalysis",
-    "RANSACRegressor",
     "RandomizedSearchCV",
     "RobustScaler",
     "SGDOneClassSVM",

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -274,7 +274,7 @@ class RANSACRegressor(
 
         Parameters
         ----------
-        X : array-like or sparse matrix, shape [n_samples, n_features]
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Training data.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
@@ -565,7 +565,7 @@ class RANSACRegressor(
 
         Parameters
         ----------
-        X : numpy array of shape [n_samples, n_features]
+        X : {array-like or sparse matrix} of shape (n_samples, n_features)
             Input data.
 
         Returns
@@ -589,10 +589,10 @@ class RANSACRegressor(
 
         Parameters
         ----------
-        X : numpy array or sparse matrix of shape [n_samples, n_features]
+        X : (array-like or sparse matrix} of shape (n_samples, n_features)
             Training data.
 
-        y : array, shape = [n_samples] or [n_samples, n_targets]
+        y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Target values.
 
         Returns

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -293,7 +293,6 @@ class RANSACRegressor(
             If no valid consensus set could be found. This occurs if
             `is_data_valid` and `is_model_valid` return False for all
             `max_trials` randomly chosen sub-samples.
-
         """
         # Need to validate separately here. We can't pass multi_ouput=True
         # because that would allow y to be csr. Delay expensive finiteness

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -214,6 +214,12 @@ class RANSACRegressor(
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    RANSACRegressor : RANSAC (RANdom SAmple Consensus) algorithm.
+    TheilSenRegressor : Theil-Sen Estimator robust multivariate regression model.
+    SGDRegressor : Fitted by minimizing a regularized empirical loss with SGD.
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/RANSAC

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -287,6 +287,11 @@ class RANSACRegressor(
 
             .. versionadded:: 0.18
 
+        Returns
+        -------
+        self : object
+            Fitted `RANSACRegressor` estimator.
+
         Raises
         ------
         ValueError

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -214,6 +214,12 @@ class RANSACRegressor(
 
         .. versionadded:: 1.0
 
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/RANSAC
+    .. [2] https://www.sri.com/sites/default/files/publications/ransac-publication.pdf
+    .. [3] http://www.bmva.org/bmvc/2009/Papers/Paper355/Paper355.pdf
+
     Examples
     --------
     >>> from sklearn.linear_model import RANSACRegressor
@@ -225,12 +231,6 @@ class RANSACRegressor(
     0.9885...
     >>> reg.predict(X[:1,])
     array([-31.9417...])
-
-    References
-    ----------
-    .. [1] https://en.wikipedia.org/wiki/RANSAC
-    .. [2] https://www.sri.com/sites/default/files/publications/ransac-publication.pdf
-    .. [3] http://www.bmva.org/bmvc/2009/Papers/Paper355/Paper355.pdf
     """  # noqa: E501
 
     def __init__(

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -95,7 +95,7 @@ class RANSACRegressor(
         :class:`linear_model.LinearRegression` is used, the user is
         encouraged to provide a value.
 
-        .. deprecated :: 1.0
+        .. deprecated:: 1.0
            Not setting `min_samples` explicitly will raise an error in version
            1.2 for models other than
            :class:`~sklearn.linear_model.LinearRegression`. To keep the old

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -216,7 +216,7 @@ class RANSACRegressor(
 
     See Also
     --------
-    RANSACRegressor : RANSAC (RANdom SAmple Consensus) algorithm.
+    HuberRegressor : Linear regression model that is robust to outliers.
     TheilSenRegressor : Theil-Sen Estimator robust multivariate regression model.
     SGDRegressor : Fitted by minimizing a regularized empirical loss with SGD.
 

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -566,6 +566,7 @@ class RANSACRegressor(
         Parameters
         ----------
         X : numpy array of shape [n_samples, n_features]
+            Input data.
 
         Returns
         -------

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -147,7 +147,7 @@ class RANSACRegressor(
         as 0.99 (the default) and e is the current fraction of inliers w.r.t.
         the total number of samples.
 
-    loss : string, callable, default='absolute_error'
+    loss : str, callable, default='absolute_error'
         String inputs, 'absolute_error' and 'squared_error' are supported which
         find the absolute error and squared error per sample respectively.
 

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -583,7 +583,7 @@ class RANSACRegressor(
         return self.estimator_.predict(X)
 
     def score(self, X, y):
-        """Returns the score of the prediction.
+        """Return the score of the prediction.
 
         This is a wrapper for `estimator_.score(X, y)`.
 


### PR DESCRIPTION

#### Reference Issues/PRs
References #20308 

#### What does this implement/fix? Explain your changes.
Changes file sklearn/linear_model/_ransac.py:
Changed order of RANSACRegressor Docstring sections
Added 'See Also' section in RANSACRegressor
Changed RANSACRegressor parameter loss to str
Removed space after deprecated in RANSACRegressor min_samples
Removed double space in RANSACRegressor.fit
Added returns section to RANSACRegressor.fit
Added description of parameter 'x' in RANSACRegressor.predict
Changed Summary description in RANSACRegressor.score

Removed RANSACRegressor for DOCSTRING_IGNORE_LIST

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
