### PR TITLE
DOC Fix incorrect heading underline length in docstrings

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1000,7 +1000,7 @@ class CalibrationDisplay:
     .. versionadded:: 1.0
 
     Parameters
-    -----------
+    ----------
     prob_true : ndarray of shape (n_bins,)
         The proportion of samples whose class is the positive class (fraction
         of positives), in each bin.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1380,7 +1380,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             to a sparse ``csr_matrix``.
 
         Yields
-        -------
+        ------
         y : generator of ndarray of shape (n_samples,)
             The predicted value of the input samples.
         """

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -996,7 +996,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
             The input samples.
 
         Yields
-        -------
+        ------
         raw_predictions : generator of ndarray of shape \
             (n_samples, n_trees_per_iteration)
             The raw predictions of the input samples. The order of the
@@ -1371,7 +1371,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
             The input samples.
 
         Yields
-        -------
+        ------
         y : generator of ndarray of shape (n_samples,)
             The predicted values of the input samples, for each iteration.
         """
@@ -1674,7 +1674,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
             The input samples.
 
         Yields
-        -------
+        ------
         y : generator of ndarray of shape (n_samples,)
             The predicted classes of the input samples, for each iteration.
         """
@@ -1710,7 +1710,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
             The input samples.
 
         Yields
-        -------
+        ------
         y : generator of ndarray of shape (n_samples,)
             The predicted class probabilities of the input samples,
             for each iteration.
@@ -1751,7 +1751,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
             The input samples.
 
         Yields
-        -------
+        ------
         decision : generator of ndarray of shape (n_samples,) or \
                 (n_samples, n_trees_per_iteration)
             The decision function of the input samples, which corresponds to

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -158,6 +158,16 @@ class IsolationForest(OutlierMixin, BaseBagging):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    sklearn.covariance.EllipticEnvelope : An object for detecting outliers in a
+        Gaussian distributed dataset.
+    sklearn.svm.OneClassSVM : Unsupervised Outlier Detection.
+        Estimate the support of a high-dimensional distribution.
+        The implementation is based on libsvm.
+    sklearn.neighbors.LocalOutlierFactor : Unsupervised Outlier Detection
+        using Local Outlier Factor (LOF).
+
     Notes
     -----
     The implementation is based on an ensemble of ExtraTreeRegressor. The
@@ -172,16 +182,6 @@ class IsolationForest(OutlierMixin, BaseBagging):
     .. [2] Liu, Fei Tony, Ting, Kai Ming and Zhou, Zhi-Hua. "Isolation-based
            anomaly detection." ACM Transactions on Knowledge Discovery from
            Data (TKDD) 6.1 (2012): 3.
-
-    See Also
-    --------
-    sklearn.covariance.EllipticEnvelope : An object for detecting outliers in a
-        Gaussian distributed dataset.
-    sklearn.svm.OneClassSVM : Unsupervised Outlier Detection.
-        Estimate the support of a high-dimensional distribution.
-        The implementation is based on libsvm.
-    sklearn.neighbors.LocalOutlierFactor : Unsupervised Outlier Detection
-        using Local Outlier Factor (LOF).
 
     Examples
     --------

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -174,7 +174,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
            Data (TKDD) 6.1 (2012): 3.
 
     See Also
-    ----------
+    --------
     sklearn.covariance.EllipticEnvelope : An object for detecting outliers in a
         Gaussian distributed dataset.
     sklearn.svm.OneClassSVM : Unsupervised Outlier Detection.

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -1246,7 +1246,7 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
             The training input samples.
 
         Yields
-        -------
+        ------
         y : generator of ndarray of shape (n_samples,)
             The predicted regression values.
         """

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -490,7 +490,7 @@ class PoissonRegressor(GeneralizedLinearRegressor):
         Actual number of iterations used in the solver.
 
     Examples
-    ----------
+    --------
     >>> from sklearn import linear_model
     >>> clf = linear_model.PoissonRegressor()
     >>> X = [[1, 2], [2, 3], [3, 4], [4, 3]]
@@ -507,7 +507,7 @@ class PoissonRegressor(GeneralizedLinearRegressor):
     array([10.676..., 21.875...])
 
     See Also
