### PR TITLE
ENH Add get_feature_names_out for random_projection module

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -162,6 +162,15 @@ Changelog
   ndarray with `np.nan` when passed a `Float32` or `Float64` pandas extension
   array with `pd.NA`. :pr:`21278` by `Thomas Fan`_.
 
+:mod:`sklearn.random_projection`
+................................
+
+- |API| Adds :term:`get_feature_names_out` to all transformers in the
+  :mod:`sklearn.random_projection` module:
+  :class:`~sklearn.random_projection.GaussianRandomProjection` and
+  :class:`~sklearn.random_projection.SparseRandomProjection`. :pr:`21330` by
+  :user:`Loïc Estève <lesteve>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -166,7 +166,7 @@ Changelog
 ................................
 
 - |API| Adds :term:`get_feature_names_out` to all transformers in the
-  :mod:`sklearn.random_projection` module:
+  :mod:`~sklearn.random_projection` module:
   :class:`~sklearn.random_projection.GaussianRandomProjection` and
   :class:`~sklearn.random_projection.SparseRandomProjection`. :pr:`21330` by
   :user:`Loïc Estève <lesteve>`.

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -34,7 +34,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from .base import BaseEstimator, TransformerMixin
-from .base import _check_feature_names_in
+from .base import _ClassNamePrefixFeaturesOutMixin
 
 from .utils import check_random_state
 from .utils.extmath import safe_sparse_dot
@@ -291,7 +291,9 @@ def _sparse_random_matrix(n_components, n_features, density="auto", random_state
         return np.sqrt(1 / density) / np.sqrt(n_components) * components
 
 
-class BaseRandomProjection(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
+class BaseRandomProjection(
+    TransformerMixin, BaseEstimator, _ClassNamePrefixFeaturesOutMixin, metaclass=ABCMeta
+):
     """Base class for random projections.
 
     Warning: This class should not be used directly.
@@ -421,25 +423,10 @@ class BaseRandomProjection(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
         X_new = safe_sparse_dot(X, self.components_.T, dense_output=self.dense_output)
         return X_new
 
-    def get_feature_names_out(self, input_features=None):
-        """Get output feature names for transformation.
-
-        Parameters
-        ----------
-        input_features : array-like of str or None, default=None
-            Not used, present here for API consistency by convention.
-
-        Returns
-        -------
-        feature_names_out : ndarray of str objects
-            Transformed feature names.
-        """
-        _check_feature_names_in(self, input_features)
-        class_name = self.__class__.__name__.lower()
-        return np.asarray(
-            [f"{class_name}{i}" for i in range(self.n_components)],
-            dtype=object,
-        )
+    @property
+    def _n_features_out(self):
+        """Number of transformed output features."""
+        return self.n_components
 
 
 class GaussianRandomProjection(BaseRandomProjection):

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -34,6 +34,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from .base import BaseEstimator, TransformerMixin
+from .base import _check_feature_names_in
 
 from .utils import check_random_state
 from .utils.extmath import safe_sparse_dot
@@ -419,6 +420,26 @@ class BaseRandomProjection(TransformerMixin, BaseEstimator, metaclass=ABCMeta):
 
         X_new = safe_sparse_dot(X, self.components_.T, dense_output=self.dense_output)
         return X_new
+
+    def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str objects
+            Transformed feature names.
+        """
+        _check_feature_names_in(self, input_features)
+        class_name = self.__class__.__name__.lower()
+        return np.asarray(
+            [f"{class_name}{i}" for i in range(self.n_components)],
+            dtype=object,
+        )
 
 
 class GaussianRandomProjection(BaseRandomProjection):

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -425,7 +425,10 @@ class BaseRandomProjection(
 
     @property
     def _n_features_out(self):
-        """Number of transformed output features."""
+        """Number of transformed output features.
+
+        Used by _ClassNamePrefixFeaturesOutMixin.get_feature_names_out.
+        """
         return self.n_components
 
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -371,7 +371,6 @@ GET_FEATURES_OUT_MODULES_TO_IGNORE = [
     "manifold",
     "neighbors",
     "neural_network",
-    "random_projection",
 ]
 
 

--- a/sklearn/tests/test_random_projection.py
+++ b/sklearn/tests/test_random_projection.py
@@ -24,7 +24,7 @@ all_random_matrix = all_sparse_random_matrix + all_dense_random_matrix
 
 all_SparseRandomProjection: List[Any] = [SparseRandomProjection]
 all_DenseRandomProjection: List[Any] = [GaussianRandomProjection]
-all_RandomProjection = set(all_SparseRandomProjection + all_DenseRandomProjection)
+all_RandomProjection = all_SparseRandomProjection + all_DenseRandomProjection
 
 
 # Make some random data with uniformly located non zero entries with

--- a/sklearn/tests/test_random_projection.py
+++ b/sklearn/tests/test_random_projection.py
@@ -359,3 +359,17 @@ def test_johnson_lindenstrauss_min_dim():
     Regression test for #17111: before #19374, 32-bit systems would fail.
     """
     assert johnson_lindenstrauss_min_dim(100, eps=1e-5) == 368416070986
+
+
+@pytest.mark.parametrize("random_projection_cls", all_RandomProjection)
+def test_random_projection_feature_names_out(random_projection_cls):
+    random_projection = random_projection_cls(n_components=2)
+    random_projection.fit(data)
+    names_out = random_projection.get_feature_names_out()
+    class_name_lower = random_projection_cls.__name__.lower()
+    expected_names_out = np.array(
+        [f"{class_name_lower}{i}" for i in range(random_projection.n_components_)],
+        dtype=object,
+    )
+
+    assert_array_equal(names_out, expected_names_out)


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #21308.

#### What does this implement/fix? Explain your changes.

Adds `get_feature_names_out` to the `random_projection` module.

#### Any other comments?

When #21079 gets merged, I could use  `generate_names=False` in `_check_feature_names_in` (see https://github.com/scikit-learn/scikit-learn/pull/21079/files#diff-962bea3f949b0a1e7b2ad40d2879f5d7ba1e6cd7da168daa82f84a87e800715e for more details) since the names of the output features don't reuse the names of the input features.