### PR TITLE
DOC Remove unused import from example

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1557,7 +1557,6 @@ class TfidfTransformer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     >>> from sklearn.feature_extraction.text import TfidfTransformer
     >>> from sklearn.feature_extraction.text import CountVectorizer
     >>> from sklearn.pipeline import Pipeline
-    >>> import numpy as np
     >>> corpus = ['this is the first document',
     ...           'this document is the second document',
     ...           'and this is the third one',


### PR DESCRIPTION
Importing Numpy is unnecessary in the `TfidfTransformer` example.

(follow-up to https://github.com/scikit-learn/scikit-learn/pull/15199.)