### PR TITLE
ENH support float32 in SpectralEmbedding for LOBPCG and PyAMG solvers

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -121,7 +121,7 @@ Changelog
 .......................
 
 - |Enhancement| :func:`manifold.spectral_embedding` supports `np.float32` dtype.
-  :pr:`21534` by :user:`Andrew Knyazev <lobpcg>`
+  :pr:`21534` by :user:`Andrew Knyazev <lobpcg>`.
 
 :mod:`sklearn.model_selection`
 ..............................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -117,6 +117,12 @@ Changelog
   backward compatibility, but this alias will be removed in 1.3.
   :pr:`21177` by :user:`Julien Jerphanion <jjerphan>`.
 
+:mod:`sklearn.manifold`
+.......................
+
+- |Enhancement| :func:`manifold.spectral_embedding` supports `np.float32` dtype.
+  :pr:`21321` by :user:`Andrew Knyazev <lobpcg>`
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -120,7 +120,9 @@ Changelog
 :mod:`sklearn.manifold`
 .......................
 
-- |Enhancement| :func:`manifold.spectral_embedding` supports `np.float32` dtype.
+- |Enhancement| :func:`manifold.spectral_embedding` and
+   :class:`manifold.SpectralEmbedding` supports `np.float32` dtype and will
+   preserve this dtype.
   :pr:`21534` by :user:`Andrew Knyazev <lobpcg>`.
 
 :mod:`sklearn.model_selection`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -121,7 +121,7 @@ Changelog
 .......................
 
 - |Enhancement| :func:`manifold.spectral_embedding` supports `np.float32` dtype.
-  :pr:`21321` by :user:`Andrew Knyazev <lobpcg>`
+  :pr:`21534` by :user:`Andrew Knyazev <lobpcg>`
 
 :mod:`sklearn.model_selection`
 ..............................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -121,8 +121,8 @@ Changelog
 .......................
 
 - |Enhancement| :func:`manifold.spectral_embedding` and
