### PR TITLE
ENH Improve compatibility with re-arranged trees

### DIFF
--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -534,7 +534,7 @@ class _DOTTreeExporter(_BaseTreeExporter):
                     # Draw True/False labels if parent is root node
                     angles = np.array([45, -45]) * ((self.rotate - 0.5) * -2)
                     self.out_file.write(" [labeldistance=2.5, labelangle=")
-                    if tree.children_left[0] == node_id:
+                    if node_id == tree.children_left[0]:
                         self.out_file.write('%d, headlabel="True"]' % angles[0])
                     else:
                         self.out_file.write('%d, headlabel="False"]' % angles[1])

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -534,7 +534,7 @@ class _DOTTreeExporter(_BaseTreeExporter):
                     # Draw True/False labels if parent is root node
                     angles = np.array([45, -45]) * ((self.rotate - 0.5) * -2)
                     self.out_file.write(" [labeldistance=2.5, labelangle=")
-                    if node_id == 1:
+                    if tree.children_left[0] == node_id:
                         self.out_file.write('%d, headlabel="True"]' % angles[0])
                     else:
                         self.out_file.write('%d, headlabel="False"]' % angles[1])


### PR DESCRIPTION
General detection of the left child which also handles  re-arranged trees e. g. after a manual subtree rotation that keeps the original IDs.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
