### PR TITLE
Added error checks for invalid combination of `include_boundaries` and `min_value/max_value`

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1418,6 +1418,15 @@ def check_scalar(
             f"Possible values are: {expected_include_boundaries}."
         )
 
+    if include_boundaries in ("left","both") and min_val==None:
+        raise ValueError(
+            f"Invalid combination of `include_boundaries` and `min_val`"
+        )
+    if include_boundaries in ("right","both") and max_val==None:
+        raise ValueError(
+            f"Invalid combination of `include_boundaries` and `min_val`"
+        )
+
     comparison_operator = (
         operator.lt if include_boundaries in ("left", "both") else operator.le
     )

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1418,13 +1418,13 @@ def check_scalar(
             f"Possible values are: {expected_include_boundaries}."
         )
 
-    if include_boundaries in ("left","both") and min_val==None:
+    if include_boundaries in ("left", "both") and min_val is None:
         raise ValueError(
-            f"Invalid combination of `include_boundaries` and `min_val`"
+            f"Invalid combination of `{include_boundaries}` and `{min_val}`"
         )
-    if include_boundaries in ("right","both") and max_val==None:
+    if include_boundaries in ("right", "both") and max_val is None:
         raise ValueError(
-            f"Invalid combination of `include_boundaries` and `min_val`"
+            f"Invalid combination of `{include_boundaries}` and `{max_val}`"
         )
 
     comparison_operator = (


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #21948


#### What does this implement/fix? Explain your changes.
Added error checks to filter out invalid combination of `include_boundaries` and `min_value/max_value`.




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
