### PR TITLE
MNT Speed up OSX builds with 3 cores on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -247,11 +247,13 @@ jobs:
         DISTRIB: 'conda'
         BLAS: 'mkl'
         CONDA_CHANNEL: 'conda-forge'
+        CPU_COUNT: '3'
       pylatest_conda_mkl_no_openmp:
         DISTRIB: 'conda'
         BLAS: 'mkl'
         SKLEARN_TEST_NO_OPENMP: 'true'
         SKLEARN_SKIP_OPENMP_TEST: 'true'
+        CPU_COUNT: '3'
 
 - template: build_tools/azure/windows.yml
   parameters:

--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -16,6 +16,7 @@ jobs:
     JUNITXML: 'test-data.xml'
     OMP_NUM_THREADS: '2'
     OPENBLAS_NUM_THREADS: '2'
+    CPU_COUNT: '2'
     SKLEARN_SKIP_NETWORK_TESTS: '1'
     NUMPY_VERSION: 'latest'
     SCIPY_VERSION: 'latest'
@@ -69,6 +70,7 @@ jobs:
         -e OPENBLAS_NUM_THREADS=$OPENBLAS_NUM_THREADS
         -e SKLEARN_SKIP_NETWORK_TESTS=$SKLEARN_SKIP_NETWORK_TESTS
         -e BLAS=$BLAS
+        -e CPU_COUNT=$CPU_COUNT
         $DOCKER_CONTAINER
         sleep 1000000
       displayName: 'Start container'

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -9,6 +9,7 @@ jobs:
 - job: ${{ parameters.name }}
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.condition }}
+  timeoutInMinutes: 120
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:
@@ -17,6 +18,7 @@ jobs:
     JUNITXML: 'test-data.xml'
     OMP_NUM_THREADS: '2'
     OPENBLAS_NUM_THREADS: '2'
+    CPU_COUNT: '2'
     SKLEARN_SKIP_NETWORK_TESTS: '1'
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     CCACHE_COMPRESS: '1'

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -50,7 +50,7 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
-    TEST_CMD="$TEST_CMD -n2"
+    TEST_CMD="$TEST_CMD -n$CPU_COUNT"
 fi
 
 if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -21,6 +21,7 @@ jobs:
     PYTEST_XDIST_VERSION: 'latest'
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
     SHOW_SHORT_SUMMARY: 'false'
+    CPU_COUNT: '2'
   strategy:
     matrix:
       ${{ insert }}: ${{ parameters.matrix }}


### PR DESCRIPTION
I noticed that OSX with no openmp will time out from time to time. [Azure's OSX machines](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#hardware) have 3 cores, so we can parallelize over them all with `pytest-xdist`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
