### PR TITLE
[ENH] Introduce graph-regularized discriminative NMF

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -938,6 +938,65 @@ stored components::
       C. Fevotte, J. Idier, 2011
 
 
+.. _GDNMF:
+
+Graph-regularized Discriminative Non-negative Matrix Factorization (GDNMF)
+==========================================================================
+
+GDNMF extends NMF to explicitly consider the local invariance and
+label information. The geometrical structure of data space is encoded by constructing
+a k nearest neighbor graph, which increases the discriminative ability of different classes
+by considering the label information. It attempts to find a parts-based representation
+discriminative space in which two data points are sufficiently close to each other if
+they are connected in the graph. To this end, a new matrix decomposition
+objective function is proposed by integrating the graph structure and label information:
+
+.. math::
+   J = Tr((X - WH)^T (X - WH)) + \lambda Tr(HLH^T) + \gamma Tr((S - AH)^T (S - AH))
+
+where :math:`X, W, H` are defined as in :class:`NMF`, and
+
+.. math::
+   C_{i, j} = \begin{cases}
+   1 & \text{if $x_i \in N_k(x_j)$ or $x_j \in N_k(x_i)$} \\
+   0 & \text{otherwise}
+   \end{cases}
+
+.. math::
+   B_{i, i} = \sum_{j=1}^n C_{i, j}, L = B - C
+
+.. math::
+   S_{i, j} = \begin{cases}
+   1 & \text{if $y_j = i$, $j = 1, 2, ..., n, i = 1, 2, ..., c$} \\
+   0 & \text{otherwise}
+   \end{cases}
+
+where :math:`N_k(x_i)` is the :math:`k` nearest neighbors of sample :math:`i`,
+:math:`n` is the number of samples and :math:`c` is the number of classes.
+
+The objective function is then solved by multiplicative iterative updates of the factor matrices.
+This generates a new parts-based data representation which takes into account
+the geometrical structure and discriminative information of the input space simultaneously.
+
+
+.. note::
+
+  Unlike NMF, GDNMF will make use of the labels (:math:`y`) to perform transformation
+  on the input matrix (:math:`X`). Therefore, if using the transformed data for further predictive
+  modelling, the label information will have "leaked" into the input. As a result, if using GDNMF
+  as part of a predictive pipeline, care should be taken to avoid such leakage.
+
+.. topic:: Examples:
+
+   * :ref:`sphx_glr_auto_examples_decomposition_plot_faces_decomposition.py`
+
+.. topic:: References:
+
+  * Long, X., Lu, H., Peng, Y. and Li, W., 2014,
+    `"Graph regularized discriminative non-negative matrix factorization for face recognition"
+    <https://link.springer.com/article/10.1007/s11042-013-1572-z>`_
+
+
 .. _LatentDirichletAllocation:
 
 Latent Dirichlet Allocation (LDA)

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -85,6 +85,10 @@ Changelog
   and :class:`~sklearn.decomposition.TruncatedSVD`. :pr:`21334` by
   `Thomas Fan`_.
 
+- |Enhancement| Introduce :class:`decomposition.GDNMF` to perform
+  non-negative matrix factorization, utilizing (side) labels and graph structure.
+  :pr:`21531` by :user:`Jason Zhang <jasonyz-ucb>`.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -32,7 +32,7 @@ rng = RandomState(0)
 
 # #############################################################################
 # Load faces data
-faces, _ = fetch_olivetti_faces(return_X_y=True, shuffle=True, random_state=rng)
+faces, labels = fetch_olivetti_faces(return_X_y=True, shuffle=True, random_state=rng)
 n_samples, n_features = faces.shape
 
 # global centering
@@ -159,6 +159,30 @@ for name, estimator, center in estimators:
     plot_gallery(
         "%s - Train time %.1fs" % (name, train_time), components_[:n_components]
     )
+
+plt.show()
+
+# #############################################################################
+# Graph-regularized Discriminative NMF
+
+print("Extracting the top %d %s..." % (n_components, "Non-negative components - GDNMF"))
+t0 = time()
+W, H, _ = decomposition.graph_regularized_nmf(
+    faces,
+    labels,
+    n_components=n_components,
+    graph_coeff=0.1,
+    label_coeff=0.1,
+    tol=5e-3,
+    random_state=rng,
+)
+train_time = time() - t0
+print("done in %0.3fs" % train_time)
+components_ = H
+plot_gallery(
+    "%s - Train time %.1fs" % ("Non-negative components - GDNMF", train_time),
+    components_[:n_components],
+)
 
 plt.show()
 