-   :class:`manifold.SpectralEmbedding` supports `np.float32` dtype and will
-   preserve this dtype.
+  :class:`manifold.SpectralEmbedding` supports `np.float32` dtype and will
+  preserve this dtype.
   :pr:`21534` by :user:`Andrew Knyazev <lobpcg>`.
 
 :mod:`sklearn.model_selection`

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -316,9 +316,7 @@ def spectral_embedding(
         if not sparse.issparse(laplacian):
             warnings.warn("AMG works better for sparse matrices")
         laplacian = check_array(
-            laplacian,
-            dtype=[np.float64, np.float32],
-            accept_sparse=True
+            laplacian, dtype=[np.float64, np.float32], accept_sparse=True
         )
         laplacian = _set_diag(laplacian, 1, norm_laplacian)
 
@@ -350,9 +348,7 @@ def spectral_embedding(
 
     if eigen_solver == "lobpcg":
         laplacian = check_array(
-            laplacian,
-            dtype=[np.float64, np.float32],
-            accept_sparse=True
+            laplacian, dtype=[np.float64, np.float32], accept_sparse=True
         )
         if n_nodes < 5 * n_components + 1:
             # see note above under arpack why lobpcg has problems with small
@@ -638,8 +634,7 @@ class SpectralEmbedding(BaseEstimator):
                 raise ValueError(
                     "%s is not a valid affinity. Expected "
                     "'precomputed', 'rbf', 'nearest_neighbors' "
-                    "or a callable."
-                    % self.affinity
+                    "or a callable." % self.affinity
                 )
         elif not callable(self.affinity):
             raise ValueError(

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -315,6 +315,7 @@ def spectral_embedding(
         # problem.
         if not sparse.issparse(laplacian):
             warnings.warn("AMG works better for sparse matrices")
+        laplacian = check_array(laplacian, dtype=[np.float64, np.float32], accept_sparse=True)
         laplacian = _set_diag(laplacian, 1, norm_laplacian)
 
         # The Laplacian matrix is always singular, having at least one zero
@@ -344,6 +345,7 @@ def spectral_embedding(
             raise ValueError
 
     if eigen_solver == "lobpcg":
+        laplacian = check_array(laplacian, dtype=[np.float64, np.float32], accept_sparse=True)
         if n_nodes < 5 * n_components + 1:
             # see note above under arpack why lobpcg has problems with small
             # number of nodes

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -315,7 +315,11 @@ def spectral_embedding(
         # problem.
         if not sparse.issparse(laplacian):
             warnings.warn("AMG works better for sparse matrices")
-        laplacian = check_array(laplacian, dtype=[np.float64, np.float32], accept_sparse=True)
+        laplacian = check_array(
+            laplacian,
+            dtype=[np.float64, np.float32],
+            accept_sparse=True
+        )
         laplacian = _set_diag(laplacian, 1, norm_laplacian)
 
         # The Laplacian matrix is always singular, having at least one zero
@@ -345,7 +349,11 @@ def spectral_embedding(
             raise ValueError
 
     if eigen_solver == "lobpcg":
-        laplacian = check_array(laplacian, dtype=[np.float64, np.float32], accept_sparse=True)
+        laplacian = check_array(
+            laplacian,
+            dtype=[np.float64, np.float32],
+            accept_sparse=True
+        )
         if n_nodes < 5 * n_components + 1:
             # see note above under arpack why lobpcg has problems with small
             # number of nodes

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -336,7 +336,7 @@ def spectral_embedding(
 
         M = ml.aspreconditioner()
         # Create initial approximation X to eigenvectors
-        X = random_state.randn(laplacian.shape[0], n_components + 1)
+        X = random_state.rand(laplacian.shape[0], n_components + 1)
         X[:, 0] = dd.ravel()
         X = X.astype(laplacian.dtype)
         _, diffusion_map = lobpcg(laplacian, X, M=M, tol=1.0e-5, largest=False)
@@ -367,7 +367,7 @@ def spectral_embedding(
             # We increase the number of eigenvectors requested, as lobpcg
             # doesn't behave well in low dimension and create initial
             # approximation X to eigenvectors
-            X = random_state.randn(laplacian.shape[0], n_components + 1)
+            X = random_state.rand(laplacian.shape[0], n_components + 1)
             X[:, 0] = dd.ravel()
             X = X.astype(laplacian.dtype)
             _, diffusion_map = lobpcg(

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -315,8 +315,6 @@ def spectral_embedding(
         # problem.
         if not sparse.issparse(laplacian):
             warnings.warn("AMG works better for sparse matrices")
-        # lobpcg needs double precision floats
-        laplacian = check_array(laplacian, dtype=np.float64, accept_sparse=True)
         laplacian = _set_diag(laplacian, 1, norm_laplacian)
 
         # The Laplacian matrix is always singular, having at least one zero
@@ -346,8 +344,6 @@ def spectral_embedding(
             raise ValueError
 
     if eigen_solver == "lobpcg":
-        # lobpcg needs double precision floats
-        laplacian = check_array(laplacian, dtype=np.float64, accept_sparse=True)
         if n_nodes < 5 * n_components + 1:
             # see note above under arpack why lobpcg has problems with small
             # number of nodes

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -634,7 +634,8 @@ class SpectralEmbedding(BaseEstimator):
                 raise ValueError(
                     "%s is not a valid affinity. Expected "
                     "'precomputed', 'rbf', 'nearest_neighbors' "
-                    "or a callable." % self.affinity
+                    "or a callable."
+                    % self.affinity
                 )
         elif not callable(self.affinity):
             raise ValueError(

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -336,8 +336,9 @@ def spectral_embedding(
 
         M = ml.aspreconditioner()
         # Create initial approximation X to eigenvectors
-        X = random_state.rand(laplacian.shape[0], n_components + 1)
+        X = random_state.randn(laplacian.shape[0], n_components + 1)
         X[:, 0] = dd.ravel()
+        X = X.astype(laplacian.dtype)
         _, diffusion_map = lobpcg(laplacian, X, M=M, tol=1.0e-5, largest=False)
         embedding = diffusion_map.T
         if norm_laplacian:
@@ -366,8 +367,9 @@ def spectral_embedding(
             # We increase the number of eigenvectors requested, as lobpcg
             # doesn't behave well in low dimension and create initial
             # approximation X to eigenvectors
-            X = random_state.rand(laplacian.shape[0], n_components + 1)
+            X = random_state.randn(laplacian.shape[0], n_components + 1)
             X[:, 0] = dd.ravel()
+            X = X.astype(laplacian.dtype)
             _, diffusion_map = lobpcg(
                 laplacian, X, tol=1e-5, largest=False, maxiter=2000
             )

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -143,7 +143,7 @@ def test_spectral_embedding_two_components(eigen_solver, dtype, seed=36):
     for dtype in [np.float32, np.float64]:
         embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))
         # thresholding on the first components using 0.
-        label_ = np.array(embedded_coordinate.ravel() < 0, dtype=np.float64)
+        label_ = np.array(embedded_coordinate.ravel() < 0, dtype=np.int64)
         assert normalized_mutual_info_score(true_label, label_) == pytest.approx(1.0)
 
 

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -132,18 +132,15 @@ def test_spectral_embedding_two_components(eigen_solver):
         eigen_solver=eigen_solver,
     )
     for dtype in [np.float32, np.float64]:
-            if eigen_solver=="amg" and not amg_loaded:
-                with pytest.warns(
-                    ValueError,
-                    match="The eigen_solver was set to 'amg', but pyamg"
-                    ):
-                        embedded_coordinate = se_precomp.fit_transform(
-                            affinity.astype(dtype)
-                            )
-            else:
+        if eigen_solver == "amg" and not amg_loaded:
+            with pytest.warns(
+                ValueError, match="The eigen_solver was set to 'amg', but"
+            ):
                 embedded_coordinate = se_precomp.fit_transform(
-                            affinity.astype(dtype)
-                            )
+                    affinity.astype(dtype))
+        else:
+            embedded_coordinate = se_precomp.fit_transform(
+                affinity.astype(dtype))
 
         # thresholding on the first components using 0.
         label_ = np.array(embedded_coordinate.ravel() < 0, dtype="float")

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -21,12 +21,11 @@ from sklearn.utils._testing import assert_array_equal
 
 try:
     from pyamg import smoothed_aggregation_solver  # noqa
-
-    is_pyamg_not_available = False
+    pyamg_available = True
 except ImportError:
-    is_pyamg_not_available = True
+    pyamg_available = False
 skip_if_no_pyamg = pytest.mark.skipif(
-    is_pyamg_not_available, reason="PyAMG is required for the tests in this function."
+    not pyamg_available, reason="PyAMG is required for the tests in this function."
 )
 
 # non centered, sparse centers to check the
@@ -239,7 +238,7 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
 @pytest.mark.skipif(
-    is_pyamg_not_available, reason="PyAMG is not installed and thus we cannot test."
+    not pyamg_available, reason="PyAMG is required for the tests in this function."
 )
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver(dtype, seed=36):
@@ -293,7 +292,7 @@ def test_spectral_embedding_amg_solver(dtype, seed=36):
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
 @pytest.mark.skipif(
-    is_pyamg_not_available, reason="PyAMG is not installed and thus we cannot test."
+    not pyamg_available, reason="PyAMG is required for the tests in this function."
 )
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver_failure(dtype, seed=36):
@@ -468,7 +467,7 @@ def test_spectral_embedding_preserves_dtype(eigen_solver, dtype):
 
 
 @pytest.mark.skipif(
-    not is_pyamg_not_available,
+    pyamg__available,
     reason="PyAMG is installed and we should not test for an error.",
 )
 def test_error_pyamg_not_available():

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -20,7 +20,7 @@ from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
 
 try:
-    import pyamg
+    from pyamg import smoothed_aggregation_solver # noqa
     is_pyamg_not_available = False
 except ImportError:
     is_pyamg_not_available = True

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -132,13 +132,11 @@ def test_spectral_embedding_two_components(eigen_solver, seed=36):
     )
     for dtype in [np.float32, np.float64]:
         if eigen_solver == "amg" and not amg_loaded:
-            # with pytest.raises(
-            #     ValueError, match="The eigen_solver was set to 'amg', but"
-            # ):
-            #     embedded_coordinate = se_precomp.fit_transform(
-            #         affinity.astype(dtype)
-            #     )
-            pass
+            with pytest.raises(ValueError) as e:
+                embedded_coordinate = se_precomp.fit_transform(
+                    affinity.astype(dtype)
+                )
+            assert "The eigen_solver was set to 'amg', but" in str(e.value)
         else:
             embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))
             # thresholding on the first components using 0.

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -122,7 +122,7 @@ def test_spectral_embedding_two_components(eigen_solver):
         n_components=1,
         affinity="precomputed",
         random_state=np.random.RandomState(seed),
-        eigen_solver="eigen_solver",
+        eigen_solver=eigen_solver,
     )
     for dtype in [np.float32, np.float64]:
         embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -133,9 +133,7 @@ def test_spectral_embedding_two_components(eigen_solver, seed=36):
     for dtype in [np.float32, np.float64]:
         if eigen_solver == "amg" and not amg_loaded:
             with pytest.raises(ValueError) as e:
-                embedded_coordinate = se_precomp.fit_transform(
-                    affinity.astype(dtype)
-                )
+                embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))
             assert "The eigen_solver was set to 'amg', but" in str(e.value)
         else:
             embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -20,7 +20,8 @@ from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
 
 try:
-    from pyamg import smoothed_aggregation_solver # noqa
+    from pyamg import smoothed_aggregation_solver  # noqa
+    
     is_pyamg_not_available = False
 except ImportError:
     is_pyamg_not_available = True

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -121,7 +121,7 @@ def test_spectral_embedding_two_components(seed=36):
         n_components=1,
         affinity="precomputed",
         random_state=np.random.RandomState(seed),
-        eigen_solver=eigen_solver,
+        eigen_solver="eigen_solver",
     )
     for dtype in [np.float32, np.float64]:
         embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -133,26 +133,34 @@ def test_spectral_embedding_two_components(eigen_solver):
     )
     for dtype in [np.float32, np.float64]:
         if eigen_solver == "amg" and not amg_loaded:
-            with pytest.warns(
+            with pytest.raises(
                 ValueError, match="The eigen_solver was set to 'amg', but"
             ):
                 embedded_coordinate = se_precomp.fit_transform(
-                    affinity.astype(dtype))
+                    affinity.astype(dtype)
+                )
         else:
             embedded_coordinate = se_precomp.fit_transform(
-                affinity.astype(dtype))
+                affinity.astype(dtype)
+            )
 
         # thresholding on the first components using 0.
         label_ = np.array(embedded_coordinate.ravel() < 0, dtype="float")
-        assert normalized_mutual_info_score(true_label, label_) == pytest.approx(1.0)
+        assert normalized_mutual_info_score(
+            true_label, label_
+        ) == pytest.approx(1.0)
 
 
-@pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])
+@pytest.mark.parametrize(
+    "X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"]
+)
 def test_spectral_embedding_precomputed_affinity(X, seed=36):
     # Test spectral embedding with precomputed kernel
     gamma = 1.0
     se_precomp = SpectralEmbedding(
-        n_components=2, affinity="precomputed", random_state=np.random.RandomState(seed)
+        n_components=2,
+        affinity="precomputed",
+        random_state=np.random.RandomState(seed),
     )
     se_rbf = SpectralEmbedding(
         n_components=2,
@@ -162,7 +170,9 @@ def test_spectral_embedding_precomputed_affinity(X, seed=36):
     )
     embed_precomp = se_precomp.fit_transform(rbf_kernel(X, gamma=gamma))
     embed_rbf = se_rbf.fit_transform(X)
