### PR TITLE
DOC Ensures that empirical_covariance passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -30,7 +30,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.cluster._optics.compute_optics_graph",
     "sklearn.cluster._spectral.spectral_clustering",
     "sklearn.compose._column_transformer.make_column_transformer",
-    "sklearn.covariance._empirical_covariance.empirical_covariance",
     "sklearn.covariance._empirical_covariance.log_likelihood",
     "sklearn.covariance._graph_lasso.graphical_lasso",
     "sklearn.covariance._robust_covariance.fast_mcd",

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -49,13 +49,12 @@ def log_likelihood(emp_cov, precision):
 
 
 def empirical_covariance(X, *, assume_centered=False):
-    """Computes the Maximum likelihood covariance estimator
-
+    """Compute the Maximum likelihood covariance estimator.
 
     Parameters
     ----------
     X : ndarray of shape (n_samples, n_features)
-        Data from which to compute the covariance estimate
+        Data from which to compute the covariance estimate.
 
     assume_centered : bool, default=False
         If True, data will not be centered before computation.

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -57,10 +57,10 @@ def empirical_covariance(X, *, assume_centered=False):
         Data from which to compute the covariance estimate.
 
     assume_centered : bool, default=False
-        If True, data will not be centered before computation.
+        If `True`, data will not be centered before computation.
         Useful when working with data whose mean is almost, but not exactly
         zero.
-        If False, data will be centered before computation.
+        If `False`, data will be centered before computation.
 
     Returns
     -------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #21350
#DataUmbrella

#### What does this implement/fix? Explain your changes.
This PR ensures `sklearn.covariance._empirical_covariance.empirical_covariance` is compatible with numpydoc:
* Remove `sklearn.covariance._empirical_covariance.empirical_covariance` from DOCSTRING_IGNORE_LIST.
* Verify that all tests are passing.
* Add backticks to bool values.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
