### PR TITLE
TST Accelerates test_check_estimator_clones

### DIFF
--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -23,11 +23,11 @@ from sklearn.utils._testing import (
 )
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.fixes import np_version, parse_version
-from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
+from sklearn.ensemble import ExtraTreesClassifier
 from sklearn.linear_model import LinearRegression, SGDClassifier
 from sklearn.mixture import GaussianMixture
 from sklearn.cluster import MiniBatchKMeans
-from sklearn.decomposition import NMF, PCA
+from sklearn.decomposition import PCA
 from sklearn.linear_model import MultiTaskElasticNet, LogisticRegression
 from sklearn.svm import SVC, NuSVC
 from sklearn.neighbors import KNeighborsRegressor

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -601,12 +601,12 @@ def test_check_estimator_clones():
     iris = load_iris()
 
     for Estimator in [
-         GaussianMixture,
-         LinearRegression,
-         SGDClassifier,
-         PCA,
-         ExtraTreesClassifier,
-         MiniBatchKMeans,
+        GaussianMixture,
+        LinearRegression,
+        SGDClassifier,
+        PCA,
+        ExtraTreesClassifier,
+        MiniBatchKMeans,
     ]:
         with ignore_warnings(category=FutureWarning):
             # when 'est = SGDClassifier()'

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -603,12 +603,10 @@ def test_check_estimator_clones():
     for Estimator in [
          GaussianMixture,
          LinearRegression,
-         RandomForestClassifier,
-         NMF,
          SGDClassifier,
-        #  PCA,
-        # ExtraTreesClassifier,
-        MiniBatchKMeans,
+         PCA,
+         ExtraTreesClassifier,
+         MiniBatchKMeans,
     ]:
         with ignore_warnings(category=FutureWarning):
             # when 'est = SGDClassifier()'

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -23,11 +23,11 @@ from sklearn.utils._testing import (
 )
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.fixes import np_version, parse_version
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
 from sklearn.linear_model import LinearRegression, SGDClassifier
 from sklearn.mixture import GaussianMixture
 from sklearn.cluster import MiniBatchKMeans
-from sklearn.decomposition import NMF
+from sklearn.decomposition import NMF, PCA
 from sklearn.linear_model import MultiTaskElasticNet, LogisticRegression
 from sklearn.svm import SVC, NuSVC
 from sklearn.neighbors import KNeighborsRegressor
@@ -601,11 +601,13 @@ def test_check_estimator_clones():
     iris = load_iris()
 
     for Estimator in [
-        GaussianMixture,
-        LinearRegression,
-        RandomForestClassifier,
-        NMF,
-        SGDClassifier,
+         GaussianMixture,
+         LinearRegression,
+         RandomForestClassifier,
+         NMF,
+         SGDClassifier,
+        #  PCA,
+        # ExtraTreesClassifier,
         MiniBatchKMeans,
     ]:
         with ignore_warnings(category=FutureWarning):


### PR DESCRIPTION
Reference Issues/PRs
Towards #21407

What does this implement/fix? Explain your changes.

These changes accelerate test case `sklearn/utils/tests/test_estimator_checks.py::test_check_estimator_clones`

The biggest gain comes from replacing `NMF `with `PCA`. Minor speed gain comes from replacing `RandomForestClassifier` with `ExtraTreesClassifier`. 
The updated version runs at **80% of the current one.**

Further options:

- Removing ExtraTrees (RF in the original version) leads to **50% runtime vs. the current one.**

Any other comments?
#DataUmbrella Sprint
By @krumeto (using the corporate github account). Need to figure out how to safely switch them :)