### PR TITLE
Extend ClassifierChain to multi-output problems (ClassifierChain.decision_function)

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -812,12 +812,15 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         Returns
         -------
-        Y_decision : array-like of shape (n_samples, n_classes)
+        Y_decision : nd-array-like of shape (n_samples, n_classes, n_outputs)
             Returns the decision function of the sample for each model
             in the chain.
         """
         X = self._validate_data(X, accept_sparse=True, reset=False)
-        Y_decision_chain = np.zeros((X.shape[0], len(self.estimators_)))
+        num_class = self.classes_[0].shape[0]
+        if self.classes_[0].shape[0] == 2:
+            num_class = 1
+        Y_decision_chain = np.zeros((X.shape[0], num_class, len(self.estimators_)))
         Y_pred_chain = np.zeros((X.shape[0], len(self.estimators_)))
         for chain_idx, estimator in enumerate(self.estimators_):
             previous_predictions = Y_pred_chain[:, :chain_idx]
@@ -825,12 +828,14 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
                 X_aug = sp.hstack((X, previous_predictions))
             else:
                 X_aug = np.hstack((X, previous_predictions))
-            Y_decision_chain[:, chain_idx] = estimator.decision_function(X_aug)
+            Y_decision_chain[:, :, chain_idx] = estimator.decision_function(
+                X_aug
+            ).reshape(X.shape[0], num_class)
             Y_pred_chain[:, chain_idx] = estimator.predict(X_aug)
 
         inv_order = np.empty_like(self.order_)
         inv_order[self.order_] = np.arange(len(self.order_))
-        Y_decision = Y_decision_chain[:, inv_order]
+        Y_decision = Y_decision_chain[:, :, inv_order]
 
         return Y_decision
 

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -468,7 +468,7 @@ def test_classifier_chain_fit_and_predict_with_linear_svc():
     Y_pred = classifier_chain.predict(X)
     assert Y_pred.shape == Y.shape
 
-    Y_decision = classifier_chain.decision_function(X)
+    Y_decision = classifier_chain.decision_function(X).reshape(Y_pred.shape)
 
     Y_binary = Y_decision >= 0
     assert_array_equal(Y_binary, Y_pred)


### PR DESCRIPTION
**Reference Issues/PRs**
Fixes #13339
Fixes #9245

**What does this implement/fix? Explain your changes.**

I have done changes in "ClassifierChain.decision_function" method to support multioutput-multiclass.
Now the output will be (n_samples, n_classes, n_outputs) instead of (n_samples, n_classes), with an exception for binary classifier where n_classes will be one instead of two. 
I also have to make suitable changes in test function "test_classifier_chain_fit_and_predict_with_linear_svc" which is present in  "sklearn/tests/test_multioutput.py".

**Any other comments?**

This can break backward compatibility, since the output now of shape  (n_samples, n_classes, n_outputs).
