### PR TITLE
DOC Ensures that PLSSVD passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -23,7 +23,6 @@ DOCSTRING_IGNORE_LIST = [
     "OrthogonalMatchingPursuit",
     "OrthogonalMatchingPursuitCV",
     "PLSRegression",
-    "PLSSVD",
     "PassiveAggressiveClassifier",
     "PassiveAggressiveRegressor",
     "PatchExtractor",

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -910,10 +910,10 @@ class CCA(_PLS):
 class PLSSVD(TransformerMixin, BaseEstimator):
     """Partial Least Square SVD.
 
-    This transformer simply performs a SVD on the crosscovariance matrix X'Y.
-    It is able to project both the training data `X` and the targets `Y`. The
-    training data X is projected on the left singular vectors, while the
-    targets are projected on the right singular vectors.
+    This transformer simply performs a SVD on the cross-covariance matrix
+    `X'Y`. It is able to project both the training data `X` and the targets
+    `Y`. The training data `X` is projected on the left singular vectors, while
+    the targets are projected on the right singular vectors.
 
     Read more in the :ref:`User Guide <cross_decomposition>`.
 
@@ -930,18 +930,18 @@ class PLSSVD(TransformerMixin, BaseEstimator):
 
     copy : bool, default=True
         Whether to copy `X` and `Y` in fit before applying centering, and
-        potentially scaling. If False, these operations will be done inplace,
+        potentially scaling. If `False`, these operations will be done inplace,
         modifying both arrays.
 
     Attributes
     ----------
     x_weights_ : ndarray of shape (n_features, n_components)
         The left singular vectors of the SVD of the cross-covariance matrix.
-        Used to project `X` in `transform`.
+        Used to project `X` in :meth:`transform`.
 
     y_weights_ : ndarray of (n_targets, n_components)
         The right singular vectors of the SVD of the cross-covariance matrix.
-        Used to project `X` in `transform`.
+        Used to project `X` in :meth:`transform`.
 
     x_scores_ : ndarray of shape (n_samples, n_components)
         The transformed training samples.
@@ -1123,7 +1123,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         Returns
         -------
         x_scores : array-like or tuple of array-like
-            The transformed data `X_tranformed` if `Y` is not None,
+            The transformed data `X_tranformed` if `Y is not None`,
             `(X_transformed, Y_transformed)` otherwise.
         """
         check_is_fitted(self)
@@ -1154,7 +1154,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         Returns
         -------
         out : array-like or tuple of array-like
-            The transformed data `X_tranformed` if `Y` is not None,
+            The transformed data `X_tranformed` if `Y is not None`,
             `(X_transformed, Y_transformed)` otherwise.
         """
         return self.fit(X, y).transform(X, y)

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -968,6 +968,11 @@ class PLSSVD(TransformerMixin, BaseEstimator):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    PLSCanonical : Partial Least Squares transformer and regressor.
+    CCA : Canonical Correlation Analysis.
+
     Examples
     --------
     >>> import numpy as np
@@ -984,11 +989,6 @@ class PLSSVD(TransformerMixin, BaseEstimator):
     >>> X_c, Y_c = pls.transform(X, Y)
     >>> X_c.shape, Y_c.shape
     ((4, 2), (4, 2))
-
-    See Also
-    --------
-    PLSCanonical
-    CCA
     """
 
     def __init__(self, n_components=2, *, scale=True, copy=True):
@@ -1006,6 +1006,11 @@ class PLSSVD(TransformerMixin, BaseEstimator):
 
         Y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Targets.
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
         """
         check_consistent_length(X, Y)
         X = self._validate_data(


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures PLSSVD is compatible with numpydoc:

- Remove `PLSSVD` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.
- Change docstrings to maintain consistency.