### PR TITLE
DOC updated variable name in KernelRidge docstring

### DIFF
--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -125,8 +125,8 @@ class KernelRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
     >>> rng = np.random.RandomState(0)
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
-    >>> clf = KernelRidge(alpha=1.0)
-    >>> clf.fit(X, y)
+    >>> krr = KernelRidge(alpha=1.0)
+    >>> krr.fit(X, y)
     KernelRidge(alpha=1.0)
     """
 


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.
The variable name used for `KernelRidge` docstring example is `clf`, which can be misleading as `clf` is usually used for Classifiers and `KernelRidge` is a Regression Method. Updated it to `krr` (short for Kernel Ridge Regression).
