### PR TITLE
CI Do not include body since GitHub issues have a 65536 limit

### DIFF
--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -82,7 +82,7 @@ jobs:
         versionSpec: '3.9'
       displayName: Place Python into path to update issue tracker
       condition: and(succeededOrFailed(), eq(variables['CREATE_ISSUE_ON_TRACKER'], 'true'),
-                     eq(variables['Build.Reason'], 'IndividualCI'))
+                     eq(variables['Build.Reason'], 'Schedule'))
     - bash: |
         set -ex
         if [[ $(BOT_GITHUB_TOKEN) == "" ]]; then
@@ -100,7 +100,7 @@ jobs:
       env:
         JUNIT_FILE: $(TEST_DIR)/$(JUNITXML)
       condition: and(succeededOrFailed(), eq(variables['CREATE_ISSUE_ON_TRACKER'], 'true'),
-                     eq(variables['Build.Reason'], 'IndividualCI'))
+                     eq(variables['Build.Reason'], 'Schedule'))
     - script: |
         build_tools/azure/upload_codecov.sh
       condition: and(succeeded(), eq(variables['COVERAGE'], 'true'))

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -82,7 +82,7 @@ jobs:
         versionSpec: '3.9'
       displayName: Place Python into path to update issue tracker
       condition: and(succeededOrFailed(), eq(variables['CREATE_ISSUE_ON_TRACKER'], 'true'),
-                     eq(variables['Build.Reason'], 'Individual CI'))
+                     eq(variables['Build.Reason'], 'IndividualCI'))
     - bash: |
         set -ex
         if [[ $(BOT_GITHUB_TOKEN) == "" ]]; then
@@ -100,7 +100,7 @@ jobs:
       env:
         JUNIT_FILE: $(TEST_DIR)/$(JUNITXML)
       condition: and(succeededOrFailed(), eq(variables['CREATE_ISSUE_ON_TRACKER'], 'true'),
-                     eq(variables['Build.Reason'], 'Individual CI'))
+                     eq(variables['Build.Reason'], 'IndividualCI'))
     - script: |
         build_tools/azure/upload_codecov.sh
       condition: and(succeeded(), eq(variables['COVERAGE'], 'true'))

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -82,7 +82,7 @@ jobs:
         versionSpec: '3.9'
       displayName: Place Python into path to update issue tracker
       condition: and(succeededOrFailed(), eq(variables['CREATE_ISSUE_ON_TRACKER'], 'true'),
-                     eq(variables['Build.Reason'], 'Schedule'))
+                     eq(variables['Build.Reason'], 'Individual CI'))
     - bash: |
         set -ex
         if [[ $(BOT_GITHUB_TOKEN) == "" ]]; then
@@ -100,7 +100,7 @@ jobs:
       env:
         JUNIT_FILE: $(TEST_DIR)/$(JUNITXML)
       condition: and(succeededOrFailed(), eq(variables['CREATE_ISSUE_ON_TRACKER'], 'true'),
-                     eq(variables['Build.Reason'], 'Schedule'))
+                     eq(variables['Build.Reason'], 'Individual CI'))
     - script: |
         build_tools/azure/upload_codecov.sh
       condition: and(succeeded(), eq(variables['COVERAGE'], 'true'))

--- a/maint_tools/create_issue_from_juint.py
+++ b/maint_tools/create_issue_from_juint.py
@@ -84,12 +84,7 @@ for item in tree.iter("testcase"):
     if failure is None:
         continue
 
-    failure_cases.append(
-        {
-            "title": item.attrib["name"],
-            "body": failure.text,
-        }
-    )
+    failure_cases.append(item.attrib["name"])
 
 if not failure_cases:
     print("Test has no failures!")
@@ -106,9 +101,6 @@ if not failure_cases:
     sys.exit()
 
 # Create content for issue
-issue_summary = (
-    "<details><summary>{title}</summary>\n\n```python\n{body}\n```\n</details>\n"
-)
-body_list = [issue_summary.format(**case) for case in failure_cases]
+body_list = [f"- {case}" for case in failure_cases]
 body = "\n".join(body_list)
 create_or_update_issue(body)


### PR DESCRIPTION
In the latest [scipy-dev build](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=35487&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=48ece25d-9bf4-566b-afd7-917e0a4fa093), the upload to the issue tracker failed because the GitHub issue body has a 65536 character limit.

This PR simplifies the script to only include the test names. Here is an [example](https://github.com/thomasjpfan/scikit-learn/issues/94) of what the results look like.