### PR TITLE
Add `mask` option to `ConfusionMatrixDisplay`

### DIFF
--- a/sklearn/metrics/_plot/tests/test_confusion_matrix_display.py
+++ b/sklearn/metrics/_plot/tests/test_confusion_matrix_display.py
@@ -365,3 +365,17 @@ def test_colormap_max(pyplot):
 
     color = disp.text_[1, 0].get_color()
     assert_allclose(color, [1.0, 1.0, 1.0, 1.0])
+
+
+def test_mask(pyplot):
+    """Check the behaviour of mask"""
+
+    confusion_matrix = np.array([[1.0, 0.0], [0.5, 0.5]])
+    mask = np.array([[True, True], [False, False]])
+
+    disp = ConfusionMatrixDisplay(confusion_matrix, mask=mask)
+    disp.plot()
+
+    expected_text = np.array(["1", "0", None, None])
+    text_text = np.array([t and t.get_text() for t in disp.text_.ravel(order="C")])
+    assert_array_equal(expected_text, text_text)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Add a `mask` option to `ConfusionMatrixDisplay` to allow hiding specified cells.

```python
import numpy as np
from sklearn.linear_model import LogisticRegression
from sklearn.datasets import make_classification
from sklearn.model_selection import train_test_split
from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay
import matplotlib.pyplot as plt


X, y = make_classification(
    n_samples=1000,
    n_classes=10,
    n_informative=5,
)

X_train, X_test, y_train, y_test = train_test_split(
    X,
    y,
    test_size=0.33,
    random_state=42,
)

model = LogisticRegression(solver="liblinear").fit(X_train, y_train)
cm = confusion_matrix(
    y_test,
    model.predict(X_test),
    normalize="true",
)

ConfusionMatrixDisplay(cm).plot(cmap="Blues")
plt.savefig("without_mask.png")

ConfusionMatrixDisplay(cm, mask=cm > 0.05).plot(cmap="Blues")
plt.savefig("with_mask.png")
```



### Without mask

![image](https://user-images.githubusercontent.com/17039389/150664219-f122986c-2d6b-4ef8-abfa-dc821a87f862.png)

### With mask

![image](https://user-images.githubusercontent.com/17039389/150664226-e614920f-3d13-449a-85a8-8fe746622555.png)


#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