-    assert_array_almost_equal(se_precomp.affinity_matrix_, se_rbf.affinity_matrix_)
+    assert_array_almost_equal(
+        se_precomp.affinity_matrix_, se_rbf.affinity_matrix_
+    )
     _assert_equal_with_sign_flipping(embed_precomp, embed_rbf, 0.05)
 
 
@@ -171,7 +181,9 @@ def test_precomputed_nearest_neighbors_filtering():
     n_neighbors = 2
     results = []
     for additional_neighbors in [0, 10]:
-        nn = NearestNeighbors(n_neighbors=n_neighbors + additional_neighbors).fit(S)
+        nn = NearestNeighbors(
+            n_neighbors=n_neighbors + additional_neighbors
+        ).fit(S)
         graph = nn.kneighbors_graph(S, mode="connectivity")
         embedding = (
             SpectralEmbedding(
@@ -188,7 +200,9 @@ def test_precomputed_nearest_neighbors_filtering():
     assert_array_equal(results[0], results[1])
 
 
-@pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])
+@pytest.mark.parametrize(
+    "X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"]
+)
 def test_spectral_embedding_callable_affinity(X, seed=36):
     # Test spectral embedding with callable affinity
     gamma = 0.9
@@ -207,7 +221,9 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
     )
     embed_rbf = se_rbf.fit_transform(X)
     embed_callable = se_callable.fit_transform(X)
