### PR TITLE
DOC Ensures that SpectralBiclustering passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -17,7 +17,6 @@ DOCSTRING_IGNORE_LIST = [
     "MultiTaskElasticNetCV",
     "OrthogonalMatchingPursuitCV",
     "PassiveAggressiveRegressor",
-    "SpectralBiclustering",
     "SpectralCoclustering",
     "SpectralEmbedding",
     "StackingRegressor",

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -758,7 +758,6 @@ class BiclusterMixin:
             Indices of rows in the dataset that belong to the bicluster.
         col_ind : ndarray, dtype=np.intp
             Indices of columns in the dataset that belong to the bicluster.
-
         """
         rows = self.rows_[i]
         columns = self.columns_[i]

--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -114,14 +114,20 @@ class BaseSpectral(BiclusterMixin, BaseEstimator, metaclass=ABCMeta):
             )
 
     def fit(self, X, y=None):
-        """Creates a biclustering for X.
+        """Create a biclustering for X.
 
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
+            Training data.
 
         y : Ignored
+            Not used, present for API consistency by convention.
 
+        Returns
+        -------
+        self : object
+            SpectralBiclustering instance.
         """
         X = self._validate_data(X, accept_sparse="csr", dtype=np.float64)
         self._check_parameters()
@@ -439,6 +445,17 @@ class SpectralBiclustering(BaseSpectral):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    SpectralCoclustering : Spectral Co-Clustering algorithm (Dhillon, 2001).
+
+    References
+    ----------
+
+    * Kluger, Yuval, et. al., 2003. `Spectral biclustering of microarray
+      data: coclustering genes and conditions
+      <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.135.1608>`__.
+    
     Examples
     --------
     >>> from sklearn.cluster import SpectralBiclustering
@@ -452,14 +469,6 @@ class SpectralBiclustering(BaseSpectral):
     array([0, 1], dtype=int32)
     >>> clustering
     SpectralBiclustering(n_clusters=2, random_state=0)
-
-    References
-    ----------
-
-    * Kluger, Yuval, et. al., 2003. `Spectral biclustering of microarray
-      data: coclustering genes and conditions
-      <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.135.1608>`__.
-
     """
 
     def __init__(


### PR DESCRIPTION
# Reference Issues/PRs

Addresses #20308

# What does this implement/fix? Explain your changes.

This PR ensures `SpectralBiclustering` is compatible with numpydoc.

 - Remove `SpectralBiclustering` from: https://github.com/scikit-learn/scikit-learn/blob/e34b64c7ac57c9e6bfee3e26f27d6d74a9bd913a/maint_tools/test_docstrings.py#L20
 - Create *See Also* section and add `SpectralCoclustering`.
 - Add *Returns* to docstring.
 - Minor style fixes (remove double line break, section order)

# Any other comments?

Thanks #DataUmbrella! Thanks so much @glemaitre for so patiently reviewing my PRs! Please let me know if there is anything I can do to improve my future PRs and help scikit-learn.