### PR TITLE
MAINT Adjust issue template labels for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Create a report to help us reproduce and correct the bug
-labels: ['Bug: triage']
+labels: ['Bug', 'Needs Triage']
 
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/doc_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.yml
@@ -1,6 +1,6 @@
 name: Documentation improvement
 description: Create a report to help us improve the documentation. Alternatively you can just open a pull request with the suggested change.
-labels: [Documentation]
+labels: [Documentation, 'Needs Triage']
 
 body:
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest a new algorithm, enhancement to an existing algorithm, etc.
-labels: ['New Feature']
+labels: ['New Feature', 'Needs Triage']
 
 body:
 - type: markdown

--- a/doc/developers/bug_triaging.rst
+++ b/doc/developers/bug_triaging.rst
@@ -149,5 +149,7 @@ The following workflow [1]_ is a good way to approach issue triaging:
    An additional useful step can be to tag the corresponding module e.g.
    `sklearn.linear_models` when relevant.
 
+#. Remove the "Needs Triage" label from the issue if the label exists.
+
 .. [1] Adapted from the pandas project `maintainers guide
        <https://dev.pandas.io/docs/development/maintaining.html>`_


### PR DESCRIPTION
As discussed during the triage meeting, this PR adds the "Needs Triage" label to all the issue templates. Note that the  "create blank issue" creates an issue with no labels. This means issues that need to be triaged either:

1. [Have no labels](https://github.com/scikit-learn/scikit-learn/issues?page=1&q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+no%3Alabel)
2. Have the [Needs Triage label](https://github.com/scikit-learn/scikit-learn/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Needs+Triage%22)

The alternative is to mark issue as "Triaged" as we triage them. I am okay with this option as well.

Data points:

- pandas uses "Needs Triage"
- pytorch uses "triaged"

CC @ogrisel @glemaitre @amueller @lorentzenchr @cmarmo