### PR TITLE
DOC explicitely add 3D axis to figure to be compatible with future matplotlib

### DIFF
--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -45,7 +45,8 @@ fignum = 1
 titles = ["8 clusters", "3 clusters", "3 clusters, bad initialization"]
 for name, est in estimators:
     fig = plt.figure(fignum, figsize=(4, 3))
-    ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134)
+    ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134, auto_add_to_figure=False)
+    fig.add_axes(ax)
     est.fit(X)
     labels = est.labels_
 
@@ -63,7 +64,8 @@ for name, est in estimators:
 
 # Plot the ground truth
 fig = plt.figure(fignum, figsize=(4, 3))
-ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134)
+ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134, auto_add_to_figure=False)
+fig.add_axes(ax)
 
 for name, label in [("Setosa", 0), ("Versicolour", 1), ("Virginica", 2)]:
     ax.text3D(


### PR DESCRIPTION
#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.

Fixes deprecation warnings in plot_cluster_iris.py.

https://scikit-learn.org/stable/auto_examples/cluster/plot_cluster_iris.html currently displays the following deprecation warning:
`plot_cluster_iris.py:48: MatplotlibDeprecationWarning: Axes3D(fig) adding itself to the figure is deprecated since 3.4. Pass the keyword argument auto_add_to_figure=False and use fig.add_axes(ax) to suppress this warning. The default value of auto_add_to_figure will change to False in mpl3.5 and True values will no longer work in 3.6.  This is consistent with other Axes classes.`

#### Any other comments?

It may be worth reviewing other pages to see where else this issue is present.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
