### PR TITLE
MAINT Follow-up on a fix for criterion="poisson" in decision trees

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -520,23 +520,23 @@ Changelog
   `n_iter_`, the number of iterations of the libsvm optimization routine.
   :pr:`21408` by :user:`Juan Martín Loyola <jmloyola>`.
 
+- |Enhancement| :func:`svm.SVR`, :func:`svm.SVC`, :func:`svm.NuSVR`,
+  :func:`svm.OneClassSVM`, :func:`svm.NuSVC` now raise an error
+  when the dual-gap estimation produce non-finite parameter weights.
+  :pr:`22149` by :user:`Christian Ritter <chritter>` and
+  :user:`Norbert Preining <norbusan>`.
+
 - |Fix| :class:`smv.NuSVC`, :class:`svm.NuSVR`, :class:`svm.SVC`,
   :class:`svm.SVR`, :class:`svm.OneClassSVM` now validate input
   parameters in `fit` instead of `__init__`.
   :pr:`21436` by :user:`Haidar Almubarak <Haidar13 >`.
 
 :mod:`sklearn.tree`
-.......................
+...................
 
 - |Fix| Fix a bug in the Poisson splitting criterion for
   :class:`tree.DecisionTreeRegressor`.
   :pr:`22191` by :user:`Christian Lorentzen <lorentzenchr>`.
-
-- |Enhancement| :func:`svm.SVR`, :func:`svm.SVC`, :func:`svm.NuSVR`,
-  :func:`svm.OneClassSVM`, :func:`svm.NuSVC` now raise an error
-  when the dual-gap estimation produce non-finite parameter weights.
-  :pr:`22149` by :user:`Christian Ritter <chritter>` and
-  :user:`Norbert Preining <norbusan>`.
 
 :mod:`sklearn.utils`
 ....................

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -229,7 +229,7 @@ def test_poisson_vs_mse():
     forest_mse.fit(X_train, y_train)
     dummy = DummyRegressor(strategy="mean").fit(X_train, y_train)
 
-    for X, y, val in [(X_train, y_train, "train"), (X_test, y_test, "test")]:
+    for X, y, data_name in [(X_train, y_train, "train"), (X_test, y_test, "test")]:
         metric_poi = mean_poisson_deviance(y, forest_poi.predict(X))
         # squared_error forest might produce non-positive predictions => clip
         # If y = 0 for those, the poisson deviance gets too good.
@@ -244,9 +244,9 @@ def test_poisson_vs_mse():
         # As squared_error might correctly predict 0 in train set, its train
         # score can be better than Poisson. This is no longer the case for the
         # test set. But keep the above comment for clipping in mind.
-        if val == "test":
+        if data_name == "val":
             assert metric_poi < metric_mse
-        assert metric_poi < 0.5 * metric_dummy
+        assert metric_poi < 0.8 * metric_dummy
 
 
 @pytest.mark.parametrize("criterion", ("poisson", "squared_error"))

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -244,7 +244,7 @@ def test_poisson_vs_mse():
         # As squared_error might correctly predict 0 in train set, its train
         # score can be better than Poisson. This is no longer the case for the
         # test set. But keep the above comment for clipping in mind.
-        if data_name == "val":
+        if data_name == "test":
             assert metric_poi < metric_mse
         assert metric_poi < 0.8 * metric_dummy
 


### PR DESCRIPTION
Follow-up PR on #22191.

- fixes the ordering of the changelog;
- make `sklearn.ensemble.test.test_forest.test_tree` robust to a change in the random seed (I tried all seed in the [0-99] range).
