### PR TITLE
[feat] enable the n_jobs for mutual info regression and classifier

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -68,6 +68,15 @@ Changelog
   error when 'min_idf' or 'max_idf' are floating-point numbers greater than 1.
   :pr:`20752` by :user:`Alek Lefebvre <AlekLefebvre>`.
 
+:mod:`sklearn.feature_selection`
+.................................
+
+- |Enhancement| Enabled parallel processing for
+  :func:`feature_selection.mutual_info_regression` and
+  :class:`feature_selection.mutual_info_classif` by offering
+  n_jobs parameters.
+  :pr:`21409` by :user:`Bingo Li <Bingoko>`.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -73,7 +73,7 @@ Changelog
 
 - |Enhancement| Enabled parallel processing for
   :func:`feature_selection.mutual_info_regression` and
-  :class:`feature_selection.mutual_info_classif` by offering
+  :func:`feature_selection.mutual_info_classif` by offering
   n_jobs parameters.
   :pr:`21409` by :user:`Bingo Li <Bingoko>`.
 

--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -332,7 +332,7 @@ def mutual_info_regression(
     n_neighbors=3,
     n_jobs=None,
     copy=True,
-    random_state=None
+    random_state=None,
 ):
     """Estimate mutual information for a continuous target variable.
 
@@ -413,14 +413,16 @@ def mutual_info_regression(
     .. [4] L. F. Kozachenko, N. N. Leonenko, "Sample Estimate of the Entropy
            of a Random Vector", Probl. Peredachi Inf., 23:2 (1987), 9-16
     """
