### PR TITLE
ENH column_or_1d cast pandas boolean extension to bool ndarray

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -334,7 +334,7 @@ Changelog
   clickable. :pr:`21298` by `Thomas Fan`_.
 
 - |Enhancement| :func:`utils.validation.column_or_1d` will cast pandas Boolean
-  Extension Dtype to a bool ndarray. :pr:`xxxxx` by `Thomas Fan`_.
+  Extension Dtype to a bool ndarray. :pr:`22004` by `Thomas Fan`_.
 
 :mod:`sklearn.neighbors`
 ........................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -153,7 +153,7 @@ Changelog
 - |Fix| :class:`feature_extraction.FeatureHasher` now validates input parameters
   in `transform` instead of `__init__`. :pr:`21573` by
   :user:`Hannah Bohle <hhnnhh>` and :user:`Maren Westermann <marenwestermann>`.
-  
+
 - |API| :func:`decomposition.FastICA` now supports unit variance for whitening.
   The default value of its `whiten` argument will change from `True`
   (which behaves like `'arbitrary-variance'`) to `'unit-variance'` in version 1.3.
@@ -279,7 +279,7 @@ Changelog
   all the models and all the splits failed. :pr:`21026` by :user:`Loïc Estève <lesteve>`.
 
 - |Fix| :class:`model_selection.GridSearchCV`, :class:`model_selection.HalvingGridSearchCV`
-   now validate input parameters in `fit` instead of `__init__`. 
+   now validate input parameters in `fit` instead of `__init__`.
    :pr:`21880` by :user:`Mrinal Tyagi <MrinalTyagi>`.
 
 :mod:`sklearn.pipeline`
@@ -332,6 +332,9 @@ Changelog
 - |Enhancement| :func:`utils.estimator_html_repr` displays an arrow on the top
   left corner of the HTML representation to show how the elements are
   clickable. :pr:`21298` by `Thomas Fan`_.
+
+- |Enhancement| :func:`utils.validation.column_or_1d` will cast pandas Boolean
+  Extension Dtype to a bool ndarray. :pr:`xxxxx` by `Thomas Fan`_.
 
 :mod:`sklearn.neighbors`
 ........................

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2256,3 +2256,19 @@ def test_large_sparse_matrix(solver):
             LogisticRegression(solver=solver).fit(X, y)
     else:
         LogisticRegression(solver=solver).fit(X, y)
+
+
+def test_with_pandas_boolean_target():
+    """Check that fit works with pandas boolean targets.
+
+    Non-regression test for #17675.
+    """
+    pd = pytest.importorskip("pandas", minversion="1.0")
+
+    X = iris.data
+    y = pd.Series((iris.target > 0), dtype="boolean")
+
+    log_reg = LogisticRegression()
+
+    # Does not raise.
+    log_reg.fit(X, y)

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -220,6 +220,15 @@ def test_column_or_1d():
                 column_or_1d(y)
 
 
+def test_column_or_1d_pandas_boolean():
+    """Check that column_or_1d maps to boolean."""
+    pd = pytest.importorskip("pandas", minversion="1.0")
+    y = pd.Series([False, True, False, True], dtype="boolean")
+    y_1d = column_or_1d(y)
+    assert y_1d.dtype == bool
+    assert_array_equal(y_1d, [False, True, False, True])
+
+
 @pytest.mark.parametrize(
     "key, dtype",
     [

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1122,7 +1122,13 @@ def column_or_1d(y, *, warn=False):
     ValueError
         If `y` is not a 1D array or a 2D array with a single row or column.
     """
-    y = np.asarray(y)
+    dtype = None
+
+    # Cast Pandas Boolean Extension Dtype to a bool.
+    if hasattr(y, "dtype") and y.dtype.name == "boolean":
+        dtype = bool
+
+    y = np.asarray(y, dtype=dtype)
     shape = np.shape(y)
     if len(shape) == 1:
         return np.ravel(y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/17675
Closes https://github.com/scikit-learn/scikit-learn/pull/17764 (Alternative)


#### What does this implement/fix? Explain your changes.
When calling `check_X_y`, `y` ends up in `column_or_1d`. This PR checks for the Boolean dtype directly and cast that into a bool.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
