### PR TITLE
[MRG] ENH speed up plot_poisson_regression_non_normal_loss.py

### DIFF
--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -435,10 +435,9 @@ plt.subplots_adjust(wspace=0.3)
 
 y_true = df_test["Frequency"].values
 exposure = df_test["Exposure"].values
-for idx, (axi, model) in enumerate(
-    zip(ax.ravel(), [dummy, ridge_glm, poisson_glm, poisson_gbrt])
+for axi, model, y_pred in zip(
+    ax.ravel(), [dummy, ridge_glm, poisson_glm, poisson_gbrt], test_preds
 ):
-    y_pred = test_preds[idx]
     q, y_true_seg, y_pred_seg = _mean_frequency_by_risk_group(
         y_true, y_pred, sample_weight=exposure, n_bins=10
     )
@@ -512,8 +511,8 @@ def lorenz_curve(y_true, y_pred, exposure):
 
 fig, ax = plt.subplots(figsize=(8, 8))
 
-for idx, model in enumerate([dummy, ridge_glm, poisson_glm, poisson_gbrt]):
-    y_pred = test_preds[idx]
+
+for model, y_pred in zip([dummy, ridge_glm, poisson_glm, poisson_gbrt], test_preds):
     cum_exposure, cum_claims = lorenz_curve(
         df_test["Frequency"], y_pred, df_test["Exposure"]
     )

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -244,17 +244,12 @@ test_preds.append(score_estimator(ridge_glm, df_test))
 
 from sklearn.linear_model import PoissonRegressor
 
-n_samples = df_train.shape[0]
-
 poisson_glm = Pipeline(
     [
         ("preprocessor", linear_model_preprocessor),
         ("regressor", PoissonRegressor(alpha=1e-12, max_iter=300)),
     ]
-)
-poisson_glm.fit(
-    df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"]
-)
+).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
 
 print("PoissonRegressor evaluation:")
 test_preds.append(score_estimator(poisson_glm, df_test))
@@ -303,10 +298,7 @@ poisson_gbrt = Pipeline(
             HistGradientBoostingRegressor(loss="poisson", max_leaf_nodes=128),
         ),
     ]
-)
-poisson_gbrt.fit(
-    df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"]
-)
+).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
 
 print("Poisson Gradient Boosted Trees evaluation:")
 test_preds.append(score_estimator(poisson_gbrt, df_test))

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -145,11 +145,7 @@ dummy = Pipeline(
         ("preprocessor", linear_model_preprocessor),
         ("regressor", DummyRegressor(strategy="mean")),
     ]
-).fit(
-    df_train.drop(columns=["Frequency"]),
-    df_train["Frequency"],
-    regressor__sample_weight=df_train["Exposure"],
-)
+).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
 
 
 ##############################################################################
@@ -163,7 +159,7 @@ from sklearn.metrics import mean_poisson_deviance
 
 def score_estimator(estimator, df_test):
     """Score an estimator on the test set."""
-    y_pred = estimator.predict(df_test.drop(columns=["Frequency"]))
+    y_pred = estimator.predict(df_test)
 
     print(
         "MSE: %.3f"
@@ -221,11 +217,7 @@ ridge_glm = Pipeline(
         ("preprocessor", linear_model_preprocessor),
         ("regressor", Ridge(alpha=1e-6)),
     ]
-).fit(
-    df_train.drop(columns=["Frequency"]),
-    df_train["Frequency"],
-    regressor__sample_weight=df_train["Exposure"],
-)
+).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
 
 # %%
 # The Poisson deviance cannot be computed on non-positive values predicted by
@@ -257,11 +249,7 @@ poisson_glm = Pipeline(
         ("preprocessor", linear_model_preprocessor),
         ("regressor", PoissonRegressor(alpha=1e-12, max_iter=300)),
     ]
-).fit(
-    df_train.drop(columns=["Frequency"]),
-    df_train["Frequency"],
-    regressor__sample_weight=df_train["Exposure"],
-)
+).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
 
 print("PoissonRegressor evaluation:")
 test_preds.append(score_estimator(poisson_glm, df_test))
