### PR TITLE
DOC use Python float instead of C double

### DIFF
--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -49,7 +49,7 @@ class Perceptron(BaseSGDClassifier):
     verbose : int, default=0
         The verbosity level.
 
-    eta0 : double, default=1
+    eta0 : float, default=1
         Constant by which the updates are multiplied.
 
     n_jobs : int, default=None

--- a/sklearn/linear_model/_sag.py
+++ b/sklearn/linear_model/_sag.py
@@ -156,7 +156,7 @@ def sag_solver(
         The max number of passes over the training data if the stopping
         criteria is not reached.
 
-    tol : double, default=0.001
+    tol : float, default=0.001
         The stopping criteria for the weights. The iterations will stop when
         max(change in weights) / max(weights) < tol.
 

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1022,12 +1022,12 @@ class SGDClassifier(BaseSGDClassifier):
             .. versionadded:: 0.20
                 Added 'adaptive' option
 
-    eta0 : double, default=0.0
+    eta0 : float, default=0.0
         The initial learning rate for the 'constant', 'invscaling' or
         'adaptive' schedules. The default value is 0.0 as eta0 is not used by
         the default schedule 'optimal'.
 
-    power_t : double, default=0.5
+    power_t : float, default=0.5
         The exponent for inverse scaling learning rate [default 0.5].
 
     early_stopping : bool, default=False
@@ -1776,11 +1776,11 @@ class SGDRegressor(BaseSGDRegressor):
             .. versionadded:: 0.20
                 Added 'adaptive' option
 
-    eta0 : double, default=0.01
+    eta0 : float, default=0.01
         The initial learning rate for the 'constant', 'invscaling' or
         'adaptive' schedules. The default value is 0.01.
 
-    power_t : double, default=0.25
+    power_t : float, default=0.25
         The exponent for inverse scaling learning rate.
 
     early_stopping : bool, default=False
@@ -2003,12 +2003,12 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
             training loss by tol or fail to increase validation score by tol if
             early_stopping is True, the current learning rate is divided by 5.
 
-    eta0 : double
+    eta0 : float
         The initial learning rate for the 'constant', 'invscaling' or
         'adaptive' schedules. The default value is 0.0 as eta0 is not used by
         the default schedule 'optimal'.
 
-    power_t : double
+    power_t : float
         The exponent for inverse scaling learning rate [default 0.5].
 
     warm_start : bool, optional

--- a/sklearn/metrics/_dist_metrics.pyx
+++ b/sklearn/metrics/_dist_metrics.pyx
@@ -337,12 +337,12 @@ cdef class DistanceMetric:
 
         Parameters
         ----------
-        rdist : float
+        rdist : double
             Surrogate distance.
 
         Returns
         -------
-        float
+        double
             True distance.
         """
         return rdist
@@ -356,12 +356,12 @@ cdef class DistanceMetric:
 
         Parameters
         ----------
-        dist : float
+        dist : double
             True distance.
 
         Returns
         -------
-        float
+        double
             Surrogate distance.
         """
         return dist

--- a/sklearn/metrics/_dist_metrics.pyx
+++ b/sklearn/metrics/_dist_metrics.pyx
@@ -337,12 +337,12 @@ cdef class DistanceMetric:
 
         Parameters
         ----------
-        rdist : double
+        rdist : float
             Surrogate distance.
 
         Returns
         -------
-        double
+        float
             True distance.
         """
         return rdist
@@ -356,12 +356,12 @@ cdef class DistanceMetric:
 
         Parameters
         ----------
-        dist : double
+        dist : float
             True distance.
 
         Returns
         -------
-        double
+        float
             Surrogate distance.
         """
         return dist

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -216,7 +216,7 @@ def mean_pinball_loss(
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
 
-    alpha: double, slope of the pinball loss, default=0.5,
+    alpha: float, slope of the pinball loss, default=0.5,
         this loss is equivalent to :ref:`mean_absolute_error` when `alpha=0.5`,
         `alpha=0.95` is minimized by estimators of the 95th percentile.
 

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -851,11 +851,11 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
 
         Only used when ``solver='sgd'``.
 
-    learning_rate_init : double, default=0.001
+    learning_rate_init : float, default=0.001
         The initial learning rate used. It controls the step-size
         in updating the weights. Only used when solver='sgd' or 'adam'.
 
-    power_t : double, default=0.5
+    power_t : float, default=0.5
         The exponent for inverse scaling learning rate.
         It is used in updating effective learning rate when the learning_rate
         is set to 'invscaling'. Only used when solver='sgd'.
@@ -1325,11 +1325,11 @@ class MLPRegressor(RegressorMixin, BaseMultilayerPerceptron):
 
         Only used when solver='sgd'.
 
-    learning_rate_init : double, default=0.001
+    learning_rate_init : float, default=0.001
         The initial learning rate used. It controls the step-size
         in updating the weights. Only used when solver='sgd' or 'adam'.
 
-    power_t : double, default=0.5
+    power_t : float, default=0.5
         The exponent for inverse scaling learning rate.
         It is used in updating effective learning rate when the learning_rate
         is set to 'invscaling'. Only used when solver='sgd'.


### PR DESCRIPTION
closes #21488

Using the Python `float` type in the documentation instead of referring to the C `double` type.