### PR TITLE
MAINT rename base_estimator to estimator in BaggingClassifier and BaggingRegressor

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -221,6 +221,12 @@ Changelog
   `warm_start` enabled.
   :pr:`22106` by :user:`Pieter Gijsbers <PGijsbers>`.
 
+- |Enhancement| Rename parameter `base_estimator` to `estimator` in
+  :class:`ensemble.BaseBagging`, :class:`ensemble.BaggingClassifier`,
+  :class:`ensemble.BaggingRegressor` to improve readability and consistency.
+  `base_estimator` is deprecated and will be removed in 1.3.
+  :pr:`22145` by :user:`Adrian Trujillo <trujillo9616>`.
+
 :mod:`sklearn.feature_extraction`
 .................................
 

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -958,7 +958,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
 
     Parameters
     ----------
-    base_estimator : object, default=None
+    estimator : object, default=None
         The base estimator to fit on random subsets of the dataset.
         If None, then the base estimator is a
         :class:`~sklearn.tree.DecisionTreeRegressor`.
@@ -1013,6 +1013,12 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
 
     verbose : int, default=0
         Controls the verbosity when fitting and predicting.
+
+    base_estimator : object, default="deprecated"
+        Use `estimator` instead.
+        .. deprecated:: 1.1
+            `base_estimator` is deprecated and will be removed in 1.3.
+            Use `estimator` instead.
 
     Attributes
     ----------
@@ -1086,7 +1092,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
     >>> X, y = make_regression(n_samples=100, n_features=4,
     ...                        n_informative=2, n_targets=1,
     ...                        random_state=0, shuffle=False)
