### PR TITLE
MNT upgrade windows image on Azure Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,7 +237,7 @@ jobs:
 - template: build_tools/azure/windows.yml
   parameters:
     name: Windows
-    vmImage: vs2017-win2016
+    vmImage: windows-latest
     dependsOn: [linting, git_commit]
     condition: |
       and(


### PR DESCRIPTION
`vs2017-win2016` is deprecated and will be removed soon:
https://github.com/actions/virtual-environments/issues/4312

I changed to `windows-latest` image. We already used this image in GitHub Actions to build the wheels.