### PR TITLE
[MRG] accelerate plot_randomized_search.py example #21598

### DIFF
--- a/examples/model_selection/plot_randomized_search.py
+++ b/examples/model_selection/plot_randomized_search.py
@@ -31,7 +31,7 @@ from sklearn.datasets import load_digits
 from sklearn.linear_model import SGDClassifier
 
 # get some data
-X, y = load_digits(return_X_y=True)
+X, y = load_digits(return_X_y=True, n_class=3)
 
 # build a classifier
 clf = SGDClassifier(loss="hinge", penalty="elasticnet", fit_intercept=True)
@@ -57,11 +57,11 @@ def report(results, n_top=3):
 param_dist = {
     "average": [True, False],
     "l1_ratio": stats.uniform(0, 1),
-    "alpha": loguniform(1e-4, 1e0),
+    "alpha": loguniform(1e-2, 1e0),
 }
 
 # run randomized search
-n_iter_search = 20
+n_iter_search = 15
 random_search = RandomizedSearchCV(
     clf, param_distributions=param_dist, n_iter=n_iter_search
 )
@@ -78,7 +78,7 @@ report(random_search.cv_results_)
 param_grid = {
     "average": [True, False],
     "l1_ratio": np.linspace(0, 1, num=10),
-    "alpha": np.power(10, np.arange(-4, 1, dtype=float)),
+    "alpha": np.power(10, np.arange(-2, 1, dtype=float)),
 }
 
 # run grid search


### PR DESCRIPTION
Speeds up ../examples/model_selection/plot_randomized_search.py (Issue #21598) by

- only using 3 (instead of 10) label classes from the digits dataset
- reducing the size of the "alpha" search dimension a little bit, which reduces number of candidate settings from 100 to 60 for GridSearchCV
- reducing number of search iterations from 20 to 15 for RandomizedSearchCV

Example now runs in sub 7s, previously 3-4 min.

**Output now:**

randomizedSearchCV took 1.20 seconds for 15 candidates parameter settings.
Model with rank: 1
Mean validation score: 0.985 (std: 0.017)
Parameters: {'alpha': 0.42727143483962227, 'average': False, 'l1_ratio': 0.21100288847068727}

Model with rank: 2
Mean validation score: 0.985 (std: 0.015)
Parameters: {'alpha': 0.01923065446247222, 'average': False, 'l1_ratio': 0.4570654700132295}

Model with rank: 3
Mean validation score: 0.985 (std: 0.013)
Parameters: {'alpha': 0.18482179083229622, 'average': False, 'l1_ratio': 0.9627445435714047}

GridSearchCV took 4.71 seconds for 60 candidate parameter settings.
Model with rank: 1
Mean validation score: 0.993 (std: 0.004)
Parameters: {'alpha': 1.0, 'average': False, 'l1_ratio': 0.0}

Model with rank: 2
Mean validation score: 0.989 (std: 0.014)
Parameters: {'alpha': 0.01, 'average': False, 'l1_ratio': 0.0}

Model with rank: 2
Mean validation score: 0.989 (std: 0.014)
Parameters: {'alpha': 0.01, 'average': False, 'l1_ratio': 0.2222222222222222}

**Previous output:**

RandomizedSearchCV took 37.23 seconds for 20 candidates parameter settings.
Model with rank: 1
Mean validation score: 0.920 (std: 0.028)
Parameters: {'alpha': 0.07316411520495676, 'average': False, 'l1_ratio': 0.29007760721044407}

Model with rank: 2
Mean validation score: 0.920 (std: 0.029)
Parameters: {'alpha': 0.0005223493320259539, 'average': True, 'l1_ratio': 0.7936977033574206}

Model with rank: 3
Mean validation score: 0.918 (std: 0.031)
Parameters: {'alpha': 0.00025790124268693137, 'average': True, 'l1_ratio': 0.5699649107012649}

GridSearchCV took 187.33 seconds for 100 candidate parameter settings.
Model with rank: 1
Mean validation score: 0.931 (std: 0.026)
Parameters: {'alpha': 0.0001, 'average': True, 'l1_ratio': 0.0}

Model with rank: 2
Mean validation score: 0.928 (std: 0.030)
Parameters: {'alpha': 0.0001, 'average': True, 'l1_ratio': 0.1111111111111111}

Model with rank: 3
Mean validation score: 0.927 (std: 0.026)
Parameters: {'alpha': 0.0001, 'average': True, 'l1_ratio': 0.5555555555555556}