### PR TITLE
FIX Escape `name_details` and add missing =

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -1104,10 +1104,10 @@ Adrian Garcia Badaracco, Adrian Sadłocha, Adrin Jalali, Agamemnon Krasoulis,
 Alberto Rubiales, Albert Thomas, Albert Villanova del Moral, Alek Lefebvre,
 Alessia Marcolini, Alexandr Fonari, Alihan Zihna, Aline Ribeiro de Almeida,
 Amanda, Amanda Dsouza, Amol Deshmukh, Ana Pessoa, Anavelyz, Andreas Mueller,
-Andrew Delong, Ashish, Ashvith Shetty, Atsushi Nukariya, Avi Gupta, Ayush
-Singh, baam, BaptBillard, Benjamin Pedigo, Bertrand Thirion, Bharat
-Raghunathan, bmalezieux, Brian Rice, Brian Sun, Bruno Charron, Bryan Chen,
-bumblebee, caherrera-meli, Carsten Allefeld, CeeThinwa, Chiara Marmo,
+Andrew Delong, Ashish, Ashvith Shetty, Atsushi Nukariya, Aurélien Geron, Avi
+Gupta, Ayush Singh, baam, BaptBillard, Benjamin Pedigo, Bertrand Thirion,
+Bharat Raghunathan, bmalezieux, Brian Rice, Brian Sun, Bruno Charron, Bryan
+Chen, bumblebee, caherrera-meli, Carsten Allefeld, CeeThinwa, Chiara Marmo,
 chrissobel, Christian Lorentzen, Christopher Yeh, Chuliang Xiao, Clément
 Fauchereau, cliffordEmmanuel, Conner Shen, Connor Tann, David Dale, David Katz,
 David Poznik, Dimitri Papadopoulos Orfanos, Divyanshu Deoli, dmallia17,

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -26,7 +26,7 @@ Changelog
 
 - |Fix| :func:`utils.estimator_html_repr` now escapes all the estimator
   descriptions in the generated HTML. :pr:`21493` by
-  :user:`Aurélien Geron <ageron>`_.
+  :user:`Aurélien Geron <ageron>`.
 
 
 .. _changes_1_0_1:

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -20,6 +20,7 @@ Changelog
   :class:`decomposition.MiniBatchDictionaryLearning`, :class:`decomposition.SparsePCA`
   and :class:`decomposition.MiniBatchSparsePCA` to be convex and match the referenced
   article. :pr:`19210` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 - |Fix| :func:`utils.estimator_html_repr` now escapes all the estimator
   descriptions in the generated HTML. :pr:`21493` by `Aurélien Geron`_.
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -21,7 +21,7 @@ Changelog
   and :class:`decomposition.MiniBatchSparsePCA` to be convex and match the referenced
   article. :pr:`19210` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 - |Fix| :func:`utils.estimator_html_repr` now escapes all the estimator
-  descriptions in the generated HTML. :pr:`#21493` by `Aurélien Geron`_.
+  descriptions in the generated HTML. :pr:`21493` by `Aurélien Geron`_.
 
 
 .. _changes_1_0_1:

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -21,6 +21,9 @@ Changelog
   and :class:`decomposition.MiniBatchSparsePCA` to be convex and match the referenced
   article. :pr:`19210` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+:mod:`sklearn.utils`
+....................
+
 - |Fix| :func:`utils.estimator_html_repr` now escapes all the estimator
   descriptions in the generated HTML. :pr:`21493` by
   :user:`Aurélien Geron <ageron>`_.

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -20,6 +20,8 @@ Changelog
   :class:`decomposition.MiniBatchDictionaryLearning`, :class:`decomposition.SparsePCA`
   and :class:`decomposition.MiniBatchSparsePCA` to be convex and match the referenced
   article. :pr:`19210` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+- |Fix| :func:`utils.estimator_html_repr` now escapes all the estimator
+  descriptions in the generated HTML. :pr:`#21493` by `Aurélien Geron`_.
 
 
 .. _changes_1_0_1:

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -22,7 +22,7 @@ Changelog
   article. :pr:`19210` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 - |Fix| :func:`utils.estimator_html_repr` now escapes all the estimator
