### PR TITLE
FIX wminkowski removed in 1.8.0.dev0

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -36,6 +36,13 @@ Changelog
   This fixes a regression introduced in 1.0.0 with respect to 0.24.2.
   :pr:`21694` by :user:`Julien Jerphanion <jjerphan>`.
 
+- |Fix| All :class:`sklearn.metrics.MinkowskiDistance` now accepts a weight
+  parameter that makes it possible to write code that behaves consistently both
+  with scipy 1.8 and earlier versions. In turns this means that all
+  neighbors-based estimators (except those that use `algorithm="kd_tree"`) now
+  accept a weight parameter with `metric="minknowski"` to yield results that
+  are always consistent with `scipy.spatial.distance.cdist`.
+  :pr:`21741` by :user:`Olivier Grisel <ogrisel>`.
 
 :mod:`sklearn.preprocessing`
 ............................

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -410,8 +410,8 @@ def test_vector_scikit_single_vs_scipy_single(seed):
     assess_same_labelling(cut, cut_scipy)
 
 
-@pytest.mark.parametrize("metric", METRICS_DEFAULT_PARAMS)
-def test_mst_linkage_core_memory_mapped(metric):
+@pytest.mark.parametrize("metric_param_grid", METRICS_DEFAULT_PARAMS)
+def test_mst_linkage_core_memory_mapped(metric_param_grid):
     """The MST-LINKAGE-CORE algorithm must work on mem-mapped dataset.
 
     Non-regression test for issue #19875.
@@ -419,9 +419,9 @@ def test_mst_linkage_core_memory_mapped(metric):
     rng = np.random.RandomState(seed=1)
     X = rng.normal(size=(20, 4))
     Xmm = create_memmap_backed_data(X)
-    argdict = METRICS_DEFAULT_PARAMS[metric]
-    keys = argdict.keys()
-    for vals in itertools.product(*argdict.values()):
+    metric, param_grid = metric_param_grid
+    keys = param_grid.keys()
+    for vals in itertools.product(*param_grid.values()):
         kwargs = dict(zip(keys, vals))
         distance_metric = DistanceMetric.get_metric(metric, **kwargs)
         mst = mst_linkage_core(X, distance_metric)

--- a/sklearn/metrics/_dist_metrics.pyx
+++ b/sklearn/metrics/_dist_metrics.pyx
@@ -119,7 +119,7 @@ cdef class DistanceMetric:
     "mahalanobis"   MahalanobisDistance   V or VI   ``sqrt((x - y)' V^-1 (x - y))``
     ==============  ====================  ========  ===============================
 
-    Note that "minkowski" with a non None parameter actually calls
+    Note that "minkowski" with a non-None `w` parameter actually calls
     `WMinkowskiDistance` with `w=w ** (1/p)` in order to be consistent with the
     parametrization of scipy 1.8 and later.
 
@@ -259,8 +259,8 @@ cdef class DistanceMetric:
             w = kwargs.pop('w', None)
             if w is not None:
                 # Be consistent with scipy 1.8 conventions: in scipy 1.8,
-                # 'wminkowski' was removed in favor adding the possibility
-                # of passing a weight vector directly to 'minkowski', however
+                # 'wminkowski' was removed in favor of passing a
+                # weight vector directly to 'minkowski', however
                 # the new weights apply to the absolute differences raised to
                 # the p power instead of the absolute difference as in
                 # previous versions of scipy.

--- a/sklearn/metrics/_dist_metrics.pyx
+++ b/sklearn/metrics/_dist_metrics.pyx
@@ -550,12 +550,11 @@ cdef class ChebyshevDistance(DistanceMetric):
 
 #------------------------------------------------------------
 # Minkowski Distance
-#  d = sum(x_i^p - y_i^p) ^ (1/p)
 cdef class MinkowskiDistance(DistanceMetric):
     r"""Minkowski Distance
 
     .. math::
