### PR TITLE
ENH Check for nonfinite dual gap estimation

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -451,6 +451,11 @@ Changelog
   parameters in `fit` instead of `__init__`.
   :pr:`21436` by :user:`Haidar Almubarak <Haidar13 >`.
 
+- |Enhancement| :func:`svm.SVR`, :func:`svm.SVC` and other support vector
+  based classes which use dual gap estimation shows error
+  messages when estimation produce non-finite parameter weights. :pr:`22149`
+  by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.
+
 :mod:`sklearn.utils`
 ....................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -451,9 +451,10 @@ Changelog
   parameters in `fit` instead of `__init__`.
   :pr:`21436` by :user:`Haidar Almubarak <Haidar13 >`.
 
-- |Enhancement| :func:`svm.SVR`, :func:`svm.SVC` and other support vector
-  based classes which use dual gap estimation shows error
-  messages when estimation produce non-finite parameter weights. :pr:`22149`
+- |Enhancement| :func:`svm.SVR`, :func:`svm.SVC`, :func:`svm.NuSVR`,
+  :func:`svm.OneClassSVM`, :func:`svm.NuSVC`
+  show error messages for dual-gap estimation when estimation 
+  produce non-finite parameter weights. :pr:`22149`
   by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.
 
 :mod:`sklearn.utils`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -452,10 +452,10 @@ Changelog
   :pr:`21436` by :user:`Haidar Almubarak <Haidar13 >`.
 
 - |Enhancement| :func:`svm.SVR`, :func:`svm.SVC`, :func:`svm.NuSVR`,
-  :func:`svm.OneClassSVM`, :func:`svm.NuSVC`
-  show error messages for dual-gap estimation when estimation 
-  produce non-finite parameter weights. :pr:`22149`
-  by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.
+  :func:`svm.OneClassSVM`, :func:`svm.NuSVC` now raise an error
+  when the dual-gap estimation produce non-finite parameter weights.
+  :pr:`22149` by :user:`Christian Ritter <chritter>` and
+  :user:`Norbert Preining <norbusan>`.
 
 :mod:`sklearn.utils`
 ....................

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -275,17 +275,14 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             self.dual_coef_ = -self.dual_coef_
 
         # check for finiteness of coefficientss
-        coef_finiteness = (
-            np.isfinite(self._dual_coef_.data).all()
-            if self._sparse
-            else np.isfinite(self._dual_coef_).all()
-        )
-        intercept_finiteness = np.isfinite(self._intercept_).all()
-        if not (coef_finiteness and intercept_finiteness):
+        dual_coef = self._dual_coef_.data if self._sparse else self._dual_coef_
+        if not all(np.isfinite(w).all() for w in [dual_coef, self._intercept_]):
             # maybe check which coeff/feature is non-finite?
-            raise ValueError("The dual coefficients or intercepts are not finite. "
-                             "The input data may contain large values and need to be"
-                             "preprocessed.")
+            raise ValueError(
+                "The dual coefficients or intercepts are not finite. "
+                "The input data may contain large values and need to be"
+                "preprocessed."
+            )
 
         # Since, in the case of SVC and NuSVC, the number of models optimized by
         # libSVM could be greater than one (depending on the input), `n_iter_`

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -283,7 +283,9 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         intercept_finiteness = np.isfinite(self._intercept_).all()
         if not (coef_finiteness and intercept_finiteness):
             # maybe check which coeff/feature is non-finite?
-            raise ValueError("Iterative parameter estimation led to non-finite values.")
+            raise ValueError("The dual coefficients or intercepts are not finite. "
+                             "The input data may contain large values and need to be"
+                             "preprocessed.")
 
         # Since, in the case of SVC and NuSVC, the number of models optimized by
         # libSVM could be greater than one (depending on the input), `n_iter_`

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -274,6 +274,17 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             self.intercept_ *= -1
             self.dual_coef_ = -self.dual_coef_
 