-  descriptions in the generated HTML. :pr:`21493` by `Aurélien Geron`_.
+  descriptions in the generated HTML. :pr:`21493` by `Aurélien Geron <ageron>`_.
 
 
 .. _changes_1_0_1:

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -22,7 +22,8 @@ Changelog
   article. :pr:`19210` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 - |Fix| :func:`utils.estimator_html_repr` now escapes all the estimator
-  descriptions in the generated HTML. :pr:`21493` by `Aurélien Geron <ageron>`_.
+  descriptions in the generated HTML. :pr:`21493` by
+  :user:`Aurélien Geron <ageron>`_.
 
 
 .. _changes_1_0_1:

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -69,6 +69,7 @@ def _write_label_html(
     name = html.escape(name)
 
     if name_details is not None:
+        name_details = html.escape(name_details)
         checked_str = "checked" if checked else ""
         est_id = uuid.uuid4()
         out.write(
@@ -354,7 +355,7 @@ def estimator_html_repr(estimator):
         )
         out.write(
             f"<style>{style_with_id}</style>"
-            f'<div id="{container_id}" class"sk-top-container">'
+            f'<div id="{container_id}" class="sk-top-container">'
             '<div class="sk-text-repr-fallback">'
             f"<pre>{html.escape(estimator_str)}</pre><b>{fallback_msg}</b>"
             "</div>"

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -69,7 +69,7 @@ def _write_label_html(
     name = html.escape(name)
 
     if name_details is not None:
-        name_details = html.escape(name_details)
+        name_details = html.escape(str(name_details))
         checked_str = "checked" if checked else ""
         est_id = uuid.uuid4()
         out.write(

--- a/sklearn/utils/tests/test_estimator_html_repr.py
+++ b/sklearn/utils/tests/test_estimator_html_repr.py
@@ -167,36 +167,37 @@ def test_estimator_html_repr_pipeline():
     html_output = estimator_html_repr(pipe)
 
     # top level estimators show estimator with changes
-    assert str(pipe) in html_output
+    assert html.escape(str(pipe)) in html_output
     for _, est in pipe.steps:
-        assert f'<div class="sk-toggleable__content"><pre>{str(est)}' in html_output
+        assert ('<div class="sk-toggleable__content"><pre>' +
+                html.escape(str(est))) in html_output
 
     # low level estimators do not show changes
     with config_context(print_changed_only=True):
-        assert str(num_trans["pass"]) in html_output
+        assert html.escape(str(num_trans["pass"])) in html_output
         assert "passthrough</label>" in html_output
-        assert str(num_trans["imputer"]) in html_output
+        assert html.escape(str(num_trans["imputer"])) in html_output
 
         for _, _, cols in preprocess.transformers:
-            assert f"<pre>{cols}</pre>" in html_output
+            assert f"<pre>{html.escape(str(cols))}</pre>" in html_output
 
         # feature union
         for name, _ in feat_u.transformer_list:
-            assert f"<label>{name}</label>" in html_output
+            assert f"<label>{html.escape(name)}</label>" in html_output
 
         pca = feat_u.transformer_list[0][1]
-        assert f"<pre>{str(pca)}</pre>" in html_output
+        assert f"<pre>{html.escape(str(pca))}</pre>" in html_output
 
         tsvd = feat_u.transformer_list[1][1]
         first = tsvd["first"]
         select = tsvd["select"]
-        assert f"<pre>{str(first)}</pre>" in html_output
-        assert f"<pre>{str(select)}</pre>" in html_output
+        assert f"<pre>{html.escape(str(first))}</pre>" in html_output
+        assert f"<pre>{html.escape(str(select))}</pre>" in html_output
 
         # voting classifier
         for name, est in clf.estimators:
-            assert f"<label>{name}</label>" in html_output
-            assert f"<pre>{str(est)}</pre>" in html_output
+            assert f"<label>{html.escape(name)}</label>" in html_output
+            assert f"<pre>{html.escape(str(est))}</pre>" in html_output
 
 
 @pytest.mark.parametrize("final_estimator", [None, LinearSVC()])
@@ -209,7 +210,7 @@ def test_stacking_classsifer(final_estimator):
 
     html_output = estimator_html_repr(clf)
 
-    assert str(clf) in html_output
+    assert html.escape(str(clf)) in html_output
     # If final_estimator's default changes from LogisticRegression
     # this should be updated
     if final_estimator is None:
@@ -225,12 +226,12 @@ def test_stacking_regressor(final_estimator):
     )
     html_output = estimator_html_repr(reg)
 
-    assert str(reg.estimators[0][0]) in html_output
+    assert html.escape(str(reg.estimators[0][0])) in html_output
     assert "LinearSVR</label>" in html_output
     if final_estimator is None:
         assert "RidgeCV</label>" in html_output
     else:
-        assert final_estimator.__class__.__name__ in html_output
+        assert html.escape(final_estimator.__class__.__name__) in html_output
 
 
 def test_birch_duck_typing_meta():
@@ -240,11 +241,11 @@ def test_birch_duck_typing_meta():
 
     # inner estimators do not show changes
     with config_context(print_changed_only=True):
-        assert f"<pre>{str(birch.n_clusters)}" in html_output
+        assert f"<pre>{html.escape(str(birch.n_clusters))}" in html_output
         assert "AgglomerativeClustering</label>" in html_output
 
     # outer estimator contains all changes
-    assert f"<pre>{str(birch)}" in html_output
+    assert f"<pre>{html.escape(str(birch))}" in html_output
 
 
 def test_ovo_classifier_duck_typing_meta():
@@ -254,11 +255,11 @@ def test_ovo_classifier_duck_typing_meta():
 
     # inner estimators do not show changes
     with config_context(print_changed_only=True):
-        assert f"<pre>{str(ovo.estimator)}" in html_output
+        assert f"<pre>{html.escape(str(ovo.estimator))}" in html_output
         assert "LinearSVC</label>" in html_output
 
     # outer estimator
-    assert f"<pre>{str(ovo)}" in html_output
+    assert f"<pre>{html.escape(str(ovo))}" in html_output
 
 
 def test_duck_typing_nested_estimator():
@@ -267,8 +268,8 @@ def test_duck_typing_nested_estimator():
     gp = GaussianProcessRegressor(kernel=kernel)
     html_output = estimator_html_repr(gp)
 
-    assert f"<pre>{str(kernel)}" in html_output
-    assert f"<pre>{str(gp)}" in html_output
+    assert f"<pre>{html.escape(str(kernel))}" in html_output
+    assert f"<pre>{html.escape(str(gp))}" in html_output
 
 
 @pytest.mark.parametrize("print_changed_only", [True, False])
@@ -276,7 +277,7 @@ def test_one_estimator_print_change_only(print_changed_only):
     pca = PCA(n_components=10)
 
     with config_context(print_changed_only=print_changed_only):
-        pca_repr = str(pca)
+        pca_repr = html.escape(str(pca))
         html_output = estimator_html_repr(pca)
         assert pca_repr in html_output
 

--- a/sklearn/utils/tests/test_estimator_html_repr.py
+++ b/sklearn/utils/tests/test_estimator_html_repr.py
@@ -169,8 +169,9 @@ def test_estimator_html_repr_pipeline():
     # top level estimators show estimator with changes
     assert html.escape(str(pipe)) in html_output
     for _, est in pipe.steps:
-        assert ('<div class="sk-toggleable__content"><pre>' +
-                html.escape(str(est))) in html_output
+        assert (
+            '<div class="sk-toggleable__content"><pre>' + html.escape(str(est))
+        ) in html_output
 
     # low level estimators do not show changes
     with config_context(print_changed_only=True):


### PR DESCRIPTION
Fixes #21494

The generated HTML generates lots of warnings in my text editor because `name_details` was not escaped. I'm not sure, but it may also be a security flaw, since someone could create a custom estimator with a `__str__()` method that generates some dangerous HTML code?

Also, there's a `=` sign missing: `class"sk-top-container"` instead of `class="sk-top-container"`.

See [#21494](https://github.com/scikit-learn/scikit-learn/issues/21494) for details.