### PR TITLE
CI Fix misleading info in pylatest_pip_openblas_pandas build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,12 +201,11 @@ jobs:
         MATPLOTLIB_VERSION: 'min'
         THREADPOOLCTL_VERSION: '2.2.0'
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
-      # Linux environment to test the latest available dependencies and MKL.
+      # Linux environment to test the latest available dependencies.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:
         DISTRIB: 'conda-pip-latest'
         PYTHON_VERSION: '3.9'
-        PANDAS_VERSION: 'none'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'


### PR DESCRIPTION
- it is not using MKL as the name implies (pylatest_pip_openblas_pandas)
- PANDAS_VERSION is only used when dependencies are installed with conda or mamba, see https://github.com/scikit-learn/scikit-learn/blob/49588ff1e677d3d6fddf8798603a06f06fdb6e61/build_tools/azure/install.sh#L59