### PR TITLE
BLD Fixes osx build by downgrading to 11.X [cd build]

### DIFF
--- a/build_tools/github/build_wheels.sh
+++ b/build_tools/github/build_wheels.sh
@@ -12,7 +12,7 @@ if [[ "$RUNNER_OS" == "macOS" ]]; then
     # supported macos version is: High Sierra / 10.13. When upgrading this, be
     # sure to update the MACOSX_DEPLOYMENT_TARGET environment variable in
     # wheels.yml accordingly. Note that Darwin_17 == High Sierra / 10.13.
-    wget https://packages.macports.org/libomp/libomp-12.0.0_0+universal.darwin_17.i386-x86_64.tbz2 -O libomp.tbz2
+    wget https://packages.macports.org/libomp/libomp-11.0.1_0+universal.darwin_17.i386-x86_64.tbz2 -O libomp.tbz2
     sudo tar -C / -xvjf libomp.tbz2 opt
 
     export CC=/usr/bin/clang


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #21182

#### What does this implement/fix? Explain your changes.
There are issues with libomp 12 on OSX. This PR downgrades the libomp version to 11.0.1.

1. I tested the wheel built by github actions on my osx python 3.9 and this fix works.

2. When testing this locally, the wheels work when `numpy` is installed through `pip` and fails when `numpy` is installed through `conda`. The biggest different I see is that with `conda`, `llvm-openmp==12.0.1` is installed.

3. The CI does not catch this error because everything is installed through `pip`.

XREF: https://github.com/microsoft/LightGBM/issues/4229

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
