### PR TITLE
DOC Fixes logo and badge on PyPi's readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@
 .. |PythonVersion| image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue
 .. _PythonVersion: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue
 
-.. |PyPi| image:: https://badge.fury.io/py/scikit-learn.svg
-.. _PyPi: https://badge.fury.io/py/scikit-learn
+.. |PyPi| image:: https://img.shields.io/pypi/v/scikit-learn
+.. _PyPi: https://pypi.org/project/scikit-learn
 
 .. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
 .. _Black: https://github.com/psf/black
@@ -41,7 +41,7 @@
 .. |SeabornMinVersion| replace:: 0.9.0
 .. |PytestMinVersion| replace:: 5.0.1
 
-.. image:: doc/logos/scikit-learn-logo.png
+.. image:: https://raw.githubusercontent.com/scikit-learn/scikit-learn/main/doc/logos/scikit-learn-logo.png
   :target: https://scikit-learn.org/
 
 **scikit-learn** is a Python module for machine learning built on top of


### PR DESCRIPTION
Currently the badge and logo on PyPi are not displaying: https://pypi.org/project/scikit-learn/

1. For the `image::`, the path to the image needs to be absolute.
2. For the `PyPi` page, using `img.shields.io` should work since it works for the other badges.