+        # check for finiteness of coefficientss
+        coef_finiteness = (
+            np.isfinite(self._dual_coef_.data).all()
+            if self._sparse
+            else np.isfinite(self._dual_coef_).all()
+        )
+        intercept_finiteness = np.isfinite(self._intercept_).all()
+        if not (coef_finiteness and intercept_finiteness):
+            # maybe check which coeff/feature is non-finite?
+            raise ValueError("Iterative parameter estimation led to non-finite values.")
+
         # Since, in the case of SVC and NuSVC, the number of models optimized by
         # libSVM could be greater than one (depending on the input), `n_iter_`
         # stores an ndarray.

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -274,10 +274,10 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             self.intercept_ *= -1
             self.dual_coef_ = -self.dual_coef_
 
-        # check for finiteness of coefficientss
         dual_coef = self._dual_coef_.data if self._sparse else self._dual_coef_
-        if not all(np.isfinite(w).all() for w in [dual_coef, self._intercept_]):
-            # maybe check which coeff/feature is non-finite?
+        intercept_finiteness = np.isfinite(self._intercept_).all()
+        dual_coef_finiteness = np.isfinite(dual_coef).all()
+        if not (intercept_finiteness and dual_coef_finiteness):
             raise ValueError(
                 "The dual coefficients or intercepts are not finite. "
                 "The input data may contain large values and need to be"

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -731,6 +731,29 @@ def test_bad_input():
         clf.predict(Xt)
 
 
+def test_svc_nonfinite_params():
+    # Check SVC throws ValueError when dealing with non-finite parameter values
+    X = np.array(
+        [
+            (1.30830774e307, 6.02217328e307),
+            (1.54166067e308, 1.75812744e308),
+            (5.57938866e307, 4.13840113e307),
+            (1.36302835e308, 1.07968131e308),
+            (1.58772669e308, 1.19380571e307),
+            (2.20362426e307, 1.58814671e308),
+            (1.06216028e308, 1.14258583e308),
+            (7.18031911e307, 1.69661213e308),
+            (7.91182553e307, 5.12892426e307),
+            (5.58470885e307, 9.13566765e306),
+        ]
+    )
+    y = np.array([0, 0, 1, 0, 0, 0, 1, 0, 1, 0])
+    clf = svm.SVC()
+    msg = "Iterative parameter estimation led to non-finite values"
+    with pytest.raises(ValueError, match=msg):
+        clf.fit(X, y)
+
+
 @pytest.mark.parametrize(
     "Estimator, data",
     [

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -733,23 +733,14 @@ def test_bad_input():
 
 def test_svc_nonfinite_params():
     # Check SVC throws ValueError when dealing with non-finite parameter values
-    X = np.array(
-        [
-            (1.30830774e307, 6.02217328e307),
-            (1.54166067e308, 1.75812744e308),
-            (5.57938866e307, 4.13840113e307),
-            (1.36302835e308, 1.07968131e308),
-            (1.58772669e308, 1.19380571e307),
-            (2.20362426e307, 1.58814671e308),
-            (1.06216028e308, 1.14258583e308),
-            (7.18031911e307, 1.69661213e308),
-            (7.91182553e307, 5.12892426e307),
-            (5.58470885e307, 9.13566765e306),
-        ]
-    )
-    y = np.array([0, 0, 1, 0, 0, 0, 1, 0, 1, 0])
+    rng = np.random.RandomState(0)
+    n_samples = 10
+    fmax = np.finfo(np.float64).max
+    X = fmax * rng.uniform(size=(n_samples, 2))
+    y = rng.randint(0, 2, size=n_samples)
+
     clf = svm.SVC()
-    msg = "Iterative parameter estimation led to non-finite values"
+    msg = "The dual coefficients or intercepts are not finite"
     with pytest.raises(ValueError, match=msg):
         clf.fit(X, y)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #17925.

#### What does this implement/fix? Explain your changes.

This implements check for non-finite values of estimator parameters: as produced from libsvm dual gap estimation for SVM models

#### Any other comments?

Work done with @norbusan.

Originally part of larger PR #22092
