### PR TITLE
ENH Accelerate plot_mlp_alpha.py

### DIFF
--- a/examples/neural_networks/plot_mlp_alpha.py
+++ b/examples/neural_networks/plot_mlp_alpha.py
@@ -45,7 +45,7 @@ for alpha in alphas:
                 random_state=1,
                 max_iter=2000,
                 early_stopping=True,
-                hidden_layer_sizes=[100, 100],
+                hidden_layer_sizes=[10, 10],
             ),
         )
     )
@@ -69,7 +69,9 @@ i = 1
 # iterate over datasets
 for X, y in datasets:
     # split into training and test part
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.4)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.4, random_state=42
+    )
 
     x_min, x_max = X[:, 0].min() - 0.5, X[:, 0].max() + 0.5
     y_min, y_max = X[:, 1].min() - 0.5, X[:, 1].max() + 0.5
@@ -98,9 +100,9 @@ for X, y in datasets:
         # Plot the decision boundary. For that, we will assign a color to each
         # point in the mesh [x_min, x_max] x [y_min, y_max].
         if hasattr(clf, "decision_function"):
-            Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
+            Z = clf.decision_function(np.column_stack([xx.ravel(), yy.ravel()]))
         else:
-            Z = clf.predict_proba(np.c_[xx.ravel(), yy.ravel()])[:, 1]
+            Z = clf.predict_proba(np.column_stack([xx.ravel(), yy.ravel()]))[:, 1]
 
         # Put the result into a color plot
         Z = Z.reshape(xx.shape)
@@ -134,7 +136,7 @@ for X, y in datasets:
         ax.text(
             xx.max() - 0.3,
             yy.min() + 0.3,
-            ("%.2f" % score).lstrip("0"),
+            f"{score:.3f}".lstrip("0"),
             size=15,
             horizontalalignment="right",
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#21598

#### What does this implement/fix? Explain your changes.
- Reduce `hidden_layer_sizes` to speed up. Moreover I think 100 is too large for these small datasets.
- `random_state` is missing in `train_test_split`. Add and tune it to preserve the trend showing overfitting to underfitting when increasing `alpha.`

before: 33 seconds
![before](https://scikit-learn.org/stable/_images/sphx_glr_plot_mlp_alpha_001.png)
after: 5 seconds
![after](https://user-images.githubusercontent.com/47032563/141535224-063000f5-beae-43b9-b651-53ab7e8487f2.png)

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
