### PR TITLE
[MRG] Add Swiss-Hole dataset and expand example

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -56,6 +56,13 @@ Changelog
   reconstruction of a `X` target when a `Y` parameter is given. :pr:`19680` by
   :user:`Robin Thibaut <robinthibaut>`.
 
+:mod:`sklearn.datasets`
+.......................
+
+- |Enhancement| :func:`datasets.make_swiss_roll` now supports the optional argument
+  hole; when set to True, it returns the swiss-hole dataset. :pr:`21482` by
+  :user:`Sebastian Pujalte <pujaltes>`.
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/examples/manifold/plot_swissroll.py
+++ b/examples/manifold/plot_swissroll.py
@@ -27,7 +27,8 @@ fig.add_axes(ax)
 ax.scatter(
     sr_points[:, 0], sr_points[:, 1], sr_points[:, 2], c=sr_color, s=50, alpha=0.8
 )
-plt.title("Swiss Roll in Ambient Space")
+ax.set_title("Swiss Roll in Ambient Space")
+ax.view_init(azim=-66, elev=12)
 _ = ax.text2D(0.8, 0.05, s="n_samples=1500", transform=ax.transAxes)
 
 # %%
@@ -77,7 +78,8 @@ fig.add_axes(ax)
 ax.scatter(
     sh_points[:, 0], sh_points[:, 1], sh_points[:, 2], c=sh_color, s=50, alpha=0.8
 )
-plt.title("Swiss-Hole in Ambient Space")
+ax.set_title("Swiss-Hole in Ambient Space")
+ax.view_init(azim=-66, elev=12)
 _ = ax.text2D(0.8, 0.05, s="n_samples=1500", transform=ax.transAxes)
 
 # %%

--- a/examples/manifold/plot_swissroll.py
+++ b/examples/manifold/plot_swissroll.py
@@ -67,7 +67,9 @@ _ = axs[1].set_title("TSNE Embedding of Swiss Roll")
 # Now let's take a look at how both algorithms deal with us adding a hole to
 # the data. First, we generate the Swiss-Hole dataset and plot it:
 
-sh_points, sh_color = datasets.make_swiss_roll(n_samples=1500, hole=True)
+sh_points, sh_color = datasets.make_swiss_roll(
+    n_samples=1500, hole=True, random_state=0
+)
 
 fig = plt.figure(figsize=(8, 6))
 ax = fig.add_subplot(111, projection="3d")

--- a/examples/manifold/plot_swissroll.py
+++ b/examples/manifold/plot_swissroll.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 from sklearn import manifold, datasets
 
 
-sr_points, sr_color = datasets.make_swiss_roll(n_samples=1500)
+sr_points, sr_color = datasets.make_swiss_roll(n_samples=1500, random_state=0)
 
 # %%
 # Now, let's take a look at our data:

--- a/examples/manifold/plot_swissroll.py
+++ b/examples/manifold/plot_swissroll.py
@@ -3,7 +3,7 @@
 Swiss Roll And Swiss-Hole Reduction
 ===================================
 This notebook seeks to compare two popular non-linear dimensionality
-techniques, t-SNE and LLE, on the classic Swiss Roll dataset. Then, we will
+techniques, T-distributed Stochastic Neighbor Embedding (t-SNE) and Locally Linear Embedding (LLE), on the classic Swiss Roll dataset. Then, we will
 explore how they both deal with the addition of a hole in the data.
 """
 # %%
@@ -50,7 +50,7 @@ fig, axs = plt.subplots(figsize=(8, 8), nrows=2)
 axs[0].scatter(sr_lle[:, 0], sr_lle[:, 1], c=sr_color)
 axs[0].set_title("LLE Embedding of Swiss Roll")
 axs[1].scatter(sr_tsne[:, 0], sr_tsne[:, 1], c=sr_color)
-_ = axs[1].set_title("TSNE Embedding of Swiss Roll")
+_ = axs[1].set_title("t-SNE Embedding of Swiss Roll")
 
 # %%
 # .. note::

--- a/examples/manifold/plot_swissroll.py
+++ b/examples/manifold/plot_swissroll.py
@@ -3,8 +3,10 @@
 Swiss Roll And Swiss-Hole Reduction
 ===================================
 This notebook seeks to compare two popular non-linear dimensionality
-techniques, T-distributed Stochastic Neighbor Embedding (t-SNE) and Locally Linear Embedding (LLE), on the classic Swiss Roll dataset. Then, we will
-explore how they both deal with the addition of a hole in the data.
+techniques, T-distributed Stochastic Neighbor Embedding (t-SNE) and
+Locally Linear Embedding (LLE), on the classic Swiss Roll dataset.
+Then, we will explore how they both deal with the addition of a hole
+in the data.
 """
 # %%
 # Swiss Roll

