### PR TITLE
DOC Ensures that PassiveAggressiveRegressor passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -16,7 +16,6 @@ DOCSTRING_IGNORE_LIST = [
     "LabelSpreading",
     "MultiTaskElasticNetCV",
     "OrthogonalMatchingPursuitCV",
-    "PassiveAggressiveRegressor",
     "SpectralCoclustering",
     "SpectralEmbedding",
     "StackingRegressor",

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -301,7 +301,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
 
 class PassiveAggressiveRegressor(BaseSGDRegressor):
-    """Passive Aggressive Regressor
+    """Passive Aggressive Regressor.
 
     Read more in the :ref:`User Guide <passive_aggressive>`.
 
@@ -352,7 +352,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     shuffle : bool, default=True
         Whether or not the training data should be shuffled after each epoch.
 
-    verbose : integer, default=0
+    verbose : int, default=0
         The verbosity level.
 
     loss : str, default="epsilon_insensitive"
@@ -416,6 +416,17 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
         Number of weight updates performed during training.
         Same as ``(n_iter_ * n_samples)``.
 
+    See Also
+    --------
+    SGDRegressor : Linear model fitted by minimizing a regularized
+        empirical loss with SGD.
+
+    References
+    ----------
+    Online Passive-Aggressive Algorithms
+    <http://jmlr.csail.mit.edu/papers/volume7/crammer06a/crammer06a.pdf>
+    K. Crammer, O. Dekel, J. Keshat, S. Shalev-Shwartz, Y. Singer - JMLR (2006).
+
     Examples
     --------
     >>> from sklearn.linear_model import PassiveAggressiveRegressor
@@ -432,18 +443,6 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     [-0.02306214]
     >>> print(regr.predict([[0, 0, 0, 0]]))
     [-0.02306214]
-
-    See Also
-    --------
-    SGDRegressor : Linear model fitted by minimizing a regularized
-        empirical loss with SGD.
-
-    References
-    ----------
-    Online Passive-Aggressive Algorithms
-    <http://jmlr.csail.mit.edu/papers/volume7/crammer06a/crammer06a.pdf>
-    K. Crammer, O. Dekel, J. Keshat, S. Shalev-Shwartz, Y. Singer - JMLR (2006).
-
     """
 
     def __init__(


### PR DESCRIPTION
# Reference Issues/PRs

Addresses #20308

# What does this implement/fix? Explain your changes.

This PR ensures `PassiveAggressiveRegressor` is compatible with numpydoc.

 - [x] Remove `PassiveAggressiveRegressor` from: https://github.com/scikit-learn/scikit-learn/blob/d4d5f8c7e02cfaced76757fbf38e21c5b28b67b0/maint_tools/test_docstrings.py#L19
 - [x] Minor style fixes (remove double line break, section order)

# Any other comments?

Thanks #DataUmbrella! Thanks so much @glemaitre for so patiently reviewing my PRs! Please let me know if there is anything I can do to improve my future PRs and help scikit-learn.