### PR TITLE
Test decision tree pickle for different endianness

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2212,12 +2212,11 @@ def test_different_endianness_pickle():
     assert np.isclose(score, new_score)
 
 
+@pytest.mark.skipif(
+    parse_version(joblib.__version__) < parse_version("1.1"),
+    reason="joblib >= 1.1 is needed to load numpy arrays in native endianness",
+)
 def test_different_endianness_joblib_pickle():
-    if parse_version(joblib.__version__) < parse_version("1.1"):
-        pytest.skip(
-            "joblib >= 1.1 is needed to load numpy arrays in native endianness"
-        )
-
     X, y = datasets.make_classification(random_state=0)
 
     clf = DecisionTreeClassifier(random_state=0, max_depth=3)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -37,6 +37,7 @@ from sklearn.utils._testing import skip_if_32bit
 
 from sklearn.utils.estimator_checks import check_sample_weights_invariance
 from sklearn.utils.validation import check_random_state
+from sklearn.utils import parse_version
 
 from sklearn.exceptions import NotFittedError
 
@@ -2212,6 +2213,11 @@ def test_different_endianness_pickle():
 
 
 def test_different_endianness_joblib_pickle():
+    if parse_version(joblib.__version__) < parse_version("1.1"):
+        pytest.skip(
+            "joblib >= 1.1 is needed to load numpy arrays in native endianness"
+        )
+
     X, y = datasets.make_classification(random_state=0)
 
     clf = DecisionTreeClassifier(random_state=0, max_depth=3)


### PR DESCRIPTION
#### Reference Issues/PRs

Close #21359

#### What does this implement/fix? Explain your changes.

This adds a test that checks that pickles containing big endian arrays can be loaded on a little-endian machine.

The way the pickles are created is to change the `Pickle` `dispatch_table` or to reimplement `NumpyPickle.save` for joblib pickles. This creates pickles with numpy arrays in big endian, which does not match exactly a pickle created on a big endian machine. The main advantage IMO is that we have some test for #17644 ...

I thought it was simpler that using qemu inside a docker image (look at https://github.com/scikit-learn/scikit-learn/issues/21237#issuecomment-938754497 for more details) as mentioned in https://github.com/scikit-learn/scikit-learn/issues/19602#issuecomment-942466588.

Doing something similar for more (or even all estimators) as mentioned in https://github.com/scikit-learn/scikit-learn/issues/19602#issuecomment-942378168 is left for a future PR.

