### PR TITLE
DOC Fix selection of parameter names in documentation

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -714,8 +714,9 @@ dl.field-list > dt:after {
 
 .classifier::before {
   font-style: normal;
-  margin: 0.3em;
+  margin: 0 0.3em;
   content: ":";
+  display: inline-block;
 }
 
 dd {


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fix the selection of parameters name (double-clicking) in the HTML rendered documentation.
Previously, when you double-clicked in a parameter name in the documentation, both the parameter and the type got selected.
![image](https://user-images.githubusercontent.com/2133361/150891808-0d6c7f5c-14df-4af1-ba90-3c28e9745b1b.png)

After this fix, the selection highlights:
![image](https://user-images.githubusercontent.com/2133361/150892039-b26fffad-6077-4856-809c-466201e0b459.png)


#### Any other comments?
This fix was taken from [Matplotlib PR 21435](https://github.com/matplotlib/matplotlib/pull/21435).

This is already fixed in [sphinx-doc v4.3.0](https://github.com/sphinx-doc/sphinx/pull/9763). When we decide to increase our current version of `sphinx-doc` to [v4.3.0](https://www.sphinx-doc.org/en/master/changes.html#release-4-3-0-released-nov-11-2021) we can remove this.
