### PR TITLE
FIX make GPR works with multi-target and normalize_y=False

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -40,7 +40,8 @@ Changelog
 
 - |Fix| :class:`gaussian_process.GaussianProcessRegressor` was not handling
   properly multi-target when `normalize_y=False`.
-  :pr:`21996` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`21996` by :user:`Guillaume Lemaitre <glemaitre>` and
+  :user:`Aidar Shakerimoff <AidarShakerimoff>`.
 
 :mod:`sklearn.metrics`
 ......................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -40,7 +40,7 @@ Changelog
 
 - |Fix| :class:`gaussian_process.GaussianProcessRegressor` was not handling
   properly multi-target when `normalize_y=False`.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`21996` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.metrics`
 ......................

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -35,6 +35,13 @@ Changelog
   and :class:`decomposition.MiniBatchSparsePCA` to be convex and match the referenced
   article. :pr:`19210` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+:mod:`sklearn.gaussian_process`
+...............................
+
+- |Fix| :class:`gaussian_process.GaussianProcessRegressor` was not handling
+  properly multi-target when `normalize_y=False`.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -239,8 +239,9 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             y = (y - self._y_train_mean) / self._y_train_std
 
         else:
-            self._y_train_mean = np.zeros(1)
-            self._y_train_std = 1
+            shape_y_stats = (y.shape[1],) if y.ndim == 2 else 1
+            self._y_train_mean = np.zeros(shape=shape_y_stats)
+            self._y_train_std = np.ones(shape=shape_y_stats)
 
         if np.iterable(self.alpha) and self.alpha.shape[0] != y.shape[0]:
             if self.alpha.shape[0] == 1:
@@ -475,8 +476,10 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             y_samples = rng.multivariate_normal(y_mean, y_cov, n_samples).T
         else:
             y_samples = [
-                rng.multivariate_normal(y_mean[:, i], y_cov, n_samples).T[:, np.newaxis]
-                for i in range(y_mean.shape[1])
+                rng.multivariate_normal(
+                    y_mean[:, target], y_cov[..., target], n_samples
+                ).T[:, np.newaxis]
+                for target in range(y_mean.shape[1])
             ]
             y_samples = np.hstack(y_samples)
         return y_samples

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -18,7 +18,6 @@ from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C, WhiteKern
 from sklearn.gaussian_process.kernels import DotProduct, ExpSineSquared
 from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.utils.validation import assert_all_finite
 from sklearn.utils._testing import (
     assert_array_less,
     assert_almost_equal,
@@ -585,8 +584,8 @@ def test_constant_target(kernel):
     gpr.fit(X, y)
     Y_pred, Y_cov = gpr.predict(X, return_cov=True)
 
-    assert_all_finite(Y_pred)
-    assert_all_finite(Y_cov)
+    assert_allclose(Y_pred[:, 1], 2)
+    assert_allclose(np.diag(Y_cov[..., 1]), 0.0, atol=1e-9)
 
     assert Y_pred.shape == (n_samples, n_targets)
     assert Y_cov.shape == (n_samples, n_samples, n_targets)


### PR DESCRIPTION
supersiding #19706

`normalize_y=False` was not properly working with multi-target in `GaussianProcessRegressor`.
It was mainly due to improper initialization of the shape of the `mean` and `std_dev` vectors.

I added tests to check the right behaviour and added a pending test from #19703