### PR TITLE
MAINT Introduce FastEuclideanPairwiseArgKmin 

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction.pyx
+++ b/sklearn/metrics/_pairwise_distances_reduction.pyx
@@ -62,16 +62,18 @@ cpdef DTYPE_t[::1] _sqeuclidean_row_norms(
         # Casting for X to remove the const qualifier is needed because APIs
         # exposed via scipy.linalg.cython_blas aren't reflecting the arguments'
         # const qualifier.
+        # See: https://github.com/scipy/scipy/issues/1426
         DTYPE_t * X_ptr = <DTYPE_t *> &X[0, 0]
         ITYPE_t idx = 0
         ITYPE_t n = X.shape[0]
         ITYPE_t d = X.shape[1]
-        DTYPE_t[::1] row_norms_squared = np.empty(n, dtype=DTYPE)
+        DTYPE_t[::1] squared_row_norms = np.empty(n, dtype=DTYPE)
 
     for idx in prange(n, schedule='static', nogil=True, num_threads=num_threads):
-        row_norms_squared[idx] = _dot(d, X_ptr + idx * d, 1, X_ptr + idx * d, 1)
+        squared_row_norms[idx] = _dot(d, X_ptr + idx * d, 1, X_ptr + idx * d, 1)
 
-    return row_norms_squared
+    return squared_row_norms
+
 
 
 cdef class PairwiseDistancesReduction:

--- a/sklearn/metrics/_pairwise_distances_reduction.pyx
+++ b/sklearn/metrics/_pairwise_distances_reduction.pyx
@@ -215,20 +215,9 @@ cdef class PairwiseDistancesReduction:
                 not issparse(Y) and Y.dtype == np.float64 and
                 metric in cls.valid_metrics())
 
-    # About __cinit__ and __init__ signatures:
-    #
-    #    - __cinit__ is responsible for C-level allocations and initializations
-    #    - __init__ is responsible for PyObject initialization
-    #    - for a given class, __cinit__ and __init__ must have a matching signatures
-    #      (up to *args and **kwargs)
-    #    - for a given class hiearchy __cinit__'s must have a matching signatures
-    #      (up to *args and **kwargs)
-    #
-    # See: https://cython.readthedocs.io/en/latest/src/userguide/special_methods.html#initialisation-methods-cinit-and-init #noqa
     def __cinit__(
         self,
-        n_samples_X,
-        n_samples_Y,
+        DatasetsPair datasets_pair,
         chunk_size=None,
         n_threads=None,
         strategy=None,
@@ -245,7 +234,9 @@ cdef class PairwiseDistancesReduction:
 
         self.effective_n_threads = _openmp_effective_n_threads(n_threads)
 
-        self.n_samples_X = n_samples_X
+        self.datasets_pair = datasets_pair
+
+        self.n_samples_X = datasets_pair.n_samples_X()
         self.X_n_samples_chunk = min(self.n_samples_X, self.chunk_size)
         X_n_full_chunks = self.n_samples_X // self.X_n_samples_chunk
         X_n_samples_remainder = self.n_samples_X % self.X_n_samples_chunk
@@ -256,7 +247,7 @@ cdef class PairwiseDistancesReduction:
         else:
             self.X_n_samples_last_chunk = self.X_n_samples_chunk
 
-        self.n_samples_Y = n_samples_Y
+        self.n_samples_Y = datasets_pair.n_samples_Y()
         self.Y_n_samples_chunk = min(self.n_samples_Y, self.chunk_size)
         Y_n_full_chunks = self.n_samples_Y // self.Y_n_samples_chunk
         Y_n_samples_remainder = self.n_samples_Y % self.Y_n_samples_chunk
@@ -289,17 +280,6 @@ cdef class PairwiseDistancesReduction:
             self.Y_n_chunks if self.execute_in_parallel_on_Y else self.X_n_chunks,
             self.effective_n_threads,
         )
-
-    def __init__(
-        self,
-        n_samples_X,
-        n_samples_Y,
-        chunk_size=None,
-        n_threads=None,
-        strategy=None,
-        DatasetsPair datasets_pair=None,
-    ):
-        self.datasets_pair = datasets_pair
 
     @final
     cdef void _parallel_on_X(self) nogil:
@@ -667,30 +647,12 @@ cdef class PairwiseDistancesArgKmin(PairwiseDistancesReduction):
         # for various back-end and/or hardware and/or datatypes, and/or fused
         # {sparse, dense}-datasetspair etc.
 
