### PR TITLE
FIX TfidfVectorizer should not assign in __init__

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -163,6 +163,14 @@ Changelog
   :class:`ensemble.ExtraTreesClassifier`.
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
 
+:mod:`sklearn.feature_extraction.text`
+......................................
+
+- |Fix| :class:`feature_extraction.text.TfidfVectorizer` now does not create
+  a :class:`feature_extraction.text.TfidfTransformer` at `__init__` as required
+  by our API.
+  :pr:`21832` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -618,13 +618,13 @@ def test_vectorizer():
 def test_tfidf_vectorizer_setters():
     tv = TfidfVectorizer(norm="l2", use_idf=False, smooth_idf=False, sublinear_tf=False)
     tv.norm = "l1"
-    assert tv._tfidf.norm == "l1"
+    assert tv._norm == "l1"
     tv.use_idf = True
-    assert tv._tfidf.use_idf
+    assert tv._use_idf
     tv.smooth_idf = True
-    assert tv._tfidf.smooth_idf
+    assert tv._smooth_idf
     tv.sublinear_tf = True
-    assert tv._tfidf.sublinear_tf
+    assert tv._sublinear_tf
 
 
 @fails_if_pypy
@@ -1222,6 +1222,7 @@ def test_tfidf_vectorizer_setter():
     orig = TfidfVectorizer(use_idf=True)
     orig.fit(JUNK_FOOD_DOCS)
     copy = TfidfVectorizer(vocabulary=orig.vocabulary_, use_idf=True)
