### PR TITLE
DOC Ensures randomized_range_finder passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -162,7 +162,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.axis0_safe_slice",
     "sklearn.utils.extmath.density",
     "sklearn.utils.extmath.fast_logdet",
-    "sklearn.utils.extmath.randomized_range_finder",
     "sklearn.utils.extmath.randomized_svd",
     "sklearn.utils.extmath.safe_sparse_dot",
     "sklearn.utils.extmath.squared_norm",

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -165,7 +165,7 @@ def safe_sparse_dot(a, b, *, dense_output=False):
 def randomized_range_finder(
     A, *, size, n_iter, power_iteration_normalizer="auto", random_state=None
 ):
-    """Computes an orthonormal matrix whose range approximates the range of A.
+    """Compute an orthonormal matrix whose range approximates the range of A.
 
     Parameters
     ----------


### PR DESCRIPTION


#### Reference Issues/PRs

Addresses #21350


#### What does this implement/fix? Explain your changes.

Make the summary for `sklearn.utils.extmath.randomized_range_finder` start with infinitive verb.

#### Any other comments?



