### PR TITLE
FIX Isomap with precomputed distances and disconnected graph

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -40,7 +40,7 @@ Changelog
 
 - |Fix| Fixed an unnecessary error when fitting :class:`manifold.Isomap` with a
   precomputed dense distance matrix where the neighbors graph has multiple
-  disconnected components. :pr:`xxx` by :user:`Tom Dupre la Tour`_.
+  disconnected components. :pr:`21915` by :user:`Tom Dupre la Tour`_.
 
 :mod:`sklearn.metrics`
 ......................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -35,6 +35,13 @@ Changelog
   and :class:`decomposition.MiniBatchSparsePCA` to be convex and match the referenced
   article. :pr:`19210` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+:mod:`sklearn.manifold`
+.......................
+
+- |Fix| Fixed an unnecessary error when fitting :class:`manifold.Isomap` with a
+  precomputed dense distance matrix where the neighbors graph has multiple
+  disconnected components. :pr:`xxx` by :user:`Tom Dupre la Tour`_.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -40,7 +40,7 @@ Changelog
 
 - |Fix| Fixed an unnecessary error when fitting :class:`manifold.Isomap` with a
   precomputed dense distance matrix where the neighbors graph has multiple
-  disconnected components. :pr:`21915` by :user:`Tom Dupre la Tour`_.
+  disconnected components. :pr:`21915` by `Tom Dupre la Tour`_.
 
 :mod:`sklearn.metrics`
 ......................

--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -224,7 +224,8 @@ class Isomap(TransformerMixin, BaseEstimator):
                     f" is {n_connected_components} > 1. The graph cannot be "
                     "completed with metric='precomputed', and Isomap cannot be"
                     "fitted. Increase the number of neighbors to avoid this "
-                    "issue, or precompute the full distance matrix."
+                    "issue, or precompute the full distance matrix instead "
+                    "of passing a sparse neighbors graph."
                 )
             warnings.warn(
                 "The number of connected components of the neighbors graph "

--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -6,6 +6,7 @@ import warnings
 
 import numpy as np
 import scipy
+from scipy.sparse import issparse
 from scipy.sparse.csgraph import shortest_path
 from scipy.sparse.csgraph import connected_components
 
@@ -217,13 +218,13 @@ class Isomap(TransformerMixin, BaseEstimator):
         # Similar fix to cluster._agglomerative._fix_connectivity.
         n_connected_components, labels = connected_components(kng)
         if n_connected_components > 1:
-            if self.metric == "precomputed":
+            if self.metric == "precomputed" and issparse(X):
                 raise RuntimeError(
                     "The number of connected components of the neighbors graph"
                     f" is {n_connected_components} > 1. The graph cannot be "
                     "completed with metric='precomputed', and Isomap cannot be"
                     "fitted. Increase the number of neighbors to avoid this "
-                    "issue."
+                    "issue, or precompute the full distance matrix."
                 )
             warnings.warn(
                 "The number of connected components of the neighbors graph "

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -8,6 +8,7 @@ from sklearn import manifold
 from sklearn import neighbors
 from sklearn import pipeline
 from sklearn import preprocessing
+from sklearn.metrics.pairwise import pairwise_distances
 
 from scipy.sparse import rand as sparse_rand
 
@@ -207,8 +208,15 @@ def test_multiple_connected_components():
 
 def test_multiple_connected_components_metric_precomputed():
     # Test that an error is raised when the graph has multiple components
-    # and when the metric is "precomputed".
+    # and when X is a precomputed neighbors graph.
     X = np.array([0, 1, 2, 5, 6, 7])[:, None]
+
+    # works with a precomputed distance matrix (dense)
+    X_distances = pairwise_distances(X)
+    with pytest.warns(UserWarning, match="number of connected components"):
+        manifold.Isomap(n_neighbors=1, metric="precomputed").fit(X_distances)
+
+    # does not work with a precomputed neighbors graph (sparse)
     X_graph = neighbors.kneighbors_graph(X, n_neighbors=2, mode="distance")
     with pytest.raises(RuntimeError, match="number of connected components"):
         manifold.Isomap(n_neighbors=1, metric="precomputed").fit(X_graph)

--- a/sklearn/utils/graph.py
+++ b/sklearn/utils/graph.py
@@ -169,6 +169,12 @@ def _fix_connected_components(
     graph : sparse matrix of shape (n_samples, n_samples)
         Graph of connection between samples, with a single connected component.
     """
+    if metric == "precomputed" and sparse.issparse(X):
+        raise RuntimeError(
+            "_fix_connected_components with metric='precomputed' requires the "
+            "full distance matrix in X, and does not work with a sparse "
+            "neighbors graph."
+        )
 
     for i in range(n_connected_components):
         idx_i = np.flatnonzero(component_labels == i)

--- a/sklearn/utils/tests/test_graph.py
+++ b/sklearn/utils/tests/test_graph.py
@@ -38,7 +38,7 @@ def test_fix_connected_components_precomputed():
     assert n_connected_components == 1
 
     # but it does not work with precomputed neighbors graph
-    with pytest.raises(RuntimeError, match="number of connected components"):
+    with pytest.raises(RuntimeError, match="does not work with a sparse"):
         _fix_connected_components(
             graph, graph, n_connected_components, labels, metric="precomputed"
         )

--- a/sklearn/utils/tests/test_graph.py
+++ b/sklearn/utils/tests/test_graph.py
@@ -4,6 +4,7 @@ from scipy.sparse.csgraph import connected_components
 
 from sklearn.neighbors import kneighbors_graph
 from sklearn.utils.graph import _fix_connected_components
+from sklearn.metrics.pairwise import pairwise_distances
 
 
 def test_fix_connected_components():
@@ -18,6 +19,29 @@ def test_fix_connected_components():
 
     n_connected_components, labels = connected_components(graph)
     assert n_connected_components == 1
+
+
+def test_fix_connected_components_precomputed():
+    # Test that _fix_connected_components accepts precomputed distance matrix.
+    X = np.array([0, 1, 2, 5, 6, 7])[:, None]
+    graph = kneighbors_graph(X, n_neighbors=2, mode="distance")
+
+    n_connected_components, labels = connected_components(graph)
+    assert n_connected_components > 1
+
+    distances = pairwise_distances(X)
+    graph = _fix_connected_components(
+        distances, graph, n_connected_components, labels, metric="precomputed"
+    )
+
+    n_connected_components, labels = connected_components(graph)
+    assert n_connected_components == 1
+
+    # but it does not work with precomputed neighbors graph
+    with pytest.raises(RuntimeError, match="number of connected components"):
+        _fix_connected_components(
+            graph, graph, n_connected_components, labels, metric="precomputed"
+        )
 
 
 def test_fix_connected_components_wrong_mode():


### PR DESCRIPTION
Issue mentioned in https://github.com/scikit-learn/scikit-learn/pull/20531#issuecomment-988090498

When Isomap has disconnected components in the neighbors graph, it needs to connect them. To do that, it uses `sklearn.utils.graph._fix_connected_components`, which requires either:
- a) the input features X
- b) the full matrix of pairwise distances
- c) It does not work with a precomputed sparse neighbors graph.

On main, the code raises an error **for both b) and c)**.
On this PR, the code raises an error **only for c)**.

____
Because the use of `_fix_connected_components` in Isomap is new to version 1.0 (#20531), I think it would be good to include this PR in the future bugfix version 1.0.2.
