### PR TITLE
FIX avoid parameter validation in init in TweedieRegressor

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -285,6 +285,10 @@ Changelog
   for the highs based solvers.
   :pr:`21086` by :user:`Venkatachalam Natchiappan <venkyyuvy>`.
 
+- |Fix| The input paramter `family` of :class:`linear_model.TweedieRegressor` is not
+  validated in `__init__` anymore. The input parameter `family` is now a string.
+  :pr:`22124` by :user:`Maren Westermann <marenwestermann>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -407,6 +407,16 @@ class GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         return 1 - dev / dev_null
 
     def _get_family_instance(self):
+        """Return the distribution of a family.
+
+        This method returns an instance of ``ExponentialDispersionModel`` based the
+        value stored in the ``family`` attribute.
+
+        Returns
+        -------
+        family_instance : ExponentialDispersionModel
+            Returns an instance of ExponentialDispersionModel.
+        """
         if isinstance(self.family, ExponentialDispersionModel):
             return self.family
         elif self.family in EDM_DISTRIBUTIONS:
@@ -806,4 +816,11 @@ class TweedieRegressor(GeneralizedLinearRegressor):
             raise ValueError("TweedieRegressor.family must be 'tweedie'!")
 
     def _get_family_instance(self):
+        """Return an instance of ``TweedieDistribution``.
+
+        Returns
+        -------
+        family_instance : TweedieDistribution
+            Returns an instance of TweedieDistribution.
+        """
         return TweedieDistribution(power=self.power)

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -71,7 +71,7 @@ def test_glm_family_argument(name, instance):
     y = np.array([0.1, 0.5])  # in range of all distributions
     X = np.array([[1], [2]])
     glm = GeneralizedLinearRegressor(family=name, alpha=0).fit(X, y)
-    assert isinstance(glm._family_instance, instance.__class__)
+    assert isinstance(glm._get_family_instance(), instance.__class__)
 
     glm = GeneralizedLinearRegressor(family="not a family")
     with pytest.raises(ValueError, match="family must be"):
@@ -429,23 +429,22 @@ def test_gamma_regression_family(regression_data):
 
 
 def test_tweedie_regression_family(regression_data):
-    # Make sure the family attribute is always a TweedieDistribution and that
+    # Make sure the family is a TweedieDistribution and that
     # the power attribute is properly updated
     power = 2.0
     est = TweedieRegressor(power=power)
-    assert isinstance(est.family, TweedieDistribution)
-    assert est.family.power == power
+    assert isinstance(est._get_family_instance(), TweedieDistribution)
+    assert est._get_family_instance().power == power
     assert est.power == power
 
     new_power = 0
-    new_family = TweedieDistribution(power=new_power)
-    est.family = new_family
-    assert isinstance(est.family, TweedieDistribution)
-    assert est.family.power == new_power
+    est.power = new_power
+    assert isinstance(est._get_family_instance(), TweedieDistribution)
+    assert est._get_family_instance().power == new_power
     assert est.power == new_power
 
-    msg = "TweedieRegressor.family must be of type TweedieDistribution!"
-    with pytest.raises(TypeError, match=msg):
+    msg = "TweedieRegressor.family must be 'tweedie'!"
+    with pytest.raises(ValueError, match=msg):
         est.family = None
 
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -427,7 +427,6 @@ VALIDATE_ESTIMATOR_INIT = [
     "FeatureUnion",
     "SGDOneClassSVM",
     "TheilSenRegressor",
-    "TweedieRegressor",
 ]
 VALIDATE_ESTIMATOR_INIT = set(VALIDATE_ESTIMATOR_INIT)
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #21406


#### What does this implement/fix? Explain your changes.
I removed the parameter validation of the attribute `family` in `TweedieRegressor.__init__` and changed the tests accordingly.

#### Any other comments?
The test failure described in #21406 was due to the attribute `family` being set to `TweedieDistribution` in init (`family=TweedieDistribution(power=power)`). 

In the module `sklearn/linear_model/_glm/glm.py` the `PoissonRegressor`, `GammaRegressor` and `TweedieRegressor` have the class `GeneralizedLinearRegressor` as a shared parent class. In the first two estimators the `family` parameter is set as a string. I therefore changed the family in `TweedieRegressor` to be a string as well, however my implementation is not backward compatible. 
I introduced the method `_get_family_instance` in `GeneralizedLinearRegressor` and `TweedieRegressor` in order to get the correct distribution for the regressors and to set the `power` correctly in `TweedieRegressor`. 


ping @adrinjalali @rth 