### PR TITLE
accelerate plot_scalable_poly_kernels.py remove multiple runs for lin…

### DIFF
--- a/examples/kernel_approximation/plot_scalable_poly_kernels.py
+++ b/examples/kernel_approximation/plot_scalable_poly_kernels.py
@@ -98,30 +98,24 @@ print(f"Linear SVM score on raw features: {lsvm_score:.2f}%")
 # much more compact representation. We repeat the experiment 5 times to
 # compensate for the stochastic nature of :class:`PolynomialCountSketch`.
 
-n_runs = 3
 for n_components in [250, 500, 1000, 2000]:
 
     ps_lsvm_time = 0
     ps_lsvm_score = 0
-    for _ in range(n_runs):
+    pipeline = Pipeline(
+        steps=[
+            (
+                "kernel_approximator",
+                PolynomialCountSketch(n_components=n_components, degree=4),
+            ),
+            ("linear_classifier", LinearSVC()),
+        ]
+    )
 
-        pipeline = Pipeline(
-            steps=[
-                (
-                    "kernel_approximator",
-                    PolynomialCountSketch(n_components=n_components, degree=4),
-                ),
-                ("linear_classifier", LinearSVC()),
-            ]
-        )
-
-        start = time.time()
-        pipeline.fit(X_train, y_train)
-        ps_lsvm_time += time.time() - start
-        ps_lsvm_score += 100 * pipeline.score(X_test, y_test)
-
-    ps_lsvm_time /= n_runs
-    ps_lsvm_score /= n_runs
+    start = time.time()
+    pipeline.fit(X_train, y_train)
+    ps_lsvm_time += time.time() - start
+    ps_lsvm_score += 100 * pipeline.score(X_test, y_test)
 
     results[f"LSVM + PS({n_components})"] = {
         "time": ps_lsvm_time,


### PR DESCRIPTION
…earSVC with PolynomialCountSketch

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/issues/21598


#### What does this implement/fix? Explain your changes.
Removed multiple run of Linearsvc with PolynomialCountSketch. results are very similar but runtime improves 24.3 seconds.

with 3 iterations
![3run](https://user-images.githubusercontent.com/25286805/142939297-0f441d0e-9ce0-40a3-b275-a92b21ea98ac.png)



with single iteration
![singlerun](https://user-images.githubusercontent.com/25286805/142939325-5b4d8e58-81ec-4e89-a333-e7882c27ad50.png)