--- a/sklearn/decomposition/__init__.py
+++ b/sklearn/decomposition/__init__.py
@@ -23,11 +23,13 @@ from ._dict_learning import (
 from ._factor_analysis import FactorAnalysis
 from ..utils.extmath import randomized_svd
 from ._lda import LatentDirichletAllocation
+from ._gdnmf import graph_regularized_nmf
 
 
 __all__ = [
     "DictionaryLearning",
     "FastICA",
+    "graph_regularized_nmf",
     "IncrementalPCA",
     "KernelPCA",
     "MiniBatchDictionaryLearning",

--- a/sklearn/decomposition/_gdnmf.py
+++ b/sklearn/decomposition/_gdnmf.py
@@ -1,0 +1,476 @@
+"""
+Graph regularized discriminative non-negative matrix factorization.
+"""
+
+# Author: Jason Zhang <jason.zhang@ucb.com>
+# License: BSD 3 clause
+
+from scipy.sparse import csgraph
+from sklearn.neighbors import NearestNeighbors
+from time import time
+from typing import Optional, Tuple
+import numbers
+import numpy as np
+import warnings
+
+from ._nmf import trace_dot
+from ..base import clone
+from ..exceptions import ConvergenceWarning
+from ..utils import check_random_state
+from ..utils.extmath import safe_sparse_dot
+from ..utils.validation import check_X_y, check_non_negative
+from .._config import config_context
+
+EPSILON = np.finfo(np.float32).eps
+
+
+def _gdnmf_objective(X, C, B, S, W, H, A, graph_coeff, label_coeff) -> float:
+    """
+    Compute the objective function (loss) for GDNMF.
+    """
+    L = B - C
+    reconstruction_error = np.trace(safe_sparse_dot(X - W @ H, (X - W @ H).T))
+    graph_regularization = graph_coeff * np.trace(W.T @ L @ W)
+    label_regularization = label_coeff * trace_dot((S - A @ W.T).T, S - A @ W.T)
+    return reconstruction_error + graph_regularization + label_regularization
+
+
+def _init_w_h_a(X, n_components: int, n_classes: int, random_state=None):
+    check_non_negative(X, "NMF initialization")
+    n_samples, n_features = X.shape
+
+    avg = np.sqrt(X.mean() / n_components)
+    rng = check_random_state(random_state)
+    H = avg * rng.randn(n_components, n_features).astype(X.dtype, copy=False)
+    W = avg * rng.randn(n_samples, n_components).astype(X.dtype, copy=False)
+    A = avg * rng.randn(n_classes, n_components).astype(X.dtype, copy=False)
+    np.abs(H, out=H)
+    np.abs(W, out=W)
+    np.abs(A, out=A)
+    return W, H, A
+
+
+def _multiplicative_update_w(X, C, B, S, W, H, A, graph_coeff, label_coeff):
+    nominator = label_coeff * A.T @ S + safe_sparse_dot(H, X.T) + graph_coeff * W.T @ C
+    nominator[nominator <= 0] = EPSILON
+    denominator = H @ H.T @ W.T + label_coeff * A.T @ A @ W.T + graph_coeff * W.T @ B
+    denominator[denominator <= 0] = 1.0
+    return nominator / denominator
+
+
+def _multiplicative_update_h(X, W, H):
+    nominator = safe_sparse_dot(X.T, W)
+    nominator[nominator <= 0] = EPSILON
+    denominator = H.T @ W.T @ W
+    denominator[denominator <= 0] = 1.0
+    return nominator / denominator
+
+
+def _multiplicative_update_a(S, W, A):
+    nominator = S @ W
+    nominator[nominator <= 0] = EPSILON
+    denominator = A @ W.T @ W
+    denominator[denominator <= 0] = 1.0
+    return nominator / denominator
+
+
+def _fit_multiplicative_update(
+    X,
+    C,
+    B,
+    S,
+    W,
+    H,
+    A,
+    graph_coeff: float = 0.0,
+    label_coeff: float = 0.0,
+    max_iter: int = 200,
+    tol: float = 1e-4,
+    verbose: int = 0,
+) -> Tuple[np.array, np.array, int]:
+    """
+    Compute Graph Regularized Discriminative Non-negative Matrix
+    Factorization with Multiplicative Update.
+
+    The objective function is _beta_divergence(X, WH) and is minimized with an
+    alternating minimization of W and H. Each minimization is done with a
+    Multiplicative Update.
+
+    Parameters
+    ----------
+    X : array-like of shape (n_samples, n_features)
+        Constant input matrix.
+
+    C : array-like of shape (n_samples, n_samples)
+        Samples neighboring relationship graph.
+
+    B : array-like of shape (n_samples, n_samples)
+        Row sum of the weight matrix C, used for graph laplacian calculation.
+
+    S : array-like of shape (n_classes, n_samples)
+        Label information matrix.
+
+    W : array-like of shape (n_samples, n_components)
+        Initial guess for the solution.
+
+    H : array-like of shape (n_components, n_features)
+        Initial guess for the solution.
+
+    A : array-like of shape (n_classes, n_components)
+        Initial guess for the solution.
+
+    graph_coeff : float, default=0.0
+        Coefficient for the graph Laplacian regularization term.
+
+    label_coeff : float, default=0.0
+        Coefficient for the label information regularization term.
+
+    max_iter : int, default=200
+        Number of iterations.
+
+    tol : float, default=1e-4
+        Tolerance of the stopping condition.
+
+    verbose : int, default=0
+        The verbosity level.
+
+    Returns
+    -------
+    W : ndarray of shape (n_samples, n_components)
+        Left factor matrix in :math:`X = WH`.
+
+    H : ndarray of shape (n_components, n_features)
+        Right factor matrix in :math:`X = WH`.
+
+    n_iter : int
+        The number of iterations done by the algorithm.
+
+    References
+    ----------
+    Long, X., Lu, H., Peng, Y., & Li, W. (2014). Graph regularized
+    discriminative non-negative matrix factorization for face recognition.
+    Multimedia tools and applications, 72(3), 2679-2699.
+    """
+    start_time = time()
+    previous_error = error = error_at_init = _gdnmf_objective(
+        X=X,
+        C=C,
+        B=B,
+        S=S,
+        W=W,
+        H=H,
+        A=A,
+        graph_coeff=graph_coeff,
+        label_coeff=label_coeff,
+    )
+
+    for n_iter in range(1, max_iter + 1):
+        # update W
+        # H_sum, HHt and XHt are saved and reused if not update_H
+        delta_W = _multiplicative_update_w(
+            X=X,
+            C=C,
+            B=B,
+            S=S,
+            W=W,
+            H=H,
+            A=A,
+            graph_coeff=graph_coeff,
+            label_coeff=label_coeff,
+        ).T
+        W *= delta_W
+
+        # update H
+        delta_H = _multiplicative_update_h(X=X, W=W, H=H).T
+        H *= delta_H
+
+        # update A
+        delta_A = _multiplicative_update_a(S=S, W=W, A=A)
+        A *= delta_A
+
+        # test convergence criterion every 10 iterations
+        if tol > 0 and n_iter % 10 == 0:
+            error = _gdnmf_objective(
+                X=X,
+                C=C,
+                B=B,
+                S=S,
+                W=W,
+                H=H,
+                A=A,
+                graph_coeff=graph_coeff,
+                label_coeff=label_coeff,
+            )
+
+            if verbose:
+                iter_time = time()
+                print(
+                    f"Epoch {n_iter:02d} reached after "
+                    f"{iter_time - start_time:.3f} seconds, error: {error}"
+                )
+
+            if (previous_error - error) / error_at_init < tol:
+                break
+            previous_error = error
+
+    # do not print if we have already printed in the convergence test
+    if verbose and (tol == 0 or n_iter % 10 != 0):
+        end_time = time()
+        print(f"Epoch {n_iter:02d} reached after {end_time - start_time:.3f} seconds.")
+
+    return W, H, n_iter
+
+
+def _check_params(
+    X,
+    y,
+    n_components,
+    n_classes,
+    tol,
+    max_iter,
+    graph_coeff,
+    label_coeff,
+    knn,
+):
+    # n_components
+    if n_components is None:
+        n_components = X.shape[1]
+    if not isinstance(n_components, numbers.Integral) or n_components <= 0:
+        raise ValueError(
+            "Number of components must be a positive integer; got "
+            f"(n_components={n_components!r})"
+        )
+
+    # n_classes
+    if n_classes is None:
+        n_classes = len(set(y))
+    if not isinstance(n_classes, numbers.Integral) or n_classes <= 0:
+        raise ValueError(
+            "Number of classes must be a positive integer; got "
+            f"(n_classes={n_classes!r})"
+        )
+
+    # max_iter
+    if not isinstance(max_iter, numbers.Integral) or max_iter < 0:
+        raise ValueError(
+            "Maximum number of iterations must be a positive "
+            f"integer; got (max_iter={max_iter!r})"
+        )
+
+    # tol
+    if not isinstance(tol, numbers.Number) or tol < 0:
+        raise ValueError(
+            "Tolerance for stopping criteria must be a positive number; got "
+            f"(tol={tol!r})"
+        )
+
+    # graph_coeff
+    if not isinstance(graph_coeff, numbers.Number) or graph_coeff < 0:
+        raise ValueError(
+            "Coefficient for the graph Laplacian regularization term must be "
+            f"a positive number; got (graph_coeff={graph_coeff!r})"
+        )
+
+    # label_coeff
+    if not isinstance(label_coeff, numbers.Number) or label_coeff < 0:
+        raise ValueError(
+            "Coefficient for the label information regularization term must be "
+            f"a positive number; got (label_coeff={label_coeff!r})"
+        )
+
+    # knn
+    if knn is None:
+        knn = NearestNeighbors(n_neighbors=min(5, X.shape[0]))
+    elif not isinstance(knn, NearestNeighbors):
+        raise ValueError(
+            "Pre-configured nearest-neighbors calculator must be of type"
+            f" NearestNeighbors; got (knn={knn!r})"
+        )
+    else:
+        knn = clone(knn)
+
+    return n_components, n_classes, tol, max_iter, graph_coeff, label_coeff, knn
+
+
+def _fit_transform(
+    X,
+    y,
+    n_components,
+    n_classes,
+    tol,
+    max_iter,
+    graph_coeff,
+    label_coeff,
+    random_state,
+    knn,
+    verbose,
+):
+    """
+    Learn a GDNMF model for the data X and returns the transformed data.
+    """
+    check_non_negative(X, "NMF (input X)")
+
+    # check parameters
+    (
+        n_components,
+        n_classes,
+        tol,
+        max_iter,
+        graph_coeff,
+        label_coeff,
+        knn,
+    ) = _check_params(
+        X, y, n_components, n_classes, tol, max_iter, graph_coeff, label_coeff, knn
+    )
+
+    # calculate graph laplacian
+    knn.fit(X)
+    C = knn.kneighbors_graph(X, mode="connectivity").toarray()
+    L = csgraph.laplacian(C)
+    B = L + C
+
+    # calculate label information matrix
+    S = np.array(
+        [
+            np.array([1 if label == cls else 0 for label in y])
+            for cls in range(n_classes)
+        ]
+    )
+
+    # initialize or check W and H
+    W, H, A = _init_w_h_a(X, n_components, n_classes, random_state)
+
+    W, H, n_iter = _fit_multiplicative_update(
+        X=X,
+        C=C,
+        B=B,
+        S=S,
+        W=W,
+        H=H,
+        A=A,
+        graph_coeff=graph_coeff,
+        label_coeff=label_coeff,
+        max_iter=max_iter,
+        tol=tol,
+        verbose=verbose,
+    )
+
+    if n_iter == max_iter and tol > 0:
+        warnings.warn(
+            f"Maximum number of iterations {max_iter} reached. Increase "
+            "it to improve convergence.",
+            ConvergenceWarning,
+        )
+
+    return W, H, n_iter
+
+
+def graph_regularized_nmf(
+    X,
+    y,
+    n_components: Optional[int] = None,
+    n_classes: Optional[int] = None,
+    tol: Optional[float] = 1e-4,
+    max_iter: Optional[int] = 200,
+    graph_coeff: Optional[float] = 0.0,
+    label_coeff: Optional[float] = 0.0,
+    random_state=None,
+    knn: Optional[NearestNeighbors] = None,
+    verbose=0,
+):
+    """
+    Graph regularized discriminative non-negative matrix factorization.
+
+    Parameters
+    ----------
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        Data matrix to be decomposed.
+
+    y : array-like of shape (n_samples)
+        Vector of the class labels for each sample.
+
+    n_components : int, default=None
+        Number of components, if n_components is not set all features
+        are kept.
+
+    n_classes : int, default=None
+        Number of unique classes, if n_classes is not set we will
+        derive from y.
+
+    tol : float, default=1e-4
+        Tolerance of the stopping condition.
+
+    max_iter : int, default=200
+        Maximum number of iterations before timing out.
+
+    graph_coeff : float, default=0.0
+        Coefficient for the graph Laplacian regularization term.
+
+    label_coeff : float, default=0.0
+        Coefficient for the label information regularization term.
+
+    random_state : int, RandomState instance or None, default=None
+        Pass an int for reproducible results across multiple function calls.
+        See :term:`Glossary <random_state>`.
+
+    knn : NearestNeighbors, default=None
+        Pre-configured nearest-neighbors calculator.
+
+    verbose : int, default=0
+        The verbosity level.
+
+    Returns
+    -------
+    W : ndarray of shape (n_samples, n_components)
+        Transformed data.
+
+    H : ndarray of shape (n_components, n_features)
+        Factorization matrix, sometimes called 'dictionary'.
+
+    n_iter_ : int
+        Actual number of iterations.
+
+    See Also
+    --------
+    NMF : Non-negative matrix factorization without labels.
+    DictionaryLearning : Find a dictionary that sparsely encodes data.
+    MiniBatchSparsePCA : Mini-batch Sparse Principal Components Analysis.
+    PCA : Principal component analysis.
+    SparseCoder : Find a sparse representation of data from a fixed,
+        precomputed dictionary.
+    SparsePCA : Sparse Principal Components Analysis.
+    TruncatedSVD : Dimensionality reduction using truncated SVD.
+
+    References
+    ----------
+    Long, X., Lu, H., Peng, Y., & Li, W. (2014). Graph regularized
+    discriminative non-negative matrix factorization for face recognition.
+    Multimedia tools and applications, 72(3), 2679-2699.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> X = np.array([[1, 1], [2, 1], [3, 1.2], [4, 1], [5, 0.8], [6, 1]])
+    >>> y = np.array([0, 0, 1, 0, 1, 1])
+    >>> from sklearn.decomposition import graph_regularized_nmf
+    >>> W, H, _ = graph_regularized_nmf(X, y, n_components=2, n_classes=2,
+    ... graph_coeff=0.1, label_coeff=0.1, random_state=0)
+    """
+    X, y = check_X_y(X, y, accept_sparse=("csr", "csc"), dtype=[np.float64, np.float32])
+
+    with config_context(assume_finite=True):
+        W, H, n_iter = _fit_transform(
+            X,
+            y,
+            n_components,
+            n_classes,
+            tol,
+            max_iter,
+            graph_coeff,
+            label_coeff,
+            random_state,
+            knn,
+            verbose,
+        )
+
+    return W, H, n_iter

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -629,7 +629,7 @@ def _multiplicative_update_w(
     numerator /= denominator
     delta_W = numerator
 
-    # gamma is in ]0, 1]
+    # gamma is in [0, 1]
     if gamma != 1:
         delta_W **= gamma
 

--- a/sklearn/decomposition/tests/test_gdnmf.py
+++ b/sklearn/decomposition/tests/test_gdnmf.py
@@ -1,0 +1,219 @@
+import numpy as np
+import pytest
+
+from scipy.sparse import csc_matrix
+from sklearn.decomposition import graph_regularized_nmf
+from sklearn.decomposition import _gdnmf as gdnmf
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.metrics import pairwise_distances
+from sklearn.neighbors import NearestNeighbors
+from sklearn.utils._testing import assert_array_almost_equal
+
+
+def test_convergence_warning():
+    convergence_warning = (
+        "Maximum number of iterations 1 reached. Increase it to improve convergence."
+    )
+    X = np.ones((2, 3))
+    y = np.ones(2)
+    nn = NearestNeighbors(n_neighbors=1)
+    with pytest.warns(ConvergenceWarning, match=convergence_warning):
+        graph_regularized_nmf(X, y, max_iter=1, knn=nn)
+
+
+def test_initialize_w_h_a_output():
+    # Test that initialization does not return negative values.
+    random_state = np.random.RandomState(42)
+    data = np.abs(random_state.randn(10, 10))
+    W, H, A = gdnmf._init_w_h_a(data, 10, n_classes=3, random_state=random_state)
+    assert not ((W < 0).any() or (H < 0).any() or (A < 0).any())
+
+
+def test_initialize_w_h_a_stable():
+    # Test that initialization returns close values for
+    # repetitive runs with the same random state.
+    random_state = np.random.RandomState(42)
+    data = np.abs(random_state.randn(10, 10))
+    W, H, A = gdnmf._init_w_h_a(data, 10, n_classes=3, random_state=0)
+    assert not ((W < 0).any() or (H < 0).any() or (A < 0).any())
+    W_2, H_2, A_2 = gdnmf._init_w_h_a(data, 10, n_classes=3, random_state=0)
+    assert not ((W_2 < 0).any() or (H_2 < 0).any() or (A_2 < 0).any())
+    assert_array_almost_equal(W_2, W, decimal=2)
+    assert_array_almost_equal(H_2, H, decimal=2)
+    assert_array_almost_equal(A_2, A, decimal=2)
+
+
+def test_parameter_checking():
+    X = np.ones((2, 3))
+    y = np.ones(2)
+
+    msg = "Negative values in data passed to"
+    with pytest.raises(ValueError, match=msg):
+        graph_regularized_nmf(-X, y)
+    with pytest.raises(ValueError, match=msg):
+        gdnmf._init_w_h_a(-X, 1, 2)
+    with pytest.raises(ValueError):
+        graph_regularized_nmf(X, y, n_components=-1)
+    with pytest.raises(ValueError):
+        graph_regularized_nmf(X, y, n_classes=-1)
+    with pytest.raises(ValueError):
+        graph_regularized_nmf(X, y, max_iter=-1)
+    with pytest.raises(ValueError):
+        graph_regularized_nmf(X, y, tol=-1)
+    with pytest.raises(ValueError):
+        graph_regularized_nmf(X, y, graph_coeff=-1)
+    with pytest.raises(ValueError):
+        graph_regularized_nmf(X, y, label_coeff=-1)
+
+    class DummyNearestNeighbor:
+        pass
+
+    with pytest.raises(ValueError):
+        graph_regularized_nmf(X, y, knn=DummyNearestNeighbor())
+
+
+@pytest.mark.parametrize("graph_coeff", (0.0, 1.0))
+@pytest.mark.parametrize("label_coeff", (0.0, 1.0))
+def test_gdnmf_fit_nn_output(graph_coeff, label_coeff):
+    # Test that the decomposition does not contain negative values.
+    X = np.c_[5.0 - np.arange(1, 6), 5.0 + np.arange(1, 6)]
+    y = np.arange(X.shape[0])
+    W, H, _ = graph_regularized_nmf(
+        X,
+        y,
+        n_components=2,
+        graph_coeff=graph_coeff,
+        label_coeff=label_coeff,
+        random_state=0,
+    )
+    assert not ((W < 0).any() or (H < 0).any())
+
+
+@pytest.mark.parametrize("graph_coeff", (0.0, 0.05, 0.1))
+@pytest.mark.parametrize("label_coeff", (0.0, 0.05, 0.1))
+def test_gdnmf_fit_close(graph_coeff, label_coeff):
+    random_state = np.random.RandomState(42)
+    # Test that the fit is not too far away from the original matrix.
+    X = np.abs(random_state.randn(6, 5))
+    y = random_state.randint(0, 3, X.shape[0])
+    W, H, _ = graph_regularized_nmf(
+        X,
+        y,
+        n_components=5,
+        n_classes=3,
+        graph_coeff=graph_coeff,
+        label_coeff=label_coeff,
+        random_state=random_state,
+        max_iter=1000,
+    )
+    assert np.linalg.norm(X - W @ H) < 0.05 * np.linalg.norm(X)
+
+
+def test_n_components_greater_n_features():
+    # Smoke test for the case of more components than features.
+    random_state = np.random.RandomState(42)
+    X = np.abs(random_state.randn(30, 10))
+    y = random_state.randint(0, 5, X.shape[0])
+    graph_regularized_nmf(
+        X, y, n_components=15, n_classes=5, random_state=random_state, tol=1e-2
+    )
+
+
+@pytest.mark.parametrize("graph_coeff", (0.0, 0.5, 1.0))
+@pytest.mark.parametrize("label_coeff", (0.0, 0.5, 1.0))
+def test_gdnmf_sparse_input(graph_coeff, label_coeff):
+    # Test that sparse matrices are accepted as input.
+    random_state = np.random.RandomState(42)
+    X = np.abs(random_state.randn(10, 10))
+    y = random_state.randint(0, 3, X.shape[0])
+    X[:, 2 * np.arange(5)] = 0
+    X_sparse = csc_matrix(X)
+
+    W_1, H_1, _ = graph_regularized_nmf(
+        X,
+        y,
+        n_components=5,
+        n_classes=3,
+        graph_coeff=graph_coeff,
+        label_coeff=label_coeff,
+        random_state=0,
+        tol=1e-2,
+    )
+    W_2, H_2, _ = graph_regularized_nmf(
+        X_sparse,
+        y,
+        n_components=5,
+        n_classes=3,
+        graph_coeff=graph_coeff,
+        label_coeff=label_coeff,
+        random_state=0,
+        tol=1e-2,
+    )
+
+    assert_array_almost_equal(W_1, W_2)
+    assert_array_almost_equal(H_1, H_2)
+
+
+@pytest.mark.parametrize("graph_coeff", (0.0, 0.5, 1.0))
+@pytest.mark.parametrize("label_coeff", (10, 20))
+def test_same_label_samples_closer(graph_coeff, label_coeff):
+    # Test the transformed samples with the same labels
+    # will be closer together.
+    random_state = np.random.RandomState(42)
+    N_CLASSES = 3
+    X = np.abs(random_state.randn(10, 10))
+    y = random_state.randint(0, N_CLASSES, X.shape[0])
+
+    W, *_ = graph_regularized_nmf(
+        X,
+        y,
+        n_components=4,
+        n_classes=N_CLASSES,
+        graph_coeff=graph_coeff,
+        label_coeff=label_coeff,
+        random_state=random_state,
+        tol=1e-5,
+    )
+
+    def intra_group_avg_dist(A):
+        n = A.shape[0]
+        return np.triu(pairwise_distances(A)).sum() / ((n - 1) * n / 2)
+
+    avg_pair_dist = intra_group_avg_dist(W)
+    for cls in range(N_CLASSES):
+        cls_samples = W[y == cls, :]
+        cls_pair_dist = intra_group_avg_dist(cls_samples)
+        assert cls_pair_dist < avg_pair_dist
+
+
+@pytest.mark.parametrize("graph_coeff", (50, 100))
+@pytest.mark.parametrize("label_coeff", (0.0, 0.5, 1.0))
+def test_preservation_of_knn(graph_coeff, label_coeff):
+    # Test nearest-neighbour structure is preserved
+    # during the tranformation.
+    random_state = np.random.RandomState(42)
+    N_CLASSES = 3
+    N_NEIGHBORS = 3
+    X = np.abs(random_state.randn(10, 10))
+    y = random_state.randint(0, N_CLASSES, X.shape[0])
+    knn = NearestNeighbors(n_neighbors=N_NEIGHBORS)
+    knn.fit(X)
+    C_1 = knn.kneighbors_graph(X, mode="connectivity").toarray()
+
+    W, *_ = graph_regularized_nmf(
+        X,
+        y,
+        n_components=4,
+        n_classes=N_CLASSES,
+        graph_coeff=graph_coeff,
+        label_coeff=label_coeff,
+        random_state=random_state,
+        tol=1e-5,
+        knn=NearestNeighbors(n_neighbors=N_NEIGHBORS),
+    )
+
+    knn = NearestNeighbors(n_neighbors=N_NEIGHBORS)
+    knn.fit(W)
+    C_2 = knn.kneighbors_graph(W, mode="connectivity").toarray()
+
+    assert np.sum(np.abs(C_1 - C_2)) <= 10


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->


#### What does this implement/fix? Explain your changes.
Introduce a variant of Non-negative Matrix Factorization where (side) labels can be used to guide the factorization process. 
Paper can be found [here](https://link.springer.com/article/10.1007/s11042-013-1572-z), but the main point is to add 2 new terms in the objective function to take into account the (side) labels and the initial topology (via k nearest neighbors),


#### Any other comments?
This is my first PR here so feel free to throw in any comments/feedback/ criticism, I'm all ears. Thank you :)
There's some duplication between this addition and the original NMF class, it would be nice if the reviewer could share some thoughts on whether it's reasonable and perhaps how to avoid it. Thanks!