### PR TITLE
[MRG] Accelerate examples/manifold/plot_t_sne_perplexity.py

### DIFF
--- a/examples/manifold/plot_t_sne_perplexity.py
+++ b/examples/manifold/plot_t_sne_perplexity.py
@@ -34,12 +34,14 @@ from matplotlib.ticker import NullFormatter
 from sklearn import manifold, datasets
 from time import time
 
-n_samples = 300
+n_samples = 150
 n_components = 2
 (fig, subplots) = plt.subplots(3, 5, figsize=(15, 8))
 perplexities = [5, 30, 50, 100]
 
-X, y = datasets.make_circles(n_samples=n_samples, factor=0.5, noise=0.05)
+X, y = datasets.make_circles(
+    n_samples=n_samples, factor=0.5, noise=0.05, random_state=0
+)
 
 red = y == 0
 green = y == 1
@@ -56,7 +58,12 @@ for i, perplexity in enumerate(perplexities):
 
     t0 = time()
     tsne = manifold.TSNE(
-        n_components=n_components, init="random", random_state=0, perplexity=perplexity
+        n_components=n_components,
+        init="random",
+        random_state=0,
+        perplexity=perplexity,
+        learning_rate="auto",
+        n_iter=300,
     )
     Y = tsne.fit_transform(X)
     t1 = time()
@@ -81,7 +88,12 @@ for i, perplexity in enumerate(perplexities):
 
     t0 = time()
     tsne = manifold.TSNE(
-        n_components=n_components, init="random", random_state=0, perplexity=perplexity
+        n_components=n_components,
+        init="random",
+        random_state=0,
+        perplexity=perplexity,
+        learning_rate="auto",
+        n_iter=300,
     )
     Y = tsne.fit_transform(X)
     t1 = time()
@@ -114,7 +126,12 @@ for i, perplexity in enumerate(perplexities):
 
     t0 = time()
     tsne = manifold.TSNE(
-        n_components=n_components, init="random", random_state=0, perplexity=perplexity
+        n_components=n_components,
+        init="random",
+        random_state=0,
+        perplexity=perplexity,
+        learning_rate="auto",
+        n_iter=400,
     )
     Y = tsne.fit_transform(X)
     t1 = time()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#21598

#### What does this implement/fix? Explain your changes.
Reduce from 18 sec to 7 sec by halving the number of samples and reducing `n_iter` from default 1000 to 300 or 400.
Also set  `learning_rate="auto"` to disable FutureWarning.

Before:
![before](https://scikit-learn.org/stable/_images/sphx_glr_plot_t_sne_perplexity_001.png)

After:
![after](https://user-images.githubusercontent.com/47032563/141348186-112be85b-d2de-4183-b839-1d2e554e26cd.png)


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
