### PR TITLE
ENH Improve efficiency of chi2 by converting the input to float first

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -140,6 +140,12 @@ Changelog
   `'auto'` in 1.3. `None` and `'warn'` will be removed in 1.3. :pr:`20145` by
   :user:`murata-yu`.
 
+:mod:`sklearn.feature_selection`
+................................
+
+- |Efficiency| Improve runtime performance of :func:`feature_selection.chi2`
+  with boolean arrays. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.datasets`
 .......................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -144,7 +144,7 @@ Changelog
 ................................
 
 - |Efficiency| Improve runtime performance of :func:`feature_selection.chi2`
-  with boolean arrays. :pr:`xxxxx` by `Thomas Fan`_.
+  with boolean arrays. :pr:`22235` by `Thomas Fan`_.
 
 :mod:`sklearn.datasets`
 .......................

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -210,6 +210,8 @@ def chi2(X, y):
 
     # XXX: we might want to do some of the following in logspace instead for
     # numerical stability.
+    # Converting X to float allows getting better performance for the
+    # safe_sparse_dot call made bellow.
     X = check_array(X, accept_sparse="csr", dtype=(np.float64, np.float32))
     if np.any((X.data if issparse(X) else X) < 0):
         raise ValueError("Input X must be non-negative.")

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -210,7 +210,7 @@ def chi2(X, y):
 
     # XXX: we might want to do some of the following in logspace instead for
     # numerical stability.
-    X = check_array(X, accept_sparse="csr")
+    X = check_array(X, accept_sparse="csr", dtype=np.float64)
     if np.any((X.data if issparse(X) else X) < 0):
         raise ValueError("Input X must be non-negative.")
 

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -210,7 +210,7 @@ def chi2(X, y):
 
     # XXX: we might want to do some of the following in logspace instead for
     # numerical stability.
-    X = check_array(X, accept_sparse="csr", dtype=np.float64)
+    X = check_array(X, accept_sparse="csr", dtype=(np.float64, np.float32))
     if np.any((X.data if issparse(X) else X) < 0):
         raise ValueError("Input X must be non-negative.")
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/22231

#### What does this implement/fix? Explain your changes.
This PR converts the input of `chi2` into float so `safe_sparse_dot` is faster. We will convert `observed` into `float64` later:

https://github.com/scikit-learn/scikit-learn/blob/0c65bbfe8ce816a181780d2a249c94dd653e115a/sklearn/feature_selection/_univariate_selection.py#L157

so I think it makes sense to do it ahead of time with `X`, so that the matmul is faster. 

CC @glemaitre 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
