### PR TITLE
DOC Ensures that OrthogonalMatchingPursuit passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -18,7 +18,6 @@ DOCSTRING_IGNORE_LIST = [
     "MultiTaskElasticNetCV",
     "MultiTaskLasso",
     "MultiTaskLassoCV",
-    "OrthogonalMatchingPursuit",
     "OrthogonalMatchingPursuitCV",
     "PassiveAggressiveClassifier",
     "PassiveAggressiveRegressor",

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -604,7 +604,7 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
         Maximum norm of the residual. If not None, overrides n_nonzero_coefs.
 
     fit_intercept : bool, default=True
-        whether to calculate the intercept for this model. If set
+        Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
@@ -653,16 +653,17 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
 
         .. versionadded:: 1.0
 
-    Examples
+    See Also
     --------
-    >>> from sklearn.linear_model import OrthogonalMatchingPursuit
-    >>> from sklearn.datasets import make_regression
-    >>> X, y = make_regression(noise=4, random_state=0)
-    >>> reg = OrthogonalMatchingPursuit(normalize=False).fit(X, y)
-    >>> reg.score(X, y)
-    0.9991...
-    >>> reg.predict(X[:1,])
-    array([-78.3854...])
+    orthogonal_mp : Solves n_targets Orthogonal Matching Pursuit problems.
+    orthogonal_mp_gram :  Solves n_targets Orthogonal Matching Pursuit problems using only 
+        the Gram matrix X.T * X and the product X.T * y.
+    lars_path : Compute Least Angle Regression or Lasso path using LARS algorithm.
+    Lars : Least Angle Regression model a.k.a. LAR.
+    LassoLars : Lasso model fit with Least Angle Regression a.k.a. Lars.
+    sklearn.decomposition.sparse_encode : Generic sparse coding.
+        Each column of the result is the solution to a Lasso problem.
+    OrthogonalMatchingPursuitCV : Cross-validated Orthogonal Matching Pursuit model (OMP).
 
     Notes
     -----
@@ -676,15 +677,16 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
     Matching Pursuit Technical Report - CS Technion, April 2008.
     https://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
 
-    See Also
+    Examples
     --------
-    orthogonal_mp
-    orthogonal_mp_gram
-    lars_path
-    Lars
-    LassoLars
-    sklearn.decomposition.sparse_encode
-    OrthogonalMatchingPursuitCV
+    >>> from sklearn.linear_model import OrthogonalMatchingPursuit
+    >>> from sklearn.datasets import make_regression
+    >>> X, y = make_regression(noise=4, random_state=0)
+    >>> reg = OrthogonalMatchingPursuit(normalize=False).fit(X, y)
+    >>> reg.score(X, y)
+    0.9991...
+    >>> reg.predict(X[:1,])
+    array([-78.3854...])
     """
 
     def __init__(
@@ -711,13 +713,12 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
             Training data.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            Target values. Will be cast to X's dtype if necessary
-
+            Target values. Will be cast to X's dtype if necessary.
 
         Returns
         -------
         self : object
-            returns an instance of self.
+            Returns an instance of self.
         """
         _normalize = _deprecate_normalize(
             self.normalize, default=True, estimator_name=self.__class__.__name__

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -656,14 +656,15 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
     See Also
     --------
     orthogonal_mp : Solves n_targets Orthogonal Matching Pursuit problems.
-    orthogonal_mp_gram :  Solves n_targets Orthogonal Matching Pursuit problems using only 
-        the Gram matrix X.T * X and the product X.T * y.
+    orthogonal_mp_gram :  Solves n_targets Orthogonal Matching Pursuit
+        problems using only the Gram matrix X.T * X and the product X.T * y.
     lars_path : Compute Least Angle Regression or Lasso path using LARS algorithm.
     Lars : Least Angle Regression model a.k.a. LAR.
     LassoLars : Lasso model fit with Least Angle Regression a.k.a. Lars.
     sklearn.decomposition.sparse_encode : Generic sparse coding.
         Each column of the result is the solution to a Lasso problem.
-    OrthogonalMatchingPursuitCV : Cross-validated Orthogonal Matching Pursuit model (OMP).
+    OrthogonalMatchingPursuitCV : Cross-validated 
+        Orthogonal Matching Pursuit model (OMP).
 
     Notes
     -----

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -663,7 +663,7 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
     LassoLars : Lasso model fit with Least Angle Regression a.k.a. Lars.
     sklearn.decomposition.sparse_encode : Generic sparse coding.
         Each column of the result is the solution to a Lasso problem.
-    OrthogonalMatchingPursuitCV : Cross-validated 
+    OrthogonalMatchingPursuitCV : Cross-validated
         Orthogonal Matching Pursuit model (OMP).
 
     Notes


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #20308

#### What does this implement/fix? Explain your changes.
Changes are made to docstrings of `OrthogonalMatchingPursuit` class and its methods to ensure they pass numpydoc validation
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
