### PR TITLE
[MRG] API Warn upon removal of NaN columns

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -592,6 +592,12 @@ Changelog
   version 1.2.
   :pr:`20161` by :user:`Shuhei Kayawari <wowry>` and :user:`arka204`.
 
+:mod:`sklearn.impute`
+................................
+- |API| The `verbose` parameter was deprecated for :class:`impute.SimpleImputer`.
+  A warning will always be raised upon the removal of empty columns.
+  :pr:`18467` by :user:`Oleh Kozynets <OlehKSS>`.
+
 :mod:`sklearn.inspection`
 .........................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -592,12 +592,6 @@ Changelog
   version 1.2.
   :pr:`20161` by :user:`Shuhei Kayawari <wowry>` and :user:`arka204`.
 
-:mod:`sklearn.impute`
-................................
-- |API| The `verbose` parameter was deprecated for :class:`impute.SimpleImputer`.
-  A warning will always be raised upon the removal of empty columns.
-  :pr:`18467` by :user:`Oleh Kozynets <OlehKSS>`.
-
 :mod:`sklearn.inspection`
 .........................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -65,6 +65,10 @@ Changelog
   :class:`impute.KNNImputer`, :class:`impute.IterativeImputer`, and
   :class:`impute.MissingIndicator`. :pr:`21078` by `Thomas Fan`_.
 
+- |API| The `verbose` parameter was deprecated for :class:`impute.SimpleImputer`.
+  A warning will always be raised upon the removal of empty columns.
+  :pr:`18467` by :user:`Oleh Kozynets <OlehKSS>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -67,7 +67,8 @@ Changelog
 
 - |API| The `verbose` parameter was deprecated for :class:`impute.SimpleImputer`.
   A warning will always be raised upon the removal of empty columns.
-  :pr:`18467` by :user:`Oleh Kozynets <OlehKSS>`.
+  :pr:`21448` by :user:`Oleh Kozynets <OlehKSS>` and
+  :user:`Christian Ritter <chritter>.
 
 :mod:`sklearn.metrics`
 ......................

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -234,13 +234,18 @@ class SimpleImputer(_BaseImputer):
      [ 4.   3.5  6. ]
      [10.   3.5  9. ]]
     """
-    def __init__(self, *, missing_values=np.nan, strategy="mean",
-                 fill_value=None, verbose="deprecated", copy=True,
-                 add_indicator=False):
-        super().__init__(
-            missing_values=missing_values,
-            add_indicator=add_indicator
-        )
+
+    def __init__(
+        self,
+        *,
+        missing_values=np.nan,
+        strategy="mean",
+        fill_value=None,
+        verbose="deprecated",
+        copy=True,
+        add_indicator=False,
+    ):
+        super().__init__(missing_values=missing_values, add_indicator=add_indicator)
         self.strategy = strategy
         self.fill_value = fill_value
         self.verbose = verbose
@@ -325,10 +330,13 @@ class SimpleImputer(_BaseImputer):
             Fitted estimator.
         """
         if self.verbose != "deprecated":
-            warnings.warn("The 'verbose' parameter was deprecated in version "
-                          "1.1 and will be removed in 1.3. A warning will "
-                          "always be raised upon the removal of empty columns "
-                          "in the future version.", FutureWarning)
+            warnings.warn(
+                "The 'verbose' parameter was deprecated in version "
+                "1.1 and will be removed in 1.3. A warning will "
+                "always be raised upon the removal of empty columns "
+                "in the future version.",
+                FutureWarning,
+            )
 
         X = self._validate_input(X, in_fit=True)
 
@@ -507,8 +515,9 @@ class SimpleImputer(_BaseImputer):
             if invalid_mask.any():
                 missing = np.arange(X.shape[1])[invalid_mask]
                 if self.verbose != "deprecated" and self.verbose:
-                    warnings.warn("Deleting features without "
-                                  "observed values: %s" % missing)
+                    warnings.warn(
+                        "Deleting features without observed values: %s" % missing
+                    )
                 X = X[:, valid_statistics_indexes]
 
         # Do actual imputation

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -167,8 +167,13 @@ class SimpleImputer(_BaseImputer):
     verbose : int, default=0
         Controls the verbosity of the imputer.
 
-    copy : bool, default=True
-        If True, a copy of `X` will be created. If False, imputation will
+        .. deprecated:: 1.0
+           The 'verbose' parameter was deprecated in version 1.0 and will be
+           removed in 1.2. A warning will always be raised upon the removal of
+           empty columns in the future version.
+
+    copy : boolean, default=True
+        If True, a copy of X will be created. If False, imputation will
         be done in-place whenever possible. Note that, in the following cases,
         a new copy will always be made, even if `copy=False`:
 
@@ -229,18 +234,13 @@ class SimpleImputer(_BaseImputer):
      [ 4.   3.5  6. ]
      [10.   3.5  9. ]]
     """
-
-    def __init__(
-        self,
-        *,
-        missing_values=np.nan,
-        strategy="mean",
-        fill_value=None,
-        verbose=0,
-        copy=True,
-        add_indicator=False,
-    ):
-        super().__init__(missing_values=missing_values, add_indicator=add_indicator)
+    def __init__(self, *, missing_values=np.nan, strategy="mean",
+                 fill_value=None, verbose=None, copy=True,
+                 add_indicator=False):
+        super().__init__(
+            missing_values=missing_values,
+            add_indicator=add_indicator
+        )
         self.strategy = strategy
         self.fill_value = fill_value
         self.verbose = verbose
@@ -324,6 +324,12 @@ class SimpleImputer(_BaseImputer):
         self : object
             Fitted estimator.
         """
