### PR TITLE
ENH Adds get_feature_names to isotonic module

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -317,7 +317,7 @@ Changelog
 :mod:`sklearn.isotonic`
 .......................
 
-- |Enhancement| Adds `get_feature_names_out` to `IsotonicRegression`.
+- |Enhancement| Adds :term:`get_feature_names_out` to `IsotonicRegression`.
   :pr:`22249` by `Thomas Fan`_.
 
 :mod:`sklearn.linear_model`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -318,7 +318,7 @@ Changelog
 .......................
 
 - |Enhancement| Adds `get_feature_names_out` to `IsotonicRegression`.
-  :pr:`xxxxx` by `Thomas Fan`_.
+  :pr:`22249` by `Thomas Fan`_.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -314,6 +314,12 @@ Changelog
   `max_iter` and `tol`.
   :pr:`21341` by :user:`Arturo Amor <ArturoAmorQ>`.
 
+:mod:`sklearn.isotonic`
+.......................
+
+- |Enhancement| Adds `get_feature_names_out` to `IsotonicRegression`.
+  :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -416,6 +416,10 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         """
         return self.transform(T)
 
+    # We implement get_feature_names_out here instead of using
+    # `_ClassNamePrefixFeaturesOutMixin`` because `input_features` are ignored.
+    # `input_features` are ignored because `IsotonicRegression` accepts 1d
+    # arrays and the semantics of `feature_names_in_` are not clear for 1d arrays.
     def get_feature_names_out(self, input_features=None):
         """Get output feature names for transformation.
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -427,7 +427,7 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         Returns
         -------
         feature_names_out : ndarray of str objects
-            An ndarray with one string i.e. ["isotonicregression0"]
+            An ndarray with one string i.e. ["isotonicregression0"].
         """
         class_name = self.__class__.__name__.lower()
         return np.asarray([f"{class_name}0"], dtype=object)

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -416,6 +416,22 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         """
         return self.transform(T)
 
+    def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str objects
+            An ndarray with one string i.e. ["isotonicregression0"]
+        """
+        class_name = self.__class__.__name__.lower()
+        return np.asarray([f"{class_name}0"], dtype=object)
+
     def __getstate__(self):
         """Pickle-protocol - return state of the estimator."""
         state = super().__getstate__()

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -382,7 +382,6 @@ def test_pandas_column_name_consistency(estimator):
 GET_FEATURES_OUT_MODULES_TO_IGNORE = [
     "cluster",
     "ensemble",
-    "isotonic",
     "kernel_approximation",
     "preprocessing",
     "manifold",

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -699,6 +699,7 @@ def test_isotonic_regression_sample_weight_not_overwritten():
 
 @pytest.mark.parametrize("shape", ["1d", "2d"])
 def test_get_feature_names_out(shape):
+    """Check `get_feature_names_out` for `IsotonicRegression`."""
     X = np.arange(10)
     if shape == "2d":
         X = X.reshape(-1, 1)
@@ -708,5 +709,4 @@ def test_get_feature_names_out(shape):
     names = iso.get_feature_names_out()
     assert isinstance(names, np.ndarray)
     assert names.dtype == object
-    assert len(names) == 1
-    assert names[0] == "isotonicregression0"
+    assert_array_equal(["isotonicregression0"], names)

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -695,3 +695,18 @@ def test_isotonic_regression_sample_weight_not_overwritten():
 
     IsotonicRegression().fit(X, y, sample_weight=sample_weight_fit)
     assert_allclose(sample_weight_fit, sample_weight_original)
+
+
+@pytest.mark.parametrize("shape", ["1d", "2d"])
+def test_get_feature_names_out(shape):
+    X = np.arange(10)
+    if shape == "2d":
+        X = X.reshape(-1, 1)
+    y = np.arange(10)
+
+    iso = IsotonicRegression().fit(X, y)
+    names = iso.get_feature_names_out()
+    assert isinstance(names, np.ndarray)
+    assert names.dtype == object
+    assert len(names) == 1
+    assert names[0] == "isotonicregression0"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #21308

#### What does this implement/fix? Explain your changes.
`IsotonicRegression` only supports 2d arrays with 1 feature and 1d arrays. In this case, I think we can have `get_feature_names_out` always return "isotonicregression0".

#### Any other comments?
Note that the common tests does not run on `IsotonicRegression` because it has the `{"X_types": ["1darray"]}` tag.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
