### PR TITLE
TST Reduce number of features of dataset in check_estimator_sparse_data

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -791,7 +791,7 @@ def _generate_sparse_matrix(X_csr):
 
 def check_estimator_sparse_data(name, estimator_orig):
     rng = np.random.RandomState(0)
-    X = rng.rand(40, 10)
+    X = rng.rand(40, 3)
     X[X < 0.8] = 0
     X = _pairwise_estimator_convert_X(X, estimator_orig)
     X_csr = sparse.csr_matrix(X)


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #21407

#### What does this implement/fix? Explain your changes.
The change accelerates the test case `sklearn/tests/test_common.py::test_estimators[SequentialFeatureSelector(estimator=LogisticRegression(C=1))-check_estimator_sparse_data]`. This change is potentially also accelerating other tests using `check_estimator_sparse_data`. 

`SequentialFeatureSelector` will run a 5-fold cross-validation for each feature in the training dataset. Hence, with this change around 15 model trainings are run instead of 50.  (5-fold cross-validation inferred from documentation).

#### Any other comments?
#DataUmbrella Sprint