### PR TITLE
[MRG] FIX segmentation fault on memory mapped contiguous memoryview

### DIFF
--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -78,7 +78,7 @@ def cythonize_extensions(top_path, config):
         },
         compiler_directives={
             "language_level": 3,
-            "boundscheck": True,
+            "boundscheck": False,
             "wraparound": False,
             "initializedcheck": False,
             "nonecheck": False,

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -78,7 +78,7 @@ def cythonize_extensions(top_path, config):
         },
         compiler_directives={
             "language_level": 3,
-            "boundscheck": False,
+            "boundscheck": True,
             "wraparound": False,
             "initializedcheck": False,
             "nonecheck": False,

--- a/sklearn/utils/_readonly_array_wrapper.pyx
+++ b/sklearn/utils/_readonly_array_wrapper.pyx
@@ -48,7 +48,7 @@ cdef class ReadonlyArrayWrapper:
         PyBuffer_Release(buffer)
 
 
-def _test_sum(NUM_TYPES[:] x):
+def _test_sum(NUM_TYPES[::1] x):
     """This function is for testing only.
 
     As this function does not modify x, we would like to define it as

--- a/sklearn/utils/_readonly_array_wrapper.pyx
+++ b/sklearn/utils/_readonly_array_wrapper.pyx
@@ -53,7 +53,7 @@ def _test_sum(NUM_TYPES[::1] x):
 
     As this function does not modify x, we would like to define it as
 
-            _test_sum(const NUM_TYPES[:] x)
+            _test_sum(const NUM_TYPES[::1] x)
 
     which is not possible as fused typed const memoryviews aren't
     supported in Cython<3.0.

--- a/sklearn/utils/_readonly_array_wrapper.pyx
+++ b/sklearn/utils/_readonly_array_wrapper.pyx
@@ -13,7 +13,6 @@ This way, we can use it on arrays that we don't touch.
 
 from cpython cimport Py_buffer
 from cpython.buffer cimport PyObject_GetBuffer, PyBuffer_Release, PyBUF_WRITABLE
-from cpython.ref cimport Py_INCREF
 
 import numpy as np
 cimport numpy as np
@@ -44,15 +43,8 @@ cdef class ReadonlyArrayWrapper:
         if request_for_writeable:
             # The following is a lie when self.wraps is readonly!
             buffer.readonly = False
-            buffer.obj = self
 
     def __releasebuffer__(self, Py_buffer *buffer):
-        # restore the state when the buffer was created
-        # because reassigning buffer.obj decrefs self, and the specification of
-        # __releasebuffer__ ways we shouldn't do that
-        Py_INCREF(self)
-        buffer.obj = self.wraps
-        buffer.readonly = True
         PyBuffer_Release(buffer)
 
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -520,19 +520,36 @@ class TempMemmap:
         _delete_folder(self.temp_folder)
 
 
-def create_memmap_backed_data(data, mmap_mode="r", return_folder=False):
+def create_memmap_backed_data(data, mmap_mode="r", return_folder=False, aligned=False):
     """
     Parameters
     ----------
     data
     mmap_mode : str, default='r'
     return_folder :  bool, default=False
+    aligned : bool, default=False
+        If True, if input is a single numpy array and if the input array is aligned,
+        the memory mapped array will also be aligned. This is a workaround for
+        https://github.com/joblib/joblib/issues/563.
     """
     temp_folder = tempfile.mkdtemp(prefix="sklearn_testing_")
     atexit.register(functools.partial(_delete_folder, temp_folder, warn=True))
-    filename = op.join(temp_folder, "data.pkl")
-    joblib.dump(data, filename)
-    memmap_backed_data = joblib.load(filename, mmap_mode=mmap_mode)
+    if aligned:
+        if isinstance(data, np.ndarray) and data.flags.aligned:
+            # https://numpy.org/doc/stable/reference/generated/numpy.memmap.html
+            filename = op.join(temp_folder, "data.dat")
+            fp = np.memmap(filename, dtype=data.dtype, mode="w+", shape=data.shape)
+            fp[:] = data[:]  # write data to memmap array
+            fp.flush()
+            memmap_backed_data = np.memmap(
+                filename, dtype=data.dtype, mode=mmap_mode, shape=data.shape
+            )
+        else:
+            raise ValueError("If aligned=True, input must be a single numpy array.")
+    else:
+        filename = op.join(temp_folder, "data.pkl")
+        joblib.dump(data, filename)
+        memmap_backed_data = joblib.load(filename, mmap_mode=mmap_mode)
     result = (
         memmap_backed_data if not return_folder else (memmap_backed_data, temp_folder)
     )

--- a/sklearn/utils/tests/test_readonly_wrapper.py
+++ b/sklearn/utils/tests/test_readonly_wrapper.py
@@ -33,3 +33,12 @@ def test_readonly_array_wrapper(readonly, dtype):
     x_readonly = ReadonlyArrayWrapper(x_readonly)
     sum_readonly = _test_sum(x_readonly)
     assert sum_readonly == pytest.approx(sum_origin, rel=1e-11)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
+def test_contig_mmapped(dtype):
+    x = np.arange(10).astype(dtype)
+    sum_origin = _test_sum(x)
+    x_mmap = create_memmap_backed_data(x, mmap_mode="w+")
+    sum_mmap = _test_sum(x_mmap)
+    assert sum_mmap == pytest.approx(sum_origin, rel=1e-11)

--- a/sklearn/utils/tests/test_readonly_wrapper.py
+++ b/sklearn/utils/tests/test_readonly_wrapper.py
@@ -13,6 +13,7 @@ def _readonly_array_copy(x):
     return y
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("readonly", [_readonly_array_copy, create_memmap_backed_data])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
 def test_readonly_array_wrapper(readonly, dtype):

--- a/sklearn/utils/tests/test_readonly_wrapper.py
+++ b/sklearn/utils/tests/test_readonly_wrapper.py
@@ -13,7 +13,6 @@ def _readonly_array_copy(x):
     return y
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("readonly", [_readonly_array_copy, create_memmap_backed_data])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
 def test_readonly_array_wrapper(readonly, dtype):

--- a/sklearn/utils/tests/test_readonly_wrapper.py
+++ b/sklearn/utils/tests/test_readonly_wrapper.py
@@ -13,7 +13,13 @@ def _readonly_array_copy(x):
     return y
 
 
-@pytest.mark.parametrize("readonly", [_readonly_array_copy, create_memmap_backed_data])
+def _create_memmap_backed_data(data):
+    return create_memmap_backed_data(
+        data, mmap_mode="r", return_folder=False, aligned=True
+    )
+
+
+@pytest.mark.parametrize("readonly", [_readonly_array_copy, _create_memmap_backed_data])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
 def test_readonly_array_wrapper(readonly, dtype):
     """Test that ReadonlyWrapper allows working with fused-typed."""
@@ -33,12 +39,3 @@ def test_readonly_array_wrapper(readonly, dtype):
     x_readonly = ReadonlyArrayWrapper(x_readonly)
     sum_readonly = _test_sum(x_readonly)
     assert sum_readonly == pytest.approx(sum_origin, rel=1e-11)
-
-
-@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
-def test_contig_mmapped(dtype):
-    x = np.arange(10).astype(dtype)
-    sum_origin = _test_sum(x)
-    x_mmap = create_memmap_backed_data(x, mmap_mode="w+")
-    sum_mmap = _test_sum(x_mmap)
-    assert sum_mmap == pytest.approx(sum_origin, rel=1e-11)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Hunting for the segmentation fault in https://github.com/scikit-learn/scikit-learn/pull/20567#issuecomment-967296818.

Edit: The fix is to not use joblib for creating readonly (memory mapped) arrays, but to use `np.memmap` instead, at least where aligned arrays are required.

#### Any other comments?
A segmentation fault happens on `Ubuntu_Bionic py37_conda_forge_openblas_ubuntu_1804` when a memory mapped readonly array (via joblib) is passed to a contiguous memoryview in Cython.