### PR TITLE
MAINT Fix Check Manifest in CI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,6 +23,7 @@ recursive-exclude benchmarks *
 recursive-exclude .binder *
 recursive-exclude .circleci *
 exclude .codecov.yml
+exclude .git-blame-ignore-revs
 exclude .mailmap
 exclude .pre-commit-config.yaml
 exclude azure-pipelines.yml


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Hopefully this will fix the error in the Check Manifest GitHub action.

#### Any other comments?

```
▼ Run check-manifest -v
  check-manifest -v
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.9.7/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.9.7/x64/lib
lists of files in version control and sdist do not match!
missing from sdist:
  .git-blame-ignore-revs
listing source files under version control: 1301 files and directories
building an sdist: scikit-learn-1.1.dev0.tar.gz: 1300 files and directories
copying source files to a temporary directory
building a clean sdist: scikit-learn-1.1.dev0.tar.gz: 1300 files and directories
Error: Process completed with exit code 1.
```