### PR TITLE
DOC Fix deprecation warning in plot_roc

### DIFF
--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -42,7 +42,6 @@ from sklearn.metrics import roc_curve, auc
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import label_binarize
 from sklearn.multiclass import OneVsRestClassifier
-from scipy import interp
 from sklearn.metrics import roc_auc_score
 
 # Import some data to play with
@@ -113,7 +112,7 @@ all_fpr = np.unique(np.concatenate([fpr[i] for i in range(n_classes)]))
 # Then interpolate all ROC curves at this points
 mean_tpr = np.zeros_like(all_fpr)
 for i in range(n_classes):
-    mean_tpr += interp(all_fpr, fpr[i], tpr[i])
+    mean_tpr += np.interp(all_fpr, fpr[i], tpr[i])
 
 # Finally average it and compute AUC
 mean_tpr /= n_classes


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixes [#21909](https://github.com/scikit-learn/scikit-learn/issues/21909)
@glemaitre 

```
DeprecationWarning: scipy.interp is deprecated and will be removed in SciPy 2.0.0, use numpy.interp instead
```
So, I used np.interp instead of scipy.interp in plot_roc.
Except for this example, there seems to be no other example of using scipy.interp.
