### PR TITLE
ENH improve error message when y_true does not provide all known classes

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1719,6 +1719,8 @@ def top_k_accuracy_score(
             raise ValueError(
                 f"Number of classes in 'y_true' ({n_classes}) not equal "
                 f"to the number of classes in 'y_score' ({y_score_n_classes})."
+                "You can provide a list of all known classes by assigning it "
+                "to the parameter `labels`."
             )
     else:
         labels = column_or_1d(labels)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1720,7 +1720,7 @@ def top_k_accuracy_score(
                 f"Number of classes in 'y_true' ({n_classes}) not equal "
                 f"to the number of classes in 'y_score' ({y_score_n_classes})."
                 "You can provide a list of all known classes by assigning it "
-                "to the parameter `labels`."
+                "to the `labels` parameter."
             )
     else:
         labels = column_or_1d(labels)


### PR DESCRIPTION
closes #21568 

Improve the error message raised in `top_k_accuracy_score` by stipulating to assign the known classes to labels when `y_true` does not contain all potential labels.