### PR TITLE
Added a new method to specify monotonicity constraints using dict of feature names in HistGradientBoostingClassifier/Regressor. Fixes #21961

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1143,6 +1143,9 @@ respectively::
   ... # positive, negative, and no constraint on the 3 features
   >>> gbdt = HistGradientBoostingRegressor(monotonic_cst=[1, -1, 0])
 
+  ... # constraints using feature names
+  >>> gbdt = HistGradientBoostingRegressor(monotonic_cst={"feature_1":1, "feature_2":-1, "feature_3":0})  
+
 In a binary classification context, imposing a monotonic constraint means
 that the feature is supposed to have a positive / negative effect on the
 probability to belong to the positive class. Monotonic constraints are not

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -230,6 +230,12 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         acc_compute_hist_time = 0.0  # time spent computing histograms
         # time spent predicting X for gradient and hessians update
         acc_prediction_time = 0.0
+        # Getting column names if monotonic_cst is a dict
+        if hasattr(X, "columns"):
+            column_names = np.asarray(X.columns, dtype=object)
+        else:
+            column_names = None
+
         X, y = self._validate_data(X, y, dtype=[X_DTYPE], force_all_finite=False)
         y = self._encode_y(y)
         check_consistent_length(X, y)
@@ -522,6 +528,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                     l2_regularization=self.l2_regularization,
                     shrinkage=self.learning_rate,
                     n_threads=n_threads,
+                    column_names=column_names,
                 )
                 grower.grow()
 
@@ -1085,10 +1092,17 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
         .. versionadded:: 0.24
 
-    monotonic_cst : array-like of int of shape (n_features), default=None
+    monotonic_cst : array-like of int of shape (n_features) or dict, default= \
+            None
         Indicates the monotonic constraint to enforce on each feature. -1, 1
         and 0 respectively correspond to a negative constraint, positive
-        constraint and no constraint. Read more in the :ref:`User Guide
+        constraint and no constraint.
+
+        - None : no constraint would be imposed.
+        - integer array-like : constraints for all features in order of indices.
+        - dict : constraints for features specified by feature names.
+
+        Read more in the :ref:`User Guide
         <monotonic_cst_gbdt>`.
 
         .. versionadded:: 0.23
@@ -1397,10 +1411,17 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
 
         .. versionadded:: 0.24
 
-    monotonic_cst : array-like of int of shape (n_features), default=None
+    monotonic_cst : array-like of int of shape (n_features) or dict, default= \
+            None
         Indicates the monotonic constraint to enforce on each feature. -1, 1
         and 0 respectively correspond to a negative constraint, positive
-        constraint and no constraint. Read more in the :ref:`User Guide
+        constraint and no constraint.
+
+        - None : no constraint would be imposed.
+        - integer array-like : constraints for all features in order of indices.
+        - dict : constraints for features specified by feature names.
+
+        Read more in the :ref:`User Guide
         <monotonic_cst_gbdt>`.
 
         .. versionadded:: 0.23

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -231,10 +231,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         # time spent predicting X for gradient and hessians update
         acc_prediction_time = 0.0
         # Getting column names if monotonic_cst is a dict
-        if hasattr(X, "columns"):
-            column_names = np.asarray(X.columns, dtype=object)
-        else:
-            column_names = None
+        column_names = np.asarray(X.columns, dtype=object) if hasattr(X, "columns") else None
 
         X, y = self._validate_data(X, y, dtype=[X_DTYPE], force_all_finite=False)
         y = self._encode_y(y)

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -231,7 +231,9 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         # time spent predicting X for gradient and hessians update
         acc_prediction_time = 0.0
         # Getting column names if monotonic_cst is a dict
-        column_names = np.asarray(X.columns, dtype=object) if hasattr(X, "columns") else None
+        column_names = (
+            np.asarray(X.columns, dtype=object) if hasattr(X, "columns") else None
+        )
 
         X, y = self._validate_data(X, y, dtype=[X_DTYPE], force_all_finite=False)
         y = self._encode_y(y)

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -163,7 +163,8 @@ class TreeGrower:
         If it's a bool, the same value is used for all features.
     is_categorical : ndarray of bool of shape (n_features,), default=None
         Indicates categorical features.
