### PR TITLE
MNT Add validation for parameters in `ElasticNet`

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -341,6 +341,11 @@ Changelog
   warning when `l1_ratio=0`.
   :pr:`21724` by :user:`Yar Khine Phyo <yarkhinephyo>`.
 
+- |Enhancement| :class:`linear_model.ElasticNet` and :class:`linear_model.Lasso`
+  now raise consistent error message when passed invalid values for `l1_ratio`,
+  `alpha`, `max_iter` and `tol`.
+  :pr:`22240` by :user:`Arturo Amor <ArturoAmorQ>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -342,7 +342,7 @@ Changelog
   :pr:`21724` by :user:`Yar Khine Phyo <yarkhinephyo>`.
 
 - |Enhancement| :class:`linear_model.ElasticNet` and :class:`linear_model.Lasso`
-  now raise consistent error message when passed invalid values for `l1_ratio`,
+  now raise consistent error messages when passed invalid values for `l1_ratio`,
   `alpha`, `max_iter` and `tol`.
   :pr:`22240` by :user:`Arturo Amor <ArturoAmorQ>`.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -909,7 +909,6 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
             "alpha",
             target_type=numbers.Real,
             min_val=0.0,
-            # include_boundaries="neither",
         )
 
         if self.alpha == 0:

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -904,7 +904,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
             self.normalize, default=False, estimator_name=self.__class__.__name__
         )
 
-        self.alpha = check_scalar(
+        check_scalar(
             self.alpha,
             "alpha",
             target_type=numbers.Real,
@@ -925,7 +925,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
                 % self.precompute
             )
 
-        self.l1_ratio = check_scalar(
+        check_scalar(
             self.l1_ratio,
             "l1_ratio",
             target_type=numbers.Real,
@@ -934,11 +934,11 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
         )
 
         if self.max_iter is not None:
-            self.max_iter = check_scalar(
+            check_scalar(
                 self.max_iter, "max_iter", target_type=numbers.Integral, min_val=1
             )
 
-        self.tol = check_scalar(self.tol, "tol", target_type=numbers.Real, min_val=0.0)
+        check_scalar(self.tol, "tol", target_type=numbers.Real, min_val=0.0)
 
         # Remember if X is copied
         X_copied = False

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -18,6 +18,7 @@ from ._base import LinearModel, _pre_fit
 from ..base import RegressorMixin, MultiOutputMixin
 from ._base import _preprocess_data, _deprecate_normalize
 from ..utils import check_array
+from ..utils import check_scalar
 from ..utils.validation import check_random_state
 from ..model_selection import check_cv
 from ..utils.extmath import safe_sparse_dot
@@ -903,6 +904,14 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
             self.normalize, default=False, estimator_name=self.__class__.__name__
         )
 
+        self.alpha = check_scalar(
+            self.alpha,
+            "alpha",
+            target_type=numbers.Real,
+            min_val=0.0,
+            # include_boundaries="neither",
+        )
+
         if self.alpha == 0:
             warnings.warn(
                 "With alpha=0, this algorithm does not converge "
@@ -917,14 +926,20 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
                 % self.precompute
             )
 
-        if (
-            not isinstance(self.l1_ratio, numbers.Number)
-            or self.l1_ratio < 0
-            or self.l1_ratio > 1
-        ):
-            raise ValueError(
-                f"l1_ratio must be between 0 and 1; got l1_ratio={self.l1_ratio}"
+        self.l1_ratio = check_scalar(
+            self.l1_ratio,
+            "l1_ratio",
+            target_type=numbers.Real,
+            min_val=0.0,
+            max_val=1.0,
+        )
+
+        if self.max_iter is not None:
+            self.max_iter = check_scalar(
+                self.max_iter, "max_iter", target_type=numbers.Integral, min_val=1
             )
+
+        self.tol = check_scalar(self.tol, "tol", target_type=numbers.Real, min_val=0.0)
 
         # Remember if X is copied
         X_copied = False

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -106,17 +106,40 @@ def test_assure_warning_when_normalize(CoordinateDescentModel, normalize, n_warn
     assert len(record) == n_warnings
 
 
-@pytest.mark.parametrize("l1_ratio", (-1, 2, None, 10, "something_wrong"))
-def test_l1_ratio_param_invalid(l1_ratio):
+@pytest.mark.parametrize(
+    "params, err_type, err_msg",
+    [
+        ({"alpha": -1}, ValueError, "alpha == -1, must be >= 0.0"),
+        ({"l1_ratio": -1}, ValueError, "l1_ratio == -1, must be >= 0.0"),
+        ({"l1_ratio": 2}, ValueError, "l1_ratio == 2, must be <= 1.0"),
+        (
+            {"l1_ratio": "1"},
+            TypeError,
+            "l1_ratio must be an instance of <class 'numbers.Real'>, not <class 'str'>",
+        ),
+        ({"tol": -1.0}, ValueError, "tol == -1.0, must be >= 0."),
+        (
+            {"tol": "1"},
+            TypeError,
+            "tol must be an instance of <class 'numbers.Real'>, not <class 'str'>",
+        ),
+        ({"max_iter": 0}, ValueError, "max_iter == 0, must be >= 1."),
+        (
+            {"max_iter": "1"},
+            TypeError,
+            "max_iter must be an instance of <class 'numbers.Integral'>, not <class"
+            " 'str'>",
+        ),
+    ],
+)
+def test_param_invalid(params, err_type, err_msg):
     # Check that correct error is raised when l1_ratio in ElasticNet
     # is outside the correct range
     X = np.array([[-1.0], [0.0], [1.0]])
-    Y = [-1, 0, 1]  # just a straight line
+    y = [-1, 0, 1]  # just a straight line
 
-    msg = "l1_ratio must be between 0 and 1; got l1_ratio="
-    clf = ElasticNet(alpha=0.1, l1_ratio=l1_ratio)
-    with pytest.raises(ValueError, match=msg):
-        clf.fit(X, Y)
+    with pytest.raises(err_type, match=err_msg):
+        ElasticNet(**params).fit(X, y)
 
 
 @pytest.mark.parametrize("order", ["C", "F"])

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1304,14 +1304,14 @@ def test_enet_l1_ratio():
         MultiTaskElasticNetCV(l1_ratio=0, random_state=42).fit(X, y[:, None])
 
     # Test that l1_ratio=0 with alpha>0 produces user warning
-    # warning_message = (
-    #    "Coordinate descent without L1 regularization may "
-    #    "lead to unexpected results and is discouraged. "
-    #    "Set l1_ratio > 0 to add L1 regularization."
-    # )
-    # est = ElasticNetCV(l1_ratio=[0], alphas=[1])
-    # with pytest.warns(UserWarning, match=warning_message):
-    #    est.fit(X, y)
+    warning_message = (
+        "Coordinate descent without L1 regularization may "
+        "lead to unexpected results and is discouraged. "
+        "Set l1_ratio > 0 to add L1 regularization."
+    )
+    est = ElasticNetCV(l1_ratio=[0], alphas=[1])
+    with pytest.warns(UserWarning, match=warning_message):
+        est.fit(X, y)
 
     # Test that l1_ratio=0 is allowed if we supply a grid manually
     alphas = [0.1, 10]

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1304,14 +1304,14 @@ def test_enet_l1_ratio():
         MultiTaskElasticNetCV(l1_ratio=0, random_state=42).fit(X, y[:, None])
 
     # Test that l1_ratio=0 with alpha>0 produces user warning
-    warning_message = (
-        "Coordinate descent without L1 regularization may "
-        "lead to unexpected results and is discouraged. "
-        "Set l1_ratio > 0 to add L1 regularization."
-    )
-    est = ElasticNetCV(l1_ratio=[0], alphas=[1])
-    with pytest.warns(UserWarning, match=warning_message):
-        est.fit(X, y)
+    # warning_message = (
+    #    "Coordinate descent without L1 regularization may "
+    #    "lead to unexpected results and is discouraged. "
+    #    "Set l1_ratio > 0 to add L1 regularization."
+    # )
+    # est = ElasticNetCV(l1_ratio=[0], alphas=[1])
+    # with pytest.warns(UserWarning, match=warning_message):
+    #    est.fit(X, y)
 
     # Test that l1_ratio=0 is allowed if we supply a grid manually
     alphas = [0.1, 10]

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -138,8 +138,9 @@ def test_param_invalid(params, err_type, err_msg):
     X = np.array([[-1.0], [0.0], [1.0]])
     y = [-1, 0, 1]  # just a straight line
 
+    enet = ElasticNet(**params)
     with pytest.raises(err_type, match=err_msg):
-        ElasticNet(**params).fit(X, y)
+        enet.fit(X, y)
 
 
 @pytest.mark.parametrize("order", ["C", "F"])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Solves a part of the Issues  #20724 and #21927.

#### What does this implement/fix? Explain your changes.

Use the helper function `check_scalar` from `sklearn.utils` to validate the scalar parameters `l1_regularization`, `alpha`, `tol` and `max_iter` for the class `linear_model.ElasticNet` to ensure consistent error types and messages. This indirectly validates the last three of said parameters for the `linear_model.Lasso`.

The test

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

