### PR TITLE
MNT speed up test_kernel_pca_solvers_equivalence

### DIFF
--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -461,7 +461,7 @@ def test_kernel_pca_solvers_equivalence(n_components):
     """Check that 'dense' 'arpack' & 'randomized' solvers give similar results"""
 
     # Generate random data
-    n_train, n_test = 2000, 100
+    n_train, n_test = 1000, 100
     X, _ = make_circles(
         n_samples=(n_train + n_test), factor=0.3, noise=0.05, random_state=0
     )

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -461,7 +461,7 @@ def test_kernel_pca_solvers_equivalence(n_components):
     """Check that 'dense' 'arpack' & 'randomized' solvers give similar results"""
 
     # Generate random data
-    n_train, n_test = 1000, 100
+    n_train, n_test = 1_000, 100
     X, _ = make_circles(
         n_samples=(n_train + n_test), factor=0.3, noise=0.05, random_state=0
     )


### PR DESCRIPTION

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #21407 

#### What does this implement/fix? Explain your changes.
This change  improves the speed of the test test_kernel_pca.py::test_kernel_pca_solvers_equivalence by decreasing the number of samples in the data set used for estimation from 2,000 to 1,000.

Test duration before change:
2.19s call     sklearn/decomposition/tests/test_kernel_pca.py::test_kernel_pca_solvers_equivalence[20]
1.20s call     sklearn/decomposition/tests/test_kernel_pca.py::test_kernel_pca_solvers_equivalence[10]
0.90s call     sklearn/decomposition/tests/test_kernel_pca.py::test_kernel_pca_solvers_equivalence[4]

Test duration after change:
0.29s call     sklearn/decomposition/tests/test_kernel_pca.py::test_kernel_pca_solvers_equivalence[20]
0.20s call     sklearn/decomposition/tests/test_kernel_pca.py::test_kernel_pca_solvers_equivalence[4]
0.19s call     sklearn/decomposition/tests/test_kernel_pca.py::test_kernel_pca_solvers_equivalence[10]


#### Any other comments?
* There is a potential to improve the speed even more by decreasing the number of samples further.

* The test is executed three times with n_components = [4, 10, 20] however as I understand the results will be identical for all these n_components since the data set only have two features. However, I am not sure if there is any other reason for why the test is performed on three different parameters so I am not confident enough to remove any of them.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
