### PR TITLE
ENH Support 2d y_score with 2 classes in top_k_accuracy_score w/ labels

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -356,7 +356,7 @@ Changelog
   :pr:`21481` by :user:`Guillaume Lemaitre <glemaitre>` and
   :user:`Andrés Babino <ababino>`.
 
-- |Enhancement| :func:`linear_model.ElasticNet` and
+- |Enhancement| :func:`linear_model.ElasticNet` and 
   and other linear model classes using coordinate descent show error
   messages when non-finite parameter weights are produced. :pr:`22148`
   by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.
@@ -380,7 +380,7 @@ Changelog
   returned by default. :pr:`17266` by :user:`Sylvain Marié <smarie>`.
 
 - |Enhancement| :func:`metrics.top_k_accuracy_score` now supports 2d `y_score` with
-  `y_score.shape[1] == 2` when `label` is passed in. :pr:`xxxxx` by `Thomas Fan`_.
+  `y_score.shape[1] == 2` when `label` is passed in. :pr:`22285` by `Thomas Fan`_.
 
 - |API| :class:`metrics.DistanceMetric` has been moved from
   :mod:`sklearn.neighbors` to :mod:`sklearn.metric`.
@@ -465,7 +465,7 @@ Changelog
 :mod:`sklearn.neural_network`
 .............................
 
-- |Enhancement| :func:`neural_network.MLPClassifier` and
+- |Enhancement| :func:`neural_network.MLPClassifier` and 
   :func:`neural_network.MLPRegressor` show error
   messages when optimizers produce non-finite parameter weights. :pr:`22150`
   by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -356,7 +356,7 @@ Changelog
   :pr:`21481` by :user:`Guillaume Lemaitre <glemaitre>` and
   :user:`Andrés Babino <ababino>`.
 
-- |Enhancement| :func:`linear_model.ElasticNet` and 
+- |Enhancement| :func:`linear_model.ElasticNet` and
   and other linear model classes using coordinate descent show error
   messages when non-finite parameter weights are produced. :pr:`22148`
   by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.
@@ -378,6 +378,9 @@ Changelog
   actual non-finite score in case of perfect predictions or constant `y_true`,
   instead of the finite approximation (`1.0` and `0.0` respectively) currently
   returned by default. :pr:`17266` by :user:`Sylvain Marié <smarie>`.
+
+- |Enhancement| :func:`metrics.top_k_accuracy_score` now supports 2d `y_score` with
+  `y_score.shape[1] == 2` when `label` is passed in. :pr:`xxxxx` by `Thomas Fan`_.
 
 - |API| :class:`metrics.DistanceMetric` has been moved from
   :mod:`sklearn.neighbors` to :mod:`sklearn.metric`.
@@ -462,7 +465,7 @@ Changelog
 :mod:`sklearn.neural_network`
 .............................
 
-- |Enhancement| :func:`neural_network.MLPClassifier` and 
+- |Enhancement| :func:`neural_network.MLPClassifier` and
   :func:`neural_network.MLPRegressor` show error
   messages when optimizers produce non-finite parameter weights. :pr:`22150`
   by :user:`Christian Ritter <chritter>` and :user:`Norbert Preining <norbusan>`.

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1701,7 +1701,7 @@ def top_k_accuracy_score(
     y_true = check_array(y_true, ensure_2d=False, dtype=None)
     y_true = column_or_1d(y_true)
     y_type = type_of_target(y_true, input_name="y_true")
-    if y_type == "binary" and labels is not None and len(labels) > 2:
+    if y_type == "binary" and labels is not None:
         y_type = "multiclass"
     y_score = check_array(y_score, ensure_2d=False)
     y_score = column_or_1d(y_score) if y_type == "binary" else y_score

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1854,6 +1854,15 @@ def test_top_k_accuracy_score_ties(y_true, k, true_score):
     assert top_k_accuracy_score(y_true, y_score, k=k) == pytest.approx(true_score)
 
 
+def test_top_k_accuracy_y_score_binary():
+    """Support y_score.shape[1] == 2 when labels is passed in for binary problems."""
+    y_score = np.asarray([[0.1, 0.9], [0.25, 0.75], [0.2, 0.8]])
+    y_true = [0, 1, 0]
+    score_2d = top_k_accuracy_score(y_true, y_score, k=1, labels=[0, 1])
+    score_1d = top_k_accuracy_score(y_true, y_score[:, 1], k=1)
+    assert score_2d == pytest.approx(score_1d)
+
+
 @pytest.mark.parametrize(
     "y_true, k",
     [


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #21173

#### What does this implement/fix? Explain your changes.
If `labels` are passed in, I think it safe to consider the problem multiclass.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
