### PR TITLE
ENH Adds get_feature_names_out for cross_decomposition

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -110,6 +110,13 @@ Changelog
   reconstruction of a `X` target when a `Y` parameter is given. :pr:`19680` by
   :user:`Robin Thibaut <robinthibaut>`.
 
+- |API| Adds :term:`get_feature_names_out` to all transformers in the
+  :mod:`~sklearn.cross_decomposition` module:
+  :class:`cross_decomposition.CCA`,
+  :class:`cross_decomposition.PLSSVD`,
+  :class:`cross_decomposition.PLSRegression`,
+  and :class:`cross_decomposition.PLSCanonical`. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.feature_extraction`
 .................................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -115,7 +115,7 @@ Changelog
   :class:`cross_decomposition.CCA`,
   :class:`cross_decomposition.PLSSVD`,
   :class:`cross_decomposition.PLSRegression`,
-  and :class:`cross_decomposition.PLSCanonical`. :pr:`xxxxx` by `Thomas Fan`_.
+  and :class:`cross_decomposition.PLSCanonical`. :pr:`22119` by `Thomas Fan`_.
 
 :mod:`sklearn.feature_extraction`
 .................................

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -13,6 +13,7 @@ from scipy.linalg import svd
 
 from ..base import BaseEstimator, RegressorMixin, TransformerMixin
 from ..base import MultiOutputMixin
+from ..base import _ClassNamePrefixFeaturesOutMixin
 from ..utils import check_array, check_consistent_length
 from ..utils.fixes import sp_version
 from ..utils.fixes import parse_version
@@ -156,7 +157,12 @@ def _svd_flip_1d(u, v):
 
 
 class _PLS(
-    TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator, metaclass=ABCMeta
+    _ClassNamePrefixFeaturesOutMixin,
+    TransformerMixin,
+    RegressorMixin,
+    MultiOutputMixin,
+    BaseEstimator,
+    metaclass=ABCMeta,
 ):
     """Partial Least Squares (PLS)
 
@@ -361,6 +367,7 @@ class _PLS(
 
         self.coef_ = np.dot(self.x_rotations_, self.y_loadings_.T)
         self.coef_ = self.coef_ * self._y_std
+        self._n_features_out = self.x_rotations_.shape[1]
         return self
 
     def transform(self, X, Y=None, copy=True):
@@ -931,7 +938,7 @@ class CCA(_PLS):
         )
 
 
-class PLSSVD(TransformerMixin, BaseEstimator):
+class PLSSVD(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
     """Partial Least Square SVD.
 
     This transformer simply performs a SVD on the cross-covariance matrix
@@ -1079,6 +1086,7 @@ class PLSSVD(TransformerMixin, BaseEstimator):
         self._y_scores = np.dot(Y, V)  # TODO: remove in 1.1
         self.x_weights_ = U
         self.y_weights_ = V
+        self._n_features_out = self.x_weights_.shape[1]
         return self
 
     # mypy error: Decorated property not supported

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -607,3 +607,19 @@ def test_pls_constant_y():
         pls.fit(x, y)
 
     assert_allclose(pls.x_rotations_, 0)
+
+
+@pytest.mark.parametrize("Klass", [CCA, PLSSVD, PLSRegression, PLSCanonical])
+def test_pls_feature_names_out(Klass):
+    """Check `get_feature_names_out` cross_decomposition module"""
+    X, Y = load_linnerud(return_X_y=True)
+
+    est = Klass().fit(X, Y)
+    names_out = est.get_feature_names_out()
+
+    class_name_lower = Klass.__name__.lower()
+    expected_names_out = np.array(
+        [f"{class_name_lower}{i}" for i in range(est.x_weights_.shape[1])],
+        dtype=object,
+    )
+    assert_array_equal(names_out, expected_names_out)

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -611,7 +611,7 @@ def test_pls_constant_y():
 
 @pytest.mark.parametrize("Klass", [CCA, PLSSVD, PLSRegression, PLSCanonical])
 def test_pls_feature_names_out(Klass):
-    """Check `get_feature_names_out` cross_decomposition module"""
+    """Check `get_feature_names_out` cross_decomposition module."""
     X, Y = load_linnerud(return_X_y=True)
 
     est = Klass().fit(X, Y)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -381,7 +381,6 @@ def test_pandas_column_name_consistency(estimator):
 # from this list to be tested
 GET_FEATURES_OUT_MODULES_TO_IGNORE = [
     "cluster",
-    "cross_decomposition",
     "discriminant_analysis",
     "ensemble",
     "isotonic",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Address a part of https://github.com/scikit-learn/scikit-learn/issues/21308


#### What does this implement/fix? Explain your changes.
This PR add `get_feature_names_out` to `cross_decomposition` estimators.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
