### PR TITLE
DOC Updated documentation in naive_bayes.py (coef_, intercept_)

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -775,12 +775,12 @@ class MultinomialNB(_BaseDiscreteNB):
         Class labels known to the classifier
 
     coef_ : ndarray of shape (n_classes, n_features)
-        Mirrors ``feature_log_prob_`` for interpreting `MultinomialNB`
+        Mirrors ``feature_log_prob_[1]`` for interpreting `MultinomialNB`
         as a linear model.
 
         .. deprecated:: 0.24
             ``coef_`` is deprecated in 0.24 and will be removed in 1.1
-            (renaming of 0.26).
+            (renaming of 0.26). Already appears as clf.feature_log_prob_[1].
 
     feature_count_ : ndarray of shape (n_classes, n_features)
         Number of samples encountered for each (class, feature)
@@ -792,12 +792,12 @@ class MultinomialNB(_BaseDiscreteNB):
         given a class, ``P(x_i|y)``.
 
     intercept_ : ndarray of shape (n_classes,)
-        Mirrors ``class_log_prior_`` for interpreting `MultinomialNB`
+        Mirrors ``class_log_prior_[1]`` for interpreting `MultinomialNB`
         as a linear model.
 
         .. deprecated:: 0.24
             ``intercept_`` is deprecated in 0.24 and will be removed in 1.1
-            (renaming of 0.26).
+            (renaming of 0.26). Already appears as clf.class_log_prior_[1].
 
     n_features_ : int
         Number of features of each sample.

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -775,12 +775,13 @@ class MultinomialNB(_BaseDiscreteNB):
         Class labels known to the classifier
 
     coef_ : ndarray of shape (n_classes, n_features)
-        Mirrors ``feature_log_prob_[1]`` for interpreting `MultinomialNB`
-        as a linear model.
+        Mirrors ``feature_log_prob_`` with a multiclass target, and 
+        ``feature_log_prob_[1]`` with a binary target for interpreting
+        `MultinomialNB`
 
         .. deprecated:: 0.24
             ``coef_`` is deprecated in 0.24 and will be removed in 1.1
-            (renaming of 0.26). Already appears as clf.feature_log_prob_[1].
+            (renaming of 0.26).
 
     feature_count_ : ndarray of shape (n_classes, n_features)
         Number of samples encountered for each (class, feature)
@@ -792,12 +793,14 @@ class MultinomialNB(_BaseDiscreteNB):
         given a class, ``P(x_i|y)``.
 
     intercept_ : ndarray of shape (n_classes,)
-        Mirrors ``class_log_prior_[1]`` for interpreting `MultinomialNB`
-        as a linear model.
+        Mirrors ``class_log_prior_`` with a multiclass target, and 
+        ``class_log_prior_[1]`` with a binary target for interpreting
+        `MultinomialNB`
+        
 
         .. deprecated:: 0.24
             ``intercept_`` is deprecated in 0.24 and will be removed in 1.1
-            (renaming of 0.26). Already appears as clf.class_log_prior_[1].
+            (renaming of 0.26).
 
     n_features_ : int
         Number of features of each sample.

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -775,8 +775,8 @@ class MultinomialNB(_BaseDiscreteNB):
         Class labels known to the classifier
 
     coef_ : ndarray of shape (n_classes, n_features)
-        Mirrors ``feature_log_prob_`` with a multiclass target, and 
-        ``feature_log_prob_[1]`` with a binary target for interpreting
+        Mirrors ``feature_log_prob_`` with a multiclass target, and
+         ``feature_log_prob_[1]`` with a binary target for interpreting
         `MultinomialNB`
 
         .. deprecated:: 0.24
@@ -793,10 +793,9 @@ class MultinomialNB(_BaseDiscreteNB):
         given a class, ``P(x_i|y)``.
 
     intercept_ : ndarray of shape (n_classes,)
-        Mirrors ``class_log_prior_`` with a multiclass target, and 
+        Mirrors ``class_log_prior_`` with a multiclass target, and
         ``class_log_prior_[1]`` with a binary target for interpreting
         `MultinomialNB`
-        
 
         .. deprecated:: 0.24
             ``intercept_`` is deprecated in 0.24 and will be removed in 1.1


### PR DESCRIPTION
#### Reference Issues/PRs

References #15752 

#### What does this implement/fix? Explain your changes.

I have added some precision to the documentation of the attributes coef_ and intercept_. These two are already present in two other array attributes respectively feature_log_prob_ and class_log_prior_. 

We could already see in the documentation that coef_ and intercept_ were mirrors but the issue was still open so I added some precision like the index where they can be found in the two arrays above.  

#### Any other comments?

If this isn't what was expected, can you please precise whats is or close the issue #15752 corresponding to this problem if nothing is to be done.