### PR TITLE
DOC Fix reference to MultiLabelBinarizer in FunctionTransformer

### DIFF
--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -91,7 +91,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
     StandardScaler : Standardize features by removing the mean and
         scaling to unit variance.
     LabelBinarizer : Binarize labels in a one-vs-all fashion.
-    MultilabelBinarizer : Transform between iterable of iterables
+    MultiLabelBinarizer : Transform between iterable of iterables
         and a multilabel format.
 
     Examples


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fix the `See Also` reference to `MultiLabelBinarizer` in [FunctionTransformer](https://scikit-learn.org/dev/modules/generated/sklearn.preprocessing.FunctionTransformer.html#sklearn.preprocessing.FunctionTransformer)