### PR TITLE
TST check equivalence sample_weight in CalibratedClassifierCV

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -2,6 +2,29 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_1_0_1:
+
+Version 1.0.1
+=============
+
+**In Development**
+
+Changelog
+---------
+
+:mod:`sklearn.calibration`
+..........................
+
+- |Fix| Fixed :class:`calibration.CalibratedClassifierCV` to take into account
+  `sample_weight` when computing the base estimator prediction when
+  `ensemble=False`.
+  :pr:`20638` by :user:`Julien Bohné <JulienB-78>`.
+
+- |Fix| Fixed a bug in :class:`calibration.CalibratedClassifierCV` with
+  `method="sigmoid"` that was ignoring the `sample_weight` when computing the
+  the Bayesian priors.
+  :pr:`21179` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 .. _changes_1_0:
 
 Version 1.0.0

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -442,7 +442,9 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
         return {
             "_xfail_checks": {
                 "check_sample_weights_invariance": (
-                    "zero sample_weight is not equivalent to removing samples"
+                    "Due to the cross-validation and sample ordering, removing a sample"
+                    " is not strictly equal to putting is weight to zero. Specific unit"
+                    " tests are added for CalibratedClassifierCV specifically."
                 ),
             }
         }

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -313,7 +313,8 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
                     "can be caused by a limitation of the current scikit-learn API. "
                     "See the following issue for more details: "
                     "https://github.com/scikit-learn/scikit-learn/issues/21134. Be "
-                    "warned that the result of the calibration is likely to be incorrect."
+                    "warned that the result of the calibration is likely to be "
+                    "incorrect."
                 )
 
             # Check that each cross-validation fold can have at least one

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -313,7 +313,7 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
                     "can be caused by a limitation of the current scikit-learn API. "
                     "See the following issue for more details: "
                     "https://github.com/scikit-learn/scikit-learn/issues/21134. Be "
-                    "warn that the result of the calibration is likely to be incorrect."
+                    "warned that the result of the calibration is likely to be incorrect."
                 )
 
             # Check that each cross-validation fold can have at least one

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -308,9 +308,12 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
             if sample_weight is not None and not supports_sw:
                 estimator_name = type(base_estimator).__name__
                 warnings.warn(
-                    f"Since {estimator_name} does not support "
-                    "sample_weights, sample weights will only be"
-                    " used for the calibration itself."
+                    f"Since {estimator_name} does not appear to accept sample_weight, "
+                    "sample weights will only be used for the calibration itself. This "
+                    "can be caused by a limitation of the current scikit-learn API. "
+                    "See the following issue for more details: "
+                    "https://github.com/scikit-learn/scikit-learn/issues/21134. Be "
+                    "warn that the result of the calibration is likely to be incorrect."
                 )
 
             # Check that each cross-validation fold can have at least one

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -776,7 +776,7 @@ def _sigmoid_calibration(predictions, y, sample_weight=None):
     else:
         prior0 = float(np.sum(mask_negative_samples))
         prior1 = y.shape[0] - prior0
