### PR TITLE
DOC fix verbose_feature_names_out usage in release highlights

### DIFF
--- a/examples/release_highlights/plot_release_highlights_1_0_0.py
+++ b/examples/release_highlights/plot_release_highlights_1_0_0.py
@@ -169,7 +169,7 @@ preprocessor = ColumnTransformer(
         ("numerical", StandardScaler(), ["age"]),
         ("categorical", OneHotEncoder(), ["pet"]),
     ],
-    prefix_feature_names_out=False,
+    verbose_feature_names_out=False,
 ).fit(X)
 
 preprocessor.get_feature_names_out()


### PR DESCRIPTION
hotfix after https://github.com/scikit-learn/scikit-learn/pull/21080, this fixes the usage in the release highlights

cc @lorentzenchr @thomasjpfan 

fixing the error observed here: https://github.com/scikit-learn/scikit-learn/pull/21090