### PR TITLE
DOC Ensures that SplineTransformer passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -28,7 +28,6 @@ DOCSTRING_IGNORE_LIST = [
     "SpectralBiclustering",
     "SpectralCoclustering",
     "SpectralEmbedding",
-    "SplineTransformer",
     "StackingRegressor",
     "TransformedTargetRegressor",
 ]

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -693,6 +693,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         Returns
         -------
         output_feature_names : list of str of shape (n_output_features,)
+            Transformed feature names.
         """
         n_splines = self.bsplines_[0].c.shape[0]
         if input_features is None:


### PR DESCRIPTION
Reference Issues/PRs

Addresses #20308 

What does this implement/fix? Explain your changes.

This PR ensures SplineTransformer is compatible with numpydoc:

- Remove `SplineTransformer` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.
- Change docstrings to maintain consistency.