+    print(copy.__dict__)
     copy.idf_ = orig.idf_
     assert_array_equal(
         copy.transform(JUNK_FOOD_DOCS).toarray(),

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1222,7 +1222,6 @@ def test_tfidf_vectorizer_setter():
     orig = TfidfVectorizer(use_idf=True)
     orig.fit(JUNK_FOOD_DOCS)
     copy = TfidfVectorizer(vocabulary=orig.vocabulary_, use_idf=True)
-    print(copy.__dict__)
     copy.idf_ = orig.idf_
     assert_array_equal(
         copy.transform(JUNK_FOOD_DOCS).toarray(),

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1244,6 +1244,11 @@ def test_tfidf_vectorizer_setter():
         copy.transform(JUNK_FOOD_DOCS).toarray(),
         orig.transform(JUNK_FOOD_DOCS).toarray(),
     )
+    # `idf_` cannot be set with `use_idf=False`
+    copy = TfidfVectorizer(vocabulary=orig.vocabulary_, use_idf=False)
+    err_msg = "`idf_` cannot be set when `user_idf=False`."
+    with pytest.raises(ValueError, match=err_msg):
+        copy.idf_ = orig.idf_
 
 
 def test_tfidfvectorizer_invalid_idf_attr():

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -616,15 +616,32 @@ def test_vectorizer():
 
 
 def test_tfidf_vectorizer_setters():
-    tv = TfidfVectorizer(norm="l2", use_idf=False, smooth_idf=False, sublinear_tf=False)
+    norm, use_idf, smooth_idf, sublinear_tf = "l2", False, False, False
+    tv = TfidfVectorizer(
+        norm=norm, use_idf=use_idf, smooth_idf=smooth_idf, sublinear_tf=sublinear_tf
+    )
+    tv.fit(JUNK_FOOD_DOCS)
+    assert tv._tfidf.norm == norm
+    assert tv._tfidf.use_idf == use_idf
+    assert tv._tfidf.smooth_idf == smooth_idf
+    assert tv._tfidf.sublinear_tf == sublinear_tf
+
+    # assigning value to `TfidfTransformer` should not have any effect until
+    # fitting
     tv.norm = "l1"
-    assert tv._norm == "l1"
     tv.use_idf = True
-    assert tv._use_idf
     tv.smooth_idf = True
-    assert tv._smooth_idf
     tv.sublinear_tf = True
-    assert tv._sublinear_tf
+    assert tv._tfidf.norm == norm
+    assert tv._tfidf.use_idf == use_idf
+    assert tv._tfidf.smooth_idf == smooth_idf
+    assert tv._tfidf.sublinear_tf == sublinear_tf
+
+    tv.fit(JUNK_FOOD_DOCS)
+    assert tv._tfidf.norm == tv.norm
+    assert tv._tfidf.use_idf == tv.use_idf
+    assert tv._tfidf.smooth_idf == tv.smooth_idf
+    assert tv._tfidf.sublinear_tf == tv.sublinear_tf
 
 
 @fails_if_pypy

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -2021,7 +2021,9 @@ class TfidfVectorizer(CountVectorizer):
     @idf_.setter
     def idf_(self, value):
         if not hasattr(self, "_tfidf"):
-            # Warm start the TFIDF transformer if does not exist yet
+            # We should support transfering `idf_` from another `TfidfTransformer`
+            # and therefore, we need to create the transformer instance it does not
+            # exist yet.
             self._tfidf = TfidfTransformer(
                 norm=self.norm,
                 use_idf=self.use_idf,

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1984,6 +1984,8 @@ class TfidfVectorizer(CountVectorizer):
 
     @idf_.setter
     def idf_(self, value):
+        if not self.use_idf:
+            raise ValueError("`idf_` cannot be set when `user_idf=False`.")
         if not hasattr(self, "_tfidf"):
             # We should support transfering `idf_` from another `TfidfTransformer`
             # and therefore, we need to create the transformer instance it does not

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1959,49 +1959,13 @@ class TfidfVectorizer(CountVectorizer):
             binary=binary,
             dtype=dtype,
         )
-        self._norm = norm
-        self._use_idf = use_idf
-        self._smooth_idf = smooth_idf
-        self._sublinear_tf = sublinear_tf
+        self.norm = norm
+        self.use_idf = use_idf
+        self.smooth_idf = smooth_idf
+        self.sublinear_tf = sublinear_tf
 
     # Broadcast the TF-IDF parameters to the underlying transformer instance
     # for easy grid search and repr
-
-    @property
-    def norm(self):
-        """Norm of each row output, can be either "l1" or "l2"."""
-        return self._norm
-
-    @norm.setter
-    def norm(self, value):
-        self._norm = value
-
-    @property
-    def use_idf(self):
-        """Whether or not IDF re-weighting is used."""
-        return self._use_idf
-
-    @use_idf.setter
-    def use_idf(self, value):
-        self._use_idf = value
-
-    @property
-    def smooth_idf(self):
-        """Whether or not IDF weights are smoothed."""
-        return self._smooth_idf
-
-    @smooth_idf.setter
-    def smooth_idf(self, value):
-        self._smooth_idf = value
-
-    @property
-    def sublinear_tf(self):
-        """Whether or not sublinear TF scaling is applied."""
-        return self._sublinear_tf
-
-    @sublinear_tf.setter
-    def sublinear_tf(self, value):
-        self._sublinear_tf = value
 
     @property
     def idf_(self):
@@ -2028,7 +1992,7 @@ class TfidfVectorizer(CountVectorizer):
                 norm=self.norm,
                 use_idf=self.use_idf,
                 smooth_idf=self.smooth_idf,
-                sublinear_tf=self._sublinear_tf,
+                sublinear_tf=self.sublinear_tf,
             )
         self._validate_vocabulary()
         if hasattr(self, "vocabulary_"):
@@ -2066,10 +2030,10 @@ class TfidfVectorizer(CountVectorizer):
         self._check_params()
         self._warn_for_unused_params()
         self._tfidf = TfidfTransformer(
-            norm=self._norm,
-            use_idf=self._use_idf,
-            smooth_idf=self._smooth_idf,
-            sublinear_tf=self._sublinear_tf,
+            norm=self.norm,
+            use_idf=self.use_idf,
+            smooth_idf=self.smooth_idf,
+            sublinear_tf=self.sublinear_tf,
         )
         X = super().fit_transform(raw_documents)
         self._tfidf.fit(X)
