### PR TITLE
DOC Ensures that max_error passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -131,7 +131,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics._ranking.roc_auc_score",
     "sklearn.metrics._ranking.roc_curve",
     "sklearn.metrics._ranking.top_k_accuracy_score",
-    "sklearn.metrics._regression.max_error",
     "sklearn.metrics._regression.mean_absolute_error",
     "sklearn.metrics._regression.mean_pinball_loss",
     "sklearn.metrics._scorer.make_scorer",

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -822,7 +822,7 @@ def r2_score(y_true, y_pred, *, sample_weight=None, multioutput="uniform_average
 
 def max_error(y_true, y_pred):
     """
-    max_error metric calculates the maximum residual error.
+    The max_error metric calculates the maximum residual error.
 
     Read more in the :ref:`User Guide <max_error>`.
 


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #21350

#### What does this implement/fix? Explain your changes.
- remove sklearn.metrics._regression.max_error from scikit-learn/maint_tools/test_docstrings.py 
- fix numpydoc validation error in sklearn.metrics._regression.max_error

#### Any other comments?
cc (pair programming partner): @iofall