### PR TITLE
FIX Do not use deprecated API in fetch_20newsgroups_vectorized

### DIFF
--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -479,7 +479,7 @@ def fetch_20newsgroups_vectorized(
         vectorizer = CountVectorizer(dtype=np.int16)
         X_train = vectorizer.fit_transform(data_train.data).tocsr()
         X_test = vectorizer.transform(data_test.data).tocsr()
-        feature_names = vectorizer.get_feature_names()
+        feature_names = vectorizer.get_feature_names_out()
 
         joblib.dump((X_train, X_test, feature_names), target_file, compress=9)
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1456,8 +1456,8 @@ def test_check_pandas_sparse_valid(ntype1, ntype2, expected_subtype):
     pd = pytest.importorskip("pandas", minversion="0.25.0")
     df = pd.DataFrame(
         {
-            "col1": pd.arrays.SparseArray([0, 1, 0], dtype=ntype1),
-            "col2": pd.arrays.SparseArray([1, 0, 1], dtype=ntype2),
+            "col1": pd.arrays.SparseArray([0, 1, 0], dtype=ntype1, fill_value=0),
+            "col2": pd.arrays.SparseArray([1, 0, 1], dtype=ntype2, fill_value=0),
         }
     )
     arr = check_array(df, accept_sparse=["csr", "csc"])

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1414,8 +1414,8 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2):
     pd = pytest.importorskip("pandas", minversion="0.25.0")
     df = pd.DataFrame(
         {
-            "col1": pd.arrays.SparseArray([0, 1, 0], dtype=ntype1),
-            "col2": pd.arrays.SparseArray([1, 0, 1], dtype=ntype2),
+            "col1": pd.arrays.SparseArray([0, 1, 0], dtype=ntype1, fill_value=0),
+            "col2": pd.arrays.SparseArray([1, 0, 1], dtype=ntype2, fill_value=0),
         }
     )
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/21212


#### What does this implement/fix? Explain your changes.
Errored during test collection time because of the deprecation warning.

#### Any other comments?
During test collection time and `SKLEARN_SKIP_NETWORK_TESTS='0'`, datasets are downloaded first to cache them. This is done because when multiple processes call `fetch_*` they can both write to the same location on the filesystem, which use to cause errors.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
