### PR TITLE
TST Handle Connection error in test_load_boston_alternative

### DIFF
--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -343,8 +343,8 @@ def test_load_boston_alternative():
     data_url = "http://lib.stat.cmu.edu/datasets/boston"
     try:
         raw_df = pd.read_csv(data_url, sep=r"\s+", skiprows=22, header=None)
-    except ConnectionResetError:
-        pytest.xfail("The dataset can't be downloaded (Connection reset by peer).")
+    except ConnectionError as e:
+        pytest.xfail(f"The dataset can't be downloaded. Got exception: {e}")
     data = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])
     target = raw_df.values[1::2, 2]
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -341,7 +341,10 @@ def test_load_boston_alternative():
     boston_sklearn = load_boston()
 
     data_url = "http://lib.stat.cmu.edu/datasets/boston"
-    raw_df = pd.read_csv(data_url, sep=r"\s+", skiprows=22, header=None)
+    try:
+        raw_df = pd.read_csv(data_url, sep=r"\s+", skiprows=22, header=None)
+    except ConnectionResetError:
+        pytest.xfail("The dataset can't be downloaded (Connection reset by peer).")
     data = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])
     target = raw_df.values[1::2, 2]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None.


#### What does this implement/fix? Explain your changes.

Currently [`ConnectionError`s](https://docs.python.org/3/library/exceptions.html#ConnectionError) can make this test fail if there is a problem with downloading the dataset.

This marks the test as xfail in this case.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
