### PR TITLE
DOC Ensures that MultiTaskElasticNetCV passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -17,7 +17,6 @@ DOCSTRING_IGNORE_LIST = [
     "LabelPropagation",
     "LabelSpreading",
     "LocallyLinearEmbedding",
-    "MultiTaskElasticNet",
     "MultiTaskElasticNetCV",
     "MultiTaskLassoCV",
     "OrthogonalMatchingPursuitCV",

--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -17,7 +17,6 @@ DOCSTRING_IGNORE_LIST = [
     "LabelPropagation",
     "LabelSpreading",
     "LocallyLinearEmbedding",
-    "MultiTaskElasticNetCV",
     "MultiTaskLassoCV",
     "OrthogonalMatchingPursuitCV",
     "PassiveAggressiveRegressor",

--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -17,6 +17,7 @@ DOCSTRING_IGNORE_LIST = [
     "LabelPropagation",
     "LabelSpreading",
     "LocallyLinearEmbedding",
+    "MultiTaskElasticNet",
     "MultiTaskLassoCV",
     "OrthogonalMatchingPursuitCV",
     "PassiveAggressiveRegressor",

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2204,8 +2204,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
 
 class MultiTaskElasticNet(Lasso):
-    """Multi-task ElasticNet model trained with L1/L2 mixed-norm as \
-    regularizer.
+    """Multi-task ElasticNet model trained with L1/L2 mixed-norm as regularizer.
 
     The optimization objective for MultiTaskElasticNet is::
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2204,7 +2204,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
 
 class MultiTaskElasticNet(Lasso):
-    """Multi-task ElasticNet model trained with L1/L2 mixed-norm as
+    """Multi-task ElasticNet model trained with L1/L2 mixed-norm as \
     regularizer.
 
     The optimization objective for MultiTaskElasticNet is::
@@ -2313,6 +2313,20 @@ class MultiTaskElasticNet(Lasso):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    MultiTaskElasticNetCV : Multi-task L1/L2 ElasticNet with built-in
+        cross-validation.
+    ElasticNet : Linear regression with combined L1 and L2 priors as regularizer.
+    MultiTaskLasso : Multi-task L1/L2 Lasso with built-in cross-validation.
+
+    Notes
+    -----
+    The algorithm used to fit the model is coordinate descent.
+
+    To avoid unnecessary memory duplication the X and y arguments of the fit
+    method should be directly passed as Fortran-contiguous numpy arrays.
+
     Examples
     --------
     >>> from sklearn import linear_model
@@ -2324,20 +2338,6 @@ class MultiTaskElasticNet(Lasso):
      [0.45663524 0.45612256]]
     >>> print(clf.intercept_)
     [0.0872422 0.0872422]
-
-    See Also
-    --------
-    MultiTaskElasticNetCV : Multi-task L1/L2 ElasticNet with built-in
-        cross-validation.
-    ElasticNet
-    MultiTaskLasso
-
-    Notes
-    -----
-    The algorithm used to fit the model is coordinate descent.
-
-    To avoid unnecessary memory duplication the X and y arguments of the fit
-    method should be directly passed as Fortran-contiguous numpy arrays.
     """
 
     def __init__(

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2647,7 +2647,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         prediction score is used. Note that a good choice of list of
         values for l1_ratio is often to put more values close to 1
         (i.e. Lasso) and less close to 0 (i.e. Ridge), as in ``[.1, .5, .7,
-        .9, .95, .99, 1]``
+        .9, .95, .99, 1]``.
 
     eps : float, default=1e-3
         Length of the path. ``eps=1e-3`` means that
@@ -2768,6 +2768,20 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    MultiTaskElasticNet : Multi-task L1/L2 ElasticNet with built-in cross-validation.
+    ElasticNetCV : Elastic net model with best model selection by cross-validation.
+    MultiTaskLassoCV : Multi-task Lasso model trained with L1/L2 mixed-norm
+        as regularizer.
+
+    Notes
+    -----
+    The algorithm used to fit the model is coordinate descent.
+
+    To avoid unnecessary memory duplication the X and y arguments of the fit
+    method should be directly passed as Fortran-contiguous numpy arrays.
+
     Examples
     --------
     >>> from sklearn import linear_model
@@ -2780,19 +2794,6 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
      [0.52875032 0.46958558]]
     >>> print(clf.intercept_)
     [0.00166409 0.00166409]
-
-    See Also
-    --------
-    MultiTaskElasticNet
-    ElasticNetCV
-    MultiTaskLassoCV
-
-    Notes
-    -----
-    The algorithm used to fit the model is coordinate descent.
-
-    To avoid unnecessary memory duplication the X and y arguments of the fit
-    method should be directly passed as Fortran-contiguous numpy arrays.
     """
 
     path = staticmethod(enet_path)
@@ -2849,13 +2850,14 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         Parameters
         ----------
         X : ndarray of shape (n_samples, n_features)
-            Data
+            Data.
         y : ndarray of shape (n_samples, n_targets)
-            Target. Will be cast to X's dtype if necessary
+            Target. Will be cast to X's dtype if necessary.
 
         Returns
         -------
         self : object
+            Returns the MultiTaskElasticNet model with coordinate descent.
         """
         return super().fit(X, y)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #20308

#### What does this implement/fix? Explain your changes.
Fixes numpydoc validation errors on MultiTaskElasticNetCV estimator docstring in the class MultiTaskElasticNetCV and the fit method.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
