### PR TITLE
FIX `CalibratedClassifierCV` should not ignore `sample_weight` if estimator does not support it

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -2,6 +2,24 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_1_0_1:
+
+Version 1.0.1
+=============
+
+**In Development**
+
+Changelog
+---------
+
+:mod:`sklearn.calibration`
+..........................
+
+- |Fix| Raise an error in :class:`calibration.CalibratedClassifierCV` when
+  `sample_weight` are used together with a :class:`pipeline.Pipeline` instead
+  of silently ignoring `sample_weight`.
+  :pr:`21143` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 .. _changes_1_0:
 
 Version 1.0.0

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -15,9 +15,9 @@ Changelog
 :mod:`sklearn.calibration`
 ..........................
 
-- |Fix| Raise an error in :class:`calibration.CalibratedClassifierCV` when
-  `sample_weight` are used together with a :class:`pipeline.Pipeline` instead
-  of silently ignoring `sample_weight`.
+- |Fix| Raise an error instead of silently ignoring `sample_weight` in
+  :class:`calibration.CalibratedClassifierCV` when the underlying estimator
+  does not support it.
   :pr:`21143` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 .. _changes_1_0:

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -309,7 +309,7 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
                     f"The estimator {base_estimator} does not support sample_weight"
                 )
             if sample_weight is not None:
-                _check_sample_weight(sample_weight, X)
+                sample_weight = _check_sample_weight(sample_weight, X)
 
             # Check that each cross-validation fold can have at least one
             # example per class

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -315,6 +315,13 @@ def test_meta_estimators_delegate_data_validation(estimator):
     assert not hasattr(estimator, "n_features_in_")
 
 
+METAESTIMATORS_ACCEPTING_SAMPLE_WEIGHTS_IN_PIPELINE = [
+    # AdaBoostRegressor can safely accepts `sample_weight` even with a `Pipeline`
+    # because the weights are not used when calling `pipeline.fit`.
+    "AdaBoostRegressor",
+]
+
+
 @pytest.mark.parametrize(
     "estimator_orig",
     [
@@ -322,10 +329,13 @@ def test_meta_estimators_delegate_data_validation(estimator):
         for est in _generate_meta_estimator_instances_with_pipeline(
             first_step=FunctionTransformer()
         )
+        if est.__class__.__name__
+        not in METAESTIMATORS_ACCEPTING_SAMPLE_WEIGHTS_IN_PIPELINE
     ],
     ids=_get_meta_estimator_id,
 )
 def test_meta_estimators_sample_weight_with_pipeline(estimator_orig):
+    """Check that passing a `Pipeline` with `sample_weight` raises an error."""
     estimator = clone(estimator_orig)
     rng = np.random.RandomState(0)
     set_random_state(estimator)

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -316,8 +316,8 @@ def test_meta_estimators_delegate_data_validation(estimator):
 
 
 METAESTIMATORS_ACCEPTING_SAMPLE_WEIGHTS_IN_PIPELINE = [
-    # AdaBoostRegressor can safely accepts `sample_weight` even with a `Pipeline`
-    # because the weights are not used when calling `pipeline.fit`.
+    # AdaBoostRegressor can safely accepts `sample_weight` even with a
+    # `Pipeline` because the weights are not used when calling `pipeline.fit`.
     "AdaBoostRegressor",
 ]
 
@@ -335,7 +335,11 @@ METAESTIMATORS_ACCEPTING_SAMPLE_WEIGHTS_IN_PIPELINE = [
     ids=_get_meta_estimator_id,
 )
 def test_meta_estimators_sample_weight_with_pipeline(estimator_orig):
-    """Check that passing a `Pipeline` with `sample_weight` raises an error."""
+    """Check that passing a `Pipeline` with `sample_weight` raises an error.
+
+    FIXME: in the future, `Pipeline` should be able to delegate `sample_weight`
+    to the inner estimator(s). An error should not be raised then.
+    """
     estimator = clone(estimator_orig)
     rng = np.random.RandomState(0)
     set_random_state(estimator)


### PR DESCRIPTION
Partially addressed #21134 

Forces to raise an error with `Pipeline` included in meta-estimators to not ignore silently `sample_weight`.
In the future, we should address #18159 and the test should not raise an error and delegate the weights to the right estimator in the `Pipeline`.