### PR TITLE
ENH Check for nonfinite in mlp models

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -468,7 +468,7 @@ Changelog
 - |Enhancement| :func:`neural_network.MLPClassifier` and 
   :func:`neural_network.MLPRegressor` shows error
   messages when optimizers produce non-finite parameter weights. :pr:`22150`
-  by :user:`Christian Ritter <chritter>`.
+  by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.
 
 
 Code and Documentation Contributors

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -463,7 +463,7 @@ Changelog
   clickable. :pr:`21298` by `Thomas Fan`_.
 
 :mod:`sklearn.neural_network`
-..........................
+.............................
 
 - |Enhancement| :func:`neural_network.MLPClassifier` and 
   :func:`neural_network.MLPRegressor` shows error

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -462,6 +462,15 @@ Changelog
   left corner of the HTML representation to show how the elements are
   clickable. :pr:`21298` by `Thomas Fan`_.
 
+:mod:`sklearn.neural_network`
+..........................
+
+- |Enhancement| :func:`neural_network.MLPClassifier` and 
+  :func:`neural_network.MLPRegressor` shows error
+  messages when optimizers produce non-finite parameter weights. :pr:`22150`
+  by :user:`Christian Ritter <chritter>`.
+
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -470,7 +470,6 @@ Changelog
   left corner of the HTML representation to show how the elements are
   clickable. :pr:`21298` by `Thomas Fan`_.
 
-
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -397,7 +397,7 @@ Changelog
 .............................
 
 - |Enhancement| :func:`neural_network.MLPClassifier` and 
-  :func:`neural_network.MLPRegressor` shows error
+  :func:`neural_network.MLPRegressor` show error
   messages when optimizers produce non-finite parameter weights. :pr:`22150`
   by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -393,6 +393,14 @@ Changelog
   instead of `__init__`. :pr:`21430` by :user:`Desislava Vasileva <DessyVV>` and
   :user:`Lucy Jimenez <LucyJimenez>`.
 
+:mod:`sklearn.neural_network`
+.............................
+
+- |Enhancement| :func:`neural_network.MLPClassifier` and 
+  :func:`neural_network.MLPRegressor` shows error
+  messages when optimizers produce non-finite parameter weights. :pr:`22150`
+  by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.
+
 :mod:`sklearn.pipeline`
 .......................
 
@@ -461,14 +469,6 @@ Changelog
 - |Enhancement| :func:`utils.estimator_html_repr` displays an arrow on the top
   left corner of the HTML representation to show how the elements are
   clickable. :pr:`21298` by `Thomas Fan`_.
-
-:mod:`sklearn.neural_network`
-.............................
-
-- |Enhancement| :func:`neural_network.MLPClassifier` and 
-  :func:`neural_network.MLPRegressor` shows error
-  messages when optimizers produce non-finite parameter weights. :pr:`22150`
-  by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.
 
 
 Code and Documentation Contributors

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -440,6 +440,20 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
             self._fit_lbfgs(
                 X, y, activations, deltas, coef_grads, intercept_grads, layer_units
             )
+
+        # validate parameter weights
+        check_weights = (
+            lambda coefs, intercept: np.isfinite(coefs).all()
+            and np.isfinite(intercept).all()
+        )
+        if not np.all(
+            [
+                check_weights(coef, inter)
+                for coef, inter in zip(self.coefs_, self.intercepts_)
+            ]
+        ):
+            raise ValueError("Solver produced non-finite parameter weights.")
+
         return self
 
     def _validate_hyperparameters(self):

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from abc import ABCMeta, abstractmethod
 import warnings
+from itertools import chain
 
 import scipy.optimize
 
@@ -442,16 +443,8 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
             )
 
         # validate parameter weights
-        check_weights = (
-            lambda coefs, intercept: np.isfinite(coefs).all()
-            and np.isfinite(intercept).all()
-        )
-        if not np.all(
-            [
-                check_weights(coef, inter)
-                for coef, inter in zip(self.coefs_, self.intercepts_)
-            ]
-        ):
+        weights = chain(self.coefs_, self.intercepts_)
+        if not all(np.isfinite(w).all() for w in weights):
             raise ValueError("Solver produced non-finite parameter weights.")
 
         return self

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -445,7 +445,10 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         # validate parameter weights
         weights = chain(self.coefs_, self.intercepts_)
         if not all(np.isfinite(w).all() for w in weights):
