### PR TITLE
DOC fix typo in load_boston docstring

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1120,7 +1120,7 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
     dataset unless the purpose of the code is to study and educate about
     ethical issues in data science and machine learning.
 
-    In this case special case, you can fetch the dataset from the original
+    In this special case, you can fetch the dataset from the original
     source::
 
         import pandas as pd

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1177,7 +1177,7 @@ def load_boston(*, return_X_y=False):
         this dataset unless the purpose of the code is to study and educate
         about ethical issues in data science and machine learning.
 
-        In this case special case, you can fetch the dataset from the original
+        In this special case, you can fetch the dataset from the original
         source::
 
             import pandas as pd  # doctest: +SKIP


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The deprecation notice for the boston housing dataset had a sentence that read "in this case special case ..." - changed to "in this special case ..."

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