--- a/examples/manifold/plot_swissroll.py
+++ b/examples/manifold/plot_swissroll.py
@@ -32,7 +32,7 @@ ax.view_init(azim=-66, elev=12)
 _ = ax.text2D(0.8, 0.05, s="n_samples=1500", transform=ax.transAxes)
 
 # %%
-# Computing the LLE and TSNE embeddings, we find that LLE seems to unroll the
+# Computing the LLE and t-SNE embeddings, we find that LLE seems to unroll the
 # Swiss Roll pretty effectively. t-SNE on the other hand, is able
 # to preserve the general structure of the data, but, poorly represents the
 # continous nature of our original data. Instead, it seems to unnecessarily
@@ -83,7 +83,7 @@ ax.view_init(azim=-66, elev=12)
 _ = ax.text2D(0.8, 0.05, s="n_samples=1500", transform=ax.transAxes)
 
 # %%
-# Computing the LLE and TSNE embeddings, we obtain similar results to the
+# Computing the LLE and t-SNE embeddings, we obtain similar results to the
 # Swiss Roll. LLE very capably unrolls the data and even preserves
 # the hole. t-SNE, again seems to clump sections of points together, but, we
 # note that it preserves the general topology of the original data.
@@ -101,7 +101,7 @@ fig, axs = plt.subplots(figsize=(8, 8), nrows=2)
 axs[0].scatter(sh_lle[:, 0], sh_lle[:, 1], c=sh_color)
 axs[0].set_title("LLE Embedding of Swiss-Hole")
 axs[1].scatter(sh_tsne[:, 0], sh_tsne[:, 1], c=sh_color)
-_ = axs[1].set_title("TSNE Embedding of Swiss-Hole")
+_ = axs[1].set_title("t-SNE Embedding of Swiss-Hole")
 
 # %%
 #
@@ -112,6 +112,6 @@ _ = axs[1].set_title("TSNE Embedding of Swiss-Hole")
 # Better results could probably have been obtained by better tuning these
 # parameters.
 #
-# We observe that, as seen in in the "Manifold learning on
+# We observe that, as seen in the "Manifold learning on
 # handwritten digits" example, t-SNE generally performs better than LLE
 # on real world data.

--- a/examples/manifold/plot_swissroll.py
+++ b/examples/manifold/plot_swissroll.py
@@ -1,46 +1,113 @@
 """
 ===================================
-Swiss Roll reduction with LLE
+Swiss Roll And Swiss-Hole Reduction
 ===================================
-
-An illustration of Swiss Roll reduction
-with locally linear embedding
-
+This notebook seeks to compare two popular non-linear dimensionality
+techniques, t-SNE and LLE, on the classic Swiss Roll dataset. Then, we will
+explore how they both deal with the addition of a hole in the data.
 """
-
-# Author: Fabian Pedregosa -- <fabian.pedregosa@inria.fr>
-# License: BSD 3 clause (C) INRIA 2011
+# %%
+# Swiss Roll
+# ---------------------------------------------------
+#
+# We start by generating the Swiss Roll dataset.
 
 import matplotlib.pyplot as plt
-
-# This import is needed to modify the way figure behaves
-from mpl_toolkits.mplot3d import Axes3D
-
-Axes3D
-
-# ----------------------------------------------------------------------
-# Locally linear embedding of the swiss roll
-
 from sklearn import manifold, datasets
 
-X, color = datasets.make_swiss_roll(n_samples=1500)
 
-print("Computing LLE embedding")
-X_r, err = manifold.locally_linear_embedding(X, n_neighbors=12, n_components=2)
-print("Done. Reconstruction error: %g" % err)
+sr_points, sr_color = datasets.make_swiss_roll(n_samples=1500)
 
-# ----------------------------------------------------------------------
-# Plot result
+# %%
+# Now, let's take a look at our data:
 
