### PR TITLE
[WIP] decision_function for MultiOutputClassifier

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -340,6 +340,14 @@ Changelog
   to train and pickle the model on 64 bit machine and load the model on a 32
   bit machine for prediction. :pr:`21552` by :user:`Loïc Estève <lesteve>`.
 
+:mod:`sklearn.multioutput`
+...................
+- |Enhancement| Added method `decision_function` to 
+  :class:`multioutput.MultiOutputClassifier` which allows to use the
+  `decision_function` of the provided estimator in the multi-class multi-label
+  case. :pr:`21960` by :user:`Christian Ritter <chritter>`.
+
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -450,7 +450,7 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
     def predict_proba(self, X):
         """Return prediction probabilities for each class of each output.
 
-        This method will raise a ``ValueError`` if any of the
+        This method will raise a ``AttributeError`` if any of the
         estimators do not have ``predict_proba``.
 
         Parameters

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -500,7 +500,7 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
         Returns
         -------
         X : list of n_outputs, each output's shape corresponds to the
-            provided estimators decision function returned shape.
+                provided estimators decision function returned shape.
             The confidence scores of the input samples. The order of the
             classes corresponds to that in the attribute :term:`classes_`.
         """

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -474,6 +474,42 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
         results = [estimator.predict_proba(X) for estimator in self.estimators_]
         return results
 
+    def _check_decision_function(self):
+        if hasattr(self, "estimators_"):
+            # raise an AttributeError if `decision_function` does not exist for
+            # each estimator
+            [getattr(est, "decision_function") for est in self.estimators_]
+            return True
+        # raise an AttributeError if `decision_function` does not exist for the
+        # unfitted estimator
+        getattr(self.estimator, "decision_function")
+        return True
+    
+    @available_if(_check_decision_function)
+    def decision_function(self, X):
+        """Return confidence scores for each class of each output.
+
+        This method will raise a ``AttributeError??`` if any of the
+        estimators do not have ``decision_function``.
+
+        Parameters
+        ----------
+        X : array-like or sparse matrix???? of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        X : list of n_outputs, each output's shape corresponds to the
+            provided estimators decision function returned shape.
+            The confidence scores of the input samples. The order of the
+            classes corresponds to that in the attribute :term:`classes_`.
+        """
+        check_is_fitted(self)
+        results = [estimator.decision_function(X) for 
+                   estimator in self.estimators_]
+        return results
+
+
     def score(self, X, y):
         """Return the mean accuracy on the given test data and labels.
 

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -484,12 +484,12 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
         # unfitted estimator
         getattr(self.estimator, "decision_function")
         return True
-    
+
     @available_if(_check_decision_function)
     def decision_function(self, X):
         """Return confidence scores for each class of each output.
 
-        This method will raise a ``AttributeError??`` if any of the
+        This method will raise a ``AttributeError`` if any of the
         estimators do not have ``decision_function``.
 
         Parameters
@@ -505,10 +505,8 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
             classes corresponds to that in the attribute :term:`classes_`.
         """
         check_is_fitted(self)
-        results = [estimator.decision_function(X) for 
-                   estimator in self.estimators_]
+        results = [estimator.decision_function(X) for estimator in self.estimators_]
         return results
-
 
     def score(self, X, y):
         """Return the mean accuracy on the given test data and labels.

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -225,7 +225,6 @@ def test_multi_output_predict_proba():
         multi_target_linear.predict_proba(X)
 
 
-# CR: check multioutput has decision_function
 def test_hasattr_multi_output_decision_function():
     # RandomForestClassifier does not have decision_function
     # hence MultiOutputClassifier won't expose it
@@ -246,7 +245,6 @@ def test_hasattr_multi_output_decision_function():
     assert hasattr(multi_target_linear, "decision_function")
 
 
-# CR: check multioutput decision_function return error
 def test_multi_output_missing_decision_function():
     # RandomForestClassifier does not have decision_function
     # hence MultiOutputClassifier won't expose it

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -225,21 +225,38 @@ def test_multi_output_predict_proba():
         multi_target_linear.predict_proba(X)
 
 
-# check multioutput has decision_function
+# CR: check multioutput has decision_function
 def test_hasattr_multi_output_decision_function():
-    # RandomForestClassifier does not have decision_function 
+    # RandomForestClassifier does not have decision_function
     # hence MultiOutputClassifier won't expose it
     forest = RandomForestClassifier(n_estimators=10, random_state=1)
     multi_target_linear = MultiOutputClassifier(forest)
     multi_target_linear.fit(X, y)
