### PR TITLE
ENH Exposes latent mean and variance for GPCs

### DIFF
--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -137,7 +137,7 @@ optimizer.
 In some scenarios, information about the uncertainty of the latent function
 :math:`f` is desired (i.e. the variance :math:`\text{Var}[f_*]` described in
 Eq. (3.24) of [RW2006]_). The :class:`GaussianProcessClassifier` provides
-access to this uncertainty on both the `predict_proba` method:
+access to this uncertainty on the `predict_proba` method:
 setting the keyword argument `return_std_of_f` to `True` will also return the
 standard deviation of the latent function :math:`f` at the query points. It
 must be emphasized that this uncertainty is **not** an uncertainty over the

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -106,11 +106,11 @@ The :class:`GaussianProcessClassifier` implements Gaussian processes (GP) for
 classification purposes, more specifically for probabilistic classification,
 where test predictions take the form of class probabilities.
 GaussianProcessClassifier places a GP prior on a latent function :math:`f`,
-which is then squashed through a link function to obtain the probabilistic
+which is then squashed through a link function :math:`\pi` to obtain the probabilistic
 classification. The latent function :math:`f` is a so-called nuisance function,
 whose values are not observed and are not relevant by themselves.
 Its purpose is to allow a convenient formulation of the model, and :math:`f`
-is removed (integrated out) during prediction. GaussianProcessClassifier
+is removed (integrated out) during prediction. :class:`GaussianProcessClassifier`
 implements the logistic link function, for which the integral cannot be
 computed analytically but is easily approximated in the binary case.
 

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -137,7 +137,7 @@ optimizer.
 In some scenarios, information about the uncertainty of the latent function
 :math:`f` is desired (i.e. the variance :math:`\text{Var}[f_*]` described in
 Eq. (3.24) of [RW2006]_). The :class:`GaussianProcessClassifier` provides
-access to this uncertainty on both the `predict` and `predict_proba` methods:
+access to this uncertainty on both the `predict_proba` method:
 setting the keyword argument `return_std_of_f` to `True` will also return the
 standard deviation of the latent function :math:`f` at the query points. It
 must be emphasized that this uncertainty is **not** an uncertainty over the

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -134,6 +134,16 @@ that have been chosen randomly from the range of allowed values.
 If the initial hyperparameters should be kept fixed, `None` can be passed as
 optimizer.
 
+In some scenarios, information about the uncertainty of the latent function
+:math:`f` is desired (i.e. the variance :math:`\text{Var}[f_*]` described in
+Eq. (3.24) of [RW2006]_). The :class:`GaussianProcessClassifier` provides
+access to this uncertainty on both the `predict` and `predict_proba` methods:
+setting the keyword argument `return_std_of_f` to `True` will also return the
+standard deviation of the latent function :math:`f` at the query points. It
+must be emphasized that this uncertainty is **not** an uncertainty over the
+class probabilities :math:`\pi(f)`, but rather the uncertainties of the latent
+variable :math:`f`.
+
 :class:`GaussianProcessClassifier` supports multi-class classification
 by performing either one-versus-rest or one-versus-one based training and
 prediction.  In one-versus-rest, one binary Gaussian process classifier is

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -134,15 +134,10 @@ that have been chosen randomly from the range of allowed values.
 If the initial hyperparameters should be kept fixed, `None` can be passed as
 optimizer.
 
-In some scenarios, information about the uncertainty of the latent function
-:math:`f` is desired (i.e. the variance :math:`\text{Var}[f_*]` described in
-Eq. (3.24) of [RW2006]_). The :class:`GaussianProcessClassifier` provides
-access to this uncertainty on the `predict_proba` method:
-setting the keyword argument `return_std_of_f` to `True` will also return the
-standard deviation of the latent function :math:`f` at the query points. It
-must be emphasized that this uncertainty is **not** an uncertainty over the
-class probabilities :math:`\pi(f)`, but rather the uncertainties of the latent
-variable :math:`f`.
+In some scenarios, information about the latent function :math:`f` is desired
+(i.e. the mean :math:`\bar{f_*}` and the variance :math:`\text{Var}[f_*]` described
+in Eqs. (3.21) and (3.24) of [RW2006]_). The :class:`GaussianProcessClassifier`
+provides access to these quantities via the `latent_mean_and_variance` method.
 
 :class:`GaussianProcessClassifier` supports multi-class classification
 by performing either one-versus-rest or one-versus-one based training and

