### PR TITLE
DOC Ensures that LabelPropagation passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -14,7 +14,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 # List of modules ignored when checking for numpydoc validation.
 DOCSTRING_IGNORE_LIST = [
     "KNNImputer",
-    "LabelPropagation",
     "LabelSpreading",
     "LocallyLinearEmbedding",
     "MultiLabelBinarizer",

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -167,7 +167,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         )
 
     def predict(self, X):
-        """Performs inductive inference across the model.
+        """Perform inductive inference across the model.
 
         Parameters
         ----------
@@ -241,6 +241,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         self : object
+            Fitted estimator.
         """
         X, y = self._validate_data(X, y)
         self.X_ = X
@@ -326,7 +327,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
 
 
 class LabelPropagation(BaseLabelPropagation):
-    """Label Propagation classifier
+    """Label Propagation classifier.
 
     Read more in the :ref:`User Guide <label_propagation>`.
 
@@ -385,6 +386,16 @@ class LabelPropagation(BaseLabelPropagation):
     n_iter_ : int
         Number of iterations run.
 
+    See Also
+    --------
+    LabelSpreading : Alternate label propagation strategy more robust to noise.
+
+    References
+    ----------
+    Xiaojin Zhu and Zoubin Ghahramani. Learning from labeled and unlabeled data
+    with label propagation. Technical Report CMU-CALD-02-107, Carnegie Mellon
+    University, 2002 http://pages.cs.wisc.edu/~jerryzhu/pub/CMU-CALD-02-107.pdf
+
     Examples
     --------
     >>> import numpy as np
@@ -398,16 +409,6 @@ class LabelPropagation(BaseLabelPropagation):
     >>> labels[random_unlabeled_points] = -1
     >>> label_prop_model.fit(iris.data, labels)
     LabelPropagation(...)
-
-    References
-    ----------
-    Xiaojin Zhu and Zoubin Ghahramani. Learning from labeled and unlabeled data
-    with label propagation. Technical Report CMU-CALD-02-107, Carnegie Mellon
-    University, 2002 http://pages.cs.wisc.edu/~jerryzhu/pub/CMU-CALD-02-107.pdf
-
-    See Also
-    --------
-    LabelSpreading : Alternate label propagation strategy more robust to noise.
     """
 
     _variant = "propagation"
@@ -449,6 +450,26 @@ class LabelPropagation(BaseLabelPropagation):
         return affinity_matrix
 
     def fit(self, X, y):
+        """Fit a semi-supervised label propagation model based.
+
+        All the input data is provided matrix X (labeled and unlabeled)
+        and corresponding label matrix y with a dedicated marker value for
+        unlabeled samples.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            A matrix of shape (n_samples, n_samples) will be created from this.
+
+        y : array-like of shape (n_samples,)
+            `n_labeled_samples` (unlabeled points are marked as -1)
+            All unlabeled samples will be transductively assigned labels.
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
+        """
         return super().fit(X, y)
 
 


### PR DESCRIPTION
Reference Issues/PRs

Addresses #20308

What does this implement/fix? Explain your changes.

This PR ensures `LabelPropagation` is compatible with numpydoc.

 - Remove `LabelPropagation` from: https://github.com/scikit-learn/scikit-learn/blob/47a49c51d14b7b648be6a4918c1441cb29c96a9e/maint_tools/test_docstrings.py#L17
 - Minor style fixes.

Any other comments?

Thanks #DataUmbrella!