### PR TITLE
MNT Postpone conversion of `RidgeCV`'s `alphas` out of `__init__`

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1483,7 +1483,7 @@ class _RidgeGCV(LinearModel):
         is_clf=False,
         alpha_per_target=False,
     ):
-        self.alphas = np.asarray(alphas)
+        self.alphas = alphas
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.scoring = scoring
@@ -1842,6 +1842,8 @@ class _RidgeGCV(LinearModel):
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 
+        self.alphas = np.asarray(self.alphas)
+
         if np.any(self.alphas <= 0):
             raise ValueError(
                 "alphas must be strictly positive. Got {} containing some "
@@ -1977,7 +1979,7 @@ class _BaseRidgeCV(LinearModel):
         store_cv_values=False,
         alpha_per_target=False,
     ):
-        self.alphas = np.asarray(alphas)
+        self.alphas = alphas
         self.fit_intercept = fit_intercept
         self.normalize = normalize
         self.scoring = scoring

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -351,7 +351,7 @@ def test_lasso_cv_positive_constraint():
 
 def _scale_alpha_inplace(estimator, n_samples):
     """Rescale the parameter alpha from when the estimator is evoked with
-    normalize set to True to when it is evoked in a Pipeline with normalize set
+    normalize set to True as if it were evoked in a Pipeline with normalize set
     to False and with a StandardScaler.
     """
     if ("alpha" not in estimator.get_params()) and (
@@ -360,7 +360,10 @@ def _scale_alpha_inplace(estimator, n_samples):
         return
 
     if isinstance(estimator, (RidgeCV, RidgeClassifierCV)):
-        alphas = estimator.alphas * n_samples
+        # alphas is not validated at this point and can be a list.
+        # We convert it to a np.ndarray to make sure broadcasting
+        # is used.
+        alphas = np.asarray(estimator.alphas) * n_samples
         return estimator.set_params(alphas=alphas)
     if isinstance(estimator, (Lasso, LassoLars, MultiTaskLasso)):
         alpha = estimator.alpha * np.sqrt(n_samples)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1110,6 +1110,27 @@ def test_ridge_classifier_cv_store_cv_values(scoring):
     assert r.cv_values_.shape == (n_samples, n_targets, n_alphas)
 
 
+@pytest.mark.parametrize("Estimator", [RidgeCV, RidgeClassifierCV])
+def test_ridgecv_alphas_conversion(Estimator):
+    rng = np.random.RandomState(0)
+    alphas = (0.1, 1.0, 10.0)
+
+    n_samples, n_features = 5, 5
+    if Estimator is RidgeCV:
+        y = rng.randn(n_samples)
+    else:
+        y = rng.randint(0, 2, n_samples)
+    X = rng.randn(n_samples, n_features)
+
+    ridge_est = Estimator(alphas=alphas)
+    assert (
+        ridge_est.alphas is alphas
+    ), f"`alphas` was mutated in `{Estimator.__name__}.__init__`"
+
+    ridge_est.fit(X, y)
+    assert_array_equal(ridge_est.alphas, np.asarray(alphas))
+
+
 def test_ridgecv_sample_weight():
     rng = np.random.RandomState(0)
     alphas = (0.1, 1.0, 10.0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Encompasses the scope of #21406. See also #19426.

#### What does this implement/fix? Explain your changes.

`alphas` used to be converted to a `np.ndarray` inside `__init__`. 
This is now postponed to `fit` to follow the scikit-learn API.
As `alphas` can now be a list, we modify the `_scale_alpha_inplace` test accordingly.
A new test `ridgecv_alphas_conversion` is created to ensure `alphas` are converted during `fit`.
This PR also clarifies the docstring of `_scale_alpha_inplace`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
