### PR TITLE
accelerate plot_kernel_ridge_regression.py

### DIFF
--- a/examples/miscellaneous/plot_kernel_ridge_regression.py
+++ b/examples/miscellaneous/plot_kernel_ridge_regression.py
@@ -45,7 +45,7 @@ from sklearn.model_selection import learning_curve
 from sklearn.kernel_ridge import KernelRidge
 import matplotlib.pyplot as plt
 
-rng = np.random.RandomState(0)
+rng = np.random.RandomState(42)
 
 # #############################################################################
 # Generate sample data
@@ -128,10 +128,10 @@ plt.figure()
 X = 5 * rng.rand(10000, 1)
 y = np.sin(X).ravel()
 y[::5] += 3 * (0.5 - rng.rand(X.shape[0] // 5))
-sizes = np.logspace(1, 4, 7).astype(int)
+sizes = np.logspace(1, 3.8, 7).astype(int)
 for name, estimator in {
-    "KRR": KernelRidge(kernel="rbf", alpha=0.1, gamma=10),
-    "SVR": SVR(kernel="rbf", C=1e1, gamma=10),
+    "KRR": KernelRidge(kernel="rbf", alpha=0.01, gamma=10),
+    "SVR": SVR(kernel="rbf", C=1e2, gamma=10),
 }.items():
     train_time = []
     test_time = []


### PR DESCRIPTION
Reference Issues/PRs
References #21598
@ogrisel 
Only the part that calculates the execution time has been modified
24.2 s -> 16.8 s

[reduce]
train_data size -30%

[modify]
randomState 0 -> 42
Ridge(alpha=0.1, gamma=10) -> Ridge(alpha=0.01, gamma=10)
SVR(C=1e1, gamma=10) -> SVR(C=1e2, gamma=10)

I think the Execution Time graph before is incorrect
**In the training of medium-sized training data**
```
KRR Train time < SVR Train time
KRR Test time > SVR Test time
```
is correct. 
But, before graph is
```
KRR Train time > SVR Train time
KRR Test time > SVR Test time
```
There may be differences in the environment..

[Before]
![image](https://user-images.githubusercontent.com/67433064/143500551-37568c6e-699e-405c-8e0d-f2ab9f599279.png)

[After]
![image](https://user-images.githubusercontent.com/67433064/143500557-bcb56743-b0fc-43cf-91dd-ee2337bc8da7.png)
