### PR TITLE
MNT Fixes deprecation error in [scipy-dev]

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/binning.py
@@ -12,6 +12,7 @@ import numpy as np
 from ...utils import check_random_state, check_array
 from ...base import BaseEstimator, TransformerMixin
 from ...utils.validation import check_is_fitted
+from ...utils.fixes import _percentile
 from ...utils._openmp_helpers import _openmp_effective_n_threads
 from ._binning import _map_to_bins
 from .common import X_DTYPE, X_BINNED_DTYPE, ALMOST_INF, X_BITSET_INNER_DTYPE
@@ -57,9 +58,9 @@ def _find_binning_thresholds(col_data, max_bins):
         # work on a fixed-size subsample of the full data.
         percentiles = np.linspace(0, 100, num=max_bins + 1)
         percentiles = percentiles[1:-1]
-        midpoints = np.percentile(
-            col_data, percentiles, interpolation="midpoint"
-        ).astype(X_DTYPE)
+        midpoints = _percentile(col_data, percentiles, method="midpoint").astype(
+            X_DTYPE
+        )
         assert midpoints.shape[0] == max_bins - 1
 
     # We avoid having +inf thresholds: +inf thresholds are only allowed in

--- a/sklearn/ensemble/_hist_gradient_boosting/binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/binning.py
@@ -12,7 +12,7 @@ import numpy as np
 from ...utils import check_random_state, check_array
 from ...base import BaseEstimator, TransformerMixin
 from ...utils.validation import check_is_fitted
-from ...utils.fixes import _percentile
+from ...utils.fixes import percentile
 from ...utils._openmp_helpers import _openmp_effective_n_threads
 from ._binning import _map_to_bins
 from .common import X_DTYPE, X_BINNED_DTYPE, ALMOST_INF, X_BITSET_INNER_DTYPE
@@ -58,9 +58,7 @@ def _find_binning_thresholds(col_data, max_bins):
         # work on a fixed-size subsample of the full data.
         percentiles = np.linspace(0, 100, num=max_bins + 1)
         percentiles = percentiles[1:-1]
-        midpoints = _percentile(col_data, percentiles, method="midpoint").astype(
-            X_DTYPE
-        )
+        midpoints = percentile(col_data, percentiles, method="midpoint").astype(X_DTYPE)
         assert midpoints.shape[0] == max_bins - 1
 
     # We avoid having +inf thresholds: +inf thresholds are only allowed in

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -280,6 +280,18 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis
         )
 
 
+def _percentile(a, q, *, method="linear", **kwargs):
+    """Rename the `method` kwarg to `interpolation` for NumPy < 1.22.
+
+    `interpolation` kwarg was deprecated in favor of `method` in NumPy >= 1.22.
+    """
+    if np_version < parse_version("1.22"):
+        return np.percentile(a, q, interpolation=method, **kwargs)
+
+    # NumPy >= 1.22
+    return np.percentile(a, q, method=method, **kwargs)
+
+
 # compatibility fix for threadpoolctl >= 3.0.0
 # since version 3 it's possible to setup a global threadpool controller to avoid
 # looping through all loaded shared libraries each time.

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -285,11 +285,13 @@ def _percentile(a, q, *, method="linear", **kwargs):
 
     `interpolation` kwarg was deprecated in favor of `method` in NumPy >= 1.22.
     """
-    if np_version < parse_version("1.22"):
-        return np.percentile(a, q, interpolation=method, **kwargs)
+    return np.percentile(a, q, interpolation=method, **kwargs)
 
-    # NumPy >= 1.22
-    return np.percentile(a, q, method=method, **kwargs)
+
+if np_version < parse_version("1.22"):
+    percentile = _percentile
+else:  # >= 1.22
+    from numpy import percentile  # type: ignore  # noqa
 
 
 # compatibility fix for threadpoolctl >= 3.0.0

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -280,11 +280,9 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis
         )
 
 
+# Rename the `method` kwarg to `interpolation` for NumPy < 1.22, because
+# `interpolation` kwarg was deprecated in favor of `method` in NumPy >= 1.22.
 def _percentile(a, q, *, method="linear", **kwargs):
-    """Rename the `method` kwarg to `interpolation` for NumPy < 1.22.
-
-    `interpolation` kwarg was deprecated in favor of `method` in NumPy >= 1.22.
-    """
     return np.percentile(a, q, interpolation=method, **kwargs)
 
 


### PR DESCRIPTION
Fixes failing [build on `main`](https://dev.azure.com/thomasjpfan/scikit-learn/_build/results?buildId=6582&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081) for scipy-dev.

In this case, `percentile` deprecated `interpolation` in favor of `method`. I am marking for 1.0.2 as this fixes a deprecation warning for NumPy in 1.22 and 1.22 is going to be released soon.