### PR TITLE
DOC Added meaning of default=None for n_components in MiniBatchSparsePCA and MiniBatchDictionaryLearning

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -762,7 +762,7 @@ def dict_learning_online(
     X : ndarray of shape (n_samples, n_features)
         Data matrix.
 
-    n_components : int, default=2
+    n_components : int or None, default=2
         Number of dictionary atoms to extract. If None, then ``n_components``
         is set to ``n_features``.
 
@@ -1336,7 +1336,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     Parameters
     ----------
-    n_components : int, default=n_features
+    n_components : int, default=None
         Number of dictionary elements to extract. If None, then ``n_components``
         is set to ``n_features``.
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1338,7 +1338,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
     ----------
     n_components : int, default=n_features
         Number of dictionary elements to extract. If None, then ``n_components``
-        is set to ``n_features_in_``.
+        is set to ``n_features``.
 
     alpha : float, default=1.0
         Sparsity controlling parameter.

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -763,7 +763,8 @@ def dict_learning_online(
         Data matrix.
 
     n_components : int, default=2
-        Number of dictionary atoms to extract.
+        Number of dictionary atoms to extract. If None, then ``n_components``
+        is set to ``n_features``.
 
     alpha : float, default=1
         Sparsity controlling parameter.
@@ -1336,7 +1337,8 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
     Parameters
     ----------
     n_components : int, default=n_features
-        Number of dictionary elements to extract.
+        Number of dictionary elements to extract. If None, then ``n_components``
+        is set to ``n_features_in_``.
 
     alpha : float, default=1.0
         Sparsity controlling parameter.

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -24,7 +24,7 @@ class SparsePCA(TransformerMixin, BaseEstimator):
     ----------
     n_components : int, default=None
         Number of sparse atoms to extract. If None, then ``n_components``
-        is set to ``n_features_in_``.
+        is set to ``n_features``.
 
     alpha : float, default=1
         Sparsity controlling parameter. Higher values lead to sparser
@@ -250,7 +250,7 @@ class MiniBatchSparsePCA(SparsePCA):
     ----------
     n_components : int, default=None
         Number of sparse atoms to extract. If None, then ``n_components``
-        is set to ``n_features_in_``.
+        is set to ``n_features``.
 
     alpha : int, default=1
         Sparsity controlling parameter. Higher values lead to sparser

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -248,7 +248,8 @@ class MiniBatchSparsePCA(SparsePCA):
     Parameters
     ----------
     n_components : int, default=None
-        Number of sparse atoms to extract.
+        Number of sparse atoms to extract. If None, then ``n_components``
+        is set to ``n_features_in_``.
 
     alpha : int, default=1
         Sparsity controlling parameter. Higher values lead to sparser


### PR DESCRIPTION
#### Reference Issues/PRs
Solves two sub-issues in #17295.

#### What does this implement/fix? Explain your changes.
The default case (None) for the `n_components` parameter in `sklearn.decomposition.MiniBatchSparsePCA` and `sklearn.decomposition.MiniBatchDictionaryLearning` was not described, so I went ahead and added a short description. In addition, I noticed that the `sklearn.decomposition.dict_learning_online` function also has a `n_components` parameter. This parameter has a default=2 value but can take None values, so I added a description for that case too.

#### Any other comments?

#DataUmbrella sprint
cc: @amueller @thomasjpfan 
