### PR TITLE
DOC fix linear programming derivation comment in QuantileRegressor

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -153,7 +153,7 @@ Changelog
 - |Fix| :class:`feature_extraction.FeatureHasher` now validates input parameters
   in `transform` instead of `__init__`. :pr:`21573` by
   :user:`Hannah Bohle <hhnnhh>` and :user:`Maren Westermann <marenwestermann>`.
-  
+
 - |API| :func:`decomposition.FastICA` now supports unit variance for whitening.
   The default value of its `whiten` argument will change from `True`
   (which behaves like `'arbitrary-variance'`) to `'unit-variance'` in version 1.3.
@@ -234,7 +234,8 @@ Changelog
   estimator of the noise variance cannot be computed.
   :pr:`21481` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |Enhancement| :class:`linear_model.QuantileRegressor` support sparse inputs.
+- |Enhancement| :class:`linear_model.QuantileRegressor` support sparse input
+  for the highs based solvers.
   :pr:`21086` by :user:`Venkatachalam Natchiappan <venkyyuvy>`.
 
 - |Fix| :class:`linear_model.LassoLarsIC` now correctly computes AIC
@@ -279,7 +280,7 @@ Changelog
   all the models and all the splits failed. :pr:`21026` by :user:`Loïc Estève <lesteve>`.
 
 - |Fix| :class:`model_selection.GridSearchCV`, :class:`model_selection.HalvingGridSearchCV`
-   now validate input parameters in `fit` instead of `__init__`. 
+   now validate input parameters in `fit` instead of `__init__`.
    :pr:`21880` by :user:`Mrinal Tyagi <MrinalTyagi>`.
 
 :mod:`sklearn.pipeline`

--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -200,13 +200,15 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
         else:
             solver_options = self.solver_options
 
+        # After rescaling alpha, the minimization problem is
+        #     min sum(pinball loss) + alpha * L1
         # Use linear programming formulation of quantile regression
         #     min_x c x
         #           A_eq x = b_eq
         #                0 <= x
         # x = (s0, s, t0, t, u, v) = slack variables
-        # intercept = s0 + t0
-        # coef = s + t
+        # intercept = s0 - t0
+        # coef = s - t
         # c = (alpha * 1_p, alpha * 1_p, quantile * 1_n, (1-quantile) * 1_n)
         # residual = y - X@coef - intercept = u - v
         # A_eq = (1_n, X, -1_n, -X, diag(1_n), -diag(1_n))

--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -226,7 +226,7 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
         # 1_n = vector of length n with entries equal one
         # see https://stats.stackexchange.com/questions/384909/
         #
-        # Filtering out zero samples weights from the beginning makes life
+        # Filtering out zero sample weights from the beginning makes life
         # easier for the linprog solver.
         indices = np.nonzero(sample_weight)[0]
         n_indices = len(indices)  # use n_mask instead of n_samples


### PR DESCRIPTION
#### Reference Issues/PRs
The comment in `linear_model.QuantileRegressor.fit()` about the linear programming formulation has an error.

#### What does this implement/fix? Explain your changes.
This only changes the comment. The code itself seems to be correct.