### PR TITLE
MNT modify test_nested_cv to speed-up CI builds

### DIFF
--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1776,7 +1776,7 @@ def test_nested_cv():
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):
         gs = GridSearchCV(
-            DummyClassifier(), 
+            DummyClassifier(),
             param_grid={"strategy": ["stratified", "most_frequent"]},
             cv=inner_cv, error_score="raise"
         )

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -37,7 +37,7 @@ from sklearn.model_selection import RepeatedKFold
 from sklearn.model_selection import RepeatedStratifiedKFold
 from sklearn.model_selection import StratifiedGroupKFold
 
-from sklearn.linear_model import Ridge
+from sklearn.dummy import DummyClassifier
 
 from sklearn.model_selection._split import _validate_shuffle_split
 from sklearn.model_selection._split import _build_repr
@@ -1770,16 +1770,13 @@ def test_nested_cv():
     groups = rng.randint(0, 5, 15)
 
     cvs = [
-        LeaveOneGroupOut(),
-        GroupKFold(n_splits=2),
         StratifiedKFold(n_splits=2),
-        StratifiedGroupKFold(n_splits=2),
         StratifiedShuffleSplit(n_splits=2, random_state=0),
     ]
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):
         gs = GridSearchCV(
-            Ridge(max_iter=1), param_grid={"alpha": [1, 0.1]}, cv=inner_cv, error_score="raise"
+            DummyClassifier(), param_grid={"strategy": ["stratified", "most_frequent"]}, cv=inner_cv, error_score="raise"
         )
         cross_val_score(
             gs, X=X, y=y, groups=groups, cv=outer_cv, fit_params={"groups": groups}

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1771,16 +1771,15 @@ def test_nested_cv():
 
     cvs = [
         LeaveOneGroupOut(),
-        LeaveOneOut(),
-        GroupKFold(n_splits=3),
-        StratifiedKFold(),
-        StratifiedGroupKFold(n_splits=3),
-        StratifiedShuffleSplit(n_splits=3, random_state=0),
+        GroupKFold(n_splits=2),
+        StratifiedKFold(n_splits=2),
+        StratifiedGroupKFold(n_splits=2),
+        StratifiedShuffleSplit(n_splits=2, random_state=0),
     ]
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):
         gs = GridSearchCV(
-            Ridge(), param_grid={"alpha": [1, 0.1]}, cv=inner_cv, error_score="raise"
+            Ridge(max_iter=1), param_grid={"alpha": [1, 0.1]}, cv=inner_cv, error_score="raise"
         )
         cross_val_score(
             gs, X=X, y=y, groups=groups, cv=outer_cv, fit_params={"groups": groups}

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1776,7 +1776,9 @@ def test_nested_cv():
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):
         gs = GridSearchCV(
-            DummyClassifier(), param_grid={"strategy": ["stratified", "most_frequent"]}, cv=inner_cv, error_score="raise"
+            DummyClassifier(), 
+            param_grid={"strategy": ["stratified", "most_frequent"]},
+            cv=inner_cv, error_score="raise"
         )
         cross_val_score(
             gs, X=X, y=y, groups=groups, cv=outer_cv, fit_params={"groups": groups}


### PR DESCRIPTION
#### Reference Issues/PRs
References #21407

#### What does this implement/fix? Explain your changes.
Edit the LeaveOneOut() model validation strategy, reduce the max_iter=1 for Ridge regression and adjust nsplits=2 for other evaluation strategies to speed up runtime to under 1s.


#### Any other comments?
Pair programming partner @Lontia
#DataUmbrella Sprint
