### PR TITLE
DOC ensures MultiTaskLasso passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -20,7 +20,6 @@ DOCSTRING_IGNORE_LIST = [
     "MultiLabelBinarizer",
     "MultiTaskElasticNet",
     "MultiTaskElasticNetCV",
-    "MultiTaskLasso",
     "MultiTaskLassoCV",
     "OrthogonalMatchingPursuit",
     "OrthogonalMatchingPursuitCV",

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2378,6 +2378,7 @@ class MultiTaskElasticNet(Lasso):
         Returns
         -------
         self : object
+            Fitted estimator.
 
         Notes
         -----
@@ -2527,7 +2528,7 @@ class MultiTaskLasso(MultiTaskElasticNet):
         If set to 'random', a random coefficient is updated every iteration
         rather than looping over features sequentially by default. This
         (setting to 'random') often leads to significantly faster convergence
-        especially when tol is higher than 1e-4
+        especially when tol is higher than 1e-4.
 
     Attributes
     ----------
@@ -2563,6 +2564,19 @@ class MultiTaskLasso(MultiTaskElasticNet):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    Lasso: Linear Model trained with L1 prior as regularizer (aka the Lasso).
+    MultiTaskLasso: Multi-task L1/L2 Lasso with built-in cross-validation.
+    MultiTaskElasticNet: Multi-task L1/L2 ElasticNet with built-in cross-validation.
+
+    Notes
+    -----
+    The algorithm used to fit the model is coordinate descent.
+
+    To avoid unnecessary memory duplication the X and y arguments of the fit
+    method should be directly passed as Fortran-contiguous numpy arrays.
+
     Examples
     --------
     >>> from sklearn import linear_model
@@ -2574,19 +2588,6 @@ class MultiTaskLasso(MultiTaskElasticNet):
     [0.         0.94592424]]
     >>> print(clf.intercept_)
     [-0.41888636 -0.87382323]
-
-    See Also
-    --------
-    MultiTaskLasso : Multi-task L1/L2 Lasso with built-in cross-validation
-    Lasso
-    MultiTaskElasticNet
-
-    Notes
-    -----
-    The algorithm used to fit the model is coordinate descent.
-
-    To avoid unnecessary memory duplication the X and y arguments of the fit
-    method should be directly passed as Fortran-contiguous numpy arrays.
     """
 
     def __init__(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #20308.


#### What does this implement/fix? Explain your changes.
- Added return value description to MultitaskLasso.fit(self, X, y)
- Added descriptions to MultitaskLasso's "See Also" section (Lasso and MultiTaskElasticNet)
- Reordered sections to match required order: Parameters, Attributes, See Also, Notes, Examples
- Added a period (.) to parameter "selection" description and to the "See Also: MultiTaskLasso" reference

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
