### PR TITLE
MNT pin PyWavelet in doc-min builds

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -145,8 +145,8 @@ fi
 
 MINICONDA_PATH=$HOME/miniconda
 # Install dependencies with miniconda
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-   -O miniconda.sh
+wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh \
+    -O miniconda.sh
 chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
 export PATH="/usr/lib/ccache:$MINICONDA_PATH/bin:$PATH"
 
@@ -165,7 +165,7 @@ fi
 source build_tools/shared.sh
 
 # packaging won't be needed once setuptools starts shipping packaging>=17.0
-conda create -n $CONDA_ENV_NAME --yes --quiet \
+mamba create -n $CONDA_ENV_NAME --yes --quiet \
     python="${PYTHON_VERSION:-*}" \
     "$(get_dep numpy $NUMPY_VERSION)" \
     "$(get_dep scipy $SCIPY_VERSION)" \

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -176,6 +176,11 @@ mamba create -n $CONDA_ENV_NAME --yes --quiet \
     joblib memory_profiler packaging seaborn pillow pytest coverage
 
 source activate testenv
+# Pin PyWavelet to 1.1.1 that is the latest version that support our minumum
+# NumPy version required. If PyWavelets 1.2+ is installed, it would require
+# NumPy 1.17+ that trigger a bug with Pandas 0.25:
+# https://github.com/numpy/numpy/issues/18355#issuecomment-774610226
+pip install PyWavelets==1.1.1
 pip install "$(get_dep scikit-image $SCIKIT_IMAGE_VERSION)"
 pip install "$(get_dep sphinx-gallery $SPHINX_GALLERY_VERSION)"
 pip install "$(get_dep numpydoc $NUMPYDOC_VERSION)"

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -7,6 +7,13 @@ import argparse
 if platform.python_implementation() == "PyPy":
     NUMPY_MIN_VERSION = "1.19.0"
 else:
+    # We pinned PyWavelet (a scikit-image dependence) to 1.1.1 in the minimum
+    # documentation CI builds that is the latest version that support our
+    # minimum NumPy version required. If PyWavelets 1.2+ is installed, it would
+    # require NumPy 1.17+ that trigger a bug with Pandas 0.25:
+    # https://github.com/numpy/numpy/issues/18355#issuecomment-774610226
+    # When upgrading NumPy, we can unpin PyWavelets but we need to update the
+    # minimum version of Pandas >= 1.0.5.
     NUMPY_MIN_VERSION = "1.14.6"
 
 SCIPY_MIN_VERSION = "1.1.0"


### PR DESCRIPTION
`PyWavelets` 1.2.0 requires `numpy` >= 1.17 that is not has a known bug with `pandas` <= 1.2.
Pinning the version of `PyWavelets` would be enough here.