### PR TITLE
[MRG] MNT use check_scalar to validate scalar in SpectralClustering

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -89,6 +89,11 @@ Changelog
   is faster on many datasets, and its results are identical, hence the change.
   :pr:`21735` by :user:`Aurélien Geron <ageron>`.
 
+- |Enhancement| :class:`cluster.SpectralClustering` now raise consistent
+  error message when passed invalid values for `n_clusters`, `n_init` `gamma`,
+  `n_neighbors`, `eigen_tol` and `degree`.
+  :pr:`21881` by :user:`Hugo Vassard <hvassard>`.
+
 :mod:`sklearn.cross_decomposition`
 ..................................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -89,9 +89,9 @@ Changelog
   is faster on many datasets, and its results are identical, hence the change.
   :pr:`21735` by :user:`Aurélien Geron <ageron>`.
 
-- |Enhancement| :class:`cluster.SpectralClustering` now raise consistent
-  error message when passed invalid values for `n_clusters`, `n_init`,
-  `gamma`, `n_neighbors`, `eigen_tol` and `degree`.
+- |Enhancement| :class:`cluster.SpectralClustering` now raises consistent
+  error messages when passed invalid values for `n_clusters`, `n_init`,
+  `gamma`, `n_neighbors`, `eigen_tol` or `degree`.
   :pr:`21881` by :user:`Hugo Vassard <hvassard>`.
 
 :mod:`sklearn.cross_decomposition`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -90,8 +90,8 @@ Changelog
   :pr:`21735` by :user:`Aurélien Geron <ageron>`.
 
 - |Enhancement| :class:`cluster.SpectralClustering` now raise consistent
-  error message when passed invalid values for `n_clusters`, `n_init`, `gamma`,
-  `n_neighbors`, `eigen_tol` and `degree`.
+  error message when passed invalid values for `n_clusters`, `n_init`,
+  `gamma`, `n_neighbors`, `eigen_tol` and `degree`.
   :pr:`21881` by :user:`Hugo Vassard <hvassard>`.
 
 :mod:`sklearn.cross_decomposition`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -90,7 +90,7 @@ Changelog
   :pr:`21735` by :user:`Aurélien Geron <ageron>`.
 
 - |Enhancement| :class:`cluster.SpectralClustering` now raise consistent
-  error message when passed invalid values for `n_clusters`, `n_init` `gamma`,
+  error message when passed invalid values for `n_clusters`, `n_init`, `gamma`,
   `n_neighbors`, `eigen_tol` and `degree`.
   :pr:`21881` by :user:`Hugo Vassard <hvassard>`.
 

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -16,8 +16,7 @@ from scipy.linalg import LinAlgError, qr, svd
 from scipy.sparse import csc_matrix
 
 from ..base import BaseEstimator, ClusterMixin
-from ..utils import check_random_state, as_float_array
-from ..utils import check_scalar
+from ..utils import as_float_array, check_random_state, check_scalar
 from ..utils.deprecation import deprecated
 from ..metrics.pairwise import pairwise_kernels
 from ..neighbors import kneighbors_graph, NearestNeighbors

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -6,6 +6,8 @@
 #         Wei LI <kuantkid@gmail.com>
 #         Andrew Knyazev <Andrew.Knyazev@ucdenver.edu>
 # License: BSD 3 clause
+
+import numbers
 import warnings
 
 import numpy as np
@@ -15,6 +17,7 @@ from scipy.sparse import csc_matrix
 
 from ..base import BaseEstimator, ClusterMixin
 from ..utils import check_random_state, as_float_array
+from ..utils import check_scalar
 from ..utils.deprecation import deprecated
 from ..metrics.pairwise import pairwise_kernels
 from ..neighbors import kneighbors_graph, NearestNeighbors
@@ -661,6 +664,55 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
                 " a custom affinity matrix, "
                 "set ``affinity=precomputed``."
             )
+
+        check_scalar(
+            self.n_clusters,
+            "n_clusters",
+            target_type=numbers.Integral,
+            min_val=1,
+            include_boundaries="left",
+        )
+
+        check_scalar(
+            self.n_init,
+            "n_init",
+            target_type=numbers.Integral,
+            min_val=1,
+            include_boundaries="left",
+        )
+
+        check_scalar(
+            self.gamma,
+            "gamma",
+            target_type=numbers.Real,
+            min_val=1.0,
+            include_boundaries="left",
+        )
+
+        check_scalar(
+            self.n_neighbors,
+            "n_neighbors",
+            target_type=numbers.Integral,
+            min_val=1,
+            include_boundaries="left",
+        )
+
+        if self.eigen_solver == "arpack":
+            check_scalar(
+                self.eigen_tol,
+                "eigen_tol",
+                target_type=numbers.Real,
+                min_val=0,
+                include_boundaries="left",
+            )
+
+        check_scalar(
+            self.degree,
+            "degree",
+            target_type=numbers.Integral,
+            min_val=1,
+            include_boundaries="left",
+        )
 
         if self.affinity == "nearest_neighbors":
             connectivity = kneighbors_graph(

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -149,8 +149,9 @@ def test_spectral_unknown_assign_labels():
 )
 def test_spectral_params_validation(input, params, err_type, err_msg):
     """Check the parameters validation in `SpectralClustering`."""
