### PR TITLE
FIX Ignore distutils warning in scipy-dev [scipy-dev]

### DIFF
--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -44,7 +44,7 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
     TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
 
     # Python 3.10 deprecates disutils and is imported by numpy interally during import time
-    TEST_CMD="$TEST_CMD -Wignore:The\ distutils:DeprecationWarning"
+    TEST_CMD="$TEST_CMD '-Wignore:The distutils:DeprecationWarning'"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -44,7 +44,7 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
     TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
 
     # Python 3.10 deprecates disutils and is imported by numpy interally during import time
-    TEST_CMD="$TEST_CMD -Wignore:'The distutils.sysconfig module is deprecated':DeprecationWarning"
+    TEST_CMD="$TEST_CMD -Wignore:'The distutils.sysconfig module is deprecated':DeprecationWarning -Wignore:'DeprecationWarning:'The distutils package is deprecated'"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -44,7 +44,7 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
     TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
 
     # Python 3.10 deprecates disutils and is imported by numpy interally during import time
-    TEST_CMD="$TEST_CMD '-Wignore:The distutils:DeprecationWarning'"
+    TEST_CMD="$TEST_CMD -Wignore:The\ distutils:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
@@ -52,5 +52,5 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
 fi
 
 set -x
-$TEST_CMD --pyargs sklearn
+eval "$TEST_CMD --pyargs sklearn"
 set +x

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -44,7 +44,7 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
     TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
 
     # Python 3.10 deprecates disutils and is imported by numpy interally during import time
-    TEST_CMD="$TEST_CMD -Wignore:'The distutils.sysconfig module is deprecated':DeprecationWarning -Wignore:'DeprecationWarning:'The distutils package is deprecated'"
+    TEST_CMD="$TEST_CMD -Wignore:'The distutils':DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -36,7 +36,7 @@ if [[ "$COVERAGE" == "true" ]]; then
     # report that otherwise hides the test failures and forces long scrolls in
     # the CI logs.
     export COVERAGE_PROCESS_START="$BUILD_SOURCESDIRECTORY/.coveragerc"
-    TEST_CMD="$TEST_CMD --cov-config=$COVERAGE_PROCESS_START --cov sklearn --cov-report="
+    TEST_CMD="$TEST_CMD --cov-config='$COVERAGE_PROCESS_START' --cov sklearn --cov-report="
 fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -36,12 +36,15 @@ if [[ "$COVERAGE" == "true" ]]; then
     # report that otherwise hides the test failures and forces long scrolls in
     # the CI logs.
     export COVERAGE_PROCESS_START="$BUILD_SOURCESDIRECTORY/.coveragerc"
-    TEST_CMD="$TEST_CMD --cov-config=$COVERAGE_PROCESS_START --cov sklearn --cov-report="
+    TEST_CMD="$TEST_CMD --cov-config='$COVERAGE_PROCESS_START' --cov sklearn --cov-report="
 fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then
     # numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
     TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
+
+    # Python 3.10 deprecates disutils and is imported by numpy interally during import time
+    TEST_CMD="$TEST_CMD -Wignore:The\ distutils:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
@@ -49,5 +52,5 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
 fi
 
 set -x
-$TEST_CMD --pyargs sklearn
+eval "$TEST_CMD --pyargs sklearn"
 set +x

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -36,15 +36,12 @@ if [[ "$COVERAGE" == "true" ]]; then
     # report that otherwise hides the test failures and forces long scrolls in
     # the CI logs.
     export COVERAGE_PROCESS_START="$BUILD_SOURCESDIRECTORY/.coveragerc"
-    TEST_CMD="$TEST_CMD --cov-config='$COVERAGE_PROCESS_START' --cov sklearn --cov-report="
+    TEST_CMD="$TEST_CMD --cov-config=$COVERAGE_PROCESS_START --cov sklearn --cov-report="
 fi
 
 if [[ -n "$CHECK_WARNINGS" ]]; then
     # numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
     TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
-
-    # Python 3.10 deprecates disutils and is imported by numpy interally during import time
-    TEST_CMD="$TEST_CMD -Wignore:The\ distutils:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
@@ -52,5 +49,5 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
 fi
 
 set -x
-eval "$TEST_CMD --pyargs sklearn"
+$TEST_CMD --pyargs sklearn
 set +x

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -42,6 +42,9 @@ fi
 if [[ -n "$CHECK_WARNINGS" ]]; then
     # numpy's 1.19.0's tostring() deprecation is ignored until scipy and joblib removes its usage
     TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
+
+    # Python 3.10 deprecates disutils and is imported by numpy interally during import time
+    TEST_CMD="$TEST_CMD -Wignore:'The distutils.sysconfig module is deprecated':DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -44,7 +44,7 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
     TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Wignore:tostring:DeprecationWarning"
 
     # Python 3.10 deprecates disutils and is imported by numpy interally during import time
-    TEST_CMD="$TEST_CMD -Wignore:'The distutils':DeprecationWarning"
+    TEST_CMD="$TEST_CMD -Wignore:The\ distutils:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -24,7 +24,7 @@ Changelog
 :mod:`sklearn.preprocessing`
 ............................
 
-- |Fix| Fixes compatibility bug with numpy 1.22 in :class:`preprocessing.OneHotEncoder`.
+- |Fix| Fixes compatibility bug with NumPy 1.22 in :class:`preprocessing.OneHotEncoder`.
   :pr:`21517` by `Thomas Fan`_.
 
 :mod:`sklearn.utils`

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -21,6 +21,12 @@ Changelog
   and :class:`decomposition.MiniBatchSparsePCA` to be convex and match the referenced
   article. :pr:`19210` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+:mod:`sklearn.preprocessing`
+............................
+
+- |Fix| Fixes compatibility bug with numpy 1.22 in :class:`preprocessing.OneHotEncoder`.
+  :pr:`21517` by `Thomas Fan`_.
+
 :mod:`sklearn.utils`
 ....................
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ addopts =
 
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning
+    # Python 3.10 deprecates disutils and is imported by numpy interally during import time
+    ignore:The distutils:DeprecationWarning
 
 [wheelhouse_uploader]
 artifact_indexes=

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,6 @@ addopts =
 
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning
-    # Python 3.10 deprecates disutils and is imported by numpy interally during import time
-    ignore:The distutils:DeprecationWarning
 
 [wheelhouse_uploader]
 artifact_indexes=

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -180,7 +180,7 @@ def test_dbscan_metric_params():
             min_samples=min_samples,
             algorithm="ball_tree",
         ).fit(X)
-    assert not warns
+    assert not warns, warns[0].message
     core_sample_1, labels_1 = db.core_sample_indices_, db.labels_
 
     # Test that sample labels are the same as passing Minkowski 'p' directly

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -544,7 +544,7 @@ class OneHotEncoder(_BaseEncoder):
 
         indptr = np.empty(n_samples + 1, dtype=int)
         indptr[0] = 0
-        np.sum(X_mask, axis=1, out=indptr[1:])
+        np.sum(X_mask, axis=1, out=indptr[1:], dtype=indptr.dtype)
         np.cumsum(indptr[1:], out=indptr[1:])
         data = np.ones(indptr[-1])
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses some of https://github.com/scikit-learn/scikit-learn/issues/21524
Related to https://github.com/scikit-learn/scikit-learn/issues/21499


#### What does this implement/fix? Explain your changes.
The scipy-dev [main build](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=34411&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf) is failing because numpy imports distuils.sysconfig` during test collection time.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
