### PR TITLE
DOC Ensures that sklearn.model_selection._validation.cross_val_predict passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -178,7 +178,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.sigmoid_kernel",
     "sklearn.model_selection._split.check_cv",
     "sklearn.model_selection._split.train_test_split",
-    "sklearn.model_selection._validation.cross_val_predict",
     "sklearn.model_selection._validation.cross_val_score",
     "sklearn.model_selection._validation.cross_validate",
     "sklearn.model_selection._validation.learning_curve",

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -815,7 +815,7 @@ def cross_val_predict(
     pre_dispatch="2*n_jobs",
     method="predict",
 ):
-    """Generate cross-validated estimates for each input data point
+    """Generate cross-validated estimates for each input data point.
 
     The data is split according to the cv parameter. Each sample belongs
     to exactly one test set, and its prediction is computed with an
@@ -853,7 +853,7 @@ def cross_val_predict(
         - None, to use the default 5-fold cross validation,
         - int, to specify the number of folds in a `(Stratified)KFold`,
         - :term:`CV splitter`,
-        - An iterable yielding (train, test) splits as arrays of indices.
+        - An iterable that generates (train, test) splits as arrays of indices.
 
         For int/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all


### PR DESCRIPTION
**Reference Issues/PRs**
Addresses #21350

**What does this implement/fix? Explain your changes.**
- remove sklearn.model_selection._validation.cross_val_predict from scikit-learn/maint_tools/test_docstrings.py
- fix numpydoc validation error in sklearn.model_selection._validation.cross_val_predict

**Any other comments?**
cc (pair programming partner): @arisayosh

**Yields Issue**
We fixed the : `YD01: No Yields section found` flake8 error by removing `yielding` from the docstring.

#DataUmbrella sprint
cc: @nestornav