+    est = SpectralClustering(**params)
     with pytest.raises(err_type, match=err_msg):
-        SpectralClustering(**params).fit(input)
+        est.fit(input)
 
 
 @pytest.mark.parametrize("assign_labels", ("kmeans", "discretize", "cluster_qr"))

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -28,6 +28,16 @@ try:
 except ImportError:
     amg_loaded = False
 
+centers = np.array([[1, 1], [-1, -1], [1, -1]]) + 10
+X, _ = make_blobs(
+    n_samples=60,
+    n_features=2,
+    centers=centers,
+    cluster_std=0.4,
+    shuffle=True,
+    random_state=0,
+)
+
 
 @pytest.mark.parametrize("eigen_solver", ("arpack", "lobpcg"))
 @pytest.mark.parametrize("assign_labels", ("kmeans", "discretize", "cluster_qr"))
@@ -100,6 +110,47 @@ def test_spectral_unknown_assign_labels():
     S = sparse.coo_matrix(S)
     with pytest.raises(ValueError):
         spectral_clustering(S, n_clusters=2, random_state=0, assign_labels="<unknown>")
+
+
+@pytest.mark.parametrize(
+    "input, params, err_type, err_msg",
+    [
+        (X, {"n_clusters": -1}, ValueError, "n_clusters == -1, must be >= 1"),
+        (X, {"n_clusters": 0}, ValueError, "n_clusters == 0, must be >= 1"),
+        (
+            X,
+            {"n_clusters": 1.5},
+            TypeError,
+            "n_clusters must be an instance of <class 'numbers.Integral'>,"
+            " not <class 'float'>",
+        ),
+        (X, {"n_init": -1}, ValueError, "n_init == -1, must be >= 1"),
+        (X, {"n_init": 0}, ValueError, "n_init == 0, must be >= 1"),
+        (
+            X,
+            {"n_init": 1.5},
+            TypeError,
+            "n_init must be an instance of <class 'numbers.Integral'>,"
+            " not <class 'float'>",
+        ),
+        (X, {"gamma": -1}, ValueError, "gamma == -1, must be >= 1"),
+        (X, {"gamma": 0}, ValueError, "gamma == 0, must be >= 1"),
+        (X, {"n_neighbors": -1}, ValueError, "n_neighbors == -1, must be >= 1"),
+        (X, {"n_neighbors": 0}, ValueError, "n_neighbors == 0, must be >= 1"),
+        (
+            X,
+            {"eigen_tol": -1, "eigen_solver": "arpack"},
+            ValueError,
+            "eigen_tol == -1, must be >= 0",
+        ),
+        (X, {"degree": -1}, ValueError, "degree == -1, must be >= 1"),
+        (X, {"degree": 0}, ValueError, "degree == 0, must be >= 1"),
+    ],
+)
+def test_spectral_params_validation(input, params, err_type, err_msg):
+    """Check the parameters validation in `SpectralClustering`."""
+    with pytest.raises(err_type, match=err_msg):
+        SpectralClustering(**params).fit(input)
 
 
 @pytest.mark.parametrize("assign_labels", ("kmeans", "discretize", "cluster_qr"))


### PR DESCRIPTION
**Reference Issues/PRs**
Addresses #20724
#DataUmbrella

**What does this implement/fix? Explain your changes.**
Summary of changes to SpectralClustering:

Add tests to ensure appropriate behavior when invalid arguments are passed in.
Use the helper function check_scalar from sklearn.utils to validate the scalar parameters.

Progress:
- [x] Add tests
- [x] Check scalar parameters with helper function

References
1. [check_scalar docs](https://scikit-learn.org/stable/modules/generated/sklearn.utils.check_scalar.html)
2. [SpectralClustering docs](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.SpectralClustering.html)
2. [PR #20723](https://github.com/scikit-learn/scikit-learn/pull/20723)

Any other comments?
This is my very first contibution to an open source project, please do not hesitate to give me a feedback. Thank you!