### PR TITLE
Use merge=union strategy for all version changelogs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-/doc/v*.rst merge=union
+/doc/whats_new/v*.rst merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-/doc/whats_new.rst merge=union
+/doc/v*.rst merge=union


### PR DESCRIPTION
#### Reference Issues/PRs

It was done originally in https://github.com/scikit-learn/scikit-learn/pull/7896 but was not updated when we split the whats_new.rst into version-specific files.

#### What does this implement/fix? Explain your changes.

This should avoid most conflicts due to changelog changes. I noticed quite a few of them recently in PRs I was following.
