### PR TITLE
DOC Simple docstring fix for OneHotEncoder.get_feature_names_out

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -702,9 +702,6 @@ class OneHotEncoder(_BaseEncoder):
     def get_feature_names_out(self, input_features=None):
         """Get output feature names for transformation.
 
-        Returns `input_features` as this transformation doesn't add or drop
-        features.
-
         Parameters
         ----------
         input_features : array-like of str or None, default=None


### PR DESCRIPTION
Placed on 1.0.1 so there is correct information in the docstring.