### PR TITLE
DOC Link to build from source in contributing guide

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -249,32 +249,10 @@ how to set up your git repository:
    account on the GitHub user account. For more details on how to fork a
    repository see `this guide <https://help.github.com/articles/fork-a-repo/>`_.
 
-3. Clone your fork of the scikit-learn repo from your GitHub account to your
-   local disk:
+3. Follow steps in :ref:`install_bleeding_edge` to build scikit-learn in
+   development mode.
 
-   .. prompt:: bash $
-
-       git clone git@github.com:YourLogin/scikit-learn.git  # add --depth 1 if your connection is slow
-       cd scikit-learn
-
-4. Install the development dependencies:
-
-    .. prompt:: bash $
-
-       pip install cython pytest pytest-cov flake8 mypy black==21.6b0
-
-5. Install scikit-learn in editable mode:
-
-    .. prompt:: bash $
-
-       pip install --no-build-isolation --editable .
-
-   If you receive errors in building scikit-learn, see the
-   :ref:`install_bleeding_edge` section.
-
-.. _upstream:
-
-6. Add the ``upstream`` remote. This saves a reference to the main
+4. Add the ``upstream`` remote. This saves a reference to the main
    scikit-learn repository, which you can use to keep your repository
    synchronized with the latest changes:
 
@@ -286,7 +264,7 @@ You should now have a working installation of scikit-learn, and your git
 repository properly configured. The next steps now describe the process of
 modifying code and submitting a PR:
 
-7. Synchronize your ``main`` branch with the ``upstream/main`` branch,
+5. Synchronize your ``main`` branch with the ``upstream/main`` branch,
    more details on `GitHub Docs <https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork>`_:
 
    .. prompt:: bash $
@@ -295,7 +273,7 @@ modifying code and submitting a PR:
         git fetch upstream
         git merge upstream/main
 
-8. Create a feature branch to hold your development changes:
+6. Create a feature branch to hold your development changes:
 
     .. prompt:: bash $
 
@@ -304,7 +282,7 @@ modifying code and submitting a PR:
    and start making changes. Always use a feature branch. It's good
    practice to never work on the ``main`` branch!
 
-9. (**Optional**) Install `pre-commit <https://pre-commit.com/#install>`_ to
+7. (**Optional**) Install `pre-commit <https://pre-commit.com/#install>`_ to
    run code style checks before each commit:
 
    .. prompt:: bash $
@@ -315,27 +293,27 @@ modifying code and submitting a PR:
    pre-commit checks can be disabled for a particular commit with
    `git commit -n`.
 
-10. Develop the feature on your feature branch on your computer, using Git to
-    do the version control. When you're done editing, add changed files using
-    ``git add`` and then ``git commit``:
+8. Develop the feature on your feature branch on your computer, using Git to
+   do the version control. When you're done editing, add changed files using
+   ``git add`` and then ``git commit``:
 
-    .. prompt:: bash $
+   .. prompt:: bash $
 
-        git add modified_files
-        git commit
+       git add modified_files
+       git commit
 
-    to record your changes in Git, then push the changes to your GitHub
-    account with:
+   to record your changes in Git, then push the changes to your GitHub
+   account with:
 
-    .. prompt:: bash $
+   .. prompt:: bash $
 
-       git push -u origin my_feature
+      git push -u origin my_feature
 
-11. Follow `these
-    <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_
-    instructions to create a pull request from your fork. This will send an
-    email to the committers. You may want to consider sending an email to the
-    mailing list for more visibility.
+9. Follow `these
+  <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_
+   instructions to create a pull request from your fork. This will send an
+   email to the committers. You may want to consider sending an email to the
+   mailing list for more visibility.
 
 .. note::
 
@@ -444,8 +422,7 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    to configure your editor to run `black`.
 
 6. **Make sure that your PR does not add PEP8 violations**. To check the
-   code that you changed, you can run the following command (see
-   :ref:`above <upstream>` to set up the ``upstream`` remote):
+   code that you changed, you can run the following command:
 
    .. prompt:: bash $
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -249,22 +249,46 @@ how to set up your git repository:
    account on the GitHub user account. For more details on how to fork a
    repository see `this guide <https://help.github.com/articles/fork-a-repo/>`_.
 
-3. Follow steps in :ref:`install_bleeding_edge` to build scikit-learn in
-   development mode.
+3. Clone your fork of the scikit-learn repo from your GitHub account to your
+   local disk:
 
