### PR TITLE
DOC Updated documentation to show jaccard score usage for image comparison

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1016,6 +1016,11 @@ In the binary case::
   >>> jaccard_score(y_true[0], y_pred[0])
   0.6666...
 
+In the 2D comparison case (e.g. image similarity):
+
+  >>> jaccard_score(y_true.flatten(), y_pred.flatten())
+  0.6
+
 In the multilabel case with binary label indicators::
 
   >>> jaccard_score(y_true, y_pred, average='samples')

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1018,7 +1018,7 @@ In the binary case::
 
 In the 2D comparison case (e.g. image similarity):
 
-  >>> jaccard_score(y_true.flatten(), y_pred.flatten())
+  >>> jaccard_score(y_true, y_pred, average="micro")
   0.6
 
 In the multilabel case with binary label indicators::

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -771,6 +771,11 @@ def jaccard_score(
     >>> jaccard_score(y_true[0], y_pred[0])
     0.6666...
 
+    In the 2D comparison case (e.g. image similarity):
+
+    >>> jaccard_score(y_true.flatten(), y_pred.flatten())
+    0.6
+
     In the multilabel case:
 
     >>> jaccard_score(y_true, y_pred, average='samples')

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -773,7 +773,7 @@ def jaccard_score(
 
     In the 2D comparison case (e.g. image similarity):
 
-    >>> jaccard_score(y_true.flatten(), y_pred.flatten())
+    >>> jaccard_score(y_true, y_pred, average="micro")
     0.6
 
     In the multilabel case:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.
Fixes #21977

#### Any other comments?

I'm not sure what the use case is for having the docs show the way to calculate the Jaccard score for the first row of a matrix, but given how long those docs have been around I'm hesitant to assume they're wrong. Instead I've added lines to show how to calculate the Jaccard score for 2D input, often used for comparing binary images.