### PR TITLE
[NO MRG] CI Use windows-2022 [cd build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,33 +49,33 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          - os: windows-latest
+          - os: windows-2022
             python: 37
             bitness: 64
             platform_id: win_amd64
-          - os: windows-latest
+          - os: windows-2022
             python: 38
             bitness: 64
             platform_id: win_amd64
-          - os: windows-latest
+          - os: windows-2022
             python: 39
             bitness: 64
             platform_id: win_amd64
-          - os: windows-latest
+          - os: windows-2022
             python: 310
             bitness: 64
             platform_id: win_amd64
 
           # Window 32 bit
-          - os: windows-latest
+          - os: windows-2022
             python: 37
             bitness: 32
             platform_id: win32
-          - os: windows-latest
+          - os: windows-2022
             python: 38
             bitness: 32
             platform_id: win32
-          - os: windows-latest
+          - os: windows-2022
             python: 39
             bitness: 32
             platform_id: win32


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #22310

#### What does this implement/fix? Explain your changes.
From reading about this issue on [stackoverflow](https://stackoverflow.com/questions/14372706/visual-studio-cant-build-due-to-rc-exe?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa), I suspect it that the compiler toolchain is not always setup correctly. It looks like the workaround is to copy `rc.exe` into a directory on the PATH. There is no clear pattern from the [logs](https://github.com/scikit-learn/scikit-learn/actions/workflows/wheels.yml?query=branch%3Amain+event%3Aschedule) on when this happens.

Before doing any workarounds around `rc.exe`, I think its worth trying an updated version of windows server and see if the problem continues on the nightly builds.

CC @ogrisel 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
