### PR TITLE
Use as_frame=False for mnist_784 examples to reduce memory usage

### DIFF
--- a/examples/linear_model/plot_sgd_early_stopping.py
+++ b/examples/linear_model/plot_sgd_early_stopping.py
@@ -59,7 +59,7 @@ from sklearn.utils import shuffle
 def load_mnist(n_samples=None, class_0="0", class_1="8"):
     """Load MNIST, select two classes, shuffle and return only n_samples."""
     # Load data from http://openml.org/d/554
-    mnist = fetch_openml("mnist_784", version=1)
+    mnist = fetch_openml("mnist_784", version=1, as_frame=False)
 
     # take only two classes for binary classification
     mask = np.logical_or(mnist.target == class_0, mnist.target == class_1)

--- a/examples/neural_networks/plot_mnist_filters.py
+++ b/examples/neural_networks/plot_mnist_filters.py
@@ -32,7 +32,7 @@ from sklearn.neural_network import MLPClassifier
 from sklearn.model_selection import train_test_split
 
 # Load data from https://www.openml.org/d/554
-X, y = fetch_openml("mnist_784", version=1, return_X_y=True)
+X, y = fetch_openml("mnist_784", version=1, return_X_y=True, as_frame=False)
 X = X / 255.0
 
 # Split data into train partition and test partition


### PR DESCRIPTION
Fix #21897

as_frame=True (or 'auto') consumes a lot more memory than `as_frame=False` for mnist_784 as noted https://github.com/scikit-learn/scikit-learn/issues/19774#issuecomment-988995348.

`as_frame=True` does not seem needed for these examples.