### PR TITLE
MAINT Use push_back directly in dbscan_inner

### DIFF
--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -10,12 +10,6 @@ import numpy as np
 np.import_array()
 
 
-# Work around Cython bug: C++ exceptions are not caught unless thrown within
-# a cdef function with an "except +" declaration.
-cdef extern inline void push(vector[np.npy_intp] &stack, np.npy_intp i) except +:
-    stack.push_back(i)
-
-
 def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
                  np.ndarray[object, ndim=1] neighborhoods,
                  np.ndarray[np.npy_intp, ndim=1, mode='c'] labels):
@@ -39,7 +33,7 @@ def dbscan_inner(np.ndarray[np.uint8_t, ndim=1, mode='c'] is_core,
                     for i in range(neighb.shape[0]):
                         v = neighb[i]
                         if labels[v] == -1:
-                            push(stack, v)
+                            stack.push_back(v)
 
             if stack.size() == 0:
                 break


### PR DESCRIPTION
This PR removes helper code and calls `push_back` directly. Looking at the `push_back` import in Cython:

https://github.com/cython/cython/blob/bba69054b4aff2c0a63a8be9d6ce5c9fdd079a52/Cython/Includes/libcpp/vector.pxd#L74

the C++ exception is already converted into a Python exception when `push_back` is called.

CC @jjerphan 

CC @glemaitre I think this is causing the complier issue in [conda-forge windows pypy3](https://github.com/conda-forge/scikit-learn-feedstock/runs/4633288588)