### PR TITLE
MAINT Lower memory usage for random_project examples

### DIFF
--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -498,11 +498,11 @@ class GaussianRandomProjection(BaseRandomProjection):
     >>> import numpy as np
     >>> from sklearn.random_projection import GaussianRandomProjection
     >>> rng = np.random.RandomState(42)
-    >>> X = rng.rand(100, 10000)
+    >>> X = rng.rand(25, 3000)
     >>> transformer = GaussianRandomProjection(random_state=rng)
     >>> X_new = transformer.fit_transform(X)
     >>> X_new.shape
-    (100, 3947)
+    (25, 2759)
     """
 
     def __init__(self, n_components="auto", *, eps=0.1, random_state=None):
@@ -648,14 +648,14 @@ class SparseRandomProjection(BaseRandomProjection):
     >>> import numpy as np
     >>> from sklearn.random_projection import SparseRandomProjection
     >>> rng = np.random.RandomState(42)
-    >>> X = rng.rand(100, 10000)
+    >>> X = rng.rand(25, 3000)
     >>> transformer = SparseRandomProjection(random_state=rng)
     >>> X_new = transformer.fit_transform(X)
     >>> X_new.shape
-    (100, 3947)
+    (25, 2759)
     >>> # very few components are non-zero
     >>> np.mean(transformer.components_ != 0)
-    0.0100...
+    0.0182...
     """
 
     def __init__(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #21528

#### What does this implement/fix? Explain your changes.
Reduces the memory usage by 80% and reduces runtime when running `pytest sklearn/random_projection.py`

### main

**runtime**: 1.2s

```
before setup: 101.220 MB, increment: 329.892 MB - sklearn/random_projection.py::sklearn.random_projection.GaussianRandomProjection
before setup: 431.161 MB, increment: 160.055 MB - sklearn/random_projection.py::sklearn.random_projection.SparseRandomProjection
```

### This PR

**runtime**: 0.2s
```
before setup: 103.186 MB, increment: 68.960 MB - sklearn/random_projection.py::sklearn.random_projection.GaussianRandomProjection
before setup: 172.179 MB, increment: 35.914 MB - sklearn/random_projection.py::sklearn.random_projection.SparseRandomProjection
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
