### PR TITLE
MNT Add sklearn-env folder into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ _configtest.o.d
 # Used by mypy
 .mypy_cache/
 
+# virtualenv from advanced installation guide
+sklearn-env/
+
 # files generated from a template
 sklearn/_loss/_loss.pyx
 sklearn/utils/_seq_dataset.pyx


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/pull/22342 which adds the entire virtualenv folder into the commit.


#### What does this implement/fix? Explain your changes.
In our [Advanced Installation](https://scikit-learn.org/stable/developers/advanced_installation.html#building-from-source) item 3, we have a virtualenv created called `sklearn-env`. I think we should add this to `gitignore` just in case someone uses this method for development.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