-    assert_array_almost_equal(se_callable.affinity_matrix_, se_rbf.affinity_matrix_)
+    assert_array_almost_equal(
+        se_callable.affinity_matrix_, se_rbf.affinity_matrix_
+    )
     assert_array_almost_equal(kern, se_rbf.affinity_matrix_)
     _assert_equal_with_sign_flipping(embed_rbf, embed_callable, 0.05)
 
@@ -298,7 +314,9 @@ def test_spectral_embedding_amg_solver_failure():
         _assert_equal_with_sign_flipping(embedding, new_embedding, tol=0.05)
 
 
-@pytest.mark.filterwarnings("ignore:the behavior of nmi will change in version 0.22")
+@pytest.mark.filterwarnings(
+    "ignore:the behavior of nmi will change in version 0.22"
+)
 def test_pipeline_spectral_clustering(seed=36):
     # Test using pipeline to do spectral clustering
     random_state = np.random.RandomState(seed)
@@ -334,7 +352,9 @@ def test_spectral_embedding_unknown_eigensolver(seed=36):
 def test_spectral_embedding_unknown_affinity(seed=36):
     # Test that SpectralClustering fails with an unknown affinity type
     se = SpectralEmbedding(
-        n_components=1, affinity="<unknown>", random_state=np.random.RandomState(seed)
+        n_components=1,
+        affinity="<unknown>",
+        random_state=np.random.RandomState(seed),
     )
     with pytest.raises(ValueError):
         se.fit(S)
