### PR TITLE
DOC Linear regression doc update

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -536,9 +536,10 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
 
     n_jobs : int, default=None
         The number of jobs to use for the computation. This will only provide
-        speedup in case of sufficient large problems if `X` is sparse or
-        `positive` is set to `True` and n_targets > 1. ``None`` means 1 unless
-        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        speedup in case of sufficiently large problems, that is if firstly
+        `n_targets > 1` and secondly `X` is sparse or if `positive` is set
+        to `True`. ``None`` means 1 unless in a
+        :obj:`joblib.parallel_backend` context. ``-1`` means using all
         processors. See :term:`Glossary <n_jobs>` for more details.
 
     positive : bool, default=False

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -535,8 +535,9 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         If True, X will be copied; else, it may be overwritten.
 
     n_jobs : int, default=None
-        The number of jobs to use for the computation. This will only provide
-        speedup for n_targets > 1 and sufficient large problems.
+        The number of jobs to use for the computation.
+        This will only provide speedup in case of sufficient large problems
+        if `X` is sparse or `positive` is set to `True` and n_targets > 1.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -535,12 +535,11 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         If True, X will be copied; else, it may be overwritten.
 
     n_jobs : int, default=None
-        The number of jobs to use for the computation.
-        This will only provide speedup in case of sufficient large problems
-        if `X` is sparse or `positive` is set to `True` and n_targets > 1.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
-        for more details.
+        The number of jobs to use for the computation. This will only provide
+        speedup in case of sufficient large problems if `X` is sparse or
+        `positive` is set to `True` and n_targets > 1. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors. See :term:`Glossary <n_jobs>` for more details.
 
     positive : bool, default=False
         When set to ``True``, forces the coefficients to be positive. This


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #21254.
Related to #14228.

#### What does this implement/fix? Explain your changes.
By fitting a LinearRegression the n_jobs parameter can set the number of threads only in case of positive=True or in case of sp.issparse(X). In other cases the linalg.lstsq is called which can handle (M, K) shaped y and there is no parameter like n_jobs in this call.

Docstring is updated according to this.