### PR TITLE
DOC Ensures that nan_euclidean_distances passes numpydoc

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -411,12 +411,12 @@ def nan_euclidean_distances(
 
     Parameters
     ----------
-    X : array-like of shape (n_samples_X, n_features) 
-        An array where each row is a sample and each column is a feature. 
+    X : array-like of shape (n_samples_X, n_features)
+        An array where each row is a sample and each column is a feature.
 
     Y : array-like of shape=(n_samples_Y, n_features), default=None
-        An array where each row is a sample and each column is a feature. 
-        If `None`, method uses `Y=X`. 
+        An array where each row is a sample and each column is a feature.
+        If `None`, method uses `Y=X`.
 
     squared : bool, default=False
         Return squared Euclidean distances.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -411,11 +411,12 @@ def nan_euclidean_distances(
 
     Parameters
     ----------
-    X : array-like of shape=(n_samples_X, n_features)
-        Array of vectors.
+    X : {array-like, sparse matrix} of shape (n_samples_X, n_features) 
+        An array where each row is a sample and each column is a feature. 
 
     Y : array-like of shape=(n_samples_Y, n_features), default=None
-        Array of vectors. If `None`, uses `Y=X`.
+        An array where each row is a sample and each column is a feature. 
+        If `None`, method uses `Y=X`. 
 
     squared : bool, default=False
         Return squared Euclidean distances.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -412,8 +412,10 @@ def nan_euclidean_distances(
     Parameters
     ----------
     X : array-like of shape=(n_samples_X, n_features)
+        Array of vectors.
 
     Y : array-like of shape=(n_samples_Y, n_features), default=None
+        Array of vectors. If `None`, uses `Y=X`.
 
     squared : bool, default=False
         Return squared Euclidean distances.
@@ -427,10 +429,19 @@ def nan_euclidean_distances(
     Returns
     -------
     distances : ndarray of shape (n_samples_X, n_samples_Y)
+        Returns the distances between the row vectors of `X`
+        and the row vectors of `Y`.
 
     See Also
     --------
     paired_distances : Distances between pairs of elements of X and Y.
+
+    References
+    ----------
+    * John K. Dixon, "Pattern Recognition with Partly Missing Data",
+      IEEE Transactions on Systems, Man, and Cybernetics, Volume: 9, Issue:
+      10, pp. 617 - 621, Oct. 1979.
+      http://ieeexplore.ieee.org/abstract/document/4310090/
 
     Examples
     --------
@@ -445,13 +456,6 @@ def nan_euclidean_distances(
     >>> nan_euclidean_distances(X, [[0, 0]])
     array([[1.        ],
            [1.41421356]])
-
-    References
-    ----------
-    * John K. Dixon, "Pattern Recognition with Partly Missing Data",
-      IEEE Transactions on Systems, Man, and Cybernetics, Volume: 9, Issue:
-      10, pp. 617 - 621, Oct. 1979.
-      http://ieeexplore.ieee.org/abstract/document/4310090/
     """
 
     force_all_finite = "allow-nan" if is_scalar_nan(missing_values) else True

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -411,7 +411,7 @@ def nan_euclidean_distances(
 
     Parameters
     ----------
-    X : {array-like, sparse matrix} of shape (n_samples_X, n_features) 
+    X : array-like of shape (n_samples_X, n_features) 
         An array where each row is a sample and each column is a feature. 
 
     Y : array-like of shape=(n_samples_Y, n_features), default=None

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -128,7 +128,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.kernel_metrics",
     "sklearn.metrics.pairwise.laplacian_kernel",
     "sklearn.metrics.pairwise.manhattan_distances",
-    "sklearn.metrics.pairwise.nan_euclidean_distances",
     "sklearn.metrics.pairwise.paired_cosine_distances",
     "sklearn.metrics.pairwise.paired_distances",
     "sklearn.metrics.pairwise.paired_euclidean_distances",


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #21350 

#### What does this implement/fix? Explain your changes.
Brings `sklearn.metrics.pairwise.nan_euclidean_distances` documentation into numpydoc compliance


#### Any other comments?
N/A