### PR TITLE
DOC Ensures that shrunk_covariance passes numpydoc validation

### DIFF
--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -32,7 +32,7 @@ def shrunk_covariance(emp_cov, shrinkage=0.1):
     Parameters
     ----------
     emp_cov : array-like of shape (n_features, n_features)
-        Covariance matrix to be shrunk
+        Covariance matrix to be shrunk.
 
     shrinkage : float, default=0.1
         Coefficient in the convex combination used for the computation

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -25,7 +25,7 @@ from ..utils import check_array
 
 
 def shrunk_covariance(emp_cov, shrinkage=0.1):
-    """Calculates a covariance matrix shrunk on the diagonal
+    """Calculate a covariance matrix shrunk on the diagonal
 
     Read more in the :ref:`User Guide <shrunk_covariance>`.
 

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -25,7 +25,7 @@ from ..utils import check_array
 
 
 def shrunk_covariance(emp_cov, shrinkage=0.1):
-    """Calculate a covariance matrix shrunk on the diagonal
+    """Calculate a covariance matrix shrunk on the diagonal.
 
     Read more in the :ref:`User Guide <shrunk_covariance>`.
 

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -45,11 +45,11 @@ def shrunk_covariance(emp_cov, shrinkage=0.1):
 
     Notes
     -----
-    The regularized (shrunk) covariance is given by:
+    The regularized (shrunk) covariance is given by::
 
-    (1 - shrinkage) * cov + shrinkage * mu * np.identity(n_features)
+        (1 - shrinkage) * cov + shrinkage * mu * np.identity(n_features)
 
-    where mu = trace(cov) / n_features
+    where `mu = trace(cov) / n_features`.
     """
     emp_cov = check_array(emp_cov)
     n_features = emp_cov.shape[0]

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -17,7 +17,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.covariance._robust_covariance.fast_mcd",
     "sklearn.covariance._shrunk_covariance.ledoit_wolf",
     "sklearn.covariance._shrunk_covariance.ledoit_wolf_shrinkage",
-    "sklearn.covariance._shrunk_covariance.shrunk_covariance",
     "sklearn.datasets._base.load_breast_cancer",
     "sklearn.datasets._base.load_digits",
     "sklearn.datasets._base.load_linnerud",

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -18,7 +18,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.covariance._robust_covariance.fast_mcd",
     "sklearn.covariance._shrunk_covariance.ledoit_wolf",
     "sklearn.covariance._shrunk_covariance.ledoit_wolf_shrinkage",
-    "sklearn.covariance._shrunk_covariance.shrunk_covariance",
     "sklearn.datasets._base.get_data_home",
     "sklearn.datasets._base.load_boston",
     "sklearn.datasets._base.load_breast_cancer",


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #21350

#### What does this implement/fix? Explain your changes.

This PR fixes the following errors that were appearing for numpydoc validation for sklearn.covariance._shrunk_covariance.shrunk_covariance

- SS03: Summary does not end with a period
- SS05: Summary must start with infinitive verb, not third person (e.g. use "Generate" instead of "Generates")
- PR09: Parameter "emp_cov" description should finish with "."

#### Any other comments?

Thanks 