### PR TITLE
Enhance mape documentation, fixes #21556

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -341,6 +341,10 @@ def mean_absolute_percentage_error(
     >>> y_pred = [2.5, 0.0, 2, 8]
     >>> mean_absolute_percentage_error(y_true, y_pred)
     0.3273...
+    >>> y_true = [1, 0, 2.4, 7]
+    >>> y_pred = [1.2, 0.1, 2.4, 8]
+    >>> mean_absolute_percentage_error(y_true, y_pred)
+    1.126e+14
     >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
     >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
     >>> mean_absolute_percentage_error(y_true, y_pred)

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -290,7 +290,7 @@ def mean_absolute_percentage_error(
 
     Note here that the output is not a percentage in range [0, 100].
     Instead, the output can be arbitrarily high when `y_true` is small
-    (which is specific to the metric) or when `abs(y_true-y_pred)` is
+    (which is specific to the metric) or when `abs(y_true - y_pred)` is
     large (which is common for most regression metrics). Read more in the
     :ref:`User Guide <mean_absolute_percentage_error>`.
 

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -286,10 +286,15 @@ def mean_pinball_loss(
 def mean_absolute_percentage_error(
     y_true, y_pred, sample_weight=None, multioutput="uniform_average"
 ):
-    """Mean absolute percentage error regression loss.
+    """Mean absolute percentage error (MAPE) regression loss.
 
-    Note here that we do not represent the output as a percentage in range
-    [0, 100]. Instead, we represent it in range [0, 1/eps]. Read more in the
+	The MAPE computes the mean of the absolute value of the distance 
+	between `y_true` and `y_pred` over `y_true`, which is a 
+	relative error term.
+
+    Note here that the output is not a percentage in range [0, 100]. 
+    Instead, it can be arbitrarily high. Hence, the best value is 0
+    and the output is not upper bounded. Read more in the
     :ref:`User Guide <mean_absolute_percentage_error>`.
 
     .. versionadded:: 0.24
@@ -318,16 +323,16 @@ def mean_absolute_percentage_error(
 
     Returns
     -------
-    loss : float or ndarray of floats in the range [0, 1/eps]
+    loss : float or ndarray of floats
         If multioutput is 'raw_values', then mean absolute percentage error
         is returned for each output separately.
         If multioutput is 'uniform_average' or an ndarray of weights, then the
         weighted average of all output errors is returned.
 
         MAPE output is non-negative floating point. The best value is 0.0.
-        But note the fact that bad predictions can lead to arbitrarily large
-        MAPE values, especially if some y_true values are very close to zero.
-        Note that we return a large value instead of `inf` when y_true is zero.
+        But note that bad predictions can lead to arbitrarily large
+        MAPE values, especially if some `y_true` values are very close to zero.
+        Note that we return a large value instead of `inf` when `y_true` is zero.
 
     Examples
     --------

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -288,10 +288,11 @@ def mean_absolute_percentage_error(
 ):
     """Mean absolute percentage error (MAPE) regression loss.
 
-    Note here that the output is not a percentage in the range [0, 100] and a value of 100
-    does not mean 100% but 1e2. Furthermore, the output can be arbitrarily high when `y_true` is small
-    (which is specific to the metric) or when `abs(y_true - y_pred)` is
-    large (which is common for most regression metrics). Read more in the
+    Note here that the output is not a percentage in the range [0, 100]
+    and a value of 100 does not mean 100% but 1e2. Furthermore, the output
+    can be arbitrarily high when `y_true` is small (which is specific to the
+    metric) or when `abs(y_true - y_pred)` is large (which is common for most
+    regression metrics). Read more in the
     :ref:`User Guide <mean_absolute_percentage_error>`.
 
     .. versionadded:: 0.24

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -288,8 +288,8 @@ def mean_absolute_percentage_error(
 ):
     """Mean absolute percentage error (MAPE) regression loss.
 
-    Note here that the output is not a percentage in range [0, 100].
-    Instead, the output can be arbitrarily high when `y_true` is small
+    Note here that the output is not a percentage in the range [0, 100] and a value of 100
+    does not mean 100% but 1e2. Furthermore, the output can be arbitrarily high when `y_true` is small
     (which is specific to the metric) or when `abs(y_true - y_pred)` is
     large (which is common for most regression metrics). Read more in the
     :ref:`User Guide <mean_absolute_percentage_error>`.

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -288,11 +288,11 @@ def mean_absolute_percentage_error(
 ):
     """Mean absolute percentage error (MAPE) regression loss.
 
-	The MAPE computes the mean of the absolute value of the distance 
-	between `y_true` and `y_pred` over `y_true`, which is a 
-	relative error term.
+        The MAPE computes the mean of the absolute value of the distance
+        between `y_true` and `y_pred` over `y_true`, which is a
+        relative error term.
 
-    Note here that the output is not a percentage in range [0, 100]. 
+    Note here that the output is not a percentage in range [0, 100].
     Instead, it can be arbitrarily high. Hence, the best value is 0
     and the output is not upper bounded. Read more in the
     :ref:`User Guide <mean_absolute_percentage_error>`.
@@ -344,7 +344,7 @@ def mean_absolute_percentage_error(
     >>> y_true = [1, 0, 2.4, 7]
     >>> y_pred = [1.2, 0.1, 2.4, 8]
     >>> mean_absolute_percentage_error(y_true, y_pred)
-    1.126e+14
+    112589990684262.48
     >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
     >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
     >>> mean_absolute_percentage_error(y_true, y_pred)

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -291,7 +291,7 @@ def mean_absolute_percentage_error(
     Note here that the output is not a percentage in range [0, 100].
     Instead, the output can be arbitrarily high when `y_true` is small
     (which is specific to the metric) or when `abs(y_true-y_pred)` is
-    large (which is common for most regressino metrics). Read more in the
+    large (which is common for most regression metrics). Read more in the
     :ref:`User Guide <mean_absolute_percentage_error>`.
 
     .. versionadded:: 0.24

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -344,9 +344,8 @@ def mean_absolute_percentage_error(
     0.5515...
     >>> mean_absolute_percentage_error(y_true, y_pred, multioutput=[0.3, 0.7])
     0.6198...
-    >>> # the value when some element of the y_true is zero
-    >>> # is arbitrarily high because of the division
-    >>> # by epsilon
+    >>> # the value when some element of the y_true is zero is arbitrarily high because
+    >>> # of the division by epsilon
     >>> y_true = [1., 0., 2.4, 7.]
     >>> y_pred = [1.2, 0.1, 2.4, 8.]
     >>> mean_absolute_percentage_error(y_true, y_pred)

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -288,13 +288,10 @@ def mean_absolute_percentage_error(
 ):
     """Mean absolute percentage error (MAPE) regression loss.
 
-        The MAPE computes the mean of the absolute value of the distance
-        between `y_true` and `y_pred` over `y_true`, which is a
-        relative error term.
-
     Note here that the output is not a percentage in range [0, 100].
-    Instead, it can be arbitrarily high. Hence, the best value is 0
-    and the output is not upper bounded. Read more in the
+    Instead, the output can be arbitrarily high when `y_true` is small
+    (which is specific to the metric) or when `abs(y_true-y_pred)` is
+    large (which is common for most regressino metrics). Read more in the
     :ref:`User Guide <mean_absolute_percentage_error>`.
 
     .. versionadded:: 0.24
@@ -341,16 +338,19 @@ def mean_absolute_percentage_error(
     >>> y_pred = [2.5, 0.0, 2, 8]
     >>> mean_absolute_percentage_error(y_true, y_pred)
     0.3273...
-    >>> y_true = [1, 0, 2.4, 7]
-    >>> y_pred = [1.2, 0.1, 2.4, 8]
-    >>> mean_absolute_percentage_error(y_true, y_pred)
-    112589990684262.48
     >>> y_true = [[0.5, 1], [-1, 1], [7, -6]]
     >>> y_pred = [[0, 2], [-1, 2], [8, -5]]
     >>> mean_absolute_percentage_error(y_true, y_pred)
     0.5515...
     >>> mean_absolute_percentage_error(y_true, y_pred, multioutput=[0.3, 0.7])
     0.6198...
+    >>> # the value when some element of the y_true is zero
+    >>> # is arbitrarily high because of the division
+    >>> # by epsilon
+    >>> y_true = [1., 0., 2.4, 7.]
+    >>> y_pred = [1.2, 0.1, 2.4, 8.]
+    >>> mean_absolute_percentage_error(y_true, y_pred)
+    112589990684262.48
     """
     y_type, y_true, y_pred, multioutput = _check_reg_targets(
         y_true, y_pred, multioutput


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #21556

#### What does this implement/fix? Explain your changes.
This PR proposes to enhance the documentation of `sklearn.metrics.mean_absolute_percentage_error` by removing a false statement in the documentation and by providing a new example to understand one of the caveats of MAPE. 