### PR TITLE
Old test for pull request

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -692,7 +692,9 @@ class OneHotEncoder(_BaseEncoder):
 
         feature_names = []
         for i in range(len(cats)):
-            names = [input_features[i] + "_" + str(t) for t in cats[i]]
+            if type(input_features[i]) is not str:
+                raise Warning("Your features names are not strings. This may cause errors later on.")
+            names = [str(input_features[i]) + "_" + str(t) for t in cats[i]]
             if self.drop_idx_ is not None and self.drop_idx_[i] is not None:
                 names.pop(self.drop_idx_[i])
             feature_names.extend(names)
@@ -724,7 +726,9 @@ class OneHotEncoder(_BaseEncoder):
 
         feature_names = []
         for i in range(len(cats)):
-            names = [input_features[i] + "_" + str(t) for t in cats[i]]
+            if type(input_features[i]) is not str:
+                raise Warning("Your features names are not strings. This may cause errors later on.")
+            names = [str(input_features[i]) + "_" + str(t) for t in cats[i]]
             if self.drop_idx_ is not None and self.drop_idx_[i] is not None:
                 names.pop(self.drop_idx_[i])
             feature_names.extend(names)


### PR DESCRIPTION
#### Reference Issues/PRs 

Fixes type problems for get_feature_names in OneHotEncoder

Hello, I have to work on this issue for a school project. 
I propose to cast integer-columns to string-columns & put a warning to inform the user that it is possible that others errors will happen later.  

I don't think we should force the user to put strings because some of the cases stated above are common (like csv files without headers). We can't change all the consistency problems of Pandas.