@@ -2096,10 +2060,10 @@ class TfidfVectorizer(CountVectorizer):
         """
         self._check_params()
         self._tfidf = TfidfTransformer(
-            norm=self._norm,
-            use_idf=self._use_idf,
-            smooth_idf=self._smooth_idf,
-            sublinear_tf=self._sublinear_tf,
+            norm=self.norm,
+            use_idf=self.use_idf,
+            smooth_idf=self.smooth_idf,
+            sublinear_tf=self.sublinear_tf,
         )
         X = super().fit_transform(raw_documents)
         self._tfidf.fit(X)


### PR DESCRIPTION
Somehow linked to https://github.com/scikit-learn/scikit-learn/issues/21406

This estimator would fail `check_no_attributes_set_in_init` if the check would be run on it.
Delay the creation of `TfidfTransformer` in `fit`. 
However, it seems that we are supporting some kind of "transfer learning" by assigning the `idf_` from another transformer/vectorizer before `fit`.

Running `check_no_attributes_set_in_init` would lead to the following traceback:

```pytb
____________________________________ test_estimators[TfidfVectorizer()-check_no_attributes_set_in_init] _____________________________________

estimator = TfidfVectorizer(), check = functools.partial(<function check_no_attributes_set_in_init at 0x1214c0940>, 'TfidfVectorizer')
request = <FixtureRequest for <Function test_estimators[TfidfVectorizer()-check_no_attributes_set_in_init]>>

    @parametrize_with_checks(list(_tested_estimators()))
    def test_estimators(estimator, check, request):
        # Common tests for estimator instances
        with ignore_warnings(category=(FutureWarning, ConvergenceWarning, UserWarning)):
            _set_checking_parameters(estimator)
>           check(estimator)

check      = functools.partial(<function check_no_attributes_set_in_init at 0x1214c0940>, 'TfidfVectorizer')
estimator  = TfidfVectorizer()
request    = <FixtureRequest for <Function test_estimators[TfidfVectorizer()-check_no_attributes_set_in_init]>>

sklearn/tests/test_common.py:110: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
sklearn/utils/_testing.py:313: in wrapper
    return fn(*args, **kwargs)
        args       = ('TfidfVectorizer', TfidfVectorizer())
        fn         = <function check_no_attributes_set_in_init at 0x1214c08b0>
        kwargs     = {}
        self       = _IgnoreWarnings(record=True)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'TfidfVectorizer', estimator_orig = TfidfVectorizer()

    @ignore_warnings(category=FutureWarning)
    def check_no_attributes_set_in_init(name, estimator_orig):
        """Check setting during init."""
        try:
            # Clone fails if the estimator does not store
            # all parameters as an attribute during init
            estimator = clone(estimator_orig)
        except AttributeError:
            raise AttributeError(
                f"Estimator {name} should store all parameters as an attribute during init."
            )
    
        if hasattr(type(estimator).__init__, "deprecated_original"):
            return
    
        init_params = _get_args(type(estimator).__init__)
        if IS_PYPY:
            # __init__ signature has additional objects in PyPy
            for key in ["obj"]:
                if key in init_params:
                    init_params.remove(key)
        parents_init_params = [
            param
            for params_parent in (_get_args(parent) for parent in type(estimator).__mro__)
            for param in params_parent
        ]
    
        # Test for no setting apart from parameters during init
        invalid_attr = set(vars(estimator)) - set(init_params) - set(parents_init_params)
>       assert not invalid_attr, (
            "Estimator %s should not set any attribute apart"
            " from parameters during init. Found attributes %s."
            % (name, sorted(invalid_attr))
        )
E       AssertionError: Estimator TfidfVectorizer should not set any attribute apart from parameters during init. Found attributes ['_tfidf'].

estimator  = TfidfVectorizer()
estimator_orig = TfidfVectorizer()
init_params = ['self', 'input', 'encoding', 'decode_error', 'strip_accents', 'lowercase', ...]
invalid_attr = {'_tfidf'}
name       = 'TfidfVectorizer'
parents_init_params = ['input', 'encoding', 'decode_error', 'strip_accents', 'lowercase', 'preprocessor', ...]

sklearn/utils/estimator_checks.py:3009: AssertionError
```