### PR TITLE
DOC Fix OneHotEncoder.get_feature_names_out docstring

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -702,9 +702,6 @@ class OneHotEncoder(_BaseEncoder):
     def get_feature_names_out(self, input_features=None):
         """Get output feature names for transformation.
 
-        Returns `input_features` as this transformation doesn't add or drop
-        features.
-
         Parameters
         ----------
         input_features : array-like of str or None, default=None


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.
OneHotEncoder is not one-to-one on features, contrary to the current docs claim.


I guess I'll try this Hacktoberfest thing, so if this is enough of a contribution please add the hacktoberfest-accepted label.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
