### PR TITLE
DOC Ensures that balanced_accuracy_score passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -91,7 +91,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.linear_model._ridge.ridge_regression",
     "sklearn.manifold._locally_linear.locally_linear_embedding",
     "sklearn.manifold._t_sne.trustworthiness",
-    "sklearn.metrics._classification.balanced_accuracy_score",
     "sklearn.metrics._classification.brier_score_loss",
     "sklearn.metrics._classification.classification_report",
     "sklearn.metrics._classification.cohen_kappa_score",

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1931,11 +1931,8 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     --------
     average_precision_score : Compute average precision (AP) from prediction
         scores.
-    precision_score : Compute the precision. The precision is the ratio
-        tp / (tp + fp) where tp is the number of true positives and fp the
-        number of false positives.
-    recall_score : Compute the ratio ``tp / (tp + fn)``, where ``tp`` is
-        the number of true positives and ``fn`` the number of false negatives.
+    precision_score : Compute the precision score.
+    recall_score : Compute the recall score.
     roc_auc_score : Compute Area Under the Receiver Operating Characteristic
         Curve (ROC AUC) from prediction scores.
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1925,10 +1925,14 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     Returns
     -------
     balanced_accuracy : float
+        Balanced accuracy score in the range 0 to 1.
 
     See Also
     --------
-    recall_score, roc_auc_score
+    recall_score : Compute the ratio ``tp / (tp + fn)``, where ``tp`` is
+        the number of true positives and ``fn`` the number of false negatives.
+    roc_auc_score : Compute Area Under the Receiver Operating Characteristic
+        Curve (ROC AUC) from prediction scores.
 
     Notes
     -----
@@ -1955,7 +1959,6 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     >>> y_pred = [0, 1, 0, 0, 0, 1]
     >>> balanced_accuracy_score(y_true, y_pred)
     0.625
-
     """
     C = confusion_matrix(y_true, y_pred, sample_weight=sample_weight)
     with np.errstate(divide="ignore", invalid="ignore"):

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1925,10 +1925,12 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     Returns
     -------
     balanced_accuracy : float
-        Balanced accuracy score in the range 0 to 1.
+        Balanced accuracy score.
 
     See Also
     --------
+    average_precision_score : Compute average precision (AP) from prediction
+        scores.
     recall_score : Compute the ratio ``tp / (tp + fn)``, where ``tp`` is
         the number of true positives and ``fn`` the number of false negatives.
     roc_auc_score : Compute Area Under the Receiver Operating Characteristic

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1931,6 +1931,9 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     --------
     average_precision_score : Compute average precision (AP) from prediction
         scores.
+    precision_score : Compute the precision. The precision is the ratio
+        tp / (tp + fp) where tp is the number of true positives and fp the
+        number of false positives.
     recall_score : Compute the ratio ``tp / (tp + fn)``, where ``tp`` is
         the number of true positives and ``fn`` the number of false negatives.
     roc_auc_score : Compute Area Under the Receiver Operating Characteristic


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #21350
#DataUmbrella

This PR ensures balanced_accuracy_score is compatible with numpydoc:

* Remove sklearn.metrics._classification.balanced_accuracy_score from DOCSTRING_IGNORE_LIST.
* Verify that all tests are passing.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
