### PR TITLE
TST check the legend instead of label names in CalibrationDisplay

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1099,6 +1099,9 @@ class CalibrationDisplay:
             ax.plot([0, 1], [0, 1], "k:", label=ref_line_label)
         self.line_ = ax.plot(self.prob_pred, self.prob_true, "s-", **line_kwargs)[0]
 
+        # Unify AxesSubplot string representation for labels across matplotlib versions
+        self.line_.set_label(self.line_.get_label().replace("child", "line"))
+
         if "label" in line_kwargs:
             ax.legend(loc="lower right")
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1099,11 +1099,8 @@ class CalibrationDisplay:
             ax.plot([0, 1], [0, 1], "k:", label=ref_line_label)
         self.line_ = ax.plot(self.prob_pred, self.prob_true, "s-", **line_kwargs)[0]
 
-        # Unify AxesSubplot string representation for labels across matplotlib versions
-        self.line_.set_label(self.line_.get_label().replace("child", "line"))
-
-        if "label" in line_kwargs:
-            ax.legend(loc="lower right")
+        # We always have to show the legend for at least the reference line
+        ax.legend(loc="lower right")
 
         xlabel = f"Mean predicted probability {info_pos_label}"
         ylabel = f"Fraction of positives {info_pos_label}"

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -689,7 +689,12 @@ def test_calibration_display_compute(pyplot, iris_data_binary, n_bins, strategy)
 
     assert viz.ax_.get_xlabel() == "Mean predicted probability (Positive class: 1)"
     assert viz.ax_.get_ylabel() == "Fraction of positives (Positive class: 1)"
-    assert viz.line_.get_label() == "LogisticRegression"
+
+    expected_legend_labels = ["LogisticRegression", "Perfectly calibrated"]
+    legend_labels = viz.ax_.get_legend().get_texts()
+    assert len(legend_labels) == len(expected_legend_labels)
+    for labels in legend_labels:
+        assert labels.get_text() in expected_legend_labels
 
 
 def test_plot_calibration_curve_pipeline(pyplot, iris_data_binary):
@@ -698,8 +703,12 @@ def test_plot_calibration_curve_pipeline(pyplot, iris_data_binary):
     clf = make_pipeline(StandardScaler(), LogisticRegression())
     clf.fit(X, y)
     viz = CalibrationDisplay.from_estimator(clf, X, y)
-    assert clf.__class__.__name__ in viz.line_.get_label()
-    assert viz.estimator_name == clf.__class__.__name__
+
+    expected_legend_labels = [viz.estimator_name, "Perfectly calibrated"]
+    legend_labels = viz.ax_.get_legend().get_texts()
+    assert len(legend_labels) == len(expected_legend_labels)
+    for labels in legend_labels:
+        assert labels.get_text() in expected_legend_labels
 
 
 @pytest.mark.parametrize(
@@ -712,7 +721,13 @@ def test_calibration_display_default_labels(pyplot, name, expected_label):
 
     viz = CalibrationDisplay(prob_true, prob_pred, y_prob, estimator_name=name)
     viz.plot()
-    assert viz.line_.get_label() == expected_label
+
+    expected_legend_labels = [] if name is None else [name]
+    expected_legend_labels.append("Perfectly calibrated")
+    legend_labels = viz.ax_.get_legend().get_texts()
+    assert len(legend_labels) == len(expected_legend_labels)
+    for labels in legend_labels:
+        assert labels.get_text() in expected_legend_labels
 
 
 def test_calibration_display_label_class_plot(pyplot):
@@ -727,7 +742,12 @@ def test_calibration_display_label_class_plot(pyplot):
     assert viz.estimator_name == name
     name = "name two"
     viz.plot(name=name)
-    assert viz.line_.get_label() == name
+
+    expected_legend_labels = [name, "Perfectly calibrated"]
+    legend_labels = viz.ax_.get_legend().get_texts()
+    assert len(legend_labels) == len(expected_legend_labels)
+    for labels in legend_labels:
+        assert labels.get_text() in expected_legend_labels
 
 
 @pytest.mark.parametrize("constructor_name", ["from_estimator", "from_predictions"])
@@ -750,11 +770,19 @@ def test_calibration_display_name_multiple_calls(
     assert viz.estimator_name == clf_name
     pyplot.close("all")
     viz.plot()
-    assert clf_name == viz.line_.get_label()
+
+    expected_legend_labels = [clf_name, "Perfectly calibrated"]
+    legend_labels = viz.ax_.get_legend().get_texts()
+    assert len(legend_labels) == len(expected_legend_labels)
+    for labels in legend_labels:
+        assert labels.get_text() in expected_legend_labels
+
     pyplot.close("all")
     clf_name = "another_name"
     viz.plot(name=clf_name)
-    assert clf_name == viz.line_.get_label()
+    assert len(legend_labels) == len(expected_legend_labels)
+    for labels in legend_labels:
+        assert labels.get_text() in expected_legend_labels
 
 
 def test_calibration_display_ref_line(pyplot, iris_data_binary):
@@ -832,7 +860,12 @@ def test_calibration_display_pos_label(
         viz.ax_.get_ylabel()
         == f"Fraction of positives (Positive class: {expected_pos_label})"
     )
-    assert viz.line_.get_label() == "LogisticRegression"
+
+    expected_legend_labels = [lr.__class__.__name__, "Perfectly calibrated"]
+    legend_labels = viz.ax_.get_legend().get_texts()
+    assert len(legend_labels) == len(expected_legend_labels)
+    for labels in legend_labels:
+        assert labels.get_text() in expected_legend_labels
 
 
 @pytest.mark.parametrize("method", ["sigmoid", "isotonic"])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #21690.


#### What does this implement/fix? Explain your changes.

`test_calibration_display_default_labels[None-_line1]` fails on main:
https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=35071&view=logs&j=78a0bf4f-79e5-5387-94ec-13e67d216d6e&t=f1857171-4a53-55c7-3ab5-90acfe091baa&l=482

This originated from a change made in matplotlib 3.5.0 by:
https://github.com/matplotlib/matplotlib/commit/e7e6c8cea7dd174751be335f89369aeb3c1f40f0#diff-501b7013d3efa42e08d1cc8dc7a27ee6944fcddb062cd7032249a0031bb01ff4R1641

It should fix the failing test.
#### Any other comments?

/cc @glemaitre 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