-            raise ValueError("Solver produced non-finite parameter weights.")
+            raise ValueError(
+                "Solver produced non-finite parameter weights. The input data may"
+                " contain large values and need to be preprocessed."
+            )
 
         return self
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -507,7 +507,7 @@ def test_partial_fit_errors():
 
 
 def test_nonfinite_params():
-    # Check MLPRegressor throws ValueError when dealing with non-finite
+    # Check that MLPRegressor throws ValueError when dealing with non-finite
     # parameter values
     rng = np.random.RandomState(0)
     n_samples = 10

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -509,21 +509,12 @@ def test_partial_fit_errors():
 def test_nonfinite_params():
     # Check MLPRegressor throws ValueError when dealing with non-finite
     # parameter values
-    X = np.array(
-        [
-            (1.30830774e307, 6.02217328e307),
-            (1.54166067e308, 1.75812744e308),
-            (5.57938866e307, 4.13840113e307),
-            (1.36302835e308, 1.07968131e308),
-            (1.58772669e308, 1.19380571e307),
-            (2.20362426e307, 1.58814671e308),
-            (1.06216028e308, 1.14258583e308),
-            (7.18031911e307, 1.69661213e308),
-            (7.91182553e307, 5.12892426e307),
-            (5.58470885e307, 9.13566765e306),
-        ]
-    )
-    y = np.array([0, 0, 1, 0, 0, 0, 1, 0, 1, 0])
+    rng = np.random.RandomState(0)    
+    n_samples = 10
+    fmax = np.finfo(np.float64).max
+    X = fmax * rng.uniform(size=(n_samples, 2))
+    y = rng.standard_normal(size= n_samples)
+    
     clf = MLPRegressor()
     msg = "Solver produced non-finite parameter weights"
     with pytest.raises(ValueError, match=msg):

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -516,7 +516,10 @@ def test_nonfinite_params():
     y = rng.standard_normal(size=n_samples)
 
     clf = MLPRegressor()
-    msg = "Solver produced non-finite parameter weights"
+    msg = (
+        "Solver produced non-finite parameter weights. The input data may contain large"
+        " values and need to be preprocessed."
+    )
     with pytest.raises(ValueError, match=msg):
         clf.fit(X, y)
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -509,12 +509,12 @@ def test_partial_fit_errors():
 def test_nonfinite_params():
     # Check MLPRegressor throws ValueError when dealing with non-finite
     # parameter values
-    rng = np.random.RandomState(0)    
+    rng = np.random.RandomState(0)
     n_samples = 10
     fmax = np.finfo(np.float64).max
     X = fmax * rng.uniform(size=(n_samples, 2))
-    y = rng.standard_normal(size= n_samples)
-    
+    y = rng.standard_normal(size=n_samples)
+
     clf = MLPRegressor()
     msg = "Solver produced non-finite parameter weights"
     with pytest.raises(ValueError, match=msg):

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -506,6 +506,30 @@ def test_partial_fit_errors():
     assert not hasattr(MLPClassifier(solver="lbfgs"), "partial_fit")
 
 
+def test_nonfinite_params():
+    # Check MLPRegressor throws ValueError when dealing with non-finite
+    # parameter values
+    X = np.array(
+        [
+            (1.30830774e307, 6.02217328e307),
+            (1.54166067e308, 1.75812744e308),
+            (5.57938866e307, 4.13840113e307),
+            (1.36302835e308, 1.07968131e308),
+            (1.58772669e308, 1.19380571e307),
+            (2.20362426e307, 1.58814671e308),
+            (1.06216028e308, 1.14258583e308),
+            (7.18031911e307, 1.69661213e308),
+            (7.91182553e307, 5.12892426e307),
+            (5.58470885e307, 9.13566765e306),
+        ]
+    )
+    y = np.array([0, 0, 1, 0, 0, 0, 1, 0, 1, 0])
+    clf = MLPRegressor()
+    msg = "Solver produced non-finite parameter weights"
+    with pytest.raises(ValueError, match=msg):
+        clf.fit(X, y)
+
+
 @pytest.mark.parametrize(
     "args",
     [


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #17925.

#### What does this implement/fix? Explain your changes.

This implements check for non-finite values of estimator parameters: as produced from optimizers in MLP models.

#### Any other comments?

Work done with @norbusan.

Originally part of larger PR #22092
