### PR TITLE
DOC Ensures that sklearn.base.clone passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -13,7 +13,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 
 FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn._config.get_config",
-    "sklearn.base.clone",
     "sklearn.cluster._affinity_propagation.affinity_propagation",
     "sklearn.cluster._kmeans.kmeans_plusplus",
     "sklearn.cluster._mean_shift.estimate_bandwidth",

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -49,7 +49,7 @@ def clone(estimator, *, safe=True):
     Returns
     -------
     estimator : object
-        The deep copy of the estimator.
+        The deep copy of the input, an estimator if input is an estimator.
 
     Notes
     -----

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -48,7 +48,7 @@ def clone(estimator, *, safe=True):
 
     Returns
     -------
-    estimator : Estimator instance
+    estimator : object
         The deep copy of the estimator.
 
     Notes

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -33,6 +33,10 @@ from .utils.validation import _get_feature_names
 def clone(estimator, *, safe=True):
     """Construct a new unfitted estimator with the same parameters.
 
+    Clone does a deep copy of the model in an estimator
+    without actually copying attached data. It returns a new estimator
+    with the same parameters that has not been fitted on any data.
+
     Parameters
     ----------
     estimator : {list, tuple, set} of estimator instance or a single \
@@ -49,10 +53,6 @@ def clone(estimator, *, safe=True):
 
     Notes
     -----
-    Clone does a deep copy of the model in an estimator
-    without actually copying attached data. It returns a new estimator
-    with the same parameters that has not been fitted on any data.
-
     If the estimator's `random_state` parameter is an integer (or if the
     estimator doesn't have a `random_state` parameter), an *exact clone* is
     returned: the clone and the original estimator will give the exact same
@@ -88,6 +88,7 @@ def clone(estimator, *, safe=True):
         new_object_params[name] = clone(param, safe=False)
     new_object = klass(**new_object_params)
     params_set = new_object.get_params(deep=False)
+
     # quick sanity check of the parameters of the clone
     for name in new_object_params:
         param1 = new_object_params[name]

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -31,29 +31,34 @@ from .utils.validation import _get_feature_names
 
 
 def clone(estimator, *, safe=True):
-    """Constructs a new unfitted estimator with the same parameters.
-
-    Clone does a deep copy of the model in an estimator
-    without actually copying attached data. It yields a new estimator
-    with the same parameters that has not been fitted on any data.
-
-    If the estimator's `random_state` parameter is an integer (or if the
-    estimator doesn't have a `random_state` parameter), an *exact clone* is
-    returned: the clone and the original estimator will give the exact same
-    results. Otherwise, *statistical clone* is returned: the clone might
-    yield different results from the original estimator. More details can be
-    found in :ref:`randomness`.
+    """Construct a new unfitted estimator with the same parameters.
 
     Parameters
     ----------
     estimator : {list, tuple, set} of estimator instance or a single \
             estimator instance
         The estimator or group of estimators to be cloned.
-
     safe : bool, default=True
         If safe is False, clone will fall back to a deep copy on objects
         that are not estimators.
 
+    Returns
+    -------
+    estimator : Estimator instance
+        The deep copy of the estimator.
+
+    Notes
+    -----
+    Clone does a deep copy of the model in an estimator
+    without actually copying attached data. It returns a new estimator
+    with the same parameters that has not been fitted on any data.
+
+    If the estimator's `random_state` parameter is an integer (or if the
+    estimator doesn't have a `random_state` parameter), an *exact clone* is
+    returned: the clone and the original estimator will give the exact same
+    results. Otherwise, *statistical clone* is returned: the clone might
+    return different results from the original estimator. More details can be
+    found in :ref:`randomness`.
     """
     estimator_type = type(estimator)
     # XXX: not handling dictionaries
@@ -83,7 +88,6 @@ def clone(estimator, *, safe=True):
         new_object_params[name] = clone(param, safe=False)
     new_object = klass(**new_object_params)
     params_set = new_object.get_params(deep=False)
-
     # quick sanity check of the parameters of the clone
     for name in new_object_params:
         param1 = new_object_params[name]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #21350

#### What does this implement/fix? Explain your changes.
This PR fixes the following errors that were appearing for numpydoc validation for Base.clone():

- SS06: Summary should fit in a single line
- GL03: Double line break found; please use only one blank line to separate sections or paragraphs, and do not leave blank lines at the end of docstrings
- SS05: Summary must start with infinitive verb, not third person (e.g. use "Generate" instead of "Generates")
- RT01: No Returns section found
- YD01: No Yields section found

#### Any other comments?

One interesting note: If the summary/description includes the word "yield", it causes the validator to expect a `Yields` section in addition to a `Returns` section. However, including both also results in an error, and so it seems like it may be good practice to avoid using the keyword "yield" altogether inside of descriptions.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
