### PR TITLE
FIX Fixes plot_tree from going out of bounds

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -67,7 +67,7 @@ Changelog
 ...................
 
 - |Fix| Prevents :func:`tree.plot_tree` from drawing out of the boundary of
-  the figure. :pr:`xxxxx` by `Thomas Fan`_.
+  the figure. :pr:`21917` by `Thomas Fan`_.
 
 :mod:`sklearn.utils`
 ....................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -63,6 +63,12 @@ Changelog
 - |Fix| Fixes compatibility bug with NumPy 1.22 in :class:`preprocessing.OneHotEncoder`.
   :pr:`21517` by `Thomas Fan`_.
 
+:mod:`sklearn.tree`
+...................
+
+- |Fix| Prevents :func:`tree.plot_tree` from drawing out of the boundary of
+  the figure. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.utils`
 ....................
 

--- a/examples/tree/plot_iris_dtc.py
+++ b/examples/tree/plot_iris_dtc.py
@@ -1,7 +1,7 @@
 """
-================================================================
-Plot the decision surface of a decision tree on the iris dataset
-================================================================
+=======================================================================
+Plot the decision surface of decision trees trained on the iris dataset
+=======================================================================
 
 Plot the decision surface of a decision tree trained on pairs
 of features of the iris dataset.
@@ -14,20 +14,23 @@ the training samples.
 
 We also show the tree structure of a model built on all of the features.
 """
+# %%
+from sklearn.datasets import load_iris
 
+iris = load_iris()
+
+
+# Print the decision functions of trees trained on all pairs of features.
+# %%
 import numpy as np
 import matplotlib.pyplot as plt
-
-from sklearn.datasets import load_iris
-from sklearn.tree import DecisionTreeClassifier, plot_tree
+from sklearn.tree import DecisionTreeClassifier
 
 # Parameters
 n_classes = 3
 plot_colors = "ryb"
 plot_step = 0.02
 
-# Load data
-iris = load_iris()
 
 for pairidx, pair in enumerate([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]]):
     # We only take the two corresponding features
@@ -67,11 +70,18 @@ for pairidx, pair in enumerate([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]])
             s=15,
         )
 
-plt.suptitle("Decision surface of a decision tree using paired features")
+plt.suptitle("Decision surface of decision trees trained on pairs of features")
 plt.legend(loc="lower right", borderpad=0, handletextpad=0)
 plt.axis("tight")
+
+
+# Print the structure of a single decision tree trained on all the features
+# together.
+# %%
+from sklearn.tree import plot_tree
 
 plt.figure()
 clf = DecisionTreeClassifier().fit(iris.data, iris.target)
 plot_tree(clf, filled=True)
+plt.title("Decision tree trained on all the iris features")
 plt.show()

--- a/examples/tree/plot_iris_dtc.py
+++ b/examples/tree/plot_iris_dtc.py
@@ -15,13 +15,14 @@ the training samples.
 We also show the tree structure of a model built on all of the features.
 """
 # %%
+# First load the copy of the Iris dataset shipped with scikit-learn:
 from sklearn.datasets import load_iris
 
 iris = load_iris()
 
 
-# Print the decision functions of trees trained on all pairs of features.
 # %%
+# Display the decision functions of trees trained on all pairs of features.
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.tree import DecisionTreeClassifier
@@ -72,12 +73,11 @@ for pairidx, pair in enumerate([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]])
 
 plt.suptitle("Decision surface of decision trees trained on pairs of features")
 plt.legend(loc="lower right", borderpad=0, handletextpad=0)
-plt.axis("tight")
+_ = plt.axis("tight")
 
-
-# Print the structure of a single decision tree trained on all the features
-# together.
 # %%
+# Display the structure of a single decision tree trained on all the features
+# together.
 from sklearn.tree import plot_tree
 
 plt.figure()

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -666,8 +666,7 @@ class _MPLTreeExporter(_BaseTreeExporter):
 
         scale_x = ax_width / max_x
         scale_y = ax_height / max_y
-
-        self.recurse(draw_tree, decision_tree.tree_, ax, scale_x, scale_y, ax_height)
+        self.recurse(draw_tree, decision_tree.tree_, ax, max_x, max_y)
 
         anns = [ann for ann in ax.get_children() if isinstance(ann, Annotation)]
 
@@ -693,7 +692,7 @@ class _MPLTreeExporter(_BaseTreeExporter):
 
         return anns
 
-    def recurse(self, node, tree, ax, scale_x, scale_y, height, depth=0):
+    def recurse(self, node, tree, ax, max_x, max_y, depth=0):
         import matplotlib.pyplot as plt
 
         kwargs = dict(
@@ -701,7 +700,7 @@ class _MPLTreeExporter(_BaseTreeExporter):
             ha="center",
             va="center",
             zorder=100 - 10 * depth,
-            xycoords="axes points",
+            xycoords="axes fraction",
             arrowprops=self.arrow_args.copy(),
         )
         kwargs["arrowprops"]["edgecolor"] = plt.rcParams["text.color"]
@@ -710,7 +709,7 @@ class _MPLTreeExporter(_BaseTreeExporter):
             kwargs["fontsize"] = self.fontsize
 
         # offset things by .5 to center them in plot
-        xy = ((node.x + 0.5) * scale_x, height - (node.y + 0.5) * scale_y)
+        xy = ((node.x + 0.5) / max_x, (max_y - node.y - 0.5) / max_y)
 
         if self.max_depth is None or depth <= self.max_depth:
             if self.filled:
@@ -723,17 +722,17 @@ class _MPLTreeExporter(_BaseTreeExporter):
                 ax.annotate(node.tree.label, xy, **kwargs)
             else:
                 xy_parent = (
-                    (node.parent.x + 0.5) * scale_x,
-                    height - (node.parent.y + 0.5) * scale_y,
+                    (node.parent.x + 0.5) / max_x,
+                    (max_y - node.parent.y - 0.5) / max_y,
                 )
                 ax.annotate(node.tree.label, xy_parent, xy, **kwargs)
             for child in node.children:
-                self.recurse(child, tree, ax, scale_x, scale_y, height, depth=depth + 1)
+                self.recurse(child, tree, ax, max_x, max_y, depth=depth + 1)
 
         else:
             xy_parent = (
-                (node.parent.x + 0.5) * scale_x,
-                height - (node.parent.y + 0.5) * scale_y,
+                (node.parent.x + 0.5) / max_x,
+                (max_y - node.parent.y - 0.5) / max_y,
             )
             kwargs["bbox"]["fc"] = "grey"
             ax.annotate("\n  (...)  \n", xy_parent, xy, **kwargs)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/21908

#### What does this implement/fix? Explain your changes.
Changes the coordination system to use `xycoords="axes fraction"`. This means all the xy coords are between (0.0, 1.0), which I think is easier to reason about.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
