### PR TITLE
MAINT: Use non-deprecated SciPy imports

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -36,6 +36,11 @@ else:
     # mypy error: Name 'lobpcg' already defined (possibly by an import)
     from ..externals._lobpcg import lobpcg  # type: ignore  # noqa
 
+try:
+    from scipy.optimize._linesearch import line_search_wolfe2, line_search_wolfe1
+except ImportError:  # SciPy < 1.8
+    from scipy.optimize.linesearch import line_search_wolfe2, line_search_wolfe1
+
 
 def _object_dtype_isnan(X):
     return X != X

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -39,7 +39,7 @@ else:
 try:
     from scipy.optimize._linesearch import line_search_wolfe2, line_search_wolfe1
 except ImportError:  # SciPy < 1.8
-    from scipy.optimize.linesearch import line_search_wolfe2, line_search_wolfe1
+    from scipy.optimize.linesearch import line_search_wolfe2, line_search_wolfe1  # type: ignore  # noqa
 
 
 def _object_dtype_isnan(X):

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -11,11 +11,6 @@ from itertools import chain
 import warnings
 
 from scipy.sparse import issparse
-
-try:
-    from scipy.sparse import spmatrix
-except ImportError:  # SciPy < 1.8
-    from scipy.sparse.base import spmatrix
 from scipy.sparse import dok_matrix
 from scipy.sparse import lil_matrix
 
@@ -275,7 +270,7 @@ def type_of_target(y, input_name=""):
     'multilabel-indicator'
     """
     valid = (
-        isinstance(y, (Sequence, spmatrix)) or hasattr(y, "__array__")
+        isinstance(y, Sequence) or issparse(y) or hasattr(y, "__array__")
     ) and not isinstance(y, str)
 
     if not valid:

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -11,7 +11,10 @@ from itertools import chain
 import warnings
 
 from scipy.sparse import issparse
-from scipy.sparse.base import spmatrix
+try:
+    from scipy.sparse import spmatrix
+except ImportError:  # SciPy < 1.8
+    from scipy.sparse.base import spmatrix
 from scipy.sparse import dok_matrix
 from scipy.sparse import lil_matrix
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -11,6 +11,7 @@ from itertools import chain
 import warnings
 
 from scipy.sparse import issparse
+
 try:
     from scipy.sparse import spmatrix
 except ImportError:  # SciPy < 1.8

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -15,12 +15,11 @@ significant speedups.
 
 import numpy as np
 import warnings
+
 try:
-    from scipy.optimize._linesearch import (
-        line_search_wolfe2, line_search_wolfe1)
+    from scipy.optimize._linesearch import line_search_wolfe2, line_search_wolfe1
 except ImportError:  # SciPy < 1.8
-    from scipy.optimize.linesearch import (
-        line_search_wolfe2, line_search_wolfe1)
+    from scipy.optimize.linesearch import line_search_wolfe2, line_search_wolfe1
 
 from ..exceptions import ConvergenceWarning
 

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -16,11 +16,7 @@ significant speedups.
 import numpy as np
 import warnings
 
-try:
-    from scipy.optimize._linesearch import line_search_wolfe2, line_search_wolfe1
-except ImportError:  # SciPy < 1.8
-    from scipy.optimize.linesearch import line_search_wolfe2, line_search_wolfe1
-
+from .fixes import line_search_wolfe1, line_search_wolfe2
 from ..exceptions import ConvergenceWarning
 
 

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -15,7 +15,12 @@ significant speedups.
 
 import numpy as np
 import warnings
-from scipy.optimize.linesearch import line_search_wolfe2, line_search_wolfe1
+try:
+    from scipy.optimize._linesearch import (
+        line_search_wolfe2, line_search_wolfe1)
+except ImportError:  # SciPy < 1.8
+    from scipy.optimize.linesearch import (
+        line_search_wolfe2, line_search_wolfe1)
 
 from ..exceptions import ConvergenceWarning
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

SciPy is deprecating a lot of semi-private namespaces. This uses the public one in one case, and the private one in another (because it didn't immediately look like there was a public variant available).
