### PR TITLE
DOC Ensures that sklearn.datasets._base.load_breast_cancer passes numpydoc validation 

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -702,6 +702,9 @@ def load_breast_cancer(*, return_X_y=False, as_frame=False):
             .. versionadded:: 0.20
 
     (data, target) : tuple if ``return_X_y`` is True
+        Returns a tuple of two ndarray of shape (n_samples, n_features)
+        A 2D array with each row representing one sample and each column
+        representing the features and/or target of a given sample.
 
         .. versionadded:: 0.18
 
@@ -981,9 +984,10 @@ def load_diabetes(*, return_X_y=False, as_frame=False, scaled=True):
             The path to the location of the target.
 
     (data, target) : tuple if ``return_X_y`` is True
-        Returns a tuple of two ndarray of shape (n_samples, n_features)
-        A 2D array with each row representing one sample and each column
-        representing the features and/or target of a given sample.
+        A tuple of two ndarrays. The first contains a 2D array of shape (442, 10) 
+        with each row representing one sample and each column representing the features. 
+        The second array of shape (442,) contains the target samples.
+
         .. versionadded:: 0.18
     """
     data_filename = "diabetes_data_raw.csv.gz"

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -21,7 +21,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.covariance._shrunk_covariance.shrunk_covariance",
     "sklearn.datasets._base.get_data_home",
     "sklearn.datasets._base.load_boston",
-    "sklearn.datasets._base.load_breast_cancer",
     "sklearn.datasets._base.load_digits",
     "sklearn.datasets._base.load_linnerud",
     "sklearn.datasets._base.load_sample_image",


### PR DESCRIPTION
Addresses #21350


#### What does this implement/fix? Explain your changes.
1. Removed sklearn.datasets._base.load_breast_cancer from FUNCTION_DOCSTRING_IGNORE_LIST
2. Added to the return value:
                  A tuple of two ndarrays. The first contains a 2D array of shape (442, 10) 
                  with each row representing one sample and each column representing the features. 
                  The second array of shape (442,) contains the target samples.


#### Any other comments?
When I run the tests I still get "Return value has no description". I don't know how to define these descriptions, I basically got this version from someone, can I get any help with this. Thanks.



