### PR TITLE
DOC Fix docstring for ngram_range parameter in Vectorizers

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -633,7 +633,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
     preprocessor : callable, default=None
         Override the preprocessing (string transformation) stage while
         preserving the tokenizing and n-grams generation steps.
-        Only applies if ``analyzer is not callable``.
+        Only applies if ``analyzer`` is not callable.
 
     tokenizer : callable, default=None
         Override the string tokenization step while preserving the
@@ -665,7 +665,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         will be used. For example an ``ngram_range`` of ``(1, 1)`` means only
         unigrams, ``(1, 2)`` means unigrams and bigrams, and ``(2, 2)`` means
         only bigrams.
-        Only applies if ``analyzer is not callable``.
+        Only applies if ``analyzer`` is not callable.
 
     analyzer : {'word', 'char', 'char_wb'} or callable, default='word'
         Whether the feature should be made of word or character n-grams.
@@ -933,7 +933,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
     preprocessor : callable, default=None
         Override the preprocessing (strip_accents and lowercase) stage while
         preserving the tokenizing and n-grams generation steps.
-        Only applies if ``analyzer is not callable``.
+        Only applies if ``analyzer`` is not callable.
 
     tokenizer : callable, default=None
         Override the string tokenization step while preserving the
@@ -969,7 +969,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         such that min_n <= n <= max_n will be used. For example an
         ``ngram_range`` of ``(1, 1)`` means only unigrams, ``(1, 2)`` means
         unigrams and bigrams, and ``(2, 2)`` means only bigrams.
-        Only applies if ``analyzer is not callable``.
+        Only applies if ``analyzer`` is not callable.
 
     analyzer : {'word', 'char', 'char_wb'} or callable, default='word'
         Whether the feature should be made of word n-gram or character
@@ -1753,7 +1753,7 @@ class TfidfVectorizer(CountVectorizer):
     preprocessor : callable, default=None
         Override the preprocessing (string transformation) stage while
         preserving the tokenizing and n-grams generation steps.
-        Only applies if ``analyzer is not callable``.
+        Only applies if ``analyzer`` is not callable.
 
     tokenizer : callable, default=None
         Override the string tokenization step while preserving the
@@ -1804,7 +1804,7 @@ class TfidfVectorizer(CountVectorizer):
         will be used. For example an ``ngram_range`` of ``(1, 1)`` means only
         unigrams, ``(1, 2)`` means unigrams and bigrams, and ``(2, 2)`` means
         only bigrams.
-        Only applies if ``analyzer is not callable``.
+        Only applies if ``analyzer`` is not callable.
 
     max_df : float or int, default=1.0
         When building the vocabulary ignore terms that have a document


### PR DESCRIPTION
Change "``analyzer is not callable``" to "``analyzer`` is not callable"

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixes a typo in the docstring for the `ngram_range` parameter of various `sklearn.feature_extraction.text.*Vectorizer` classes that had the wrong monospace bracketing.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
