### PR TITLE
ENH Fix AttributeError of compound kernel of Gaussian processes

### DIFF
--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -484,6 +484,8 @@ Note that magic methods ``__add__``, ``__mul___`` and ``__pow__`` are
 overridden on the Kernel objects, so one can use e.g. ``RBF() + RBF()`` as
 a shortcut for ``Sum(RBF(), RBF())``.
 
+Note: CompoundKernel cannot be used in `GaussianProcessClassifier`
+
 Radial-basis function (RBF) kernel
 ----------------------------------
 The :class:`RBF` kernel is a stationary kernel. It is also known as the "squared

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -484,7 +484,6 @@ Note that magic methods ``__add__``, ``__mul___`` and ``__pow__`` are
 overridden on the Kernel objects, so one can use e.g. ``RBF() + RBF()`` as
 a shortcut for ``Sum(RBF(), RBF())``.
 
-Note: CompoundKernel cannot be used in `GaussianProcessClassifier`
 
 Radial-basis function (RBF) kernel
 ----------------------------------

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -484,7 +484,6 @@ Note that magic methods ``__add__``, ``__mul___`` and ``__pow__`` are
 overridden on the Kernel objects, so one can use e.g. ``RBF() + RBF()`` as
 a shortcut for ``Sum(RBF(), RBF())``.
 
-
 Radial-basis function (RBF) kernel
 ----------------------------------
 The :class:`RBF` kernel is a stationary kernel. It is also known as the "squared

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -277,7 +277,7 @@ Changelog
 ...............................
 
 - |Fix| Raise better error if `CompoundKernel is passed to 
-  `GaussianProcessClassifier` as kernel .
+  :class:`gaussian_process.GaussianProcessClassifier` as kernel .
   :pr:`22223` by :user:`MarcoM <marcozzxx810>`.
 
 :mod:`sklearn.impute`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -276,8 +276,8 @@ Changelog
 :mod:`sklearn.gaussian_process`
 ...............................
 
-- |Fix| Raise better error if `CompoundKernel is passed to 
-  :class:`gaussian_process.GaussianProcessClassifier` as kernel .
+- |Fix| :class:`gaussian_process.GaussianProcessClassifier` raises
+  a more informative error if `CompoundKernel` is passed via `kernel`.
   :pr:`22223` by :user:`MarcoM <marcozzxx810>`.
 
 :mod:`sklearn.impute`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -273,6 +273,13 @@ Changelog
   F-statistic).
   :pr:`17819` by :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
 
+:mod:`sklearn.gaussian_process`
+...............................
+
+- |Fix| Raise better error if `CompoundKernel is passed to 
+  `GaussianProcessClassifier` as kernel .
+  :pr:`22223` by :user:`MarcoM <marcozzxx810>`.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -673,6 +673,13 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         self : object
             Returns an instance of self.
         """
+        if isinstance(
+            self.kernel, CompoundKernel
+        ):  # CompoundKernel is only used internally in scikit-learn
+            raise ValueError(
+                "Incompatible Kernel is used, %s" % (self.kernel.__class__)
+            )
+
         if self.kernel is None or self.kernel.requires_vector_input:
             X, y = self._validate_data(
                 X, y, multi_output=False, ensure_2d=True, dtype="numeric"

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -504,7 +504,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         The kernel specifying the covariance function of the GP. If None is
         passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
         the kernel's hyperparameters are optimized during fitting. Also kernel
-        cannot be a CompoundKernel as it is a private API.
+        cannot be a `CompoundKernel`.
 
     optimizer : 'fmin_l_bfgs_b' or callable, default='fmin_l_bfgs_b'
         Can either be one of the internally supported optimizers for optimizing

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -503,7 +503,8 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
     kernel : kernel instance, default=None
         The kernel specifying the covariance function of the GP. If None is
         passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
-        the kernel's hyperparameters are optimized during fitting.
+        the kernel's hyperparameters are optimized during fitting. Also kernel
+        cannot be a CompoundKernel as it is a private API.
 
     optimizer : 'fmin_l_bfgs_b' or callable, default='fmin_l_bfgs_b'
         Can either be one of the internally supported optimizers for optimizing
@@ -673,12 +674,8 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         self : object
             Returns an instance of self.
         """
-        if isinstance(
-            self.kernel, CompoundKernel
-        ):  # CompoundKernel is only used internally in scikit-learn
-            raise ValueError(
-                "Incompatible Kernel is used, %s" % (self.kernel.__class__)
-            )
+        if isinstance(self.kernel, CompoundKernel):
+            raise ValueError("kernel cannot be a CompoundKernel")
 
         if self.kernel is None or self.kernel.requires_vector_input:
             X, y = self._validate_data(

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -268,7 +268,7 @@ def test_warning_bounds():
 
 
 @pytest.mark.parametrize(
-    "params, TypeError, err_msg",
+    "params, error_type, err_msg",
     [
         (
             {"kernel": CompoundKernel(0)},
@@ -277,8 +277,8 @@ def test_warning_bounds():
         )
     ],
 )
-def test_gpc_fit_error(params, TypeError, err_msg):
+def test_gpc_fit_error(params, error_type, err_msg):
     """Check that expected error are raised during fit."""
     gpc = GaussianProcessClassifier(**params)
-    with pytest.raises(TypeError, match=err_msg):
+    with pytest.raises(error_type, match=err_msg):
         gpc.fit(X, y)

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -273,8 +273,7 @@ def test_warning_bounds():
         (
             {"kernel": CompoundKernel(0)},
             ValueError,
-            "Incompatible Kernel is used, <class"
-            " 'sklearn.gaussian_process.kernels.CompoundKernel'>",
+            "kernel cannot be a CompoundKernel",
         )
     ],
 )

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -11,7 +11,12 @@ from scipy.optimize import approx_fprime
 import pytest
 
 from sklearn.gaussian_process import GaussianProcessClassifier
-from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C, WhiteKernel
+from sklearn.gaussian_process.kernels import (
+    RBF,
+    CompoundKernel,
+    ConstantKernel as C,
+    WhiteKernel,
+)
 from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 from sklearn.exceptions import ConvergenceWarning
 
@@ -260,3 +265,21 @@ def test_warning_bounds():
         "Increasing the bound and calling "
         "fit again may find a better value."
     )
+
+
+@pytest.mark.parametrize(
+    "params, TypeError, err_msg",
+    [
+        (
+            {"kernel": CompoundKernel(0)},
+            ValueError,
+            "Incompatible Kernel is used, <class"
+            " 'sklearn.gaussian_process.kernels.CompoundKernel'>",
+        )
+    ],
+)
+def test_gpc_fit_error(params, TypeError, err_msg):
+    """Check that expected error are raised during fit."""
+    gpc = GaussianProcessClassifier(**params)
+    with pytest.raises(TypeError, match=err_msg):
+        gpc.fit(X, y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #21973


#### What does this implement/fix? Explain your changes.

Raise better error if `CompoundKernel` is passed to `GaussianProcessClassifier` as kernel

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
This was originally proposed in [scikit-learn/issues/21973#issuecomment-996936548](https://github.com/scikit-learn/scikit-learn/issues/21973#issuecomment-996936548)