-    return _estimate_mi(X=X,
-                        y=y,
-                        discrete_features=discrete_features,
-                        discrete_target=False,
-                        n_neighbors=n_neighbors,
-                        n_jobs=n_jobs,
-                        copy=copy,
-                        random_state=random_state)
+    return _estimate_mi(
+        X=X,
+        y=y,
+        discrete_features=discrete_features,
+        discrete_target=False,
+        n_neighbors=n_neighbors,
+        n_jobs=n_jobs,
+        copy=copy,
+        random_state=random_state,
+    )
 
 
 def mutual_info_classif(
@@ -431,7 +433,7 @@ def mutual_info_classif(
     n_neighbors=3,
     n_jobs=None,
     copy=True,
-    random_state=None
+    random_state=None,
 ):
     """Estimate mutual information for a discrete target variable.
 
@@ -513,11 +515,13 @@ def mutual_info_classif(
            of a Random Vector:, Probl. Peredachi Inf., 23:2 (1987), 9-16
     """
     check_classification_targets(y)
-    return _estimate_mi(X=X,
-                        y=y,
-                        discrete_features=discrete_features,
-                        discrete_target=True,
-                        n_neighbors=n_neighbors,
-                        n_jobs=n_jobs,
-                        copy=copy,
-                        random_state=random_state)
+    return _estimate_mi(
+        X=X,
+        y=y,
+        discrete_features=discrete_features,
+        discrete_target=True,
+        n_neighbors=n_neighbors,
+        n_jobs=n_jobs,
+        copy=copy,
+        random_state=random_state,
+    )

--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -325,7 +325,14 @@ def _estimate_mi(
 
 
 def mutual_info_regression(
-    X, y, *, discrete_features="auto", n_neighbors=3, n_jobs=None, copy=True, random_state=None
+    X,
+    y,
+    *,
+    discrete_features="auto",
+    n_neighbors=3,
+    n_jobs=None,
+    copy=True,
+    random_state=None
 ):
     """Estimate mutual information for a continuous target variable.
 
@@ -406,11 +413,25 @@ def mutual_info_regression(
     .. [4] L. F. Kozachenko, N. N. Leonenko, "Sample Estimate of the Entropy
            of a Random Vector", Probl. Peredachi Inf., 23:2 (1987), 9-16
     """
-    return _estimate_mi(X, y, discrete_features, False, n_neighbors, n_jobs, copy, random_state)
+    return _estimate_mi(X=X,
+                        y=y,
+                        discrete_features=discrete_features,
+                        discrete_target=False,
+                        n_neighbors=n_neighbors,
+                        n_jobs=n_jobs,
+                        copy=copy,
+                        random_state=random_state)
 
 
 def mutual_info_classif(
-    X, y, *, discrete_features="auto", n_neighbors=3, n_jobs=None, copy=True, random_state=None
+    X,
+    y,
+    *,
+    discrete_features="auto",
+    n_neighbors=3,
+    n_jobs=None,
+    copy=True,
+    random_state=None
 ):
     """Estimate mutual information for a discrete target variable.
 
@@ -492,4 +513,11 @@ def mutual_info_classif(
            of a Random Vector:, Probl. Peredachi Inf., 23:2 (1987), 9-16
     """
     check_classification_targets(y)
-    return _estimate_mi(X, y, discrete_features, True, n_neighbors, n_jobs, copy, random_state)
+    return _estimate_mi(X=X,
+                        y=y,
+                        discrete_features=discrete_features,
+                        discrete_target=True,
+                        n_neighbors=n_neighbors,
+                        n_jobs=n_jobs,
+                        copy=copy,
+                        random_state=random_state)

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -19,6 +19,7 @@ def test_compute_mi_dd():
     I_xy = H_x + H_y - H_xy
 
     assert_almost_equal(_compute_mi(x, y, True, True), I_xy)
+    assert_almost_equal(_compute_mi(x, y, True, True, n_jobs=2), I_xy)
 
 
 def test_compute_mi_cc():
@@ -51,6 +52,10 @@ def test_compute_mi_cc():
     # first figures after decimal point match.
     for n_neighbors in [3, 5, 7]:
         I_computed = _compute_mi(x, y, False, False, n_neighbors)
+        assert_almost_equal(I_computed, I_theory, 1)
+
+    for n_neighbors in [3, 5, 7]:
+        I_computed = _compute_mi(x, y, False, False, n_neighbors, n_jobs=2)
         assert_almost_equal(I_computed, I_theory, 1)
 
 
@@ -90,6 +95,10 @@ def test_compute_mi_cd():
             I_computed = _compute_mi(x, y, True, False, n_neighbors)
             assert_almost_equal(I_computed, I_theory, 1)
 
+        for n_neighbors in [3, 5, 7]:
+            I_computed = _compute_mi(x, y, True, False, n_neighbors, n_jobs=2)
+            assert_almost_equal(I_computed, I_theory, 1)
+
 
 def test_compute_mi_cd_unique_label():
     # Test that adding unique label doesn't change MI.
@@ -102,12 +111,15 @@ def test_compute_mi_cd_unique_label():
     y[~mask] = np.random.uniform(0, 2, size=np.sum(~mask))
 
     mi_1 = _compute_mi(x, y, True, False)
+    mi_1_ = _compute_mi(x, y, True, False, n_jobs=2)
 
     x = np.hstack((x, 2))
     y = np.hstack((y, 10))
     mi_2 = _compute_mi(x, y, True, False)
+    mi_2_ = _compute_mi(x, y, True, False, n_jobs=2)
 
     assert mi_1 == mi_2
+    assert mi_1_ == mi_2_
 
 
 # We are going test that feature ordering by MI matches our expectations.
@@ -139,6 +151,9 @@ def test_mutual_info_regression():
     mi = mutual_info_regression(X, y, random_state=0)
     assert_array_equal(np.argsort(-mi), np.array([1, 2, 0]))
 
+    mi = mutual_info_regression(X, y, random_state=0, n_jobs=2)
+    assert_array_equal(np.argsort(-mi), np.array([1, 2, 0]))
+
 
 def test_mutual_info_classif_mixed():
     # Here the target is discrete and there are two continuous and one
@@ -154,6 +169,20 @@ def test_mutual_info_classif_mixed():
     for n_neighbors in [5, 7, 9]:
         mi_nn = mutual_info_classif(
             X, y, discrete_features=[2], n_neighbors=n_neighbors, random_state=0
+        )
+        # Check that the continuous values have an higher MI with greater
+        # n_neighbors
+        assert mi_nn[0] > mi[0]
+        assert mi_nn[1] > mi[1]
+        # The n_neighbors should not have any effect on the discrete value
+        # The MI should be the same
+        assert mi_nn[2] == mi[2]
+
+    mi = mutual_info_classif(X, y, discrete_features=[2], n_neighbors=3, random_state=0, n_jobs=2)
+    assert_array_equal(np.argsort(-mi), [2, 0, 1])
+    for n_neighbors in [5, 7, 9]:
+        mi_nn = mutual_info_classif(
+            X, y, discrete_features=[2], n_neighbors=n_neighbors, random_state=0, n_jobs=2
         )
         # Check that the continuous values have an higher MI with greater
         # n_neighbors

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -55,8 +55,8 @@ def test_compute_mi_cc():
         assert_almost_equal(I_computed, I_theory, 1)
 
     for n_neighbors in [3, 5, 7]:
-        I_computed = _compute_mi(x, y, False, False, n_neighbors, n_jobs=2)
-        assert_almost_equal(I_computed, I_theory, 1)
+        I_computed_ = _compute_mi(x, y, False, False, n_neighbors, n_jobs=2)
+        assert_almost_equal(I_computed_, I_theory, 1)
 
 
 def test_compute_mi_cd():
@@ -96,8 +96,8 @@ def test_compute_mi_cd():
             assert_almost_equal(I_computed, I_theory, 1)
 
         for n_neighbors in [3, 5, 7]:
-            I_computed = _compute_mi(x, y, True, False, n_neighbors, n_jobs=2)
-            assert_almost_equal(I_computed, I_theory, 1)
+            I_computed_ = _compute_mi(x, y, True, False, n_neighbors, n_jobs=2)
+            assert_almost_equal(I_computed_, I_theory, 1)
 
 
 def test_compute_mi_cd_unique_label():
@@ -151,8 +151,8 @@ def test_mutual_info_regression():
     mi = mutual_info_regression(X, y, random_state=0)
     assert_array_equal(np.argsort(-mi), np.array([1, 2, 0]))
 
-    mi = mutual_info_regression(X, y, random_state=0, n_jobs=2)
-    assert_array_equal(np.argsort(-mi), np.array([1, 2, 0]))
+    mi_ = mutual_info_regression(X, y, random_state=0, n_jobs=2)
+    assert_array_equal(np.argsort(-mi_), np.array([1, 2, 0]))
 
 
 def test_mutual_info_classif_mixed():
@@ -178,19 +178,19 @@ def test_mutual_info_classif_mixed():
         # The MI should be the same
         assert mi_nn[2] == mi[2]
 
-    mi = mutual_info_classif(X, y, discrete_features=[2], n_neighbors=3, random_state=0, n_jobs=2)
-    assert_array_equal(np.argsort(-mi), [2, 0, 1])
+    mi_ = mutual_info_classif(X, y, discrete_features=[2], n_neighbors=3, random_state=0, n_jobs=2)
+    assert_array_equal(np.argsort(-mi_), [2, 0, 1])
     for n_neighbors in [5, 7, 9]:
-        mi_nn = mutual_info_classif(
+        mi_nn_ = mutual_info_classif(
             X, y, discrete_features=[2], n_neighbors=n_neighbors, random_state=0, n_jobs=2
         )
         # Check that the continuous values have an higher MI with greater
         # n_neighbors
-        assert mi_nn[0] > mi[0]
-        assert mi_nn[1] > mi[1]
+        assert mi_nn_[0] > mi_[0]
+        assert mi_nn_[1] > mi_[1]
         # The n_neighbors should not have any effect on the discrete value
         # The MI should be the same
-        assert mi_nn[2] == mi[2]
+        assert mi_nn_[2] == mi_[2]
 
 
 def test_mutual_info_options():

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -178,11 +178,18 @@ def test_mutual_info_classif_mixed():
         # The MI should be the same
         assert mi_nn[2] == mi[2]
 
-    mi_ = mutual_info_classif(X, y, discrete_features=[2], n_neighbors=3, random_state=0, n_jobs=2)
+    mi_ = mutual_info_classif(
+        X, y, discrete_features=[2], n_neighbors=3, random_state=0, n_jobs=2
+    )
     assert_array_equal(np.argsort(-mi_), [2, 0, 1])
     for n_neighbors in [5, 7, 9]:
         mi_nn_ = mutual_info_classif(
-            X, y, discrete_features=[2], n_neighbors=n_neighbors, random_state=0, n_jobs=2
+            X,
+            y,
+            discrete_features=[2],
+            n_neighbors=n_neighbors,
+            random_state=0,
+            n_jobs=2,
         )
         # Check that the continuous values have an higher MI with greater
         # n_neighbors


### PR DESCRIPTION
Before, mutal_info use NearestNeighbors but did not enable n_jobs to accelerate the speed