### PR TITLE
add tfidf token2idf_ property

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -2005,6 +2005,11 @@ class TfidfVectorizer(CountVectorizer):
         """
         return self._tfidf.idf_
 
+    @property
+    def token2idf_(self):
+        """TODO"""
+        return {token: self.idf_[idx] for token, idx in self.vocabulary_.items()}
+
     @idf_.setter
     def idf_(self, value):
         self._validate_vocabulary()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
n/a

#### What does this implement/fix? Explain your changes.
Working with TfidfVectorizer I often face the situation when I need to work with token to idf mapper/dictionary.
I can create this mapper by myself (especially for this, I even created GitHub Gist: [link](https://gist.github.com/dayyass/6facec923472ebba4530e238cadb4366)), but it would be convenient if TfidfVectorizer class object had such mapping as a property.
This PR just implements this.

#### Any other comments?
n/a

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
