### PR TITLE
DOC Ensures that LabelSpreading passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -13,7 +13,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 
 # List of modules ignored when checking for numpydoc validation.
 DOCSTRING_IGNORE_LIST = [
-    "LabelSpreading",
     "MultiTaskElasticNetCV",
     "OrthogonalMatchingPursuitCV",
     "PassiveAggressiveRegressor",

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -476,7 +476,7 @@ class LabelPropagation(BaseLabelPropagation):
 
 
 class LabelSpreading(BaseLabelPropagation):
-    """LabelSpreading model for semi-supervised learning
+    """LabelSpreading model for semi-supervised learning.
 
     This model is similar to the basic Label Propagation algorithm,
     but uses affinity matrix based on the normalized graph Laplacian
@@ -546,6 +546,16 @@ class LabelSpreading(BaseLabelPropagation):
     n_iter_ : int
         Number of iterations run.
 
+    See Also
+    --------
+    LabelPropagation : Unregularized graph based semi-supervised learning.
+
+    References
+    ----------
+    Dengyong Zhou, Olivier Bousquet, Thomas Navin Lal, Jason Weston,
+    Bernhard Schoelkopf. Learning with local and global consistency (2004)
+    http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.115.3219
+
     Examples
     --------
     >>> import numpy as np
@@ -559,16 +569,6 @@ class LabelSpreading(BaseLabelPropagation):
     >>> labels[random_unlabeled_points] = -1
     >>> label_prop_model.fit(iris.data, labels)
     LabelSpreading(...)
-
-    References
-    ----------
-    Dengyong Zhou, Olivier Bousquet, Thomas Navin Lal, Jason Weston,
-    Bernhard Schoelkopf. Learning with local and global consistency (2004)
-    http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.115.3219
-
-    See Also
-    --------
-    LabelPropagation : Unregularized graph based semi-supervised learning.
     """
 
     _variant = "spreading"


### PR DESCRIPTION
# Reference Issues/PRs

Addresses #20308

# What does this implement/fix? Explain your changes.

This PR ensures `LabelSpreading` is compatible with numpydoc.

 - [x] Remove `LabelSpreading` from: https://github.com/scikit-learn/scikit-learn/blob/d4d5f8c7e02cfaced76757fbf38e21c5b28b67b0/maint_tools/test_docstrings.py#L16
 - [x] Minor style fixes (remove double line break, section order)

# Any other comments?

Thanks #DataUmbrella! Thanks so much @glemaitre for so patiently reviewing my PRs! Please let me know if there is anything I can do to improve my future PRs and help scikit-learn.