### PR TITLE
DOC Ensures that graphical_lasso passes numpydoc validation

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -183,8 +183,10 @@ def graphical_lasso(
 
     See Also
     --------
-    GraphicalLasso : Sparse inverse covariance estimation with an l1-penalized estimator.
-    GraphicalLassoCV : Sparse inverse covariance with cross-validated choice of the l1 penalty.
+    GraphicalLasso : Sparse inverse covariance estimation
+        with an l1-penalized estimator.
+    GraphicalLassoCV : Sparse inverse covariance with
+        cross-validated choice of the l1 penalty.
 
     Notes
     -----

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -111,7 +111,7 @@ def graphical_lasso(
     eps=np.finfo(np.float64).eps,
     return_n_iter=False,
 ):
-    """l1-penalized covariance estimator
+    """L1-penalized covariance estimator.
 
     Read more in the :ref:`User Guide <sparse_inverse_covariance>`.
 
@@ -183,7 +183,8 @@ def graphical_lasso(
 
     See Also
     --------
-    GraphicalLasso, GraphicalLassoCV
+    GraphicalLasso : Sparse inverse covariance estimation with an l1-penalized estimator.
+    GraphicalLassoCV : Sparse inverse covariance with cross-validated choice of the l1 penalty.
 
     Notes
     -----

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -12,7 +12,6 @@ import sklearn
 numpydoc_validation = pytest.importorskip("numpydoc.validate")
 
 FUNCTION_DOCSTRING_IGNORE_LIST = [
-    "sklearn.covariance._graph_lasso.graphical_lasso",
     "sklearn.covariance._robust_covariance.fast_mcd",
     "sklearn.covariance._shrunk_covariance.ledoit_wolf",
     "sklearn.covariance._shrunk_covariance.ledoit_wolf_shrinkage",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350


#### What does this implement/fix? Explain your changes.

Wrote missing description of GraphicalLasso and GraphicalLassoCV in sklearn.covariance.graphical_lasso.

#### Any other comments?
Description of GraphicalLasso is wrong in sklearn.covariance.GraphicalLassoCV.
Have already raised issue at Addresses #22325 
