### PR TITLE
[DOC] Remove old error functions from docstrings

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -2061,8 +2061,7 @@ class ExtraTreesRegressor(ForestRegressor):
            The default value of ``n_estimators`` changed from 10 to 100
            in 0.22.
 
-    criterion : {"squared_error", "mse", "absolute_error", "mae"}, \
-            default="squared_error"
+    criterion : {"squared_error", "absolute_error"}, default="squared_error"
         The function to measure the quality of a split. Supported criteria
         are "squared_error" for the mean squared error, which is equal to
         variance reduction as feature selection criterion, and "absolute_error"

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1474,8 +1474,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
 
     Parameters
     ----------
-    loss : {'squared_error', 'ls', 'absolute_error', 'lad', 'huber', \
-            'quantile'}, default='squared_error'
+    loss : {'squared_error', 'absolute_error', 'huber', 'quantile'},
+            default='squared_error'
         Loss function to be optimized. 'squared_error' refers to the squared
         error for regression. 'absolute_error' refers to the absolute error of
         regression and is a robust loss function. 'huber' is a

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1474,7 +1474,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
 
     Parameters
     ----------
-    loss : {'squared_error', 'absolute_error', 'huber', 'quantile'},
+    loss : {'squared_error', 'absolute_error', 'huber', 'quantile'}, \
             default='squared_error'
         Loss function to be optimized. 'squared_error' refers to the squared
         error for regression. 'absolute_error' refers to the absolute error of

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1021,10 +1021,10 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
     Parameters
     ----------
-    loss : {'squared_error', 'least_squares', 'absolute_error', \
-            'least_absolute_deviation', 'poisson'}, default='squared_error'
+    loss : {'squared_error', 'absolute_error', 'poisson'}, \
+            default='squared_error'
         The loss function to use in the boosting process. Note that the
-        "least squares" and "poisson" losses actually implement
+        "squared error" and "poisson" losses actually implement
         "half least squares loss" and "half poisson deviance" to simplify the
         computation of the gradient. Furthermore, "poisson" loss internally
         uses a log-link and requires ``y >= 0``.

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1038,8 +1038,8 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
 
     Parameters
     ----------
-    criterion : {"squared_error", "mse", "friedman_mse", "absolute_error", \
-            "mae", "poisson"}, default="squared_error"
+    criterion : {"squared_error", "friedman_mse", "absolute_error", \
+            "poisson"}, default="squared_error"
         The function to measure the quality of a split. Supported criteria
         are "squared_error" for the mean squared error, which is equal to
         variance reduction as feature selection criterion and minimizes the L2
@@ -1630,8 +1630,7 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
 
     Parameters
     ----------
-    criterion : {"squared_error", "mse", "friedman_mse", "mae"}, \
-            default="squared_error"
+    criterion : {"squared_error", "friedman_mse"}, default="squared_error"
         The function to measure the quality of a split. Supported criteria
         are "squared_error" for the mean squared error, which is equal to
         variance reduction as feature selection criterion and "mae" for the


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Removes "mae", "mse", "least_squares", "squared_loss", "lad", "least_absolute_deviation" and "absolute_loss" from docstrings.

Since the errors were standardized in 1.0, maybe they can be removed from the documentation, leaving only the deprecation text.

If PR #21306 is accepted, that only fixes the docstring in `RandomForestRegression`, It would be natural to fix the other classes documentations.

According to [v1.0 changelog](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/v1.0.rst#changelog-1);

> |API| The option for using the squared error via loss and criterion parameters was made more consistent. The preferred way is by setting the value to "squared_error". Old option names are still valid, produce the same models, but are deprecated and will be removed in version 1.2. :pr:`19310` by :user:`Christian Lorentzen <lorentzenchr>`.
> * For :class:`ensemble.ExtraTreesRegressor`, criterion="mse" is deprecated, use "squared_error" instead which is now the default.
> * For :class:`ensemble.GradientBoostingRegressor`, loss="ls" is deprecated, use "squared_error" instead which is now the default.
> * For :class:`ensemble.RandomForestRegressor`, criterion="mse" is deprecated, use "squared_error" instead which is now the default.
> * For :class:`ensemble.HistGradientBoostingRegressor`, loss="least_squares" is deprecated, use "squared_error" instead which is now the default.
> * For :class:`linear_model.RANSACRegressor`, loss="squared_loss" is deprecated, use "squared_error" instead.
> * For :class:`linear_model.SGDRegressor`, loss="squared_loss" is deprecated, use "squared_error" instead which is now the default.
> * For :class:`tree.DecisionTreeRegressor`, criterion="mse" is deprecated, use "squared_error" instead which is now the default.
> * For :class:`tree.ExtraTreeRegressor`, criterion="mse" is deprecated, use "squared_error" instead which is now the default.
>
> |API| The option for using the absolute error via loss and criterion parameters was made more consistent. The preferred way is by setting the value to "absolute_error". Old option names are still valid, produce the same models, but are deprecated and will be removed in version 1.2. :pr:`19733` by :user:`Christian Lorentzen <lorentzenchr>`.
> * For :class:`ensemble.ExtraTreesRegressor`, criterion="mae" is deprecated, use "absolute_error" instead.
> * For :class:`ensemble.GradientBoostingRegressor`, loss="lad" is deprecated, use "absolute_error" instead.
> * For :class:`ensemble.RandomForestRegressor`, criterion="mae" is deprecated, use "absolute_error" instead.
> * For :class:`ensemble.HistGradientBoostingRegressor`, loss="least_absolute_deviation" is deprecated, use "absolute_error" instead.
> * For :class:`linear_model.RANSACRegressor`, loss="absolute_loss" is deprecated, use "absolute_error" instead which is now the default.
> * For :class:`tree.DecisionTreeRegressor`, criterion="mae" is deprecated, use "absolute_error" instead.
For :class:`tree.ExtraTreeRegressor`, criterion="mae" is deprecated, use "absolute_error" instead.

So this PR also checks the following classes:
|  class  | error |
| ------ | ------ |
| `ensemble.ExtraTreesRegressor` | "mse" |
| `ensemble.GradientBoostingRegressor` | "ls" |
| ~~`ensemble.RandomForestRegressor`~~ |  ~~"mse"~~  #21306 |
| `ensemble.HistGradientBoostingRegressor` | "least_squares" |
| `ensemble.HistGradientBoostingRegressor` | "least_absolute_deviation" |
| `linear_model.RANSACRegressor` | "squared_loss" |
| `linear_model.SGDRegressor` | "squared_loss" |
| `tree.DecisionTreeRegressor` | "mse" |
| `tree.ExtraTreeRegressor` | "mse" |
| `ensemble.ExtraTreesRegressor` | "mae" |
| `ensemble.GradientBoostingRegressor` | "lad" |
| `ensemble.RandomForestRegressor` | "mae" |
| `ensemble.HistGradientBoostingRegressor` | "least_absolute_deviation" |
| `linear_model.RANSACRegressor` | "absolute_loss" |
| `tree.DecisionTreeRegressor` | "mae" | 
| `tree.ExtraTreeRegressor` | "mae" |