### PR TITLE
FIX Add BaggingClassifier support for class_weights with string labels

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -182,7 +182,7 @@ Changelog
 
 - |Fix| :class:`ensemble.BaggingClassifier` now supports `base_estimators`
   with `class_weight` that uses string targets or non-standard integer encoding.
-  :pr:`xxxxx` by `Thomas Fan`_.
+  :pr:`22021` by `Thomas Fan`_.
 
 - |API| Changed the default of :func:`max_features` to 1.0 for
   :class:`ensemble.RandomForestRegressor` and to `"sqrt"` for

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -180,6 +180,10 @@ Changelog
   ``bootstrap=False`` and ``max_samples`` is not ``None``.
   :pr:`21295` :user:`Haoyin Xu <PSSF23>`.
 
+- |Fix| :class:`ensemble.BaggingClassifier` now supports `base_estimators`
+  with `class_weight` that uses string targets or non-standard integer encoding.
+  :pr:`xxxxx` by `Thomas Fan`_.
+
 - |API| Changed the default of :func:`max_features` to 1.0 for
   :class:`ensemble.RandomForestRegressor` and to `"sqrt"` for
   :class:`ensemble.RandomForestClassifier`. Note that these give the same fit

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -12,9 +12,11 @@ from warnings import warn
 
 from joblib import Parallel
 
+from ..base import clone
 from ._base import BaseEnsemble, _partition_estimators
 from ..base import ClassifierMixin, RegressorMixin
 from ..metrics import r2_score, accuracy_score
+from ..preprocessing import LabelEncoder
 from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
 from ..utils import check_random_state, column_or_1d, deprecated
 from ..utils import indices_to_mask
@@ -675,6 +677,18 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
     def _validate_estimator(self):
         """Check the estimator and set the base_estimator_ attribute."""
         super()._validate_estimator(default=DecisionTreeClassifier())
+        base_est = self.base_estimator_
+
+        # re-encode class_weights when needed
+        if hasattr(base_est, "class_weight") and isinstance(
+            base_est.class_weight, dict
+        ):
+            labels, weights = zip(*base_est.class_weight.items())
+            encoded_labels = self._le.transform(labels)
+            new_class_weight = dict(zip(encoded_labels, weights))
+            self.base_estimator_ = clone(base_est).set_params(
+                class_weight=new_class_weight
+            )
 
     def _set_oob_score(self, X, y):
         n_samples = y.shape[0]
@@ -718,7 +732,11 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
     def _validate_y(self, y):
         y = column_or_1d(y, warn=True)
         check_classification_targets(y)
-        self.classes_, y = np.unique(y, return_inverse=True)
+
+        self._le = LabelEncoder()
+        y = self._le.fit_transform(y)
+
+        self.classes_ = self._le.classes_
         self.n_classes_ = len(self.classes_)
 
         return y

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -732,7 +732,6 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
     def _validate_y(self, y):
         y = column_or_1d(y, warn=True)
         check_classification_targets(y)
-
         self._le = LabelEncoder()
         y = self._le.fit_transform(y)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #19665

#### What does this implement/fix? Explain your changes.
This PR enables `BaggingClassifier` to re-encode the `class_weights` for `base_estimator`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