-        if metric in ("euclidean", "sqeuclidean") and not issparse(X) and not issparse(Y):
-            use_squared_distances = metric == "sqeuclidean"
-            pda = FastEuclideanPairwiseDistancesArgKmin(
-                n_samples_X=X.shape[0],
-                n_samples_Y=Y.shape[0],
-                chunk_size=chunk_size,
-                n_threads=n_threads,
-                strategy=strategy,
-                X=X,
-                Y=Y,
-                k=k,
-                use_squared_distances=use_squared_distances,
-                metric_kwargs=metric_kwargs,
-            )
-        else:
-            pda = PairwiseDistancesArgKmin(
-                n_samples_X=X.shape[0],
-                n_samples_Y=Y.shape[0],
-                chunk_size=chunk_size,
-                n_threads=n_threads,
-                strategy=strategy,
-                k=k,
-                datasets_pair=DatasetsPair.get_for(X, Y, metric, metric_kwargs),
-            )
+        pda = PairwiseDistancesArgKmin(
+            datasets_pair=DatasetsPair.get_for(X, Y, metric, metric_kwargs),
+            k=k,
+            chunk_size=chunk_size,
+            strategy=strategy,
+        )
 
         # Limit the number of threads in second level of nested parallelism for BLAS
         # to avoid threads over-subscription (in GEMM for instance).
@@ -702,16 +664,16 @@ cdef class PairwiseDistancesArgKmin(PairwiseDistancesReduction):
 
         return pda._finalize_results(return_distance)
 
-    def __cinit__(
+    def __init__(
         self,
-        n_samples_X,
-        n_samples_Y,
+        DatasetsPair datasets_pair,
         chunk_size=None,
         n_threads=None,
         strategy=None,
-        *args,
-        **kwargs,
-     ):
+        ITYPE_t k=1,
+    ):
+        self.k = check_scalar(k, "k", Integral, min_val=1)
+
         # Allocating pointers to datastructures but not the datastructures themselves.
         # There are as many pointers as effective threads.
         #
@@ -727,26 +689,6 @@ cdef class PairwiseDistancesArgKmin(PairwiseDistancesReduction):
         self.heaps_indices_chunks = <ITYPE_t **> malloc(
             sizeof(ITYPE_t *) * self.chunks_n_threads
         )
-
-    def __init__(
-        self,
-        n_samples_X,
-        n_samples_Y,
-        chunk_size=None,
-        n_threads=None,
-        strategy=None,
-        DatasetsPair datasets_pair=None,
-        ITYPE_t k=1,
-    ):
-        super().__init__(
-            n_samples_X=n_samples_X,
-            n_samples_Y=n_samples_Y,
-            chunk_size=chunk_size,
-            n_threads=n_threads,
-            strategy=strategy,
-            datasets_pair=datasets_pair,
-        )
-        self.k = check_scalar(k, "k", Integral, min_val=1)
 
         # Main heaps which will be returned as results by `PairwiseDistancesArgKmin.compute`.
         self.argkmin_indices = np.full((self.n_samples_X, self.k), 0, dtype=ITYPE)
@@ -958,32 +900,14 @@ cdef class FastEuclideanPairwiseDistancesArgKmin(PairwiseDistancesArgKmin):
         return (PairwiseDistancesArgKmin.is_usable_for(X, Y, metric) and
                 not _in_unstable_openblas_configuration())
 
-    def __cinit__(
-        self,
-        n_samples_X,
-        n_samples_Y,
-        chunk_size=None,
-        n_threads=None,
-        strategy=None,
-        *args,
-        **kwargs,
-     ):
-        # Temporary datastructures used in threads
-        self.dist_middle_terms_chunks = <DTYPE_t **> malloc(
-            sizeof(DTYPE_t *) * self.chunks_n_threads
-        )
-
     def __init__(
         self,
-        n_samples_X,
-        n_samples_Y,
-        chunk_size=None,
-        n_threads=None,
-        strategy=None,
-        X=None,
-        Y=None,
-        ITYPE_t k=1,
+        X,
+        Y,
+        ITYPE_t k,
         bint use_squared_distances=False,
+        chunk_size=None,
+        strategy=None,
         metric_kwargs=None,
     ):
         if metric_kwargs is not None and len(metric_kwargs) > 0:
