### PR TITLE
MAINT pin max numpydoc for now

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -147,7 +147,7 @@ fi
 if [[ "$TEST_DOCSTRINGS" == "true" ]]; then
     # numpydoc requires sphinx
     python -m pip install sphinx
-    python -m pip install numpydoc
+    python -m pip install "numpydoc<1.2"  # TODO: update the docstring
 fi
 
 python --version

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -147,7 +147,9 @@ fi
 if [[ "$TEST_DOCSTRINGS" == "true" ]]; then
     # numpydoc requires sphinx
     python -m pip install sphinx
-    python -m pip install "numpydoc<1.2"  # TODO: update the docstring
+    # TODO: update the docstring checks to be compatible with new
+    # numpydoc versions
+    python -m pip install "numpydoc<1.2"
 fi
 
 python --version


### PR DESCRIPTION
numpydoc 1.2 is breaking many PRs on unrelated test failures (`test_check_docstring_parameters`):

```
RuntimeError: Error for sklearn.utils.tests.test_testing.Klass.f_bad_sections:
```

There is no quick fix as several tests in `test_testing` needs to be updated. So in the mean time let's pin numpydoc.