### PR TITLE
Allow the creation of a pipeline for non-parametric functions like TSNE

### DIFF
--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -417,7 +417,7 @@ version, the algorithms will try to preserve the order of the distances, and
 hence seek for a monotonic relationship between the distances in the embedded
 space and the similarities/dissimilarities.
 
-.. figure:: ../auto_examples/manifold/images/sphx_glr_plot_lle_digits_010.png
+.. figure:: ../auto_examples/manifold/images/sphx_glr_plot_lle_digits_002.png
    :target: ../auto_examples/manifold/plot_lle_digits.html
    :align: center
    :scale: 50

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -146,6 +146,7 @@ class Pipeline(_BaseComposition):
         self.steps = steps
         self.memory = memory
         self.verbose = verbose
+        self._validate_steps()
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.
@@ -201,14 +202,13 @@ class Pipeline(_BaseComposition):
         for t in transformers:
             if t is None or t == "passthrough":
                 continue
-            if not (hasattr(t, "fit") or hasattr(t, "fit_transform")) or not hasattr(
-                t, "transform"
-            ):
+            if (not hasattr(t, "fit_transform") and
+                    (not hasattr(t, "fit") and hasattr(t, "transform"))):
                 raise TypeError(
                     "All intermediate steps should be "
-                    "transformers and implement fit and transform "
-                    "or be the string 'passthrough' "
-                    "'%s' (type %s) doesn't" % (t, type(t))
+                    "transform, fit_transform or be the string "
+                    "'passthrough'. '%s' (type %s) doesn't"
+                    % (t, type(t))
                 )
 
         # We allow last estimator to be None as an identity transformation
@@ -218,8 +218,8 @@ class Pipeline(_BaseComposition):
             and not hasattr(estimator, "fit")
         ):
             raise TypeError(
-                "Last step of Pipeline should implement fit "
-                "or be the string 'passthrough'. "
+                "Last step of Pipeline should implement fit, "
+                "fit_transform or be the string 'passthrough'. "
                 "'%s' (type %s) doesn't" % (estimator, type(estimator))
             )
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -146,7 +146,6 @@ class Pipeline(_BaseComposition):
         self.steps = steps
         self.memory = memory
         self.verbose = verbose
-        self._validate_steps()
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.
@@ -202,14 +201,12 @@ class Pipeline(_BaseComposition):
         for t in transformers:
             if t is None or t == "passthrough":
                 continue
-            if (not hasattr(t, "fit_transform") and
-                    (not hasattr(t, "fit") and hasattr(t, "transform"))):
-                raise TypeError(
-                    "All intermediate steps should be "
-                    "transform, fit_transform or be the string "
-                    "'passthrough'. '%s' (type %s) doesn't"
-                    % (t, type(t))
-                )
+            if (not (hasattr(t, "fit") or hasattr(t, "fit_transform")) or not
+                    hasattr(t, "transform")):
+                raise TypeError("All intermediate steps should be "
+                                "transformers and implement fit and transform "
+                                "or be the string 'passthrough' "
+                                "'%s' (type %s) doesn't" % (t, type(t)))
 
         # We allow last estimator to be None as an identity transformation
         if (
@@ -218,10 +215,9 @@ class Pipeline(_BaseComposition):
             and not hasattr(estimator, "fit")
         ):
             raise TypeError(
-                "Last step of Pipeline should implement fit, "
-                "fit_transform or be the string 'passthrough'. "
-                "'%s' (type %s) doesn't" % (estimator, type(estimator))
-            )
+                "Last step of Pipeline should implement fit "
+                "or be the string 'passthrough'. "
+                "'%s' (type %s) doesn't" % (estimator, type(estimator)))
 
     def _iter(self, with_final=True, filter_passthrough=True):
         """


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #16710. See also #16714.

#### What does this implement/fix? Explain your changes.

Calling a pipeline for a non-parametric function like TSNE() returns an error because the transform() function is missing.  However, for non-parametric functions, there is no transform() method because there is no projection or mapping, yet we can use dimensionality reduction.

So, we must be able to create a pipeline even if the transform() method does not exist. This PR allows it

#### Any other comments?

However, I have the impression that the constructor of the current library no longer calls "validate_step()" as I added it in the "init". What is the problem? It was this function that was creating the error and I have modified this function. I am waiting for your feedback.
