### PR TITLE
FIX typo in .github/workflows/check-changelog.yml

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -61,7 +61,7 @@ jobs:
             echo "If you see this error and there is already a changelog entry,"
             echo "check that the PR number is correct."
             echo ""
-            echo" If you believe that this PR does no warrant a changelog"
+            echo "If you believe that this PR does no warrant a changelog"
             echo "entry, say so in a comment so that a maintainer will label "
             echo "the PR with 'No Changelog Needed' to bypass this check."
             exit 1


### PR DESCRIPTION
This is causing a confusing message:

```
+ 'echo If you believe that this PR does no warrant a changelog'
/home/runner/work/_temp/d5ca2478-f6a1-461f-adf2-bd19e30cf126.sh: line 41: echo If you believe that this PR does no warrant a changelog: command not found
```

for instance in:

https://github.com/scikit-learn/scikit-learn/runs/4895147486?check_suite_focus=true#step:4:24283

Observed in #22247.