### PR TITLE
MAINT enable verbose pytest on Azure to debug #MercuryRetrograde stalled builds

### DIFF
--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -52,5 +52,5 @@ if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
 fi
 
 set -x
-eval "$TEST_CMD --pyargs sklearn"
+eval "$TEST_CMD --verbose --pyargs sklearn"
 set +x


### PR DESCRIPTION
Trying to understand why some builds stall on Azure Pipelines despite the merge of #22302 that disabled `pytest-xdist`.

Edit: example stalled test after the merge of #22302:

- `Linux_Nightly pylatest_pip_scipy_dev` at 43% apparently in `neighbors/tests/test_neighbors.py`: https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=37402&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081
- `Linux pylatest_pip_openblas_pandas` at 97% in `utils/tests/test_optimize.py`: https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=37396&view=logs&j=78a0bf4f-79e5-5387-94ec-13e67d216d6e&t=f1857171-4a53-55c7-3ab5-90acfe091baa
- `macOS pylatest_conda_forge_mkl` at 97% in `utils/tests/test_optimize.py`: https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=37396&view=logs&j=97641769-79fb-5590-9088-a30ce9b850b9&t=4745baa1-36b5-56c8-9a8e-6480742db1a6
- `Linux pylatest_pip_openblas_pandas` at 97% in`utils/tests/test_optimize.py`: https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=37404&view=logs&j=78a0bf4f-79e5-5387-94ec-13e67d216d6e&t=f1857171-4a53-55c7-3ab5-90acfe091baa
- `macOS pylatest_conda_forge_mkl` at 47% in `neighbors/tests/test_neighbors.py` https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=37404&view=logs&j=97641769-79fb-5590-9088-a30ce9b850b9&t=4745baa1-36b5-56c8-9a8e-6480742db1a6

Stalled builds from this PR with verbosity enabled:

- `Linux_Runs pylatest_conda_forge_mkl` after `utils/tests/test_parallel.py::test_configuration_passes_through_to_joblib[multiprocessing-1] PASSED [ 97%]` https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=37403&view=logs&j=dde5042c-7464-5d47-9507-31bdd2ee0a3a&t=4bd2dad8-62b3-5bf9-08a5-a9880c530c94
- `Linux pylatest_pip_openblas_pandas` after after `neighbors/tests/test_neighbors.py::test_same_radius_neighbors_parallel[auto] PASSED [ 43%]` https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=37403&view=logs&j=78a0bf4f-79e5-5387-94ec-13e67d216d6e
- `macOS pylatest_conda_mkl_no_openmp` after `neighbors/tests/test_neighbors.py::test_knn_forcing_backend[kd_tree-testing] PASSED [ 47%]` https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=37403&view=logs&j=e6d5b7c0-0dfd-5ddf-13d5-c71bebf56ce2&t=c500742d-7cbe-569e-8da5-94db9b4cd21e