-    >>> regr = BaggingRegressor(base_estimator=SVR(),
+    >>> regr = BaggingRegressor(estimator=SVR(),
     ...                         n_estimators=10, random_state=0).fit(X, y)
     >>> regr.predict([[0, 0, 0, 0]])
     array([-2.8720...])
@@ -1094,7 +1100,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
 
     def __init__(
         self,
-        base_estimator=None,
+        estimator=None,
         n_estimators=10,
         *,
         max_samples=1.0,
@@ -1106,9 +1112,10 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
         n_jobs=None,
         random_state=None,
         verbose=0,
+        base_estimator="deprecated",
     ):
         super().__init__(
-            base_estimator,
+            estimator,
             n_estimators=n_estimators,
             max_samples=max_samples,
             max_features=max_features,
@@ -1119,6 +1126,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
+            base_estimator=base_estimator,
         )
 
     def predict(self, X):

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -209,7 +209,7 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
     @abstractmethod
     def __init__(
         self,
-        estimator=None,
+        base_estimator=None,
         n_estimators=10,
         *,
         max_samples=1.0,
@@ -221,11 +221,9 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
         n_jobs=None,
         random_state=None,
         verbose=0,
-        base_estimator="deprecated",
     ):
-        super().__init__(base_estimator=estimator, n_estimators=n_estimators)
+        super().__init__(base_estimator=base_estimator, n_estimators=n_estimators)
 
-        self.estimator = estimator
         self.max_samples = max_samples
         self.max_features = max_features
         self.bootstrap = bootstrap
@@ -235,7 +233,6 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
         self.n_jobs = n_jobs
         self.random_state = random_state
         self.verbose = verbose
-        self.base_estimator = base_estimator
 
     def fit(self, X, y, sample_weight=None):
         """Build a Bagging ensemble of estimators from the training set (X, y).
@@ -269,23 +266,7 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
             force_all_finite=False,
             multi_output=True,
         )
-        if self.base_estimator != "deprecated" and self.estimator is None:
-            warn(
-                "`base_estimator` was renamed to `estimator` in version 1.1 and "
-                "will be removed in 1.3.",
-                FutureWarning,
-            )
-            self.estimator = self.base_estimator
         return self._fit(X, y, self.max_samples, sample_weight=sample_weight)
-
-    def _validate_estimator(self, default=None):
-        self.base_estimator = self.estimator
-        super()._validate_estimator(default=default)
-
-    def set_params(self, **params):
-        self.base_estimator = self.estimator
-        super().set_params(**params)
-        return self
 
     def _parallel_args(self):
         return {}
@@ -669,7 +650,7 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
 
     def __init__(
         self,
-        estimator=None,
+        base_estimator=None,
         n_estimators=10,
         *,
         max_samples=1.0,
@@ -681,11 +662,10 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
         n_jobs=None,
         random_state=None,
         verbose=0,
-        base_estimator="deprecated",
     ):
 
         super().__init__(
-            estimator,
+            base_estimator,
             n_estimators=n_estimators,
             max_samples=max_samples,
             max_features=max_features,
@@ -696,7 +676,6 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
-            base_estimator=base_estimator,
         )
 
     def _validate_estimator(self):
@@ -1100,7 +1079,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
 
     def __init__(
         self,
-        estimator=None,
+        base_estimator=None,
         n_estimators=10,
         *,
         max_samples=1.0,
@@ -1112,10 +1091,9 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
         n_jobs=None,
         random_state=None,
         verbose=0,
-        base_estimator="deprecated",
     ):
         super().__init__(
-            estimator,
+            base_estimator,
             n_estimators=n_estimators,
             max_samples=max_samples,
             max_features=max_features,
@@ -1126,7 +1104,6 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
-            base_estimator=base_estimator,
         )
 
     def predict(self, X):

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -650,7 +650,7 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
 
     def __init__(
         self,
-        base_estimator=None,
+        estimator=None,
         n_estimators=10,
         *,
         max_samples=1.0,
@@ -662,6 +662,7 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
         n_jobs=None,
         random_state=None,
         verbose=0,
+        base_estimator="deprecated",
     ):
 
         super().__init__(
@@ -678,9 +679,27 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
             verbose=verbose,
         )
 
+        self.estimator = estimator
+
+    def fit(self, X, y, sample_weight=None):
+        if self.base_estimator != "deprecated":
+            warn(
+                "`base_estimator` was renamed to `estimator` in version 1.1 and "
+                "will be removed in 1.3.",
+                FutureWarning,
+            )
+            self.estimator = self.base_estimator
+        return super().fit(X, y, sample_weight=sample_weight)
+
     def _validate_estimator(self):
         """Check the estimator and set the base_estimator_ attribute."""
+        self.base_estimator = self.estimator
         super()._validate_estimator(default=DecisionTreeClassifier())
+
+    def set_params(self, **params):
+        self.base_estimator = self.estimator
+        super().set_params(**params)
+        return self
 
     def _set_oob_score(self, X, y):
         n_samples = y.shape[0]
@@ -995,6 +1014,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
 
     base_estimator : object, default="deprecated"
         Use `estimator` instead.
+
         .. deprecated:: 1.1
             `base_estimator` is deprecated and will be removed in 1.3.
             Use `estimator` instead.
@@ -1079,7 +1099,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
 
     def __init__(
         self,
-        base_estimator=None,
+        estimator=None,
         n_estimators=10,
         *,
         max_samples=1.0,
@@ -1091,6 +1111,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
         n_jobs=None,
         random_state=None,
         verbose=0,
+        base_estimator="deprecated",
     ):
         super().__init__(
             base_estimator,
@@ -1105,6 +1126,23 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
             random_state=random_state,
             verbose=verbose,
         )
+
+        self.estimator = estimator
+
+    def fit(self, X, y, sample_weight=None):
+        if self.base_estimator != "deprecated":
+            warn(
+                "`base_estimator` was renamed to `estimator` in version 1.1 and "
+                "will be removed in 1.3.",
+                FutureWarning,
+            )
+            self.estimator = self.base_estimator
+        return super().fit(X, y, sample_weight=sample_weight)
+
+    def set_params(self, **params):
+        self.base_estimator = self.estimator
+        super().set_params(**params)
+        return self
 
     def predict(self, X):
         """Predict regression target for X.
@@ -1154,6 +1192,7 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
 
     def _validate_estimator(self):
         """Check the estimator and set the base_estimator_ attribute."""
+        self.base_estimator = self.estimator
         super()._validate_estimator(default=DecisionTreeRegressor())
 
     def _set_oob_score(self, X, y):

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -518,7 +518,7 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
 
     Parameters
     ----------
-    base_estimator : object, default=None
+    estimator : object, default=None
         The base estimator to fit on random subsets of the dataset.
         If None, then the base estimator is a
         :class:`~sklearn.tree.DecisionTreeClassifier`.
@@ -576,6 +576,12 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
 
     verbose : int, default=0
         Controls the verbosity when fitting and predicting.
+
+    base_estimator : object, default="deprecated"
+        Use `estimator` instead.
+        .. deprecated:: 1.1
+            `base_estimator` is deprecated and will be removed in 1.3.
+            Use `estimator` instead.
 
     Attributes
     ----------
@@ -655,7 +661,7 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
     >>> X, y = make_classification(n_samples=100, n_features=4,
     ...                            n_informative=2, n_redundant=0,
     ...                            random_state=0, shuffle=False)
-    >>> clf = BaggingClassifier(base_estimator=SVC(),
+    >>> clf = BaggingClassifier(estimator=SVC(),
     ...                         n_estimators=10, random_state=0).fit(X, y)
     >>> clf.predict([[0, 0, 0, 0]])
     array([1])
@@ -663,7 +669,7 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
 
     def __init__(
         self,
-        base_estimator=None,
+        estimator=None,
         n_estimators=10,
         *,
         max_samples=1.0,
@@ -675,10 +681,11 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
         n_jobs=None,
         random_state=None,
         verbose=0,
+        base_estimator="deprecated",
     ):
 
         super().__init__(
-            base_estimator,
+            estimator,
             n_estimators=n_estimators,
             max_samples=max_samples,
             max_features=max_features,
@@ -689,6 +696,7 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
+            base_estimator=base_estimator,
         )
 
     def _validate_estimator(self):

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -959,3 +959,31 @@ def test_n_features_deprecation(Estimator):
 
     with pytest.warns(FutureWarning, match="`n_features_` was deprecated"):
         est.n_features_
+
+
+def test_bagging_clf_base_estimator_deprecated():
+    X = np.array([[1, 2], [3, 4]])
+    y = np.array([1, 0])
+    clf = BaggingClassifier(base_estimator=DecisionTreeClassifier(), n_estimators=10)
+
+    err_msg = (
+        "`base_estimator` was renamed to `estimator` in version 1.1 and "
+        "will be removed in 1.3."
+    )
+
+    with pytest.warns(FutureWarning, match=err_msg):
+        clf.fit(X, y)
+
+
+def test_bagging_regr_base_estimator_deprecated():
+    X = np.array([[1, 2], [3, 4]])
+    y = np.array([1, 0])
+    regr = BaggingRegressor(base_estimator=DecisionTreeRegressor(), n_estimators=10)
+
+    err_msg = (
+        "`base_estimator` was renamed to `estimator` in version 1.1 and "
+        "will be removed in 1.3."
+    )
+
+    with pytest.warns(FutureWarning, match=err_msg):
+        regr.fit(X, y)

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -75,7 +75,7 @@ def test_classification():
     # doing the full cartesian product to keep the test durations low.
     for params, estimator in zip(grid, cycle(estimators)):
         BaggingClassifier(
-            base_estimator=estimator,
+            estimator=estimator,
             random_state=rng,
             n_estimators=2,
             **params,
@@ -125,7 +125,7 @@ def test_sparse_classification(sparse_format, params, method):
     X_test_sparse = sparse_format(X_test)
     # Trained on sparse format
     sparse_classifier = BaggingClassifier(
-        base_estimator=CustomSVC(kernel="linear", decision_function_shape="ovr"),
+        estimator=CustomSVC(kernel="linear", decision_function_shape="ovr"),
         random_state=1,
         **params,
     ).fit(X_train_sparse, y_train)
@@ -133,7 +133,7 @@ def test_sparse_classification(sparse_format, params, method):
 
     # Trained on dense format
     dense_classifier = BaggingClassifier(
-        base_estimator=CustomSVC(kernel="linear", decision_function_shape="ovr"),
+        estimator=CustomSVC(kernel="linear", decision_function_shape="ovr"),
         random_state=1,
         **params,
     ).fit(X_train, y_train)
@@ -169,7 +169,7 @@ def test_regression():
         SVR(),
     ]:
         for params in grid:
-            BaggingRegressor(base_estimator=estimator, random_state=rng, **params).fit(
+            BaggingRegressor(estimator=estimator, random_state=rng, **params).fit(
                 X_train, y_train
             ).predict(X_test)
 
@@ -213,13 +213,13 @@ def test_sparse_regression():
 
             # Trained on sparse format
             sparse_classifier = BaggingRegressor(
-                base_estimator=CustomSVR(), random_state=1, **params
+                estimator=CustomSVR(), random_state=1, **params
             ).fit(X_train_sparse, y_train)
             sparse_results = sparse_classifier.predict(X_test_sparse)
 
             # Trained on dense format
             dense_results = (
-                BaggingRegressor(base_estimator=CustomSVR(), random_state=1, **params)
+                BaggingRegressor(estimator=CustomSVR(), random_state=1, **params)
                 .fit(X_train, y_train)
                 .predict(X_test)
             )
@@ -249,7 +249,7 @@ def test_bootstrap_samples():
 
     # without bootstrap, all trees are perfect on the training set
     ensemble = BaggingRegressor(
-        base_estimator=DecisionTreeRegressor(),
+        estimator=DecisionTreeRegressor(),
         max_samples=1.0,
         bootstrap=False,
         random_state=rng,
@@ -259,7 +259,7 @@ def test_bootstrap_samples():
 
     # with bootstrap, trees are no longer perfect on the training set
     ensemble = BaggingRegressor(
-        base_estimator=DecisionTreeRegressor(),
+        estimator=DecisionTreeRegressor(),
         max_samples=1.0,
         bootstrap=True,
         random_state=rng,
@@ -270,9 +270,9 @@ def test_bootstrap_samples():
     # check that each sampling correspond to a complete bootstrap resample.
     # the size of each bootstrap should be the same as the input data but
     # the data should be different (checked using the hash of the data).
-    ensemble = BaggingRegressor(
-        base_estimator=DummySizeEstimator(), bootstrap=True
-    ).fit(X_train, y_train)
+    ensemble = BaggingRegressor(estimator=DummySizeEstimator(), bootstrap=True).fit(
+        X_train, y_train
+    )
     training_hash = []
     for estimator in ensemble.estimators_:
         assert estimator.training_size_ == X_train.shape[0]
@@ -288,7 +288,7 @@ def test_bootstrap_features():
     )
 
     ensemble = BaggingRegressor(
-        base_estimator=DecisionTreeRegressor(),
+        estimator=DecisionTreeRegressor(),
         max_features=1.0,
         bootstrap_features=False,
         random_state=rng,
@@ -298,7 +298,7 @@ def test_bootstrap_features():
         assert diabetes.data.shape[1] == np.unique(features).shape[0]
 
     ensemble = BaggingRegressor(
-        base_estimator=DecisionTreeRegressor(),
+        estimator=DecisionTreeRegressor(),
         max_features=1.0,
         bootstrap_features=True,
         random_state=rng,
@@ -318,7 +318,7 @@ def test_probability():
     with np.errstate(divide="ignore", invalid="ignore"):
         # Normal case
         ensemble = BaggingClassifier(
-            base_estimator=DecisionTreeClassifier(), random_state=rng
+            estimator=DecisionTreeClassifier(), random_state=rng
         ).fit(X_train, y_train)
 
         assert_array_almost_equal(
@@ -331,7 +331,7 @@ def test_probability():
 
         # Degenerate case, where some classes are missing
         ensemble = BaggingClassifier(
-            base_estimator=LogisticRegression(), random_state=rng, max_samples=5
+            estimator=LogisticRegression(), random_state=rng, max_samples=5
         ).fit(X_train, y_train)
 
         assert_array_almost_equal(
@@ -353,7 +353,7 @@ def test_oob_score_classification():
 
     for estimator in [DecisionTreeClassifier(), SVC()]:
         clf = BaggingClassifier(
-            base_estimator=estimator,
+            estimator=estimator,
             n_estimators=100,
             bootstrap=True,
             oob_score=True,
@@ -371,7 +371,7 @@ def test_oob_score_classification():
         )
         with pytest.warns(UserWarning, match=warn_msg):
             clf = BaggingClassifier(
-                base_estimator=estimator,
+                estimator=estimator,
                 n_estimators=1,
                 bootstrap=True,
                 oob_score=True,
@@ -389,7 +389,7 @@ def test_oob_score_regression():
     )
 
     clf = BaggingRegressor(
-        base_estimator=DecisionTreeRegressor(),
+        estimator=DecisionTreeRegressor(),
         n_estimators=50,
         bootstrap=True,
         oob_score=True,
@@ -407,7 +407,7 @@ def test_oob_score_regression():
     )
     with pytest.warns(UserWarning, match=warn_msg):
         regr = BaggingRegressor(
-            base_estimator=DecisionTreeRegressor(),
+            estimator=DecisionTreeRegressor(),
             n_estimators=1,
             bootstrap=True,
             oob_score=True,
@@ -424,7 +424,7 @@ def test_single_estimator():
     )
 
     clf1 = BaggingRegressor(
-        base_estimator=KNeighborsRegressor(),
+        estimator=KNeighborsRegressor(),
         n_estimators=1,
         bootstrap=False,
         bootstrap_features=False,
@@ -782,9 +782,7 @@ def test_estimators_samples_deterministic():
     base_pipeline = make_pipeline(
         SparseRandomProjection(n_components=2), LogisticRegression()
     )
-    clf = BaggingClassifier(
-        base_estimator=base_pipeline, max_samples=0.5, random_state=0
-    )
+    clf = BaggingClassifier(estimator=base_pipeline, max_samples=0.5, random_state=0)
     clf.fit(X, y)
     pipeline_estimator_coef = clf.estimators_[0].steps[-1][1].coef_.copy()
 
@@ -944,7 +942,7 @@ def test_bagging_get_estimators_indices():
         def fit(self, X, y):
             self._sample_indices = y
 
-    clf = BaggingRegressor(base_estimator=MyEstimator(), n_estimators=1, random_state=0)
+    clf = BaggingRegressor(estimator=MyEstimator(), n_estimators=1, random_state=0)
     clf.fit(X, y)
 
     assert_array_equal(clf.estimators_[0]._sample_indices, clf.estimators_samples_[0])

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -75,7 +75,7 @@ def test_classification():
     # doing the full cartesian product to keep the test durations low.
     for params, estimator in zip(grid, cycle(estimators)):
         BaggingClassifier(
-            estimator=estimator,
+            base_estimator=estimator,
             random_state=rng,
             n_estimators=2,
             **params,
@@ -125,7 +125,7 @@ def test_sparse_classification(sparse_format, params, method):
     X_test_sparse = sparse_format(X_test)
     # Trained on sparse format
     sparse_classifier = BaggingClassifier(
-        estimator=CustomSVC(kernel="linear", decision_function_shape="ovr"),
+        base_estimator=CustomSVC(kernel="linear", decision_function_shape="ovr"),
         random_state=1,
         **params,
     ).fit(X_train_sparse, y_train)
@@ -133,7 +133,7 @@ def test_sparse_classification(sparse_format, params, method):
 
     # Trained on dense format
     dense_classifier = BaggingClassifier(
-        estimator=CustomSVC(kernel="linear", decision_function_shape="ovr"),
+        base_estimator=CustomSVC(kernel="linear", decision_function_shape="ovr"),
         random_state=1,
         **params,
     ).fit(X_train, y_train)
@@ -169,7 +169,7 @@ def test_regression():
         SVR(),
     ]:
         for params in grid:
-            BaggingRegressor(estimator=estimator, random_state=rng, **params).fit(
+            BaggingRegressor(base_estimator=estimator, random_state=rng, **params).fit(
                 X_train, y_train
             ).predict(X_test)
 
@@ -213,13 +213,13 @@ def test_sparse_regression():
 
             # Trained on sparse format
             sparse_classifier = BaggingRegressor(
-                estimator=CustomSVR(), random_state=1, **params
+                base_estimator=CustomSVR(), random_state=1, **params
             ).fit(X_train_sparse, y_train)
             sparse_results = sparse_classifier.predict(X_test_sparse)
 
             # Trained on dense format
             dense_results = (
-                BaggingRegressor(estimator=CustomSVR(), random_state=1, **params)
+                BaggingRegressor(base_estimator=CustomSVR(), random_state=1, **params)
                 .fit(X_train, y_train)
                 .predict(X_test)
             )
@@ -249,7 +249,7 @@ def test_bootstrap_samples():
 
     # without bootstrap, all trees are perfect on the training set
     ensemble = BaggingRegressor(
-        estimator=DecisionTreeRegressor(),
+        base_estimator=DecisionTreeRegressor(),
         max_samples=1.0,
         bootstrap=False,
         random_state=rng,
@@ -259,7 +259,7 @@ def test_bootstrap_samples():
 
     # with bootstrap, trees are no longer perfect on the training set
     ensemble = BaggingRegressor(
-        estimator=DecisionTreeRegressor(),
+        base_estimator=DecisionTreeRegressor(),
         max_samples=1.0,
         bootstrap=True,
         random_state=rng,
@@ -270,9 +270,9 @@ def test_bootstrap_samples():
     # check that each sampling correspond to a complete bootstrap resample.
     # the size of each bootstrap should be the same as the input data but
     # the data should be different (checked using the hash of the data).
-    ensemble = BaggingRegressor(estimator=DummySizeEstimator(), bootstrap=True).fit(
-        X_train, y_train
-    )
+    ensemble = BaggingRegressor(
+        base_estimator=DummySizeEstimator(), bootstrap=True
+    ).fit(X_train, y_train)
     training_hash = []
     for estimator in ensemble.estimators_:
         assert estimator.training_size_ == X_train.shape[0]
@@ -288,7 +288,7 @@ def test_bootstrap_features():
     )
 
     ensemble = BaggingRegressor(
-        estimator=DecisionTreeRegressor(),
+        base_estimator=DecisionTreeRegressor(),
         max_features=1.0,
         bootstrap_features=False,
         random_state=rng,
@@ -298,7 +298,7 @@ def test_bootstrap_features():
         assert diabetes.data.shape[1] == np.unique(features).shape[0]
 
     ensemble = BaggingRegressor(
-        estimator=DecisionTreeRegressor(),
+        base_estimator=DecisionTreeRegressor(),
         max_features=1.0,
         bootstrap_features=True,
         random_state=rng,
@@ -318,7 +318,7 @@ def test_probability():
     with np.errstate(divide="ignore", invalid="ignore"):
         # Normal case
         ensemble = BaggingClassifier(
-            estimator=DecisionTreeClassifier(), random_state=rng
+            base_estimator=DecisionTreeClassifier(), random_state=rng
         ).fit(X_train, y_train)
 
         assert_array_almost_equal(
@@ -331,7 +331,7 @@ def test_probability():
 
         # Degenerate case, where some classes are missing
         ensemble = BaggingClassifier(
-            estimator=LogisticRegression(), random_state=rng, max_samples=5
+            base_estimator=LogisticRegression(), random_state=rng, max_samples=5
         ).fit(X_train, y_train)
 
         assert_array_almost_equal(
@@ -353,7 +353,7 @@ def test_oob_score_classification():
 
     for estimator in [DecisionTreeClassifier(), SVC()]:
         clf = BaggingClassifier(
-            estimator=estimator,
+            base_estimator=estimator,
             n_estimators=100,
             bootstrap=True,
             oob_score=True,
@@ -371,7 +371,7 @@ def test_oob_score_classification():
         )
         with pytest.warns(UserWarning, match=warn_msg):
             clf = BaggingClassifier(
-                estimator=estimator,
+                base_estimator=estimator,
                 n_estimators=1,
                 bootstrap=True,
                 oob_score=True,
@@ -389,7 +389,7 @@ def test_oob_score_regression():
     )
 
     clf = BaggingRegressor(
-        estimator=DecisionTreeRegressor(),
+        base_estimator=DecisionTreeRegressor(),
         n_estimators=50,
         bootstrap=True,
         oob_score=True,
@@ -407,7 +407,7 @@ def test_oob_score_regression():
     )
     with pytest.warns(UserWarning, match=warn_msg):
         regr = BaggingRegressor(
-            estimator=DecisionTreeRegressor(),
+            base_estimator=DecisionTreeRegressor(),
             n_estimators=1,
             bootstrap=True,
             oob_score=True,
@@ -424,7 +424,7 @@ def test_single_estimator():
     )
 
     clf1 = BaggingRegressor(
-        estimator=KNeighborsRegressor(),
+        base_estimator=KNeighborsRegressor(),
         n_estimators=1,
         bootstrap=False,
         bootstrap_features=False,
@@ -782,7 +782,9 @@ def test_estimators_samples_deterministic():
     base_pipeline = make_pipeline(
         SparseRandomProjection(n_components=2), LogisticRegression()
     )
-    clf = BaggingClassifier(estimator=base_pipeline, max_samples=0.5, random_state=0)
+    clf = BaggingClassifier(
+        base_estimator=base_pipeline, max_samples=0.5, random_state=0
+    )
     clf.fit(X, y)
     pipeline_estimator_coef = clf.estimators_[0].steps[-1][1].coef_.copy()
 
@@ -942,7 +944,7 @@ def test_bagging_get_estimators_indices():
         def fit(self, X, y):
             self._sample_indices = y
 
-    clf = BaggingRegressor(estimator=MyEstimator(), n_estimators=1, random_state=0)
+    clf = BaggingRegressor(base_estimator=MyEstimator(), n_estimators=1, random_state=0)
     clf.fit(X, y)
 
     assert_array_equal(clf.estimators_[0]._sample_indices, clf.estimators_samples_[0])


### PR DESCRIPTION
#### Reference Issues/PRs

See also #9104. This PR enhances some of the proposed changes in the referenced issue.


#### What does this implement/fix? Explain your changes.

For _bagging.py:

- BaseBagging:
This enhancement renames the `base_estimator` parameter to `estimator` in the BaseBagging class for improved readability and consistency. An if function was added to check if the `base_estimator` was initialized by the user, a warning will be outputted in that case. Since the class BaseEnsemble, from which BaseBagging inherits, still uses the `base_estimator` parameter, an override for `_validate_estimator` and `set_params` was done just for assigning the estimator object to `self.base_estimator`.

- BaggingClassifier and BagginRegressor:
This enhancement renames the `base_estimator` parameter to `estimator` in both classes for improved readability and consistency.


For test_bagging.py:
Tests in the test_bagging.py. file were modified for using the updated parameter. Two new test cases was added to check if the warning has been raised when setting the base_estimator parameter in both BaggingClassifier and BaggingRegressor.

