### PR TITLE
[WIP] Make it possible to pass an arbitrary regressor as `method` for CalibratedClassifierCV

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -860,9 +860,6 @@ class _SigmoidCalibration(RegressorMixin, BaseEstimator):
 
 def _non_parametric_calibration(predictions, y, n_bins, sample_weight):
     """Estimate the calibrated probabilities with binning."""
-    if len(np.unique(y)) > 2:
-        raise NotImplementedError("Multidim not yet implemented.")
-
     if (predictions > 1).any() or (predictions < 0).any():
         raise ValueError("Predicted probas should be in [0, 1].")
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -863,6 +863,9 @@ def _non_parametric_calibration(predictions, y, n_bins, sample_weight=None):
     if len(np.unique(y)) > 2:
         raise NotImplementedError("Multidim not yet implemented.")
 
+    if (predictions > 1).any() or (predictions < 0).any():
+        raise ValueError("Predicted probas should be in [0, 1].")
+
     predictions = column_or_1d(predictions)
     y = column_or_1d(y)
 
@@ -888,6 +891,9 @@ def _non_parametric_calibration(predictions, y, n_bins, sample_weight=None):
 
     # Return the indices of the bins to which each input proba belongs
     i_bins = np.digitize(predictions, bins=bins)
+    # When a score is equal to the upper bound of the greatest bin (here 1),
+    # np.digitize associates it to bin number n_bins+1 which is out of bound.
+    i_bins = np.clip(i_bins, 1, n_bins)
 
     # For each predicted proba, get the estimated true proba
     prob_cal = prob_bins[i_bins - 1]

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -908,6 +908,7 @@ class _NonParametricCalibration(RegressorMixin, BaseEstimator):
         self.confidence_method = confidence_method
 
     def _process(self, X):
+        X = X.reshape(-1, 1)
         """Convert given scores to probas if they come from decision_function."""
         if self.confidence_method == "predict_proba":
             return X
@@ -919,7 +920,7 @@ class _NonParametricCalibration(RegressorMixin, BaseEstimator):
                 f"or 'decision_function'. Got {self.confidence_method}."
             )
 
-    def fit(self, X, y, sample_weight):
+    def fit(self, X, y, sample_weight=None):
         X = self._process(X)
         # Estimate the calibrated probabilities using bins
         prob_cal = _non_parametric_calibration(X, y, self.n_bins, sample_weight)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -50,7 +50,7 @@ def data():
 
 
 @pytest.mark.parametrize(
-    "method", ["sigmoid", "isotonic", HistGradientBoostingRegressor(monotonic_cst=[1])]
+    "method", ["sigmoid", "isotonic", HistGradientBoostingRegressor()]
 )
 @pytest.mark.parametrize("ensemble", [True, False])
 def test_calibration(data, method, ensemble):

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -229,7 +229,7 @@ def test_calibration_multiclass(method, ensemble, seed):
     # only decision function.
     clf = LinearSVC(random_state=7)
     X, y = make_blobs(
-        n_samples=500, n_features=100, random_state=seed, centers=10, cluster_std=15.0
+        n_samples=750, n_features=100, random_state=seed, centers=10, cluster_std=15.0
     )
 
     # Use an unbalanced dataset by collapsing 8 clusters into one class

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -45,7 +45,7 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 
 @pytest.fixture(scope="module")
 def data():
-    X, y = make_classification(n_samples=200, n_features=6, random_state=42)
+    X, y = make_classification(n_samples=250, n_features=6, random_state=42)
     return X, y
 
 
@@ -55,7 +55,7 @@ def data():
 @pytest.mark.parametrize("ensemble", [True, False])
 def test_calibration(data, method, ensemble):
     # Test calibration objects with isotonic, sigmoid and custom regressor
-    n_samples = 100
+    n_samples = 200
     X, y = data
     sample_weight = np.random.RandomState(seed=42).uniform(size=y.size)
 

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -39,6 +39,7 @@ from sklearn.metrics import brier_score_loss
 from sklearn.calibration import CalibratedClassifierCV, _CalibratedClassifier
 from sklearn.calibration import _sigmoid_calibration, _SigmoidCalibration
 from sklearn.calibration import calibration_curve, CalibrationDisplay
+from sklearn.calibration import _NonParametricCalibration
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 
@@ -369,8 +370,12 @@ def test_calibration_ensemble_false(data, method):
     unbiased_preds = cross_val_predict(clf, X, y, cv=3, method="decision_function")
     if method == "isotonic":
         calibrator = IsotonicRegression(out_of_bounds="clip")
-    else:
+    elif method == "sigmoid":
         calibrator = _SigmoidCalibration()
+    else:
+        calibrator = _NonParametricCalibration(
+            method=method, confidence_method="decision_function"
+        )
     calibrator.fit(unbiased_preds, y)
     # Use `clf` fit on all data
     clf.fit(X, y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #21280.

#### What does this implement/fix? Explain your changes.
This is a draft of a proposed solution to #21280.
- [x] Implements a third calibration method using a custom scikit-learn regressor in `CalibratedClassifierCV`.
- [x] Update calibration tests with this new method.
- [x] Docstrings.
- [ ] Docstring tests.
- [ ] Find meaningful names for new variables/functions/classes.
- [ ] Extend at least one calibration example to demonstrate this new capability.
- [ ] Update the [Probability calibration](https://scikit-learn.org/stable/modules/calibration.html) page in the user guide with a paragraph on this method.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
