### PR TITLE
DOC Ensures that QuadraticDiscriminantAnalysis passes numpydoc validatation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -25,7 +25,6 @@ DOCSTRING_IGNORE_LIST = [
     "OrthogonalMatchingPursuit",
     "OrthogonalMatchingPursuitCV",
     "PassiveAggressiveRegressor",
-    "QuadraticDiscriminantAnalysis",
     "SparseRandomProjection",
     "SpectralBiclustering",
     "SpectralCoclustering",

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -707,7 +707,7 @@ class LinearDiscriminantAnalysis(
 
 
 class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
-    """Quadratic Discriminant Analysis
+    """Quadratic Discriminant Analysis.
 
     A classifier with a quadratic decision boundary, generated
     by fitting class conditional densities to the data
@@ -790,6 +790,10 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    LinearDiscriminantAnalysis : Linear Discriminant Analysis.
+
     Examples
     --------
     >>> from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
@@ -801,10 +805,6 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
     QuadraticDiscriminantAnalysis()
     >>> print(clf.predict([[-0.8, -1]]))
     [1]
-
-    See Also
-    --------
-    LinearDiscriminantAnalysis : Linear Discriminant Analysis.
     """
 
     def __init__(
@@ -832,7 +832,12 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
             `n_features` is the number of features.
 
         y : array-like of shape (n_samples,)
-            Target values (integers)
+            Target values (integers).
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
         """
         X, y = self._validate_data(X, y)
         check_classification_targets(y)
@@ -935,10 +940,13 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
+            Vector to be scored, where `n_samples` is the number of samples and
+            `n_features` is the number of features.
 
         Returns
         -------
         C : ndarray of shape (n_samples,)
+            Estimated probabilities.
         """
         d = self._decision_function(X)
         y_pred = self.classes_.take(d.argmax(1))


### PR DESCRIPTION
Reference Issues/PRs

Addresses #20308

What does this implement/fix? Explain your changes.

This PR ensures QuadraticDiscriminantAnalysis is compatible with numpydoc.

  - Remove `QuadraticDiscriminantAnalysis` from: https://github.com/scikit-learn/scikit-learn/blob/47a49c51d14b7b648be6a4918c1441cb29c96a9e/maint_tools/test_docstrings.py#L28.
  - Add descriptions.
  - Minor style fixes.

Any other comments?

Thanks #DataUmbrella!