### PR TITLE
CI Adds pytest plugin to check memory usage in tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,6 +168,7 @@ jobs:
         BLAS: 'openblas'
         COVERAGE: 'false'
         BUILD_WITH_ICC: 'false'
+        CHECK_MEMORY: 'true'
 
 - template: build_tools/azure/posix.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -190,6 +190,7 @@ jobs:
         PANDAS_VERSION: 'none'
         THREADPOOLCTL_VERSION: 'min'
         COVERAGE: 'false'
+        CHECK_MEMORY: 'true'
       # Linux + Python 3.7 build with OpenBLAS and without SITE_JOBLIB
       py37_conda_defaults_openblas:
         DISTRIB: 'conda'

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -150,6 +150,10 @@ if [[ "$TEST_DOCSTRINGS" == "true" ]]; then
     python -m pip install numpydoc
 fi
 
+if [[ "$CHECK_MEMORY" == "true" ]]; then
+    python -m pip install psutil
+fi
+
 python --version
 python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -37,6 +37,7 @@ jobs:
     TEST_DOCSTRINGS: 'false'
     CREATE_ISSUE_ON_TRACKER: 'false'
     SHOW_SHORT_SUMMARY: 'false'
+    CHECK_MEMORY: 'false'
   strategy:
     matrix:
       ${{ insert }}: ${{ parameters.matrix }}

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -58,7 +58,7 @@ if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
 fi
 
 if [[ "$CHECK_MEMORY" == "true" ]]; then
-    TEST_CMD="$TEST_CMD --min-ram=50"
+    TEST_CMD="$TEST_CMD --min-ram=1"  # DEBUG with low value
 fi
 
 set -x

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -57,6 +57,10 @@ if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
     TEST_CMD="$TEST_CMD -ra"
 fi
 
+if [[ "$CHECK_MEMORY" == "true" ]]; then
+    TEST_CMD="$TEST_CMD --min-ram=50"
+fi
+
 set -x
 eval "$TEST_CMD --pyargs sklearn"
 set +x

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ addopts =
     --disable-pytest-warnings
     --color=yes
     -rN
+    -p sklearn.tests.memory_plugin
 
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning

--- a/sklearn/tests/memory_plugin.py
+++ b/sklearn/tests/memory_plugin.py
@@ -108,16 +108,15 @@ class MemoryUsage:
     def pytest_terminal_summary(self, terminalreporter):
         tr = terminalreporter
         if self.stats:
-            tr._tw.sep(
-                "=",
-                f"Tests that Incremented RAM more than {self.min_ram} MB",
-                yellow=True,
-            )
             stats_filtered = filter(
                 lambda x: x[-1]["diff"] > self.min_ram, self.stats.items()
             )
             stats = sorted(stats_filtered, key=lambda x: x[-1]["diff"], reverse=True)