-       D(x, y) = [\sum_i (x_i - y_i)^p] ^ (1/p)
+       D(x, y) = [\sum_i |x_i - y_i|^p] ^ (1/p)
 
     Minkowski Distance requires p >= 1 and finite. For p = infinity,
     use ChebyshevDistance.
@@ -597,7 +596,6 @@ cdef class MinkowskiDistance(DistanceMetric):
 
 #------------------------------------------------------------
 # W-Minkowski Distance
-#  d = sum(w_i^p * (x_i^p - y_i^p)) ^ (1/p)
 cdef class WMinkowskiDistance(DistanceMetric):
     r"""Weighted Minkowski Distance
 

--- a/sklearn/metrics/_dist_metrics.pyx
+++ b/sklearn/metrics/_dist_metrics.pyx
@@ -265,7 +265,7 @@ cdef class DistanceMetric:
                 # the p power instead of the absolute difference as in
                 # previous versions of scipy.
                 # WMinkowskiDistance in sklearn implements the weighting
-                # scheme of the old 'wminkowski' in scipy < 1.8 and the
+                # scheme of the old 'wminkowski' in scipy < 1.8, hence the
                 # following adaptation:
                 return WMinkowskiDistance(p, w ** (1/p), **kwargs)
             if p == 1:

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -72,7 +72,7 @@ def test_cdist(metric, X1, X2):
             # See: https://github.com/scipy/scipy/issues/13861
             pytest.xfail("scipy#13861: cdist with 'mahalanobis' fails onmemmap data")
         elif metric == "wminkowski":
-            if sp_version >= parse_version("1.8.0"):
+            if sp_version >= parse_version("1.8.0.dev0"):
                 pytest.skip("wminkowski will be removed in SciPy 1.8.0")
 
             # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -59,14 +59,14 @@ METRICS_DEFAULT_PARAMS = [
     ("braycurtis", {}),
 ]
 if sp_version >= parse_version("1.8.0.dev0"):
-    # In scipy 1.8.0.dev0, minkowski now accept a weighting parameter
-    # directly.
+    # Starting from scipy 1.8.0.dev0, minkowski now accepts w, the weighting
+    # parameter directly and using it is preferred over using wminkowski.
     METRICS_DEFAULT_PARAMS.append(
         ("minkowski", dict(p=(1, 1.5, 3), w=(rng.random_sample(d),))),
     )
 else:
     # For previous versions of scipy, this was possible through a dedicated
-    # metric (deprecated 1.6 and removed in 1.8).
+    # metric (deprecated in 1.6 and removed in 1.8).
     METRICS_DEFAULT_PARAMS.append(
         ("wminkowski", dict(p=(1, 1.5, 3), w=(rng.random_sample(d),))),
     )

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -47,44 +47,61 @@ BOOL_METRICS = [
     "sokalsneath",
 ]
 
-METRICS_DEFAULT_PARAMS = {
-    "euclidean": {},
-    "cityblock": {},
-    "minkowski": dict(p=(1, 1.5, 2, 3)),
-    "chebyshev": {},
-    "seuclidean": dict(V=(rng.random_sample(d),)),
-    "wminkowski": dict(p=(1, 1.5, 3), w=(rng.random_sample(d),)),
-    "mahalanobis": dict(VI=(VI,)),
-    "hamming": {},
-    "canberra": {},
-    "braycurtis": {},
-}
+METRICS_DEFAULT_PARAMS = [
+    ("euclidean", {}),
+    ("cityblock", {}),
+    ("minkowski", dict(p=(1, 1.5, 2, 3))),
+    ("chebyshev", {}),
+    ("seuclidean", dict(V=(rng.random_sample(d),))),
+    ("mahalanobis", dict(VI=(VI,))),
+    ("hamming", {}),
+    ("canberra", {}),
+    ("braycurtis", {}),
+]
+if sp_version >= parse_version("1.8.0.dev0"):
+    # In scipy 1.8.0.dev0, minkowski now accept a weighting parameter
+    # directly.
+    METRICS_DEFAULT_PARAMS.append(
+        ("minkowski", dict(p=(1, 1.5, 3), w=(rng.random_sample(d),))),
+    )
+else:
+    # For previous versions of scipy, this was possible through a dedicated
+    # metric (deprecated 1.6 and removed in 1.8).
+    METRICS_DEFAULT_PARAMS.append(
+        ("wminkowski", dict(p=(1, 1.5, 3), w=(rng.random_sample(d),))),
+    )
 
 
-@pytest.mark.parametrize("metric", METRICS_DEFAULT_PARAMS)
+def check_cdist(metric, kwargs, X1, X2):
+    if metric == "wminkowski":
+        # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
+        WarningToExpect = None
+        if sp_version >= parse_version("1.6.0"):
+            WarningToExpect = DeprecationWarning
+        with pytest.warns(WarningToExpect):
+            D_scipy_cdist = cdist(X1, X2, metric, **kwargs)
+    else:
+        D_scipy_cdist = cdist(X1, X2, metric, **kwargs)
+
+    dm = DistanceMetric.get_metric(metric, **kwargs)
+    D_sklearn = dm.pairwise(X1, X2)
+    assert_array_almost_equal(D_sklearn, D_scipy_cdist)
+
+
+@pytest.mark.parametrize("metric_param_grid", METRICS_DEFAULT_PARAMS)
 @pytest.mark.parametrize("X1, X2", [(X1, X2), (X1_mmap, X2_mmap)])
-def test_cdist(metric, X1, X2):
-    argdict = METRICS_DEFAULT_PARAMS[metric]
-    keys = argdict.keys()
-    for vals in itertools.product(*argdict.values()):
+def test_cdist(metric_param_grid, X1, X2):
+    metric, param_grid = metric_param_grid
+    keys = param_grid.keys()
+    for vals in itertools.product(*param_grid.values()):
         kwargs = dict(zip(keys, vals))
         if metric == "mahalanobis":
             # See: https://github.com/scipy/scipy/issues/13861
-            pytest.xfail("scipy#13861: cdist with 'mahalanobis' fails onmemmap data")
-        elif metric == "wminkowski":
-            if sp_version >= parse_version("1.8.0.dev0"):
-                pytest.skip("wminkowski will be removed in SciPy 1.8.0")
-
-            # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
-            ExceptionToAssert = None
-            if sp_version >= parse_version("1.6.0"):
-                ExceptionToAssert = DeprecationWarning
-            with pytest.warns(ExceptionToAssert):
-                D_true = cdist(X1, X2, metric, **kwargs)
-        else:
-            D_true = cdist(X1, X2, metric, **kwargs)
-
-        check_cdist(metric, kwargs, D_true)
+            # Possibly caused by: https://github.com/joblib/joblib/issues/563
+            pytest.xfail(
+                "scipy#13861: cdist with 'mahalanobis' fails on joblib memmap data"
+            )
+        check_cdist(metric, kwargs, X1, X2)
 
 
 @pytest.mark.parametrize("metric", BOOL_METRICS)
@@ -96,24 +113,18 @@ def test_cdist_bool_metric(metric, X1_bool, X2_bool):
     check_cdist_bool(metric, D_true)
 
 
-def check_cdist(metric, kwargs, D_true):
-    dm = DistanceMetric.get_metric(metric, **kwargs)
-    D12 = dm.pairwise(X1, X2)
-    assert_array_almost_equal(D12, D_true)
-
-
 def check_cdist_bool(metric, D_true):
     dm = DistanceMetric.get_metric(metric)
     D12 = dm.pairwise(X1_bool, X2_bool)
     assert_array_almost_equal(D12, D_true)
 
 
-@pytest.mark.parametrize("metric", METRICS_DEFAULT_PARAMS)
+@pytest.mark.parametrize("metric_param_grid", METRICS_DEFAULT_PARAMS)
 @pytest.mark.parametrize("X1, X2", [(X1, X2), (X1_mmap, X2_mmap)])
-def test_pdist(metric, X1, X2):
-    argdict = METRICS_DEFAULT_PARAMS[metric]
-    keys = argdict.keys()
-    for vals in itertools.product(*argdict.values()):
+def test_pdist(metric_param_grid, X1, X2):
+    metric, param_grid = metric_param_grid
+    keys = param_grid.keys()
+    for vals in itertools.product(*param_grid.values()):
         kwargs = dict(zip(keys, vals))
         if metric == "mahalanobis":
             # See: https://github.com/scipy/scipy/issues/13861
@@ -159,11 +170,11 @@ def check_pdist_bool(metric, D_true):
 
 
 @pytest.mark.parametrize("use_read_only_kwargs", [True, False])
-@pytest.mark.parametrize("metric", METRICS_DEFAULT_PARAMS)
-def test_pickle(use_read_only_kwargs, metric):
-    argdict = METRICS_DEFAULT_PARAMS[metric]
-    keys = argdict.keys()
-    for vals in itertools.product(*argdict.values()):
+@pytest.mark.parametrize("metric_param_grid", METRICS_DEFAULT_PARAMS)
+def test_pickle(use_read_only_kwargs, metric_param_grid):
+    metric, param_grid = metric_param_grid
+    keys = param_grid.keys()
+    for vals in itertools.product(*param_grid.values()):
         if use_read_only_kwargs:
             for val in vals:
                 if isinstance(val, np.ndarray):

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -448,18 +448,21 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         # For minkowski distance, use more efficient methods where available
         if self.metric == "minkowski":
             p = self.effective_metric_params_.pop("p", 2)
+            w = self.effective_metric_params_.pop("w", None)
             if p < 1:
                 raise ValueError(
                     "p must be greater or equal to one for minkowski metric"
                 )
-            elif p == 1:
+            elif p == 1 and w is None:
                 self.effective_metric_ = "manhattan"
-            elif p == 2:
+            elif p == 2 and w is None:
                 self.effective_metric_ = "euclidean"
-            elif p == np.inf:
+            elif p == np.inf and w is None:
                 self.effective_metric_ = "chebyshev"
             else:
+                # Use the generic minkowski metric, possibly weighted.
                 self.effective_metric_params_["p"] = p
+                self.effective_metric_params_["w"] = w
 
         if isinstance(X, NeighborsBase):
             self._fit_X = X._fit_X


### PR DESCRIPTION
This should fix the scipy-dev nightly build failure:

https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=35203&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081

```python
________________________ test_cdist[X10-X20-wminkowski] ________________________
[gw0] linux -- Python 3.10.0 /usr/share/miniconda/envs/testvenv/bin/python

[...]
        elif isinstance(metric, str):
            mstr = metric.lower()
            metric_info = _METRIC_ALIAS.get(mstr, None)
            if metric_info is not None:
                cdist_fn = metric_info.cdist_func
                return cdist_fn(XA, XB, out=out, **kwargs)
            elif mstr.startswith("test_"):
                metric_info = _TEST_METRICS.get(mstr, None)
                if metric_info is None:
                    raise ValueError(f'Unknown "Test" Distance Metric: {mstr[5:]}')
                XA, XB, typ, kwargs = _validate_cdist_input(
                    XA, XB, mA, mB, n, metric_info, **kwargs)
                return _cdist_callable(
                    XA, XB, metric=metric_info.dist_func, out=out, **kwargs)
            else:
>               raise ValueError('Unknown Distance Metric: %s' % mstr)
E               ValueError: Unknown Distance Metric: wminkowski
```

I tested locally and it seems to work as expected.


EDIT: to be consistent with scipy 1.8 overall, it was also necessary to make it possible to pass a `w` parameter when `metric="minkowski"` in which case the weights are to be raised to the power `p` to be consistent with scipy 1.8.