### PR TITLE
fix skip unnecessary check of gram_matrix in coordinate_descent

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -792,6 +792,7 @@ def _pre_fit(
     fit_intercept,
     copy,
     check_input=True,
+    check_gram=True,
     sample_weight=None,
 ):
     """Aux function used at beginning of fit in linear models
@@ -846,7 +847,7 @@ def _pre_fit(
             # recompute Gram
             precompute = "auto"
             Xy = None
-        elif check_input:
+        elif check_gram:
             # If we're going to use the user's precomputed gram matrix, we
             # do a quick check to make sure its not totally bogus.
             _check_precomputed_gram_matrix(X, precompute, X_offset, X_scale)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -504,6 +504,7 @@ def enet_path(
     max_iter = params.pop("max_iter", 1000)
     random_state = params.pop("random_state", None)
     selection = params.pop("selection", "cyclic")
+    check_gram = params.pop("check_gram", True)
 
     if len(params) > 0:
         raise ValueError("Unexpected parameters in params", params.keys())
@@ -564,6 +565,7 @@ def enet_path(
             fit_intercept=False,
             copy=False,
             check_input=check_input,
+            check_gram=check_gram,
         )
     if alphas is None:
         # No need to normalize of fit_intercept: it has been done
@@ -1392,6 +1394,7 @@ def _path_residuals(
     path_params["precompute"] = precompute
     path_params["copy_X"] = False
     path_params["alphas"] = alphas
+    path_params["check_gram"] = False
 
     if "l1_ratio" in path_params:
         path_params["l1_ratio"] = l1_ratio


### PR DESCRIPTION
Example: Fixes #21997. See also #19004.
