### PR TITLE
MAINT Removes short summary for most builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,7 @@ jobs:
         PYTHON_VERSION: '*'
         BLAS: 'mkl'
         COVERAGE: 'true'
+        SHOW_SHORT_SUMMARY: 'true'
 
 # Check compilation with Ubuntu bionic 18.04 LTS and scipy from conda-forge
 - template: build_tools/azure/posix.yml

--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -34,6 +34,7 @@ jobs:
     # Set in azure-pipelines.yml
     DISTRIB: ''
     DOCKER_CONTAINER: ''
+    SHOW_SHORT_SUMMARY: 'false'
   strategy:
     matrix:
       ${{ insert }}: ${{ parameters.matrix }}

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -33,6 +33,7 @@ jobs:
     THREADPOOLCTL_VERSION: 'latest'
     COVERAGE: 'true'
     TEST_DOCSTRINGS: 'false'
+    SHOW_SHORT_SUMMARY: 'false'
   strategy:
     matrix:
       ${{ insert }}: ${{ parameters.matrix }}

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -50,6 +50,10 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
     TEST_CMD="$TEST_CMD -n2"
 fi
 
+if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
+    TEST_CMD="$TEST_CMD -rN"
+fi
+
 set -x
 eval "$TEST_CMD --pyargs sklearn"
 set +x

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -50,8 +50,8 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
     TEST_CMD="$TEST_CMD -n2"
 fi
 
-if [[ "$SHOW_SHORT_SUMMARY" == "false" ]]; then
-    TEST_CMD="$TEST_CMD -rN"
+if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
+    TEST_CMD="$TEST_CMD -rxXs"
 fi
 
 set -x

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -50,7 +50,7 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
     TEST_CMD="$TEST_CMD -n2"
 fi
 
-if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
+if [[ "$SHOW_SHORT_SUMMARY" == "false" ]]; then
     TEST_CMD="$TEST_CMD -rN"
 fi
 

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -51,7 +51,7 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
 fi
 
 if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
-    TEST_CMD="$TEST_CMD -rxXs"
+    TEST_CMD="$TEST_CMD -ra"
 fi
 
 set -x

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -20,6 +20,7 @@ jobs:
     PYTEST_XDIST: 'true'
     PYTEST_XDIST_VERSION: 'latest'
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
+    SHOW_SHORT_SUMMARY: 'false'
   strategy:
     matrix:
       ${{ insert }}: ${{ parameters.matrix }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ addopts =
     --doctest-modules
     --disable-pytest-warnings
     --color=yes
-    -rxXs
+    -rN
 
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning


### PR DESCRIPTION
When looking at CI builds, I frequently scroll pass the summary. This PR removes the summary except for one of the builds on the CI.

CC @jjerphan @glemaitre @ogrisel 