### PR TITLE
DOC Ensures that make_sparse_spd_matrix passes numpydoc

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1411,7 +1411,7 @@ def make_sparse_spd_matrix(
 
     norm_diag : bool, default=False
         Whether to normalize the output matrix to make the leading diagonal
-        elements all 1
+        elements all 1.
 
     smallest_coef : float, default=0.1
         The value of the smallest coefficient between 0 and 1.
@@ -1429,15 +1429,15 @@ def make_sparse_spd_matrix(
     prec : sparse matrix of shape (dim, dim)
         The generated matrix.
 
+    See Also
+    --------
+    make_spd_matrix : Generate a random symmetric, positive-definite matrix.
+
     Notes
     -----
     The sparsity is actually imposed on the cholesky factor of the matrix.
     Thus alpha does not translate directly into the filling fraction of
     the matrix itself.
-
-    See Also
-    --------
-    make_spd_matrix
     """
     random_state = check_random_state(random_state)
 

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -36,7 +36,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.datasets._samples_generator.make_multilabel_classification",
     "sklearn.datasets._samples_generator.make_regression",
     "sklearn.datasets._samples_generator.make_sparse_coded_signal",
-    "sklearn.datasets._samples_generator.make_sparse_spd_matrix",
     "sklearn.datasets._samples_generator.make_spd_matrix",
     "sklearn.datasets._species_distributions.fetch_species_distributions",
     "sklearn.datasets._svmlight_format_io.dump_svmlight_file",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR fixes the following error that was appearing for numpydoc validation for sklearn.datasets._samples_generator.make_sparse_spd_matrix

- GL07: Sections are in the wrong order. Correct order is: Parameters, Returns, See Also, Notes
- PR09: Parameter "norm_diag" description should finish with "."
- SA04: Missing description for See Also "make_spd_matrix" reference

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
