### PR TITLE
FIX set docstrings on sklearn.utils.fixes.threadpool_limits/info

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -228,6 +228,10 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.extmath.weighted_mode",
     "sklearn.utils.fixes.delayed",
     "sklearn.utils.fixes.linspace",
+    # To be fixed in upstream issue:
+    # https://github.com/joblib/threadpoolctl/issues/108
+    "sklearn.utils.fixes.threadpool_info",
+    "sklearn.utils.fixes.threadpool_limits",
     "sklearn.utils.gen_batches",
     "sklearn.utils.gen_even_slices",
     "sklearn.utils.get_chunk_n_rows",

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -297,9 +297,15 @@ def threadpool_limits(limits=None, user_api=None):
         return threadpoolctl.threadpool_limits(limits=limits, user_api=user_api)
 
 
+threadpool_limits.__doc__ = threadpoolctl.threadpool_limits.__doc__
+
+
 def threadpool_info():
     controller = _get_threadpool_controller()
     if controller is not None:
         return controller.info()
     else:
         return threadpoolctl.threadpool_info()
+
+
+threadpool_info.__doc__ = threadpoolctl.threadpool_info.__doc__


### PR DESCRIPTION
Try to fix a CI failure caused by the recent merge of two unrelated but interacting PRs.