### PR TITLE
DOC Update plot_partial_dependence.py

### DIFF
--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -191,7 +191,7 @@ display.figure_.subplots_adjust(wspace=0.4, hspace=0.3)
 # Analysis of the plots
 # .....................
 #
-# We can clearly see on the PDPs (thick orange line) that the median house price
+# We can clearly see on the PDPs (dashed orange line) that the median house price
 # shows a linear relationship with the median income (top left) and that the
 # house price drops when the average occupants per household increases (top
 # middle). The top right plot shows that the house age in a district does not

--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -191,7 +191,7 @@ display.figure_.subplots_adjust(wspace=0.4, hspace=0.3)
 # Analysis of the plots
 # .....................
 #
-# We can clearly see on the PDPs (thick blue line) that the median house price
+# We can clearly see on the PDPs (thick orange line) that the median house price
 # shows a linear relationship with the median income (top left) and that the
 # house price drops when the average occupants per household increases (top
 # middle). The top right plot shows that the house age in a district does not


### PR DESCRIPTION
PDP's are represented with orange line in the plot

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #22006
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This fixes a typo error - the PDP's are represented with thick orange line in the plot instead of thick blue line.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
