### PR TITLE
DOC Consistently use "or newer" to document Python version

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -167,7 +167,7 @@
         </li>
         <li><strong>May 2020.</strong> scikit-learn 0.23.0 is available for download (<a href="whats_new/v0.23.html#version-0-23-0">Changelog</a>).
         </li>
-        <li><strong>Scikit-learn from 0.23 requires Python 3.6 or greater.</strong>
+        <li><strong>Scikit-learn from 0.23 requires Python 3.6 or newer.</strong>
         </li>
         <li><strong>March 2020.</strong> scikit-learn 0.22.2 is available for download (<a href="whats_new/v0.22.html#version-0-22-2">Changelog</a>).
         <li><strong>January 2020.</strong> scikit-learn 0.22.1 is available for download (<a href="whats_new/v0.22.html#version-0-22-1">Changelog</a>).


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Consistently use "_requires Python x.x **or newer**_" instead of "_requires Python x.x **or greater**_".

#### Any other comments?

It's "_or newer_" everywhere else:
[README.rst](https://github.com/scikit-learn/scikit-learn/blob/8e8e610/README.rst)
[doc/install.rst](https://github.com/scikit-learn/scikit-learn/blob/8e8e610/doc/install.rst)