-    monotonic_cst : array-like of shape (n_features,), dtype=int, default=None
+    monotonic_cst : array-like of shape (n_features,) or dict, dtype=int, \
+            default=None
         Indicates the monotonic constraint to enforce on each feature. -1, 1
         and 0 respectively correspond to a positive constraint, negative
         constraint and no constraint. Read more in the :ref:`User Guide
@@ -182,6 +183,9 @@ class TreeGrower:
         to determine the effective number of threads use, which takes cgroups CPU
         quotes into account. See the docstring of `_openmp_effective_n_threads`
         for details.
+    column_names: list, default=None
+        Contains column names of X if X is of DataFrame type when passed to fit
+        function.
     """
 
     def __init__(
@@ -202,6 +206,7 @@ class TreeGrower:
         min_hessian_to_split=1e-3,
         shrinkage=1.0,
         n_threads=None,
+        column_names=None,
     ):
 
         self._validate_parameters(
@@ -238,6 +243,10 @@ class TreeGrower:
             )
         else:
             self.with_monotonic_cst = True
+            # If monotonicity constraint is a dict
+            if isinstance(monotonic_cst, dict):
+                monotonic_cst = self._monotonic_cst_dict(column_names, monotonic_cst)
+
             monotonic_cst = np.asarray(monotonic_cst, dtype=np.int8)
 
             if monotonic_cst.shape[0] != X_binned.shape[1]:
@@ -248,9 +257,7 @@ class TreeGrower:
                     )
                 )
             if np.any(monotonic_cst < -1) or np.any(monotonic_cst > 1):
-                raise ValueError(
-                    "monotonic_cst must be None or an array-like of -1, 0 or 1."
-                )
+                raise ValueError("monotonic_cst must be None or of values -1, 0 or 1.")
 
         if is_categorical is None:
             is_categorical = np.zeros(shape=X_binned.shape[1], dtype=np.uint8)
@@ -353,6 +360,21 @@ class TreeGrower:
             raise ValueError(
                 "min_hessian_to_split={} must be positive.".format(min_hessian_to_split)
             )
+
+    def _monotonic_cst_dict(self, column_names, monotonic_cst):
+        """Converts monotonic constraints passed as dict to list"""
+        if column_names is None:
+            raise ValueError(
+                "X should have column names to specify monotonic constraints as dict"
+            )
+
+        monotone_cst_list = list()
+        for column in column_names:
+            if column in monotonic_cst:
+                monotone_cst_list.append(monotonic_cst[column])
+            else:
+                monotone_cst_list.append(MonotonicConstraint.NO_CST)
+        return monotone_cst_list
 
     def grow(self):
         """Grow the tree, from root to leaves."""

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -265,7 +265,7 @@ def test_input_error():
     for monotonic_cst in ([1, 3], [1, -3]):
         gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
         with pytest.raises(
-            ValueError, match="must be None or an array-like of -1, 0 or 1"
+            ValueError, match="monotonic_cst must be None or of values -1, 0 or 1."
         ):
             gbdt.fit(X, y)
 
@@ -275,6 +275,15 @@ def test_input_error():
         match="monotonic constraints are not supported for multiclass classification",
     ):
         gbdt.fit(X, y)
+
+    y = [0, 1, 1]
+    gbdt = HistGradientBoostingClassifier(monotonic_cst={"A": 0, "B": 1})
+    with pytest.raises(
+        ValueError,
+        match="X should have column names to specify monotonic constraints as dict",
+    ):
+        gbdt.fit(X, y)
+    # Need to add pandas dependency to test constraints with column names
 
 
 def test_bounded_value_min_gain_to_split():


### PR DESCRIPTION
Added a new method to specify monotonicity constraints using dict of feature names in HistGradientBoostingClassifier/Regressor. 

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See  #https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #21961

#### What does this implement/fix? Explain your changes.
This implementation adds a method to specify the monotonicity constraints for HistGradientBoostingClassifier and Regressor.

Changes:
- sklearn/ensemble/_hist_gradient_boosting/grower.py
    - Added function to read a dict and generate an array-like representation of the constraints. 
    - Changed docstring to accommodate accepting dict as a valid input type.
    - Added validation checks to verify if input X is a dataframe type and has string columns
- sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py:
    - Added function to obtain column names for input X
    - Added parameter to pass the column names to grower.py
-  sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py:
    - Added tests
-  doc/modules/ensemble.rst:
    - Added documentation for accepting constraints as dict 


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
