### PR TITLE
DOC Fix davies_bouldin_score for numpydoc

### DIFF
--- a/maint_tools/test_docstrings.py
+++ b/maint_tools/test_docstrings.py
@@ -120,7 +120,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.cluster._supervised.pair_confusion_matrix",
     "sklearn.metrics.cluster._supervised.rand_score",
     "sklearn.metrics.cluster._supervised.v_measure_score",
-    "sklearn.metrics.cluster._unsupervised.davies_bouldin_score",
     "sklearn.metrics.cluster._unsupervised.silhouette_samples",
     "sklearn.metrics.cluster._unsupervised.silhouette_score",
     "sklearn.metrics.pairwise.additive_chi2_kernel",

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -303,7 +303,7 @@ def calinski_harabasz_score(X, labels):
 
 
 def davies_bouldin_score(X, labels):
-    """Computes the Davies-Bouldin score.
+    """Compute the Davies-Bouldin score.
 
     The score is defined as the average similarity measure of each cluster with
     its most similar cluster, where similarity is the ratio of within-cluster


### PR DESCRIPTION
…_score passes numpydoc validation #21350


#### Reference Issues/PRs
DOC Ensures that sklearn.metrics.cluster._unsupervised.davies_bouldin_score #21350 


#### What does this implement/fix? Explain your changes.
Make summary start with infinitive verb. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
