### PR TITLE
FIX Support integers in silhouette_score for precomputed distances

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -284,6 +284,9 @@ Changelog
   A deprecation cycle was introduced.
   :pr:`21576` by :user:`Paul-Emile Dugnat <pedugnat>`.
 
+- |Fix| :func:`metrics.silhouette_score` now supports integer input for precomputed
+  distances. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.manifold`
 .......................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -285,7 +285,7 @@ Changelog
   :pr:`21576` by :user:`Paul-Emile Dugnat <pedugnat>`.
 
 - |Fix| :func:`metrics.silhouette_score` now supports integer input for precomputed
-  distances. :pr:`xxxxx` by `Thomas Fan`_.
+  distances. :pr:`22108` by `Thomas Fan`_.
 
 :mod:`sklearn.manifold`
 .......................

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -221,8 +221,7 @@ def silhouette_samples(X, labels, *, metric="euclidean", **kwds):
             atol = np.finfo(X.dtype).eps * 100
             if np.any(np.abs(np.diagonal(X)) > atol):
                 raise ValueError(error_msg)
-        else:  # integer
-            if np.any(np.diagonal(X) != 0):
+        elif np.any(np.diagonal(X) != 0):  # integral dtype
                 raise ValueError(error_msg)
 
     le = LabelEncoder()

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -213,12 +213,17 @@ def silhouette_samples(X, labels, *, metric="euclidean", **kwds):
 
     # Check for non-zero diagonal entries in precomputed distance matrix
     if metric == "precomputed":
-        atol = np.finfo(X.dtype).eps * 100
-        if np.any(np.abs(np.diagonal(X)) > atol):
-            raise ValueError(
-                "The precomputed distance matrix contains non-zero "
-                "elements on the diagonal. Use np.fill_diagonal(X, 0)."
-            )
+        error_msg = ValueError(
+            "The precomputed distance matrix contains non-zero "
+            "elements on the diagonal. Use np.fill_diagonal(X, 0)."
+        )
+        if X.dtype.kind == "f":
+            atol = np.finfo(X.dtype).eps * 100
+            if np.any(np.abs(np.diagonal(X)) > atol):
+                raise ValueError(error_msg)
+        else:  # integer
+            if np.any(np.diagonal(X) != 0):
+                raise ValueError(error_msg)
 
     le = LabelEncoder()
     labels = le.fit_transform(labels)

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -222,7 +222,7 @@ def silhouette_samples(X, labels, *, metric="euclidean", **kwds):
             if np.any(np.abs(np.diagonal(X)) > atol):
                 raise ValueError(error_msg)
         elif np.any(np.diagonal(X) != 0):  # integral dtype
-                raise ValueError(error_msg)
+            raise ValueError(error_msg)
 
     le = LabelEncoder()
     labels = le.fit_transform(labels)

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -354,3 +354,20 @@ def test_davies_bouldin_score():
     X = [[0, 0], [2, 2], [3, 3], [5, 5]]
     labels = [0, 0, 1, 2]
     pytest.approx(davies_bouldin_score(X, labels), (5.0 / 4) / 3)
+
+
+def test_silhouette_score_integer_precomputed():
+    """Check that silhouette_score works for precomputed metrics that are integers.
+
+    Non-regression test for #22107.
+    """
+    result = silhouette_score(
+        [[0, 1, 2], [1, 0, 1], [2, 1, 0]], [0, 0, 1], metric="precomputed"
+    )
+    assert result == pytest.approx(1 / 6)
+
+    # non-zero on diagonal for ints raises an error
+    with pytest.raises(ValueError, match="contains non-zero"):
+        silhouette_score(
+            [[1, 1, 2], [1, 0, 1], [2, 1, 0]], [0, 0, 1], metric="precomputed"
+        )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #22107

#### What does this implement/fix? Explain your changes.
This PR adds adjusts the diagonal check to allow for integer input.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