-fig = plt.figure()
+fig = plt.figure(figsize=(8, 6))
+ax = fig.add_subplot(111, projection="3d")
+fig.add_axes(ax)
+ax.scatter(
+    sr_points[:, 0], sr_points[:, 1], sr_points[:, 2], c=sr_color, s=50, alpha=0.8
+)
+plt.title("Swiss Roll in Ambient Space")
+_ = ax.text2D(0.8, 0.05, s="n_samples=1500", transform=ax.transAxes)
 
-ax = fig.add_subplot(211, projection="3d")
-ax.scatter(X[:, 0], X[:, 1], X[:, 2], c=color, cmap=plt.cm.Spectral)
+# %%
+# Computing the LLE and TSNE embeddings, we find that LLE seems to unroll the
+# Swiss Roll pretty effectively. t-SNE on the other hand, is able
+# to preserve the general structure of the data, but, poorly represents the
+# continous nature of our original data. Instead, it seems to unnecessarily
+# clump sections of points together.
 
-ax.set_title("Original data")
-ax = fig.add_subplot(212)
-ax.scatter(X_r[:, 0], X_r[:, 1], c=color, cmap=plt.cm.Spectral)
-plt.axis("tight")
-plt.xticks([]), plt.yticks([])
-plt.title("Projected data")
-plt.show()
+sr_lle, sr_err = manifold.locally_linear_embedding(
+    sr_points, n_neighbors=12, n_components=2
+)
+
+sr_tsne = manifold.TSNE(
+    n_components=2, learning_rate="auto", perplexity=40, init="pca", random_state=0
+).fit_transform(sr_points)
+
+fig, axs = plt.subplots(figsize=(8, 8), nrows=2)
+axs[0].scatter(sr_lle[:, 0], sr_lle[:, 1], c=sr_color)
+axs[0].set_title("LLE Embedding of Swiss Roll")
+axs[1].scatter(sr_tsne[:, 0], sr_tsne[:, 1], c=sr_color)
+_ = axs[1].set_title("TSNE Embedding of Swiss Roll")
+
+# %%
+# .. note::
+#
+#     LLE seems to be stretching the points from the center (purple)
+#     of the swiss roll. However, we observe that this is simply a byproduct
+#     of how the data was generated. There is a higher density of points near the
+#     center of the roll, which ultimately affects how LLE reconstructs the
+#     data in a lower dimension.
+
+# %%
+# Swiss-Hole
+# ---------------------------------------------------
+#
+# Now let's take a look at how both algorithms deal with us adding a hole to
+# the data. First, we generate the Swiss-Hole dataset and plot it:
+
+sh_points, sh_color = datasets.make_swiss_roll(n_samples=1500, hole=True)
+
+fig = plt.figure(figsize=(8, 6))
+ax = fig.add_subplot(111, projection="3d")
+fig.add_axes(ax)
+ax.scatter(
+    sh_points[:, 0], sh_points[:, 1], sh_points[:, 2], c=sh_color, s=50, alpha=0.8
+)
+plt.title("Swiss-Hole in Ambient Space")
+_ = ax.text2D(0.8, 0.05, s="n_samples=1500", transform=ax.transAxes)
+
+# %%
+# Computing the LLE and TSNE embeddings, we obtain similar results to the
+# Swiss Roll. LLE very capably unrolls the data and even preserves
+# the hole. t-SNE, again seems to clump sections of points together, but, we
+# note that it preserves the general topology of the original data.
+
+
+sh_lle, sh_err = manifold.locally_linear_embedding(
+    sh_points, n_neighbors=12, n_components=2
+)
+
+sh_tsne = manifold.TSNE(
+    n_components=2, learning_rate="auto", perplexity=40, init="random", random_state=0
+).fit_transform(sh_points)
+
+fig, axs = plt.subplots(figsize=(8, 8), nrows=2)
+axs[0].scatter(sh_lle[:, 0], sh_lle[:, 1], c=sh_color)
+axs[0].set_title("LLE Embedding of Swiss-Hole")
+axs[1].scatter(sh_tsne[:, 0], sh_tsne[:, 1], c=sh_color)
+_ = axs[1].set_title("TSNE Embedding of Swiss-Hole")
+
+# %%
+#
+# Concluding remarks
+# ------------------
+#
+# We note that t-SNE benefits from testing more combinations of parameters.
+# Better results could probably have been obtained by better tuning these
+# parameters.
+#
+# We observe that, as seen in in the "Manifold learning on
+# handwritten digits" example, t-SNE generally performs better than LLE
+# on real world data.

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1469,7 +1469,7 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None, hole=False):
     Parameters
     ----------
     n_samples : int, default=100
