### PR TITLE
MNT remove deprecated components_ in SparseCoder

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -15,7 +15,6 @@ from scipy import linalg
 from joblib import Parallel, effective_n_jobs
 
 from ..base import BaseEstimator, TransformerMixin, _ClassNamePrefixFeaturesOutMixin
-from ..utils import deprecated
 from ..utils import check_array, check_random_state, gen_even_slices, gen_batches
 from ..utils.extmath import randomized_svd, row_norms, svd_flip
 from ..utils.validation import check_is_fitted
@@ -1172,13 +1171,6 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
 
     Attributes
     ----------
-    components_ : ndarray of shape (n_components, n_features)
-        The unchanged dictionary atoms.
-
-        .. deprecated:: 0.24
-           This attribute is deprecated in 0.24 and will be removed in
-           1.1 (renaming of 0.26). Use `dictionary` instead.
-
     n_components_ : int
         Number of atoms.
 
@@ -1270,15 +1262,6 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
             Returns the instance itself.
         """
         return self
-
-    @deprecated(  # type: ignore
-        "The attribute `components_` is deprecated "
-        "in 0.24 and will be removed in 1.1 (renaming of 0.26). Use the "
-        "`dictionary` instead."
-    )
-    @property
-    def components_(self):
-        return self.dictionary
 
     def transform(self, X, y=None):
         """Encode the data as a sparse combination of the dictionary atoms.

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -618,18 +618,6 @@ def test_sparse_coder_common_transformer():
     check_transformers_unfitted(sc.__class__.__name__, sc)
 
 
-# TODO: remove in 1.1
-def test_sparse_coder_deprecation():
-    # check that we raise a deprecation warning when accessing `components_`
-    rng = np.random.RandomState(777)
-    n_components, n_features = 40, 64
-    init_dict = rng.rand(n_components, n_features)
-    sc = SparseCoder(init_dict)
-
-    with pytest.warns(FutureWarning, match="`components_` is deprecated"):
-        sc.components_
-
-
 def test_sparse_coder_n_features_in():
     d = np.array([[1, 2, 3], [1, 2, 3]])
     sc = SparseCoder(d)


### PR DESCRIPTION
Remove deprecated attribute `components_` in `SparseCoder`.