### PR TITLE
TST Trying to fix test_parallel_classification

### DIFF
--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -471,8 +471,6 @@ def test_error():
 
 def test_parallel_classification():
     # Check parallel classification.
-    rng = check_random_state(0)
-
     # Classification
     X_train, X_test, y_train, y_test = train_test_split(
         iris.data, iris.target, random_state=rng
@@ -483,9 +481,8 @@ def test_parallel_classification():
     ).fit(X_train, y_train)
 
     # predict_proba
-    ensemble.set_params(n_jobs=1)
     y1 = ensemble.predict_proba(X_test)
-    ensemble.set_params(n_jobs=2)
+    ensemble.set_params(n_jobs=1)
     y2 = ensemble.predict_proba(X_test)
     assert_array_almost_equal(y1, y2)
 
@@ -501,9 +498,8 @@ def test_parallel_classification():
         SVC(decision_function_shape="ovr"), n_jobs=3, random_state=0
     ).fit(X_train, y_train)
 
-    ensemble.set_params(n_jobs=1)
     decisions1 = ensemble.decision_function(X_test)
-    ensemble.set_params(n_jobs=2)
+    ensemble.set_params(n_jobs=1)
     decisions2 = ensemble.decision_function(X_test)
     assert_array_almost_equal(decisions1, decisions2)
 

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -471,9 +471,8 @@ def test_error():
 
 def test_parallel_classification():
     # Check parallel classification.
-    # Classification
     X_train, X_test, y_train, y_test = train_test_split(
-        iris.data, iris.target, random_state=rng
+        iris.data, iris.target, random_state=0
     )
 
     ensemble = BaggingClassifier(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses: #21407

#### What does this implement/fix? Explain your changes.
As we are testing for parallel and set_param is taking time in doing the task so removing for n_jobs 2 and just comparing n_jobs 1 and n_jobs 3 reduces the time taken from 2.48s to 0.6s.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
