### PR TITLE
[MRG] SimpleImputer skipped feature warning with feature names

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -121,6 +121,10 @@ Changelog
   :pr:`21448` by :user:`Oleh Kozynets <OlehKSS>` and
   :user:`Christian Ritter <chritter>`.
 
+- |Enhancement| Added warning with feature names for skipped features
+  due to no observed values in :class:`SimpleImputer`.
+  :pr:`21617` by :user:`Christian Ritter <chritter>`.
+
 - |Fix| Fix a bug in :class:`linear_model.RidgeClassifierCV` where the method
   `predict` was performing an `argmax` on the scores obtained from
   `decision_function` instead of returning the multilabel indicator matrix.

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -121,8 +121,9 @@ Changelog
   :pr:`21448` by :user:`Oleh Kozynets <OlehKSS>` and
   :user:`Christian Ritter <chritter>`.
 
-- |Enhancement| Added warning with feature names for skipped features
-  due to no observed values in :class:`SimpleImputer`.
+- |Enhancement| :class:`SimpleImputer` now warns with feature names
+  when features which are skipped due to the lack of any observed
+  values in the training set.
   :pr:`21617` by :user:`Christian Ritter <chritter>`.
 
 - |Fix| Fix a bug in :class:`linear_model.RidgeClassifierCV` where the method

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -517,18 +517,16 @@ class SimpleImputer(_BaseImputer):
             valid_statistics_indexes = np.flatnonzero(valid_mask)
 
             if invalid_mask.any():
-                missing = np.arange(X.shape[1])[invalid_mask]
+                invalid_features = np.arange(X.shape[1])[invalid_mask]
                 if self.verbose != "deprecated" and self.verbose:
                     # use feature names warning if features are provided
                     if hasattr(self, "feature_names_in_"):
-                        warnings.warn(
-                            "Skipping features without observed values: %s"
-                            % self.feature_names_in_[missing]
-                        )
-                    else:
-                        warnings.warn(
-                            "Skipping features without observed values: %s" % missing
-                        )
+                        invalid_features = self.feature_names_in_[invalid_features]
+                    warnings.warn(
+                        "Skipping features without any observed values:"
+                        f" {invalid_features}. At least one non-missing value is needed"
+                        f" for imputation with strategy='{self.strategy}'."
+                    )
                 X = X[:, valid_statistics_indexes]
 
         # Do actual imputation

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -519,9 +519,16 @@ class SimpleImputer(_BaseImputer):
             if invalid_mask.any():
                 missing = np.arange(X.shape[1])[invalid_mask]
                 if self.verbose != "deprecated" and self.verbose:
-                    warnings.warn(
-                        "Skipping features without observed values: %s" % missing
-                    )
+                    # use feature names warning if features are provided
+                    if hasattr(self, "feature_names_in_"):
+                        warnings.warn(
+                            "Skipping features without observed values: %s"
+                            % self.feature_names_in_[missing]
+                        )
+                    else:
+                        warnings.warn(
+                            "Skipping features without observed values: %s" % missing
+                        )
                 X = X[:, valid_statistics_indexes]
 
         # Do actual imputation

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -142,7 +142,7 @@ def test_imputation_deletion_warning_feature_names(strategy):
 
     # ensure that skipped feature warning includes feature name
     with pytest.warns(
-        UserWarning, match="Skipping features without observed values: \['b'\]"
+        UserWarning, match=r"Skipping features without observed values: \['b'\]"
     ):
         imputer.transform(X)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -142,7 +142,7 @@ def test_imputation_deletion_warning_feature_names(strategy):
 
     # ensure that skipped feature warning includes feature name
     with pytest.warns(
-        UserWarning, match=r"Skipping features without observed values: \['b'\]"
+        UserWarning, match=r"Skipping features without any observed values: \['b'\]"
     ):
         imputer.transform(X)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -116,6 +116,37 @@ def test_imputation_deletion_warning(strategy):
         imputer.transform(X)
 
 
+@pytest.mark.parametrize("strategy", ["mean", "median", "most_frequent"])
+def test_imputation_deletion_warning_feature_names(strategy):
+
+    pd = pytest.importorskip("pandas")
+
+    missing_values = np.nan
+    feature_names = np.array(["a", "b", "c", "d"], dtype=object)
+    X = pd.DataFrame(
+        [
+            [missing_values, missing_values, 1, missing_values],
+            [4, missing_values, 2, 10],
+        ],
+        columns=feature_names,
+    )
+
+    imputer = SimpleImputer(strategy=strategy, verbose=1)
+
+    # TODO: Remove in 1.3
+    with pytest.warns(FutureWarning, match="The 'verbose' parameter"):
+        imputer.fit(X)
+
+    # check SimpleImputer returning feature name attribute correctly
+    assert_array_equal(imputer.feature_names_in_, feature_names)
+
+    # ensure that skipped feature warning includes feature name
+    with pytest.warns(
+        UserWarning, match="Skipping features without observed values: \['b'\]"
+    ):
+        imputer.transform(X)
+
+
 @pytest.mark.parametrize("strategy", ["mean", "median", "most_frequent", "constant"])
 def test_imputation_error_sparse_0(strategy):
     # check that error are raised when missing_values = 0 and input is sparse


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #21616.


#### What does this implement/fix? Explain your changes.
If feature names are provided SimpleImputer will warn about skipped features with actual feature names. Previously only indices were provided. I introduced an additional test to ensure warning is raised correctly.

#### Any other comments?

#DataUmbrella Sprint
@reshamas