@@ -995,14 +919,10 @@ cdef class FastEuclideanPairwiseDistancesArgKmin(PairwiseDistancesArgKmin):
             )
 
         super().__init__(
-            n_samples_X=n_samples_X,
-            n_samples_Y=n_samples_Y,
-            chunk_size=chunk_size,
-            n_threads=n_threads,
-            strategy=strategy,
             # The datasets pair here is used for exact distances computations
             datasets_pair=DatasetsPair.get_for(X, Y, metric="euclidean"),
             k=k,
+            chunk_size=chunk_size,
         )
         # X and Y are checked by the DatasetsPair implemented as a DenseDenseDatasetsPair
         cdef:
@@ -1020,6 +940,11 @@ cdef class FastEuclideanPairwiseDistancesArgKmin(PairwiseDistancesArgKmin):
             _sqeuclidean_row_norms(self.X, self.effective_n_threads)
         )
         self.use_squared_distances = use_squared_distances
+
+        # Temporary datastructures used in threads
+        self.dist_middle_terms_chunks = <DTYPE_t **> malloc(
+            sizeof(DTYPE_t *) * self.chunks_n_threads
+        )
 
     def __dealloc__(self):
         if self.dist_middle_terms_chunks is not NULL:

--- a/sklearn/metrics/_pairwise_distances_reduction.pyx
+++ b/sklearn/metrics/_pairwise_distances_reduction.pyx
@@ -953,7 +953,7 @@ cdef class FastEuclideanPairwiseDistancesArgKmin(PairwiseDistancesArgKmin):
         self.X, self.Y = datasets_pair.X, datasets_pair.Y
 
         if metric_kwargs is not None and "Y_norm_squared" in metric_kwargs:
-            self.Y_norm_squared = metric_kwargs.pop("Y_norm_squared", None)
+            self.Y_norm_squared = metric_kwargs.pop("Y_norm_squared")
         else:
             self.Y_norm_squared = _sqeuclidean_row_norms(self.Y, self.effective_n_threads)
 
@@ -1059,11 +1059,10 @@ cdef class FastEuclideanPairwiseDistancesArgKmin(PairwiseDistancesArgKmin):
             DTYPE_t * B = <DTYPE_t*> & Y_c[0, 0]
             ITYPE_t ldb = X_c.shape[1]
             DTYPE_t beta = 0.
-            DTYPE_t * C = dist_middle_terms
             ITYPE_t ldc = Y_c.shape[0]
 
         # dist_middle_terms = `-2 * X_c @ Y_c.T`
-        _gemm(order, ta, tb, m, n, K, alpha, A, lda, B, ldb, beta, C, ldc)
+        _gemm(order, ta, tb, m, n, K, alpha, A, lda, B, ldb, beta, dist_middle_terms, ldc)
 
         # Pushing the distance and their associated indices on heaps
         # which keep tracks of the argkmin.

--- a/sklearn/metrics/_pairwise_distances_reduction.pyx
+++ b/sklearn/metrics/_pairwise_distances_reduction.pyx
@@ -897,9 +897,6 @@ cdef class FastEuclideanPairwiseDistancesArgKmin(PairwiseDistancesArgKmin):
     better running time when the alternative is IO bound, but it can suffer
     from numerical instability caused by catastrophic cancellation potentially
     introduced by the subtraction in the arithmetic expression above.
-
-    PairwiseDistancesArgKmin with EuclideanDistance must be used when higher
-    numerical precision is needed.
     """
 
     cdef:

--- a/sklearn/metrics/_pairwise_distances_reduction.pyx
+++ b/sklearn/metrics/_pairwise_distances_reduction.pyx
@@ -36,7 +36,7 @@ from ..utils._cython_blas cimport (
 )
 from ..utils._heap cimport simultaneous_sort, heap_push
 from ..utils._openmp_helpers cimport _openmp_thread_num
-from ..utils._typedefs cimport ITYPE_t, DTYPE_t, DITYPE_t
+from ..utils._typedefs cimport ITYPE_t, DTYPE_t
 
 from numbers import Integral
 from typing import List
@@ -62,7 +62,7 @@ cpdef DTYPE_t[::1] _sqeuclidean_row_norms(
         # Casting for X to remove the const qualifier is needed because APIs
         # exposed via scipy.linalg.cython_blas aren't reflecting the arguments'
         # const qualifier.
-        # See: https://github.com/scipy/scipy/issues/1426
+        # See: https://github.com/scipy/scipy/issues/14262
         DTYPE_t * X_ptr = <DTYPE_t *> &X[0, 0]
         ITYPE_t idx = 0
         ITYPE_t n = X.shape[0]
@@ -80,7 +80,7 @@ cdef class PairwiseDistancesReduction:
     """Abstract base class for pairwise distance computation & reduction.
 
     Subclasses of this class compute pairwise distances between a set of
