### PR TITLE
DOC Ensures that as_float_array passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -222,7 +222,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.sparsefuncs.mean_variance_axis",
     "sklearn.utils.sparsefuncs.min_max_axis",
     "sklearn.utils.tosequence",
-    "sklearn.utils.validation.as_float_array",
     "sklearn.utils.validation.assert_all_finite",
     "sklearn.utils.validation.check_is_fitted",
     "sklearn.utils.validation.check_memory",

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -144,7 +144,7 @@ def as_float_array(X, *, copy=True, force_all_finite=True):
     Parameters
     ----------
     X : {array-like, sparse matrix}
-        The input array.
+        The input data.
 
     copy : bool, default=True
         If True, a copy of X will be created. If False, a copy may still be

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -135,7 +135,7 @@ def assert_all_finite(X, *, allow_nan=False):
 
 
 def as_float_array(X, *, copy=True, force_all_finite=True):
-    """Converts an array-like to an array of floats.
+    """Convert an array-like to an array of floats.
 
     The new dtype will be np.float32 or np.float64, depending on the original
     type. The function can create a copy or modify the argument depending
@@ -144,6 +144,7 @@ def as_float_array(X, *, copy=True, force_all_finite=True):
     Parameters
     ----------
     X : {array-like, sparse matrix}
+        The input array.
 
     copy : bool, default=True
         If True, a copy of X will be created. If False, a copy may still be


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixing docs to allow allow as_float_array docstring to pass numpydoc validation in sklearn.utils.validation.as_float_array
#### Any other comments?
#DataUmbrella Sprint
(@reshamas)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
