### PR TITLE
TST Fix test to actually check writable and readable ndarrays

### DIFF
--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -1,5 +1,6 @@
 import itertools
 import pickle
+import copy
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
@@ -169,16 +170,17 @@ def check_pdist_bool(metric, D_true):
     assert_array_almost_equal(D12, D_true)
 
 
-@pytest.mark.parametrize("use_read_only_kwargs", [True, False])
+@pytest.mark.parametrize("writable_kwargs", [True, False])
 @pytest.mark.parametrize("metric_param_grid", METRICS_DEFAULT_PARAMS)
-def test_pickle(use_read_only_kwargs, metric_param_grid):
+def test_pickle(writable_kwargs, metric_param_grid):
     metric, param_grid = metric_param_grid
     keys = param_grid.keys()
     for vals in itertools.product(*param_grid.values()):
-        if use_read_only_kwargs:
+        if any(isinstance(val, np.ndarray) for val in vals):
+            vals = copy.deepcopy(vals)
             for val in vals:
                 if isinstance(val, np.ndarray):
-                    val.setflags(write=False)
+                    val.setflags(write=writable_kwargs)
         kwargs = dict(zip(keys, vals))
         check_pickle(metric, kwargs)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to https://github.com/scikit-learn/scikit-learn/pull/21694


#### What does this implement/fix? Explain your changes.
Fixes `test_pickle` to actually check readable and writable arrays. On `main`, `use_read_only_kwargs=True` will alter the arrays in `METRICS_DEFAULT_PARAMS` by setting `write=False`. When `use_read_only_kwargs=False`, the arrays will remain not writable. This means only ndarrays with `write=False` are tested.

CC @jjerphan 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
