### PR TITLE
DOC - Ensure that SGDOneClassSVM pass numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -34,7 +34,6 @@ DOCSTRING_IGNORE_LIST = [
     "QuadraticDiscriminantAnalysis",
     "RandomizedSearchCV",
     "RobustScaler",
-    "SGDOneClassSVM",
     "SGDRegressor",
     "SelfTrainingClassifier",
     "SparseRandomProjection",

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -2059,6 +2059,17 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    sklearn.svm.OneClassSVM
+
+    Notes
+    -----
+    This estimator has a linear complexity in the number of training samples
+    and is thus better suited than the `sklearn.svm.OneClassSVM`
+    implementation for datasets with a large number of training samples (say
+    > 10,000).
+
     Examples
     --------
     >>> import numpy as np
@@ -2070,17 +2081,6 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
 
     >>> print(clf.predict([[4, 4]]))
     [1]
-
-    See also
-    --------
-    sklearn.svm.OneClassSVM
-
-    Notes
-    -----
-    This estimator has a linear complexity in the number of training samples
-    and is thus better suited than the `sklearn.svm.OneClassSVM`
-    implementation for datasets with a large number of training samples (say
-    > 10,000).
     """
 
     loss_functions = {"hinge": (Hinge, 1.0)}

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1975,8 +1975,8 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
         Whether or not the training data should be shuffled after each epoch.
         Defaults to True.
 
-    verbose : integer, optional
-        The verbosity level
+    verbose : int, optional
+        The verbosity level.
 
     random_state : int, RandomState instance or None, optional (default=None)
         The seed of the pseudo random number generator to use when shuffling
@@ -2061,7 +2061,7 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
 
     See Also
     --------
-    sklearn.svm.OneClassSVM
+    sklearn.svm.OneClassSVM : Unsupervised Outlier Detection.
 
     Notes
     -----

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -2295,6 +2295,8 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
         ----------
         X : {array-like, sparse matrix}, shape (n_samples, n_features)
             Subset of the training data.
+        y : Ignored
+            Not used, present for API consistency by convention.
 
         sample_weight : array-like, shape (n_samples,), optional
             Weights applied to individual samples.

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -2383,6 +2383,8 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
         ----------
         X : {array-like, sparse matrix}, shape (n_samples, n_features)
             Training data.
+        y : Ignored
+            Not used, present for API consistency by convention.
 
         coef_init : array, shape (n_classes, n_features)
             The initial coefficients to warm-start the optimization.

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -2398,7 +2398,8 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
 
         Returns
         -------
-        self : returns an instance of self.
+        self : object
+            returns an instance of self.
         """
 
         alpha = self.nu / 2

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1985,7 +1985,7 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
         generator; If None, the random number generator is the RandomState
         instance used by `np.random`.
 
-    learning_rate : string, optional
+    learning_rate : str, optional
         The learning rate schedule to use with `fit`. (If using `partial_fit`,
         learning rate must be controlled directly).
 

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -2304,7 +2304,8 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
 
         Returns
         -------
-        self : returns an instance of self.
+        self : object
+            Returns a fitted instance of self.
         """
 
         alpha = self.nu / 2
@@ -2403,7 +2404,7 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
         Returns
         -------
         self : object
-            Returns an instance of self.
+            Returns a fitted instance of self.
         """
 
         alpha = self.nu / 2

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -2401,7 +2401,7 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
         Returns
         -------
         self : object
-            returns an instance of self.
+            Returns an instance of self.
         """
 
         alpha = self.nu / 2


### PR DESCRIPTION

#### Reference Issues/PRs
References #20308 

#### What does this implement/fix? Explain your changes.
Changes to sklearn/linear_model/_stochastic_gradient.py:
Changed order of sections for SGDOneClassSVM Docstring
Changed parameter 'verbose' to int and added period to SGDOneClassSVM Docstring
Changed parameter 'learning rate' to str in SGDOneClassSVM Docstring
Added description for 'Returns' section for SGDOneClassSVM.fit Docstring
Added parameter 'y' and description for SGDOneClassSVM.fit Docstring
Added description for 'Returns' section for SGDOneClassSVM.partial_fit Docstring
Assed parameter 'y' and description for SGDOneClassSVM.partial_fit Docstring

Removed SGDOneClassSVM from DOCSTRING_IGNORE_LIST

#### Any other comments?



-->
