### PR TITLE
DOC One more typo in release highlights

### DIFF
--- a/examples/release_highlights/plot_release_highlights_1_0_0.py
+++ b/examples/release_highlights/plot_release_highlights_1_0_0.py
@@ -194,7 +194,7 @@ pipe[:-1].get_feature_names_out()
 # :class:`metrics.PrecisionRecallDisplay`, :class:`metrics.DetCurveDisplay`,
 # and :class:`inspection.PartialDependenceDisplay` now expose two class
 # methods: `from_estimator` and `from_predictions` which allow users to create
-# a plot given the predictions or an estimator. This means the corresponsing
+# a plot given the predictions or an estimator. This means the corresponding
 # `plot_*` functions are deprecated. Please check :ref:`example one
 # <sphx_glr_auto_examples_model_selection_plot_confusion_matrix.py>` and
 # :ref:`example two


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

One more typo found by codespell.

#### Any other comments?

Either it's a new typo, or I had missed it in #21096.