### PR TITLE
DOC Ensures that sklearn.metrics._classification.accuracy_score passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -96,7 +96,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.linear_model._ridge.ridge_regression",
     "sklearn.manifold._locally_linear.locally_linear_embedding",
     "sklearn.manifold._t_sne.trustworthiness",
-    "sklearn.metrics._classification.accuracy_score",
     "sklearn.metrics._classification.balanced_accuracy_score",
     "sklearn.metrics._classification.brier_score_loss",
     "sklearn.metrics._classification.classification_report",

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -178,12 +178,12 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
     See Also
     --------
     balanced_accuracy_score : Compute the balanced accuracy to deal with
-    imbalanced datasets.
+        imbalanced datasets.
     jaccard_score : Compute the Jaccard similarity coefficient score.
     hamming_loss : Compute the average Hamming loss or Hamming distance between
-    two sets of samples.
+        two sets of samples.
     zero_one_loss : Compute the Zero-one classification loss. By default, the
-    function will return the percentage of imperfectly predicted subsets.
+        function will return the percentage of imperfectly predicted subsets.
 
     Notes
     -----

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -177,9 +177,12 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
 
     See Also
     --------
-    jaccard_score : Jaccard similarity coefficient score.
-    hamming_loss : Compute the average Hamming loss.
-    zero_one_loss : Zero-one classification loss.
+    balanced_accuracy_score : Compute the balanced accuracy to deal with imbalanced datasets.
+    jaccard_score : Compute the Jaccard similarity coefficient score.
+    hamming_loss : Compute the average Hamming loss or Hamming distance between
+    two sets of samples.
+    zero_one_loss : Compute the Zero-one classification loss. By default, the
+    function will return the percentage of imperfectly predicted subsets.
 
     Notes
     -----

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -177,7 +177,9 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
 
     See Also
     --------
-    jaccard_score, hamming_loss, zero_one_loss
+    jaccard_score : Jaccard similarity coefficient score.
+    hamming_loss : Compute the average Hamming loss.
+    zero_one_loss : Zero-one classification loss.
 
     Notes
     -----

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -177,7 +177,8 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
 
     See Also
     --------
-    balanced_accuracy_score : Compute the balanced accuracy to deal with imbalanced datasets.
+    balanced_accuracy_score : Compute the balanced accuracy to deal with
+    imbalanced datasets.
     jaccard_score : Compute the Jaccard similarity coefficient score.
     hamming_loss : Compute the average Hamming loss or Hamming distance between
     two sets of samples.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #21350
#DataUmbrella

What does this implement/fix? Explain your changes.
This PR ensures sklearn.metrics._classification.accuracy_score is compatible with numpydoc:

* Remove sklearn.metrics._classification.accuracy_score from DOCSTRING_IGNORE_LIST.
* Verify that all tests are passing.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
