### PR TITLE
FIX out of bounds error on X_indptr in kmeans

### DIFF
--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -523,7 +523,7 @@ def elkan_iter_chunked_sparse(
             _update_chunk_sparse(
                 X_data[X_indptr[start]: X_indptr[end]],
                 X_indices[X_indptr[start]: X_indptr[end]],
-                X_indptr[start: end],
+                X_indptr[start: end+1],
                 sample_weight[start: end],
                 centers_old,
                 centers_squared_norms,

--- a/sklearn/cluster/_k_means_lloyd.pyx
+++ b/sklearn/cluster/_k_means_lloyd.pyx
@@ -322,7 +322,7 @@ def lloyd_iter_chunked_sparse(
             _update_chunk_sparse(
                 X_data[X_indptr[start]: X_indptr[end]],
                 X_indices[X_indptr[start]: X_indptr[end]],
-                X_indptr[start: end],
+                X_indptr[start: end+1],
                 sample_weight[start: end],
                 x_squared_norms[start: end],
                 centers_old,


### PR DESCRIPTION
#### Reference Issues/PRs
When compiled with `boundscheck=True`, Kmeans tests like `test_kmeans_results` throws
```
sklearn/cluster/tests/test_k_means.py:73: AssertionError
------------------------------------------------------- Captured stderr call -------------------------------------------------------
IndexError: Out of bounds on buffer access (axis 0)
IndexError: Out of bounds on buffer access (axis 0)
```

#### What does this implement/fix? Explain your changes.
A CSR matrix `X` with `n` rows, has `X.indptr` with `n+1` elements as beautifully explained in https://stackoverflow.com/a/52299730/16761084.

The `n+1`th element might never be accessed such that this is not a user visible bug.

#### Any other comments?
Found by working on #21654.