### PR TITLE
ENH Improve `plot_semi_supervised_newsgroups.py` example

### DIFF
--- a/examples/semi_supervised/plot_semi_supervised_newsgroups.py
+++ b/examples/semi_supervised/plot_semi_supervised_newsgroups.py
@@ -11,7 +11,6 @@ loader or setting them to `None` to get all 20 of them.
 
 """
 
-import os
 
 import numpy as np
 

--- a/examples/semi_supervised/plot_semi_supervised_newsgroups.py
+++ b/examples/semi_supervised/plot_semi_supervised_newsgroups.py
@@ -26,7 +26,17 @@ from sklearn.semi_supervised import SelfTrainingClassifier
 from sklearn.semi_supervised import LabelSpreading
 from sklearn.metrics import f1_score
 
-data = fetch_20newsgroups(subset="train", categories=None)
+# Loading dataset containing first five categories
+data = fetch_20newsgroups(
+    subset="train",
+    categories=[
+        "alt.atheism",
+        "comp.graphics",
+        "comp.os.ms-windows.misc",
+        "comp.sys.ibm.pc.hardware",
+        "comp.sys.mac.hardware",
+    ],
+)
 print("%d documents" % len(data.filenames))
 print("%d categories" % len(data.target_names))
 print()

--- a/examples/semi_supervised/plot_semi_supervised_newsgroups.py
+++ b/examples/semi_supervised/plot_semi_supervised_newsgroups.py
@@ -108,7 +108,5 @@ if __name__ == "__main__":
     print("SelfTrainingClassifier on 20% of the training data (rest is unlabeled):")
     eval_and_print_metrics(st_pipeline, X_train, y_train, X_test, y_test)
 
-    if "CI" not in os.environ:
-        # LabelSpreading takes too long to run in the online documentation
-        print("LabelSpreading on 20% of the data (rest is unlabeled):")
-        eval_and_print_metrics(ls_pipeline, X_train, y_train, X_test, y_test)
+    print("LabelSpreading on 20% of the data (rest is unlabeled):")
+    eval_and_print_metrics(ls_pipeline, X_train, y_train, X_test, y_test)


### PR DESCRIPTION
#### Reference Issues/PRs
#21598

#### What does this implement/fix? Explain your changes.
* Reduce the number of categories from 20 to five.

before: ~104 seconds

```
11314 documents
20 categories

Supervised SGDClassifier on 100% of the data:
Number of training samples: 8485
Unlabeled samples in training set: 0
Micro-averaged F1 score on test set: 0.913
----------

Supervised SGDClassifier on 20% of the training data:
Number of training samples: 1673
Unlabeled samples in training set: 0
Micro-averaged F1 score on test set: 0.793
----------

SelfTrainingClassifier on 20% of the training data (rest is unlabeled):
Number of training samples: 8485
Unlabeled samples in training set: 6812
End of iteration 1, added 2834 new labels.
End of iteration 2, added 678 new labels.
End of iteration 3, added 279 new labels.
End of iteration 4, added 98 new labels.
End of iteration 5, added 39 new labels.
End of iteration 6, added 27 new labels.
End of iteration 7, added 19 new labels.
End of iteration 8, added 12 new labels.
End of iteration 9, added 9 new labels.
End of iteration 10, added 8 new labels.
Micro-averaged F1 score on test set: 0.834
----------

LabelSpreading on 20% of the data (rest is unlabeled):
Number of training samples: 8485
Unlabeled samples in training set: 6812
Micro-averaged F1 score on test set: 0.651
----------
```

after: ~9 seconds

```
2823 documents
5 categories

Supervised SGDClassifier on 100% of the data:
Number of training samples: 2117
Unlabeled samples in training set: 0
Micro-averaged F1 score on test set: 0.888
----------

Supervised SGDClassifier on 20% of the training data:
Number of training samples: 442
Unlabeled samples in training set: 0
Micro-averaged F1 score on test set: 0.746
----------

SelfTrainingClassifier on 20% of the training data (rest is unlabeled):
Number of training samples: 2117
Unlabeled samples in training set: 1675
End of iteration 1, added 1103 new labels.
End of iteration 2, added 191 new labels.
End of iteration 3, added 67 new labels.
End of iteration 4, added 8 new labels.
End of iteration 5, added 6 new labels.
End of iteration 6, added 8 new labels.
End of iteration 7, added 6 new labels.
End of iteration 8, added 5 new labels.
End of iteration 9, added 2 new labels.
End of iteration 10, added 1 new labels.
Micro-averaged F1 score on test set: 0.831
----------

LabelSpreading on 20% of the data (rest is unlabeled):
Number of training samples: 2117
Unlabeled samples in training set: 1675
Micro-averaged F1 score on test set: 0.700
----------
```