-    row vectors of X and another set of row vectors pf Y and apply a reduction on top.
+    row vectors of X and another set of row vectors of Y and apply a reduction on top.
     The reduction takes a matrix of pairwise distances between rows of X and Y
     as input and outputs an aggregate data-structure for each row of X.
     The aggregate values are typically smaller than the number of rows in Y,
@@ -1030,6 +1030,7 @@ cdef class FastEuclideanPairwiseDistancesArgKmin(PairwiseDistancesArgKmin):
             DTYPE_t alpha = - 2.
             # Casting for A and B to remove the const is needed because APIs exposed via
             # scipy.linalg.cython_blas aren't reflecting the arguments' const qualifier.
+            # See: https://github.com/scipy/scipy/issues/14262
             DTYPE_t * A = <DTYPE_t*> & X_c[0, 0]
             ITYPE_t lda = X_c.shape[1]
             DTYPE_t * B = <DTYPE_t*> & Y_c[0, 0]

--- a/sklearn/metrics/_pairwise_distances_reduction.pyx
+++ b/sklearn/metrics/_pairwise_distances_reduction.pyx
@@ -649,6 +649,10 @@ cdef class PairwiseDistancesArgKmin(PairwiseDistancesReduction):
             and not issparse(X)
             and not issparse(Y)
         ):
+            # Specialized implementation with improved arithmetic intensity
+            # and vector instructions (SIMD) by processing several vectors
+            # at time to leverage a call to the BLAS GEMM routine as explained
+            # in more details in the docstring.
             use_squared_distances = metric == "sqeuclidean"
             pda = FastEuclideanPairwiseDistancesArgKmin(
                 X=X, Y=Y, k=k,
@@ -657,7 +661,9 @@ cdef class PairwiseDistancesArgKmin(PairwiseDistancesReduction):
                 strategy=strategy,
                 metric_kwargs=metric_kwargs,
             )
