### PR TITLE
DOC Ensures that StackingRegressor passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -14,7 +14,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 # List of modules ignored when checking for numpydoc validation.
 DOCSTRING_IGNORE_LIST = [
     "SpectralCoclustering",
-    "StackingRegressor",
 ]
 
 FUNCTION_DOCSTRING_IGNORE_LIST = [

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -753,6 +753,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         Returns
         -------
         self : object
+            Returns a fitted instance.
         """
         y = column_or_1d(y, warn=True)
         return super().fit(X, y, sample_weight)

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -670,6 +670,10 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
     stack_method_ : list of str
         The method used by each base estimator.
 
+    See Also
+    --------
+    StackingClassifier : Stack of estimators with a final classifier.
+
     References
     ----------
     .. [1] Wolpert, David H. "Stacked generalization." Neural networks 5.2
@@ -698,7 +702,6 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
     ... )
     >>> reg.fit(X_train, y_train).score(X_test, y_test)
     0.3...
-
     """
 
     def __init__(


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #20308 

#### What does this implement/fix? Explain your changes.

- `StackingRegressor` removed from `DOCSTRING_IGNORE_LIST` in test_docstrings.py
- In `StackingRegressor`: "See Also" section added.
- In `StackingRegressor.fit`: `return` description added.

