### PR TITLE
DOC Ensures that MultiLabelBinarizer passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -13,7 +13,6 @@ DOCSTRING_IGNORE_LIST = [
     "LabelPropagation",
     "LabelSpreading",
     "LocallyLinearEmbedding",
-    "MultiLabelBinarizer",
     "MultiTaskElasticNet",
     "MultiTaskElasticNetCV",
     "MultiTaskLasso",

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -748,7 +748,7 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
         Returns
         -------
         self : object
-            Returns this MultiLabelBinarizer instance.
+            Fitted estimator.
         """
         self._cached_dict = None
         if self.classes is None:
@@ -779,7 +779,7 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
         Returns
         -------
         y_indicator : {ndarray, sparse matrix} of shape (n_samples, n_classes)
-            A matrix such that `y_indicator[i, j] = 1` i.f.f. `classes_[j]`
+            A matrix such that `y_indicator[i, j] = 1` iff `classes_[j]`
             is in `y[i]`, and 0 otherwise. Sparse matrix will be of CSR
             format.
         """
@@ -847,6 +847,10 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
         Parameters
         ----------
         y : iterable of iterables
+            A set of labels (any orderable and hashable object) for each
+            sample. If the `classes` parameter is set, `y` will not be
+            iterated.
+
         class_mapping : Mapping
             Maps from label to column index in label indicator matrix.
 

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -692,6 +692,11 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
         Otherwise it corresponds to the sorted set of classes found
         when fitting.
 
+    See Also
+    --------
+    OneHotEncoder : Encode categorical features using a one-hot aka one-of-K
+        scheme.
+
     Examples
     --------
     >>> from sklearn.preprocessing import MultiLabelBinarizer
@@ -724,11 +729,6 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
     MultiLabelBinarizer()
     >>> mlb.classes_
     array(['comedy', 'sci-fi', 'thriller'], dtype=object)
-
-    See Also
-    --------
-    OneHotEncoder : Encode categorical features using a one-hot aka one-of-K
-        scheme.
     """
 
     def __init__(self, *, classes=None, sparse_output=False):
@@ -747,7 +747,8 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
 
         Returns
         -------
-        self : returns this MultiLabelBinarizer instance
+        self : object
+            Returns this MultiLabelBinarizer instance.
         """
         self._cached_dict = None
         if self.classes is None:


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308


#### What does this implement/fix? Explain your changes.
This PR ensures MultiLabelBinarizer is compatible with numpydoc:

- Remove `MultiLabelBinarizer` from `DOCSTRING_IGNORE_LIST`.
- Verify that all tests are passing.
- Change docstrings to maintain consistency.