### PR TITLE
API Change ColumnTransformer parameter name to verbose_feature_names_out

### DIFF
--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -452,10 +452,10 @@ By default, the remaining rating columns are ignored (``remainder='drop'``)::
   ...     remainder='drop', verbose_feature_names_out=False)
 
   >>> column_trans.fit(X)
-  ColumnTransformer(verbose_feature_names_out=False,
-                    transformers=[('categories', OneHotEncoder(dtype='int'),
+  ColumnTransformer(transformers=[('categories', OneHotEncoder(dtype='int'),
                                    ['city']),
-                                  ('title_bow', CountVectorizer(), 'title')])
+                                  ('title_bow', CountVectorizer(), 'title')],
+                    verbose_feature_names_out=False)
 
   >>> column_trans.get_feature_names_out()
   array(['city_London', 'city_Paris', 'city_Sallisaw', 'bow', 'feast',

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -449,10 +449,10 @@ By default, the remaining rating columns are ignored (``remainder='drop'``)::
   >>> column_trans = ColumnTransformer(
   ...     [('categories', OneHotEncoder(dtype='int'), ['city']),
   ...      ('title_bow', CountVectorizer(), 'title')],
-  ...     remainder='drop', prefix_feature_names_out=False)
+  ...     remainder='drop', verbose_feature_names_out=False)
 
   >>> column_trans.fit(X)
-  ColumnTransformer(prefix_feature_names_out=False,
+  ColumnTransformer(verbose_feature_names_out=False,
                     transformers=[('categories', OneHotEncoder(dtype='int'),
                                    ['city']),
                                   ('title_bow', CountVectorizer(), 'title')])

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -251,7 +251,7 @@ Changelog
   an adequate transformer.
   :pr:`18898` by :user:`Oras Phongpanagnam <panangam>`.
 
-- |API| Adds `prefix_feature_names_out` to :class:`compose.ColumnTransformer`.
+- |API| Adds `verbose_feature_names_out` to :class:`compose.ColumnTransformer`.
   This flag controls the prefixing of feature names out in
   :term:`get_feature_names_out`. :pr:`18444` by `Thomas Fan`_.
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -253,7 +253,7 @@ Changelog
 
 - |API| Adds `verbose_feature_names_out` to :class:`compose.ColumnTransformer`.
   This flag controls the prefixing of feature names out in
-  :term:`get_feature_names_out`. :pr:`18444` by `Thomas Fan`_.
+  :term:`get_feature_names_out`. :pr:`18444` and :pr:`21080` by `Thomas Fan`_.
 
 :mod:`sklearn.covariance`
 .........................

--- a/examples/inspection/plot_linear_model_coefficient_interpretation.py
+++ b/examples/inspection/plot_linear_model_coefficient_interpretation.py
@@ -135,7 +135,7 @@ numerical_columns = ["EDUCATION", "EXPERIENCE", "AGE"]
 preprocessor = make_column_transformer(
     (OneHotEncoder(drop="if_binary"), categorical_columns),
     remainder="passthrough",
-    prefix_feature_names_out=False,
+    verbose_feature_names_out=False,
 )
 
 # %%

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -112,7 +112,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         If True, the time elapsed while fitting each transformer will be
         printed as it is completed.
 
-    prefix_feature_names_out : bool, default=True
+    verbose_feature_names_out : bool, default=True
         If True, :meth:`get_feature_names_out` will prefix all feature names
         with the name of the transformer that generated that feature.
         If False, :meth:`get_feature_names_out` will not prefix any feature
@@ -204,7 +204,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         n_jobs=None,
         transformer_weights=None,
         verbose=False,
-        prefix_feature_names_out=True,
+        verbose_feature_names_out=True,
     ):
         self.transformers = transformers
         self.remainder = remainder
@@ -212,7 +212,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         self.n_jobs = n_jobs
         self.transformer_weights = transformer_weights
         self.verbose = verbose
-        self.prefix_feature_names_out = prefix_feature_names_out
+        self.verbose_feature_names_out = verbose_feature_names_out
 
     @property
     def _transformers(self):
@@ -489,7 +489,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             # No feature names
             return np.array([], dtype=object)
 
-        if self.prefix_feature_names_out:
+        if self.verbose_feature_names_out:
             # Prefix the feature names out with the transformers name
             names = list(
                 chain.from_iterable(
@@ -499,7 +499,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             )
             return np.asarray(names, dtype=object)
 
-        # prefix_feature_names_out is False
+        # verbose_feature_names_out is False
         # Check that names are all unique without a prefix
         feature_names_count = Counter(
             chain.from_iterable(s for _, s in transformer_with_feature_names_out)
@@ -517,7 +517,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                 names_repr = str(top_6_overlap)
             raise ValueError(
                 f"Output feature names: {names_repr} are not unique. Please set "
-                "prefix_feature_names_out=True to add prefixes to feature names"
+                "verbose_feature_names_out=True to add prefixes to feature names"
             )
 
         return np.concatenate(
@@ -856,7 +856,7 @@ def make_column_transformer(
     sparse_threshold=0.3,
     n_jobs=None,
     verbose=False,
-    prefix_feature_names_out=True,
+    verbose_feature_names_out=True,
 ):
     """Construct a ColumnTransformer from the given transformers.
 
@@ -919,7 +919,7 @@ def make_column_transformer(
         If True, the time elapsed while fitting each transformer will be
         printed as it is completed.
 
-    prefix_feature_names_out : bool, default=True
+    verbose_feature_names_out : bool, default=True
         If True, :meth:`get_feature_names_out` will prefix all feature names
         with the name of the transformer that generated that feature.
         If False, :meth:`get_feature_names_out` will not prefix any feature
@@ -959,7 +959,7 @@ def make_column_transformer(
         remainder=remainder,
         sparse_threshold=sparse_threshold,
         verbose=verbose,
-        prefix_feature_names_out=prefix_feature_names_out,
+        verbose_feature_names_out=verbose_feature_names_out,
     )
 
 

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1760,8 +1760,8 @@ class TransWithNames(Trans):
         ),
     ],
 )
-def test_feature_names_out_prefix_true(transformers, remainder, expected_names):
-    """Check feature_names_out for verbose_feature_names_out==True (default)"""
+def test_verbose_feature_names_out_true(transformers, remainder, expected_names):
+    """Check feature_names_out for verbose_feature_names_out=True (default)"""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"])
     ct = ColumnTransformer(
@@ -1835,8 +1835,8 @@ def test_feature_names_out_prefix_true(transformers, remainder, expected_names):
         ),
     ],
 )
-def test_feature_names_out_prefix_false(transformers, remainder, expected_names):
-    """Check feature_names_out for verbose_feature_names_out==True (default)"""
+def test_verbose_feature_names_out_false(transformers, remainder, expected_names):
+    """Check feature_names_out for verbose_feature_names_out=False"""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"])
     ct = ColumnTransformer(
@@ -1923,10 +1923,10 @@ def test_feature_names_out_prefix_false(transformers, remainder, expected_names)
         ),
     ],
 )
-def test_feature_names_out_prefix_false_errors(
+def test_verbose_feature_names_out_false_errors(
     transformers, remainder, colliding_columns
 ):
-    """Check feature_names_out for verbose_feature_names_out==False"""
+    """Check feature_names_out for verbose_feature_names_out=False"""
 
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"])

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -709,7 +709,7 @@ def test_column_transformer_get_set_params():
         "trans2__with_std": True,
         "transformers": ct.transformers,
         "transformer_weights": None,
-        "prefix_feature_names_out": True,
+        "verbose_feature_names_out": True,
         "verbose": False,
     }
 
@@ -730,7 +730,7 @@ def test_column_transformer_get_set_params():
         "trans2__with_std": True,
         "transformers": ct.transformers,
         "transformer_weights": None,
-        "prefix_feature_names_out": True,
+        "verbose_feature_names_out": True,
         "verbose": False,
     }
 
@@ -1149,7 +1149,7 @@ def test_column_transformer_get_set_params_with_remainder():
         "trans1__with_std": True,
         "transformers": ct.transformers,
         "transformer_weights": None,
-        "prefix_feature_names_out": True,
+        "verbose_feature_names_out": True,
         "verbose": False,
     }
 
@@ -1169,7 +1169,7 @@ def test_column_transformer_get_set_params_with_remainder():
         "trans1": "passthrough",
         "transformers": ct.transformers,
         "transformer_weights": None,
-        "prefix_feature_names_out": True,
+        "verbose_feature_names_out": True,
         "verbose": False,
     }
     assert ct.get_params() == exp
@@ -1761,7 +1761,7 @@ class TransWithNames(Trans):
     ],
 )
 def test_feature_names_out_prefix_true(transformers, remainder, expected_names):
-    """Check feature_names_out for prefix_feature_names_out==True (default)"""
+    """Check feature_names_out for verbose_feature_names_out==True (default)"""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"])
     ct = ColumnTransformer(
@@ -1836,13 +1836,13 @@ def test_feature_names_out_prefix_true(transformers, remainder, expected_names):
     ],
 )
 def test_feature_names_out_prefix_false(transformers, remainder, expected_names):
-    """Check feature_names_out for prefix_feature_names_out==True (default)"""
+    """Check feature_names_out for verbose_feature_names_out==True (default)"""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"])
     ct = ColumnTransformer(
         transformers,
         remainder=remainder,
-        prefix_feature_names_out=False,
+        verbose_feature_names_out=False,
     )
     ct.fit(df)
 
@@ -1926,20 +1926,20 @@ def test_feature_names_out_prefix_false(transformers, remainder, expected_names)
 def test_feature_names_out_prefix_false_errors(
     transformers, remainder, colliding_columns
 ):
-    """Check feature_names_out for prefix_feature_names_out==False"""
+    """Check feature_names_out for verbose_feature_names_out==False"""
 
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"])
     ct = ColumnTransformer(
         transformers,
         remainder=remainder,
-        prefix_feature_names_out=False,
+        verbose_feature_names_out=False,
     )
     ct.fit(df)
 
     msg = re.escape(
         f"Output feature names: {colliding_columns} are not unique. Please set "
-        "prefix_feature_names_out=True to add prefixes to feature names"
+        "verbose_feature_names_out=True to add prefixes to feature names"
     )
     with pytest.raises(ValueError, match=msg):
         ct.get_feature_names_out()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/21073


#### What does this implement/fix? Explain your changes.
This PR changes the `ColumnTransformer`'s parameter name from `prefix_feature_names_out` to `verbose_feature_names_out` as described in [SLEP007](https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep007/proposal.html#verbose-feature-names).

`verbose_feature_names_out` feels more generic and can be used by third party developers that implement `get_feature_names_out`.

#### Any other comments?
Placing this as blocker for 1.0 so we do not need to deprecate the parameter if we decide we want to use `verbose_feature_names_out`.

CC @scikit-learn/core-devs  

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
