### PR TITLE
CI Explicitly list out wheel builds in config [cd build gh]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,36 +47,116 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        python: [37, 38, 39]
-        bitness: [32, 64]
-        manylinux_image: [manylinux1, manylinux2010]
         include:
-          # Run 32 and 64 bit version in parallel for Linux and Windows
+          # Window 64 bit
           - os: windows-latest
+            python: 37
             bitness: 64
             platform_id: win_amd64
           - os: windows-latest
+            python: 38
+            bitness: 64
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 39
+            bitness: 64
+            platform_id: win_amd64
+
+          # Window 32 bit
+          - os: windows-latest
+            python: 37
             bitness: 32
             platform_id: win32
+          - os: windows-latest
+            python: 38
+            bitness: 32
+            platform_id: win32
+          - os: windows-latest
+            python: 39
+            bitness: 32
+            platform_id: win32
+
+          # Linux 64 bit manylinux1
           - os: ubuntu-latest
+            python: 37
             bitness: 64
             platform_id: manylinux_x86_64
+            manylinux_image: manylinux1
           - os: ubuntu-latest
+            python: 38
+            bitness: 64
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux1
+          - os: ubuntu-latest
+            python: 39
+            bitness: 64
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux1
+
+          # Linux 64 bit manylinux2010
+          - os: ubuntu-latest
+            python: 37
+            bitness: 64
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2010
+          - os: ubuntu-latest
+            python: 38
+            bitness: 64
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2010
+          - os: ubuntu-latest
+            python: 39
+            bitness: 64
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2010
+
+          # Linux 32 bit manylinux1
+          - os: ubuntu-latest
+            python: 37
             bitness: 32
             platform_id: manylinux_i686
+            manylinux_image: manylinux1
+          - os: ubuntu-latest
+            python: 38
+            bitness: 32
+            platform_id: manylinux_i686
+            manylinux_image: manylinux1
+          - os: ubuntu-latest
+            python: 39
+            bitness: 32
+            platform_id: manylinux_i686
+            manylinux_image: manylinux1
+
+          # Linux 32 bit manylinux2010
+          - os: ubuntu-latest
+            python: 37
+            bitness: 32
+            platform_id: manylinux_i686
+            manylinux_image: manylinux2010
+          - os: ubuntu-latest
+            python: 38
+            bitness: 32
+            platform_id: manylinux_i686
+            manylinux_image: manylinux2010
+          - os: ubuntu-latest
+            python: 39
+            bitness: 32
+            platform_id: manylinux_i686
+            manylinux_image: manylinux2010
+
+          # MacOS x86_64
           - os: macos-latest
             bitness: 64
+            python: 37
             platform_id: macosx_x86_64
-        exclude:
           - os: macos-latest
-            bitness: 32
-          # Remove manylinux1 from the windows and osx build matrix since
-          # manylinux_image is not used for these platforms
-          - os: windows-latest
-            manylinux_image: manylinux1
+            bitness: 64
+            python: 38
+            platform_id: macosx_x86_64
           - os: macos-latest
-            manylinux_image: manylinux1
+            bitness: 64
+            python: 39
+            platform_id: macosx_x86_64
 
     steps:
       - name: Checkout scikit-learn

--- a/build_tools/github/check_build_trigger.sh
+++ b/build_tools/github/check_build_trigger.sh
@@ -5,8 +5,9 @@ set -x
 
 COMMIT_MSG=$(git log --no-merges -1 --oneline)
 
-# The commit marker "[cd build]" will trigger the build when required
+# The commit marker "[cd build]" or "[cd build gh]" will trigger the build when required
 if [[ "$GITHUB_EVENT_NAME" == schedule ||
-      "$COMMIT_MSG" =~ \[cd\ build\] ]]; then
+      "$COMMIT_MSG" =~ \[cd\ build\] ||
+      "$COMMIT_MSG" =~ \[cd\ build\ gh\] ]]; then
     echo "::set-output name=build::true"
 fi

--- a/build_tools/github/check_wheels.py
+++ b/build_tools/github/check_wheels.py
@@ -8,14 +8,8 @@ gh_wheel_path = Path.cwd() / ".github" / "workflows" / "wheels.yml"
 with gh_wheel_path.open("r") as f:
     wheel_config = yaml.safe_load(f)
 
-build_matrix = wheel_config["jobs"]["build_wheels"]["strategy"]["matrix"]
-n_python_versions = len(build_matrix["python"])
-
-# For each python version we have: 7 wheels
-# 1 osx wheel (x86_64)
-# 4 linux wheel (i686 + x86_64) * (manylinux1 + manylinux2010)
-# 2 windows wheel (win32 + wind_amd64)
-n_wheels = 7 * n_python_versions
+build_matrix = wheel_config["jobs"]["build_wheels"]["strategy"]["matrix"]["include"]
+n_wheels = len(build_matrix)
 
 # plus one more for the sdist
 n_wheels += 1

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -559,6 +559,7 @@ message, the following actions are taken.
     ---------------------- -------------------
     [ci skip]              CI is skipped completely
     [cd build]             CD is run (wheels and source distribution are built)
+    [cd build gh]          CD is run only for GitHub Actions
     [lint skip]            Azure pipeline skips linting
     [scipy-dev]            Build & test with our dependencies (numpy, scipy, etc ...) development builds
     [icc-build]            Build & test with the Intel C compiler (ICC)


### PR DESCRIPTION
Related to https://github.com/scikit-learn/scikit-learn/pull/21827 (macos arm64 wheels)
Related to https://github.com/scikit-learn/scikit-learn/pull/21232 (Python 3.10 wheels)

This PR does 

1. `[cd build gh]` build tag to trigger GitHub and to save Travis CI credit
2. Explicitly lists out all the wheel configurations on GitHub Actions, see https://github.com/scikit-learn/scikit-learn/pull/21232/files#r753384532

CC @adrinjalali @ogrisel 