-    T = np.zeros_like(y)
+    T = np.zeros_like(y, dtype=np.float64)
     T[y > 0] = (prior1 + 1.0) / (prior1 + 2.0)
     T[y <= 0] = 1.0 / (prior0 + 2.0)
     T1 = 1.0 - T

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -267,6 +267,8 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
         """
         check_classification_targets(y)
         X, y = indexable(X, y)
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X)
 
         if self.base_estimator is None:
             # we want all classifiers that don't expose a random_state
@@ -303,15 +305,13 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
             # sample_weight checks
             fit_parameters = signature(base_estimator.fit).parameters
             supports_sw = "sample_weight" in fit_parameters
-            if sample_weight is not None:
-                sample_weight = _check_sample_weight(sample_weight, X)
-                if not supports_sw:
-                    estimator_name = type(base_estimator).__name__
-                    warnings.warn(
-                        f"Since {estimator_name} does not support "
-                        "sample_weights, sample weights will only be"
-                        " used for the calibration itself."
-                    )
+            if sample_weight is not None and not supports_sw:
+                estimator_name = type(base_estimator).__name__
+                warnings.warn(
+                    f"Since {estimator_name} does not support "
+                    "sample_weights, sample weights will only be"
+                    " used for the calibration itself."
+                )
 
             # Check that each cross-validation fold can have at least one
             # example per class

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -788,7 +788,7 @@ def test_calibration_display_ref_line(pyplot, iris_data_binary):
 
 @pytest.mark.parametrize("method", ["sigmoid", "isotonic"])
 @pytest.mark.parametrize("ensemble", [True, False])
-def test_calibrated_classifier_cv_sample_weights_equivalence(method, ensemble):
+def test_calibrated_classifier_cv_double_sample_weights_equivalence(method, ensemble):
     """Check that passing repeating twice the dataset `X` is equivalent to
     passing a `sample_weight` with a factor 2."""
     X, y = load_iris(return_X_y=True)
@@ -818,6 +818,50 @@ def test_calibrated_classifier_cv_sample_weights_equivalence(method, ensemble):
 
     calibrated_clf_with_weights.fit(X, y, sample_weight=sample_weight)
     calibrated_clf_without_weights.fit(X_twice, y_twice)
+
+    # Check that the underlying fitted estimators have the same coefficients
+    for est_with_weights, est_without_weights in zip(
+        calibrated_clf_with_weights.calibrated_classifiers_,
+        calibrated_clf_without_weights.calibrated_classifiers_,
+    ):
+        assert_allclose(
+            est_with_weights.base_estimator.coef_,
+            est_without_weights.base_estimator.coef_,
+        )
+
+    # Check that the predictions are the same
+    y_pred_with_weights = calibrated_clf_with_weights.predict_proba(X)
+    y_pred_without_weights = calibrated_clf_without_weights.predict_proba(X)
+
+    assert_allclose(y_pred_with_weights, y_pred_without_weights)
+
+
+@pytest.mark.parametrize("method", ["sigmoid", "isotonic"])
+@pytest.mark.parametrize("ensemble", [True, False])
+def test_calibrated_classifier_cv_zeros_sample_weights_equivalence(method, ensemble):
+    """Check that passing removing some sample from the dataset `X` is
+    equivalent to passing a `sample_weight` with a factor 0."""
+    X, y = load_iris(return_X_y=True)
+    # Scale the data to avoid any convergence issue
+    X = StandardScaler().fit_transform(X)
+    # Only use 2 classes and select samples such that 2-fold cross-validation
+    # split will lead to an equivalence with a `sample_weight` of 0
+    X = np.vstack((X[:40], X[50:90]))
+    y = np.hstack((y[:40], y[50:90]))
+    sample_weight = np.zeros_like(y)
+    sample_weight[::2] = 1
+
+    base_estimator = LogisticRegression()
+    calibrated_clf_without_weights = CalibratedClassifierCV(
+        base_estimator,
+        method=method,
+        ensemble=ensemble,
+        cv=2,
+    )
+    calibrated_clf_with_weights = clone(calibrated_clf_without_weights)
+
+    calibrated_clf_with_weights.fit(X, y, sample_weight=sample_weight)
+    calibrated_clf_without_weights.fit(X[::2], y[::2])
 
     # Check that the underlying fitted estimators have the same coefficients
     for est_with_weights, est_without_weights in zip(


### PR DESCRIPTION
related to https://github.com/scikit-learn/scikit-learn/pull/21143

This PR looks at the impact of `sample_weight` in `CalibratedClassifierCV`.

- [x] Add a test that checks the equivalence between having twice the same sample and passing sample weights of 2 for each sample.
- [x] Add a test that checks the equivalence between removing sample and passing null sample weights.