### PR TITLE
CI Updates vmimage for macOS in azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -235,7 +235,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
     dependsOn: [linting, git_commit]
     condition: |
       and(


### PR DESCRIPTION
Azure CI on main has [recently failed](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=35916&view=logs&j=97641769-79fb-5590-9088-a30ce9b850b9) because macOS-10.14 has been removed. This PR updates the instance to use 10.15.