### PR TITLE
TST accelerate runtime for test svm/tests/test_svm.py::test_svc_ovr_tie_breaking[NuSVC]

### DIFF
--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1204,24 +1204,26 @@ def test_svc_ovr_tie_breaking(SVCClass):
     """Test if predict breaks ties in OVR mode.
     Related issue: https://github.com/scikit-learn/scikit-learn/issues/8277
     """
-    X, y = make_blobs(random_state=27, n_samples=10)
+    X, y = make_blobs(random_state=0, n_samples=20, n_features=2)
 
     xs = np.linspace(X[:, 0].min(), X[:, 0].max(), 100)
     ys = np.linspace(X[:, 1].min(), X[:, 1].max(), 100)
     xx, yy = np.meshgrid(xs, ys)
 
+    common_params = dict(
+        kernel="rbf", gamma=1e6, random_state=42, decision_function_shape="ovr"
+    )
     svm = SVCClass(
-        kernel="linear",
-        decision_function_shape="ovr",
         break_ties=False,
-        random_state=42,
+        **common_params,
     ).fit(X, y)
     pred = svm.predict(np.c_[xx.ravel(), yy.ravel()])
     dv = svm.decision_function(np.c_[xx.ravel(), yy.ravel()])
     assert not np.all(pred == np.argmax(dv, axis=1))
 
     svm = SVCClass(
-        kernel="linear", decision_function_shape="ovr", break_ties=True, random_state=42
+        break_ties=True,
+        **common_params,
     ).fit(X, y)
     pred = svm.predict(np.c_[xx.ravel(), yy.ravel()])
     dv = svm.decision_function(np.c_[xx.ravel(), yy.ravel()])

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1204,10 +1204,10 @@ def test_svc_ovr_tie_breaking(SVCClass):
     """Test if predict breaks ties in OVR mode.
     Related issue: https://github.com/scikit-learn/scikit-learn/issues/8277
     """
-    X, y = make_blobs(random_state=27)
+    X, y = make_blobs(random_state=27, n_samples=10)
 
-    xs = np.linspace(X[:, 0].min(), X[:, 0].max(), 1000)
-    ys = np.linspace(X[:, 1].min(), X[:, 1].max(), 1000)
+    xs = np.linspace(X[:, 0].min(), X[:, 0].max(), 100)
+    ys = np.linspace(X[:, 1].min(), X[:, 1].max(), 100)
     xx, yy = np.meshgrid(xs, ys)
 
     svm = SVCClass(

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1204,24 +1204,29 @@ def test_svc_ovr_tie_breaking(SVCClass):
     """Test if predict breaks ties in OVR mode.
     Related issue: https://github.com/scikit-learn/scikit-learn/issues/8277
     """
-    X, y = make_blobs(random_state=27, n_samples=10)
+    X, y = make_blobs(random_state=0, n_samples=20, n_features=2)
 
     xs = np.linspace(X[:, 0].min(), X[:, 0].max(), 100)
     ys = np.linspace(X[:, 1].min(), X[:, 1].max(), 100)
     xx, yy = np.meshgrid(xs, ys)
 
-    svm = SVCClass(
-        kernel="linear",
-        decision_function_shape="ovr",
-        break_ties=False,
+    common_params = dict(
+        kernel="rbf",
+        gamma=1e6,
         random_state=42,
+        decision_function_shape="ovr"
+    )
+    svm = SVCClass(
+        break_ties=False,
+        **common_params,
     ).fit(X, y)
     pred = svm.predict(np.c_[xx.ravel(), yy.ravel()])
     dv = svm.decision_function(np.c_[xx.ravel(), yy.ravel()])
     assert not np.all(pred == np.argmax(dv, axis=1))
 
     svm = SVCClass(
-        kernel="linear", decision_function_shape="ovr", break_ties=True, random_state=42
+        break_ties=True,
+        **common_params,
     ).fit(X, y)
     pred = svm.predict(np.c_[xx.ravel(), yy.ravel()])
     dv = svm.decision_function(np.c_[xx.ravel(), yy.ravel()])


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #21407

#### What does this implement/fix? Explain your changes.

Reduces test runtime for test svm/tests/test_svm.py::test_svc_ovr_tie_breaking[NuSVC]
Environment: local
Previous runtime: 4.65 s
Current runtime: 0.09 s

#### Any other comments?

Programming partner: @mohaseeb 
#DataUmbrella Sprint
