### PR TITLE
[MRG] accelerate test_bagging.py::test_classification with hyperparam adjustment and cartesian product suppression

### DIFF
--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -66,7 +66,7 @@ def test_classification():
     estimators = [
         None,
         DummyClassifier(),
-        Perceptron(max_iter=5),
+        Perceptron(max_iter=20),
         DecisionTreeClassifier(max_depth=2),
         KNeighborsClassifier(),
         SVC(),

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -28,6 +28,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.datasets import load_diabetes, load_iris, make_hastie_10_2
 from sklearn.utils import check_random_state
 from sklearn.preprocessing import FunctionTransformer, scale
+from itertools import cycle
 
 from scipy.sparse import csc_matrix, csr_matrix
 
@@ -57,27 +58,28 @@ def test_classification():
     grid = ParameterGrid(
         {
             "max_samples": [0.5, 1.0],
-            "max_features": [1, 2, 4],
+            "max_features": [1, 4],
             "bootstrap": [True, False],
             "bootstrap_features": [True, False],
         }
     )
-
-    for base_estimator in [
+    estimators = [
         None,
         DummyClassifier(),
         Perceptron(max_iter=5),
         DecisionTreeClassifier(max_depth=2),
         KNeighborsClassifier(),
         SVC(),
-    ]:
-        for params in grid:
-            BaggingClassifier(
-                base_estimator=base_estimator,
-                random_state=rng,
-                n_estimators=2,
-                **params,
-            ).fit(X_train, y_train).predict(X_test)
+    ]
+    # Try different parameter settings with different base classifiers without
+    # doing the full cartesian product to keep the test durations low.
+    for params, base_estimator in zip(grid, cycle(estimators)):
+        BaggingClassifier(
+            base_estimator=base_estimator,
+            random_state=rng,
+            n_estimators=2,
+            **params,
+        ).fit(X_train, y_train).predict(X_test)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -66,15 +66,15 @@ def test_classification():
     for base_estimator in [
         None,
         DummyClassifier(),
-        Perceptron(),
-        DecisionTreeClassifier(),
+        Perceptron(max_iter=5),
+        DecisionTreeClassifier(max_depth=2),
         KNeighborsClassifier(),
         SVC(),
     ]:
         for params in grid:
             BaggingClassifier(
-                base_estimator=base_estimator, random_state=rng, **params
-            ).fit(X_train, y_train).predict(X_test)
+                base_estimator=base_estimator, random_state=rng,
+                n_estimators=2, **params).fit(X_train, y_train).predict(X_test)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -73,8 +73,11 @@ def test_classification():
     ]:
         for params in grid:
             BaggingClassifier(
-                base_estimator=base_estimator, random_state=rng,
-                n_estimators=2, **params).fit(X_train, y_train).predict(X_test)
+                base_estimator=base_estimator,
+                random_state=rng,
+                n_estimators=2,
+                **params,
+            ).fit(X_train, y_train).predict(X_test)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #21407


#### What does this implement/fix? Explain your changes.
These changes are accelerating test case `sklearn/ensemble/tests/test_bagging.py:test_classification`

#### Any other comments?

 #DataUmbrella Sprint