### PR TITLE
MAINT Revert HOTFIX introduced in #21549

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -13,8 +13,6 @@ fi
 
 make_conda() {
     TO_INSTALL="$@"
-    # TODO: Remove this line once setuptools#2849 is resolved.
-    TO_INSTALL="$TO_INSTALL setuptools<58.5"
     if [[ "$DISTRIB" == *"mamba"* ]]; then
         mamba create -n $VIRTUALENV --yes $TO_INSTALL
     else
@@ -90,8 +88,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     source $VIRTUALENV/bin/activate
     setup_ccache
     python -m pip install $(get_dep cython $CYTHON_VERSION) \
-                          $(get_dep joblib $JOBLIB_VERSION) \
-    "setuptools<58.5" # TODO: Remove this line once setuptools#2849 is resolved.
+                          $(get_dep joblib $JOBLIB_VERSION)
 
 elif [[ "$DISTRIB" == "debian-32" ]]; then
     apt-get update
@@ -101,8 +98,7 @@ elif [[ "$DISTRIB" == "debian-32" ]]; then
     source $VIRTUALENV/bin/activate
     setup_ccache
     python -m pip install $(get_dep cython $CYTHON_VERSION) \
-                          $(get_dep joblib $JOBLIB_VERSION) \
-    "setuptools<58.5" # TODO: Remove this line once setuptools#2849 is resolved.
+                          $(get_dep joblib $JOBLIB_VERSION)
 
 elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     # FIXME: temporary fix to link against system libraries on linux

--- a/build_tools/azure/install_win.sh
+++ b/build_tools/azure/install_win.sh
@@ -4,8 +4,7 @@ set -e
 set -x
 
 if [[ "$PYTHON_ARCH" == "64" ]]; then
-    conda create -n $VIRTUALENV -q -y python=$PYTHON_VERSION numpy scipy cython matplotlib wheel pillow joblib \
-    "setuptools<58.5" # TODO: Remove this line once setuptools#2849 is resolved.
+    conda create -n $VIRTUALENV -q -y python=$PYTHON_VERSION numpy scipy cython matplotlib wheel pillow joblib
 
     source activate $VIRTUALENV
 
@@ -17,8 +16,7 @@ if [[ "$PYTHON_ARCH" == "64" ]]; then
         pip install pytest==$PYTEST_VERSION
     fi
 else
-    pip install numpy scipy cython pytest wheel pillow joblib threadpoolctl \
-    "setuptools<58.5" # TODO: Remove this line once setuptools#2849 is resolved.
+    pip install numpy scipy cython pytest wheel pillow joblib threadpoolctl
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -181,8 +181,6 @@ pip install "$(get_dep sphinx-gallery $SPHINX_GALLERY_VERSION)"
 pip install "$(get_dep numpydoc $NUMPYDOC_VERSION)"
 pip install "$(get_dep sphinx-prompt $SPHINX_PROMPT_VERSION)"
 pip install "$(get_dep sphinxext-opengraph $SPHINXEXT_OPENGRAPH_VERSION)"
-# TODO: Remove this line once setuptools#2849 is resolved.
-pip install "setuptools<58.5"
 
 # Set parallelism to 3 to overlap IO bound tasks with CPU bound tasks on CI
 # workers with 2 cores when building the compiled extensions of scikit-learn.

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -50,9 +50,7 @@ mamba install --verbose -y  ccache \
                             $(get_dep joblib $JOBLIB_VERSION) \
                             $(get_dep threadpoolctl $THREADPOOLCTL_VERSION) \
                             $(get_dep pytest $PYTEST_VERSION) \
-                            $(get_dep pytest-xdist $PYTEST_XDIST_VERSION) \
-                            "setuptools<58.5" # TODO: Remove this line once setuptools#2849 is resolved.
-
+                            $(get_dep pytest-xdist $PYTEST_XDIST_VERSION)
 setup_ccache
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -13,8 +13,7 @@ conda install -y mamba
 mamba create -n pypy -y \
     pypy numpy scipy cython \
     joblib threadpoolctl pillow pytest \
-    sphinx numpydoc docutils \
-    "setuptools<58.5" # TODO: remove this line once setuptools#2849 is resolved.
+    sphinx numpydoc docutils
 
 eval "$(conda shell.bash hook)"
 conda activate pypy

--- a/build_tools/travis/install_main.sh
+++ b/build_tools/travis/install_main.sh
@@ -47,8 +47,6 @@ conda create -n testenv --yes python=3.7
 source activate testenv
 conda install -y scipy numpy pandas cython
 pip install joblib threadpoolctl
-# TODO: This line once setuptools#2849 is resolved.
-pip install "setuptools<58.5"
 
 pip install $(get_dep pytest $PYTEST_VERSION) pytest-xdist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    # TODO: Remove the specifier once setuptools#2849 is resolved.
-    "setuptools<58.5",
+    "setuptools",
     "wheel",
     "Cython>=0.28.5",
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Reverts #21549.
Relates to https://github.com/pypa/setuptools/pull/2855.

#### What does this implement/fix? Explain your changes.

The fix for https://github.com/pypa/setuptools/issues/2849 has been introduced in setuptools 58.5.3 via https://github.com/pypa/setuptools/pull/2855 (See: https://github.com/pypa/setuptools/pull/2855#issuecomment-961487836).

This reverts commit 953d101c709d47355d65079d9696c0562a2b5dda which introduced a temporary hotfix.