-
+            tr._tw.sep(
+                "=",
+                f"{len(stats)} tests that incremented RAM more than {self.min_ram} MB",
+                yellow=True,
+            )
             for test_name, info in stats:
                 line = "before setup: {:.3f} MB, increment: {:.3f} MB - {}".format(
                     info["setup"], info["diff"], test_name

--- a/sklearn/tests/memory_plugin.py
+++ b/sklearn/tests/memory_plugin.py
@@ -114,7 +114,8 @@ class MemoryUsage:
             stats = sorted(stats_filtered, key=lambda x: x[-1]["diff"], reverse=True)
             tr._tw.sep(
                 "=",
-                f"{len(stats)} tests that incremented RAM more than {self.min_ram} MB",
+                f"{len(stats)} tests with a RAM usage increment larger than"
+                f" {self.min_ram} MB",
                 yellow=True,
             )
             for test_name, info in stats:

--- a/sklearn/tests/memory_plugin.py
+++ b/sklearn/tests/memory_plugin.py
@@ -1,0 +1,148 @@
+import os
+import pytest
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--min-ram",
+        type=int,
+        help="Minimal amount of memory (MB) incremented to display in summary",
+    )
+
+
+def pytest_configure(config):
+    min_ram = config.getoption("--min-ram")
+    if min_ram is not None:
+        if psutil is None:
+            raise ValueError("psutil needs to be installed to use --min-ram")
+        memory_usage_plugin = MemoryUsage(config, min_ram)
+        config.pluginmanager.register(memory_usage_plugin)
+
+
+def is_main_process(config):
+    """True if the code running the given pytest.config object is running in a xdist main
+    node or not running xdist at all.
+    """
+    return not hasattr(config, "workerinput")
+
+
+def get_usage_memory_mb():
+    """
+    Measures memory usage per Python process
+
+    Returns
+    -------
+    memory_usage : float
+    """
+    process = psutil.Process(os.getpid())
+    memory_use = process.memory_info()
+    return memory_use.rss / 1e6  # to MB
+
+
+class MemoryUsage:
+    """Measure memory usage during test execution.
+
+    This plugin can also collect memory usage data from pytest-xdist workers.
+
+    This code is directly adapted from:
+    https://gist.github.com/DKorytkin/8a186693af9a015abe89f6b874ca0795 by
+    Dmytro Korytkin.
+    """
+
+    SHARED_MEMORY_USAGE_INFO = "memory_usage"
+
+    def __init__(self, config, min_ram):
+        """Setup the plugin.
+
+        Parameters
+        ----------
+        config : _pytest.config.Config
+        min_ram : int
+        """
+        self.config = config
+        self.min_ram = min_ram
+        self.is_main_process = is_main_process(config)
+        self.stats = {}
+
+    def add(self, name):
+        self.stats[name] = self.stats.get(name) or {}
+        return self.stats[name]
+
+    def pytest_runtest_setup(self, item):
+        """Record maxrss for pre-setup."""
+        self.add(item.nodeid)["setup"] = get_usage_memory_mb()
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(self, item):
+        """Track test memory usage
+
+        This collects memory usage data before and after each test run.
+
+        However, we do not measure the peak memory usage during the test run
+        itself. This would require some kind of sampling mechanism (e.g. using
+        `memory_profiler`) but this does not see to be easily achievable using
+        the pytest plugin API.
+
+        Parameters
+        ----------
+        item : _pytest.main.Item
+        """
+        start = get_usage_memory_mb()
+        yield
+        end = get_usage_memory_mb()
+        node_stats = self.add(item.nodeid)
+        if "setup" in node_stats:
+            reference = node_stats["setup"]
+        else:
+            reference = start
+
+        node_stats["diff"] = end - reference
+        node_stats["end"] = end
+        node_stats["start"] = start
+
+    def pytest_terminal_summary(self, terminalreporter):
+        tr = terminalreporter
+        if self.stats:
+            tr._tw.sep(
+                "=",
+                f"Tests that Incremented RAM more than {self.min_ram} MB",
+                yellow=True,
+            )
+            stats_filtered = filter(
+                lambda x: x[-1]["diff"] > self.min_ram, self.stats.items()
+            )
+            stats = sorted(stats_filtered, key=lambda x: x[-1]["diff"], reverse=True)
+
+            for test_name, info in stats:
+                line = "before setup: {:.3f} MB, increment: {:.3f} MB - {}".format(
+                    info["setup"], info["diff"], test_name
+                )
+                tr._tw.line(line)
+
+    def pytest_testnodedown(self, node, error):
+        """Collect memory usage stats from pytest-xdist nodes.
+
+        All stats are merged into the main process stats.
+        """
+        node_stats = node.workeroutput[self.SHARED_MEMORY_USAGE_INFO]
+        self.stats.update(node_stats)
+
+    @pytest.hookimpl(hookwrapper=True, trylast=True)
+    def pytest_sessionfinish(self, session, exitstatus):
+        """Dump memory usage statistics to `workeroutput`
+
+        Executed once per node if with xdist and will gen from mater node
+
+        Parameters
+        ----------
+        session : _pytest.Session
+        exitstatus : int
+        """
+        yield
+        if not self.is_main_process:
+            self.config.workeroutput[self.SHARED_MEMORY_USAGE_INFO] = self.stats


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Continues https://github.com/scikit-learn/scikit-learn/pull/21528


#### What does this implement/fix? Explain your changes.
This PR adds a pytest plugin that checks the memory usage of our tests suite. You can enable it by using the `--min-ram` option, which works with `--pyargs`, running pytest directly from the source folder, and `pytest-xdist`. There is some overhead with query the memory before and after each test, so the check is only enabled for one of the CI instances.

CC @ogrisel 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
