### PR TITLE
CI: improve installed libraries listing

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -33,7 +33,7 @@ setup_ccache() {
     ccache -M 256M
 }
 
-# imports get_dep
+# defines the get_dep and show_installed_libraries functions
 source build_tools/shared.sh
 
 if [[ "$DISTRIB" == "conda" || "$DISTRIB" == *"mamba"* ]]; then
@@ -164,7 +164,8 @@ except ImportError:
 # workers with 2 cores when building the compiled extensions of scikit-learn.
 export SKLEARN_BUILD_PARALLEL=3
 
-python -m pip list
+show_installed_libraries
+
 if [[ "$DISTRIB" == "conda-pip-latest" ]]; then
     # Check that pip can automatically build scikit-learn with the build
     # dependencies specified in pyproject.toml using an isolated build

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# defines the show_installed_libraries function
+source build_tools/shared.sh
+
 if [[ "$DISTRIB" =~ ^conda.* ]]; then
     source activate $VIRTUALENV
 elif [[ "$DISTRIB" == "ubuntu" ]] || [[ "$DISTRIB" == "debian-32" ]]; then
@@ -18,13 +21,7 @@ cd $TEST_DIR
 
 python -c "import sklearn; sklearn.show_versions()"
 
-if ! command -v conda &> /dev/null
-then
-    pip list
-else
-    # conda list provides more info than pip list (when available)
-    conda list
-fi
+show_installed_libraries
 
 TEST_CMD="python -m pytest --showlocals --durations=20 --junitxml=$JUNITXML"
 

--- a/build_tools/shared.sh
+++ b/build_tools/shared.sh
@@ -19,7 +19,7 @@ show_installed_libraries(){
     # use conda list when inside a conda environment. conda list shows more
     # info than pip list, e.g. whether OpenBLAS or MKL is installed as well as
     # the version of OpenBLAS or MKL
-    if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
+    if [[ -n "$CONDA_PREFIX" ]]; then
         conda list
     else
         python -m pip list

--- a/build_tools/shared.sh
+++ b/build_tools/shared.sh
@@ -14,3 +14,14 @@ get_dep() {
         echo "$package==$(python sklearn/_min_dependencies.py $package)"
     fi
 }
+
+show_installed_libraries(){
+    # use conda list when inside a conda environment. conda list shows more
+    # info than pip list, e.g. whether OpenBLAS or MKL is installed as well as
+    # the version of OpenBLAS or MKL
+    if [[ -n "$CONDA_DEFAULT_ENV" ]]; then
+        conda list
+    else
+        python -m pip list
+    fi
+}


### PR DESCRIPTION
- uses conda list instead than pip list during Azure install since it shows more info (for example, OpenBLAS vs MKL + the OpenBLAS or MKL version)
- since a similar thing was done already in azure test, create a bash function in build_tools/shared.sh
- checking CONDA_DEFAULT_ENV seems less brittle than checking if the conda command exists.

We need to double-check the Azure logs to make sure this actually uses conda list when possible