### PR TITLE
Accelerate `feature_selection/tests/test_sequential.py::test_nan_support`

### DIFF
--- a/sklearn/feature_selection/tests/test_sequential.py
+++ b/sklearn/feature_selection/tests/test_sequential.py
@@ -115,7 +115,7 @@ def test_nan_support():
     # Make sure nans are OK if the underlying estimator supports nans
 
     rng = np.random.RandomState(0)
-    n_samples, n_features = 100, 10
+    n_samples, n_features = 40, 4
     X, y = make_regression(n_samples, n_features, random_state=0)
     nan_mask = rng.randint(0, 2, size=(n_samples, n_features), dtype=bool)
     X[nan_mask] = np.nan


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: 
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #21407

#### What does this implement/fix? Explain your changes.
Hi. This is my first contribution so I hope everything is ok. 
Accelerate the test `feature_selection/tests/test_sequential.py::test_nan_support`
The reduction of `n_samples` (100 to 40) and `n_features` (10 to 4), which is used for a nan mask, accelerates the test.
On my local machine it decreased from 7.80s call to 0.90 s call.

#### Any other comments?

 I guess these two variables can be further decreased to also decrease the test time, but I'm not sure how much more they can be decreased.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
