### PR TITLE
MNT Speed up plot_sparse_logistic_regression_20newsgroups.py

### DIFF
--- a/examples/linear_model/plot_sparse_logistic_regression_20newsgroups.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_20newsgroups.py
@@ -40,7 +40,7 @@ t0 = timeit.default_timer()
 solver = "saga"
 
 # Turn down for faster run time
-n_samples = 10000
+n_samples = 5000
 
 X, y = fetch_20newsgroups_vectorized(subset="all", return_X_y=True)
 X = X[:n_samples]
@@ -58,8 +58,8 @@ print(
 )
 
 models = {
-    "ovr": {"name": "One versus Rest", "iters": [1, 2, 4]},
-    "multinomial": {"name": "Multinomial", "iters": [1, 3, 7]},
+    "ovr": {"name": "One versus Rest", "iters": [1, 2, 3]},
+    "multinomial": {"name": "Multinomial", "iters": [1, 2, 5]},
 }
 
 for model in models:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

Hello! First time contributing. Please tell me if I have done something wrong! Thank you!

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #21598 

#### What does this implement/fix? Explain your changes.

Specifically, speed up `examples/linear_model/plot_sparse_logistic_regression_20newsgroups.py` from 18.05 seconds to 4.59 seconds.

I've updated the number of epochs and training labels to speed it up. Also confirmed the expected result where multinomial logistic regression is more accurate and faster than 1 vs all L1 logistic regression.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
