### PR TITLE
CI Fixes wheel building

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -80,22 +80,22 @@ jobs:
             bitness: 32
             platform_id: win32
 
-          # Linux 64 bit manylinux1
+          # Linux 64 bit manylinux2014
           - os: ubuntu-latest
             python: 37
             bitness: 64
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 38
             bitness: 64
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 39
             bitness: 64
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
 
           # Linux 64 bit manylinux2010
           - os: ubuntu-latest
@@ -113,7 +113,7 @@ jobs:
             bitness: 64
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2010
-            
+
           # NumPy on Python 3.10 only supports 64bit and is only available with manylinux2014
           - os: ubuntu-latest
             python: 310
@@ -121,22 +121,22 @@ jobs:
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
-          # Linux 32 bit manylinux1
+          # Linux 32 bit manylinux2014
           - os: ubuntu-latest
             python: 37
             bitness: 32
             platform_id: manylinux_i686
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 38
             bitness: 32
             platform_id: manylinux_i686
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 39
             bitness: 32
             platform_id: manylinux_i686
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
 
           # Linux 32 bit manylinux2010
           - os: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -80,22 +80,22 @@ jobs:
             bitness: 32
             platform_id: win32
 
-          # Linux 64 bit manylinux2014
+          # Linux 64 bit manylinux1
           - os: ubuntu-latest
             python: 37
             bitness: 64
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux1
           - os: ubuntu-latest
             python: 38
             bitness: 64
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux1
           - os: ubuntu-latest
             python: 39
             bitness: 64
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux1
 
           # Linux 64 bit manylinux2010
           - os: ubuntu-latest
@@ -121,22 +121,22 @@ jobs:
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
-          # Linux 32 bit manylinux2014
+          # Linux 32 bit manylinux1
           - os: ubuntu-latest
             python: 37
             bitness: 32
             platform_id: manylinux_i686
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux1
           - os: ubuntu-latest
             python: 38
             bitness: 32
             platform_id: manylinux_i686
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux1
           - os: ubuntu-latest
             python: 39
             bitness: 32
             platform_id: manylinux_i686
-            manylinux_image: manylinux2014
+            manylinux_image: manylinux1
 
           # Linux 32 bit manylinux2010
           - os: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -80,22 +80,22 @@ jobs:
             bitness: 32
             platform_id: win32
 
-          # Linux 64 bit manylinux1
+          # Linux 64 bit manylinux2014
           - os: ubuntu-latest
             python: 37
             bitness: 64
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 38
             bitness: 64
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 39
             bitness: 64
             platform_id: manylinux_x86_64
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
 
           # Linux 64 bit manylinux2010
           - os: ubuntu-latest
@@ -121,22 +121,22 @@ jobs:
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
-          # Linux 32 bit manylinux1
+          # Linux 32 bit manylinux2014
           - os: ubuntu-latest
             python: 37
             bitness: 32
             platform_id: manylinux_i686
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 38
             bitness: 32
             platform_id: manylinux_i686
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 39
             bitness: 32
             platform_id: manylinux_i686
-            manylinux_image: manylinux1
+            manylinux_image: manylinux2014
 
           # Linux 32 bit manylinux2010
           - os: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools",
+    "setuptools<60.0",
     "wheel",
     "Cython>=0.28.5",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires = [
     # Override oldest-supported-numpy setting because pandas 0.25.0 requires 1.14.6
     "numpy==1.14.6; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'",
 
-    "scipy>=1.1.0,<=1.7.1",
+    "scipy>=1.1.0",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires = [
     # Override oldest-supported-numpy setting because pandas 0.25.0 requires 1.14.6
     "numpy==1.14.6; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'",
 
-    "scipy>=1.1.0",
+    "scipy>=1.1.0,<=1.7.1",
 ]
 
 [tool.black]

--- a/sklearn/linear_model/tests/test_quantile.py
+++ b/sklearn/linear_model/tests/test_quantile.py
@@ -13,6 +13,7 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import HuberRegressor, QuantileRegressor
 from sklearn.metrics import mean_pinball_loss
 from sklearn.utils._testing import assert_allclose
+from sklearn.utils._testing import skip_if_32bit
 from sklearn.utils.fixes import parse_version, sp_version
 
 
@@ -268,6 +269,7 @@ def test_linprog_failure():
         reg.fit(X, y)
 
 
+@skip_if_32bit
 @pytest.mark.skipif(
     sp_version <= parse_version("1.6.0"),
     reason="Solvers are available as of scipy 1.6.0",

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -172,6 +172,7 @@ def test_svc_with_custom_kernel():
     assert_array_equal(clf_lin.predict(X_sp), clf_mylin.predict(X_sp))
 
 
+@skip_if_32bit
 def test_svc_iris():
     # Test the sparse SVC with the iris dataset
     for k in ("linear", "poly", "rbf"):


### PR DESCRIPTION
Fixes wheel building scipy 1.7.3 no longer has [manylinux1 wheels on pypi](https://pypi.org/project/scipy/1.7.3/#files). Either we restrict the scipy version for building or we remove `manylinux`.