### PR TITLE
[WIP] CountVectorizer and TfidfVectorizer option to featurize out-of-vocab.

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -127,6 +127,14 @@ Changelog
   ``bootstrap=False`` and ``max_samples`` is not ``None``.
   :pr:`21295` :user:`Haoyin Xu <PSSF23>`.
 
+:mod:`sklearn.feature_extraction`
+............................
+
+- |Enhancement| :class:`feature_extraction.text.CountVectorizer` and
+  `feature_extraction.text.TfidfVectorizer` added a parameter `out_of_vocab_features`
+  to add count and hash-bag counts for out-of-vocabulary matches.
+  :pr:`21801` by :user:`Geoff McDonald <glmcdona>`.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1240,12 +1240,7 @@ def test_vectorizer_pipeline_grid_selection(out_of_vocab_features):
     assert not best_vectorizer.fixed_vocabulary_
 
 
-@pytest.mark.parametrize("out_of_vocab_features", (None, 1))
-def test_vectorizer_pipeline_cross_validation(out_of_vocab_features):
-    if out_of_vocab_features and IS_PYPY:
-        # PYPY not supported for out_of_vocab features, pass test.
-        return
-
+def test_vectorizer_pipeline_cross_validation():
     # raw documents
     data = JUNK_FOOD_DOCS + NOTJUNK_FOOD_DOCS
 
@@ -1254,7 +1249,7 @@ def test_vectorizer_pipeline_cross_validation(out_of_vocab_features):
 
     pipeline = Pipeline(
         [
-            ("vect", TfidfVectorizer(out_of_vocab_features=out_of_vocab_features)),
+            ("vect", TfidfVectorizer()),
             ("svc", LinearSVC()),
         ]
     )

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1037,12 +1037,12 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
     out_of_vocab_features : int, default=None
         If not None, will add the specified number of out-of-vocabulary
         features.
-        If set to 1, it will add a single feature as count the
-        out-of-vocab features.
-        If >1, it will add the specified number of features to represent
-        all the out-of-vocab features through overlapping feature hashing
-        count buckets. Note hash bag uses Murmurhash3 and the out-of-vocab
-        features will overlap into these count buckets.
+        If set to 1, it will add a single feature as count of the
+        out-of-vocab features matched per document.
+        If set to >1, it will add the specified number of features to
+        represent all out-of-vocab features through overlapping feature
+        hashing count buckets. Note hash bag uses Murmurhash3 and the
+        out-of-vocab features will overlap into these count buckets.
         This option is usually used in conjunction with feature trimming
         `max_features`, `min_df`, `max_df`, and/or `vocabulary` options to
         featurize the trimmed-off features in a compact form.

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1048,7 +1048,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         `max_features`, `min_df`, `max_df`, and/or `vocabulary` options to
         featurize the trimmed-off features in a compact form.
 
-        .. versionadded:: 0.TODO
+        .. versionadded:: 1.1.0
 
     Attributes
     ----------
@@ -1337,7 +1337,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         return vocabulary, X
 
     def _validate_params(self):
-        """Validation of min_df, max_df and max_features"""
+        """Validation of min_df, max_df, max_features, and out_of_vocab_features"""
         super()._validate_params()
 
         if self.max_features is not None:
@@ -1352,6 +1352,14 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
             check_scalar(self.max_df, "max_df", numbers.Integral, min_val=0)
         else:
             check_scalar(self.max_df, "max_df", numbers.Real, min_val=0.0, max_val=1.0)
+
+        if self.out_of_vocab_features is not None:
+            check_scalar(
+                self.out_of_vocab_features,
+                "out_of_vocab_features",
+                numbers.Integral,
+                min_val=1,
+            )
 
     def fit(self, raw_documents, y=None):
         """Learn a vocabulary dictionary of all tokens in the raw documents.
@@ -1956,6 +1964,21 @@ class TfidfVectorizer(CountVectorizer):
     sublinear_tf : bool, default=False
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
+    out_of_vocab_features : int, default=None
+        If not None, will add the specified number of out-of-vocabulary
+        features counting the number of vocabulary misses.
+        If set to 1, it will add a single feature as count of the
+        out-of-vocab features matched per document.
+        If set to >1, it will add the specified number of features to
+        represent all out-of-vocab features through overlapping feature
+        hashing count buckets. Note hash bag uses Murmurhash3 and the
+        out-of-vocab features will overlap into these count buckets.
+        This option is often used in conjunction with feature trimming
+        `max_features`, `min_df`, `max_df`, and/or `vocabulary` options to
+        featurize the trimmed-off features in a compact form.
+
+        .. versionadded:: 1.1.0
+
     Attributes
     ----------
     vocabulary_ : dict
@@ -2033,6 +2056,7 @@ class TfidfVectorizer(CountVectorizer):
         use_idf=True,
         smooth_idf=True,
         sublinear_tf=False,
+        out_of_vocab_features=None,
     ):
 
         super().__init__(
@@ -2053,6 +2077,7 @@ class TfidfVectorizer(CountVectorizer):
             vocabulary=vocabulary,
             binary=binary,
             dtype=dtype,
+            out_of_vocab_features=out_of_vocab_features,
         )
 
         self._tfidf = TfidfTransformer(

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1263,9 +1263,10 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
             # Add the out-of-vocab features
             if self.out_of_vocab_features and fixed_vocab:
                 # One count feature for out-of-vocabulary, add as last feature index
-                j_indices.append(len(vocabulary))
-                values.append(oov_count)
-                oov_count = 0
+                if oov_count > 0:
+                    j_indices.append(len(vocabulary))
+                    values.append(oov_count)
+                    oov_count = 0
 
                 if self.out_of_vocab_features > 1:
                     # For >1 out of vocabulary features, also add a hashbag. Build

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -5,6 +5,7 @@
 #          Robert Layton <robertlayton@gmail.com>
 #          Jochen Wersdörfer <jochen@wersdoerfer.de>
 #          Roman Sinayev <roman.sinayev@gmail.com>
+#          Geoff McDonald <glmcdona@gmail.com>
 #
 # License: BSD 3 clause
 """
