### PR TITLE
MAINT Indicate Python 3.10 compatibility in `README.rst` and `setup.py`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@
 .. |Nightly wheels| image:: https://github.com/scikit-learn/scikit-learn/workflows/Wheel%20builder/badge.svg?event=schedule
 .. _`Nightly wheels`: https://github.com/scikit-learn/scikit-learn/actions?query=workflow%3A%22Wheel+builder%22+event%3Aschedule
 
-.. |PythonVersion| image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue
-.. _PythonVersion: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue
+.. |PythonVersion| image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue
+.. _PythonVersion: https://docs.python.org/3
 
 .. |PyPi| image:: https://img.shields.io/pypi/v/scikit-learn
 .. _PyPi: https://pypi.org/project/scikit-learn

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@
 .. _`Nightly wheels`: https://github.com/scikit-learn/scikit-learn/actions?query=workflow%3A%22Wheel+builder%22+event%3Aschedule
 
 .. |PythonVersion| image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue
-.. _PythonVersion: https://docs.python.org/3
+.. _PythonVersion: https://pypi.org/project/scikit-learn/
 
 .. |PyPi| image:: https://img.shields.io/pypi/v/scikit-learn
 .. _PyPi: https://pypi.org/project/scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,7 @@ def setup_package():
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
         ],


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR updates the `README.rst` Python badge to include 3.10, as `cp310` wheels are [available](https://pypi.org/project/scikit-learn/#files).
