### PR TITLE
FIX check skip network in test_load_boston_alternative

### DIFF
--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -333,7 +333,7 @@ def test_load_boston_warning():
 @pytest.mark.filterwarnings("ignore:Function load_boston is deprecated")
 def test_load_boston_alternative():
     pd = pytest.importorskip("pandas")
-    if not os.environ.get("SKLEARN_SKIP_NETWORK_TESTS", "1") == "1":
+    if os.environ.get("SKLEARN_SKIP_NETWORK_TESTS", "1") == "1":
         raise SkipTest(
             "This test requires an internet connection to fetch the dataset."
         )


### PR DESCRIPTION
The precedence of the `not` operator would make this test always download the dataset on our CI, irrespective of the environment variable value leading to random failures in our nightly wheel build:

https://github.com/scikit-learn/scikit-learn/runs/4113295478?check_suite_focus=true#step:4:7274

Furthermore, we want "1" to raise SkipTest.