### PR TITLE
DOC update the News section in website

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -155,7 +155,7 @@
         <ul class="sk-landing-call-list list-unstyled">
         <li><strong>On-going development:</strong>
         <a href="https://scikit-learn.org/dev/whats_new.html"><strong>What's new</strong> (Changelog)</a>
-        <li><strong>September 2021.</strong> scikit-learn 1.0 is available for download (<a href="whats_new/v1.0.html#version-1-0">Changelog</a>).
+        <li><strong>October 2021.</strong> scikit-learn 1.0.1 is available for download (<a href="whats_new/v1.0.html#version-1-0-1">Changelog</a>).
         </li>
         <li><strong>April 2021.</strong> scikit-learn 0.24.2 is available for download (<a href="whats_new/v0.24.html#version-0-24-2">Changelog</a>).
         </li>

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -155,7 +155,9 @@
         <ul class="sk-landing-call-list list-unstyled">
         <li><strong>On-going development:</strong>
         <a href="https://scikit-learn.org/dev/whats_new.html"><strong>What's new</strong> (Changelog)</a>
-        <li><strong>October 2021.</strong> scikit-learn 1.0.1 is available for download (<a href="whats_new/v1.0.html#version-1-0-1">Changelog</a>).
+        <li><strong>October 2021.</strong> scikit-learn 1.0.1 is available for download (<a href="whats_new/v1.0.html#version-1-0-1">Changelog</a>)
+        </li>
+        <li><strong>September 2021.</strong> scikit-learn 1.0 is available for download (<a href="whats_new/v1.0.html#version-1-0">Changelog</a>)
         </li>
         <li><strong>April 2021.</strong> scikit-learn 0.24.2 is available for download (<a href="whats_new/v0.24.html#version-0-24-2">Changelog</a>).
         </li>

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -155,9 +155,9 @@
         <ul class="sk-landing-call-list list-unstyled">
         <li><strong>On-going development:</strong>
         <a href="https://scikit-learn.org/dev/whats_new.html"><strong>What's new</strong> (Changelog)</a>
-        <li><strong>October 2021.</strong> scikit-learn 1.0.1 is available for download (<a href="whats_new/v1.0.html#version-1-0-1">Changelog</a>)
+        <li><strong>October 2021.</strong> scikit-learn 1.0.1 is available for download (<a href="whats_new/v1.0.html#version-1-0-1">Changelog</a>).
         </li>
-        <li><strong>September 2021.</strong> scikit-learn 1.0 is available for download (<a href="whats_new/v1.0.html#version-1-0">Changelog</a>)
+        <li><strong>September 2021.</strong> scikit-learn 1.0 is available for download (<a href="whats_new/v1.0.html#version-1-0">Changelog</a>).
         </li>
         <li><strong>April 2021.</strong> scikit-learn 0.24.2 is available for download (<a href="whats_new/v0.24.html#version-0-24-2">Changelog</a>).
         </li>


### PR DESCRIPTION
Update the date on the website.
We should delay the merging when https://github.com/scikit-learn/scikit-learn/pull/21404 is ready.
Need to be backported to https://github.com/scikit-learn/scikit-learn/pull/21404