-        The number of sample points on the S curve.
+        The number of sample points on the Swiss Roll.
 
     noise : float, default=0.0
         The standard deviation of the gaussian noise.

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1461,7 +1461,7 @@ def make_sparse_spd_matrix(
     return prec
 
 
-def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None):
+def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None, hole=False):
     """Generate a swiss roll dataset.
 
     Read more in the :ref:`User Guide <sample_generators>`.
@@ -1478,6 +1478,9 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None):
         Determines random number generation for dataset creation. Pass an int
         for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
+
+    hole : bool, default=False
+        If True generates the swiss roll with hole dataset
 
     Returns
     -------
@@ -1500,12 +1503,22 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None):
     """
     generator = check_random_state(random_state)
 
-    t = 1.5 * np.pi * (1 + 2 * generator.rand(1, n_samples))
+    if not hole:
+        t = 1.5 * np.pi * (1 + 2 * generator.rand(n_samples))
+        y = 21 * generator.rand(n_samples)
+    else:
+        corners = np.array(
+            [[np.pi * (1.5 + i), j * 7] for i in range(3) for j in range(3)]
+        )
+        corners = np.delete(corners, 4, axis=0)
+        corner_index = generator.choice(8, n_samples)
+        parameters = generator.rand(2, n_samples) * np.array([[np.pi], [7]])
+        t, y = corners[corner_index].T + parameters
+
     x = t * np.cos(t)
-    y = 21 * generator.rand(1, n_samples)
     z = t * np.sin(t)
 
-    X = np.concatenate((x, y, z))
+    X = np.vstack((x, y, z))
     X += noise * generator.randn(3, n_samples)
     X = X.T
     t = np.squeeze(t)

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1480,7 +1480,7 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None, hole=False):
         See :term:`Glossary <random_state>`.
 
     hole : bool, default=False
-        If True generates the swiss roll with hole dataset
+        If True generates the swiss roll with hole dataset.
 
     Returns
     -------

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -523,21 +523,14 @@ def test_make_spd_matrix():
     )
 
 
-def test_make_swiss_roll():
-    X, t = make_swiss_roll(n_samples=5, noise=0.0, random_state=0)
+@pytest.mark.parametrize("hole", [False, True])
+def test_make_swiss_roll(hole):
+    X, t = make_swiss_roll(n_samples=5, noise=0.0, random_state=0, hole=hole)
 
-    assert X.shape == (5, 3), "X shape mismatch"
-    assert t.shape == (5,), "t shape mismatch"
+    assert X.shape == (5, 3)
+    assert t.shape == (5,)
     assert_array_almost_equal(X[:, 0], t * np.cos(t))
     assert_array_almost_equal(X[:, 2], t * np.sin(t))
-
-    # Test Swiss Hole case
-    X_h, t_h = make_swiss_roll(n_samples=5, noise=0.0, random_state=0, hole=True)
-
-    assert X_h.shape == (5, 3), "X shape mismatch with hole"
-    assert t_h.shape == (5,), "t shape mismatch with hole"
-    assert_array_almost_equal(X_h[:, 0], t_h * np.cos(t_h))
-    assert_array_almost_equal(X_h[:, 2], t_h * np.sin(t_h))
 
 
 def test_make_s_curve():

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -530,14 +530,6 @@ def test_make_swiss_roll():
     assert t.shape == (5,), "t shape mismatch"
     assert_array_almost_equal(X[:, 0], t * np.cos(t))
     assert_array_almost_equal(X[:, 2], t * np.sin(t))
