### PR TITLE
Fix broken link in load_boston

### DIFF
--- a/sklearn/datasets/descr/california_housing.rst
+++ b/sklearn/datasets/descr/california_housing.rst
@@ -38,7 +38,7 @@ columns may take surpinsingly large values for block groups with few households
 and many empty houses, such as vacation resorts.
 
 It can be downloaded/loaded using the
-:func:`sklearn.datasets.fetch_california_housing` function.
+:func:`~sklearn.datasets.fetch_california_housing` function.
 
 .. topic:: References
 


### PR DESCRIPTION
~I found the simple broken link in `load_boston` (https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_boston.html).~

#### What does this implement/fix? Explain your changes.
N/A

#### Any other comments?
N/A (thank you for developing/maintaining sklearn. I'm always helped by it!)