@@ -420,7 +440,9 @@ def test_spectral_embedding_first_eigen_vector():
 
 
 # TODO: Remove in 1.1
-@pytest.mark.parametrize("affinity", ["precomputed", "precomputed_nearest_neighbors"])
+@pytest.mark.parametrize(
+    "affinity", ["precomputed", "precomputed_nearest_neighbors"]
+)
 def test_spectral_embedding_pairwise_deprecated(affinity):
     se = SpectralEmbedding(affinity=affinity)
     msg = r"Attribute `_pairwise` was deprecated in version 0\.24"

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -21,7 +21,7 @@ from sklearn.utils._testing import assert_array_equal
 
 try:
     from pyamg import smoothed_aggregation_solver  # noqa
-    
+
     is_pyamg_not_available = False
 except ImportError:
     is_pyamg_not_available = True

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -87,7 +87,7 @@ def test_sparse_graph_connected_component():
 
 @pytest.mark.parametrize("eigen_solver", ("arpack", "lobpcg", "amg"))
 def test_spectral_embedding_two_components(eigen_solver):
-    seed=36
+    seed = 36
     # Test spectral embedding with two components
     random_state = np.random.RandomState(seed)
     n_sample = 100

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -245,7 +245,9 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
-def test_spectral_embedding_amg_solver(seed=36):
+@pytest.mark.parametrize("dtype", ("'float32'", "'float64'"))
+def test_spectral_embedding_amg_solver(dtype):
+    seed = 36
     # Test spectral embedding with amg solver
     pytest.importorskip("pyamg")
 
@@ -263,8 +265,8 @@ def test_spectral_embedding_amg_solver(seed=36):
         n_neighbors=5,
         random_state=np.random.RandomState(seed),
     )
-    embed_amg = se_amg.fit_transform(S)
-    embed_arpack = se_arpack.fit_transform(S)
+    embed_amg = se_amg.fit_transform(S.astype(dtype))
+    embed_arpack = se_arpack.fit_transform(S.astype(dtype))
     _assert_equal_with_sign_flipping(embed_amg, embed_arpack, 1e-5)
 
     # same with special case in which amg is not actually used
@@ -279,8 +281,8 @@ def test_spectral_embedding_amg_solver(seed=36):
     ).toarray()
     se_amg.affinity = "precomputed"
     se_arpack.affinity = "precomputed"
-    embed_amg = se_amg.fit_transform(affinity)
-    embed_arpack = se_arpack.fit_transform(affinity)
+    embed_amg = se_amg.fit_transform(affinity.astype(dtype))
+    embed_arpack = se_arpack.fit_transform(affinity.astype(dtype))
     _assert_equal_with_sign_flipping(embed_amg, embed_arpack, 1e-5)
 
 
@@ -298,12 +300,14 @@ def test_spectral_embedding_amg_solver(seed=36):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
-def test_spectral_embedding_amg_solver_failure():
+@pytest.mark.parametrize("dtype", ("'float32'", "'float64'"))
+def test_spectral_embedding_amg_solver_failure(dtype):
     # Non-regression test for amg solver failure (issue #13393 on github)
     pytest.importorskip("pyamg")
     seed = 36
     num_nodes = 100
     X = sparse.rand(num_nodes, num_nodes, density=0.1, random_state=seed)
