### PR TITLE
DOC Ensures that MultiTaskElasticNet passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -17,7 +17,6 @@ DOCSTRING_IGNORE_LIST = [
     "LabelPropagation",
     "LabelSpreading",
     "LocallyLinearEmbedding",
-    "MultiTaskElasticNet",
     "MultiTaskElasticNetCV",
     "MultiTaskLassoCV",
     "OrthogonalMatchingPursuitCV",

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2204,8 +2204,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
 
 class MultiTaskElasticNet(Lasso):
-    """Multi-task ElasticNet model trained with L1/L2 mixed-norm as \
-    regularizer.
+    """Multi-task ElasticNet model trained with L1/L2 mixed-norm as regularizer.
 
     The optimization objective for MultiTaskElasticNet is::
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2204,7 +2204,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
 
 class MultiTaskElasticNet(Lasso):
-    """Multi-task ElasticNet model trained with L1/L2 mixed-norm as
+    """Multi-task ElasticNet model trained with L1/L2 mixed-norm as \
     regularizer.
 
     The optimization objective for MultiTaskElasticNet is::
@@ -2313,6 +2313,20 @@ class MultiTaskElasticNet(Lasso):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    MultiTaskElasticNetCV : Multi-task L1/L2 ElasticNet with built-in
+        cross-validation.
+    ElasticNet : Linear regression with combined L1 and L2 priors as regularizer.
+    MultiTaskLasso : Multi-task L1/L2 Lasso with built-in cross-validation.
+
+    Notes
+    -----
+    The algorithm used to fit the model is coordinate descent.
+
+    To avoid unnecessary memory duplication the X and y arguments of the fit
+    method should be directly passed as Fortran-contiguous numpy arrays.
+
     Examples
     --------
     >>> from sklearn import linear_model
@@ -2324,20 +2338,6 @@ class MultiTaskElasticNet(Lasso):
      [0.45663524 0.45612256]]
     >>> print(clf.intercept_)
     [0.0872422 0.0872422]
-
-    See Also
-    --------
-    MultiTaskElasticNetCV : Multi-task L1/L2 ElasticNet with built-in
-        cross-validation.
-    ElasticNet
-    MultiTaskLasso
-
-    Notes
-    -----
-    The algorithm used to fit the model is coordinate descent.
-
-    To avoid unnecessary memory duplication the X and y arguments of the fit
-    method should be directly passed as Fortran-contiguous numpy arrays.
     """
 
     def __init__(


### PR DESCRIPTION

#### Reference Issues/PRs

Addresses #20308


#### What does this implement/fix? Explain your changes.

Fixes numpydoc validation errors on MultiTaskElasticNet estimator docstring in the __init__ function.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
