### PR TITLE
ENH log1pexp for binomial loss in loss module

### DIFF
--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -208,7 +208,7 @@ np.import_array()
 # Note: The only important cutoff is at x = 18. All others are to save computation
 # time. Compared to the reference, we add the additional case distiction x <= -2 in
 # order to use log instead of log1p for improved performance. As with the other
-# cutoffs, this is precise within machine precision of double.
+# cutoffs, this is accurate within machine precision of double.
 cdef inline double log1pexp(double x) nogil:
     if x <= -37:
         return exp(x)

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -204,10 +204,11 @@ np.import_array()
 # Helper functions
 # -------------------------------------
 # Numerically stable version of log(1 + exp(x)) for double precision, see Eq. (10) of
-# https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf.
+# https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
 # Note: The only important cutoff is at x = 18. All others are to save computation
 # time. Compared to the reference, we add the additional case distiction x <= -2 in
-# order to use log instead of log1p for improved performance.
+# order to use log instead of log1p for improved performance. As with the other
+# cutoffs, this is precise within machine precision of double.
 cdef inline double log1pexp(double x) nogil:
     if x <= -37:
         return exp(x)

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -203,13 +203,18 @@ np.import_array()
 # -------------------------------------
 # Helper functions
 # -------------------------------------
-# Numerically stable version of log(1 + exp(x)) for double precision
-# See https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
+# Numerically stable version of log(1 + exp(x)) for double precision, see Eq. (10) of
+# https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf.
+# Note: The only important cutoff is at x = 18. All others are to save computation
+# time. Compared to the reference, we add the additional case distiction x <= -2 in
+# order to use log instead of log1p for improved performance.
 cdef inline double log1pexp(double x) nogil:
     if x <= -37:
         return exp(x)
-    elif x <= 18:
+    elif x <= -2:
         return log1p(exp(x))
+    elif x <= 18:
+        return log(1. + exp(x))
     elif x <= 33.3:
         return x + exp(-x)
     else:

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -119,7 +119,7 @@ class BaseLoss:
     differentiable = True
     is_multiclass = False
 
-    def __init__(self, closs, link, n_classes=1):
+    def __init__(self, closs, link, n_classes=None):
         self.closs = closs
         self.link = link
         self.approx_hessian = False


### PR DESCRIPTION
#### Reference Issues/PRs
Follow-up of #20567

#### What does this implement/fix? Explain your changes.
This PR improves helper function `log1pexp` a bit, which speeds up `HalfBinomialLoss.loss(..)`

#### Any other comments?
Ideally, this PR is merged before #21808 and #20811. It will improve their benchmarks.