--- a/doc/whats_new/upcoming_changes/sklearn.gaussian_process/22227.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.gaussian_process/22227.enhancement.rst
@@ -1,1 +1,1 @@
-- :class:`gaussian_process.GaussianProcessClassifier` now includes a `latent_mean_and_variance` method that exposes the mean and the variance of the latent function used in the Laplace approximation. By :user:`Miguel González Duque <miguelgondu>`
+- :class:`gaussian_process.GaussianProcessClassifier` now includes a `latent_mean_and_variance` method that exposes the mean and the variance of the latent function, :math:`f`, used in the Laplace approximation. By :user:`Miguel González Duque <miguelgondu>`

--- a/doc/whats_new/upcoming_changes/sklearn.gaussian_process/22227.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.gaussian_process/22227.enhancement.rst
@@ -1,0 +1,1 @@
+- :class:`gaussian_process.GaussianProcessClassifier` now includes a `latent_mean_and_variance` method that exposes the mean and the variance of the latent function used in the Laplace approximation. By :user:`Miguel González Duque <miguelgondu>`

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -756,8 +756,8 @@ Changelog
 :mod:`sklearn.gaussian_process`
 ...............................
 
-- |Enhancement| The methods `predict` and `predict_proba` of
-  :class:`gaussian_process.GaussianProcessClassifier` now expose
+- |Enhancement| The method `predict_proba` of
+  :class:`gaussian_process.GaussianProcessClassifier` now exposes
   the standard deviation of the latent function f with a
   `return_std_of_f` flag. :pr:`22227` by
   :user:`Miguel González Duque <miguelgondu>`

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -753,6 +753,15 @@ Changelog
   :class:`sklearn.metrics.pairwise.polynomial_kernel`.
   :pr:`27668` by :user:`Nolan McMahon <NolantheNerd>`.
 
+:mod:`sklearn.gaussian_process`
+...............................
+
+- |Enhancement| The methods `predict` and `predict_proba` of
+  :class:`gaussian_process.GaussianProcessClassifier` now expose
+  the standard deviation of the latent function f with a
+  `return_std_of_f` flag. :pr:`22227` by
+  :user:`Miguel González Duque <miguelgondu>`
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -753,15 +753,6 @@ Changelog
   :class:`sklearn.metrics.pairwise.polynomial_kernel`.
   :pr:`27668` by :user:`Nolan McMahon <NolantheNerd>`.
 