@@ -1043,12 +1044,11 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         represent all out-of-vocab features through overlapping feature
         hashing count buckets. Note hash bag uses Murmurhash3 and the
         out-of-vocab features will overlap into these count buckets.
-        This option is usually used in conjunction with feature trimming
+        This option is often used in conjunction with feature trimming
         `max_features`, `min_df`, `max_df`, and/or `vocabulary` options to
         featurize the trimmed-off features in a compact form.
 
         .. versionadded:: 0.TODO
-
 
     Attributes
     ----------

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1036,7 +1036,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
 
     out_of_vocab_features : int, default=None
         If not None, will add the specified number of out-of-vocabulary
-        features.
+        features counting the number of vocabulary misses.
         If set to 1, it will add a single feature as count of the
         out-of-vocab features matched per document.
         If set to >1, it will add the specified number of features to


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

Tasks:
- [x] Implement out-of-vocab count feature (`out_of_vocab_features=1`)
- [x] Implement out-of-vocab hashbag count feature (`out_of_vocab_features>1`)
- [ ] Add documentation and example
- [x] Add option version number
- [x] Added `out_of_vocab_features` option to `TfidfVectorizer` as well
- [x] Unit tests
- [x] Implement `inverse_transform` for added features
- [ ] Example cases where this feature improves outcome versus without these features

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes [#21790](https://github.com/scikit-learn/scikit-learn/issues/21790).


#### What does this implement/fix? Explain your changes.
Adds `out_of_vocab_features` option to `CountVectorizer`:
```
    out_of_vocab_features : int, default=None
        If not None, will add the specified number of out-of-vocabulary
        features counting the terms not in the vocabulary.
        If set to 1, it will add a single feature as total count of the
        out-of-vocab terms found per document.
        If set to >1, on top of the single count feature above it will also
        add the specified number of features to represent all out-of-vocab
        terms through overlapping feature hashing count buckets. For example,
        a value of 1024 will add single feature counting the total out-of-
        vocabulary terms, plus 1024 features from a hash-bag counting
        out-of-vocabulary terms in overlapping buckets. Note hash bag uses
        Murmurhash3 and the out-of-vocab terms will overlap into these
        count buckets.
        This option is often used in conjunction with feature trimming
        `max_features`, `min_df`, `max_df`, and/or `vocabulary` options to
        featurize the trimmed-off terms in a compact form.
```

Many tabular data models run CountVectorizer against categorical and text data to featurize the data. At the large scale especially, the min_df or max_features are commonly used to limit the dimensionality to the most frequent terms. This is important to reduce memory and sometimes may help with generalization of the resulting model.

One problem is that sometimes this long-tail of low-count terms has useful information, and researchers sometimes instead replace these features with a flag indicating that the feature was filtered out. This can further be extended to not only replace it with a single-feature denoting out of dictionary, but a hashbag of N terms denoting the long tail. Eg. a hashbag of 100 terms could be used to denote the long-tail of out of dictionary terms.

Example tests of current version:
```python
from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
corpus = [
    'This is the first document test test.',
    'This document is the second document.',
    'And this is the third one.',
    'Is this the first document?',
]


# Test usage without out-of-vocabulary features
vectorizer = CountVectorizer(analyzer='word', ngram_range=(1, 1), min_df=2)
X = vectorizer.fit_transform(corpus)

print(vectorizer.get_feature_names_out())
print(X.toarray())

'''
Output:
['document' 'first' 'is' 'the' 'this']
[[1 1 1 1 1]
 [2 0 1 1 1]
 [0 0 1 1 1]
 [1 1 1 1 1]]
'''

# Test usage with a single out-of-vocabulary feature count
vectorizer = CountVectorizer(analyzer='word', ngram_range=(1, 1), min_df=2, out_of_vocab_features=1)
X = vectorizer.fit_transform(corpus)

print(vectorizer.get_feature_names_out())
print(X.toarray())

'''
Output:
['document' 'first' 'is' 'the' 'this']
[[1 1 1 1 1 2]
 [2 0 1 1 1 1]
 [0 0 1 1 1 3]
 [1 1 1 1 1 0]]
'''

# Test usage with a eight out-of-vocabulary feature counts
vectorizer = CountVectorizer(analyzer='word', ngram_range=(1, 1), min_df=2, out_of_vocab_features=8)
X = vectorizer.fit_transform(corpus)

print(vectorizer.get_feature_names_out())
print(X.toarray())

'''
Output:
['document' 'first' 'is' 'the' 'this']
[[1 1 1 1 1 2 0 0 0 0 0 2 0 0]
 [2 0 1 1 1 1 0 0 0 1 0 0 0 0]
 [0 0 1 1 1 3 0 0 0 0 1 2 0 0]
 [1 1 1 1 1 0 0 0 0 0 0 0 0 0]]
'''
```

#### Any other comments?

I added `out_of_vocab_features` to the end of the parameters of `CountVectorizer` to be fully backwards compatible. Style-wise it makes more sense after `max_features` and before `vocabulary` in my opinion. Thoughts if I should I leave this at the end for compatibility, or place the new option more logically?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
