### PR TITLE
DOC Adjust class style to match previous style

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -650,14 +650,16 @@ table.longtable tr.row-odd {
   overflow: auto;
 }
 
-code.descname {
+span.descname {
   font-weight: bold;
   background-color: transparent;
   padding: 0;
+  font-family: monospace;
 }
 
-code.descclassname {
+span.descclassname {
   background-color: transparent;
+  font-family: monospace;
 }
 
 .viewcode-link {


### PR DESCRIPTION
This PR adjusts the class style to match what it looked like it [0.24](https://scikit-learn.org/0.24/modules/generated/sklearn.cluster.MeanShift.html#sklearn.cluster.MeanShift)

#### This PR

![Screen Shot 2022-01-24 at 11 02 38 PM](https://user-images.githubusercontent.com/5402633/150908775-c6f46501-1dd7-4a4c-8f3d-8a43b250b783.jpg)

#### main

![Screen Shot 2022-01-24 at 11 01 49 PM](https://user-images.githubusercontent.com/5402633/150908781-9a3212b5-9a88-47ed-8986-f0d7e8eee637.jpg)

(New version of sphinx turn these code tags into spans)
