### PR TITLE
[DOC] Remove "mse" from `RandomForestRegression` docstring

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1417,7 +1417,7 @@ class RandomForestRegressor(ForestRegressor):
            The default value of ``n_estimators`` changed from 10 to 100
            in 0.22.
 
-    criterion : {"squared_error", "mse", "absolute_error", "poisson"}, \
+    criterion : {"squared_error", "absolute_error", "poisson"}, \
             default="squared_error"
         The function to measure the quality of a split. Supported criteria
         are "squared_error" for the mean squared error, which is equal to


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The _"mae"_ criterion was removed from the docstring in 36915ae390fab4742f98c82dc6802f072c4effa5. For consistency I think that _"mse"_ should be removed as well since both were deprecated in 1.0.

#### Any other comments?

Both criterions are still in `ExtraTreesRegressor` and I think they could be removed as well.