### PR TITLE
MAINT pin python version for source tarball builder [cd build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -124,6 +124,8 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'  # update once build dependencies are available
 
       - name: Build source distribution
         run: bash build_tools/github/build_source.sh


### PR DESCRIPTION
This should fix the broken `[cd build]` workflow.

Assuming the fix works as intended, I think we will need to include it in 1.0.X to release 1.0.1.