### PR TITLE
MAINT Make test_iterative_imputer_catch_warning failures more informative

### DIFF
--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -950,7 +950,7 @@ def test_iterative_imputer_catch_warning():
     imputer = IterativeImputer(n_nearest_features=5, sample_posterior=True)
     with pytest.warns(None) as record:
         X_fill = imputer.fit_transform(X, y)
-    assert not record.list
+    assert not [w.message for w in record.list]
     assert not np.any(np.isnan(X_fill))
 
 


### PR DESCRIPTION
For instance we recently got random failures such as:

https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=35106&view=logs&j=78a0bf4f-79e5-5387-94ec-13e67d216d6e&t=f1857171-4a53-55c7-3ab5-90acfe091baa&s=96ac2280-8cb4-5df5-99de-dd2da759617d