+        if self.verbose is not None:
+            warnings.warn("The 'verbose' parameter was deprecated in version "
+                          "1.0 and will be removed in 1.2. A warning will "
+                          "always be raised upon the removal of empty columns "
+                          "in the future version.", FutureWarning)
+
         X = self._validate_input(X, in_fit=True)
 
         # default fill_value is 0 for numerical input and "missing_value"

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -167,9 +167,9 @@ class SimpleImputer(_BaseImputer):
     verbose : int, default=0
         Controls the verbosity of the imputer.
 
-        .. deprecated:: 1.0
-           The 'verbose' parameter was deprecated in version 1.0 and will be
-           removed in 1.2. A warning will always be raised upon the removal of
+        .. deprecated:: 1.1
+           The 'verbose' parameter was deprecated in version 1.1 and will be
+           removed in 1.3. A warning will always be raised upon the removal of
            empty columns in the future version.
 
     copy : boolean, default=True
@@ -326,7 +326,7 @@ class SimpleImputer(_BaseImputer):
         """
         if self.verbose != "deprecated":
             warnings.warn("The 'verbose' parameter was deprecated in version "
-                          "1.0 and will be removed in 1.2. A warning will "
+                          "1.1 and will be removed in 1.3. A warning will "
                           "always be raised upon the removal of empty columns "
                           "in the future version.", FutureWarning)
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -516,7 +516,7 @@ class SimpleImputer(_BaseImputer):
                 missing = np.arange(X.shape[1])[invalid_mask]
                 if self.verbose != "deprecated" and self.verbose:
                     warnings.warn(
-                        "Deleting features without observed values: %s" % missing
+                        "Skipping features without observed values: %s" % missing
                     )
                 X = X[:, valid_statistics_indexes]
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -172,7 +172,7 @@ class SimpleImputer(_BaseImputer):
            removed in 1.3. A warning will always be raised upon the removal of
            empty columns in the future version.
 
-    copy : boolean, default=True
+    copy : bool, default=True
         If True, a copy of X will be created. If False, imputation will
         be done in-place whenever possible. Note that, in the following cases,
         a new copy will always be made, even if `copy=False`:

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -235,7 +235,7 @@ class SimpleImputer(_BaseImputer):
      [10.   3.5  9. ]]
     """
     def __init__(self, *, missing_values=np.nan, strategy="mean",
-                 fill_value=None, verbose=None, copy=True,
+                 fill_value=None, verbose="deprecated", copy=True,
                  add_indicator=False):
         super().__init__(
             missing_values=missing_values,
@@ -324,7 +324,7 @@ class SimpleImputer(_BaseImputer):
         self : object
             Fitted estimator.
         """
-        if self.verbose is not None:
+        if self.verbose != "deprecated":
             warnings.warn("The 'verbose' parameter was deprecated in version "
                           "1.0 and will be removed in 1.2. A warning will "
                           "always be raised upon the removal of empty columns "
@@ -506,10 +506,9 @@ class SimpleImputer(_BaseImputer):
 
             if invalid_mask.any():
                 missing = np.arange(X.shape[1])[invalid_mask]
-                if self.verbose:
-                    warnings.warn(
-                        "Deleting features without observed values: %s" % missing
-                    )
+                if self.verbose != "deprecated" and self.verbose:
+                    warnings.warn("Deleting features without "
+                                  "observed values: %s" % missing)
                 X = X[:, valid_statistics_indexes]
 
         # Do actual imputation

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -98,7 +98,7 @@ def test_imputation_deletion_warning(strategy):
     X[:, 0] = np.nan
     imputer = SimpleImputer(strategy=strategy, verbose=1)
 
-    # TODO: Remove in 1.2
+    # TODO: Remove in 1.3
     with pytest.warns(FutureWarning, match="The 'verbose' parameter"):
         imputer.fit(X)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -96,10 +96,13 @@ def test_imputation_error_invalid_strategy(strategy):
 def test_imputation_deletion_warning(strategy):
     X = np.ones((3, 5))
     X[:, 0] = np.nan
+    imputer = SimpleImputer(strategy=strategy, verbose=1)
+
+    with pytest.warns(FutureWarning, match="The 'verbose' parameter"):
+        imputer.fit(X)
 
     with pytest.warns(UserWarning, match="Deleting"):
-        imputer = SimpleImputer(strategy=strategy, verbose=True)
-        imputer.fit_transform(X)
+        imputer.transform(X)
 
 
 @pytest.mark.parametrize("strategy", ["mean", "median", "most_frequent", "constant"])

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -98,6 +98,7 @@ def test_imputation_deletion_warning(strategy):
     X[:, 0] = np.nan
     imputer = SimpleImputer(strategy=strategy, verbose=1)
 
+    # TODO: Remove in 1.2
     with pytest.warns(FutureWarning, match="The 'verbose' parameter"):
         imputer.fit(X)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -102,7 +102,7 @@ def test_imputation_deletion_warning(strategy):
     with pytest.warns(FutureWarning, match="The 'verbose' parameter"):
         imputer.fit(X)
 
-    with pytest.warns(UserWarning, match="Deleting"):
+    with pytest.warns(UserWarning, match="Skipping"):
         imputer.transform(X)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

Update of PR https://github.com/scikit-learn/scikit-learn/pull/18467 by @OlehKSS which was stalled. Fixes #8781.


#### What does this implement/fix? Explain your changes.
* Work done in referenced PR above which commits were adopted: SimpleImputer issues a warning when columns that are completely NAN are removed during imputation by default.
* Work contributed by me: Update of depreciation version numbers, move from whatsnew file 1.0 to 1.1.

#### Any other comments?

Thank you to the main contributor @OlehKSS to whose fork I  could not push/update. Hence I created this new PR.

#DataUmbrella Sprint
@reshamas @thomasjpfan 