### PR TITLE
MAINT set testpaths = sklearn for pytest in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,13 +5,8 @@ test = pytest
 # disable-pytest-warnings should be removed once we rewrite tests
 # using yield with parametrize
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
+testpaths = sklearn
 addopts =
-    --ignore build_tools
-    --ignore benchmarks
-    --ignore doc
-    --ignore examples
-    --ignore maint_tools
-    --ignore asv_benchmarks
     --doctest-modules
     --disable-pytest-warnings
     --color=yes


### PR DESCRIPTION
I think this will make the maintenance more robust and avoid running expensive Python code with potentially detrimental side-effects by mistake when pytest is scanning and importing Python files for test collection.

It just happened to myself with a temporary benchmark script I left in the root of the source folder and was causing trouble with high CPU usage on my machine with the VS Code pytest plugin.