-:mod:`sklearn.gaussian_process`
-...............................
-
-- |Enhancement| The method `predict_proba` of
-  :class:`gaussian_process.GaussianProcessClassifier` now exposes
-  the standard deviation of the latent function f with a
-  `return_std_of_f` flag. :pr:`22227` by
-  :user:`Miguel González Duque <miguelgondu>`
-
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -936,11 +936,11 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
     def latent_mean_and_variance(self, X):
         """Compute the mean and variance of the latent function.
 
-        Based on algorithm 3.2 of [RW2006]_, this function returns
-        the latent mean (Line 4) and variance (Line 6) of the
-        Gaussian process classification model.
-        Note that this function is only supported for binary
-        classification.
+        Based on algorithm 3.2 of [RW2006]_, this function returns the latent
+        mean (Line 4) and variance (Line 6) of the Gaussian process
+        classification model. 
+        
+        Note that this function is only supported for binary classification.
 
         Parameters
         ----------
@@ -957,10 +957,9 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         """
         if self.n_classes_ > 2:
             raise ValueError(
-                "Returning the mean and variance of the "
-                "latent function f is only supported for GPCs "
-                "that use the Laplace Approximation (i.e. 2 classes, "
-                f"received {self.n_classes_})."
+                "Returning the mean and variance of the latent function f "
+                "is only supported for binary classification, received "
+                f"{self.n_classes_} classes."
             )
         check_is_fitted(self)
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -306,7 +306,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         """
         check_is_fitted(self)
 
-        # Compute the mean and variance of the latent function values
+        # Compute the mean and variance of the latent function
         # (Lines 4-6 of Algorithm 3.2 of GPML)
         f_star, var_f_star = self.latent_mean_and_variance(X)
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -278,7 +278,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
 
-        return_std_of_f: bool, default=False
+        return_std_of_f : bool, default=False
             If True, returns predictions and the standard deviation of the
             latent function f.
 
@@ -806,7 +806,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
 
-        return_std_of_f: bool, optional (default=False)
+        return_std_of_f : bool, optional (default=False)
             Returns the standard deviation of the latent variable f.
             Only works for binary classification.
 
@@ -815,7 +815,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         C : ndarray of shape (n_samples,)
             Predicted target values for X, values are from ``classes_``.
 
-        f_std: ndarray of shape (n_samples,), optional
+        f_std : ndarray of shape (n_samples,), optional
             Standard deviation of the latent function f at the test vectors X.
         """
         check_is_fitted(self)
@@ -852,7 +852,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         X : array-like of shape (n_samples, n_features) or list of object
             Query points where the GP is evaluated for classification.
 
-        return_std_of_f: bool, optional (default=False)
+        return_std_of_f : bool, optional (default=False)
             Returns the standard deviation of the latent variable f.
             Only works for binary classification.
 
@@ -863,7 +863,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
             the model. The columns correspond to the classes in sorted
             order, as they appear in the attribute :term:`classes_`.
 
-        f_std: ndarray of shape (n_samples,), optional
+        f_std : ndarray of shape (n_samples,), optional
             Standard deviation of the latent function f at the test vectors X.
         """
         check_is_fitted(self)

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -820,14 +820,14 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self)
         if self.n_classes_ > 2 and return_std_of_f:
-            assert isinstance(
+            if not isinstance(
                 self.base_estimator_, _BinaryGaussianProcessClassifierLaplace
-            )
-            raise ValueError(
-                "Returning the standard deviation of "
-                "the latent function f is not supported for "
-                "more than 2 classes."
-            )
+            ):
+                raise ValueError(
+                    "Returning the standard deviation of "
+                    "the latent function f is not supported for "
+                    "more than 2 classes."
+                )
 
         if self.kernel is None or self.kernel.requires_vector_input:
             X = validate_data(self, X, ensure_2d=True, dtype="numeric", reset=False)

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -873,23 +873,24 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
                 "predicting probability estimates. Use "
                 "one_vs_rest mode instead."
             )
-        if self.n_classes_ > 2 and return_std_of_f:
+
+        can_return_f_std = isinstance(
+            self.base_estimator_, _BinaryGaussianProcessClassifierLaplace
+        )
+        if not can_return_f_std and return_std_of_f:
             error_msg = (
                 "Returning the standard deviation of the "
                 "latent function f is only supported for GPCs "
                 "that use the Laplace Approximation."
             )
-            if not isinstance(
-                self.base_estimator_, _BinaryGaussianProcessClassifierLaplace
-            ):
-                raise ValueError(error_msg)
+            raise ValueError(error_msg)
 
         if self.kernel is None or self.kernel.requires_vector_input:
             X = validate_data(self, X, ensure_2d=True, dtype="numeric", reset=False)
         else:
             X = validate_data(self, X, ensure_2d=False, dtype=None, reset=False)
 
-        if isinstance(self.base_estimator_, _BinaryGaussianProcessClassifierLaplace):
+        if can_return_f_std:
             return self.base_estimator_.predict_proba(
                 X, return_std_of_f=return_std_of_f
             )

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -410,11 +410,11 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
     def latent_mean_and_variance(self, X):
         """Compute the mean and variance of the latent function values.
 
