### PR TITLE
DOC Fixed an error in plot_digits_last_image

### DIFF
--- a/examples/datasets/plot_digits_last_image.py
+++ b/examples/datasets/plot_digits_last_image.py
@@ -26,7 +26,7 @@ import matplotlib.pyplot as plt
 # Load the digits dataset
 digits = datasets.load_digits()
 
-# Display the first digit
+# Display the last digit
 plt.figure(1, figsize=(3, 3))
 plt.imshow(digits.images[-1], cmap=plt.cm.gray_r, interpolation="nearest")
 plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
The comment stated that the function displays the first image, but the code was referring to the last item in the list.
This changes the comment to match accordingly

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
