### PR TITLE
Plot nca classification.py

### DIFF
--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -80,7 +80,10 @@ tic = time()
 est = make_pipeline(
     QuantileTransformer(),
     MLPRegressor(
-        hidden_layer_sizes=(50, 50), learning_rate_init=0.01, early_stopping=True
+        hidden_layer_sizes=(30, 15),
+        learning_rate_init=0.01,
+        early_stopping=True,
+        random_state=0,
     ),
 )
 est.fit(X_train, y_train)
@@ -145,7 +148,7 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 
 print("Training HistGradientBoostingRegressor...")
 tic = time()
-est = HistGradientBoostingRegressor()
+est = HistGradientBoostingRegressor(max_depth=7, random_state=0)
 est.fit(X_train, y_train)
 print(f"done in {time() - tic:.3f}s")
 print(f"Test R2 score: {est.score(X_test, y_test):.2f}")
@@ -269,8 +272,9 @@ pdp = partial_dependence(
 )
 XX, YY = np.meshgrid(pdp["values"][0], pdp["values"][1])
 Z = pdp.average[0].T
-ax = Axes3D(fig)
+ax = Axes3D(fig, auto_add_to_figure=False)
 fig.add_axes(ax)
+
 surf = ax.plot_surface(XX, YY, Z, rstride=1, cstride=1, cmap=plt.cm.BuPu, edgecolor="k")
 ax.set_xlabel(features[0])
 ax.set_ylabel(features[1])

--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -272,7 +272,7 @@ pdp = partial_dependence(
 )
 XX, YY = np.meshgrid(pdp["values"][0], pdp["values"][1])
 Z = pdp.average[0].T
-ax = Axes3D(fig, auto_add_to_figure=False)
+ax = Axes3D(fig)
 fig.add_axes(ax)
 
 surf = ax.plot_surface(XX, YY, Z, rstride=1, cstride=1, cmap=plt.cm.BuPu, edgecolor="k")

--- a/examples/neighbors/plot_nca_classification.py
+++ b/examples/neighbors/plot_nca_classification.py
@@ -40,7 +40,7 @@ X_train, X_test, y_train, y_test = train_test_split(
     X, y, stratify=y, test_size=0.7, random_state=42
 )
 
-h = 0.015  # step size in the mesh
+h = 0.01  # step size in the mesh
 
 # Create color maps
 cmap_light = ListedColormap(["#FFAAAA", "#AAFFAA", "#AAAAFF"])

--- a/examples/neighbors/plot_nca_classification.py
+++ b/examples/neighbors/plot_nca_classification.py
@@ -40,7 +40,7 @@ X_train, X_test, y_train, y_test = train_test_split(
     X, y, stratify=y, test_size=0.7, random_state=42
 )
 
-h = 0.01  # step size in the mesh
+h = 0.015  # step size in the mesh
 
 # Create color maps
 cmap_light = ListedColormap(["#FFAAAA", "#AAFFAA", "#AAAAFF"])


### PR DESCRIPTION
Almost 90 percent of runtime is related directly to step size and changing it from 0.01 to 0.015 improves the runtime by 50 percent.
I'm not sure it even deserves a PR but based on my observation the difference in quality of boundaries is negligible.

with 0.01 step size: 25.3 second runtime

![a1](https://user-images.githubusercontent.com/25286805/143130582-99a2cb7b-35da-4189-a68e-f679e802379d.png)

![b1](https://user-images.githubusercontent.com/25286805/143130611-ca291197-66b0-4ea4-bee7-2f429bdc201e.png)

with 0.015 step size: 10.6 second runtime

![a2](https://user-images.githubusercontent.com/25286805/143130681-63fb60f3-f574-49b2-8ad7-7cf5496dba9e.png)

![b2](https://user-images.githubusercontent.com/25286805/143130696-a7243571-8d57-4bd6-9a12-1abdd5fd6eba.png)


####

 Reference Issues/PRs


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
