### PR TITLE
DOC Add Flower to related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -180,6 +180,11 @@ and tasks.
   Keras to interface it with scikit-learn. SciKeras is the successor
   of `tf.keras.wrappers.scikit_learn`.
 
+**Federated Learning**
+
+- `Flower <https://flower.dev/>`_ Is a friendly federated learning framework with a 
+  unified approach that can federate any workload, any ML framework, and any programming language.
+
 **Broad scope**
 
 - `mlxtend <https://github.com/rasbt/mlxtend>`_ Includes a number of additional

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -182,7 +182,7 @@ and tasks.
 
 **Federated Learning**
 
-- `Flower <https://flower.dev/>`_ Is a friendly federated learning framework with a 
+- `Flower <https://flower.dev/>`_ A friendly federated learning framework with a 
   unified approach that can federate any workload, any ML framework, and any programming language.
 
 **Broad scope**


### PR DESCRIPTION
#### Reference Issues/PRs

Add Flower to the Documentation (related projects): see https://github.com/scikit-learn/scikit-learn/issues/22060


#### What does this implement/fix? Explain your changes.

The related_projects.rst has an additional section with federated learning where Flower is now listed. Flower has scikit example where a logistic regression model is federated across multiple data partitions.

#### Any other comments?

-