### PR TITLE
DOC Ensures that fetch_20newsgroups passes numpydoc validation

### DIFF
--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -239,6 +239,10 @@ def fetch_20newsgroups(
             The names of target classes.
 
     (data, target) : tuple if `return_X_y=True`
+        A tuple of two ndarrays. The first contains a 2D array of shape (n_samples, n_classes) 
+        with each row representing one sample and each column representing the features. 
+        The second array of shape (n_samples,) contains the target samples.
+
         .. versionadded:: 0.22
     """
 

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -239,9 +239,10 @@ def fetch_20newsgroups(
             The names of target classes.
 
     (data, target) : tuple if `return_X_y=True`
-        A tuple of two ndarrays. The first contains a 2D array of shape (n_samples, n_classes) 
-        with each row representing one sample and each column representing the features. 
-        The second array of shape (n_samples,) contains the target samples.
+        A tuple of two ndarrays. The first contains a 2D array of shape
+        (n_samples, n_classes) with each row representing one sample and each
+        column representing the features. The second array of shape
+        (n_samples,) contains the target samples.
 
         .. versionadded:: 0.22
     """

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -42,7 +42,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.datasets._svmlight_format_io.dump_svmlight_file",
     "sklearn.datasets._svmlight_format_io.load_svmlight_file",
     "sklearn.datasets._svmlight_format_io.load_svmlight_files",
-    "sklearn.datasets._twenty_newsgroups.fetch_20newsgroups",
     "sklearn.decomposition._dict_learning.dict_learning",
     "sklearn.decomposition._dict_learning.dict_learning_online",
     "sklearn.decomposition._dict_learning.sparse_encode",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR fixes the following error that was appearing for numpydoc validation for sklearn.datasets._twenty_newsgroups.fetch_20newsgroups


-RT03: Return value has no description

#### Any other comments?
Thanks

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
