### PR TITLE
CI Auto labels blank issuse with Needs Triage

### DIFF
--- a/.github/workflows/label-blank-issue.yml
+++ b/.github/workflows/label-blank-issue.yml
@@ -1,0 +1,14 @@
+name: Labels Blank issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label-blank-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "Needs Triage"
+          ignore-if-labeled: true


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to https://github.com/scikit-learn/scikit-learn/pull/21951

#### What does this implement/fix? Explain your changes.
This PR enables the CI to automatically label blank issues with "Needs Triage" if the issue is not already labeled. This means, we will only need to filter by "Needs Triage" to know which issues still needs to be triaged.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
