### PR TITLE
Accelerate plot_image_denoising.py

### DIFF
--- a/examples/decomposition/plot_image_denoising.py
+++ b/examples/decomposition/plot_image_denoising.py
@@ -79,7 +79,7 @@ print("done in %.2fs." % (time() - t0))
 
 print("Learning the dictionary...")
 t0 = time()
-dico = MiniBatchDictionaryLearning(n_components=100, alpha=1, n_iter=500)
+dico = MiniBatchDictionaryLearning(n_components=50, alpha=1, n_iter=250)
 V = dico.fit(data).components_
 dt = time() - t0
 print("done in %.2fs." % dt)
@@ -139,7 +139,7 @@ print("done in %.2fs." % (time() - t0))
 transform_algorithms = [
     ("Orthogonal Matching Pursuit\n1 atom", "omp", {"transform_n_nonzero_coefs": 1}),
     ("Orthogonal Matching Pursuit\n2 atoms", "omp", {"transform_n_nonzero_coefs": 2}),
-    ("Least-angle regression\n5 atoms", "lars", {"transform_n_nonzero_coefs": 5}),
+    ("Least-angle regression\n4 atoms", "lars", {"transform_n_nonzero_coefs": 4}),
     ("Thresholding\n alpha=0.1", "threshold", {"transform_alpha": 0.1}),
 ]
 

--- a/examples/decomposition/plot_image_denoising.py
+++ b/examples/decomposition/plot_image_denoising.py
@@ -62,7 +62,7 @@ height, width = face.shape
 # Distort the right half of the image
 print("Distorting image...")
 distorted = face.copy()
-distorted[:, width // 2:] += 0.075 * np.random.randn(height, width // 2)
+distorted[:, width // 2 :] += 0.075 * np.random.randn(height, width // 2)
 
 # Extract all reference patches from the left half of the image
 print("Extracting reference patches...")
@@ -130,7 +130,7 @@ show_with_diff(distorted, face, "Distorted image")
 
 print("Extracting noisy patches... ")
 t0 = time()
-data = extract_patches_2d(distorted[:, width // 2:], patch_size)
+data = extract_patches_2d(distorted[:, width // 2 :], patch_size)
 data = data.reshape(data.shape[0], -1)
 intercept = np.mean(data, axis=0)
 data -= intercept
@@ -157,7 +157,7 @@ for title, transform_algorithm, kwargs in transform_algorithms:
     if transform_algorithm == "threshold":
         patches -= patches.min()
         patches /= patches.max()
-    reconstructions[title][:, width // 2:] = reconstruct_from_patches_2d(
+    reconstructions[title][:, width // 2 :] = reconstruct_from_patches_2d(
         patches, (height, width // 2)
     )
     dt = time() - t0

--- a/examples/decomposition/plot_image_denoising.py
+++ b/examples/decomposition/plot_image_denoising.py
@@ -62,7 +62,7 @@ height, width = face.shape
 # Distort the right half of the image
 print("Distorting image...")
 distorted = face.copy()
-distorted[:, width // 2 :] += 0.075 * np.random.randn(height, width // 2)
+distorted[:, width // 2:] += 0.075 * np.random.randn(height, width // 2)
 
 # Extract all reference patches from the left half of the image
 print("Extracting reference patches...")
@@ -130,7 +130,7 @@ show_with_diff(distorted, face, "Distorted image")
 
 print("Extracting noisy patches... ")
 t0 = time()
-data = extract_patches_2d(distorted[:, width // 2 :], patch_size)
+data = extract_patches_2d(distorted[:, width // 2:], patch_size)
 data = data.reshape(data.shape[0], -1)
 intercept = np.mean(data, axis=0)
 data -= intercept
@@ -157,7 +157,7 @@ for title, transform_algorithm, kwargs in transform_algorithms:
     if transform_algorithm == "threshold":
         patches -= patches.min()
         patches /= patches.max()
-    reconstructions[title][:, width // 2 :] = reconstruct_from_patches_2d(
+    reconstructions[title][:, width // 2:] = reconstruct_from_patches_2d(
         patches, (height, width // 2)
     )
     dt = time() - t0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

 #21598

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.


Accelerate computation time for the example plot_image_denoising.

I changed :

- in the function MiniBatchDictionaryLearning : n_component which has decrease from 100 to 50 and n_iter which has decrease from 500 to 250
- for the lars function : I choosed 4 instead of 5 to accelerate it

These are the results that I obtained  :

![contrib_final](https://user-images.githubusercontent.com/71873530/143591150-4d7f266c-2cd3-4256-ba06-a72e71a59886.png)


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
