### PR TITLE
ENH Removes validation from __init__ for SGDOneClassSVM

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -229,6 +229,11 @@ Changelog
   :pr:`21481` by :user:`Guillaume Lemaitre <glemaitre>` and
   :user:`Andrés Babino <ababino>`.
 
+- |Fix| :class:`linear_model.SGDOneClassSVM` now does not validate in 
+  `__init__`. All the validation is now handled through `fit()` and 
+  `partial_fit()`.
+  :pr:`21944` by :user:`Yogendrasingh <iofall>` and :user: `Arisa Y. <arisayosh>`
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -2098,7 +2098,7 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
         average=False,
     ):
 
-        alpha = nu / 2
+        alpha = None
         self.nu = nu
         super(SGDOneClassSVM, self).__init__(
             loss="hinge",
@@ -2305,8 +2305,8 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
             Returns a fitted instance of self.
         """
 
-        alpha = self.nu / 2
         self._validate_params(for_partial_fit=True)
+        alpha = self.nu / 2
 
         return self._partial_fit(
             X,
@@ -2331,7 +2331,6 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
         offset_init=None,
         sample_weight=None,
     ):
-        self._validate_params()
 
         if self.warm_start and hasattr(self, "coef_"):
             if coef_init is None:
@@ -2404,6 +2403,7 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
             Returns a fitted instance of self.
         """
 
+        self._validate_params()
         alpha = self.nu / 2
         self._fit(
             X,

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -429,7 +429,6 @@ VALIDATE_ESTIMATOR_INIT = [
     "GridSearchCV",
     "HalvingGridSearchCV",
     "Pipeline",
-    "SGDOneClassSVM",
     "TheilSenRegressor",
     "TweedieRegressor",
 ]

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -428,7 +428,6 @@ VALIDATE_ESTIMATOR_INIT = [
     "FeatureUnion",
     "GridSearchCV",
     "HalvingGridSearchCV",
-    "Pipeline",
     "TheilSenRegressor",
     "TweedieRegressor",
 ]


### PR DESCRIPTION
Addresses #21406

#### What does this implement/fix? Explain your changes.
1. Changed `alpha` to `None` in `__init__`
2. Previously `alpha` was initialized as `self.nu / 2` in `__init__` which was performed before validation of `nu`. This caused type errors in the `__init__` method. 
3. Now `alpha` is initialized as `None` and modified after validation in its respective `fit()` & `partial_fit()` methods

cc: @arisayosh 