### PR TITLE
DOC Ensures that linkage_tree passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -23,7 +23,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn._config.get_config",
     "sklearn.base.clone",
     "sklearn.cluster._affinity_propagation.affinity_propagation",
-    "sklearn.cluster._agglomerative.linkage_tree",
     "sklearn.cluster._kmeans.k_means",
     "sklearn.cluster._kmeans.kmeans_plusplus",
     "sklearn.cluster._mean_shift.estimate_bandwidth",

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -429,11 +429,11 @@ def linkage_tree(
               observations of the two sets.
 
     affinity : str or callable, default='euclidean'
-        which metric to use. Can be 'euclidean', 'manhattan', or any
+        Which metric to use. Can be 'euclidean', 'manhattan', or any
         distance known to paired distance (see metric.pairwise).
 
     return_distance : bool, default=False
-        whether or not to return the distances between the clusters.
+        Whether or not to return the distances between the clusters.
 
     Returns
     -------


### PR DESCRIPTION

#### Reference Issues/PRs

Addresses #21350 

#### What does this implement/fix? Explain your changes.

Fixed docstring to allow `linkage_tree` docstring to pass numpydoc validation.

#### Any other comments?

Work done with @fortune-uwha.

#DataUmbrella Sprint
@reshamas 
