### PR TITLE
DOC - Ensure that TweedieRegressor pass numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -46,7 +46,6 @@ DOCSTRING_IGNORE_LIST = [
     "StackingClassifier",
     "StackingRegressor",
     "TransformedTargetRegressor",
-    "TweedieRegressor",
 ]
 
 

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -801,6 +801,7 @@ class TweedieRegressor(GeneralizedLinearRegressor):
 
     @property
     def family(self):
+        """Return the family of the regressor."""
         # We use a property with a setter to make sure that the family is
         # always a Tweedie distribution, and that self.power and
         # self.family.power are identical by construction.

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -752,6 +752,11 @@ class TweedieRegressor(GeneralizedLinearRegressor):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    PoissonRegressor : Generalized Linear Model with a Poisson distribution.
+    GammaRegressor : Generalized Linear Model with a Gamma distribution.
+
     Examples
     ----------
     >>> from sklearn import linear_model


### PR DESCRIPTION

#### Reference Issues/PRs
References #20308 

#### What does this implement/fix? Explain your changes.
Changes to sklearn/linear_model/_glm/glm.py:
Add 'See Also' section for TweedieRegressor
Added Docstring for TweedieRegressor.family

Removed TweedieRegressor from DOCSTRING_IGNORE_LIST

#### Any other comments?
