### PR TITLE
FIX Make fetch_openml atomically cache the download

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -113,10 +113,10 @@ Changelog
 
 - |Fix| :class:`decomposition.FastICA` now validates input parameters in `fit` instead of `__init__`.
   :pr:`21432` by :user:`Hannah Bohle <hhnnhh>` and :user:`Maren Westermann <marenwestermann>`.
-  
+
 - |Fix| :class:`decomposition.FactorAnalysis` now validates input parameters
   in `fit` instead of `__init__`.
-  :pr:`21713` by :user:`Haya <HayaAlmutairi>` and 
+  :pr:`21713` by :user:`Haya <HayaAlmutairi>` and
   :user:`Krum Arnaudov <krumeto>`.
 
 - |Fix| :class:`decomposition.KernelPCA` now validates input parameters in
@@ -290,6 +290,13 @@ Changelog
   been generated on a platform with a different bitness. A typical example is
   to train and pickle the model on 64 bit machine and load the model on a 32
   bit machine for prediction. :pr:`21552` by :user:`Loïc Estève <lesteve>`.
+
+:mod:`sklearn.datasets`
+...................
+
+- |Fix| The fetch_* functions are now thread safe. Data is first downloaded
+  to a temprary folder and then renamed.
+  :pr:`21552` by :user:`Siavash Rezazadeh <siavrez>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -295,7 +295,7 @@ Changelog
 ...................
 
 - |Fix| The fetch_* functions are now thread safe. Data is first downloaded
-  to a temprary folder and then renamed.
+  to a temporary subfolder and then renamed.
   :pr:`21833` by :user:`Siavash Rezazadeh <siavrez>`.
 
 Code and Documentation Contributors

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -296,7 +296,7 @@ Changelog
 
 - |Fix| The fetch_* functions are now thread safe. Data is first downloaded
   to a temprary folder and then renamed.
-  :pr:`21552` by :user:`Siavash Rezazadeh <siavrez>`.
+  :pr:`21833` by :user:`Siavash Rezazadeh <siavrez>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -294,7 +294,7 @@ Changelog
 :mod:`sklearn.datasets`
 ...................
 
-- |Fix| The fetch_* functions are now thread safe. Data is first downloaded
+- |Fix| :func:`datasets.fetch_openml` is now thread safe. Data is first downloaded
   to a temporary subfolder and then renamed.
   :pr:`21833` by :user:`Siavash Rezazadeh <siavrez>`.
 

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -12,7 +12,7 @@ import itertools
 from collections.abc import Generator
 from collections import OrderedDict
 from functools import partial
-from threading import get_native_id
+from threading import get_ident
 from string import ascii_lowercase, digits
 from random import Random
 
@@ -49,7 +49,7 @@ def _get_local_path(openml_path: str, data_home: str) -> str:
 
 
 def _get_tempfile_local_path(dir_name: str) -> str:
-    rng = Random(get_native_id())
+    rng = Random(get_ident())
     tempfile_name = "".join(rng.choices(ascii_lowercase + digits, k=10))
     tempfile_local_path = os.path.join(dir_name, tempfile_name + ".gz")
     return tempfile_local_path

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -108,12 +108,7 @@ def _open_openml_url(openml_path: str, data_home: Optional[str]):
     local_path = _get_local_path(openml_path, data_home)
     dir_name, file_name = os.path.split(local_path)
     if not os.path.exists(local_path):
-        try:
-            os.makedirs(dir_name)
-        except OSError:
-            # potentially, the directory has been created already
-            pass
-
+        os.makedirs(dir_name, exist_ok=True)
         try:
             with TemporaryDirectory(dir=dir_name) as tmpdir:
                 with closing(urlopen(req)) as fsrc:

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -115,7 +115,7 @@ def _open_openml_url(openml_path: str, data_home: Optional[str]):
             pass
 
         try:
-            with TemporaryDirectory(dir=data_home) as tmpdir:
+            with TemporaryDirectory(dir=dir_name) as tmpdir:
                 with closing(urlopen(req)) as fsrc:
                     opener: Callable
                     if is_gzip_encoded(fsrc):

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -124,7 +124,7 @@ def _open_openml_url(openml_path: str, data_home: Optional[str]):
                         opener = gzip.GzipFile
                     with opener(os.path.join(tmpdir, file_name), "wb") as fdst:
                         shutil.copyfileobj(fsrc, fdst)
-                shutil.move(fdst, local_path)
+                shutil.move(fdst.name, local_path)
         except Exception:
             if os.path.exists(local_path):
                 os.unlink(local_path)

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -110,6 +110,10 @@ def _open_openml_url(openml_path: str, data_home: Optional[str]):
     if not os.path.exists(local_path):
         os.makedirs(dir_name, exist_ok=True)
         try:
+            # Create a tmpdir as a subfolder of dir_name where the final file will
+            # be moved to if the download is successful. This guarantees that the
+            # renaming operation to the final location is atomic to ensure the
+            # concurrence safety of the dataset caching mechanism.
             with TemporaryDirectory(dir=dir_name) as tmpdir:
                 with closing(urlopen(req)) as fsrc:
                     opener: Callable

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -1158,7 +1158,6 @@ def test_open_openml_url_cache(monkeypatch, gzip_response, tmpdir):
     assert response1.read() == response2.read()
 
 
-@pytest.mark.skip(reason="must be updated")
 @pytest.mark.parametrize("gzip_response", [True, False])
 @pytest.mark.parametrize("write_to_disk", [True, False])
 def test_open_openml_url_unlinks_local_path(

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -1158,6 +1158,7 @@ def test_open_openml_url_cache(monkeypatch, gzip_response, tmpdir):
     assert response1.read() == response2.read()
 
 
+@pytest.mark.skip(reason="must be updated")
 @pytest.mark.parametrize("gzip_response", [True, False])
 @pytest.mark.parametrize("write_to_disk", [True, False])
 def test_open_openml_url_unlinks_local_path(


### PR DESCRIPTION
Adding a tempfile name generator
change _retry_with_clean_cache function

#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/issues/21798

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
