### PR TITLE
DOC Fix docstring for AdditiveChi2Sampler regarding output shape

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -510,7 +510,7 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
 
     Since the kernel that is to be approximated is additive, the components of
     the input vectors can be treated separately.  Each entry in the original
-    space is transformed into 2*sample_steps+1 features, where sample_steps is
+    space is transformed into 2*sample_steps-1 features, where sample_steps is
     a parameter of the method. Typical values of sample_steps include 1, 2 and
     3.
 
@@ -635,7 +635,7 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
         Returns
         -------
         X_new : {ndarray, sparse matrix}, \
-               shape = (n_samples, n_features * (2*sample_steps + 1))
+               shape = (n_samples, n_features * (2*sample_steps - 1))
             Whether the return value is an array or sparse matrix depends on
             the type of the input X.
         """


### PR DESCRIPTION
This PR updates the docstring for the output shape of `AdditiveChi2Sampler.transform` to what is implemented in code:

```python
from sklearn.datasets import load_digits
from sklearn.kernel_approximation import AdditiveChi2Sampler

X, y = load_digits(return_X_y=True)
n_features = X.shape[1]

for sample_steps in range(1, 4):
    
    chi2sampler = AdditiveChi2Sampler(sample_steps=sample_steps)

    # Updated formula
    n_features_out = n_features * (2 * sample_steps - 1)
    X_transformed = chi2sampler.fit_transform(X, y)

    assert X_transformed.shape[1] == n_features_out
```