### PR TITLE
DOC Ensures that SpectralEmbedding passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -18,7 +18,6 @@ DOCSTRING_IGNORE_LIST = [
     "OrthogonalMatchingPursuitCV",
     "PassiveAggressiveRegressor",
     "SpectralCoclustering",
-    "SpectralEmbedding",
     "StackingRegressor",
 ]
 

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -473,7 +473,7 @@ class SpectralEmbedding(BaseEstimator):
 
     See Also
     --------
-    Isomap: Non-linear dimensionality reduction through Isometric Mapping.
+    Isomap : Non-linear dimensionality reduction through Isometric Mapping.
 
     References
     ----------

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -672,7 +672,7 @@ class SpectralEmbedding(BaseEstimator):
         Returns
         -------
         X_new : array-like of shape (n_samples, n_components)
-                Spectral embedding of the training matrix.
+            Spectral embedding of the training matrix.
         """
         self.fit(X)
         return self.embedding_

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -471,17 +471,9 @@ class SpectralEmbedding(BaseEstimator):
     n_neighbors_ : int
         Number of nearest neighbors effectively used.
 
-    Examples
+    See Also
     --------
-    >>> from sklearn.datasets import load_digits
-    >>> from sklearn.manifold import SpectralEmbedding
-    >>> X, _ = load_digits(return_X_y=True)
-    >>> X.shape
-    (1797, 64)
-    >>> embedding = SpectralEmbedding(n_components=2)
-    >>> X_transformed = embedding.fit_transform(X[:100])
-    >>> X_transformed.shape
-    (100, 2)
+    Isomap: Non-linear dimensionality reduction through Isometric Mapping.
 
     References
     ----------
@@ -497,6 +489,18 @@ class SpectralEmbedding(BaseEstimator):
     - Normalized cuts and image segmentation, 2000
       Jianbo Shi, Jitendra Malik
       http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.160.2324
+    
+    Examples
+    --------
+    >>> from sklearn.datasets import load_digits
+    >>> from sklearn.manifold import SpectralEmbedding
+    >>> X, _ = load_digits(return_X_y=True)
+    >>> X.shape
+    (1797, 64)
+    >>> embedding = SpectralEmbedding(n_components=2)
+    >>> X_transformed = embedding.fit_transform(X[:100])
+    >>> X_transformed.shape
+    (100, 2)
     """
 
     def __init__(
@@ -607,6 +611,7 @@ class SpectralEmbedding(BaseEstimator):
             samples.
 
         y : Ignored
+            Not used, present for API consistency by convention.
 
         Returns
         -------
@@ -662,10 +667,12 @@ class SpectralEmbedding(BaseEstimator):
             samples.
 
         y : Ignored
+            Not used, present for API consistency by convention.
 
         Returns
         -------
         X_new : array-like of shape (n_samples, n_components)
+                Spectral embedding of the training matrix.
         """
         self.fit(X)
         return self.embedding_

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -489,7 +489,7 @@ class SpectralEmbedding(BaseEstimator):
     - Normalized cuts and image segmentation, 2000
       Jianbo Shi, Jitendra Malik
       http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.160.2324
-    
+
     Examples
     --------
     >>> from sklearn.datasets import load_digits


### PR DESCRIPTION
# Reference Issues/PRs

Addresses #20308

# What does this implement/fix? Explain your changes.

This PR ensures `SpectralEmbedding` is compatible with numpydoc.

 - [x] Remove `SpectralEmbedding` from: https://github.com/scikit-learn/scikit-learn/blob/d4d5f8c7e02cfaced76757fbf38e21c5b28b67b0/maint_tools/test_docstrings.py#L21
 - [x] Create *See Also* section and add `Isomap`.
 - [x] Minor style fixes (remove double line break, section order)

# Any other comments?

Thanks #DataUmbrella! Thanks so much scikit-learn for so patiently reviewing my PRs! Please let me know if there is anything I can do to improve my future PRs.