### PR TITLE
[MRG] Accelerate example plot_sparse_logistic_regression_mnist.py

### DIFF
--- a/examples/linear_model/plot_sparse_logistic_regression_mnist.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_mnist.py
@@ -26,7 +26,7 @@ from math import sqrt
 import matplotlib.pyplot as plt
 import numpy as np
 
-from sklearn.datasets import fetch_openml
+# from sklearn.datasets import fetch_openml
 from sklearn.datasets import load_digits
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
@@ -56,7 +56,13 @@ scaler = StandardScaler()
 X_train = scaler.fit_transform(X_train)
 X_test = scaler.transform(X_test)
 
-clf = LogisticRegression(C=20.0 / train_samples, penalty="l1", solver="saga", tol=0.1, random_state=random_state)
+clf = LogisticRegression(
+    C=20.0 / train_samples,
+    penalty="l1",
+    solver="saga",
+    tol=0.1,
+    random_state=random_state,
+)
 clf.fit(X_train, y_train)
 sparsity = np.mean(clf.coef_ == 0) * 100
 score = clf.score(X_test, y_test)

--- a/examples/linear_model/plot_sparse_logistic_regression_mnist.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_mnist.py
@@ -27,6 +27,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from sklearn.datasets import fetch_openml
+from sklearn.datasets import load_digits
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
@@ -34,8 +35,11 @@ from sklearn.utils import check_random_state
 
 t0 = time.time()
 
-# Load data from https://www.openml.org/d/554
-X, y = fetch_openml("mnist_784", version=1, return_X_y=True, as_frame=False)
+# Load toy dataset
+X, y = load_digits(return_X_y=True, as_frame=False)
+
+# Alternatively, load larger MNIST data set from OpenML, https://www.openml.org/d/554
+# X, y = fetch_openml("mnist_784", version=1, return_X_y=True, as_frame=False)
 
 random_state = check_random_state(0)
 permutation = random_state.permutation(X.shape[0])
@@ -52,7 +56,7 @@ scaler = StandardScaler()
 X_train = scaler.fit_transform(X_train)
 X_test = scaler.transform(X_test)
 
-clf = LogisticRegression(C=50.0 / train_samples, penalty="l1", solver="saga", tol=0.1, random_state=random_state)
+clf = LogisticRegression(C=20.0 / train_samples, penalty="l1", solver="saga", tol=0.1, random_state=random_state)
 clf.fit(X_train, y_train)
 sparsity = np.mean(clf.coef_ == 0) * 100
 score = clf.score(X_test, y_test)

--- a/examples/linear_model/plot_sparse_logistic_regression_mnist.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_mnist.py
@@ -44,7 +44,7 @@ y = y[permutation]
 X = X.reshape((X.shape[0], -1))
 
 X_train, X_test, y_train, y_test = train_test_split(
-    X, y, train_size=train_samples, test_size=10000
+    X, y, train_size=train_samples, test_size=10000, random_state=random_state
 )
 
 scaler = StandardScaler()
@@ -52,7 +52,7 @@ X_train = scaler.fit_transform(X_train)
 X_test = scaler.transform(X_test)
 
 # Turn up tolerance for faster convergence
-clf = LogisticRegression(C=50.0 / train_samples, penalty="l1", solver="saga", tol=0.1)
+clf = LogisticRegression(C=50.0 / train_samples, penalty="l1", solver="saga", tol=0.1, random_state=random_state)
 clf.fit(X_train, y_train)
 sparsity = np.mean(clf.coef_ == 0) * 100
 score = clf.score(X_test, y_test)

--- a/examples/linear_model/plot_sparse_logistic_regression_mnist.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_mnist.py
@@ -32,9 +32,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils import check_random_state
 
-# Turn down for faster convergence
 t0 = time.time()
-train_samples = 5000
 
 # Load data from https://www.openml.org/d/554
 X, y = fetch_openml("mnist_784", version=1, return_X_y=True, as_frame=False)
@@ -46,14 +44,14 @@ y = y[permutation]
 X = X.reshape((X.shape[0], -1))
 
 X_train, X_test, y_train, y_test = train_test_split(
-    X, y, train_size=train_samples, test_size=10000, random_state=random_state
+    X, y, test_size=0.2, random_state=random_state
 )
+train_samples, _ = X_train.shape
 
 scaler = StandardScaler()
 X_train = scaler.fit_transform(X_train)
 X_test = scaler.transform(X_test)
 
-# Turn up tolerance for faster convergence
 clf = LogisticRegression(C=50.0 / train_samples, penalty="l1", solver="saga", tol=0.1, random_state=random_state)
 clf.fit(X_train, y_train)
 sparsity = np.mean(clf.coef_ == 0) * 100

--- a/examples/linear_model/plot_sparse_logistic_regression_mnist.py
+++ b/examples/linear_model/plot_sparse_logistic_regression_mnist.py
@@ -21,6 +21,8 @@ multi-layer perceptron model on this dataset.
 # License: BSD 3 clause
 
 import time
+from math import sqrt
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -65,8 +67,9 @@ plt.figure(figsize=(10, 5))
 scale = np.abs(coef).max()
 for i in range(10):
     l1_plot = plt.subplot(2, 5, i + 1)
+    pixels = int(sqrt(coef[i].shape[0]))
     l1_plot.imshow(
-        coef[i].reshape(28, 28),
+        coef[i].reshape(pixels, pixels),
         interpolation="nearest",
         cmap=plt.cm.RdBu,
         vmin=-scale,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
References #21598 


#### What does this implement/fix? Explain your changes.

This replaces the MNIST dataset with the internal toy dataset for hand-written digits, roughly keeping the weight vector sparsity and test score, but reducing the test execution time from ~20 seconds to < 1 second. Visualization of the weight vector may be slightly worse (after all it is only 8x8 digits), but the main features of the digits 0-9 are still recognizable.

#### Any other comments?

Mainly, the previous implementation was slow because of the `fetch_openml` function.
I kept the reference to MNIST to comment in/out.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
