### PR TITLE
CI Removes build directory from cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,6 @@ jobs:
             - ~/.cache/ccache
             - ~/.cache/pip
             - ~/scikit_learn_data
-            # The source build folder.
-            - ~/project/build
   deploy:
     docker:
       - image: circleci/python:3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,18 +159,18 @@ jobs:
 
 workflows:
   version: 2
-  build-doc-and-deploy:
-    jobs:
-      - lint
-      - doc:
-          requires:
-            - lint
-      - doc-min-dependencies:
-          requires:
-            - lint
-      - deploy:
-          requires:
-            - doc
+  # build-doc-and-deploy:
+  #   jobs:
+  #     - lint
+  #     - doc:
+  #         requires:
+  #           - lint
+  #     - doc-min-dependencies:
+  #         requires:
+  #           - lint
+  #     - deploy:
+  #         requires:
+  #           - doc
   linux-arm64:
     jobs:
       - linux-arm64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,18 +159,18 @@ jobs:
 
 workflows:
   version: 2
-  # build-doc-and-deploy:
-  #   jobs:
-  #     - lint
-  #     - doc:
-  #         requires:
-  #           - lint
-  #     - doc-min-dependencies:
-  #         requires:
-  #           - lint
-  #     - deploy:
-  #         requires:
-  #           - doc
+  build-doc-and-deploy:
+    jobs:
+      - lint
+      - doc:
+          requires:
+            - lint
+      - doc-min-dependencies:
+          requires:
+            - lint
+      - deploy:
+          requires:
+            - doc
   linux-arm64:
     jobs:
       - linux-arm64

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -85,4 +85,4 @@ cd /tmp
 python -c "import sklearn; sklearn.show_versions()"
 python -m threadpoolctl --import sklearn
 # Test using as many workers as available cores
-pytest --pyargs -n $N_CORES sklearn
+# pytest --pyargs -n $N_CORES sklearn

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -72,7 +72,7 @@ export SKLEARN_BUILD_PARALLEL=$(($N_CORES + 1))
 # Disable the build isolation and build in the tree so that the same folder can be
 # cached between CI runs.
 # TODO: remove the '--use-feature' flag when made obsolete in pip 21.3.
-time pip install --verbose --no-build-isolation --use-feature=in-tree-build .
+pip install --verbose --no-build-isolation --use-feature=in-tree-build .
 
 # Report cache usage
 ccache -s --verbose
@@ -85,4 +85,4 @@ cd /tmp
 python -c "import sklearn; sklearn.show_versions()"
 python -m threadpoolctl --import sklearn
 # Test using as many workers as available cores
-# pytest --pyargs -n $N_CORES sklearn
+pytest --pyargs -n $N_CORES sklearn

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -72,7 +72,7 @@ export SKLEARN_BUILD_PARALLEL=$(($N_CORES + 1))
 # Disable the build isolation and build in the tree so that the same folder can be
 # cached between CI runs.
 # TODO: remove the '--use-feature' flag when made obsolete in pip 21.3.
-pip install --verbose --no-build-isolation --use-feature=in-tree-build .
+time pip install --verbose --no-build-isolation --use-feature=in-tree-build .
 
 # Report cache usage
 ccache -s --verbose


### PR DESCRIPTION
There were issues caching `~/project/build` in https://github.com/scikit-learn/scikit-learn/pull/22083

This PR removes the build directory. I ran a circleci run on my fork before and after the cache, where I commented out `pytest` part and left the `time pip install ...` to check the build times.

1. [Before cache](https://app.circleci.com/pipelines/github/thomasjpfan/scikit-learn/174/workflows/9db39392-9491-437c-9306-e135b721bea6/jobs/454) the build took 4m44.561s
2. [After loading the cache](https://app.circleci.com/pipelines/github/thomasjpfan/scikit-learn/175/workflows/3d74ece0-b37b-412a-949e-3fb78b3d6796/jobs/455) the build took 0m57.409s and we can see the cache hits:

```
+ ccache -s --verbose
Summary:
  Cache directory:    /home/circleci/.cache/ccache
  Primary config:     /home/circleci/.config/ccache/ccache.conf
  Secondary config:   /home/circleci/miniconda/envs/testenv/etc/ccache.conf
  Stats updated:      Tue Jan 11 19:09:21 2022
  Hits:                 72 /  154 (46.75 %)
    Direct:             72 /  156 (46.15 %)
    Preprocessed:        0 /   84 (0.00 %)
  Misses:               82
    Direct:             84
    Preprocessed:       84
  Uncacheable:         128
Primary storage:
  Hits:                144 /  312 (46.15 %)
  Misses:              168
  Cache size (GB):    0.04 / 0.00
  Files:               164
Uncacheable:
  Called for linking:  122
  Compilation failed:    2
  No input file:         4
```

CC @glemaitre @jjerphan @ogrisel 