-        Based on algorithm 3.2 of [RW2006]_, this function returns
-        the latent mean (Line 4) and variance (Line 6) of the
-        Gaussian process classification model.
-        Note that this function is only supported for binary
-        classification.
+        Based on algorithm 3.2 of [RW2006]_, this function returns the latent
+        mean (Line 4) and variance (Line 6) of the Gaussian process
+        classification model.
+
+        Note that this function is only supported for binary classification.
 
         Parameters
         ----------
@@ -938,8 +938,8 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
         Based on algorithm 3.2 of [RW2006]_, this function returns the latent
         mean (Line 4) and variance (Line 6) of the Gaussian process
-        classification model. 
-        
+        classification model.
+
         Note that this function is only supported for binary classification.
 
         Parameters

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -305,9 +305,8 @@ def test_gpc_latent_mean_and_variance_complain_on_more_than_2_classes():
     # Check that the latent mean and variance have the right shape
     with pytest.raises(
         ValueError,
-        match="Returning the mean and variance of the "
-        "latent function f is only supported for GPCs "
-        "that use the Laplace Approximation",
+        match="Returning the mean and variance of the latent function f "
+        "is only supported for binary classification",
     ):
         gpc.latent_mean_and_variance(X)
 

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -310,3 +310,12 @@ def test_gpc_latent_mean_and_variance_complain_on_more_than_2_classes():
         "that use the Laplace Approximation",
     ):
         gpc.latent_mean_and_variance(X)
+
+
+def test_latent_mean_and_variance_works_on_structured_kernels():
+    X = ["A", "AB", "B"]
+    y = np.array([True, False, True])
+    kernel = MiniSeqKernel(baseline_similarity_bounds="fixed")
+    gpc = GaussianProcessClassifier(kernel=kernel).fit(X, y)
+
+    gpc.latent_mean_and_variance(X)

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -295,3 +295,18 @@ def test_gpc_latent_mean_and_variance_shape(kernel):
     latent_mean, latent_variance = gpc.latent_mean_and_variance(X)
     assert latent_mean.shape == (X.shape[0],)
     assert latent_variance.shape == (X.shape[0],)
+
+
+def test_gpc_latent_mean_and_variance_complain_on_more_than_2_classes():
+    """Checks that the latent mean and variance have the right shape."""
+    gpc = GaussianProcessClassifier(kernel=RBF())
+    gpc.fit(X, y_mc)
+
+    # Check that the latent mean and variance have the right shape
+    with pytest.raises(
+        ValueError,
+        match="Returning the mean and variance of the "
+        "latent function f is only supported for GPCs "
+        "that use the Laplace Approximation",
+    ):
+        gpc.latent_mean_and_variance(X)

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -283,3 +283,15 @@ def test_gpc_fit_error(params, error_type, err_msg):
     gpc = GaussianProcessClassifier(**params)
     with pytest.raises(error_type, match=err_msg):
         gpc.fit(X, y)
+
+
+@pytest.mark.parametrize("kernel", kernels)
+def test_gpc_latent_mean_and_variance_shape(kernel):
+    """Checks that the latent mean and variance have the right shape."""
+    gpc = GaussianProcessClassifier(kernel=kernel)
+    gpc.fit(X, y)
+
+    # Check that the latent mean and variance have the right shape
+    latent_mean, latent_variance = gpc.latent_mean_and_variance(X)
+    assert latent_mean.shape == (X.shape[0],)
+    assert latent_variance.shape == (X.shape[0],)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #22226. 


#### What does this implement/fix? Explain your changes.
Adds a `return_std_of_f` flag for binary Gaussian Process Classifiers. This value was already being computed in some of the methods, so this PR just exposes that variable and adds checks in the API to ensure this is only possible for binary (and not multiclass) classification using the Laplace approximation.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
