### PR TITLE
FIX enforce keyword-only arguments in mean_absolute_percentage_error

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -126,7 +126,7 @@ Changelog
 
 - |API| Parameters ``sample_weight`` and ``multioutput`` of
   :func:`metrics.mean_absolute_percentage_error` are now keyword-only,
-  in accordance withSLEP009. A deprecation cycle was introduced.
+  in accordance with SLEP009. A deprecation cycle was introduced.
   :pr:`21576` by :user:`Paul-Emile Dugnat <pedugnat>`.
 
 :mod:`sklearn.manifold`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -60,7 +60,7 @@ Changelog
   add this information to the plot.
   :pr:`21038` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |Enhancement| :class:`cluster.SpectralClustering` and :func:`cluster.spectral` 
+- |Enhancement| :class:`cluster.SpectralClustering` and :func:`cluster.spectral`
   now include the new `'cluster_qr'` method from :func:`cluster.cluster_qr`
   that clusters samples in the embedding space as an alternative to the existing
   `'kmeans'` and `'discrete'` methods.
@@ -124,6 +124,11 @@ Changelog
   backward compatibility, but this alias will be removed in 1.3.
   :pr:`21177` by :user:`Julien Jerphanion <jjerphan>`.
 
+- |API| Parameters ``sample_weight`` and ``multioutput`` of
+  :func:`metrics.mean_absolute_percentage_error` are now keyword-only,
+  in accordance withSLEP009. A deprecation cycle was introduced.
+  :pr:`21576` by :user:`Paul-Emile Dugnat <pedugnat>`.
+
 :mod:`sklearn.manifold`
 .......................
 
@@ -162,7 +167,7 @@ Changelog
 ..................
 
 - |Fix| :class:`smv.NuSVC`, :class:`svm.NuSVR`, :class:`svm.SVC`,
-  :class:`svm.SVR`, :class:`svm.OneClassSVM` now validate input 
+  :class:`svm.SVR`, :class:`svm.OneClassSVM` now validate input
   parameters in `fit` instead of `__init__`.
   :pr:`21436` by :user:`Haidar Almubarak <Haidar13 >`.
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -124,9 +124,10 @@ Changelog
   backward compatibility, but this alias will be removed in 1.3.
   :pr:`21177` by :user:`Julien Jerphanion <jjerphan>`.
 
-- |API| Parameters ``sample_weight`` and ``multioutput`` of
-  :func:`metrics.mean_absolute_percentage_error` are now keyword-only,
-  in accordance with SLEP009. A deprecation cycle was introduced.
+- |API| Parameters ``sample_weight`` and ``multioutput`` of :func:`metrics.
+  mean_absolute_percentage_error` are now keyword-only, in accordance with `SLEP009
+  <https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep009/proposal.html>`.
+  A deprecation cycle was introduced.
   :pr:`21576` by :user:`Paul-Emile Dugnat <pedugnat>`.
 
 :mod:`sklearn.manifold`

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -284,7 +284,7 @@ def mean_pinball_loss(
 
 
 def mean_absolute_percentage_error(
-    y_true, y_pred, sample_weight=None, multioutput="uniform_average"
+    y_true, y_pred, *, sample_weight=None, multioutput="uniform_average"
 ):
     """Mean absolute percentage error regression loss.
 

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -30,9 +30,14 @@ import numpy as np
 
 from .._loss.glm_distribution import TweedieDistribution
 from ..exceptions import UndefinedMetricWarning
-from ..utils.validation import check_array, check_consistent_length, _num_samples
-from ..utils.validation import column_or_1d
-from ..utils.validation import _check_sample_weight
+from ..utils.validation import (
+    check_array,
+    check_consistent_length,
+    _num_samples,
+    column_or_1d,
+    _check_sample_weight,
+    _deprecate_positional_args,
+)
 from ..utils.stats import _weighted_percentile
 
 
@@ -283,6 +288,7 @@ def mean_pinball_loss(
     return np.average(output_errors, weights=multioutput)
 
 
+@_deprecate_positional_args(version="1.1")
 def mean_absolute_percentage_error(
     y_true, y_pred, *, sample_weight=None, multioutput="uniform_average"
 ):

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -362,6 +362,22 @@ def test_regression_single_sample(metric):
         assert np.isnan(score)
 
 
+def test_deprecation_positional_arguments_mape():
+    y_true = [1, 1, 1]
+    y_pred = [1, 0, 1]
+    sample_weights = [0.5, 0.1, 0.2]
+    multioutput = "raw_values"
+
+    warning_msg = "passing these as positional arguments will result in an error"
+
+    # Trigger the warning
+    with pytest.warns(FutureWarning, match=warning_msg):
+        mape = mean_absolute_percentage_error(
+            y_true, y_pred, sample_weights, multioutput
+        )
+        assert mape == pytest.approx([0.125])
+
+
 def test_tweedie_deviance_continuity():
     n_samples = 100
 

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -372,9 +372,7 @@ def test_deprecation_positional_arguments_mape():
 
     # Trigger the warning
     with pytest.warns(FutureWarning, match=warning_msg):
-        mean_absolute_percentage_error(
-            y_true, y_pred, sample_weights, multioutput
-        )
+        mean_absolute_percentage_error(y_true, y_pred, sample_weights, multioutput)
 
 
 def test_tweedie_deviance_continuity():

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -372,10 +372,9 @@ def test_deprecation_positional_arguments_mape():
 
     # Trigger the warning
     with pytest.warns(FutureWarning, match=warning_msg):
-        mape = mean_absolute_percentage_error(
+        mean_absolute_percentage_error(
             y_true, y_pred, sample_weights, multioutput
         )
-        assert mape == pytest.approx([0.125])
 
 
 def test_tweedie_deviance_continuity():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #21575

#### What does this implement/fix? Explain your changes.
The PR enforces the use of keyword-only arguments for `sklearn.metrics.mean_absolute_percentage_error`.