### PR TITLE
FIX sphinx formatting in load_boston

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1133,7 +1133,7 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
         target = raw_df.values[1::2, 2]
 
     Alternative datasets include the California housing dataset (i.e.
-    func:`~sklearn.datasets.fetch_california_housing`) and the Ames housing
+    :func:`~sklearn.datasets.fetch_california_housing`) and the Ames housing
     dataset. You can load the datasets as follows:
 
         from sklearn.datasets import fetch_california_housing

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1134,12 +1134,12 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
 
     Alternative datasets include the California housing dataset (i.e.
     :func:`~sklearn.datasets.fetch_california_housing`) and the Ames housing
-    dataset. You can load the datasets as follows:
+    dataset. You can load the datasets as follows::
 
         from sklearn.datasets import fetch_california_housing
         housing = fetch_california_housing()
 
-    for the California housing dataset and:
+    for the California housing dataset and::
 
         from sklearn.datasets import fetch_openml
         housing = fetch_openml(name="house_prices", as_frame=True)

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1190,7 +1190,7 @@ def load_boston(*, return_X_y=False):
             target = raw_df.values[1::2, 2]
 
         Alternative datasets include the California housing dataset [3]_
-        (i.e. func:`~sklearn.datasets.fetch_california_housing`) and Ames
+        (i.e. :func:`~sklearn.datasets.fetch_california_housing`) and Ames
         housing dataset [4]_. You can load the datasets as follows::
 
             from sklearn.datasets import fetch_california_housing


### PR DESCRIPTION
Follow-up for: #16155.

I suspect this is indirectly causing the lack of rendering of subsequent indented code snippets in:

https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_boston.html?highlight=load_boston#sklearn.datasets.load_boston

![image](https://user-images.githubusercontent.com/89061/135128607-8bef4f33-e1d8-4d7a-9afd-9a86527ffaa3.png)

Let's check on the rendered HTML artifact of this PR.

This would probably deserve a backport to 1.0.X to fix the online doc for this function which was deprecated in 1.0.0.