### PR TITLE
FIX validate parameters in `fit` for `FastICA`

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -52,6 +52,12 @@ Changelog
   reconstruction of a `X` target when a `Y` parameter is given. :pr:`19680` by
   :user:`Robin Thibaut <robinthibaut>`.
 
+:mod:`sklearn.decomposition`
+............................
+
+- |Fix| :class:`decomposition.FastICA` now validates input parameters in `fit` instead of `__init__`.
+  :pr:`21432` by :user:`Hannah Bohle <hhnnhh>` and :user:`Maren Westermann <marenwestermann>`.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -444,10 +444,6 @@ class FastICA(TransformerMixin, BaseEstimator):
         random_state=None,
     ):
         super().__init__()
-        if max_iter < 1:
-            raise ValueError(
-                "max_iter should be greater than 1, got (max_iter={})".format(max_iter)
-            )
         self.n_components = n_components
         self.algorithm = algorithm
         self.whiten = whiten
@@ -553,6 +549,13 @@ class FastICA(TransformerMixin, BaseEstimator):
                     "w_init has invalid shape -- should be %(shape)s"
                     % {"shape": (n_components, n_components)}
                 )
+
+        if self.max_iter < 1:
+            raise ValueError(
+                "max_iter should be greater than 1, got (max_iter={})".format(
+                    self.max_iter
+                )
+            )
 
         kwargs = {
             "tol": self.tol,

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -274,9 +274,9 @@ def test_fastica_errors():
     rng = np.random.RandomState(0)
     X = rng.random_sample((n_samples, n_features))
     w_init = rng.randn(n_features + 1, n_features + 1)
-    fastica = FastICA(max_iter=0)
+    fastica_estimator = FastICA(max_iter=0)
     with pytest.raises(ValueError, match="max_iter should be greater than 1"):
-        fastica.fit(X)
+        fastica_estimator.fit(X)
     with pytest.raises(ValueError, match=r"alpha must be in \[1,2\]"):
         fastica(X, fun_args={"alpha": 0})
     with pytest.raises(

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -275,7 +275,7 @@ def test_fastica_errors():
     X = rng.random_sample((n_samples, n_features))
     w_init = rng.randn(n_features + 1, n_features + 1)
     with pytest.raises(ValueError, match="max_iter should be greater than 1"):
-        FastICA(max_iter=0)
+        FastICA(max_iter=0).fit(X)
     with pytest.raises(ValueError, match=r"alpha must be in \[1,2\]"):
         fastica(X, fun_args={"alpha": 0})
     with pytest.raises(

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -274,8 +274,9 @@ def test_fastica_errors():
     rng = np.random.RandomState(0)
     X = rng.random_sample((n_samples, n_features))
     w_init = rng.randn(n_features + 1, n_features + 1)
+    fastica = FastICA(max_iter=0)
     with pytest.raises(ValueError, match="max_iter should be greater than 1"):
-        FastICA(max_iter=0).fit(X)
+        fastica.fit(X)
     with pytest.raises(ValueError, match=r"alpha must be in \[1,2\]"):
         fastica(X, fun_args={"alpha": 0})
     with pytest.raises(

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -408,7 +408,6 @@ def test_transformers_get_feature_names_out(transformer):
 VALIDATE_ESTIMATOR_INIT = [
     "ColumnTransformer",
     "FactorAnalysis",
-    "FastICA",
     "FeatureHasher",
     "FeatureUnion",
     "GridSearchCV",


### PR DESCRIPTION


#### Reference Issues/PRs
Addresses #21406 


#### What does this implement/fix? Explain your changes.
1. Moves ValueError from __init__ to _fit 
2. checks ValueError in test_fastica.py 


#### Any other comments?

#DataUmbrella


