### PR TITLE
MAINT Continue on error for cache on azure

### DIFF
--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -51,6 +51,7 @@ jobs:
         key: '"$(Agent.JobName)"'
         path: $(CCACHE_DIR)
       displayName: ccache
+      continueOnError: true
     - script: |
         build_tools/azure/install.sh
       displayName: 'Install'


### PR DESCRIPTION
Until the Azure Pipeline's cache is fixed in https://github.com/microsoft/azure-pipelines-tasks/issues/15518, I think we need a temporary solution failure.

CC @ogrisel 