### PR TITLE
DOC Ensures that fetch_rcv1 passes numpydoc validation

### DIFF
--- a/sklearn/datasets/_rcv1.py
+++ b/sklearn/datasets/_rcv1.py
@@ -136,8 +136,8 @@ def fetch_rcv1(
     Returns
     -------
     dataset : :class:`~sklearn.utils.Bunch`
-        Dictionary-like object. Returned only if `return_X_y` is False. Has
-        the following attributes.
+        Dictionary-like object. Returned only if `return_X_y` is False. 
+        `dataset` has the following attributes:
 
         data : sparse matrix of shape (804414, 47236), dtype=np.float64
             The array has 0.16% of non zero values. Will be of CSR format.

--- a/sklearn/datasets/_rcv1.py
+++ b/sklearn/datasets/_rcv1.py
@@ -136,7 +136,7 @@ def fetch_rcv1(
     Returns
     -------
     dataset : :class:`~sklearn.utils.Bunch`
-        Dictionary-like object. Returned only if `return_X_y` is False. 
+        Dictionary-like object. Returned only if `return_X_y` is False.
         `dataset` has the following attributes:
 
         data : sparse matrix of shape (804414, 47236), dtype=np.float64

--- a/sklearn/datasets/_rcv1.py
+++ b/sklearn/datasets/_rcv1.py
@@ -136,7 +136,8 @@ def fetch_rcv1(
     Returns
     -------
     dataset : :class:`~sklearn.utils.Bunch`
-        Dictionary-like object, with the following attributes.
+        Dictionary-like object. Returned only if `return_X_y` is False. Has
+        the following attributes.
 
         data : sparse matrix of shape (804414, 47236), dtype=np.float64
             The array has 0.16% of non zero values. Will be of CSR format.
@@ -150,7 +151,9 @@ def fetch_rcv1(
         DESCR : str
             Description of the RCV1 dataset.
 
-    (data, target) : tuple if ``return_X_y`` is True
+    (data, target) : tuple
+        A tuple consisting of `dataset.data` and `dataset.target`, as
+        described above. Returned only if `return_X_y` is True.
 
         .. versionadded:: 0.20
     """

--- a/sklearn/datasets/_rcv1.py
+++ b/sklearn/datasets/_rcv1.py
@@ -139,16 +139,16 @@ def fetch_rcv1(
         Dictionary-like object. Returned only if `return_X_y` is False.
         `dataset` has the following attributes:
 
-        data : sparse matrix of shape (804414, 47236), dtype=np.float64
+        - data : sparse matrix of shape (804414, 47236), dtype=np.float64
             The array has 0.16% of non zero values. Will be of CSR format.
-        target : sparse matrix of shape (804414, 103), dtype=np.uint8
+        - target : sparse matrix of shape (804414, 103), dtype=np.uint8
             Each sample has a value of 1 in its categories, and 0 in others.
             The array has 3.15% of non zero values. Will be of CSR format.
-        sample_id : ndarray of shape (804414,), dtype=np.uint32,
+        - sample_id : ndarray of shape (804414,), dtype=np.uint32,
             Identification number of each sample, as ordered in dataset.data.
-        target_names : ndarray of shape (103,), dtype=object
+        - target_names : ndarray of shape (103,), dtype=object
             Names of each target (RCV1 topics), as ordered in dataset.target.
-        DESCR : str
+        - DESCR : str
             Description of the RCV1 dataset.
 
     (data, target) : tuple

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -33,7 +33,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.datasets._lfw.fetch_lfw_people",
     "sklearn.datasets._olivetti_faces.fetch_olivetti_faces",
     "sklearn.datasets._openml.fetch_openml",
-    "sklearn.datasets._rcv1.fetch_rcv1",
     "sklearn.datasets._samples_generator.make_biclusters",
     "sklearn.datasets._samples_generator.make_blobs",
     "sklearn.datasets._samples_generator.make_checkerboard",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Addresses #21350


#### What does this implement/fix? Explain your changes.

Ensured that datasets._rcv1.fetch_rcv1 passes numpydoc validation.

- Removed the function from the list `FUNCTION_DOCSTRING_IGNORE_LIST`.
- Made sure that the second return value has a description.
- Added sentence to each return value stating under which condition it is returned.
- Changed the type description for `(data, target)` to `tuple` from `tuple if ``return_X_y`` is True`. It doesn't seem that the type of this return value depends on the value of `return_X_y`. Instead, whether or not such a return value exists depends on this.



#### Any other comments?

The type description `tuple if ``return_X_y`` is True` appears in several other function docstrings. 
