### PR TITLE
DOC Ensures that OrthogonalMatchingPursuitCV passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -15,7 +15,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 DOCSTRING_IGNORE_LIST = [
     "LabelSpreading",
     "MultiTaskElasticNetCV",
-    "OrthogonalMatchingPursuitCV",
     "PassiveAggressiveRegressor",
     "SpectralCoclustering",
     "SpectralEmbedding",

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -880,7 +880,7 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
         copy is made anyway.
 
     fit_intercept : bool, default=True
-        whether to calculate the intercept for this model. If set
+        Whether to calculate the intercept for this model. If set
         to false, no intercept will be used in calculations
         (i.e. data is expected to be centered).
 
@@ -953,6 +953,20 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    orthogonal_mp : Solves n_targets Orthogonal Matching Pursuit problems.
+    orthogonal_mp_gram : Solves n_targets Orthogonal Matching Pursuit
+        problems using only the Gram matrix X.T * X and the product X.T * y.
+    lars_path : Compute Least Angle Regression or Lasso path using LARS algorithm.
+    Lars : Least Angle Regression model a.k.a. LAR.
+    LassoLars : Lasso model fit with Least Angle Regression a.k.a. Lars.
+    OrthogonalMatchingPursuit : Orthogonal Matching Pursuit model (OMP).
+    LarsCV : Cross-validated Least Angle Regression model.
+    LassoLarsCV : Cross-validated Lasso model fit with Least Angle Regression.
+    sklearn.decomposition.sparse_encode : Generic sparse coding.
+        Each column of the result is the solution to a Lasso problem.
+
     Examples
     --------
     >>> from sklearn.linear_model import OrthogonalMatchingPursuitCV
@@ -966,19 +980,6 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
     10
     >>> reg.predict(X[:1,])
     array([-78.3854...])
-
-    See Also
-    --------
-    orthogonal_mp
-    orthogonal_mp_gram
-    lars_path
-    Lars
-    LassoLars
-    OrthogonalMatchingPursuit
-    LarsCV
-    LassoLarsCV
-    sklearn.decomposition.sparse_encode
-
     """
 
     def __init__(
@@ -1014,7 +1015,7 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
         Returns
         -------
         self : object
-            returns an instance of self.
+            Returns an instance of self.
         """
 
         _normalize = _deprecate_normalize(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #20308

#### What does this implement/fix? Explain your changes.

This PR ensures that `OrthogonalMatchingPursuitCV` estimator passes all numpydoc validation checks.

- [x] Remove `OrthogonalMatchingPursuitCV` from `DOCSTRING_IGNORE_LIST`.

- Fixes on OrthogonalMatchingPursuitCV class docstring :
   - Some grammar fixes.
   - Sections order rearranged.
   - Missing descriptions for some references added.
   - Minor grammar fixes on fit method docstring.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