+    X = X.astype(dtype)
     upper = sparse.triu(X) - sparse.diags(X.diagonal())
     sym_matrix = upper + upper.T
     embedding = spectral_embedding(

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -93,8 +93,7 @@ def test_sparse_graph_connected_component():
 
 
 @pytest.mark.parametrize("eigen_solver", ("arpack", "lobpcg", "amg"))
-def test_spectral_embedding_two_components(eigen_solver):
-    seed = 36
+def test_spectral_embedding_two_components(eigen_solver, seed=36):
     # Test spectral embedding with two components
     random_state = np.random.RandomState(seed)
     n_sample = 100
@@ -152,8 +151,7 @@ def test_spectral_embedding_two_components(eigen_solver):
 @pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])
 @pytest.mark.parametrize("eigen_solver", ("arpack", "lobpcg", "amg"))
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
-def test_spectral_embedding_precomputed_affinity(X, eigen_solver, dtype):
-    seed = 36
+def test_spectral_embedding_precomputed_affinity(X, eigen_solver, dtype, seed=36):
     # Test spectral embedding with precomputed kernel
     gamma = 1.0
     se_precomp = SpectralEmbedding(
@@ -246,8 +244,7 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
-def test_spectral_embedding_amg_solver(dtype):
-    seed = 36
+def test_spectral_embedding_amg_solver(dtype, seed=36):
     # Test spectral embedding with amg solver
     pytest.importorskip("pyamg")
 
@@ -301,10 +298,9 @@ def test_spectral_embedding_amg_solver(dtype):
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
-def test_spectral_embedding_amg_solver_failure(dtype):
+def test_spectral_embedding_amg_solver_failure(dtype, seed=36):
     # Non-regression test for amg solver failure (issue #13393 on github)
     pytest.importorskip("pyamg")
-    seed = 36
     num_nodes = 100
     X = sparse.rand(num_nodes, num_nodes, density=0.1, random_state=seed)
     X = X.astype(dtype)

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -151,7 +151,7 @@ def test_spectral_embedding_two_components(eigen_solver):
 
 @pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])
 @pytest.mark.parametrize("eigen_solver", ("arpack", "lobpcg", "amg"))
-@pytest.mark.parametrize("dtype", ("float32", "float64"))
+@pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_precomputed_affinity(X, eigen_solver, dtype):
     seed = 36
     # Test spectral embedding with precomputed kernel
@@ -245,7 +245,7 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
-@pytest.mark.parametrize("dtype", ("float32", "float64"))
+@pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver(dtype):
     seed = 36
     # Test spectral embedding with amg solver
@@ -300,7 +300,7 @@ def test_spectral_embedding_amg_solver(dtype):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
-@pytest.mark.parametrize("dtype", ("float32", "float64"))
+@pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver_failure(dtype):
     # Non-regression test for amg solver failure (issue #13393 on github)
     pytest.importorskip("pyamg")

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -86,7 +86,8 @@ def test_sparse_graph_connected_component():
 
 
 @pytest.mark.parametrize("eigen_solver", ("arpack", "lobpcg", "amg"))
-def test_spectral_embedding_two_components(seed=36):
+def test_spectral_embedding_two_components(eigen_solver):
+    seed=36
     # Test spectral embedding with two components
     random_state = np.random.RandomState(seed)
     n_sample = 100

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -21,6 +21,7 @@ from sklearn.utils._testing import assert_array_equal
 
 try:
     from pyamg import smoothed_aggregation_solver  # noqa
+
     pyamg_available = True
 except ImportError:
     pyamg_available = False

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -133,27 +133,23 @@ def test_spectral_embedding_two_components(eigen_solver):
     )
     for dtype in [np.float32, np.float64]:
         if eigen_solver == "amg" and not amg_loaded:
-            with pytest.raises(
-                ValueError, match="The eigen_solver was set to 'amg', but"
-            ):
-                embedded_coordinate = se_precomp.fit_transform(
-                    affinity.astype(dtype)
-                )
+            # with pytest.raises(
+            #     ValueError, match="The eigen_solver was set to 'amg', but"
+            # ):
+            #     embedded_coordinate = se_precomp.fit_transform(
+            #         affinity.astype(dtype)
+            #     )
+            pass
         else:
-            embedded_coordinate = se_precomp.fit_transform(
-                affinity.astype(dtype)
+            embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))
+            # thresholding on the first components using 0.
+            label_ = np.array(embedded_coordinate.ravel() < 0, dtype="float")
+            assert normalized_mutual_info_score(true_label, label_) == pytest.approx(
+                1.0
             )
 
-        # thresholding on the first components using 0.
-        label_ = np.array(embedded_coordinate.ravel() < 0, dtype="float")
-        assert normalized_mutual_info_score(
-            true_label, label_
-        ) == pytest.approx(1.0)
 
-
-@pytest.mark.parametrize(
-    "X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"]
-)
+@pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])
 def test_spectral_embedding_precomputed_affinity(X, seed=36):
     # Test spectral embedding with precomputed kernel
     gamma = 1.0
@@ -170,9 +166,7 @@ def test_spectral_embedding_precomputed_affinity(X, seed=36):
     )
     embed_precomp = se_precomp.fit_transform(rbf_kernel(X, gamma=gamma))
     embed_rbf = se_rbf.fit_transform(X)