-        else:  # Fall back on the default
+        else:
+             # Fall back on a generic implementation that handles most scipy
+             # metrics by computing the distances between 2 vectors at a time.
             pda = PairwiseDistancesArgKmin(
                 datasets_pair=DatasetsPair.get_for(X, Y, metric, metric_kwargs),
                 k=k,

--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -10,6 +10,7 @@ from sklearn.metrics._pairwise_distances_reduction import (
     _sqeuclidean_row_norms,
 )
 
+from sklearn.metrics import euclidean_distances
 from sklearn.utils.fixes import sp_version, parse_version
 
 # Common supported metric between scipy.spatial.distance.cdist
@@ -306,7 +307,7 @@ def test_strategies_consistency(
 
 
 @pytest.mark.parametrize("n_features", [50, 500])
-@pytest.mark.parametrize("translation", [0, 1e8])
+@pytest.mark.parametrize("translation", [0, 1e6])
 @pytest.mark.parametrize("metric", CDIST_PAIRWISE_DISTANCES_REDUCTION_COMMON_METRICS)
 @pytest.mark.parametrize("strategy", ("parallel_on_X", "parallel_on_Y"))
 def test_pairwise_distances_argkmin(
@@ -331,7 +332,11 @@ def test_pairwise_distances_argkmin(
     metric_kwargs = _get_dummy_metric_params_list(metric, n_features)[0]
 
     # Reference for argkmin results
-    dist_matrix = cdist(X, Y, metric=metric, **metric_kwargs)
+    if metric == "euclidean":
+        # Compare to scikit-learn GEMM optimized implementation
+        dist_matrix = euclidean_distances(X, Y)
+    else:
+        dist_matrix = cdist(X, Y, metric=metric, **metric_kwargs)
     # Taking argkmin (indices of the k smallest values)
     argkmin_indices_ref = np.argsort(dist_matrix, axis=1)[:, :k]
     # Getting the associated distances

--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -7,6 +7,7 @@ from scipy.spatial.distance import cdist
 from sklearn.metrics._pairwise_distances_reduction import (
     PairwiseDistancesReduction,
     PairwiseDistancesArgKmin,
+    _sqeuclidean_row_norms,
 )
 
 from sklearn.utils.fixes import sp_version, parse_version
@@ -355,3 +356,24 @@ def test_pairwise_distances_argkmin(
     ASSERT_RESULT[PairwiseDistancesArgKmin](
         argkmin_distances, argkmin_distances_ref, argkmin_indices, argkmin_indices_ref
     )
+
+
+@pytest.mark.parametrize("seed", range(10))
+@pytest.mark.parametrize("n_samples", [100, 1000])
+@pytest.mark.parametrize("n_features", [5, 10, 100])
+@pytest.mark.parametrize("num_threads", [1, 2, 8])
+def test_sqeuclidean_row_norms(
+    seed,
+    n_samples,
+    n_features,
+    num_threads,
+    dtype=np.float64,
+):
+    rng = np.random.RandomState(seed)
+    spread = 100
+    X = rng.rand(n_samples, n_features).astype(dtype) * spread
+
+    sq_row_norm_reference = np.linalg.norm(X, axis=1) ** 2
+    sq_row_norm = np.asarray(_sqeuclidean_row_norms(X, num_threads=num_threads))
+
+    assert_allclose(sq_row_norm_reference, sq_row_norm)

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -26,7 +26,7 @@ from .class_weight import compute_class_weight, compute_sample_weight
 from . import _joblib
 from ..exceptions import DataConversionWarning
 from .deprecation import deprecated
-from .fixes import np_version, parse_version
+from .fixes import np_version, parse_version, threadpool_info
 from ._estimator_html_repr import estimator_html_repr
 from .validation import (
     as_float_array,
@@ -79,6 +79,39 @@ __all__ = [
 
 IS_PYPY = platform.python_implementation() == "PyPy"
 _IS_32BIT = 8 * struct.calcsize("P") == 32
+
+
+def _in_unstable_openblas_configuration():
+    """Return True if in an unstable configuration for OpenBLAS"""
+
+    # Import libraries which might load OpenBLAS.
+    import numpy  # noqa
+    import scipy  # noqa
+
+    modules_info = threadpool_info()
+
+    open_blas_used = any(info["internal_api"] == "openblas" for info in modules_info)
+    if not open_blas_used:
+        return False
+
+    # OpenBLAS 0.3.16 fixed unstability for arm64, see:
+    # https://github.com/xianyi/OpenBLAS/blob/1b6db3dbba672b4f8af935bd43a1ff6cff4d20b7/Changelog.txt#L56-L58 # noqa
+    openblas_arm64_stable_version = parse_version("0.3.16")
+    for info in modules_info:
+        if info["internal_api"] != "openblas":
+            continue
+        openblas_version = info.get("version")
+        openblas_architecture = info.get("architecture")
+        if openblas_version is None or openblas_architecture is None:
+            # Cannot be sure that OpenBLAS is good enough. Assume unstable:
+            return True
+        if (
+            openblas_architecture == "neoversen1"
+            and parse_version(openblas_version) < openblas_arm64_stable_version
+        ):
+            # See discussions in https://github.com/numpy/numpy/issues/19411
+            return True
+    return False
 
 
 class Bunch(dict):

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -48,7 +48,12 @@ import numpy as np
 import joblib
 
 import sklearn
-from sklearn.utils import IS_PYPY, _IS_32BIT, deprecated
+from sklearn.utils import (
+    IS_PYPY,
+    _IS_32BIT,
+    deprecated,
+    _in_unstable_openblas_configuration,
+)
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import (
     check_array,
@@ -448,6 +453,10 @@ try:
         os.environ.get("TRAVIS") == "true", reason="skip on travis"
     )
     fails_if_pypy = pytest.mark.xfail(IS_PYPY, reason="not compatible with PyPy")
+    fails_if_unstable_openblas = pytest.mark.xfail(
+        _in_unstable_openblas_configuration(),
+        reason="OpenBLAS is unstable for this configuration",
+    )
     skip_if_no_parallel = pytest.mark.skipif(
         not joblib.parallel.mp, reason="joblib is in serial mode"
     )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Part of splitting https://github.com/scikit-learn/scikit-learn/pull/21462#issuecomment-993862788

⚠ This targets the `upstream:pairwise-distances-argkmin` feature branch not `upstream:main`.

#### What does this implement/fix? Explain your changes.

This introduces `FastEuclideanPairwiseDistancesArgKmin` a specialization of `PairwiseDistancesArgkmin` for the euclidean and squared euclidean distances which uses the GEMM trick.

#### Any other comments

I will rebase and force-push on update made to https://github.com/scikit-learn/scikit-learn/pull/22064.