-    
-    # Test Swiss Hole case
-    X_h, t_h = make_s_curve(n_samples=5, noise=0.0, random_state=0, hole=True)
-
-    assert X_h.shape == (5, 3), "X shape mismatch with hole"
-    assert t_h.shape == (5,), "t shape mismatch with hole"
-    assert_array_almost_equal(X_h[:, 0], np.sin(t_h))
-    assert_array_almost_equal(X_h[:, 2], np.sign(t_h) * (np.cos(t_h) - 1))
 
 
 def test_make_s_curve():

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -530,6 +530,14 @@ def test_make_swiss_roll():
     assert t.shape == (5,), "t shape mismatch"
     assert_array_almost_equal(X[:, 0], t * np.cos(t))
     assert_array_almost_equal(X[:, 2], t * np.sin(t))
+    
+    # Test Swiss Hole case
+    X_h, t_h = make_s_curve(n_samples=5, noise=0.0, random_state=0, hole=True)
+
+    assert X_h.shape == (5, 3), "X shape mismatch with hole"
+    assert t_h.shape == (5,), "t shape mismatch with hole"
+    assert_array_almost_equal(X_h[:, 0], np.sin(t_h))
+    assert_array_almost_equal(X_h[:, 2], np.sign(t_h) * (np.cos(t_h) - 1))
 
 
 def test_make_s_curve():

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -530,6 +530,7 @@ def test_make_swiss_roll():
     assert t.shape == (5,), "t shape mismatch"
     assert_array_almost_equal(X[:, 0], t * np.cos(t))
     assert_array_almost_equal(X[:, 2], t * np.sin(t))
+    
     # Test Swiss Hole case
     X_h, t_h = make_s_curve(n_samples=5, noise=0.0, random_state=0, hole=True)
 

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -536,8 +536,9 @@ def test_make_swiss_roll():
 
     assert X_h.shape == (5, 3), "X shape mismatch with hole"
     assert t_h.shape == (5,), "t shape mismatch with hole"
-    assert_array_almost_equal(X_h[:, 0], np.sin(t_h))
-    assert_array_almost_equal(X_h[:, 2], np.sign(t_h) * (np.cos(t_h) - 1))
+    assert_array_almost_equal(X_h[:, 0], t_h * np.cos(t_h))
+    assert_array_almost_equal(X_h[:, 2], t_h * np.sin(t_h))
+
 
 def test_make_s_curve():
     X, t = make_s_curve(n_samples=5, noise=0.0, random_state=0)

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -530,7 +530,6 @@ def test_make_swiss_roll():
     assert t.shape == (5,), "t shape mismatch"
     assert_array_almost_equal(X[:, 0], t * np.cos(t))
     assert_array_almost_equal(X[:, 2], t * np.sin(t))
-    
     # Test Swiss Hole case
     X_h, t_h = make_s_curve(n_samples=5, noise=0.0, random_state=0, hole=True)
 

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -531,6 +531,13 @@ def test_make_swiss_roll():
     assert_array_almost_equal(X[:, 0], t * np.cos(t))
     assert_array_almost_equal(X[:, 2], t * np.sin(t))
 
+    # Test Swiss Hole case
+    X_h, t_h = make_swiss_roll(n_samples=5, noise=0.0, random_state=0, hole=True)
+
+    assert X_h.shape == (5, 3), "X shape mismatch with hole"
+    assert t_h.shape == (5,), "t shape mismatch with hole"
+    assert_array_almost_equal(X_h[:, 0], np.sin(t_h))
+    assert_array_almost_equal(X_h[:, 2], np.sign(t_h) * (np.cos(t_h) - 1))
 
 def test_make_s_curve():
     X, t = make_s_curve(n_samples=5, noise=0.0, random_state=0)


### PR DESCRIPTION
#### Reference Issues/PRs
I had previously worked on this in #20950. As discussed with @ogrisel I also expanded and modernised the plot_swisroll example. However, after some errors by my part, I wasn't able to reconcile the conflicts with the main branch which is why I'm creating this new PR. I hope it doesn't seem spammy.


#### What does this implement/fix? Explain your changes.
This expands the swiss roll generator by adding the option to have a hole in the swiss roll. The swiss hole dataset appears in many articles (see [[1]](10.1007/s11390-011-9422-9) [[2]](10.1111/cgf.12655)) and is useful in studying the robustness of non-linear dimensionality reduction algorithms (NLDA) in preserving topological structures.

Furthermore, I expanded the plot_swissroll.py by adding a second part where I analyzed how NLDA's dealt with the hole. I also repreated all the analysis with t-sne to have a comparison to LLE.