-    assert_array_almost_equal(
-        se_precomp.affinity_matrix_, se_rbf.affinity_matrix_
-    )
+    assert_array_almost_equal(se_precomp.affinity_matrix_, se_rbf.affinity_matrix_)
     _assert_equal_with_sign_flipping(embed_precomp, embed_rbf, 0.05)
 
 
@@ -181,9 +175,7 @@ def test_precomputed_nearest_neighbors_filtering():
     n_neighbors = 2
     results = []
     for additional_neighbors in [0, 10]:
-        nn = NearestNeighbors(
-            n_neighbors=n_neighbors + additional_neighbors
-        ).fit(S)
+        nn = NearestNeighbors(n_neighbors=n_neighbors + additional_neighbors).fit(S)
         graph = nn.kneighbors_graph(S, mode="connectivity")
         embedding = (
             SpectralEmbedding(
@@ -200,9 +192,7 @@ def test_precomputed_nearest_neighbors_filtering():
     assert_array_equal(results[0], results[1])
 
 
-@pytest.mark.parametrize(
-    "X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"]
-)
+@pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])
 def test_spectral_embedding_callable_affinity(X, seed=36):
     # Test spectral embedding with callable affinity
     gamma = 0.9
@@ -221,9 +211,7 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
     )
     embed_rbf = se_rbf.fit_transform(X)
     embed_callable = se_callable.fit_transform(X)
-    assert_array_almost_equal(
-        se_callable.affinity_matrix_, se_rbf.affinity_matrix_
-    )
+    assert_array_almost_equal(se_callable.affinity_matrix_, se_rbf.affinity_matrix_)
     assert_array_almost_equal(kern, se_rbf.affinity_matrix_)
     _assert_equal_with_sign_flipping(embed_rbf, embed_callable, 0.05)
 
@@ -314,9 +302,7 @@ def test_spectral_embedding_amg_solver_failure():
         _assert_equal_with_sign_flipping(embedding, new_embedding, tol=0.05)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:the behavior of nmi will change in version 0.22"
-)
+@pytest.mark.filterwarnings("ignore:the behavior of nmi will change in version 0.22")
 def test_pipeline_spectral_clustering(seed=36):
     # Test using pipeline to do spectral clustering
     random_state = np.random.RandomState(seed)
@@ -440,9 +426,7 @@ def test_spectral_embedding_first_eigen_vector():
 
 
 # TODO: Remove in 1.1
-@pytest.mark.parametrize(
-    "affinity", ["precomputed", "precomputed_nearest_neighbors"]
-)
+@pytest.mark.parametrize("affinity", ["precomputed", "precomputed_nearest_neighbors"])
 def test_spectral_embedding_pairwise_deprecated(affinity):
     se = SpectralEmbedding(affinity=affinity)
     msg = r"Attribute `_pairwise` was deprecated in version 0\.24"

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -99,7 +99,7 @@ def test_sparse_graph_connected_component():
         "arpack",
         "lobpcg",
         pytest.param("amg", marks=skip_if_no_pyamg),
-    ]
+    ],
 )
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_spectral_embedding_two_components(eigen_solver, dtype, seed=36):
@@ -143,9 +143,7 @@ def test_spectral_embedding_two_components(eigen_solver, dtype, seed=36):
         embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))
         # thresholding on the first components using 0.
         label_ = np.array(embedded_coordinate.ravel() < 0, dtype=np.float64)
-        assert normalized_mutual_info_score(true_label, label_) == pytest.approx(
-            1.0
-        )
+        assert normalized_mutual_info_score(true_label, label_) == pytest.approx(1.0)
 
 
 @pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])
@@ -155,7 +153,7 @@ def test_spectral_embedding_two_components(eigen_solver, dtype, seed=36):
         "arpack",
         "lobpcg",
         pytest.param("amg", marks=skip_if_no_pyamg),
-    ]
+    ],
 )
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_precomputed_affinity(X, eigen_solver, dtype, seed=36):
@@ -174,9 +172,7 @@ def test_spectral_embedding_precomputed_affinity(X, eigen_solver, dtype, seed=36
         random_state=np.random.RandomState(seed),
         eigen_solver=eigen_solver,
     )
-    embed_precomp = se_precomp.fit_transform(
-        rbf_kernel(X.astype(dtype), gamma=gamma)
-    )
+    embed_precomp = se_precomp.fit_transform(rbf_kernel(X.astype(dtype), gamma=gamma))
     embed_rbf = se_rbf.fit_transform(X.astype(dtype))
     assert_array_almost_equal(se_precomp.affinity_matrix_, se_rbf.affinity_matrix_)
     _assert_equal_with_sign_flipping(embed_precomp, embed_rbf, 0.05)

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -300,7 +300,7 @@ def test_spectral_embedding_amg_solver(dtype):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
-@pytest.mark.parametrize("dtype", ("'float32'", "'float64'"))
+@pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver_failure(dtype):
     # Non-regression test for amg solver failure (issue #13393 on github)
     pytest.importorskip("pyamg")

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -151,7 +151,7 @@ def test_spectral_embedding_two_components(eigen_solver):
 
 @pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])
 @pytest.mark.parametrize("eigen_solver", ("arpack", "lobpcg", "amg"))
