### PR TITLE
DOC fix cache argument documentation in fetch_openml

### DIFF
--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -651,7 +651,7 @@ def fetch_openml(
         can handle all types of multi-output combinations)
 
     cache : bool, default=True
-        Whether to cache downloaded datasets using joblib.
+        Whether to cache downloaded datasets.
 
     return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object. See

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -651,7 +651,7 @@ def fetch_openml(
         can handle all types of multi-output combinations)
 
     cache : bool, default=True
-        Whether to cache downloaded datasets.
+        Whether to cache the downloaded datasets into `data_home`.
 
     return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object. See


### PR DESCRIPTION
Fix #22301 
Update `cache` argument description in `fetch_openml` doc so that it matches the implementation.
