### PR TITLE
MAINT reduce scope of test_linear_models_cv_fit_for_all_backends to reduce CI usage

### DIFF
--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1631,7 +1631,7 @@ def test_enet_cv_sample_weight_sparse(estimator):
 
 
 @pytest.mark.parametrize("estimator", [ElasticNetCV, LassoCV])
-def test_linear_models_cv_fit_with_joblib(estimator):
+def test_linear_models_cv_fit_with_loky(estimator):
     # LinearModelsCV.fit performs inplace operations on fancy-indexed memmapped
     # data when using the loky backend, causing an error due to unexpected
     # behavior of fancy indexing of read-only memmaps (cf. numpy#14132).
@@ -1641,7 +1641,8 @@ def test_linear_models_cv_fit_with_joblib(estimator):
     # change the max_nbyte of the inner Parallel call.
     X, y = make_regression(int(1e6) // 8 + 1, 1)
     assert X.nbytes > 1e6  # 1 MB
-    estimator(n_jobs=2, cv=3).fit(X, y)
+    with parallel_backend("loky"):
+        estimator(n_jobs=2, cv=3).fit(X, y)
 
 
 @pytest.mark.parametrize("check_input", [True, False])

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from scipy import interpolate, sparse
 from copy import deepcopy
+import joblib
 
 from sklearn.base import is_classifier
 from sklearn.base import clone
@@ -1641,7 +1642,7 @@ def test_linear_models_cv_fit_with_loky(estimator):
     # change the max_nbyte of the inner Parallel call.
     X, y = make_regression(int(1e6) // 8 + 1, 1)
     assert X.nbytes > 1e6  # 1 MB
-    with parallel_backend("loky"):
+    with joblib.parallel_backend("loky"):
         estimator(n_jobs=2, cv=3).fit(X, y)
 
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 from scipy import interpolate, sparse
 from copy import deepcopy
-import joblib
 
 from sklearn.base import is_classifier
 from sklearn.base import clone
@@ -29,7 +28,6 @@ from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._testing import _convert_container
 
 from sklearn.utils._testing import TempMemmap
-from sklearn.utils.fixes import parse_version
 from sklearn.utils import check_random_state
 from sklearn.utils.sparsefuncs import mean_variance_axis
 
@@ -1632,24 +1630,18 @@ def test_enet_cv_sample_weight_sparse(estimator):
         reg.fit(X, y, sample_weight=sw)
 
 
-@pytest.mark.parametrize("backend", ["loky", "threading"])
-@pytest.mark.parametrize(
-    "estimator", [ElasticNetCV, MultiTaskElasticNetCV, LassoCV, MultiTaskLassoCV]
-)
-def test_linear_models_cv_fit_for_all_backends(backend, estimator):
-    # LinearModelsCV.fit performs inplace operations on input data which is
-    # memmapped when using loky backend, causing an error due to unexpected
+@pytest.mark.parametrize("estimator", [ElasticNetCV, LassoCV])
+def test_linear_models_cv_fit_with_joblib(estimator):
+    # LinearModelsCV.fit performs inplace operations on fancy-indexed memmapped
+    # data when using the loky backend, causing an error due to unexpected
     # behavior of fancy indexing of read-only memmaps (cf. numpy#14132).
 
-    if parse_version(joblib.__version__) < parse_version("0.12") and backend == "loky":
-        pytest.skip("loky backend does not exist in joblib <0.12")
-
     # Create a problem sufficiently large to cause memmapping (1MB).
-    n_targets = 1 + (estimator in (MultiTaskElasticNetCV, MultiTaskLassoCV))
-    X, y = make_regression(20000, 10, n_targets=n_targets)
-
-    with joblib.parallel_backend(backend=backend):
-        estimator(n_jobs=2, cv=3).fit(X, y)
+    # Unfortunately the scikit-learn and joblib APIs do not make it possible to
+    # change the max_nbyte of the inner Parallel call.
+    X, y = make_regression(int(1e6) // 8 + 1, 1)
+    assert X.nbytes > 1e6  # 1 MB
+    estimator(n_jobs=2, cv=3).fit(X, y)
 
 
 @pytest.mark.parametrize("check_input", [True, False])

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -29,6 +29,7 @@ from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._testing import _convert_container
 
 from sklearn.utils._testing import TempMemmap
+from sklearn.utils.fixes import parse_version
 from sklearn.utils import check_random_state
 from sklearn.utils.sparsefuncs import mean_variance_axis
 
@@ -1636,6 +1637,9 @@ def test_linear_models_cv_fit_with_loky(estimator):
     # LinearModelsCV.fit performs inplace operations on fancy-indexed memmapped
     # data when using the loky backend, causing an error due to unexpected
     # behavior of fancy indexing of read-only memmaps (cf. numpy#14132).
+
+    if parse_version(joblib.__version__) < parse_version("0.12"):
+        pytest.skip("loky backend does not exist in joblib <0.12")
 
     # Create a problem sufficiently large to cause memmapping (1MB).
     # Unfortunately the scikit-learn and joblib APIs do not make it possible to


### PR DESCRIPTION
Alternative to #21907.
Towards: #21407.

Do not test for the threading backend which was not involved in the original problem.
Do not test for the multitask variants that are much more computationally intensive. LassoCV and ElasticNetCV should be enough to cover as a non-regression test for the original problem.
Use the minimal dataset for the fewest number of features to trigger memmaping in joblib.