### PR TITLE
MNT remove X_idx_sorted parameter in decision trees

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -147,9 +147,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         check_is_fitted(self)
         return self.tree_.n_leaves
 
-    def fit(
-        self, X, y, sample_weight=None, check_input=True, X_idx_sorted="deprecated"
-    ):
+    def fit(self, X, y, sample_weight=None, check_input=True):
 
         random_state = check_random_state(self.random_state)
 
@@ -334,16 +332,6 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
         if self.min_impurity_decrease < 0.0:
             raise ValueError("min_impurity_decrease must be greater than or equal to 0")
-
-        # TODO: Remove in 1.1
-        if X_idx_sorted != "deprecated":
-            warnings.warn(
-                "The parameter 'X_idx_sorted' is deprecated and has no "
-                "effect. It will be removed in 1.1 (renaming of 0.26). You "
-                "can suppress this warning by not passing any value to the "
-                "'X_idx_sorted' parameter.",
-                FutureWarning,
-            )
 
         # Build tree
         criterion = self.criterion
@@ -896,9 +884,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
             ccp_alpha=ccp_alpha,
         )
 
-    def fit(
-        self, X, y, sample_weight=None, check_input=True, X_idx_sorted="deprecated"
-    ):
+    def fit(self, X, y, sample_weight=None, check_input=True):
         """Build a decision tree classifier from the training set (X, y).
 
         Parameters
@@ -922,12 +908,6 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
             Allow to bypass several input checking.
             Don't use this parameter unless you know what you do.
 
-        X_idx_sorted : deprecated, default="deprecated"
-            This parameter is deprecated and has no effect.
-            It will be removed in 1.1 (renaming of 0.26).
-
-            .. deprecated:: 0.24
-
         Returns
         -------
         self : DecisionTreeClassifier
@@ -939,7 +919,6 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
             y,
             sample_weight=sample_weight,
             check_input=check_input,
-            X_idx_sorted=X_idx_sorted,
         )
         return self
 
@@ -1275,9 +1254,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
             ccp_alpha=ccp_alpha,
         )
 
-    def fit(
-        self, X, y, sample_weight=None, check_input=True, X_idx_sorted="deprecated"
-    ):
+    def fit(self, X, y, sample_weight=None, check_input=True):
         """Build a decision tree regressor from the training set (X, y).
 
         Parameters
@@ -1300,12 +1277,6 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
             Allow to bypass several input checking.
             Don't use this parameter unless you know what you do.
 
-        X_idx_sorted : deprecated, default="deprecated"
-            This parameter is deprecated and has no effect.
-            It will be removed in 1.1 (renaming of 0.26).
-
-            .. deprecated:: 0.24
-
         Returns
         -------
         self : DecisionTreeRegressor
@@ -1317,7 +1288,6 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
             y,
             sample_weight=sample_weight,
             check_input=check_input,
-            X_idx_sorted=X_idx_sorted,
         )
         return self
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2138,21 +2138,6 @@ def test_decision_tree_regressor_sample_weight_consistentcy(criterion):
     assert_allclose(tree1.predict(X), tree2.predict(X))
 
 
-# TODO: Remove in v1.1
-@pytest.mark.parametrize(
-    "TreeEstimator", [DecisionTreeClassifier, DecisionTreeRegressor]
-)
-def test_X_idx_sorted_deprecated(TreeEstimator):
-    X_idx_sorted = np.argsort(X, axis=0)
-
-    tree = TreeEstimator()
-
-    with pytest.warns(
-        FutureWarning, match="The parameter 'X_idx_sorted' is deprecated"
-    ):
-        tree.fit(X, y, X_idx_sorted=X_idx_sorted)
-
-
 # TODO: Remove in v1.2
 @pytest.mark.parametrize("Tree", REG_TREES.values())
 @pytest.mark.parametrize(


### PR DESCRIPTION
Remove `X_idx_sorted` parameter in decision trees after its deprecation cycle.