### PR TITLE
MAINT using pytest-xdist and pin coverage to 6.2

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -137,7 +137,7 @@ python -m pip install $(get_dep threadpoolctl $THREADPOOLCTL_VERSION) \
                       $(get_dep pytest-xdist $PYTEST_XDIST_VERSION)
 
 if [[ "$COVERAGE" == "true" ]]; then
-    # coverage is pinned to 6.2 because 6.3 multiprocessing fork-safe
+    # XXX: coverage is temporary pinned to 6.2 because 6.3 multiprocessing fork-safe
     # cf. https://github.com/nedbat/coveragepy/issues/1310
     python -m pip install codecov pytest-cov coverage==6.2
 fi

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -137,6 +137,8 @@ python -m pip install $(get_dep threadpoolctl $THREADPOOLCTL_VERSION) \
                       $(get_dep pytest-xdist $PYTEST_XDIST_VERSION)
 
 if [[ "$COVERAGE" == "true" ]]; then
+    # coverage is pinned to 6.2 because 6.3 multiprocessing fork-safe
+    # cf. https://github.com/nedbat/coveragepy/issues/1310
     python -m pip install codecov pytest-cov coverage==6.2
 fi
 

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -137,7 +137,7 @@ python -m pip install $(get_dep threadpoolctl $THREADPOOLCTL_VERSION) \
                       $(get_dep pytest-xdist $PYTEST_XDIST_VERSION)
 
 if [[ "$COVERAGE" == "true" ]]; then
-    python -m pip install codecov pytest-cov
+    python -m pip install codecov pytest-cov coverage==6.2
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then

--- a/build_tools/azure/install_win.sh
+++ b/build_tools/azure/install_win.sh
@@ -24,7 +24,7 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then
-    # coverage is pinned to 6.2 because 6.3 multiprocessing fork-safe
+    # XXX: coverage is temporary pinned to 6.2 because 6.3 multiprocessing fork-safe
     # cf. https://github.com/nedbat/coveragepy/issues/1310
     pip install coverage codecov pytest-cov coverage==6.2
 fi

--- a/build_tools/azure/install_win.sh
+++ b/build_tools/azure/install_win.sh
@@ -24,7 +24,7 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then
-    pip install coverage codecov pytest-cov
+    pip install coverage codecov pytest-cov coverage==6.2
 fi
 
 python --version

--- a/build_tools/azure/install_win.sh
+++ b/build_tools/azure/install_win.sh
@@ -24,6 +24,8 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then
+    # coverage is pinned to 6.2 because 6.3 multiprocessing fork-safe
+    # cf. https://github.com/nedbat/coveragepy/issues/1310
     pip install coverage codecov pytest-cov coverage==6.2
 fi
 

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -32,7 +32,7 @@ jobs:
     MATPLOTLIB_VERSION: 'latest'
     PYTEST_VERSION: 'latest'
     # Disable pytest-xdist as it can stall builds
-    PYTEST_XDIST_VERSION: 'none'
+    PYTEST_XDIST_VERSION: 'latest'
     THREADPOOLCTL_VERSION: 'latest'
     COVERAGE: 'true'
     TEST_DOCSTRINGS: 'false'

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -18,7 +18,7 @@ jobs:
     SKLEARN_SKIP_NETWORK_TESTS: '1'
     PYTEST_VERSION: '5.2.1'
     # Disable pytest-xdist as it can stall builds
-    PYTEST_XDIST_VERSION: 'none'
+    PYTEST_XDIST_VERSION: 'latest'
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
     SHOW_SHORT_SUMMARY: 'false'
     CPU_COUNT: '2'

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -54,7 +54,7 @@ mamba install --verbose -y  ccache \
 setup_ccache
 
 if [[ "$COVERAGE" == "true" ]]; then
-    # coverage is pinned to 6.2 because 6.3 multiprocessing fork-safe
+    # XXX: coverage is temporary pinned to 6.2 because 6.3 multiprocessing fork-safe
     # cf. https://github.com/nedbat/coveragepy/issues/1310
     mamba install --verbose -y codecov pytest-cov coverage==6.2
 fi

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -54,6 +54,8 @@ mamba install --verbose -y  ccache \
 setup_ccache
 
 if [[ "$COVERAGE" == "true" ]]; then
+    # coverage is pinned to 6.2 because 6.3 multiprocessing fork-safe
+    # cf. https://github.com/nedbat/coveragepy/issues/1310
     mamba install --verbose -y codecov pytest-cov coverage==6.2
 fi
 

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -54,7 +54,7 @@ mamba install --verbose -y  ccache \
 setup_ccache
 
 if [[ "$COVERAGE" == "true" ]]; then
-    mamba install --verbose -y codecov pytest-cov
+    mamba install --verbose -y codecov pytest-cov coverage==6.2
 fi
 
 if [[ "$TEST_DOCSTRINGS" == "true" ]]; then

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -56,7 +56,7 @@ setup_ccache
 if [[ "$COVERAGE" == "true" ]]; then
     # XXX: coverage is temporary pinned to 6.2 because 6.3 multiprocessing fork-safe
     # cf. https://github.com/nedbat/coveragepy/issues/1310
-    mamba install --verbose -y codecov pytest-cov coverage==6.2
+    mamba install --verbose -y codecov pytest-cov coverage=6.2
 fi
 
 if [[ "$TEST_DOCSTRINGS" == "true" ]]; then


### PR DESCRIPTION
Related to #22309

Just checked that the upgrade from `coverage` 6.2 to 6.3 is not the reason for CI builds to stall.