### PR TITLE
add sklearn.metrics Display class to plot Precision/Recall/F1 for probability thresholds

### DIFF
--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -348,6 +348,50 @@ class PrecisionRecallDisplay:
         return viz.plot(ax=ax, name=name, **kwargs)
 
 
+class PrecisionRecallF1Display:
+    """TODO"""
+
+    def __init__(
+        self,
+        precision,
+        recall,
+        thresholds,
+        plot_f1 = True,
+    ):
+        """TODO"""
+
+        self.precision = precision
+        self.recall = recall
+        self.thresholds = thresholds
+
+        self.plot_f1 = plot_f1
+
+        if plot_f1:
+            self.f1_score = 2 * precision * recall / (precision + recall)
+
+    def plot(self):
+        """TODO"""
+
+        import matplotlib.pyplot as plt
+
+        _, ax = plt.subplots()
+
+        ax.plot(self.thresholds, self.precision[:-1], label="precision")
+        ax.plot(self.thresholds, self.recall[:-1], label="recall")
+
+        if self.plot_f1:
+            ax.plot(self.thresholds, self.f1_score[:-1], label="f1-score")
+
+        ax.set(xlabel="Threshold", ylabel="Metrics")
+        ax.legend()
+        ax.grid()
+
+        self.ax_ = ax
+        self.figure_ = ax.figure
+
+        return self
+
+
 @deprecated(
     "Function `plot_precision_recall_curve` is deprecated in 1.0 and will be "
     "removed in 1.2. Use one of the class methods: "


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Implement #21391

#### What does this implement/fix? Explain your changes.
Working with binary classifiers I often, in addition to PR-curve and ROC-curve, need Precision / Recall / F1 (y-axis) for probability thresholds (x-axis).

#### Any other comments?
```python
import numpy as np
from sklearn.metrics import precision_recall_curve, PrecisionRecallF1Display

y_true = np.array([0, 0, 1, 1])
y_scores = np.array([0.1, 0.4, 0.35, 0.8])

precision, recall, thresholds = precision_recall_curve(y_true, y_scores)

display = PrecisionRecallF1Display(precision, recall, thresholds, plot_f1=True)
display.plot()
```

<img width="392" alt="prf1-curve" src="https://user-images.githubusercontent.com/26326659/138347579-8992e22a-b007-459b-84e5-9f5a98746931.png">


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
