### PR TITLE
FIX break inheritance in CSS style to show diagram

### DIFF
--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -307,6 +307,11 @@ _STYLE = """
   text-align: center;
 }
 #$id div.sk-container {
+  /* jupyter's `normalize.less` sets `[hidden] { display: none; }`
+     but bootstrap.min.css set `[hidden] { display: none !important; }`
+     so we also need the `!important` here to be able to override the
+     default hidden behavior on the sphinx rendered scikit-learn.org. 
+     See: https://github.com/scikit-learn/scikit-learn/issues/21755 */
   display: inline-block !important;
   position: relative;
 }

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -307,7 +307,7 @@ _STYLE = """
   text-align: center;
 }
 #$id div.sk-container {
-  display: inline-block;
+  display: inline-block !important;
   position: relative;
 }
 #$id div.sk-text-repr-fallback {


### PR DESCRIPTION
closes #21755 

Should solve the problem due to `bootstrap`.