### PR TITLE
MAINT accelerate plot_partial_dependence.py 

### DIFF
--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -148,7 +148,7 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 
 print("Training HistGradientBoostingRegressor...")
 tic = time()
-est = HistGradientBoostingRegressor(max_depth=7, random_state=0)
+est = HistGradientBoostingRegressor(random_state=0)
 est.fit(X_train, y_train)
 print(f"done in {time() - tic:.3f}s")
 print(f"Test R2 score: {est.score(X_test, y_test):.2f}")
@@ -236,8 +236,8 @@ display = PartialDependenceDisplay.from_estimator(
     X_train,
     features,
     kind="average",
-    n_jobs=3,
-    grid_resolution=20,
+    n_jobs=2,
+    grid_resolution=10,
     ax=ax,
 )
 print(f"done in {time() - tic:.3f}s")
@@ -268,7 +268,7 @@ fig = plt.figure()
 
 features = ("AveOccup", "HouseAge")
 pdp = partial_dependence(
-    est, X_train, features=features, kind="average", grid_resolution=20
+    est, X_train, features=features, kind="average", grid_resolution=10
 )
 XX, YY = np.meshgrid(pdp["values"][0], pdp["values"][1])
 Z = pdp.average[0].T

--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -80,7 +80,10 @@ tic = time()
 est = make_pipeline(
     QuantileTransformer(),
     MLPRegressor(
-        hidden_layer_sizes=(50, 50), learning_rate_init=0.01, early_stopping=True
+        hidden_layer_sizes=(30, 15),
+        learning_rate_init=0.01,
+        early_stopping=True,
+        random_state=0,
     ),
 )
 est.fit(X_train, y_train)
@@ -145,7 +148,7 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 
 print("Training HistGradientBoostingRegressor...")
 tic = time()
-est = HistGradientBoostingRegressor()
+est = HistGradientBoostingRegressor(max_depth=7, random_state=0)
 est.fit(X_train, y_train)
 print(f"done in {time() - tic:.3f}s")
 print(f"Test R2 score: {est.score(X_test, y_test):.2f}")
@@ -269,8 +272,9 @@ pdp = partial_dependence(
 )
 XX, YY = np.meshgrid(pdp["values"][0], pdp["values"][1])
 Z = pdp.average[0].T
-ax = Axes3D(fig)
+ax = Axes3D(fig, auto_add_to_figure=False)
 fig.add_axes(ax)
+
 surf = ax.plot_surface(XX, YY, Z, rstride=1, cstride=1, cmap=plt.cm.BuPu, edgecolor="k")
 ax.set_xlabel(features[0])
 ax.set_ylabel(features[1])

--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -272,7 +272,7 @@ pdp = partial_dependence(
 )
 XX, YY = np.meshgrid(pdp["values"][0], pdp["values"][1])
 Z = pdp.average[0].T
-ax = Axes3D(fig, auto_add_to_figure=False)
+ax = Axes3D(fig)
 fig.add_axes(ax)
 
 surf = ax.plot_surface(XX, YY, Z, rstride=1, cstride=1, cmap=plt.cm.BuPu, edgecolor="k")


### PR DESCRIPTION
Changed MPLRegressor layers from (50, 50) to (30, 15) added random_state=0
R2 is 0.82 from previous 0.81
Added max_depth=7 and random_state=0 to HistGradientBoostingRegressor
R2 is the same 0.85
Prevously preceptrons convergence was the main time consuming element and for different runs it was between 25 seconds to 48  seconds
with new params it's 18.3.
Also added auto_add_to_figure=False to matplotlib Axe3D to selent depecation warning. 


#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/issues/21598


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
