### PR TITLE
DOC correct typo in StandardScaler documentation

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -646,11 +646,8 @@ class StandardScaler(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
     Standardization of a dataset is a common requirement for many
     machine learning estimators: they might behave badly if the
-    individual features are not on the same scale. Standardization 
-    helps their performance by bringing the features into the same scale of measurement. 
-    In addition to that, many learning algorithms assume that features are centered around 0 
-    and have similar variances. Standardization improves the performance of these algorithms 
-    by making sure all features have a distribution with mean 0 and standard deviation 1.
+    individual features do not more or less look like standard normally
+    distributed data (e.g. Gaussian with 0 mean and unit variance).
 
     For instance many elements used in the objective function of
     a learning algorithm (such as the RBF kernel of Support Vector

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -646,15 +646,18 @@ class StandardScaler(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
     Standardization of a dataset is a common requirement for many
     machine learning estimators: they might behave badly if the
-    individual features do not more or less look like standard normally
-    distributed data (e.g. Gaussian with 0 mean and unit variance).
+    individual features are not on the same scale. Standardization 
+    helps their performance by bringing the features into the same scale of measurement. 
+    In addition to that, many learning algorithms assume that features are centered around 0 
+    and have similar variances. Standardization improves the performance of these algorithms 
+    by making sure all features have a distribution with mean 0 and standard deviation 1.
 
     For instance many elements used in the objective function of
     a learning algorithm (such as the RBF kernel of Support Vector
     Machines or the L1 and L2 regularizers of linear models) assume that
     all features are centered around 0 and have variance in the same
     order. If a feature has a variance that is orders of magnitude larger
-    that others, it might dominate the objective function and make the
+    than others, it might dominate the objective function and make the
     estimator unable to learn from other features correctly as expected.
 
     This scaler can also be applied to sparse CSR or CSC matrices by passing


### PR DESCRIPTION
Hi,
This is my first pull request for this project. I changed part of the description because I noticed it mentioned standardization as a means to make the data look more Gaussian or like the standard normal distribution. However, standardization does not make the distribution of data any more Gaussian. It does convert the mean to 0 and standard deviation d to 1 but it does not make the distribution more symmetric.

I also changed a small grammatical error in the next paragraph.
Best,
Behrouz

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
