### PR TITLE
DOC Ensures that train_test_split passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -173,7 +173,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.rbf_kernel",
     "sklearn.metrics.pairwise.sigmoid_kernel",
     "sklearn.model_selection._split.check_cv",
-    "sklearn.model_selection._split.train_test_split",
     "sklearn.model_selection._validation.cross_val_score",
     "sklearn.model_selection._validation.cross_validate",
     "sklearn.model_selection._validation.learning_curve",

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2326,7 +2326,7 @@ def train_test_split(
     shuffle=True,
     stratify=None,
 ):
-    """Split arrays or matrices into random train and test subsets
+    """Split arrays or matrices into random train and test subsets.
 
     Quick utility that wraps input validation and
     ``next(ShuffleSplit().split(X, y))`` and application to input data
@@ -2358,7 +2358,6 @@ def train_test_split(
         Controls the shuffling applied to the data before applying the split.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
-
 
     shuffle : bool, default=True
         Whether or not to shuffle the data before splitting. If shuffle=False
@@ -2410,7 +2409,6 @@ def train_test_split(
 
     >>> train_test_split(y, shuffle=False)
     [[0, 1, 2], [3, 4]]
-
     """
     n_arrays = len(arrays)
     if n_arrays == 0:


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #21350

#### What does this implement/fix? Explain your changes.
- removed `sklearn.model_selection._split.train_test_split` from [scikit-learn/maint_tools/test_docstrings.py](https://github.com/scikit-learn/scikit-learn/blob/47a49c51d14b7b648be6a4918c1441cb29c96a9e/maint_tools/test_docstrings.py#L37)
- edited docstring to address: 
    - GL03: Double line break found; please use only one blank line to separate sections or paragraphs, and do not leave blank lines at the end of docstrings
    - SS03: Summary does not end with a period

#### Any other comments?
#DataUmbrella sprint
cc: @nestornav