### PR TITLE
BUG Fix upstream updater when test collection fails

### DIFF
--- a/maint_tools/create_issue_from_juint.py
+++ b/maint_tools/create_issue_from_juint.py
@@ -73,6 +73,12 @@ if not junit_path.exists():
 tree = ET.parse(args.junit_file)
 failure_cases = []
 
+# Check if test collection failed
+error = tree.find("./testsuite/testcase/error")
+if error is not None:
+    # Get information for test collection error
+    failure_cases.append({"title": "Test Collection Failure", "body": error.text})
+
 for item in tree.iter("testcase"):
     failure = item.find("failure")
     if failure is None:


### PR DESCRIPTION
I saw that the issue board was not updated with a [recent upstream failure](https://dev.azure.com/thomasjpfan/scikit-learn/_build/results?buildId=6558&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081). This PR updates the script to handle test collection failures. I tested on this my [fork](https://github.com/thomasjpfan/scikit-learn/issues/93)

I will merge before the scheduled kicks off today as a test for the script.