### PR TITLE
TST Do not use cache for fetch_openml tests

### DIFF
--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -13,7 +13,7 @@ import scipy.sparse
 import sklearn
 import pytest
 from sklearn import config_context
-from sklearn.datasets import fetch_openml
+from sklearn.datasets import fetch_openml as fetch_openml_orig
 from sklearn.datasets._openml import (
     _open_openml_url,
     _arff,
@@ -37,6 +37,10 @@ from sklearn.utils._testing import fails_if_pypy
 OPENML_TEST_DATA_MODULE = "sklearn.datasets.tests.data.openml"
 # if True, urlopen will be monkey patched to only use local files
 test_offline = True
+
+
+# Do not use a cache for `fetch_openml` to avoid issues with `pytest-xdist`
+fetch_openml = partial(fetch_openml_orig, data_home=None)
 
 
 def _test_features_list(data_id):

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -39,7 +39,11 @@ OPENML_TEST_DATA_MODULE = "sklearn.datasets.tests.data.openml"
 test_offline = True
 
 
-# Do not use a cache for `fetch_openml` to avoid issues with `pytest-xdist`
+# Do not use a cache for `fetch_openml` to avoid concurrent writing
+# issues with `pytest-xdist`.
+# Furthermore sklearn/datasets/tests/data/openml/ is not always consistent
+# with the version on openml.org. If one were to load the dataset outside of
+# the tests, it may result in data that does not represent openml.org.
 fetch_openml = partial(fetch_openml_orig, data_home=None)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Workaround for https://github.com/scikit-learn/scikit-learn/issues/21798

#### What does this implement/fix? Explain your changes.
Since all the HTTP calls in `test_openml.py` tests are mocked, setting `data_home=None` disables the cache for the mocked calls.

I think this is an improvement over `main` because the data in `sklearn/datasets/tests/data/openml/` is not always consistent with the version on openml.org. If one were to load the dataset outside of the tests, it may result in data that does not represent openml.org.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
