### PR TITLE
TST Simplify `test_spectral_embedding_two_components`

### DIFF
--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -140,11 +140,11 @@ def test_spectral_embedding_two_components(eigen_solver, dtype, seed=36):
         random_state=np.random.RandomState(seed),
         eigen_solver=eigen_solver,
     )
-    for dtype in [np.float32, np.float64]:
-        embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))
-        # thresholding on the first components using 0.
-        label_ = np.array(embedded_coordinate.ravel() < 0, dtype=np.int64)
-        assert normalized_mutual_info_score(true_label, label_) == pytest.approx(1.0)
+
+    embedded_coordinate = se_precomp.fit_transform(affinity.astype(dtype))
+    # thresholding on the first components using 0.
+    label_ = np.array(embedded_coordinate.ravel() < 0, dtype=np.int64)
+    assert normalized_mutual_info_score(true_label, label_) == pytest.approx(1.0)
 
 
 @pytest.mark.parametrize("X", [S, sparse.csr_matrix(S)], ids=["dense", "sparse"])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Small follow-up for #21534.


#### What does this implement/fix? Explain your changes.

`test_spectral_embedding_two_components` is parametrized on `dtype`, removing the need for iterating a second time.

/cc @lobpcg, @glemaitre 



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
