### PR TITLE
DEBUG try to reproduce Cython segfault on non-aligned data

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Store artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           path: wheelhouse/*.whl
 

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -160,6 +160,11 @@ try:
 except ImportError:
     print('pandas not installed')
 "
+
+if [[ $(type -P "gcc") ]]; then
+    gcc --version
+fi
+
 # Set parallelism to 3 to overlap IO bound tasks with CPU bound tasks on CI
 # workers with 2 cores when building the compiled extensions of scikit-learn.
 export SKLEARN_BUILD_PARALLEL=3

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -55,5 +55,5 @@ if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
 fi
 
 set -x
-eval "$TEST_CMD -v -k test_memmap_on_contiguous_data --pyargs sklearn.utils.tests.test_testing"
+eval "$TEST_CMD -s -v -k test_memmap_on_contiguous_data --pyargs sklearn.utils.tests.test_testing"
 set +x

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -46,9 +46,9 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
     TEST_CMD="$TEST_CMD -Wignore:The\ distutils:DeprecationWarning"
 fi
 
-if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
-    TEST_CMD="$TEST_CMD -n2"
-fi
+# if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
+#     TEST_CMD="$TEST_CMD -n2"
+# fi
 
 if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
     TEST_CMD="$TEST_CMD -ra"

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -55,5 +55,5 @@ if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
 fi
 
 set -x
-eval "$TEST_CMD --pyargs sklearn"
+eval "$TEST_CMD -v -k test_memmap_on_contiguous_data --pyargs sklearn.utils.tests.test_testing"
 set +x

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -78,7 +78,7 @@ def cythonize_extensions(top_path, config):
         },
         compiler_directives={
             "language_level": 3,
-            "boundscheck": True,
+            "boundscheck": False,
             "wraparound": False,
             "initializedcheck": False,
             "nonecheck": False,

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -78,7 +78,7 @@ def cythonize_extensions(top_path, config):
         },
         compiler_directives={
             "language_level": 3,
-            "boundscheck": False,
+            "boundscheck": True,
             "wraparound": False,
             "initializedcheck": False,
             "nonecheck": False,

--- a/sklearn/utils/_readonly_array_wrapper.pyx
+++ b/sklearn/utils/_readonly_array_wrapper.pyx
@@ -48,7 +48,7 @@ cdef class ReadonlyArrayWrapper:
         PyBuffer_Release(buffer)
 
 
-def _test_sum(NUM_TYPES[:] x):
+def _test_sum(NUM_TYPES[::1] x):
     """This function is for testing only.
 
     As this function does not modify x, we would like to define it as

--- a/sklearn/utils/_readonly_array_wrapper.pyx
+++ b/sklearn/utils/_readonly_array_wrapper.pyx
@@ -13,7 +13,6 @@ This way, we can use it on arrays that we don't touch.
 
 from cpython cimport Py_buffer
 from cpython.buffer cimport PyObject_GetBuffer, PyBuffer_Release, PyBUF_WRITABLE
-from cpython.ref cimport Py_INCREF
 
 import numpy as np
 cimport numpy as np
@@ -44,15 +43,8 @@ cdef class ReadonlyArrayWrapper:
         if request_for_writeable:
             # The following is a lie when self.wraps is readonly!
             buffer.readonly = False
-            buffer.obj = self
 
     def __releasebuffer__(self, Py_buffer *buffer):
-        # restore the state when the buffer was created
-        # because reassigning buffer.obj decrefs self, and the specification of
-        # __releasebuffer__ ways we shouldn't do that
-        Py_INCREF(self)
-        buffer.obj = self.wraps
-        buffer.readonly = True
         PyBuffer_Release(buffer)
 
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -520,19 +520,36 @@ class TempMemmap:
         _delete_folder(self.temp_folder)
 
 
-def create_memmap_backed_data(data, mmap_mode="r", return_folder=False):
+def create_memmap_backed_data(data, mmap_mode="r", return_folder=False, aligned=False):
     """
     Parameters
     ----------
     data
     mmap_mode : str, default='r'
     return_folder :  bool, default=False
+    aligned : bool, default=False
+        If True, if input is a single numpy array and if the input array is aligned,
+        the memory mapped array will also be aligned. This is a workaround for
+        https://github.com/joblib/joblib/issues/563.
     """
     temp_folder = tempfile.mkdtemp(prefix="sklearn_testing_")
     atexit.register(functools.partial(_delete_folder, temp_folder, warn=True))
-    filename = op.join(temp_folder, "data.pkl")
-    joblib.dump(data, filename)
-    memmap_backed_data = joblib.load(filename, mmap_mode=mmap_mode)
+    if aligned:
+        if isinstance(data, np.ndarray) and data.flags.aligned:
+            # https://numpy.org/doc/stable/reference/generated/numpy.memmap.html
+            filename = op.join(temp_folder, "data.dat")
+            fp = np.memmap(filename, dtype=data.dtype, mode="w+", shape=data.shape)
+            fp[:] = data[:]  # write data to memmap array
+            fp.flush()
+            memmap_backed_data = np.memmap(
+                filename, dtype=data.dtype, mode=mmap_mode, shape=data.shape
+            )
+        else:
+            raise ValueError("If aligned=True, input must be a single numpy array.")
+    else:
+        filename = op.join(temp_folder, "data.pkl")
+        joblib.dump(data, filename)
+        memmap_backed_data = joblib.load(filename, mmap_mode=mmap_mode)
     result = (
         memmap_backed_data if not return_folder else (memmap_backed_data, temp_folder)
     )

--- a/sklearn/utils/tests/test_readonly_wrapper.py
+++ b/sklearn/utils/tests/test_readonly_wrapper.py
@@ -33,3 +33,12 @@ def test_readonly_array_wrapper(readonly, dtype):
     x_readonly = ReadonlyArrayWrapper(x_readonly)
     sum_readonly = _test_sum(x_readonly)
     assert sum_readonly == pytest.approx(sum_origin, rel=1e-11)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
+def test_contig_mmapped(dtype):
+    x = np.arange(10).astype(dtype)
+    sum_origin = _test_sum(x)
+    x_mmap = create_memmap_backed_data(x, mmap_mode="w+")
+    sum_mmap = _test_sum(x_mmap)
+    assert sum_mmap == pytest.approx(sum_origin, rel=1e-11)

--- a/sklearn/utils/tests/test_readonly_wrapper.py
+++ b/sklearn/utils/tests/test_readonly_wrapper.py
@@ -13,6 +13,7 @@ def _readonly_array_copy(x):
     return y
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("readonly", [_readonly_array_copy, create_memmap_backed_data])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
 def test_readonly_array_wrapper(readonly, dtype):

--- a/sklearn/utils/tests/test_readonly_wrapper.py
+++ b/sklearn/utils/tests/test_readonly_wrapper.py
@@ -13,7 +13,6 @@ def _readonly_array_copy(x):
     return y
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("readonly", [_readonly_array_copy, create_memmap_backed_data])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
 def test_readonly_array_wrapper(readonly, dtype):

--- a/sklearn/utils/tests/test_readonly_wrapper.py
+++ b/sklearn/utils/tests/test_readonly_wrapper.py
@@ -13,7 +13,13 @@ def _readonly_array_copy(x):
     return y
 
 
-@pytest.mark.parametrize("readonly", [_readonly_array_copy, create_memmap_backed_data])
+def _create_memmap_backed_data(data):
+    return create_memmap_backed_data(
+        data, mmap_mode="r", return_folder=False, aligned=True
+    )
+
+
+@pytest.mark.parametrize("readonly", [_readonly_array_copy, _create_memmap_backed_data])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
 def test_readonly_array_wrapper(readonly, dtype):
     """Test that ReadonlyWrapper allows working with fused-typed."""
@@ -33,12 +39,3 @@ def test_readonly_array_wrapper(readonly, dtype):
     x_readonly = ReadonlyArrayWrapper(x_readonly)
     sum_readonly = _test_sum(x_readonly)
     assert sum_readonly == pytest.approx(sum_origin, rel=1e-11)
-
-
-@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
-def test_contig_mmapped(dtype):
-    x = np.arange(10).astype(dtype)
-    sum_origin = _test_sum(x)
-    x_mmap = create_memmap_backed_data(x, mmap_mode="w+")
-    sum_mmap = _test_sum(x_mmap)
-    assert sum_mmap == pytest.approx(sum_origin, rel=1e-11)

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -731,7 +731,8 @@ def test_memmap_on_contiguous_data(dtype):
     # aligned=True so avoid https://github.com/joblib/joblib/issues/563
     # without alignment, this can produce segmentation faults, see
     # https://github.com/scikit-learn/scikit-learn/pull/21654
-    x_mmap = create_memmap_backed_data(x, mmap_mode="r+", aligned=True)
+    x_mmap = create_memmap_backed_data(x, mmap_mode="r+", aligned=False)
+    print(x_mmap.flags)
     sum_mmap = _test_sum(x_mmap)
     assert sum_mmap == pytest.approx(sum_origin, rel=1e-11)
 


### PR DESCRIPTION
Let's see if `_test_sum` actually crashes with when mmap array is created with `aligned=False`.

Based on #21654.