### PR TITLE
#22061 [fix] image documentation

### DIFF
--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -417,7 +417,7 @@ version, the algorithms will try to preserve the order of the distances, and
 hence seek for a monotonic relationship between the distances in the embedded
 space and the similarities/dissimilarities.
 
-.. figure:: ../auto_examples/manifold/images/sphx_glr_plot_lle_digits_010.png
+.. figure:: ../auto_examples/manifold/images/sphx_glr_plot_lle_digits_002.png
    :target: ../auto_examples/manifold/plot_lle_digits.html
    :align: center
    :scale: 50

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -146,6 +146,7 @@ class Pipeline(_BaseComposition):
         self.steps = steps
         self.memory = memory
         self.verbose = verbose
+        self._validate_steps()
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.
@@ -201,14 +202,13 @@ class Pipeline(_BaseComposition):
         for t in transformers:
             if t is None or t == "passthrough":
                 continue
-            if not (hasattr(t, "fit") or hasattr(t, "fit_transform")) or not hasattr(
-                t, "transform"
-            ):
+            if (not hasattr(t, "fit_transform") and
+                    (not hasattr(t, "fit") and hasattr(t, "transform"))):
                 raise TypeError(
                     "All intermediate steps should be "
-                    "transformers and implement fit and transform "
-                    "or be the string 'passthrough' "
-                    "'%s' (type %s) doesn't" % (t, type(t))
+                    "transform, fit_transform or be the string "
+                    "'passthrough'. '%s' (type %s) doesn't"
+                    % (t, type(t))
                 )
 
         # We allow last estimator to be None as an identity transformation
@@ -218,8 +218,8 @@ class Pipeline(_BaseComposition):
             and not hasattr(estimator, "fit")
         ):
             raise TypeError(
-                "Last step of Pipeline should implement fit "
-                "or be the string 'passthrough'. "
+                "Last step of Pipeline should implement fit, "
+                "fit_transform or be the string 'passthrough'. "
                 "'%s' (type %s) doesn't" % (estimator, type(estimator))
             )
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -204,12 +204,11 @@ class Pipeline(_BaseComposition):
                 continue
             if (not hasattr(t, "fit_transform") and
                     (not hasattr(t, "fit") and hasattr(t, "transform"))):
-                raise TypeError(
-                    "All intermediate steps should be "
-                    "transform, fit_transform or be the string "
-                    "'passthrough'. '%s' (type %s) doesn't"
-                    % (t, type(t))
-                )
+                raise TypeError("All intermediate steps should be "
+                                "transformers and implement fit and "
+                                "transform, fit_transform or be the string "
+                                "'passthrough'. '%s' (type %s) doesn't"
+                                % (t, type(t)))
 
         # We allow last estimator to be None as an identity transformation
         if (
@@ -220,8 +219,7 @@ class Pipeline(_BaseComposition):
             raise TypeError(
                 "Last step of Pipeline should implement fit, "
                 "fit_transform or be the string 'passthrough'. "
-                "'%s' (type %s) doesn't" % (estimator, type(estimator))
-            )
+                "'%s' (type %s) doesn't" % (estimator, type(estimator)))
 
     def _iter(self, with_final=True, filter_passthrough=True):
         """


### PR DESCRIPTION
Fixes #22061

#### What does this implement/fix? Explain your changes.

The image in the MDS document is not present
https://scikit-learn.org/stable/modules/manifold.html#multi-dimensional-scaling-mds 
 
I changed the path of the image to something similar to the old version: https://scikit-learn.org/0.24/modules/manifold.html#multi-dimensional-scaling-mds 

#### Any other comments?

Other images are not present in this same documentation page: only sphx_glr_plot_lle_digits_001.png and sphx_glr_plot_lle_digits_002.png exist in the image folder (doc/auto_example/manifold/images) but all others do not (3,4,5,6,7,8,9 and 13). This could be the occasion of another issue. I don't know what images to put instead. For my part, I changed the image 010 to 002.

Mine was generated from https://scikit-learn.org/dev/auto_examples/manifold/plot_lle_digits.html#sphx-glr-auto-examples-manifold-plot-lle-digits-py
