### PR TITLE
Add partial model evaluation to gradient boosting

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -53,6 +53,11 @@ Changelog
   :class:`ensemble.HistGradientBoostingRegressor`.
   :pr:`21130` :user:`Christian Lorentzen <lorentzenchr>`.
 
+- |Enhancement| :class:`ensemble.GradientBoostingClassifier` and
+  :class:`ensemble.GradientBoostingRegressor` can now be evaluated with `.predict` and `.staged_predict` before all the estimators are present.
+  This allows for more custom progress monitoring in the `monitor` function.
+  :pr:`21292` by :user:`Marcin Konowalczyk <MarcinKonowalczyk>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 


### PR DESCRIPTION
This PR is an enhancement proposal and it does not relate to any PR.

#### What does this implement/fix?

I found myself wanting to evaluate partially-trained GB models in the `monitor` function. This turned out to be impossible since some of the estimators in `self.estimators_` were not there yet, and `None`'s were being passed on to `predict_stages` (in `\estimators\_gradient_boosting.pyx`). This PR adds a None-check to allow for this.

#### Comments 

I've played around with having the None-check on the cython level, but I've decided it would be better to keep the inner loops tight. Also, note the comment in `_staged_raw_predict`.