-@pytest.mark.parametrize("dtype", (float32, float64))
+@pytest.mark.parametrize("dtype", ("float32", "float64"))
 def test_spectral_embedding_precomputed_affinity(X, eigen_solver, dtype):
     seed = 36
     # Test spectral embedding with precomputed kernel
@@ -245,7 +245,7 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
-@pytest.mark.parametrize("dtype", (float32, float64))
+@pytest.mark.parametrize("dtype", ("float32", "float64"))
 def test_spectral_embedding_amg_solver(dtype):
     seed = 36
     # Test spectral embedding with amg solver
@@ -300,7 +300,7 @@ def test_spectral_embedding_amg_solver(dtype):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
-@pytest.mark.parametrize("dtype", (float32, float64))
+@pytest.mark.parametrize("dtype", ("float32", "float64"))
 def test_spectral_embedding_amg_solver_failure(dtype):
     # Non-regression test for amg solver failure (issue #13393 on github)
     pytest.importorskip("pyamg")

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -151,7 +151,7 @@ def test_spectral_embedding_two_components(eigen_solver):
 
 @pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])
 @pytest.mark.parametrize("eigen_solver", ("arpack", "lobpcg", "amg"))
-@pytest.mark.parametrize("dtype", ("np.float32", "np.float64"))
+@pytest.mark.parametrize("dtype", (float32, float64))
 def test_spectral_embedding_precomputed_affinity(X, eigen_solver, dtype):
     seed = 36
     # Test spectral embedding with precomputed kernel
@@ -245,7 +245,7 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
-@pytest.mark.parametrize("dtype", ("'float32'", "'float64'"))
+@pytest.mark.parametrize("dtype", (float32, float64))
 def test_spectral_embedding_amg_solver(dtype):
     seed = 36
     # Test spectral embedding with amg solver
@@ -300,7 +300,7 @@ def test_spectral_embedding_amg_solver(dtype):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
-@pytest.mark.parametrize("dtype", (np.float32, np.float64))
+@pytest.mark.parametrize("dtype", (float32, float64))
 def test_spectral_embedding_amg_solver_failure(dtype):
     # Non-regression test for amg solver failure (issue #13393 on github)
     pytest.importorskip("pyamg")

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -467,7 +467,7 @@ def test_spectral_embedding_preserves_dtype(eigen_solver, dtype):
 
 
 @pytest.mark.skipif(
-    pyamg__available,
+    pyamg_available,
     reason="PyAMG is installed and we should not test for an error.",
 )
 def test_error_pyamg_not_available():

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -241,6 +241,9 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
+@pytest.mark.skipif(
+    is_pyamg_not_available, reason="PyAMG is not installed and thus we cannot test."
+)
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver(dtype, seed=36):
     # Test spectral embedding with amg solver

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -243,9 +243,6 @@ def test_spectral_embedding_callable_affinity(X, seed=36):
 )
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver(dtype, seed=36):
-    # Test spectral embedding with amg solver
-    pytest.importorskip("pyamg")
-
     se_amg = SpectralEmbedding(
         n_components=2,
         affinity="nearest_neighbors",
@@ -295,10 +292,12 @@ def test_spectral_embedding_amg_solver(dtype, seed=36):
 @pytest.mark.filterwarnings(
     "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
 )
+@pytest.mark.skipif(
+    is_pyamg_not_available, reason="PyAMG is not installed and thus we cannot test."
+)
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver_failure(dtype, seed=36):
     # Non-regression test for amg solver failure (issue #13393 on github)
-    pytest.importorskip("pyamg")
     num_nodes = 100
     X = sparse.rand(num_nodes, num_nodes, density=0.1, random_state=seed)
     X = X.astype(dtype)


### PR DESCRIPTION
Remove check_array call for float64, since both lobpcg function and pyamg package support float32 for a few years now; see
https://github.com/scikit-learn/scikit-learn/issues/21321


#### Reference Issues/PRs
Fixes #21321.

#### What does this implement/fix? Explain your changes.
Remove check_array call for float64, since both lobpcg function and pyamg package support float32 for a few years now