### PR TITLE
EXA speed up ensemble/tests/test_gradient_boosting

### DIFF
--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1204,8 +1204,8 @@ def test_gradient_boosting_early_stopping():
     )
     gbr.fit(X, y)
 
-    assert gbc.n_estimators_ == 5
-    assert gbr.n_estimators_ == 10
+    assert gbc.n_estimators_ == 50
+    assert gbr.n_estimators_ == 30
 
 
 def test_gradient_boosting_validation_fraction():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1166,7 +1166,7 @@ def test_gradient_boosting_early_stopping():
     X, y = make_classification(n_samples=1000, random_state=0)
 
     gbc = GradientBoostingClassifier(
-        n_estimators=1000,
+        n_estimators=100,
         n_iter_no_change=10,
         learning_rate=0.1,
         max_depth=3,
@@ -1174,7 +1174,7 @@ def test_gradient_boosting_early_stopping():
     )
 
     gbr = GradientBoostingRegressor(
-        n_estimators=1000,
+        n_estimators=100,
         n_iter_no_change=10,
         learning_rate=0.1,
         max_depth=3,
@@ -1196,16 +1196,16 @@ def test_gradient_boosting_early_stopping():
 
     # Without early stopping
     gbc = GradientBoostingClassifier(
-        n_estimators=100, learning_rate=0.1, max_depth=3, random_state=42
+        n_estimators=5, learning_rate=0.1, max_depth=3, random_state=42
     )
     gbc.fit(X, y)
     gbr = GradientBoostingRegressor(
-        n_estimators=200, learning_rate=0.1, max_depth=3, random_state=42
+        n_estimators=10, learning_rate=0.1, max_depth=3, random_state=42
     )
     gbr.fit(X, y)
 
-    assert gbc.n_estimators_ == 100
-    assert gbr.n_estimators_ == 200
+    assert gbc.n_estimators_ == 5
+    assert gbr.n_estimators_ == 10
 
 
 def test_gradient_boosting_validation_fraction():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1166,7 +1166,7 @@ def test_gradient_boosting_early_stopping():
     X, y = make_classification(n_samples=1000, random_state=0)
 
     gbc = GradientBoostingClassifier(
-        n_estimators=100,
+        n_estimators=1000,
         n_iter_no_change=10,
         learning_rate=0.1,
         max_depth=3,

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1196,7 +1196,7 @@ def test_gradient_boosting_early_stopping():
 
     # Without early stopping
     gbc = GradientBoostingClassifier(
-        n_estimators=5, learning_rate=0.1, max_depth=3, random_state=42
+        n_estimators=50, learning_rate=0.1, max_depth=3, random_state=42
     )
     gbc.fit(X, y)
     gbr = GradientBoostingRegressor(

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1174,7 +1174,7 @@ def test_gradient_boosting_early_stopping():
     )
 
     gbr = GradientBoostingRegressor(
-        n_estimators=100,
+        n_estimators=1000,
         n_iter_no_change=10,
         learning_rate=0.1,
         max_depth=3,

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1200,7 +1200,7 @@ def test_gradient_boosting_early_stopping():
     )
     gbc.fit(X, y)
     gbr = GradientBoostingRegressor(
-        n_estimators=10, learning_rate=0.1, max_depth=3, random_state=42
+        n_estimators=30, learning_rate=0.1, max_depth=3, random_state=42
     )
     gbr.fit(X, y)
 


### PR DESCRIPTION
…g.py::test_gradient_boosting_early_stopping.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Meta-issue: accelerate the slowest running tests #21407
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
These changes halve the magnitude of n_estimators used in various functions called within the test.
As a result, the run time of the test has sped up to under 1 second on my machine.
Before changes it took 2.05 seconds and decreased to 0.6 seconds.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