-    ----------
+    --------
     GeneralizedLinearRegressor : Generalized Linear Model with a Poisson
         distribution.
     """
@@ -758,7 +758,7 @@ class TweedieRegressor(GeneralizedLinearRegressor):
     GammaRegressor : Generalized Linear Model with a Gamma distribution.
 
     Examples
-    ----------
+    --------
     >>> from sklearn import linear_model
     >>> clf = linear_model.TweedieRegressor()
     >>> X = [[1, 2], [2, 3], [3, 4], [4, 3]]

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -489,6 +489,11 @@ class PoissonRegressor(GeneralizedLinearRegressor):
     n_iter_ : int
         Actual number of iterations used in the solver.
 
+    See Also
+    --------
+    GeneralizedLinearRegressor : Generalized Linear Model with a Poisson
+        distribution.
+
     Examples
     --------
     >>> from sklearn import linear_model
@@ -505,11 +510,6 @@ class PoissonRegressor(GeneralizedLinearRegressor):
     2.088...
     >>> clf.predict([[1, 1], [3, 4]])
     array([10.676..., 21.875...])
-
-    See Also
-    --------
-    GeneralizedLinearRegressor : Generalized Linear Model with a Poisson
-        distribution.
     """
 
     def __init__(

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -21,7 +21,7 @@ class PrecisionRecallDisplay:
     Read more in the :ref:`User Guide <visualizations>`.
 
     Parameters
-    -----------
+    ----------
     precision : ndarray
         Precision values.
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -826,7 +826,7 @@ def manhattan_distances(X, Y=None, *, sum_over_features=True):
         the pairwise L1 distances.
 
     Notes
-    --------
+    -----
     When X and/or Y are CSR sparse matrices and they are not already
     in canonical format, this function modifies them in-place to
     make them canonical.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1321,7 +1321,7 @@ class GridSearchCV(BaseSearchCV):
     n_jobs`.
 
     See Also
-    ---------
+    --------
     ParameterGrid : Generates all the combinations of a hyperparameter grid.
     train_test_split : Utility function to split the data into a development
         set usable for fitting a GridSearchCV instance and an evaluation set

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1307,6 +1307,15 @@ class GridSearchCV(BaseSearchCV):
 
         .. versionadded:: 1.0
 
+    See Also
+    --------
+    ParameterGrid : Generates all the combinations of a hyperparameter grid.
+    train_test_split : Utility function to split the data into a development
+        set usable for fitting a GridSearchCV instance and an evaluation set
+        for its final evaluation.
+    sklearn.metrics.make_scorer : Make a scorer from a performance metric or
+        loss function.
+
     Notes
     -----
     The parameters selected are those that maximize the score of the left out
@@ -1319,15 +1328,6 @@ class GridSearchCV(BaseSearchCV):
     this case is to set `pre_dispatch`. Then, the memory is copied only
     `pre_dispatch` many times. A reasonable value for `pre_dispatch` is `2 *
     n_jobs`.
-
-    See Also
-    --------
-    ParameterGrid : Generates all the combinations of a hyperparameter grid.
-    train_test_split : Utility function to split the data into a development
-        set usable for fitting a GridSearchCV instance and an evaluation set
-        for its final evaluation.
-    sklearn.metrics.make_scorer : Make a scorer from a performance metric or
-        loss function.
 
     Examples
     --------

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -488,17 +488,6 @@ def cross_val_score(
     scores : ndarray of float of shape=(len(list(cv)),)
         Array of scores of the estimator for each run of the cross validation.
 
-    Examples
-    --------
-    >>> from sklearn import datasets, linear_model
-    >>> from sklearn.model_selection import cross_val_score
-    >>> diabetes = datasets.load_diabetes()
-    >>> X = diabetes.data[:150]
-    >>> y = diabetes.target[:150]
-    >>> lasso = linear_model.Lasso()
-    >>> print(cross_val_score(lasso, X, y, cv=3))
-    [0.3315057  0.08022103 0.03531816]
-
     See Also
     --------
     cross_validate : To run cross-validation on multiple metrics and also to
@@ -509,6 +498,17 @@ def cross_val_score(
 
     sklearn.metrics.make_scorer : Make a scorer from a performance metric or
         loss function.
+
+    Examples
+    --------
+    >>> from sklearn import datasets, linear_model
+    >>> from sklearn.model_selection import cross_val_score
+    >>> diabetes = datasets.load_diabetes()
+    >>> X = diabetes.data[:150]
+    >>> y = diabetes.target[:150]
+    >>> lasso = linear_model.Lasso()
+    >>> print(cross_val_score(lasso, X, y, cv=3))
+    [0.3315057  0.08022103 0.03531816]
     """
     # To ensure multimetric format is not supported
     scorer = check_scoring(estimator, scoring=scoring)

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -240,7 +240,7 @@ def cross_validate(
     [0.28009951 0.3908844  0.22784907]
 
     See Also
-    ---------
+    --------
     cross_val_score : Run cross-validation for single metric evaluation.
 
     cross_val_predict : Get predictions from each split of cross-validation for
@@ -500,7 +500,7 @@ def cross_val_score(
     [0.3315057  0.08022103 0.03531816]
 
     See Also
-    ---------
+    --------
     cross_validate : To run cross-validation on multiple metrics and also to
         return train scores, fit times and score times.
 

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -170,8 +170,8 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
     n_samples_fit_ : int
         It is the number of samples in the fitted data.
 
-    See also
-    ----------
+    See Also
+    --------
     sklearn.svm.OneClassSVM: Unsupervised Outlier Detection using
         Support Vector Machine.
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1118,7 +1118,7 @@ def column_or_1d(y, *, warn=False):
        Output data.
 
     Raises
-    -------
+    ------
     ValueError
         If `y` is not a 1D array or a 2D array with a single row or column.
     """


### PR DESCRIPTION
numpydoc 1.2 (currently in rc1) raises a UserWarning during docstring parsing when the heading underline lengths do not match the length of the heading. This PR will prevent these warnings from being emitted during the docs build process when numpydoc 1.2 is released.