### PR TITLE
MNT accelerate example plot_lle_digits.py

### DIFF
--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -51,9 +51,13 @@ from sklearn.preprocessing import MinMaxScaler
 def plot_embedding(X, title, ax):
     X = MinMaxScaler().fit_transform(X)
 
-    for t in np.unique(y):
+    for digit in digits.target_names:
         ax.scatter(
-            *X[y == t].T, marker=f"${t}$", s=60, color=plt.cm.Dark2(t), alpha=0.7
+            *X[y == digit].T,
+            marker=f"${digit}$",
+            s=60,
+            color=plt.cm.Dark2(digit),
+            alpha=0.7,
         )
     shown_images = np.array([[1.0, 1.0]])  # just something big
     for i in range(X.shape[0]):
@@ -127,7 +131,7 @@ embeddings = {
     "LTSA LLE embedding": LocallyLinearEmbedding(
         n_neighbors=n_neighbors, n_components=2, method="ltsa"
     ),
-    "MDS embedding": MDS(n_components=2, n_init=1, max_iter=100),
+    "MDS embedding": MDS(n_components=2, n_init=1, max_iter=100, n_jobs=-1),
     "Random Trees embedding": make_pipeline(
         RandomTreesEmbedding(n_estimators=200, max_depth=5, random_state=0),
         TruncatedSVD(n_components=2),
@@ -136,10 +140,16 @@ embeddings = {
         n_components=2, random_state=0, eigen_solver="arpack"
     ),
     "t-SNE embeedding": TSNE(
-        n_components=2, init="pca", learning_rate="auto", random_state=0
+        n_components=2,
+        init="pca",
+        learning_rate="auto",
+        n_iter=500,
+        n_iter_without_progress=150,
+        n_jobs=-1,
+        random_state=0,
     ),
     "NCA embedding": NeighborhoodComponentsAnalysis(
-        n_components=2, init="random", random_state=0
+        n_components=2, init="pca", random_state=0
     ),
 }
 
@@ -147,7 +157,7 @@ embeddings = {
 # Once we declared all the methodes of interest, we can run and perform the projection
 # of the original data. We will store the projected data as well as the computational
 # time needed to perform each projection.
-from time import perf_counter
+from time import time
 
 projections, timing = {}, {}
 for name, transformer in embeddings.items():
@@ -158,9 +168,9 @@ for name, transformer in embeddings.items():
         data = X
 
     print(f"Computing {name}...")
-    start_time = perf_counter()
+    start_time = time()
     projections[name] = transformer.fit_transform(data, y)
-    timing[name] = perf_counter() - start_time
+    timing[name] = time() - start_time
 
 # %%
 # Finally, we can plot the resulting projection given by each method.

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -51,17 +51,13 @@ from sklearn.preprocessing import MinMaxScaler
 def plot_embedding(X, title, ax):
     X = MinMaxScaler().fit_transform(X)
 
+    for t in np.unique(y):
+        ax.scatter(
+            *X[y == t].T, marker=f"${t}$", s=60, color=plt.cm.Dark2(t), alpha=0.7
+        )
     shown_images = np.array([[1.0, 1.0]])  # just something big
     for i in range(X.shape[0]):
         # plot every digit on the embedding
-        ax.text(
-            X[i, 0],
-            X[i, 1],
-            str(y[i]),
-            color=plt.cm.Dark2(y[i]),
-            fontdict={"weight": "bold", "size": 9},
-        )
-
         # show an annotation box for a group of digits
         dist = np.sum((X[i] - shown_images) ** 2, 1)
         if np.min(dist) < 4e-3:
@@ -151,7 +147,7 @@ embeddings = {
 # Once we declared all the methodes of interest, we can run and perform the projection
 # of the original data. We will store the projected data as well as the computational
 # time needed to perform each projection.
-from time import time
+from time import perf_counter
 
 projections, timing = {}, {}
 for name, transformer in embeddings.items():
@@ -162,9 +158,9 @@ for name, transformer in embeddings.items():
         data = X
 
     print(f"Computing {name}...")
-    start_time = time()
+    start_time = perf_counter()
     projections[name] = transformer.fit_transform(data, y)
-    timing[name] = time() - start_time
+    timing[name] = perf_counter() - start_time
 
 # %%
 # Finally, we can plot the resulting projection given by each method.

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -69,8 +69,9 @@ def plot_embedding(X, title, ax):
             continue
         shown_images = np.concatenate([shown_images, [X[i]]], axis=0)
         imagebox = offsetbox.AnnotationBbox(
-            offsetbox.OffsetImage(digits.images[i], cmap=plt.cm.gray_r), X[i], zorder=1
+            offsetbox.OffsetImage(digits.images[i], cmap=plt.cm.gray_r), X[i]
         )
+        imagebox.set(zorder=1)
         ax.add_artist(imagebox)
 
     ax.set_title(title)

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -50,14 +50,14 @@ from sklearn.preprocessing import MinMaxScaler
 
 def plot_embedding(X, title, ax):
     X = MinMaxScaler().fit_transform(X)
-
     for digit in digits.target_names:
         ax.scatter(
             *X[y == digit].T,
             marker=f"${digit}$",
             s=60,
             color=plt.cm.Dark2(digit),
-            alpha=0.7,
+            alpha=0.425,
+            zorder=2,
         )
     shown_images = np.array([[1.0, 1.0]])  # just something big
     for i in range(X.shape[0]):
@@ -69,7 +69,7 @@ def plot_embedding(X, title, ax):
             continue
         shown_images = np.concatenate([shown_images, [X[i]]], axis=0)
         imagebox = offsetbox.AnnotationBbox(
-            offsetbox.OffsetImage(digits.images[i], cmap=plt.cm.gray_r), X[i]
+            offsetbox.OffsetImage(digits.images[i], cmap=plt.cm.gray_r), X[i], zorder=1
         )
         ax.add_artist(imagebox)
 
@@ -131,7 +131,7 @@ embeddings = {
     "LTSA LLE embedding": LocallyLinearEmbedding(
         n_neighbors=n_neighbors, n_components=2, method="ltsa"
     ),
-    "MDS embedding": MDS(n_components=2, n_init=1, max_iter=100, n_jobs=-1),
+    "MDS embedding": MDS(n_components=2, n_init=1, max_iter=120, n_jobs=2),
     "Random Trees embedding": make_pipeline(
         RandomTreesEmbedding(n_estimators=200, max_depth=5, random_state=0),
         TruncatedSVD(n_components=2),
@@ -145,7 +145,7 @@ embeddings = {
         learning_rate="auto",
         n_iter=500,
         n_iter_without_progress=150,
-        n_jobs=-1,
+        n_jobs=2,
         random_state=0,
     ),
     "NCA embedding": NeighborhoodComponentsAnalysis(


### PR DESCRIPTION
Changing matplotlib.text with matplotlib.scatter and Markers created from TeX symbols improves runtime by almost 25 seconds.
Also changed time.time with time.perf_counter.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/issues/21598


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
