### PR TITLE
DOC Ensures that load_diabetes passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -31,7 +31,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.datasets._base.get_data_home",
     "sklearn.datasets._base.load_boston",
     "sklearn.datasets._base.load_breast_cancer",
-    "sklearn.datasets._base.load_diabetes",
     "sklearn.datasets._base.load_digits",
     "sklearn.datasets._base.load_files",
     "sklearn.datasets._base.load_iris",

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -928,7 +928,7 @@ def load_diabetes(*, return_X_y=False, as_frame=False):
 
     Parameters
     ----------
-    return_X_y : bool, default=False.
+    return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object.
         See below for more information about the `data` and `target` object.
 
@@ -969,7 +969,9 @@ def load_diabetes(*, return_X_y=False, as_frame=False):
             The path to the location of the target.
 
     (data, target) : tuple if ``return_X_y`` is True
-
+        Returns a tuple of two ndarray of shape (n_samples, n_features)
+        A 2D array with each row representing one sample and each column
+        representing the features and/or target of a given sample.
         .. versionadded:: 0.18
     """
     data_filename = "diabetes_data.csv.gz"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#21350

#### What does this implement/fix? Explain your changes.
This PR ensure that `sklearn.datasets._base.load_diabetes` function docstrings passes all numpydoc validation checks.

- [x] `sklearn.datasets._base.load_diabetes` removed from [scikit-learn/maint_tools/test_docstrings.py](scikit-learn/maint_tools/test_docstrings.py)
- [x] Minor grammar error fixed.
- [x] Added description to returned values ('data' and 'target').




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