@@ -310,11 +298,7 @@ poisson_gbrt = Pipeline(
             HistGradientBoostingRegressor(loss="poisson", max_leaf_nodes=128),
         ),
     ]
-).fit(
-    df_train.drop(columns=["Frequency"]),
-    df_train["Frequency"],
-    regressor__sample_weight=df_train["Exposure"],
-)
+).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
 
 print("Poisson Gradient Boosted Trees evaluation:")
 test_preds.append(score_estimator(poisson_gbrt, df_test))
@@ -346,7 +330,7 @@ for row_idx, label, df in zip(range(2), ["train", "test"], [df_train, df_test]):
 
     for idx, model in enumerate([ridge_glm, poisson_glm, poisson_gbrt]):
         if label == "train":
-            y_pred = model.predict(df.drop(columns=["Frequency"]))
+            y_pred = model.predict(df)
         else:
             y_pred = test_preds[idx + 1]
 

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -145,7 +145,11 @@ dummy = Pipeline(
         ("preprocessor", linear_model_preprocessor),
         ("regressor", DummyRegressor(strategy="mean")),
     ]
-).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
+).fit(
+    df_train.drop(columns=["Frequency"]),
+    df_train["Frequency"],
+    regressor__sample_weight=df_train["Exposure"],
+)
 
 
 ##############################################################################
@@ -159,7 +163,7 @@ from sklearn.metrics import mean_poisson_deviance
 
 def score_estimator(estimator, df_test):
     """Score an estimator on the test set."""
-    y_pred = estimator.predict(df_test)
+    y_pred = estimator.predict(df_test.drop(columns=["Frequency"]))
 
     print(
         "MSE: %.3f"
@@ -217,7 +221,11 @@ ridge_glm = Pipeline(
         ("preprocessor", linear_model_preprocessor),
         ("regressor", Ridge(alpha=1e-6)),
     ]
-).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
+).fit(
+    df_train.drop(columns=["Frequency"]),
+    df_train["Frequency"],
+    regressor__sample_weight=df_train["Exposure"],
+)
 
 # %%
 # The Poisson deviance cannot be computed on non-positive values predicted by
@@ -249,7 +257,11 @@ poisson_glm = Pipeline(
         ("preprocessor", linear_model_preprocessor),
         ("regressor", PoissonRegressor(alpha=1e-12, max_iter=300)),
     ]
-).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
+).fit(
+    df_train.drop(columns=["Frequency"]),
+    df_train["Frequency"],
+    regressor__sample_weight=df_train["Exposure"],
+)
 
 print("PoissonRegressor evaluation:")
 test_preds.append(score_estimator(poisson_glm, df_test))
@@ -298,7 +310,11 @@ poisson_gbrt = Pipeline(
             HistGradientBoostingRegressor(loss="poisson", max_leaf_nodes=128),
         ),
     ]
-).fit(df_train, df_train["Frequency"], regressor__sample_weight=df_train["Exposure"])
+).fit(
+    df_train.drop(columns=["Frequency"]),
+    df_train["Frequency"],
+    regressor__sample_weight=df_train["Exposure"],
+)
 
 print("Poisson Gradient Boosted Trees evaluation:")
 test_preds.append(score_estimator(poisson_gbrt, df_test))
@@ -330,7 +346,7 @@ for row_idx, label, df in zip(range(2), ["train", "test"], [df_train, df_test]):
 
     for idx, model in enumerate([ridge_glm, poisson_glm, poisson_gbrt]):
         if label == "train":
-            y_pred = model.predict(df)
+            y_pred = model.predict(df.drop(columns=["Frequency"]))
         else:
             y_pred = test_preds[idx + 1]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#21598

#### What does this implement/fix? Explain your changes.
- Speed up `../examples/linear_model/plot_poisson_regression_non_normal_loss.py` by storing test predictions and reuse them on figures
- Fix train/test `X` by removing `y` columns.

#### Any other comments?
The only way to **really** reduce the running time would be using a smaller dataset...

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
