### PR TITLE
MAINT Use Python 3.9 for Circle CI job 'doc'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - OMP_NUM_THREADS: 2
       - MKL_NUM_THREADS: 2
       - CONDA_ENV_NAME: testenv
-      - PYTHON_VERSION: 3
+      - PYTHON_VERSION: '3.9'
       - NUMPY_VERSION: 'latest'
       - SCIPY_VERSION: 'latest'
       - MATPLOTLIB_VERSION: 'latest'


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Several PRs, e.g.  https://github.com/scikit-learn/scikit-learn/pull/18139 and https://github.com/scikit-learn/scikit-learn/pull/21341

#### What does this implement/fix? Explain your changes.

The `doc` job sometimes fails on Circle CI (e.g https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn/20372/workflows/ea9b8ea7-3a40-4987-bdab-03e90512e8f2/jobs/163634?invite=true#step-105-2111, e.g.  https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn/20310/workflows/25087498-3650-41fe-95c9-1a84de0af8e1/jobs/163379)
It seems that this is due to some problems on Python 3.10.
The minor version of Python 3 to use is not specified.

This PR proposes pinning the version of Python 3 to use to 3.9 for Circle CI, solving those problems.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
