### PR TITLE
MNT move bunch to its own file

### DIFF
--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -41,6 +41,7 @@ from .validation import (
     check_scalar,
 )
 from .. import get_config
+from ._bunch import Bunch
 
 
 # Do not deprecate parallel_backend and register_parallel_backend as they are
@@ -75,60 +76,11 @@ __all__ = [
     "all_estimators",
     "DataConversionWarning",
     "estimator_html_repr",
+    "Bunch",
 ]
 
 IS_PYPY = platform.python_implementation() == "PyPy"
 _IS_32BIT = 8 * struct.calcsize("P") == 32
-
-
-class Bunch(dict):
-    """Container object exposing keys as attributes.
-
-    Bunch objects are sometimes used as an output for functions and methods.
-    They extend dictionaries by enabling values to be accessed by key,
-    `bunch["value_key"]`, or by an attribute, `bunch.value_key`.
-
-    Examples
-    --------
-    >>> from sklearn.utils import Bunch
-    >>> b = Bunch(a=1, b=2)
-    >>> b['b']
-    2
-    >>> b.b
-    2
-    >>> b.a = 3
-    >>> b['a']
-    3
-    >>> b.c = 6
-    >>> b['c']
-    6
-    """
-
-    def __init__(self, **kwargs):
-        super().__init__(kwargs)
-
-    def __setattr__(self, key, value):
-        self[key] = value
-
-    def __dir__(self):
-        return self.keys()
-
-    def __getattr__(self, key):
-        try:
-            return self[key]
-        except KeyError:
-            raise AttributeError(key)
-
-    def __setstate__(self, state):
-        # Bunch pickles generated with scikit-learn 0.16.* have an non
-        # empty __dict__. This causes a surprising behaviour when
-        # loading these pickles scikit-learn 0.17: reading bunch.key
-        # uses __dict__ but assigning to bunch.key use __setattr__ and
-        # only changes bunch['key']. More details can be found at:
-        # https://github.com/scikit-learn/scikit-learn/issues/6196.
-        # Overriding __setstate__ to be a noop has the effect of
-        # ignoring the pickled __dict__
-        pass
 
 
 def safe_mask(X, mask):

--- a/sklearn/utils/_bunch.py
+++ b/sklearn/utils/_bunch.py
@@ -1,0 +1,48 @@
+class Bunch(dict):
+    """Container object exposing keys as attributes.
+
+    Bunch objects are sometimes used as an output for functions and methods.
+    They extend dictionaries by enabling values to be accessed by key,
+    `bunch["value_key"]`, or by an attribute, `bunch.value_key`.
+
+    Examples
+    --------
+    >>> from sklearn.utils import Bunch
+    >>> b = Bunch(a=1, b=2)
+    >>> b['b']
+    2
+    >>> b.b
+    2
+    >>> b.a = 3
+    >>> b['a']
+    3
+    >>> b.c = 6
+    >>> b['c']
+    6
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(kwargs)
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+    def __dir__(self):
+        return self.keys()
+
+    def __getattr__(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
+
+    def __setstate__(self, state):
+        # Bunch pickles generated with scikit-learn 0.16.* have an non
+        # empty __dict__. This causes a surprising behaviour when
+        # loading these pickles scikit-learn 0.17: reading bunch.key
+        # uses __dict__ but assigning to bunch.key use __setattr__ and
+        # only changes bunch['key']. More details can be found at:
+        # https://github.com/scikit-learn/scikit-learn/issues/6196.
+        # Overriding __setstate__ to be a noop has the effect of
+        # ignoring the pickled __dict__
+        pass


### PR DESCRIPTION
During #22083 I realized I need to import `Bunch` inside a `utils` module, which would only be possible if we move it out of `utils/__init__.py` due to circular imports.

This PR moves `Bunch` to a separate file.

cc @glemaitre @thomasjpfan 