### PR TITLE
MNT Add extern to avoid build warning in _dbscan_inner.pyx

### DIFF
--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -12,7 +12,7 @@ np.import_array()
 
 # Work around Cython bug: C++ exceptions are not caught unless thrown within
 # a cdef function with an "except +" declaration.
-cdef inline void push(vector[np.npy_intp] &stack, np.npy_intp i) except +:
+cdef extern inline void push(vector[np.npy_intp] &stack, np.npy_intp i) except +:
     stack.push_back(i)
 
 


### PR DESCRIPTION
This PR adds an `extern` to avoid the following warning when building:

```bash
warning: sklearn/cluster/_dbscan_inner.pyx:15:21: Only extern functions can throw C++ exceptions.
```

CC @jjerphan 