### PR TITLE
DOC Ensures that sklearn.utils.check_pandas_support passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -175,7 +175,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.svm._bounds.l1_min_c",
     "sklearn.tree._export.plot_tree",
     "sklearn.utils.axis0_safe_slice",
-    "sklearn.utils.check_pandas_support",
     "sklearn.utils.extmath.density",
     "sklearn.utils.extmath.fast_logdet",
     "sklearn.utils.extmath.randomized_range_finder",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -1108,8 +1108,7 @@ def check_matplotlib_support(caller_name):
 
 
 def check_pandas_support(caller_name):
-    """Raise ImportError with detailed error message if pandas is not
-    installed.
+    """Raise ImportError with detailed error message if pandas is not installed.
 
     Plot utilities like :func:`fetch_openml` should lazily import
     pandas and call this helper before any computation.
@@ -1118,6 +1117,11 @@ def check_pandas_support(caller_name):
     ----------
     caller_name : str
         The name of the caller that requires pandas.
+
+    Returns
+    -------
+    pandas
+        The pandas package.
     """
     try:
         import pandas  # noqa


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR fixes the following errors that were appearing for numpydoc validation for check_pandas_support():

- SS06: Summary should fit in a single line
- RT01: No Returns section found

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
