### PR TITLE
CI Fixes test_rank_deficient_design

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -43,6 +43,12 @@ Fixed models
   between sparse and dense input. :pr:`21195`
   by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+:mod:`sklearn.linear_model`
+...........................
+
+- |Fix| Improves stability of :class:`linear_model.LassoLars` for different
+  versions of openblas. :pr:`21340` by `Thomas Fan`_.
+
 :mod:`sklearn.neighbors`
 ........................
 
@@ -677,7 +683,7 @@ Changelog
   Dupre la Tour`_.
 
 - |Fix| Decrease the numerical default tolerance in the lobpcg call
-  in :func:`manifold.spectral_embedding` to prevent numerical instability. 
+  in :func:`manifold.spectral_embedding` to prevent numerical instability.
   :pr:`21194` by :user:`Andrew Knyazev <lobpcg>`.
 
 :mod:`sklearn.metrics`

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -544,6 +544,7 @@ def _lars_path_solver(
             sys.stdout.flush()
 
     tiny32 = np.finfo(np.float32).tiny  # to avoid division by 0 warning
+    cov_precision = np.finfo(Cov.dtype).precision
     equality_tolerance = np.finfo(np.float32).eps
 
     if Gram is not None:
@@ -725,6 +726,9 @@ def _lars_path_solver(
             # think could be avoided if we just update it using an
             # orthogonal (QR) decomposition of X
             corr_eq_dir = np.dot(Gram[:n_active, n_active:].T, least_squares)
+
+        # Workaround for inconsistent rounding in openblas
+        np.around(corr_eq_dir, decimals=cov_precision, out=corr_eq_dir)
 
         g1 = arrayfuncs.min_pos((C - Cov) / (AA - corr_eq_dir + tiny32))
         if positive:

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -727,7 +727,8 @@ def _lars_path_solver(
             # orthogonal (QR) decomposition of X
             corr_eq_dir = np.dot(Gram[:n_active, n_active:].T, least_squares)
 
-        # Workaround for inconsistent rounding in openblas
+        # Explicit rounding can be necessary to avoid `np.argmax(Cov)` yielding
+        # unstable results because of rounding errors.
         np.around(corr_eq_dir, decimals=cov_precision, out=corr_eq_dir)
 
         g1 = arrayfuncs.min_pos((C - Cov) / (AA - corr_eq_dir + tiny32))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/21340


#### What does this implement/fix? Explain your changes.
This issue came down to:

https://github.com/scikit-learn/scikit-learn/blob/47a49c51d14b7b648be6a4918c1441cb29c96a9e/sklearn/linear_model/_least_angle.py#L722

where the `np.dot` had a slightly different result between openblas 0.3.18 and 0.3.17:

```python
import numpy as np

X_T_active = np.array([
    [6.666666666666666, -3.3333333333333335, -3.3333333333333335],
    [-0.3333333333333333, -0.3333333333333333, 0.6666666666666667]
], dtype=np.float64)

eq_dir = np.array([0.816496580927726, -0.4082482904638631, -0.4082482904638631], dtype=np.float64)

[i for i in np.dot(X_T_active, eq_dir)]
```

On `openblas=0.3.18`, the above result was: `[8.16496580927726, -0.4082482904638631]`
On `openblas=0.3.17`, the above result was: `[8.164965809277259, -0.4082482904638631]`

This slight difference worked its way down to generating a slightly different `Cov`, which snowballed from there.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
