### PR TITLE
CI show the diff when black is applied

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
         pip install pytest flake8 mypy==0.782 black==21.6b0
       displayName: Install linters
     - bash: |
-        black --check .
+        black --check --diff .
       displayName: Run black
     - bash: |
         ./build_tools/circle/linting.sh

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -908,7 +908,10 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
            [ 1.,  2.]])
     """
 
-    def __init__(self, n_clusters=8, *,
+    def __init__(
+        self,
+        n_clusters=8,
+        *,
         init="k-means++",
         n_init=10,
         max_iter=300,

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -908,10 +908,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
            [ 1.,  2.]])
     """
 
-    def __init__(
-        self,
-        n_clusters=8,
-        *,
+    def __init__(self, n_clusters=8, *,
         init="k-means++",
         n_init=10,
         max_iter=300,


### PR DESCRIPTION
Sometimes it could be handy to see the diff when `black` is failing on the CI.
It could give a hint to some contributors.