+
     assert not hasattr(multi_target_linear, "decision_function")
-    
+
     # case where decision_threshold exists
     sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5)
     multi_target_linear = MultiOutputClassifier(sgd_linear_clf)
+
+    # ensure decision_function available before fit
+    assert hasattr(multi_target_linear, "decision_function")
     multi_target_linear.fit(X, y)
+    # ensure  decision_function availability after fit
     assert hasattr(multi_target_linear, "decision_function")
 
+
+# CR: check multioutput decision_function return error
+def test_multi_output_missing_decision_function():
+    # RandomForestClassifier does not have decision_function
+    # hence MultiOutputClassifier won't expose it
+    forest = RandomForestClassifier(n_estimators=10, random_state=1)
+    multi_target_linear = MultiOutputClassifier(forest)
+    multi_target_linear.fit(X, y)
+    # ensure error message is returned by estimator RandomForestClassifier
+    err_msg = "'RandomForestClassifier' object has no attribute 'decision_function'"
+    with pytest.raises(AttributeError, match=err_msg):
+        multi_target_linear.decision_function(X)
 
 
 def test_multi_output_classification_partial_fit():
@@ -367,6 +384,46 @@ def test_multiclass_multioutput_estimator_predict_proba():
                 [0.16751315, 0.18256843, 0.64991843],
                 [0.27357372, 0.55201592, 0.17441036],
                 [0.65745193, 0.26062899, 0.08191907],
+            ]
+        ),
+    ]
+
+    for i in range(len(y_actual)):
+        assert_almost_equal(y_result[i], y_actual[i])
+
+
+def test_multiclass_multioutput_estimator_decision_function():
+    seed = 542
+
+    # make test deterministic
+    rng = np.random.RandomState(seed)
+
+    # random features
+    X = rng.normal(size=(5, 5))
+
+    # random labels
+    y1 = np.array(["b", "a", "a", "b", "a"]).reshape(5, 1)  # 2 classes
+    y2 = np.array(["d", "e", "f", "e", "d"]).reshape(5, 1)  # 3 classes
+
+    Y = np.concatenate([y1, y2], axis=1)
+
+    clf = MultiOutputClassifier(
+        LogisticRegression(solver="liblinear", random_state=seed)
+    )
+
+    clf.fit(X, Y)
+
+    y_result = clf.decision_function(X)
+
+    y_actual = [
+        np.array([1.181305, -0.71706655, -0.18780802, 0.62414541, -1.02976684]),
+        np.array(
+            [
+                [0.40278396, -0.96074739, -0.93055779],
+                [-0.9333856, 1.49696158, -1.54819887],
+                [-1.35860664, -1.24917287, 1.34488183],
+                [-0.8923613, 0.3491747, -1.4809791],
+                [1.418385, -0.75766164, -2.19373733],
             ]
         ),
     ]

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -225,6 +225,23 @@ def test_multi_output_predict_proba():
         multi_target_linear.predict_proba(X)
 
 
+# check multioutput has decision_function
+def test_hasattr_multi_output_decision_function():
+    # RandomForestClassifier does not have decision_function 
+    # hence MultiOutputClassifier won't expose it
+    forest = RandomForestClassifier(n_estimators=10, random_state=1)
+    multi_target_linear = MultiOutputClassifier(forest)
+    multi_target_linear.fit(X, y)
+    assert not hasattr(multi_target_linear, "decision_function")
+    
+    # case where decision_threshold exists
+    sgd_linear_clf = SGDClassifier(random_state=1, max_iter=5)
+    multi_target_linear = MultiOutputClassifier(sgd_linear_clf)
+    multi_target_linear.fit(X, y)
+    assert hasattr(multi_target_linear, "decision_function")
+
+
+
 def test_multi_output_classification_partial_fit():
     # test if multi_target initializes correctly with base estimator and fit
     # assert predictions work as expected for predict


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #21861

#### What does this implement/fix? Explain your changes.

This enhancement exposes the `decision_function` function of the estimator passed to MultiOutputClassifier. It allows users to leverage the decision/confidence scores if available for the estimator in the multi-class multi-output case. This follows closely the implementation of `predict_proba` which is exposed for estimators with this attribute. 


#### Any other comments?

I have also corrected the docstring of `predict_proba`  to mention the rising of an ``AttributeError`` instead of incorrectly a ``ValueError``.



