### PR TITLE
Fix CircleCI doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       - CYTHON_VERSION: 'latest'
       - SCIKIT_IMAGE_VERSION: 'latest'
       # Bump the sphinx version from time to time. Avoid latest sphinx version
-      # that tend to break things slightly too often
+      # that tends to break things slightly too often
       - SPHINX_VERSION: 4.2.0
       - PANDAS_VERSION: 'latest'
       - SPHINX_GALLERY_VERSION: 'latest'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,13 +53,15 @@ jobs:
       - OMP_NUM_THREADS: 2
       - MKL_NUM_THREADS: 2
       - CONDA_ENV_NAME: testenv
-      - PYTHON_VERSION: 3.9
+      - PYTHON_VERSION: 3
       - NUMPY_VERSION: 'latest'
       - SCIPY_VERSION: 'latest'
       - MATPLOTLIB_VERSION: 'latest'
       - CYTHON_VERSION: 'latest'
       - SCIKIT_IMAGE_VERSION: 'latest'
-      - SPHINX_VERSION: 'min'
+      # Bump the sphinx version from time to time. Avoid latest sphinx version
+      # that tend to break things slightly too often
+      - SPHINX_VERSION: 4.2.0
       - PANDAS_VERSION: 'latest'
       - SPHINX_GALLERY_VERSION: 'latest'
       - NUMPYDOC_VERSION: 'latest'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - OMP_NUM_THREADS: 2
       - MKL_NUM_THREADS: 2
       - CONDA_ENV_NAME: testenv
-      - PYTHON_VERSION: 3
+      - PYTHON_VERSION: 3.9
       - NUMPY_VERSION: 'latest'
       - SCIPY_VERSION: 'latest'
       - MATPLOTLIB_VERSION: 'latest'


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Work-around for CircleCI failure: https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn/20216/workflows/48912744-6176-4bcd-bea7-c5b0b3dc2a49/jobs/162969

Looks like sphinx may not be supporting Python 3.10 yet?
```
Traceback (most recent call last):
  File "/home/circleci/miniconda/envs/testenv/bin/sphinx-build", line 6, in <module>
    from sphinx.cmd.build import main
  File "/home/circleci/miniconda/envs/testenv/lib/python3.10/site-packages/sphinx/cmd/build.py", line 25, in <module>
    from sphinx.application import Sphinx
  File "/home/circleci/miniconda/envs/testenv/lib/python3.10/site-packages/sphinx/application.py", line 31, in <module>
    from sphinx.config import Config
  File "/home/circleci/miniconda/envs/testenv/lib/python3.10/site-packages/sphinx/config.py", line 21, in <module>
    from sphinx.util import logging
  File "/home/circleci/miniconda/envs/testenv/lib/python3.10/site-packages/sphinx/util/__init__.py", line 41, in <module>
    from sphinx.util.typing import PathMatcher
  File "/home/circleci/miniconda/envs/testenv/lib/python3.10/site-packages/sphinx/util/typing.py", line 37, in <module>
    from types import Union as types_Union
ImportError: cannot import name 'Union' from 'types' (/home/circleci/miniconda/envs/testenv/lib/python3.10/types.py)
make: *** [Makefile:48: html] Error 1

Exited with code exit status 2
```