### PR TITLE
DOC Ensures that load_files passes numpydoc validation

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -31,7 +31,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.datasets._base.load_boston",
     "sklearn.datasets._base.load_breast_cancer",
     "sklearn.datasets._base.load_digits",
-    "sklearn.datasets._base.load_files",
     "sklearn.datasets._base.load_iris",
     "sklearn.datasets._base.load_linnerud",
     "sklearn.datasets._base.load_sample_image",

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -142,7 +142,7 @@ def load_files(
     Parameters
     ----------
     container_path : str
-        Path to the main folder holding one subfolder per category
+        Path to the main folder holding one subfolder per category.
 
     description : str, default=None
         A paragraph describing the characteristic of the dataset: its source,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
[#21350 ](https://github.com/scikit-learn/scikit-learn/issues/21350)


#### What does this implement/fix? Explain your changes.
This PR ensure that sklearn.datasets._base.load_files function docstrings passes all numpydoc validation checks.

 

- [x] sklearn.datasets._base.load_files removed from scikit-learn/maint_tools/test_docstrings.py
- [x] "." added in the end of "container_path" description to solve the PR09 error