-4. Add the ``upstream`` remote. This saves a reference to the main
+   .. prompt:: bash $
+
+      git clone git@github.com:YourLogin/scikit-learn.git  # add --depth 1 if your connection is slow
+      cd scikit-learn
+
+3. Follow steps 2-7 in :ref:`install_bleeding_edge` to build scikit-learn in
+   development mode and return to this document.
+
+4. Install the development dependencies:
+
+   .. prompt:: bash $
+
+        pip install pytest pytest-cov flake8 mypy black==21.6b0
+
+.. _upstream:
+
+5. Add the ``upstream`` remote. This saves a reference to the main
    scikit-learn repository, which you can use to keep your repository
    synchronized with the latest changes:
 
    .. prompt:: bash $
 
-    git remote add upstream https://github.com/scikit-learn/scikit-learn.git
+        git remote add upstream git@github.com:scikit-learn/scikit-learn.git
+
+6. Check that the `upstream` and `origin` remote aliases are configured correctly
+   by running `git remote -v` which should display::
+
+        origin	git@github.com:YourLogin/scikit-learn.git (fetch)
+        origin	git@github.com:YourLogin/scikit-learn.git (push)
+        upstream	git@github.com:scikit-learn/scikit-learn.git (fetch)
+        upstream	git@github.com:scikit-learn/scikit-learn.git (push)
 
 You should now have a working installation of scikit-learn, and your git
 repository properly configured. The next steps now describe the process of
 modifying code and submitting a PR:
 
-5. Synchronize your ``main`` branch with the ``upstream/main`` branch,
+7. Synchronize your ``main`` branch with the ``upstream/main`` branch,
    more details on `GitHub Docs <https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork>`_:
 
    .. prompt:: bash $
@@ -273,7 +297,7 @@ modifying code and submitting a PR:
         git fetch upstream
         git merge upstream/main
 
-6. Create a feature branch to hold your development changes:
+8. Create a feature branch to hold your development changes:
 
     .. prompt:: bash $
 
@@ -282,7 +306,7 @@ modifying code and submitting a PR:
    and start making changes. Always use a feature branch. It's good
    practice to never work on the ``main`` branch!
 
-7. (**Optional**) Install `pre-commit <https://pre-commit.com/#install>`_ to
+9. (**Optional**) Install `pre-commit <https://pre-commit.com/#install>`_ to
    run code style checks before each commit:
 
    .. prompt:: bash $
@@ -293,27 +317,27 @@ modifying code and submitting a PR:
    pre-commit checks can be disabled for a particular commit with
    `git commit -n`.
 
-8. Develop the feature on your feature branch on your computer, using Git to
-   do the version control. When you're done editing, add changed files using
-   ``git add`` and then ``git commit``:
+10. Develop the feature on your feature branch on your computer, using Git to
+    do the version control. When you're done editing, add changed files using
+    ``git add`` and then ``git commit``:
 
-   .. prompt:: bash $
+    .. prompt:: bash $
 
-       git add modified_files
-       git commit
+        git add modified_files
+        git commit
 
-   to record your changes in Git, then push the changes to your GitHub
-   account with:
+    to record your changes in Git, then push the changes to your GitHub
+    account with:
 
-   .. prompt:: bash $
+    .. prompt:: bash $
 
-      git push -u origin my_feature
+       git push -u origin my_feature
 
-9. Follow `these
-  <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_
-   instructions to create a pull request from your fork. This will send an
-   email to the committers. You may want to consider sending an email to the
-   mailing list for more visibility.
+11. Follow `these
+    <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_
+    instructions to create a pull request from your fork. This will send an
+    email to the committers. You may want to consider sending an email to the
+    mailing list for more visibility.
 
 .. note::
 
@@ -422,7 +446,8 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    to configure your editor to run `black`.
 
 6. **Make sure that your PR does not add PEP8 violations**. To check the
-   code that you changed, you can run the following command:
+   code that you changed, you can run the following command (see
+   :ref:`above <upstream>` to set up the ``upstream`` remote):
 
    .. prompt:: bash $
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #21353 and the comment from @reshamas https://github.com/scikit-learn/scikit-learn/pull/21353#issuecomment-945167213

#### What does this implement/fix? Explain your changes.
In this PR, I link directly to "Building from Source" from the contributing steps. This way when looking at scikit-learn.org/dev/developers/contributing.html a contributor can redirect to the "Building from source page". The upside is that there is only one "building from source" location. The downside is that contributors need to navigate back and forth.

#### Any other comments?
CC @ogrisel 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
