### PR TITLE
[MRG] Accelerate example plot_kernel_ridge_regression.py

### DIFF
--- a/examples/miscellaneous/plot_kernel_ridge_regression.py
+++ b/examples/miscellaneous/plot_kernel_ridge_regression.py
@@ -17,10 +17,12 @@ consists of a sinusoidal target function and strong noise added to every fifth
 datapoint. The first figure compares the learned model of KRR and SVR when both
 complexity/regularization and bandwidth of the RBF kernel are optimized using
 grid-search. The learned functions are very similar; however, fitting KRR is
-approx. seven times faster than fitting SVR (both with grid-search). However,
-prediction of 100000 target values is more than tree times faster with SVR
-since it has learned a sparse model using only approx. 1/3 of the 100 training
-datapoints as support vectors.
+approx. seven times faster than fitting SVR (both with grid-search). The speed
+of prediction of SVR could in theory be 3x faster than KRR because SVR uses
+approximately 1/3 of the 100 training datapoints as support vectors. However
+here we observe that this not the case, probably because of implementations
+details (the SVR prediction code does not seem to be as well optimized as the
+KRR prediction code).
 
 The next figure compares the time for fitting and prediction of KRR and SVR for
 different sizes of the training set. Fitting KRR is faster than SVR for medium-
@@ -49,13 +51,13 @@ rng = np.random.RandomState(0)
 
 # #############################################################################
 # Generate sample data
-X = 5 * rng.rand(10000, 1)
+X = 5 * rng.rand(7000, 1)
 y = np.sin(X).ravel()
 
 # Add noise to targets
 y[::5] += 3 * (0.5 - rng.rand(X.shape[0] // 5))
 
-X_plot = np.linspace(0, 5, 100000)[:, None]
+X_plot = np.linspace(0, 5, 10000)[:, None]
 
 # #############################################################################
 # Fit regression model
@@ -125,7 +127,7 @@ plt.legend()
 plt.figure()
 
 # Generate sample data
-X = 5 * rng.rand(10000, 1)
+X = 5 * rng.rand(7000, 1)
 y = np.sin(X).ravel()
 y[::5] += 3 * (0.5 - rng.rand(X.shape[0] // 5))
 sizes = np.logspace(1, 4, 7).astype(int)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

References #21598

#### What does this implement/fix? Explain your changes.

Speed up `../examples/miscellaneous/plot_kernel_ridge_regression.py`  by reducing the number of samples from 10000 to 7000 for `X`, and 100000 to 70000 for `X_plot`.

Output before the changes:

<div align="center">
<img src="https://user-images.githubusercontent.com/55442731/143567725-3f99916a-0b9f-4e16-9f51-aa6c9b02606a.png" width="350">
<img src="https://user-images.githubusercontent.com/55442731/143567734-2ea53caf-82f8-4ceb-8aeb-e2d35aaea6d2.png" width="350">
<img src="https://user-images.githubusercontent.com/55442731/143567741-58e9e952-ba7a-4359-b5e5-d141e13742c6.png" width="350">
</div>

And after:

<div align="center">
<img src="https://user-images.githubusercontent.com/55442731/143566725-41e61f9a-9c70-4df7-8c44-81e8a4e4b17b.png" width="350">
<img src="https://user-images.githubusercontent.com/55442731/143566739-01efaf8e-298b-470f-a7c2-c6c0b18ca2c1.png" width="350">
<img src="https://user-images.githubusercontent.com/55442731/143566750-f3e26c80-803a-4017-b471-0d7e3a1019de.png" width="350">
</div>


#### Any other comments?

/

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
