### PR TITLE
MAINT move PyPy back to scheduled build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -190,6 +190,28 @@ jobs:
 
 - template: build_tools/azure/posix-docker.yml
   parameters:
+    name: Linux_Docker_PyPy
+    vmImage: ubuntu-20.04
+    dependsOn: [linting, git_commit]
+    condition: |
+      and(
+        succeeded(),
+        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
+        or(
+          eq(variables['Build.Reason'], 'Schedule'),
+          contains(dependencies['git_commit']['outputs']['commit.message'], '[pypy]')
+        )
+      )
+    matrix:
+      pypy3:
+        DISTRIB: 'conda-mamba-pypy3'
+        DOCKER_CONTAINER: 'condaforge/mambaforge-pypy3:4.10.3-5'
+        PILLOW_VERSION: 'none'
+        PANDAS_VERSION: 'none'
+        CREATE_ISSUE_ON_TRACKER: 'true'
+
+- template: build_tools/azure/posix-docker.yml
+  parameters:
     name: Linux_Docker
     vmImage: ubuntu-20.04
     dependsOn: [linting, git_commit]
@@ -200,11 +222,6 @@ jobs:
         ne(variables['Build.Reason'], 'Schedule')
       )
     matrix:
-      pypy3:
-        DISTRIB: 'conda-mamba-pypy3'
-        DOCKER_CONTAINER: 'condaforge/mambaforge-pypy3:4.10.3-5'
-        PILLOW_VERSION: 'none'
-        PANDAS_VERSION: 'none'
       debian_atlas_32bit:
         DISTRIB: 'debian-32'
         DOCKER_CONTAINER: 'i386/debian:10.9'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,6 +106,28 @@ jobs:
         COVERAGE: 'false'
         BUILD_WITH_ICC: 'true'
 
+- template: build_tools/azure/posix-docker.yml
+  parameters:
+    name: Linux_Nightly_PyPy
+    vmImage: ubuntu-20.04
+    dependsOn: [linting, git_commit]
+    condition: |
+      and(
+        succeeded(),
+        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
+        or(
+          eq(variables['Build.Reason'], 'Schedule'),
+          contains(dependencies['git_commit']['outputs']['commit.message'], '[pypy]')
+        )
+      )
+    matrix:
+      pypy3:
+        DISTRIB: 'conda-mamba-pypy3'
+        DOCKER_CONTAINER: 'condaforge/mambaforge-pypy3:4.10.3-5'
+        PILLOW_VERSION: 'none'
+        PANDAS_VERSION: 'none'
+        CREATE_ISSUE_ON_TRACKER: 'true'
+
 # Will run all the time regardless of linting outcome.
 - template: build_tools/azure/posix.yml
   parameters:
@@ -187,28 +209,6 @@ jobs:
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
-
-- template: build_tools/azure/posix-docker.yml
-  parameters:
-    name: Linux_Docker_PyPy
-    vmImage: ubuntu-20.04
-    dependsOn: [linting, git_commit]
-    condition: |
-      and(
-        succeeded(),
-        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
-        or(
-          eq(variables['Build.Reason'], 'Schedule'),
-          contains(dependencies['git_commit']['outputs']['commit.message'], '[pypy]')
-        )
-      )
-    matrix:
-      pypy3:
-        DISTRIB: 'conda-mamba-pypy3'
-        DOCKER_CONTAINER: 'condaforge/mambaforge-pypy3:4.10.3-5'
-        PILLOW_VERSION: 'none'
-        PANDAS_VERSION: 'none'
-        CREATE_ISSUE_ON_TRACKER: 'true'
 
 - template: build_tools/azure/posix-docker.yml
   parameters:

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -549,7 +549,7 @@ Continuous Integration (CI)
 * Azure pipelines are used for testing scikit-learn on Linux, Mac and Windows,
   with different dependencies and settings.
 * CircleCI is used to build the docs for viewing, for linting with flake8, and
-  for testing with PyPy and ARM64 / aarch64 on Linux
+  for testing with ARM64 / aarch64 on Linux
 
 Please note that if one of the following markers appear in the latest commit
 message, the following actions are taken.
@@ -560,8 +560,9 @@ message, the following actions are taken.
     [ci skip]              CI is skipped completely
     [cd build]             CD is run (wheels and source distribution are built)
     [lint skip]            Azure pipeline skips linting
-    [scipy-dev]            Add a Travis build with our dependencies (numpy, scipy, etc ...) development builds
-    [icc-build]            Add a Travis build with the Intel C compiler (ICC)
+    [scipy-dev]            Build & test with our dependencies (numpy, scipy, etc ...) development builds
+    [icc-build]            Build & test with the Intel C compiler (ICC)
+    [pypy]                 Build & test with PyPy
     [doc skip]             Docs are not built
     [doc quick]            Docs built, but excludes example gallery plots
     [doc build]            Docs built including example gallery plots (very long)


### PR DESCRIPTION
Fixes #21286.
Follow-up on #21544.

This should disable the slow PyPy build from the PRs but notify us by creating an issue when PyPy is broken in the scheduled build.