### PR TITLE
ENH Allow n_components = n_features in TruncatedSVD

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -177,6 +177,10 @@ Changelog
   preserve dtype for `numpy.float32`.
   :pr:`22111` by :user:`Takeshi Oura <takoika>`.
 
+- |Enhancement| :class:`decomposition.TruncatedSVD` now allows n_components == n_features, if
+  `algorithm='randomized'`.
+  :pr:`22181` by :user:`Zach Deane-Mayer <zachmayer>`.
+
 - |API| Adds :term:`get_feature_names_out` to all transformers in the
   :mod:`~sklearn.decomposition` module:
   :class:`~sklearn.decomposition.DictionaryLearning`,

--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -203,9 +203,9 @@ class TruncatedSVD(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         elif self.algorithm == "randomized":
             k = self.n_components
             n_features = X.shape[1]
-            if k >= n_features:
+            if k > n_features:
                 raise ValueError(
-                    "n_components must be < n_features; got %d >= %d" % (k, n_features)
+                    "n_components must be <= n_features; got %d > %d" % (k, n_features)
                 )
             U, Sigma, VT = randomized_svd(
                 X, self.n_components, n_iter=self.n_iter, random_state=random_state

--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -6,7 +6,7 @@
 #         Michael Becker <mike@beckerfuffle.com>
 # License: 3-clause BSD.
 
-import numbers
+from numbers import Integral
 import numpy as np
 import scipy.sparse as sp
 from scipy.sparse.linalg import svds
@@ -207,7 +207,7 @@ class TruncatedSVD(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
             check_scalar(
                 k,
                 "n_components",
-                target_type=numbers.Integral,
+                target_type=Integral,
                 min_val=1,
                 max_val=n_features,
             )

--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -44,7 +44,8 @@ class TruncatedSVD(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
     ----------
     n_components : int, default=2
         Desired dimensionality of output data.
-        Must be strictly less than the number of features.
+        If algorithm='arpack', must be strictly less than the number of features.
+        If algorithm='randomized', must be less than or equal to the number of features.
         The default value is useful for visualisation. For LSA, a value of
         100 is recommended.
 

--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -6,6 +6,7 @@
 #         Michael Becker <mike@beckerfuffle.com>
 # License: 3-clause BSD.
 
+import numbers
 import numpy as np
 import scipy.sparse as sp
 from scipy.sparse.linalg import svds
@@ -15,8 +16,7 @@ from ..utils import check_array, check_random_state
 from ..utils._arpack import _init_arpack_v0
 from ..utils.extmath import randomized_svd, safe_sparse_dot, svd_flip
 from ..utils.sparsefuncs import mean_variance_axis
-from ..utils.validation import check_is_fitted
-
+from ..utils.validation import check_is_fitted, check_scalar
 
 __all__ = ["TruncatedSVD"]
 
@@ -204,10 +204,13 @@ class TruncatedSVD(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
         elif self.algorithm == "randomized":
             k = self.n_components
             n_features = X.shape[1]
-            if k > n_features:
-                raise ValueError(
-                    "n_components must be <= n_features; got %d > %d" % (k, n_features)
-                )
+            check_scalar(
+                k,
+                "n_components",
+                target_type=numbers.Integral,
+                min_val=1,
+                max_val=n_features,
+            )
             U, Sigma, VT = randomized_svd(
                 X, self.n_components, n_iter=self.n_iter, random_state=random_state
             )

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -52,8 +52,11 @@ def test_too_many_components(algorithm, X_sparse):
     n_features = X_sparse.shape[1]
     for n_components in (n_features, n_features + 1):
         tsvd = TruncatedSVD(n_components=n_components, algorithm=algorithm)
-        with pytest.raises(ValueError):
+        if n_components == n_features and algorithm == "randomized":
             tsvd.fit(X_sparse)
+        else:
+            with pytest.raises(ValueError):
+                tsvd.fit(X_sparse)
 
 
 @pytest.mark.parametrize("fmt", ("array", "csr", "csc", "coo", "lil"))

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -39,7 +39,7 @@ def test_solvers(X_sparse, solver, kind):
     assert_allclose(comp_a[9:], comp[9:], atol=1e-2)
 
 
-@pytest.mark.parametrize("n_components", (10, 25, 41))
+@pytest.mark.parametrize("n_components", (10, 25, 41, 55))
 def test_attributes(n_components, X_sparse):
     n_features = X_sparse.shape[1]
     tsvd = TruncatedSVD(n_components).fit(X_sparse)
@@ -47,16 +47,18 @@ def test_attributes(n_components, X_sparse):
     assert tsvd.components_.shape == (n_components, n_features)
 
 
-@pytest.mark.parametrize("algorithm", SVD_SOLVERS)
-def test_too_many_components(algorithm, X_sparse):
-    n_features = X_sparse.shape[1]
-    for n_components in (n_features, n_features + 1):
-        tsvd = TruncatedSVD(n_components=n_components, algorithm=algorithm)
-        if n_components == n_features and algorithm == "randomized":
-            tsvd.fit(X_sparse)
-        else:
-            with pytest.raises(ValueError):
-                tsvd.fit(X_sparse)
+@pytest.mark.parametrize(
+    "algorithm, n_components",
+    [
+        ("arpack", 55),
+        ("arpack", 56),
+        ("randomized", 56),
+    ],
+)
+def test_too_many_components(X_sparse, algorithm, n_components):
+    tsvd = TruncatedSVD(n_components=n_components, algorithm=algorithm)
+    with pytest.raises(ValueError):
+        tsvd.fit(X_sparse)
 
 
 @pytest.mark.parametrize("fmt", ("array", "csr", "csc", "coo", "lil"))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #22135

#### What does this implement/fix? Explain your changes.

Update `sklearn.decomposition.TruncatedSVD` to allow `n_components == min(n_samples, n_features)` if `algorithm == 'randomized'`.


`sklearn.decomposition.PCA` allows me to use `svd_solver = 'randomized'` with `n_components == min(n_samples, n_features)` (in fact, this is the *default*!). However, if I use `sklearn.decomposition.TruncatedSVD` with the same data and `algorithm == 'randomized'` I get an error asking me to reset `n_components` to `min(n_samples, n_features) - 1`.

This seems odd to me.  If the randomized algorithm works fine for PCA with `n_components == min(n_samples, n_features)`, why not allow this same case for TruncatedSVD? The PCA class even says `Notice that this class does not support sparse input. See TruncatedSVD for an alternative with sparse data`, which implies that you can use `TruncatedSVD` to achieve PCA on sparse  input, but if you want to use `n_components == min(n_samples, n_features)`, this isn't actually the case.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
