### PR TITLE
DOC Added the meaning of the default=None case in SparsePCA

### DIFF
--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -24,7 +24,7 @@ class SparsePCA(TransformerMixin, BaseEstimator):
     ----------
     n_components : int, default=None
         Number of sparse atoms to extract. If None, then ``n_components``
-        is set to ``n_features``.
+        is set to ``n_features_in_``.
 
     alpha : float, default=1
         Sparsity controlling parameter. Higher values lead to sparser

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -23,7 +23,8 @@ class SparsePCA(TransformerMixin, BaseEstimator):
     Parameters
     ----------
     n_components : int, default=None
-        Number of sparse atoms to extract.
+        Number of sparse atoms to extract. If None, then ``n_components``
+        is set to ``n_features``.
 
     alpha : float, default=1
         Sparsity controlling parameter. Higher values lead to sparser


### PR DESCRIPTION
#### Reference Issues/PRs
Solves one sub-issue in #17295.

#### What does this implement/fix? Explain your changes.
The default case for the `n_components` parameter in `sklearn.decomposition.SparsePCA` was not described, so I went ahead and added a short description.

#### Any other comments?

#DataUmbrella sprint
cc: @amueller 