### PR TITLE
MNT speed up plot_ensemble_oob.py

### DIFF
--- a/examples/ensemble/plot_ensemble_oob.py
+++ b/examples/ensemble/plot_ensemble_oob.py
@@ -81,10 +81,10 @@ error_rate = OrderedDict((label, []) for label, _ in ensemble_clfs)
 
 # Range of `n_estimators` values to explore.
 min_estimators = 15
-max_estimators = 125
+max_estimators = 150
 
 for label, clf in ensemble_clfs:
-    for i in range(min_estimators, max_estimators + 1):
+    for i in range(min_estimators, max_estimators + 1, 5):
         clf.set_params(n_estimators=i)
         clf.fit(X, y)
 

--- a/examples/ensemble/plot_ensemble_oob.py
+++ b/examples/ensemble/plot_ensemble_oob.py
@@ -81,7 +81,7 @@ error_rate = OrderedDict((label, []) for label, _ in ensemble_clfs)
 
 # Range of `n_estimators` values to explore.
 min_estimators = 15
-max_estimators = 175
+max_estimators = 125
 
 for label, clf in ensemble_clfs:
     for i in range(min_estimators, max_estimators + 1):


### PR DESCRIPTION
After 125, more estimators does not help the models and reducing max_estimators to 125 improves  runtime by almost 50%
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/issues/21598


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
