### PR TITLE
FIX: tol in _spectral_embedding.py

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -608,10 +608,6 @@ Changelog
 :mod:`sklearn.manifold`
 .......................
 
-- |Fix| Decrease the numerical default tolerance in the lobpcg call
-  in :func:`manifold.spectral_embedding` to prevent numerical instability. 
-  :pr:`21194` by :user:`Andrew Knyazev <lobpcg>`.
-
 - |Enhancement| Implement `'auto'` heuristic for the `learning_rate` in
   :class:`manifold.TSNE`. It will become default in 1.2. The default
   initialization will change to `pca` in 1.2. PCA initialization will
@@ -627,6 +623,10 @@ Changelog
   of the neighbors graph along some minimum distance pairs, instead of changing
   every infinite distances to zero. :pr:`20531` by `Roman Yurchak`_ and `Tom
   Dupre la Tour`_.
+
+- |Fix| Decrease the numerical default tolerance in the lobpcg call
+  in :func:`manifold.spectral_embedding` to prevent numerical instability. 
+  :pr:`21194` by :user:`Andrew Knyazev <lobpcg>`.
 
 :mod:`sklearn.metrics`
 ......................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -608,6 +608,10 @@ Changelog
 :mod:`sklearn.manifold`
 .......................
 
+- |Fix| Decrease the numerical default tolerance in the lobpcg call
+  in :func:`manifold.spectral_embedding` to prevent numerical instability. 
+  :pr:`21194` by :user:`Andrew Knyazev <lobpcg>`.
+
 - |Enhancement| Implement `'auto'` heuristic for the `learning_rate` in
   :class:`manifold.TSNE`. It will become default in 1.2. The default
   initialization will change to `pca` in 1.2. PCA initialization will

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -318,3 +318,13 @@ def test_spectral_clustering_np_matrix_raises():
     msg = r"spectral_clustering does not support passing in affinity as an np\.matrix"
     with pytest.raises(TypeError, match=msg):
         spectral_clustering(X)
+
+
+def test_spectral_embedding_lobpcg_tol_decrease():
+    """Check that spectral_embedding call of lobpcg does not fail due to toll
+    too small. Fixes #21147; see #21194"""
+    X = np.random.randn(100, 10)
+    A = X @ X.T
+    Q = np.random.randn(X.shape[0], 4)
+    eigenvalues, _ = lobpcg(A, Q, maxiter=20)
+    assert(np.max(eigenvalues) > 0)

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -318,13 +318,3 @@ def test_spectral_clustering_np_matrix_raises():
     msg = r"spectral_clustering does not support passing in affinity as an np\.matrix"
     with pytest.raises(TypeError, match=msg):
         spectral_clustering(X)
-
-
-def test_spectral_embedding_lobpcg_tol_decrease():
-    """Check that spectral_embedding call of lobpcg does not fail due to toll
-    too small. Fixes #21147; see #21194"""
-    X = np.random.randn(100, 10)
-    A = X @ X.T
-    Q = np.random.randn(X.shape[0], 4)
-    eigenvalues, _ = lobpcg(A, Q, maxiter=20)
-    assert(np.max(eigenvalues) > 0)

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -367,7 +367,7 @@ def spectral_embedding(
             X = random_state.rand(laplacian.shape[0], n_components + 1)
             X[:, 0] = dd.ravel()
             _, diffusion_map = lobpcg(
-                laplacian, X, tol=1e-15, largest=False, maxiter=2000
+                laplacian, X, tol=1e-5, largest=False, maxiter=2000
             )
             embedding = diffusion_map.T[:n_components]
             if norm_laplacian:


### PR DESCRIPTION
Fix the typo in tol from -15 to -5, making it consistent with other calls of lobpcg here.

#### Reference Issues/PRs
Fixes #21147

#### What does this implement/fix? Explain your changes.
Excessively small tol in lobpcg not only makes it unnecessary slower, increasing the number of iterations for no good reason, but can also make it fail due to numerical instabilities, as found in  #21147

#### Any other comments?
