### PR TITLE
DOC Fix link to the Scipy Development Workflow

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -538,7 +538,7 @@ profiling and Cython optimizations.
 
    For two very well documented and more detailed guides on development
    workflow, please pay a visit to the `Scipy Development Workflow
-   <https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html>`_ -
+   <https://docs.scipy.org/doc/scipy/reference/dev/contributor/development_workflow.html>`_ -
    and the `Astropy Workflow for Developers
    <https://astropy.readthedocs.io/en/latest/development/workflow/development_workflow.html>`_
    sections.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR fixes a broken link to the Scipy Development Workflow in the contributing guide.