### PR TITLE
[WIP] variance in f_regression is forced to be positive

### DIFF
--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -281,7 +281,8 @@ def r_regression(X, y, *, center=True):
         else:
             X_means = X.mean(axis=0)
         # Compute the scaled standard deviations via moments
-        X_norms = np.sqrt(row_norms(X.T, squared=True) - n_samples * X_means ** 2)
+        X_norms = np.sqrt(np.abs(row_norms(X.T, squared=True)
+                                 - n_samples * X_means ** 2))
     else:
         X_norms = row_norms(X.T)
 


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #11395 

#### What does this implement/fix? Explain your changes.
When the variance of a feature in a dataset is zero, f_regression computes the variance and sometimes gets small (machine precision) negative values instead of zero. This throws an error when the sqrt of the variance is computed.

#### Any other comments?
Still missing a regression test.
Still needs to be tested with current regression tests

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
