### PR TITLE
MNT modify test_nested_cv to speed-up CI build two

### DIFF
--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1776,7 +1776,7 @@ def test_nested_cv():
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):
         gs = GridSearchCV(
-            DummyClassifier(), 
+            DummyClassifier(),
             param_grid={"strategy": ["stratified", "most_frequent"]},
             cv=inner_cv, error_score="raise"
         )

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1770,8 +1770,9 @@ def test_nested_cv():
     groups = rng.randint(0, 5, 15)
 
     cvs = [
+        LeaveOneGroupOut(),
         StratifiedKFold(n_splits=2),
-        StratifiedShuffleSplit(n_splits=2, random_state=0),
+        GroupKFold(n_splits=3),
     ]
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -37,7 +37,7 @@ from sklearn.model_selection import RepeatedKFold
 from sklearn.model_selection import RepeatedStratifiedKFold
 from sklearn.model_selection import StratifiedGroupKFold
 
-from sklearn.linear_model import Ridge
+from sklearn.dummy import DummyClassifier
 
 from sklearn.model_selection._split import _validate_shuffle_split
 from sklearn.model_selection._split import _build_repr
@@ -1770,16 +1770,13 @@ def test_nested_cv():
     groups = rng.randint(0, 5, 15)
 
     cvs = [
-        LeaveOneGroupOut(),
-        GroupKFold(n_splits=2),
         StratifiedKFold(n_splits=2),
-        StratifiedGroupKFold(n_splits=2),
         StratifiedShuffleSplit(n_splits=2, random_state=0),
     ]
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):
         gs = GridSearchCV(
-            Ridge(max_iter=1), param_grid={"alpha": [1, 0.1]}, cv=inner_cv, error_score="raise"
+            DummyClassifier(), param_grid={"strategy": ["stratified", "most_frequent"]}, cv=inner_cv, error_score="raise"
         )
         cross_val_score(
             gs, X=X, y=y, groups=groups, cv=outer_cv, fit_params={"groups": groups}

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1771,16 +1771,15 @@ def test_nested_cv():
 
     cvs = [
         LeaveOneGroupOut(),
-        LeaveOneOut(),
-        GroupKFold(n_splits=3),
-        StratifiedKFold(),
-        StratifiedGroupKFold(n_splits=3),
-        StratifiedShuffleSplit(n_splits=3, random_state=0),
+        GroupKFold(n_splits=2),
+        StratifiedKFold(n_splits=2),
+        StratifiedGroupKFold(n_splits=2),
+        StratifiedShuffleSplit(n_splits=2, random_state=0),
     ]
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):
         gs = GridSearchCV(
-            Ridge(), param_grid={"alpha": [1, 0.1]}, cv=inner_cv, error_score="raise"
+            Ridge(max_iter=1), param_grid={"alpha": [1, 0.1]}, cv=inner_cv, error_score="raise"
         )
         cross_val_score(
             gs, X=X, y=y, groups=groups, cv=outer_cv, fit_params={"groups": groups}

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1776,7 +1776,9 @@ def test_nested_cv():
 
     for inner_cv, outer_cv in combinations_with_replacement(cvs, 2):
         gs = GridSearchCV(
-            DummyClassifier(), param_grid={"strategy": ["stratified", "most_frequent"]}, cv=inner_cv, error_score="raise"
+            DummyClassifier(), 
+            param_grid={"strategy": ["stratified", "most_frequent"]},
+            cv=inner_cv, error_score="raise"
         )
         cross_val_score(
             gs, X=X, y=y, groups=groups, cv=outer_cv, fit_params={"groups": groups}

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1778,7 +1778,8 @@ def test_nested_cv():
         gs = GridSearchCV(
             DummyClassifier(),
             param_grid={"strategy": ["stratified", "most_frequent"]},
-            cv=inner_cv, error_score="raise"
+            cv=inner_cv,
+            error_score="raise",
         )
         cross_val_score(
             gs, X=X, y=y, groups=groups, cv=outer_cv, fit_params={"groups": groups}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
References #21407, #21507

#### What does this implement/fix? Explain your changes.
I run black to format the code into the standard format. Please find specific changes to the test_split.py to the PR #21407 and #21507 

Before changes:
`pytest -v --durations=1 -k test_nested_cv test_split.py` the call took 4.69s.

After changes:
`pytest -v --durations=1 -k test_nested_cv test_split.py` the call took 0.13s 

#### Any other comments?
I had edited the file initially using github editor, hence, no tests were run. Now, I run it in my PC and following instructions by @glemaitre and @thomasjpfan thanks so much.

Pair programming partner @Lontia
#DataUmbrella Sprint