### PR TITLE
MAINT Shorten parametrized test names with long error messages

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1656,7 +1656,7 @@ def test_forest_degenerate_feature_importances():
     ],
     # Avoid long error messages in test names:
     # https://github.com/scikit-learn/scikit-learn/issues/21362
-    ids=lambda x: "error" if isinstance(x, str) and len(x) > 10 else x,
+    ids=lambda x: x[:10].replace("]", "") if isinstance(x, str) else x,
 )
 def test_max_samples_exceptions(name, max_samples, exc_type, exc_msg):
     # Check invalid `max_samples` values

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1654,6 +1654,9 @@ def test_forest_degenerate_feature_importances():
             r"'\<class 'numpy.ndarray'\>'",
         ),
     ],
+    # Avoid long error messages in test names:
+    # https://github.com/scikit-learn/scikit-learn/issues/21362
+    ids=lambda x: "error" if isinstance(x, str) and len(x) > 10 else x,
 )
 def test_max_samples_exceptions(name, max_samples, exc_type, exc_msg):
     # Check invalid `max_samples` values

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -107,7 +107,7 @@ def test_classification_toy(loss):
     ],
     # Avoid long error messages in test names:
     # https://github.com/scikit-learn/scikit-learn/issues/21362
-    ids=lambda x: "error" if isinstance(x, str) and len(x) > 10 else x,
+    ids=lambda x: x[:10].replace("]", "") if isinstance(x, str) else x,
 )
 @pytest.mark.parametrize(
     "GradientBoosting, X, y",

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -105,6 +105,9 @@ def test_classification_toy(loss):
         ({"max_features": -0.1}, r"max_features must be in \(0, n_features\]"),
         ({"n_iter_no_change": "invalid"}, "n_iter_no_change should either be"),
     ],
+    # Avoid long error messages in test names:
+    # https://github.com/scikit-learn/scikit-learn/issues/21362
+    ids=lambda x: "error" if isinstance(x, str) and len(x) > 10 else x,
 )
 @pytest.mark.parametrize(
     "GradientBoosting, X, y",

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -250,7 +250,7 @@ def asgd(klass, X, y, eta, alpha, weight_init=None, intercept_init=0.0):
     ],
     # Avoid long error messages in test names:
     # https://github.com/scikit-learn/scikit-learn/issues/21362
-    ids=lambda x: "error" if isinstance(x, str) and len(x) > 10 else x,
+    ids=lambda x: x[:10].replace("]", "") if isinstance(x, str) else x,
 )
 def test_sgd_estimator_params_validation(klass, fit_method, params, err_msg):
     """Validate parameters in the different SGD estimators."""

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -248,6 +248,9 @@ def asgd(klass, X, y, eta, alpha, weight_init=None, intercept_init=0.0):
         ),
         ({"n_iter_no_change": 0}, "n_iter_no_change must be >= 1"),
     ],
+    # Avoid long error messages in test names:
+    # https://github.com/scikit-learn/scikit-learn/issues/21362
+    ids=lambda x: "error" if isinstance(x, str) and len(x) > 10 else x,
 )
 def test_sgd_estimator_params_validation(klass, fit_method, params, err_msg):
     """Validate parameters in the different SGD estimators."""


### PR DESCRIPTION
Fixes  #21362.

I think those long error messages are too long anyways.