### PR TITLE
MNT Adds render to bug report version as a codeblock

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,6 +81,7 @@ body:
 - type: textarea
   attributes:
     label: Versions
+    render: shell
     description: |
       Please run the following and paste the output below.
       ```python


### PR DESCRIPTION
This PR adds the render attribute makes sure that the output is treated as a code block.

On `main`, we get [this rendering by default](https://github.com/thomasjpfan/scikit-learn/issues/101) where the version info is treated as markdown.

With this PR, we get [this rendering by default](https://github.com/thomasjpfan/scikit-learn/issues/100), where the version info is always in a codeblock.