### PR TITLE
FIX make sure to limit ClassifierChain to multilabel-indicator target

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -232,6 +232,13 @@ Changelog
   splits failed. Similarly raise an error during grid-search when the fits for
   all the models and all the splits failed. :pr:`21026` by :user:`Loïc Estève <lesteve>`.
 
+:mod:`sklearn.multioutput`
+..........................
+
+- |Fix| raise an error if the type of target is different from `"multilabel-indicator"`
+  in :class:`multioutput.ClassifierChain`.
+  :pr:`21839` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.pipeline`
 .......................
 

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -25,7 +25,7 @@ from .model_selection import cross_val_predict
 from .utils.metaestimators import available_if
 from .utils import check_random_state
 from .utils.validation import check_is_fitted, has_fit_parameter, _check_fit_params
-from .utils.multiclass import check_classification_targets
+from .utils.multiclass import check_classification_targets, type_of_target
 from .utils.fixes import delayed
 
 __all__ = [
@@ -554,6 +554,13 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
             Returns a fitted instance.
         """
         X, Y = self._validate_data(X, Y, multi_output=True, accept_sparse=True)
+        if is_classifier(self):
+            target_type = type_of_target(Y)
+            if target_type != "multilabel-indicator":
+                raise ValueError(
+                    f"{self.__class__.__name__} only supports a target of type "
+                    f" 'multilabel-indicator'. Got {target_type!r} instead."
+                )
 
         random_state = check_random_state(self.random_state)
         self.order_ = self.order

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -839,7 +839,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
 
 class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
-    """A multi-label model that arranges regressions into a chain.
+    """A multi-output model that arranges regressions into a chain.
 
     Each model makes a prediction in the order specified by the chain using
     all of the available features provided to the model plus the predictions
@@ -856,7 +856,7 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
 
     order : array-like of shape (n_outputs,) or 'random', default=None
         If `None`, the order will be determined by the order of columns in
-        the label matrix Y.::
+        the matrix Y.::
 
             order = [0, 1, 2, ..., Y.shape[1] - 1]
 

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -835,7 +835,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         return Y_decision
 
     def _more_tags(self):
-        return {"_skip_test": True, "multioutput_only": True}
+        return {"_skip_test": True, "multioutput_only": True, "multilabel": True}
 
 
 class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -590,7 +590,6 @@ def test_base_chain_crossval_fit_and_predict():
     [
         RandomForestClassifier(n_estimators=2),
         MultiOutputClassifier(RandomForestClassifier(n_estimators=2)),
-        ClassifierChain(RandomForestClassifier(n_estimators=2)),
     ],
 )
 def test_multi_output_classes_(estimator):
@@ -716,3 +715,15 @@ def test_multioutputregressor_ducktypes_fitted_estimator():
 
     # Does not raise
     reg.predict(X)
+
+
+def test_classifier_chain_error_wrong_target_type():
+    """Check that we raise an error if the type of target is not multilabel."""
+    chain = ClassifierChain(RandomForestClassifier())
+
+    err_msg = (
+        "ClassifierChain only supports a target of type  'multilabel-indicator'. "
+        "Got 'multiclass-multioutput' instead."
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        chain.fit(X, y)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -836,7 +836,10 @@ def check_estimator_sparse_data(name, estimator_orig):
                 estimator.fit(X, y)
             if hasattr(estimator, "predict"):
                 pred = estimator.predict(X)
-                assert pred.shape == y.shape
+                if tags["multioutput_only"]:
+                    assert pred.shape == (X.shape[0], 1)
+                else:
+                    assert pred.shape == (X.shape[0],)
             if hasattr(estimator, "predict_proba"):
                 probs = estimator.predict_proba(X)
                 if tags["binary_only"]:
@@ -3224,11 +3227,7 @@ def _enforce_estimator_tags_y(estimator, y):
     # Estimators in mono_output_task_error raise ValueError if y is of 1-D
     # Convert into a 2-D y for those estimators.
     if _safe_tags(estimator, key="multioutput_only"):
-        y_2d = np.repeat(y[:, np.newaxis], 2, axis=1)
-        if _safe_tags(estimator, key="multilabel"):
-            # In multilabel classification, each target should be binary.
-            return (y_2d > 0).astype(np.int64)
-        return y_2d
+        return np.reshape(y, (-1, 1))
     return y
 
 


### PR DESCRIPTION
Requires to solve #21841 before.

`ClassifierChain` should be limited to `multilabel-indicator`. Fitting a `multiclass-mulltiouput` and call `.decision_function` will lead to an assignment error.

In addition, the common tests are not modifying the `y` properly when considering `multioutput`/`multilabel` estimator. One should indeed make sure to have 2 targets (a single target in a 2d array, would be considered as `binary` or `multiclass` by our `type_of_target`).

This is necessary to be able to run `check_estimators_dtypes` on `ClassifierChain` (and estimators in general). Currently the test is not ran.