### PR TITLE
#16710 allow only fit transform

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -146,6 +146,7 @@ class Pipeline(_BaseComposition):
         self.steps = steps
         self.memory = memory
         self.verbose = verbose
+        self._validate_steps()
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.
@@ -201,15 +202,15 @@ class Pipeline(_BaseComposition):
         for t in transformers:
             if t is None or t == "passthrough":
                 continue
-            if not (hasattr(t, "fit") or hasattr(t, "fit_transform")) or not hasattr(
-                t, "transform"
-            ):
+            if (not hasattr(t, "fit_transform") and
+                    (not hasattr(t, "fit") and hasattr(t, "transform"))):
+
                 raise TypeError(
                     "All intermediate steps should be "
-                    "transformers and implement fit and transform "
-                    "or be the string 'passthrough' "
-                    "'%s' (type %s) doesn't" % (t, type(t))
-                )
+                    "transformers and implement fit and "
+                    "transform, fit_transform or be the string "
+                    "'passthrough'. '%s' (type %s) doesn't"
+                    % (t, type(t)))
 
         # We allow last estimator to be None as an identity transformation
         if (
@@ -218,8 +219,8 @@ class Pipeline(_BaseComposition):
             and not hasattr(estimator, "fit")
         ):
             raise TypeError(
-                "Last step of Pipeline should implement fit "
-                "or be the string 'passthrough'. "
+                "Last step of Pipeline should implement fit, "
+                "fit_transform or be the string 'passthrough'. "
                 "'%s' (type %s) doesn't" % (estimator, type(estimator))
             )
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+from sklearn.pipeline import make_pipeline
+make_pipeline(TSNE(), PCA())
+

--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-from sklearn.decomposition import PCA
-from sklearn.manifold import TSNE
-from sklearn.pipeline import make_pipeline
-make_pipeline(TSNE(), PCA())
-


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #16710. See also #16714.

#### What does this implement/fix? Explain your changes.

Calling a pipeline for a non-parametric function like TSNE() returns an error because the transform() function is missing.  However, for non-parametric functions, there is no transform() method because there is no projection or mapping, yet we can use dimensionality reduction.

So, we must be able to create a pipeline even if the transform() method does not exist. This PR allows it

#### Any other comments?

However, I have the impression that the constructor of the current library no longer calls "validate_step()" as I added it in the "init". What is the problem? It was this function that was creating the error and I have modified this function.




