### PR TITLE
HOTFIX Temporarily unset ccache for Azure CI

### DIFF
--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -46,11 +46,13 @@ jobs:
     - bash: sudo chown -R $USER $CONDA
       displayName: Take ownership of conda installation
       condition: startsWith(variables['DISTRIB'], 'conda')
-    - task: Cache@2
-      inputs:
-        key: '"$(Agent.JobName)"'
-        path: $(CCACHE_DIR)
-      displayName: ccache
+    # TODO: Uncomment once Azure is fixed.
+    #
+    # - task: Cache@2
+    #   inputs:
+    #     key: '"$(Agent.JobName)"'
+    #     path: $(CCACHE_DIR)
+    #   displayName: ccache
     - script: |
         build_tools/azure/install.sh
       displayName: 'Install'


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fire on Azure.


#### What does this implement/fix? Explain your changes.

Azure CI randomly fails on this setup, e.g.:
https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=35162&view=logs&j=97641769-79fb-5590-9088-a30ce9b850b9&t=03471438-3bde-5c06-1937-439ff2f6f118&l=22

This temporarily unsets the failing step, i.e `ccache`.



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
