### PR TITLE
Speed up example on plot_gradient_boosting_categorical.py 

### DIFF
--- a/examples/ensemble/plot_gradient_boosting_categorical.py
+++ b/examples/ensemble/plot_gradient_boosting_categorical.py
@@ -125,7 +125,10 @@ hist_ordinal = make_pipeline(
 
 # The ordinal encoder will first output the categorical features, and then the
 # continuous (passed-through) features
-categorical_mask = [True] * n_columns + [False] * n_columns
+n_categorical_features = len(X.select_dtypes(include="category").columns)
+n_numerical_features = len(X.select_dtypes(include="number").columns)
+
+categorical_mask = [True] * n_categorical_features + [False] * n_numerical_features
 hist_native = make_pipeline(
     ordinal_encoder,
     HistGradientBoostingRegressor(

--- a/examples/ensemble/plot_gradient_boosting_categorical.py
+++ b/examples/ensemble/plot_gradient_boosting_categorical.py
@@ -28,12 +28,9 @@ and categorical features, where the houses' sales prices is the target.
 # -------------------------
 # First, we load the Ames Housing data as a pandas dataframe. The features
 # are either categorical or numerical:
-import warnings
 from sklearn.datasets import fetch_openml
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", category=UserWarning)
-    X, y = fetch_openml(data_id=41211, as_frame=True, return_X_y=True)
+X, y = fetch_openml(data_id=41211, as_frame=True, return_X_y=True)
 
 # take a subset of features of X, both from categorical and numerical columns
 categorical_features = X.select_dtypes(include="category").columns

--- a/examples/ensemble/plot_gradient_boosting_categorical.py
+++ b/examples/ensemble/plot_gradient_boosting_categorical.py
@@ -36,17 +36,17 @@ X, y = fetch_openml(data_id=41211, as_frame=True, return_X_y=True)
 categorical_features = X.select_dtypes(include="category").columns
 numerical_features = X.select_dtypes(include="number").columns
 
-k_columns = 10
-columns_subset = list(categorical_features[:k_columns]) + list(
-    numerical_features[:k_columns]
+n_columns = 10
+columns_subset = list(categorical_features[:n_columns]) + list(
+    numerical_features[:n_columns]
 )
 
 X = X[columns_subset]
 
 print(f"Number of samples: {X.shape[0]}")
 print(f"Number of features: {X.shape[1]}")
-print(f"Number of categorical features: {k_columns}")
-print(f"Number of numerical features: {k_columns}")
+print(f"Number of categorical features: {n_columns}")
+print(f"Number of numerical features: {n_columns}")
 
 # %%
 # Gradient boosting estimator with dropped categorical features
@@ -125,7 +125,7 @@ hist_ordinal = make_pipeline(
 
 # The ordinal encoder will first output the categorical features, and then the
 # continuous (passed-through) features
-categorical_mask = [True] * k_columns + [False] * k_columns
+categorical_mask = [True] * n_columns + [False] * n_columns
 hist_native = make_pipeline(
     ordinal_encoder,
     HistGradientBoostingRegressor(

--- a/examples/ensemble/plot_gradient_boosting_categorical.py
+++ b/examples/ensemble/plot_gradient_boosting_categorical.py
@@ -32,7 +32,7 @@ from sklearn.datasets import fetch_openml
 
 X, y = fetch_openml(data_id=41211, as_frame=True, return_X_y=True)
 
-# take a subset of features of X, both from categorical and numerical columns
+# Take a subset of features of X to make the example faster to run
 categorical_features = X.select_dtypes(include="category").columns
 numerical_features = X.select_dtypes(include="number").columns
 

--- a/examples/ensemble/plot_gradient_boosting_categorical.py
+++ b/examples/ensemble/plot_gradient_boosting_categorical.py
@@ -43,10 +43,13 @@ columns_subset = list(categorical_features[:n_columns]) + list(
 
 X = X[columns_subset]
 
+n_categorical_features = len(X.select_dtypes(include="category").columns)
+n_numerical_features = len(X.select_dtypes(include="number").columns)
+
 print(f"Number of samples: {X.shape[0]}")
 print(f"Number of features: {X.shape[1]}")
-print(f"Number of categorical features: {n_columns}")
-print(f"Number of numerical features: {n_columns}")
+print(f"Number of categorical features: {n_categorical_features}")
+print(f"Number of numerical features: {n_numerical_features}")
 
 # %%
 # Gradient boosting estimator with dropped categorical features
@@ -125,8 +128,6 @@ hist_ordinal = make_pipeline(
 
 # The ordinal encoder will first output the categorical features, and then the
 # continuous (passed-through) features
-n_categorical_features = len(X.select_dtypes(include="category").columns)
-n_numerical_features = len(X.select_dtypes(include="number").columns)
 
 categorical_mask = [True] * n_categorical_features + [False] * n_numerical_features
 hist_native = make_pipeline(
@@ -173,14 +174,14 @@ def plot_results(figure_title):
             native_result[key],
         ]
 
-        mape = [np.mean(np.abs(item)) for item in items]
-        std_pred = [np.std(item) for item in items]
+        mape_cv_mean = [np.mean(-item) for item in items]
+        mape_cv_std = [np.std(item) for item in items]
 
         ax.bar(
             x=x,
-            height=mape,
+            height=mape_cv_mean,
             width=width,
-            yerr=std_pred,
+            yerr=mape_cv_std,
             color=["C0", "C1", "C2", "C3"],
         )
         ax.set(
@@ -193,7 +194,7 @@ def plot_results(figure_title):
     fig.suptitle(figure_title)
 
 
-plot_results("Gradient Boosting on Adult Census")
+plot_results("Gradient Boosting on Ames Housing")
 
 # %%
 # We see that the model with one-hot-encoded data is by far the slowest. This
@@ -244,7 +245,7 @@ one_hot_result = cross_validate(hist_one_hot, X, y, cv=n_cv_folds, scoring=scori
 ordinal_result = cross_validate(hist_ordinal, X, y, cv=n_cv_folds, scoring=scoring)
 native_result = cross_validate(hist_native, X, y, cv=n_cv_folds, scoring=scoring)
 
-plot_results("Gradient Boosting on Adult Census (few and small trees)")
+plot_results("Gradient Boosting on Ames Housing (few and small trees)")
 
 plt.show()
 


### PR DESCRIPTION
#### Reference Issues/PRs
Contributes to #21598.

#### What does this implement/fix? Explain your changes.
In order to speed up the example, I did two main things : 

1. Decrease the number of columns of the chosen dataset from 80 to 20, keeping both numerical and categorical columns
2. Decrease the number of iterations of the `HistGradientBoostingRegressor` from 100 to 50

Please see the before-after for the plots, and the cProfile of the old and new versions: on my computer, the new version takes 4.5s vs 15.5s; the rank of the fit time and the error (plots) is the same for both figures: 

- cProfiles new version: `3894443 function calls (3808982 primitive calls) in 4.671 seconds`
- cProfiles old version: `6640438 function calls (6468083 primitive calls) in 15.580 seconds`

- plots new version : 
![Figure_1](https://user-images.githubusercontent.com/34744445/141309449-bf061340-bbc5-48bb-a004-43a4030f8566.png)
![Figure_2](https://user-images.githubusercontent.com/34744445/141309446-c8b45f42-addb-4696-87b2-2be85f8767d0.png)

- plots old version
![sphx_glr_plot_gradient_boosting_categorical_001](https://user-images.githubusercontent.com/34744445/141309543-0db2e5c9-7d23-42c1-bf09-fd4e1e4639dd.png)
![sphx_glr_plot_gradient_boosting_categorical_002](https://user-images.githubusercontent.com/34744445/141309549-46703640-fd36-4b41-8ad7-f5ca6a356988.png)


