### PR TITLE
MAINT pytest plugin to monitor memory usage in tests

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -60,6 +60,7 @@ if [[ "$DISTRIB" == "conda" || "$DISTRIB" == *"mamba"* ]]; then
     TO_INSTALL="$TO_INSTALL $(get_dep pyamg $PYAMG_VERSION)"
     TO_INSTALL="$TO_INSTALL $(get_dep Pillow $PILLOW_VERSION)"
     TO_INSTALL="$TO_INSTALL $(get_dep matplotlib $MATPLOTLIB_VERSION)"
+    TO_INSTALL="$TO_INSTALL $(get_dep psutil $PSUTIL_VERSION)"
 
     if [[ "$UNAMESTR" == "Darwin" ]]; then
         if [[ "$SKLEARN_TEST_NO_OPENMP" != "true" ]]; then

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -114,7 +114,7 @@ elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     # Do not build scikit-image from source because it is an optional dependency
     python -m pip install --only-binary :all: scikit-image || true
 
-    python -m pip install pandas matplotlib pyamg
+    python -m pip install pandas matplotlib pyamg psutil
     # do not install dependencies for lightgbm since it requires scikit-learn.
     python -m pip install "lightgbm>=3.0.0" --no-deps
 elif [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -31,6 +31,7 @@ jobs:
     PYTEST_VERSION: 'latest'
     PYTEST_XDIST_VERSION: 'latest'
     THREADPOOLCTL_VERSION: 'latest'
+    PSUTIL_VERSION: 'latest'
     COVERAGE: 'true'
     TEST_DOCSTRINGS: 'false'
   strategy:

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -1,8 +1,13 @@
+import os
 from os import environ
 from functools import wraps
 import platform
 import sys
 
+try:
+    import psutil
+except ImportError:
+    psutil = None
 import pytest
 from threadpoolctl import threadpool_limits
 from _pytest.doctest import DoctestItem
@@ -230,3 +235,128 @@ def pytest_configure(config):
         matplotlib.use("agg")
     except ImportError:
         pass
+
+    if psutil is not None:
+        memory_usage_plugin = MemoryUsage(config)
+        config.pluginmanager.register(memory_usage_plugin)
+
+
+def is_main_process(config):
+    """True if the code running the given pytest.config object is running in a xdist main
+    node or not running xdist at all.
+    """
+    return not hasattr(config, "workerinput")
+
+
+def get_usage_memory_mb():
+    """
+    Measures memory usage per Python process
+
+    Returns
+    -------
+    memory_usage : float
+    """
+    process = psutil.Process(os.getpid())
+    memory_use = process.memory_info()
+    return memory_use.rss / 1e6  # to MB
+
+
+class MemoryUsage:
+    """Measure memory usage during test execution.
+
+    This plugin can also collect memory usage data from pytest-xdist workers.
+
+    This code is directly adapted from:
+    https://gist.github.com/DKorytkin/8a186693af9a015abe89f6b874ca0795 by
+    Dmytro Korytkin.
+    """
+
+    LIMIT = 5
+    SHARED_MEMORY_USAGE_INFO = "memory_usage"
+
+    def __init__(self, config):
+        """Setup the plugin.
+
+        Parameters
+        ----------
+        config : _pytest.config.Config
+        """
+        self.config = config
+        self.is_main_process = is_main_process(config)
+        self.stats = {}
+
+    def add(self, name):
+        self.stats[name] = self.stats.get(name) or {}
+        return self.stats[name]
+
+    def pytest_runtest_setup(self, item):
+        """Record maxrss for pre-setup."""
+        self.add(item.nodeid)["setup"] = get_usage_memory_mb()
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(self, item):
+        """Track test memory usage
+
+        This collects memory usage data before and after each test run.
+
+        However, we do not measure the peak memory usage during the test run
+        itself. This would require some kind of sampling mechanism (e.g. using
+        `memory_profiler`) but this does not see to be easily achievable using
+        the pytest plugin API.
+
+        Parameters
+        ----------
+        item : _pytest.main.Item
+        """
+        start = get_usage_memory_mb()
+        yield
+        end = get_usage_memory_mb()
+        node_stats = self.add(item.nodeid)
+        if "setup" in node_stats:
+            reference = node_stats["setup"]
+        else:
+            reference = start
+
+        node_stats["diff"] = end - reference
+        node_stats["end"] = end
+        node_stats["start"] = start
+
+    def pytest_terminal_summary(self, terminalreporter):
+        tr = terminalreporter
+        if self.stats:
+            tr._tw.sep(
+                "=",
+                "TOP {} tests which increased RAM usage".format(self.LIMIT),
+                yellow=True,
+            )
+            stats = sorted(
+                self.stats.items(), key=lambda x: x[-1]["diff"], reverse=True
+            )
+            for test_name, info in stats[: self.LIMIT]:
+                line = "before setup: {:.3f} MB, increment: {:.3f} MB - {}".format(
+                    info["setup"], info["diff"], test_name
+                )
+                tr._tw.line(line)
+
+    def pytest_testnodedown(self, node, error):
+        """Collect memory usage stats from pytest-xdist nodes.
+
+        All stats are merged into the main process stats.
+        """
+        node_stats = node.workeroutput[self.SHARED_MEMORY_USAGE_INFO]
+        self.stats.update(node_stats)
+
+    @pytest.hookimpl(hookwrapper=True, trylast=True)
+    def pytest_sessionfinish(self, session, exitstatus):
+        """Dump memory usage statistics to `workeroutput`
+
+        Executed once per node if with xdist and will gen from mater node
+
+        Parameters
+        ----------
+        session : _pytest.Session
+        exitstatus : int
+        """
+        yield
+        if not self.is_main_process:
+            self.config.workeroutput[self.SHARED_MEMORY_USAGE_INFO] = self.stats


### PR DESCRIPTION
While investigating random crashes when running the tests on the linux/arm64 travis executors (see #21508 and #21457), we suspect that some tests are allocate a lot of memory causing the OS to OOM kill the pytest-xdist workers.

Here  is a pytest-plugin to try to spot those problematic tests.

Here is the report of the worst offenders on a local run:

```
========================================= TOP 5 tests which increased RAM usage ==========================================
before setup: 230.457 MB, increment: 533.479 MB - sklearn/metrics/cluster/tests/test_supervised.py::test_adjusted_rand_score_overflow
before setup: 158.663 MB, increment: 307.610 MB - sklearn/feature_extraction/tests/test_text.py::test_pickling_vectorizer
before setup: 126.796 MB, increment: 228.590 MB - sklearn/ensemble/tests/test_voting.py::test_parallel_fit
before setup: 161.071 MB, increment: 224.444 MB - sklearn/metrics/_plot/confusion_matrix.py::sklearn.metrics._plot.confusion_matrix.ConfusionMatrixDisplay.from_estimator
before setup: 151.749 MB, increment: 223.707 MB - sklearn/utils/tests/test_parallel.py::test_configuration_passes_through_to_joblib[multiprocessing-2]
```

The precise numbers are not very stable because it depends on on the test order which is not deterministic when running in parallel (I ran with 8 pytest-xdist workers) but the ranking of the worst offenders stays approximately the same across workers and seems to match the tests that tend to crash the most in #21457.

Note that this plugin does not measure the memory usage during the tests execution but only before and after each test. It therefore does not measure the peak memory usage. This would require using memory_profiler but it seems not trivial to adapt to the `yield`-based plugin API of pytest plugins.

I think this is informative enough to spot problematic tests that allocate more than 200 MB though.