### PR TITLE
FIX downcast nominal features whenever possible in LIAC-ARFF

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -145,6 +145,10 @@ Changelog
   3 times in case of a network failure with a delay between each try.
   :pr:`21901` by :user:`Rileran <rileran>`.
 
+- |Fix| :func:`datasets.fetch_openml` now downcast whenever possible values
+  that are specified as nominal features instead of storing them as strings.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -145,7 +145,7 @@ Changelog
   3 times in case of a network failure with a delay between each try.
   :pr:`21901` by :user:`Rileran <rileran>`.
 
-- |Fix| :func:`datasets.fetch_openml` now downcast whenever possible values
+- |Fix| :func:`datasets.fetch_openml` now downcasts whenever possible values
   that are specified as nominal features instead of storing them as strings.
   :pr:`22354` by :user:`Guillaume Lemaitre <glemaitre>`.
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -147,7 +147,7 @@ Changelog
 
 - |Fix| :func:`datasets.fetch_openml` now downcast whenever possible values
   that are specified as nominal features instead of storing them as strings.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`22354` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.decomposition`
 ............................

--- a/sklearn/externals/_arff.py
+++ b/sklearn/externals/_arff.py
@@ -24,7 +24,7 @@
 # SOFTWARE.
 # =============================================================================
 
-'''
+"""
 The liac-arff module implements functions to read and write ARFF files in
 Python. It was created in the Connectionist Artificial Intelligence Laboratory
 (LIAC), which takes place at the Federal University of Rio Grande do Sul
@@ -140,12 +140,14 @@ This module provides several features, including:
 - Fully compatible with Python 2.7+, Python 3.5+, pypy and pypy3;
 - Under `MIT License <http://opensource.org/licenses/MIT>`_
 
-'''
-__author__ = 'Renato de Pontes Pereira, Matthias Feurer, Joel Nothman'
-__author_email__ = ('renato.ppontes@gmail.com, '
-                    'feurerm@informatik.uni-freiburg.de, '
-                    'joel.nothman@gmail.com')
-__version__ = '2.4.0'
+"""
+__author__ = "Renato de Pontes Pereira, Matthias Feurer, Joel Nothman"
+__author_email__ = (
+    "renato.ppontes@gmail.com, "
+    "feurerm@informatik.uni-freiburg.de, "
+    "joel.nothman@gmail.com"
+)
+__version__ = "2.4.0"
 
 import re
 import csv
@@ -153,20 +155,20 @@ from typing import TYPE_CHECKING
 from typing import Optional, List, Dict, Any, Iterator, Union, Tuple
 
 # CONSTANTS ===================================================================
-_SIMPLE_TYPES = ['NUMERIC', 'REAL', 'INTEGER', 'STRING']
+_SIMPLE_TYPES = ["NUMERIC", "REAL", "INTEGER", "STRING"]
 
-_TK_DESCRIPTION = '%'
-_TK_COMMENT     = '%'
-_TK_RELATION    = '@RELATION'
-_TK_ATTRIBUTE   = '@ATTRIBUTE'
-_TK_DATA        = '@DATA'
+_TK_DESCRIPTION = "%"
+_TK_COMMENT = "%"
+_TK_RELATION = "@RELATION"
+_TK_ATTRIBUTE = "@ATTRIBUTE"
+_TK_DATA = "@DATA"
 
-_RE_RELATION     = re.compile(r'^([^\{\}%,\s]*|\".*\"|\'.*\')$', re.UNICODE)
-_RE_ATTRIBUTE    = re.compile(r'^(\".*\"|\'.*\'|[^\{\}%,\s]*)\s+(.+)$', re.UNICODE)
+_RE_RELATION = re.compile(r"^([^\{\}%,\s]*|\".*\"|\'.*\')$", re.UNICODE)
+_RE_ATTRIBUTE = re.compile(r"^(\".*\"|\'.*\'|[^\{\}%,\s]*)\s+(.+)$", re.UNICODE)
 _RE_QUOTE_CHARS = re.compile(r'["\'\\\s%,\000-\031]', re.UNICODE)
 _RE_ESCAPE_CHARS = re.compile(r'(?=["\'\\%])|[\n\r\t\000-\031]')
-_RE_SPARSE_LINE = re.compile(r'^\s*\{.*\}\s*$', re.UNICODE)
-_RE_NONTRIVIAL_DATA = re.compile('["\'{}\\s]', re.UNICODE)
+_RE_SPARSE_LINE = re.compile(r"^\s*\{.*\}\s*$", re.UNICODE)
+_RE_NONTRIVIAL_DATA = re.compile("[\"'{}\\s]", re.UNICODE)
 
 ArffDenseDataType = Iterator[List]
 ArffSparseDataType = Tuple[List, ...]
@@ -182,12 +184,13 @@ if TYPE_CHECKING:
         attributes: List
         data: Union[ArffDenseDataType, ArffSparseDataType]
 
+
 else:
     ArffContainerType = Dict[str, Any]
 
 
 def _build_re_values():
-    quoted_re = r'''
+    quoted_re = r"""
                     "      # open quote followed by zero or more of:
                     (?:
                         (?<!\\)    # no additional backslash
@@ -199,30 +202,37 @@ def _build_re_values():
                         [^"\\]     # non-quote char
                     )*
                     "      # close quote
-                    '''
+                    """
     # a value is surrounded by " or by ' or contains no quotables
-    value_re = r'''(?:
+    value_re = r"""(?:
         %s|          # a value may be surrounded by "
         %s|          # or by '
         [^,\s"'{}]+  # or may contain no characters requiring quoting
-        )''' % (quoted_re,
-                quoted_re.replace('"', "'"))
+        )""" % (
+        quoted_re,
+        quoted_re.replace('"', "'"),
+    )
 
     # This captures (value, error) groups. Because empty values are allowed,
     # we cannot just look for empty values to handle syntax errors.
     # We presume the line has had ',' prepended...
-    dense = re.compile(r'''(?x)
+    dense = re.compile(
+        r"""(?x)
         ,                # may follow ','
         \s*
         ((?=,)|$|{value_re})  # empty or value
         |
         (\S.*)           # error
-        '''.format(value_re=value_re))
+        """.format(
+            value_re=value_re
+        )
+    )
 
     # This captures (key, value) groups and will have an empty key/value
     # in case of syntax errors.
     # It does not ensure that the line starts with '{' or ends with '}'.
-    sparse = re.compile(r'''(?x)
+    sparse = re.compile(
+        r"""(?x)
         (?:^\s*\{|,)   # may follow ',', or '{' at line start
         \s*
         (\d+)          # attribute key
@@ -232,29 +242,30 @@ def _build_re_values():
         (?!}\s*$)      # not an error if it's }$
         (?!^\s*{\s*}\s*$)  # not an error if it's ^{}$
         \S.*           # error
-        ''' % {'value_re': value_re})
+        """
+        % {"value_re": value_re}
+    )
     return dense, sparse
-
 
 
 _RE_DENSE_VALUES, _RE_SPARSE_KEY_VALUES = _build_re_values()
 
 
 _ESCAPE_SUB_MAP = {
-    '\\\\': '\\',
+    "\\\\": "\\",
     '\\"': '"',
     "\\'": "'",
-    '\\t': '\t',
-    '\\n': '\n',
-    '\\r': '\r',
-    '\\b': '\b',
-    '\\f': '\f',
-    '\\%': '%',
+    "\\t": "\t",
+    "\\n": "\n",
+    "\\r": "\r",
+    "\\b": "\b",
+    "\\f": "\f",
+    "\\%": "%",
 }
-_UNESCAPE_SUB_MAP = {chr(i): '\\%03o' % i for i in range(32)}
+_UNESCAPE_SUB_MAP = {chr(i): "\\%03o" % i for i in range(32)}
 _UNESCAPE_SUB_MAP.update({v: k for k, v in _ESCAPE_SUB_MAP.items()})
-_UNESCAPE_SUB_MAP[''] = '\\'
-_ESCAPE_SUB_MAP.update({'\\%d' % i: chr(i) for i in range(10)})
+_UNESCAPE_SUB_MAP[""] = "\\"
+_ESCAPE_SUB_MAP.update({"\\%d" % i: chr(i) for i in range(10)})
 
 
 def _escape_sub_callback(match):
@@ -263,8 +274,8 @@ def _escape_sub_callback(match):
         try:
             return _ESCAPE_SUB_MAP[s]
         except KeyError:
-            raise ValueError('Unsupported escape sequence: %s' % s)
-    if s[1] == 'u':
+            raise ValueError("Unsupported escape sequence: %s" % s)
+    if s[1] == "u":
         return chr(int(s[2:], 16))
     else:
         return chr(int(s[1:], 8))
@@ -272,50 +283,65 @@ def _escape_sub_callback(match):
 
 def _unquote(v):
     if v[:1] in ('"', "'"):
-        return re.sub(r'\\([0-9]{1,3}|u[0-9a-f]{4}|.)', _escape_sub_callback,
-                      v[1:-1])
-    elif v in ('?', ''):
+        return re.sub(r"\\([0-9]{1,3}|u[0-9a-f]{4}|.)", _escape_sub_callback, v[1:-1])
+    elif v in ("?", ""):
         return None
     else:
         return v
 
 
+def _downcast(value):
+    """Downcast a value to integral or float type if possible."""
+    if value is None:
+        return value
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
 def _parse_values(s):
-    '''(INTERNAL) Split a line into a list of values'''
+    """(INTERNAL) Split a line into a list of values"""
     if not _RE_NONTRIVIAL_DATA.search(s):
         # Fast path for trivial cases (unfortunately we have to handle missing
         # values because of the empty string case :(.)
-        return [None if s in ('?', '') else s
-                for s in next(csv.reader([s]))]
+        values = [
+            None if s in ("?", "") else _downcast(s) for s in next(csv.reader([s]))
+        ]
 
     # _RE_DENSE_VALUES tokenizes despite quoting, whitespace, etc.
-    values, errors = zip(*_RE_DENSE_VALUES.findall(',' + s))
+    values, errors = zip(*_RE_DENSE_VALUES.findall("," + s))
     if not any(errors):
-        return [_unquote(v) for v in values]
+        return [_downcast(_unquote(v)) for v in values]
     if _RE_SPARSE_LINE.match(s):
         try:
-            return {int(k): _unquote(v)
-                    for k, v in _RE_SPARSE_KEY_VALUES.findall(s)}
+            return {
+                int(k): _downcast(_unquote(v))
+                for k, v in _RE_SPARSE_KEY_VALUES.findall(s)
+            }
         except ValueError:
             # an ARFF syntax error in sparse data
             for match in _RE_SPARSE_KEY_VALUES.finditer(s):
                 if not match.group(1):
-                    raise BadLayout('Error parsing %r' % match.group())
-            raise BadLayout('Unknown parsing error')
+                    raise BadLayout("Error parsing %r" % match.group())
+            raise BadLayout("Unknown parsing error")
     else:
         # an ARFF syntax error
         for match in _RE_DENSE_VALUES.finditer(s):
             if match.group(2):
-                raise BadLayout('Error parsing %r' % match.group())
-        raise BadLayout('Unknown parsing error')
+                raise BadLayout("Error parsing %r" % match.group())
+        raise BadLayout("Unknown parsing error")
 
 
-DENSE = 0     # Constant value representing a dense matrix
-COO = 1       # Constant value representing a sparse matrix in coordinate format
-LOD = 2       # Constant value representing a sparse matrix in list of
-              # dictionaries format
-DENSE_GEN = 3 # Generator of dictionaries
-LOD_GEN = 4   # Generator of dictionaries
+DENSE = 0  # Constant value representing a dense matrix
+COO = 1  # Constant value representing a sparse matrix in coordinate format
+LOD = 2  # Constant value representing a sparse matrix in list of
+# dictionaries format
+DENSE_GEN = 3  # Generator of dictionaries
+LOD_GEN = 4  # Generator of dictionaries
 _SUPPORTED_DATA_STRUCTURES = [DENSE, COO, LOD, DENSE_GEN, LOD_GEN]
 
 
@@ -327,89 +353,104 @@ class ArffException(Exception):
         self.line = -1
 
     def __str__(self):
-        return self.message%self.line
+        return self.message % self.line
+
 
 class BadRelationFormat(ArffException):
-    '''Error raised when the relation declaration is in an invalid format.'''
-    message = 'Bad @RELATION format, at line %d.'
+    """Error raised when the relation declaration is in an invalid format."""
+
+    message = "Bad @RELATION format, at line %d."
+
 
 class BadAttributeFormat(ArffException):
-    '''Error raised when some attribute declaration is in an invalid format.'''
-    message = 'Bad @ATTRIBUTE format, at line %d.'
+    """Error raised when some attribute declaration is in an invalid format."""
+
+    message = "Bad @ATTRIBUTE format, at line %d."
+
 
 class BadDataFormat(ArffException):
-    '''Error raised when some data instance is in an invalid format.'''
+    """Error raised when some data instance is in an invalid format."""
+
     def __init__(self, value):
         super().__init__()
-        self.message = (
-            'Bad @DATA instance format in line %d: ' +
-            ('%s' % value)
-        )
+        self.message = "Bad @DATA instance format in line %d: " + "%s" % value
+
 
 class BadAttributeType(ArffException):
-    '''Error raised when some invalid type is provided into the attribute
-    declaration.'''
-    message = 'Bad @ATTRIBUTE type, at line %d.'
+    """Error raised when some invalid type is provided into the attribute
+    declaration."""
+
+    message = "Bad @ATTRIBUTE type, at line %d."
+
 
 class BadAttributeName(ArffException):
-    '''Error raised when an attribute name is provided twice the attribute
-    declaration.'''
+    """Error raised when an attribute name is provided twice the attribute
+    declaration."""
 
     def __init__(self, value, value2):
         super().__init__()
         self.message = (
-            ('Bad @ATTRIBUTE name %s at line' % value) +
-            ' %d, this name is already in use in line' +
-            (' %d.' % value2)
+            "Bad @ATTRIBUTE name %s at line" % value
+            + " %d, this name is already in use in line"
+            + " %d." % value2
         )
+
 
 class BadNominalValue(ArffException):
-    '''Error raised when a value in used in some data instance but is not
-    declared into it respective attribute declaration.'''
+    """Error raised when a value in used in some data instance but is not
+    declared into it respective attribute declaration."""
 
     def __init__(self, value):
         super().__init__()
         self.message = (
-            ('Data value %s not found in nominal declaration, ' % value)
-            + 'at line %d.'
-        )
+            "Data value %s not found in nominal declaration, " % value
+        ) + "at line %d."
+
 
 class BadNominalFormatting(ArffException):
-    '''Error raised when a nominal value with space is not properly quoted.'''
+    """Error raised when a nominal value with space is not properly quoted."""
+
     def __init__(self, value):
         super().__init__()
         self.message = (
-            ('Nominal data value "%s" not properly quoted in line ' % value) +
-            '%d.'
-        )
+            'Nominal data value "%s" not properly quoted in line ' % value
+        ) + "%d."
+
 
 class BadNumericalValue(ArffException):
-    '''Error raised when and invalid numerical value is used in some data
-    instance.'''
-    message = 'Invalid numerical value, at line %d.'
+    """Error raised when and invalid numerical value is used in some data
+    instance."""
+
+    message = "Invalid numerical value, at line %d."
+
 
 class BadStringValue(ArffException):
-    '''Error raise when a string contains space but is not quoted.'''
-    message = 'Invalid string value at line %d.'
+    """Error raise when a string contains space but is not quoted."""
+
+    message = "Invalid string value at line %d."
+
 
 class BadLayout(ArffException):
-    '''Error raised when the layout of the ARFF file has something wrong.'''
-    message = 'Invalid layout of the ARFF file, at line %d.'
+    """Error raised when the layout of the ARFF file has something wrong."""
 
-    def __init__(self, msg=''):
+    message = "Invalid layout of the ARFF file, at line %d."
+
+    def __init__(self, msg=""):
         super().__init__()
         if msg:
-            self.message = BadLayout.message + ' ' + msg.replace('%', '%%')
+            self.message = BadLayout.message + " " + msg.replace("%", "%%")
 
 
 class BadObject(ArffException):
-    '''Error raised when the object representing the ARFF file has something
-    wrong.'''
-    def __init__(self, msg='Invalid object.'):
+    """Error raised when the object representing the ARFF file has something
+    wrong."""
+
+    def __init__(self, msg="Invalid object."):
         self.msg = msg
 
     def __str__(self):
-        return '%s' % self.msg
+        return "%s" % self.msg
+
 
 # =============================================================================
 
@@ -454,8 +495,8 @@ class NominalConversor:
 
 
 class DenseGeneratorData:
-    '''Internal helper class to allow for different matrix types without
-    making the code a huge collection of if statements.'''
+    """Internal helper class to allow for different matrix types without
+    making the code a huge collection of if statements."""
 
     def decode_rows(self, stream, conversors):
         for row in stream:
@@ -465,8 +506,9 @@ class DenseGeneratorData:
                 if values and max(values) >= len(conversors):
                     raise BadDataFormat(row)
                 # XXX: int 0 is used for implicit values, not '0'
-                values = [values[i] if i in values else 0 for i in
-                          range(len(conversors))]
+                values = [
+                    values[i] if i in values else 0 for i in range(len(conversors))
+                ]
             else:
                 if len(values) != len(conversors):
                     raise BadDataFormat(row)
@@ -476,16 +518,17 @@ class DenseGeneratorData:
     @staticmethod
     def _decode_values(values, conversors):
         try:
-            values = [None if value is None else conversor(value)
-                      for conversor, value
-                      in zip(conversors, values)]
+            values = [
+                None if value is None else conversor(value)
+                for conversor, value in zip(conversors, values)
+            ]
         except ValueError as exc:
-            if 'float: ' in str(exc):
+            if "float: " in str(exc):
                 raise BadNumericalValue()
         return values
 
     def encode_data(self, data, attributes):
-        '''(INTERNAL) Encodes a line of data.
+        """(INTERNAL) Encodes a line of data.
 
         Data instances follow the csv format, i.e, attribute values are
         delimited by commas. After converted from csv.
@@ -493,30 +536,31 @@ class DenseGeneratorData:
         :param data: a list of values.
         :param attributes: a list of attributes. Used to check if data is valid.
         :return: a string with the encoded data line.
-        '''
+        """
         current_row = 0
 
         for inst in data:
             if len(inst) != len(attributes):
                 raise BadObject(
-                    'Instance %d has %d attributes, expected %d' %
-                     (current_row, len(inst), len(attributes))
+                    "Instance %d has %d attributes, expected %d"
+                    % (current_row, len(inst), len(attributes))
                 )
 
             new_data = []
             for value in inst:
-                if value is None or value == '' or value != value:
-                    s = '?'
+                if value is None or value == "" or value != value:
+                    s = "?"
                 else:
                     s = encode_string(str(value))
                 new_data.append(s)
 
             current_row += 1
-            yield ','.join(new_data)
+            yield ",".join(new_data)
 
 
 class _DataListMixin:
     """Mixin to return a list from decode_rows instead of a generator"""
+
     def decode_rows(self, stream, conversors):
         return list(super().decode_rows(stream, conversors))
 
@@ -536,10 +580,12 @@ class COOData:
                 continue
             row_cols, values = zip(*sorted(values.items()))
             try:
-                values = [value if value is None else conversors[key](value)
-                          for key, value in zip(row_cols, values)]
+                values = [
+                    value if value is None else conversors[key](value)
+                    for key, value in zip(row_cols, values)
+                ]
             except ValueError as exc:
-                if 'float: ' in str(exc):
+                if "float: " in str(exc):
                     raise BadNumericalValue()
                 raise
             except IndexError:
@@ -563,30 +609,30 @@ class COOData:
 
         # Check if the rows are sorted
         if not all(row[i] <= row[i + 1] for i in range(len(row) - 1)):
-            raise ValueError("liac-arff can only output COO matrices with "
-                             "sorted rows.")
+            raise ValueError("liac-arff can only output COO matrices with sorted rows.")
 
         for v, col, row in zip(data, col, row):
             if row > current_row:
                 # Add empty rows if necessary
                 while current_row < row:
-                    yield " ".join(["{", ','.join(new_data), "}"])
+                    yield " ".join(["{", ",".join(new_data), "}"])
                     new_data = []
                     current_row += 1
 
             if col >= num_attributes:
                 raise BadObject(
-                    'Instance %d has at least %d attributes, expected %d' %
-                    (current_row, col + 1, num_attributes)
+                    "Instance %d has at least %d attributes, expected %d"
+                    % (current_row, col + 1, num_attributes)
                 )
 
-            if v is None or v == '' or v != v:
-                s = '?'
+            if v is None or v == "" or v != v:
+                s = "?"
             else:
                 s = encode_string(str(v))
             new_data.append("%d %s" % (col, s))
 
-        yield " ".join(["{", ','.join(new_data), "}"])
+        yield " ".join(["{", ",".join(new_data), "}"])
+
 
 class LODGeneratorData:
     def decode_rows(self, stream, conversors):
@@ -596,10 +642,12 @@ class LODGeneratorData:
             if not isinstance(values, dict):
                 raise BadLayout()
             try:
-                yield {key: None if value is None else conversors[key](value)
-                       for key, value in values.items()}
+                yield {
+                    key: None if value is None else conversors[key](value)
+                    for key, value in values.items()
+                }
             except ValueError as exc:
-                if 'float: ' in str(exc):
+                if "float: " in str(exc):
                     raise BadNumericalValue()
                 raise
             except IndexError:
@@ -615,20 +663,21 @@ class LODGeneratorData:
 
             if len(row) > 0 and max(row) >= num_attributes:
                 raise BadObject(
-                    'Instance %d has %d attributes, expected %d' %
-                    (current_row, max(row) + 1, num_attributes)
+                    "Instance %d has %d attributes, expected %d"
+                    % (current_row, max(row) + 1, num_attributes)
                 )
 
             for col in sorted(row):
                 v = row[col]
-                if v is None or v == '' or v != v:
-                    s = '?'
+                if v is None or v == "" or v != v:
+                    s = "?"
                 else:
                     s = encode_string(str(v))
                 new_data.append("%d %s" % (col, s))
 
             current_row += 1
-            yield " ".join(["{", ','.join(new_data), "}"])
+            yield " ".join(["{", ",".join(new_data), "}"])
+
 
 class LODData(_DataListMixin, LODGeneratorData):
     pass
@@ -648,31 +697,33 @@ def _get_data_object_for_decoding(matrix_type):
     else:
         raise ValueError("Matrix type %s not supported." % str(matrix_type))
 
+
 def _get_data_object_for_encoding(matrix):
     # Probably a scipy.sparse
-    if hasattr(matrix, 'format'):
-        if matrix.format == 'coo':
+    if hasattr(matrix, "format"):
+        if matrix.format == "coo":
             return COOData()
         else:
-            raise ValueError('Cannot guess matrix format!')
+            raise ValueError("Cannot guess matrix format!")
     elif isinstance(matrix[0], dict):
         return LODData()
     else:
         return Data()
 
+
 # =============================================================================
 
 # ADVANCED INTERFACE ==========================================================
 class ArffDecoder:
-    '''An ARFF decoder.'''
+    """An ARFF decoder."""
 
     def __init__(self):
-        '''Constructor.'''
+        """Constructor."""
         self._conversors = []
         self._current_line = 0
 
     def _decode_comment(self, s):
-        '''(INTERNAL) Decodes a comment line.
+        """(INTERNAL) Decodes a comment line.
 
         Comments are single line strings starting, obligatorily, with the ``%``
         character, and can have any symbol, including whitespaces or special
@@ -683,12 +734,12 @@ class ArffDecoder:
 
         :param s: a normalized string.
         :return: a string with the decoded comment.
-        '''
-        res = re.sub(r'^\%( )?', '', s)
+        """
+        res = re.sub(r"^\%( )?", "", s)
         return res
 
     def _decode_relation(self, s):
-        '''(INTERNAL) Decodes a relation line.
+        """(INTERNAL) Decodes a relation line.
 
         The relation declaration is a line with the format ``@RELATION
         <relation-name>``, where ``relation-name`` is a string. The string must
@@ -700,18 +751,18 @@ class ArffDecoder:
 
         :param s: a normalized string.
         :return: a string with the decoded relation name.
-        '''
-        _, v = s.split(' ', 1)
+        """
+        _, v = s.split(" ", 1)
         v = v.strip()
 
         if not _RE_RELATION.match(v):
             raise BadRelationFormat()
 
-        res = str(v.strip('"\''))
+        res = str(v.strip("\"'"))
         return res
 
     def _decode_attribute(self, s):
-        '''(INTERNAL) Decodes an attribute line.
+        """(INTERNAL) Decodes an attribute line.
 
         The attribute is the most complex declaration in an arff file. All
         attributes must follow the template::
@@ -736,8 +787,8 @@ class ArffDecoder:
 
         :param s: a normalized string.
         :return: a tuple (ATTRIBUTE_NAME, TYPE_OR_VALUES).
-        '''
-        _, v = s.split(' ', 1)
+        """
+        _, v = s.split(" ", 1)
         v = v.strip()
 
         # Verify the general structure of declaration
@@ -749,12 +800,12 @@ class ArffDecoder:
         name, type_ = m.groups()
 
         # Extracts the final name
-        name = str(name.strip('"\''))
+        name = str(name.strip("\"'"))
 
         # Extracts the final type
         if type_[:1] == "{" and type_[-1:] == "}":
             try:
-                type_ = _parse_values(type_.strip('{} '))
+                type_ = _parse_values(type_.strip("{} "))
             except Exception:
                 raise BadAttributeType()
             if isinstance(type_, dict):
@@ -763,27 +814,27 @@ class ArffDecoder:
         else:
             # If not nominal, verify the type name
             type_ = str(type_).upper()
-            if type_ not in ['NUMERIC', 'REAL', 'INTEGER', 'STRING']:
+            if type_ not in ["NUMERIC", "REAL", "INTEGER", "STRING"]:
                 raise BadAttributeType()
 
         return (name, type_)
 
     def _decode(self, s, encode_nominal=False, matrix_type=DENSE):
-        '''Do the job the ``encode``.'''
+        """Do the job the ``encode``."""
 
         # Make sure this method is idempotent
         self._current_line = 0
 
         # If string, convert to a list of lines
         if isinstance(s, str):
-            s = s.strip('\r\n ').replace('\r\n', '\n').split('\n')
+            s = s.strip("\r\n ").replace("\r\n", "\n").split("\n")
 
         # Create the return object
         obj: ArffContainerType = {
-            'description': '',
-            'relation': '',
-            'attributes': [],
-            'data': []
+            "description": "",
+            "relation": "",
+            "attributes": [],
+            "data": [],
         }
         attribute_names = {}
 
@@ -796,14 +847,15 @@ class ArffDecoder:
         for row in s:
             self._current_line += 1
             # Ignore empty lines
-            row = row.strip(' \r\n')
-            if not row: continue
+            row = row.strip(" \r\n")
+            if not row:
+                continue
 
             u_row = row.upper()
 
             # DESCRIPTION -----------------------------------------------------
             if u_row.startswith(_TK_DESCRIPTION) and STATE == _TK_DESCRIPTION:
-                obj['description'] += self._decode_comment(row) + '\n'
+                obj["description"] += self._decode_comment(row) + "\n"
             # -----------------------------------------------------------------
 
             # RELATION --------------------------------------------------------
@@ -812,7 +864,7 @@ class ArffDecoder:
                     raise BadLayout()
 
                 STATE = _TK_RELATION
-                obj['relation'] = self._decode_relation(row)
+                obj["relation"] = self._decode_relation(row)
             # -----------------------------------------------------------------
 
             # ATTRIBUTE -------------------------------------------------------
@@ -827,7 +879,7 @@ class ArffDecoder:
                     raise BadAttributeName(attr[0], attribute_names[attr[0]])
                 else:
                     attribute_names[attr[0]] = self._current_line
-                obj['attributes'].append(attr)
+                obj["attributes"].append(attr)
 
                 if isinstance(attr[1], (list, tuple)):
                     if encode_nominal:
@@ -835,10 +887,12 @@ class ArffDecoder:
                     else:
                         conversor = NominalConversor(attr[1])
                 else:
-                    CONVERSOR_MAP = {'STRING': str,
-                                     'INTEGER': lambda x: int(float(x)),
-                                     'NUMERIC': float,
-                                     'REAL': float}
+                    CONVERSOR_MAP = {
+                        "STRING": str,
+                        "INTEGER": lambda x: int(float(x)),
+                        "NUMERIC": float,
+                        "REAL": float,
+                    }
                     conversor = CONVERSOR_MAP[attr[1]]
 
                 self._conversors.append(conversor)
@@ -869,14 +923,14 @@ class ArffDecoder:
                     yield row
 
         # Alter the data object
-        obj['data'] = data.decode_rows(stream(), self._conversors)
-        if obj['description'].endswith('\n'):
-            obj['description'] = obj['description'][:-1]
+        obj["data"] = data.decode_rows(stream(), self._conversors)
+        if obj["description"].endswith("\n"):
+            obj["description"] = obj["description"][:-1]
 
         return obj
 
     def decode(self, s, encode_nominal=False, return_type=DENSE):
-        '''Returns the Python representation of a given ARFF file.
+        """Returns the Python representation of a given ARFF file.
 
         When a file object is passed as an argument, this method reads lines
         iteratively, avoiding to load unnecessary information to the memory.
@@ -889,20 +943,21 @@ class ArffDecoder:
             `arff.DENSE_GEN` or `arff.LOD_GEN`.
             Consult the sections on `working with sparse data`_ and `loading
             progressively`_.
-        '''
+        """
         try:
-            return self._decode(s, encode_nominal=encode_nominal,
-                                matrix_type=return_type)
+            return self._decode(
+                s, encode_nominal=encode_nominal, matrix_type=return_type
+            )
         except ArffException as e:
             e.line = self._current_line
             raise e
 
 
 class ArffEncoder:
-    '''An ARFF encoder.'''
+    """An ARFF encoder."""
 
-    def _encode_comment(self, s=''):
-        '''(INTERNAL) Encodes a comment line.
+    def _encode_comment(self, s=""):
+        """(INTERNAL) Encodes a comment line.
 
         Comments are single line strings starting, obligatorily, with the ``%``
         character, and can have any symbol, including whitespaces or special
@@ -912,30 +967,30 @@ class ArffEncoder:
 
         :param s: (OPTIONAL) string.
         :return: a string with the encoded comment line.
-        '''
+        """
         if s:
-            return '%s %s'%(_TK_COMMENT, s)
+            return "%s %s" % (_TK_COMMENT, s)
         else:
-            return '%s' % _TK_COMMENT
+            return "%s" % _TK_COMMENT
 
     def _encode_relation(self, name):
-        '''(INTERNAL) Decodes a relation line.
+        """(INTERNAL) Decodes a relation line.
 
         The relation declaration is a line with the format ``@RELATION
         <relation-name>``, where ``relation-name`` is a string.
 
         :param name: a string.
         :return: a string with the encoded relation declaration.
-        '''
-        for char in ' %{},':
+        """
+        for char in " %{},":
             if char in name:
-                name = '"%s"'%name
+                name = '"%s"' % name
                 break
 
-        return '%s %s'%(_TK_RELATION, name)
+        return "%s %s" % (_TK_RELATION, name)
 
     def _encode_attribute(self, name, type_):
-        '''(INTERNAL) Encodes an attribute line.
+        """(INTERNAL) Encodes an attribute line.
 
         The attribute follow the template::
 
@@ -956,94 +1011,99 @@ class ArffEncoder:
         :param name: a string.
         :param type_: a string or a list of string.
         :return: a string with the encoded attribute declaration.
-        '''
-        for char in ' %{},':
+        """
+        for char in " %{},":
             if char in name:
-                name = '"%s"'%name
+                name = '"%s"' % name
                 break
 
         if isinstance(type_, (tuple, list)):
-            type_tmp = ['%s' % encode_string(type_k) for type_k in type_]
-            type_ = '{%s}'%(', '.join(type_tmp))
+            type_tmp = ["%s" % encode_string(type_k) for type_k in type_]
+            type_ = "{%s}" % ", ".join(type_tmp)
 
-        return '%s %s %s'%(_TK_ATTRIBUTE, name, type_)
+        return "%s %s %s" % (_TK_ATTRIBUTE, name, type_)
 
     def encode(self, obj):
-        '''Encodes a given object to an ARFF file.
+        """Encodes a given object to an ARFF file.
 
         :param obj: the object containing the ARFF information.
         :return: the ARFF file as an string.
-        '''
+        """
         data = [row for row in self.iter_encode(obj)]
 
-        return '\n'.join(data)
+        return "\n".join(data)
 
     def iter_encode(self, obj):
-        '''The iterative version of `arff.ArffEncoder.encode`.
+        """The iterative version of `arff.ArffEncoder.encode`.
 
         This encodes iteratively a given object and return, one-by-one, the
         lines of the ARFF file.
 
         :param obj: the object containing the ARFF information.
         :return: (yields) the ARFF file as strings.
-        '''
+        """
         # DESCRIPTION
-        if obj.get('description', None):
-            for row in obj['description'].split('\n'):
+        if obj.get("description", None):
+            for row in obj["description"].split("\n"):
                 yield self._encode_comment(row)
 
         # RELATION
-        if not obj.get('relation'):
-            raise BadObject('Relation name not found or with invalid value.')
+        if not obj.get("relation"):
+            raise BadObject("Relation name not found or with invalid value.")
 
-        yield self._encode_relation(obj['relation'])
-        yield ''
+        yield self._encode_relation(obj["relation"])
+        yield ""
 
         # ATTRIBUTES
-        if not obj.get('attributes'):
-            raise BadObject('Attributes not found.')
+        if not obj.get("attributes"):
+            raise BadObject("Attributes not found.")
 
         attribute_names = set()
-        for attr in obj['attributes']:
+        for attr in obj["attributes"]:
             # Verify for bad object format
-            if not isinstance(attr, (tuple, list)) or \
-               len(attr) != 2 or \
-               not isinstance(attr[0], str):
-                raise BadObject('Invalid attribute declaration "%s"'%str(attr))
+            if (
+                not isinstance(attr, (tuple, list))
+                or len(attr) != 2
+                or not isinstance(attr[0], str)
+            ):
+                raise BadObject('Invalid attribute declaration "%s"' % str(attr))
 
             if isinstance(attr[1], str):
                 # Verify for invalid types
                 if attr[1] not in _SIMPLE_TYPES:
-                    raise BadObject('Invalid attribute type "%s"'%str(attr))
+                    raise BadObject('Invalid attribute type "%s"' % str(attr))
 
             # Verify for bad object format
             elif not isinstance(attr[1], (tuple, list)):
-                raise BadObject('Invalid attribute type "%s"'%str(attr))
+                raise BadObject('Invalid attribute type "%s"' % str(attr))
 
             # Verify attribute name is not used twice
             if attr[0] in attribute_names:
-                raise BadObject('Trying to use attribute name "%s" for the '
-                                'second time.' % str(attr[0]))
+                raise BadObject(
+                    'Trying to use attribute name "%s" for the second time.'
+                    % str(attr[0])
+                )
             else:
                 attribute_names.add(attr[0])
 
             yield self._encode_attribute(attr[0], attr[1])
-        yield ''
-        attributes = obj['attributes']
+        yield ""
+        attributes = obj["attributes"]
 
         # DATA
         yield _TK_DATA
-        if 'data' in obj:
-            data = _get_data_object_for_encoding(obj.get('data'))
-            yield from data.encode_data(obj.get('data'), attributes)
+        if "data" in obj:
+            data = _get_data_object_for_encoding(obj.get("data"))
+            yield from data.encode_data(obj.get("data"), attributes)
 
-        yield ''
+        yield ""
+
 
 # =============================================================================
 
 # BASIC INTERFACE =============================================================
 def load(fp, encode_nominal=False, return_type=DENSE):
-    '''Load a file-like object containing the ARFF document and convert it into
+    """Load a file-like object containing the ARFF document and convert it into
     a Python object.
 
     :param fp: a file-like object.
@@ -1055,13 +1115,13 @@ def load(fp, encode_nominal=False, return_type=DENSE):
         Consult the sections on `working with sparse data`_ and `loading
         progressively`_.
     :return: a dictionary.
-     '''
+    """
     decoder = ArffDecoder()
-    return decoder.decode(fp, encode_nominal=encode_nominal,
-                          return_type=return_type)
+    return decoder.decode(fp, encode_nominal=encode_nominal, return_type=return_type)
+
 
 def loads(s, encode_nominal=False, return_type=DENSE):
-    '''Convert a string instance containing the ARFF document into a Python
+    """Convert a string instance containing the ARFF document into a Python
     object.
 
     :param s: a string object.
@@ -1073,35 +1133,38 @@ def loads(s, encode_nominal=False, return_type=DENSE):
         Consult the sections on `working with sparse data`_ and `loading
         progressively`_.
     :return: a dictionary.
-    '''
+    """
     decoder = ArffDecoder()
-    return decoder.decode(s, encode_nominal=encode_nominal,
-                          return_type=return_type)
+    return decoder.decode(s, encode_nominal=encode_nominal, return_type=return_type)
+
 
 def dump(obj, fp):
-    '''Serialize an object representing the ARFF document to a given file-like
+    """Serialize an object representing the ARFF document to a given file-like
     object.
 
     :param obj: a dictionary.
     :param fp: a file-like object.
-    '''
+    """
     encoder = ArffEncoder()
     generator = encoder.iter_encode(obj)
 
     last_row = next(generator)
     for row in generator:
-        fp.write(last_row + '\n')
+        fp.write(last_row + "\n")
         last_row = row
     fp.write(last_row)
 
     return fp
 
+
 def dumps(obj):
-    '''Serialize an object representing the ARFF document, returning a string.
+    """Serialize an object representing the ARFF document, returning a string.
 
     :param obj: a dictionary.
     :return: a string with the ARFF document.
-    '''
+    """
     encoder = ArffEncoder()
     return encoder.encode(obj)
+
+
 # =============================================================================

--- a/sklearn/externals/_arff.py
+++ b/sklearn/externals/_arff.py
@@ -24,7 +24,7 @@
 # SOFTWARE.
 # =============================================================================
 
-"""
+'''
 The liac-arff module implements functions to read and write ARFF files in
 Python. It was created in the Connectionist Artificial Intelligence Laboratory
 (LIAC), which takes place at the Federal University of Rio Grande do Sul
@@ -140,14 +140,12 @@ This module provides several features, including:
 - Fully compatible with Python 2.7+, Python 3.5+, pypy and pypy3;
 - Under `MIT License <http://opensource.org/licenses/MIT>`_
 
-"""
-__author__ = "Renato de Pontes Pereira, Matthias Feurer, Joel Nothman"
-__author_email__ = (
-    "renato.ppontes@gmail.com, "
-    "feurerm@informatik.uni-freiburg.de, "
-    "joel.nothman@gmail.com"
-)
-__version__ = "2.4.0"
+'''
+__author__ = 'Renato de Pontes Pereira, Matthias Feurer, Joel Nothman'
+__author_email__ = ('renato.ppontes@gmail.com, '
+                    'feurerm@informatik.uni-freiburg.de, '
+                    'joel.nothman@gmail.com')
+__version__ = '2.4.0'
 
 import re
 import csv
@@ -155,20 +153,20 @@ from typing import TYPE_CHECKING
 from typing import Optional, List, Dict, Any, Iterator, Union, Tuple
 
 # CONSTANTS ===================================================================
-_SIMPLE_TYPES = ["NUMERIC", "REAL", "INTEGER", "STRING"]
+_SIMPLE_TYPES = ['NUMERIC', 'REAL', 'INTEGER', 'STRING']
 
-_TK_DESCRIPTION = "%"
-_TK_COMMENT = "%"
-_TK_RELATION = "@RELATION"
-_TK_ATTRIBUTE = "@ATTRIBUTE"
-_TK_DATA = "@DATA"
+_TK_DESCRIPTION = '%'
+_TK_COMMENT     = '%'
+_TK_RELATION    = '@RELATION'
+_TK_ATTRIBUTE   = '@ATTRIBUTE'
+_TK_DATA        = '@DATA'
 
-_RE_RELATION = re.compile(r"^([^\{\}%,\s]*|\".*\"|\'.*\')$", re.UNICODE)
-_RE_ATTRIBUTE = re.compile(r"^(\".*\"|\'.*\'|[^\{\}%,\s]*)\s+(.+)$", re.UNICODE)
+_RE_RELATION     = re.compile(r'^([^\{\}%,\s]*|\".*\"|\'.*\')$', re.UNICODE)
+_RE_ATTRIBUTE    = re.compile(r'^(\".*\"|\'.*\'|[^\{\}%,\s]*)\s+(.+)$', re.UNICODE)
 _RE_QUOTE_CHARS = re.compile(r'["\'\\\s%,\000-\031]', re.UNICODE)
 _RE_ESCAPE_CHARS = re.compile(r'(?=["\'\\%])|[\n\r\t\000-\031]')
-_RE_SPARSE_LINE = re.compile(r"^\s*\{.*\}\s*$", re.UNICODE)
-_RE_NONTRIVIAL_DATA = re.compile("[\"'{}\\s]", re.UNICODE)
+_RE_SPARSE_LINE = re.compile(r'^\s*\{.*\}\s*$', re.UNICODE)
+_RE_NONTRIVIAL_DATA = re.compile('["\'{}\\s]', re.UNICODE)
 
 ArffDenseDataType = Iterator[List]
 ArffSparseDataType = Tuple[List, ...]
@@ -184,13 +182,12 @@ if TYPE_CHECKING:
         attributes: List
         data: Union[ArffDenseDataType, ArffSparseDataType]
 
-
 else:
     ArffContainerType = Dict[str, Any]
 
 
 def _build_re_values():
-    quoted_re = r"""
+    quoted_re = r'''
                     "      # open quote followed by zero or more of:
                     (?:
                         (?<!\\)    # no additional backslash
@@ -202,37 +199,30 @@ def _build_re_values():
                         [^"\\]     # non-quote char
                     )*
                     "      # close quote
-                    """
+                    '''
     # a value is surrounded by " or by ' or contains no quotables
-    value_re = r"""(?:
+    value_re = r'''(?:
         %s|          # a value may be surrounded by "
         %s|          # or by '
         [^,\s"'{}]+  # or may contain no characters requiring quoting
-        )""" % (
-        quoted_re,
-        quoted_re.replace('"', "'"),
-    )
+        )''' % (quoted_re,
+                quoted_re.replace('"', "'"))
 
     # This captures (value, error) groups. Because empty values are allowed,
     # we cannot just look for empty values to handle syntax errors.
     # We presume the line has had ',' prepended...
-    dense = re.compile(
-        r"""(?x)
+    dense = re.compile(r'''(?x)
         ,                # may follow ','
         \s*
         ((?=,)|$|{value_re})  # empty or value
         |
         (\S.*)           # error
-        """.format(
-            value_re=value_re
-        )
-    )
+        '''.format(value_re=value_re))
 
     # This captures (key, value) groups and will have an empty key/value
     # in case of syntax errors.
     # It does not ensure that the line starts with '{' or ends with '}'.
-    sparse = re.compile(
-        r"""(?x)
+    sparse = re.compile(r'''(?x)
         (?:^\s*\{|,)   # may follow ',', or '{' at line start
         \s*
         (\d+)          # attribute key
@@ -242,30 +232,29 @@ def _build_re_values():
         (?!}\s*$)      # not an error if it's }$
         (?!^\s*{\s*}\s*$)  # not an error if it's ^{}$
         \S.*           # error
-        """
-        % {"value_re": value_re}
-    )
+        ''' % {'value_re': value_re})
     return dense, sparse
+
 
 
 _RE_DENSE_VALUES, _RE_SPARSE_KEY_VALUES = _build_re_values()
 
 
 _ESCAPE_SUB_MAP = {
-    "\\\\": "\\",
+    '\\\\': '\\',
     '\\"': '"',
     "\\'": "'",
-    "\\t": "\t",
-    "\\n": "\n",
-    "\\r": "\r",
-    "\\b": "\b",
-    "\\f": "\f",
-    "\\%": "%",
+    '\\t': '\t',
+    '\\n': '\n',
+    '\\r': '\r',
+    '\\b': '\b',
+    '\\f': '\f',
+    '\\%': '%',
 }
-_UNESCAPE_SUB_MAP = {chr(i): "\\%03o" % i for i in range(32)}
+_UNESCAPE_SUB_MAP = {chr(i): '\\%03o' % i for i in range(32)}
 _UNESCAPE_SUB_MAP.update({v: k for k, v in _ESCAPE_SUB_MAP.items()})
-_UNESCAPE_SUB_MAP[""] = "\\"
-_ESCAPE_SUB_MAP.update({"\\%d" % i: chr(i) for i in range(10)})
+_UNESCAPE_SUB_MAP[''] = '\\'
+_ESCAPE_SUB_MAP.update({'\\%d' % i: chr(i) for i in range(10)})
 
 
 def _escape_sub_callback(match):
@@ -274,8 +263,8 @@ def _escape_sub_callback(match):
         try:
             return _ESCAPE_SUB_MAP[s]
         except KeyError:
-            raise ValueError("Unsupported escape sequence: %s" % s)
-    if s[1] == "u":
+            raise ValueError('Unsupported escape sequence: %s' % s)
+    if s[1] == 'u':
         return chr(int(s[2:], 16))
     else:
         return chr(int(s[1:], 8))
@@ -283,8 +272,9 @@ def _escape_sub_callback(match):
 
 def _unquote(v):
     if v[:1] in ('"', "'"):
-        return re.sub(r"\\([0-9]{1,3}|u[0-9a-f]{4}|.)", _escape_sub_callback, v[1:-1])
-    elif v in ("?", ""):
+        return re.sub(r'\\([0-9]{1,3}|u[0-9a-f]{4}|.)', _escape_sub_callback,
+                      v[1:-1])
+    elif v in ('?', ''):
         return None
     else:
         return v
@@ -304,44 +294,41 @@ def _downcast(value):
 
 
 def _parse_values(s):
-    """(INTERNAL) Split a line into a list of values"""
+    '''(INTERNAL) Split a line into a list of values'''
     if not _RE_NONTRIVIAL_DATA.search(s):
         # Fast path for trivial cases (unfortunately we have to handle missing
         # values because of the empty string case :(.)
-        values = [
-            None if s in ("?", "") else _downcast(s) for s in next(csv.reader([s]))
-        ]
+        return [None if s in ('?', '') else _downcast(s)
+                for s in next(csv.reader([s]))]
 
     # _RE_DENSE_VALUES tokenizes despite quoting, whitespace, etc.
-    values, errors = zip(*_RE_DENSE_VALUES.findall("," + s))
+    values, errors = zip(*_RE_DENSE_VALUES.findall(',' + s))
     if not any(errors):
         return [_downcast(_unquote(v)) for v in values]
     if _RE_SPARSE_LINE.match(s):
         try:
-            return {
-                int(k): _downcast(_unquote(v))
-                for k, v in _RE_SPARSE_KEY_VALUES.findall(s)
-            }
+            return {int(k): _downcast(_unquote(v))
+                    for k, v in _RE_SPARSE_KEY_VALUES.findall(s)}
         except ValueError:
             # an ARFF syntax error in sparse data
             for match in _RE_SPARSE_KEY_VALUES.finditer(s):
                 if not match.group(1):
-                    raise BadLayout("Error parsing %r" % match.group())
-            raise BadLayout("Unknown parsing error")
+                    raise BadLayout('Error parsing %r' % match.group())
+            raise BadLayout('Unknown parsing error')
     else:
         # an ARFF syntax error
         for match in _RE_DENSE_VALUES.finditer(s):
             if match.group(2):
-                raise BadLayout("Error parsing %r" % match.group())
-        raise BadLayout("Unknown parsing error")
+                raise BadLayout('Error parsing %r' % match.group())
+        raise BadLayout('Unknown parsing error')
 
 
-DENSE = 0  # Constant value representing a dense matrix
-COO = 1  # Constant value representing a sparse matrix in coordinate format
-LOD = 2  # Constant value representing a sparse matrix in list of
-# dictionaries format
-DENSE_GEN = 3  # Generator of dictionaries
-LOD_GEN = 4  # Generator of dictionaries
+DENSE = 0     # Constant value representing a dense matrix
+COO = 1       # Constant value representing a sparse matrix in coordinate format
+LOD = 2       # Constant value representing a sparse matrix in list of
+              # dictionaries format
+DENSE_GEN = 3 # Generator of dictionaries
+LOD_GEN = 4   # Generator of dictionaries
 _SUPPORTED_DATA_STRUCTURES = [DENSE, COO, LOD, DENSE_GEN, LOD_GEN]
 
 
@@ -353,104 +340,89 @@ class ArffException(Exception):
         self.line = -1
 
     def __str__(self):
-        return self.message % self.line
-
+        return self.message%self.line
 
 class BadRelationFormat(ArffException):
-    """Error raised when the relation declaration is in an invalid format."""
-
-    message = "Bad @RELATION format, at line %d."
-
+    '''Error raised when the relation declaration is in an invalid format.'''
+    message = 'Bad @RELATION format, at line %d.'
 
 class BadAttributeFormat(ArffException):
-    """Error raised when some attribute declaration is in an invalid format."""
-
-    message = "Bad @ATTRIBUTE format, at line %d."
-
+    '''Error raised when some attribute declaration is in an invalid format.'''
+    message = 'Bad @ATTRIBUTE format, at line %d.'
 
 class BadDataFormat(ArffException):
-    """Error raised when some data instance is in an invalid format."""
-
+    '''Error raised when some data instance is in an invalid format.'''
     def __init__(self, value):
         super().__init__()
-        self.message = "Bad @DATA instance format in line %d: " + "%s" % value
-
+        self.message = (
+            'Bad @DATA instance format in line %d: ' +
+            ('%s' % value)
+        )
 
 class BadAttributeType(ArffException):
-    """Error raised when some invalid type is provided into the attribute
-    declaration."""
-
-    message = "Bad @ATTRIBUTE type, at line %d."
-
+    '''Error raised when some invalid type is provided into the attribute
+    declaration.'''
+    message = 'Bad @ATTRIBUTE type, at line %d.'
 
 class BadAttributeName(ArffException):
-    """Error raised when an attribute name is provided twice the attribute
-    declaration."""
+    '''Error raised when an attribute name is provided twice the attribute
+    declaration.'''
 
     def __init__(self, value, value2):
         super().__init__()
         self.message = (
-            "Bad @ATTRIBUTE name %s at line" % value
-            + " %d, this name is already in use in line"
-            + " %d." % value2
+            ('Bad @ATTRIBUTE name %s at line' % value) +
+            ' %d, this name is already in use in line' +
+            (' %d.' % value2)
         )
 
-
 class BadNominalValue(ArffException):
-    """Error raised when a value in used in some data instance but is not
-    declared into it respective attribute declaration."""
+    '''Error raised when a value in used in some data instance but is not
+    declared into it respective attribute declaration.'''
 
     def __init__(self, value):
         super().__init__()
         self.message = (
-            "Data value %s not found in nominal declaration, " % value
-        ) + "at line %d."
-
+            ('Data value %s not found in nominal declaration, ' % value)
+            + 'at line %d.'
+        )
 
 class BadNominalFormatting(ArffException):
-    """Error raised when a nominal value with space is not properly quoted."""
-
+    '''Error raised when a nominal value with space is not properly quoted.'''
     def __init__(self, value):
         super().__init__()
         self.message = (
-            'Nominal data value "%s" not properly quoted in line ' % value
-        ) + "%d."
-
+            ('Nominal data value "%s" not properly quoted in line ' % value) +
+            '%d.'
+        )
 
 class BadNumericalValue(ArffException):
-    """Error raised when and invalid numerical value is used in some data
-    instance."""
-
-    message = "Invalid numerical value, at line %d."
-
+    '''Error raised when and invalid numerical value is used in some data
+    instance.'''
+    message = 'Invalid numerical value, at line %d.'
 
 class BadStringValue(ArffException):
-    """Error raise when a string contains space but is not quoted."""
-
-    message = "Invalid string value at line %d."
-
+    '''Error raise when a string contains space but is not quoted.'''
+    message = 'Invalid string value at line %d.'
 
 class BadLayout(ArffException):
-    """Error raised when the layout of the ARFF file has something wrong."""
+    '''Error raised when the layout of the ARFF file has something wrong.'''
+    message = 'Invalid layout of the ARFF file, at line %d.'
 
-    message = "Invalid layout of the ARFF file, at line %d."
-
-    def __init__(self, msg=""):
+    def __init__(self, msg=''):
         super().__init__()
         if msg:
-            self.message = BadLayout.message + " " + msg.replace("%", "%%")
+            self.message = BadLayout.message + ' ' + msg.replace('%', '%%')
 
 
 class BadObject(ArffException):
-    """Error raised when the object representing the ARFF file has something
-    wrong."""
-
-    def __init__(self, msg="Invalid object."):
+    '''Error raised when the object representing the ARFF file has something
+    wrong.'''
+    def __init__(self, msg='Invalid object.'):
         self.msg = msg
 
     def __str__(self):
-        return "%s" % self.msg
-
+        return '%s' % self.msg
 
 # =============================================================================
 
@@ -495,8 +467,8 @@ class NominalConversor:
 
 
 class DenseGeneratorData:
-    """Internal helper class to allow for different matrix types without
-    making the code a huge collection of if statements."""
+    '''Internal helper class to allow for different matrix types without
+    making the code a huge collection of if statements.'''
 
     def decode_rows(self, stream, conversors):
         for row in stream:
@@ -506,9 +478,8 @@ class DenseGeneratorData:
                 if values and max(values) >= len(conversors):
                     raise BadDataFormat(row)
                 # XXX: int 0 is used for implicit values, not '0'
-                values = [
-                    values[i] if i in values else 0 for i in range(len(conversors))
-                ]
+                values = [values[i] if i in values else 0 for i in
+                          range(len(conversors))]
             else:
                 if len(values) != len(conversors):
                     raise BadDataFormat(row)
@@ -518,17 +489,16 @@ class DenseGeneratorData:
     @staticmethod
     def _decode_values(values, conversors):
         try:
-            values = [
-                None if value is None else conversor(value)
-                for conversor, value in zip(conversors, values)
-            ]
+            values = [None if value is None else conversor(value)
+                      for conversor, value
+                      in zip(conversors, values)]
         except ValueError as exc:
-            if "float: " in str(exc):
+            if 'float: ' in str(exc):
                 raise BadNumericalValue()
         return values
 
     def encode_data(self, data, attributes):
-        """(INTERNAL) Encodes a line of data.
+        '''(INTERNAL) Encodes a line of data.
 
         Data instances follow the csv format, i.e, attribute values are
         delimited by commas. After converted from csv.
@@ -536,31 +506,30 @@ class DenseGeneratorData:
         :param data: a list of values.
         :param attributes: a list of attributes. Used to check if data is valid.
         :return: a string with the encoded data line.
-        """
+        '''
         current_row = 0
 
         for inst in data:
             if len(inst) != len(attributes):
                 raise BadObject(
-                    "Instance %d has %d attributes, expected %d"
-                    % (current_row, len(inst), len(attributes))
+                    'Instance %d has %d attributes, expected %d' %
+                     (current_row, len(inst), len(attributes))
                 )
 
             new_data = []
             for value in inst:
-                if value is None or value == "" or value != value:
-                    s = "?"
+                if value is None or value == '' or value != value:
+                    s = '?'
                 else:
                     s = encode_string(str(value))
                 new_data.append(s)
 
             current_row += 1
-            yield ",".join(new_data)
+            yield ','.join(new_data)
 
 
 class _DataListMixin:
     """Mixin to return a list from decode_rows instead of a generator"""
-
     def decode_rows(self, stream, conversors):
         return list(super().decode_rows(stream, conversors))
 
@@ -580,12 +549,10 @@ class COOData:
                 continue
             row_cols, values = zip(*sorted(values.items()))
             try:
-                values = [
-                    value if value is None else conversors[key](value)
-                    for key, value in zip(row_cols, values)
-                ]
+                values = [value if value is None else conversors[key](value)
+                          for key, value in zip(row_cols, values)]
             except ValueError as exc:
-                if "float: " in str(exc):
+                if 'float: ' in str(exc):
                     raise BadNumericalValue()
                 raise
             except IndexError:
@@ -609,30 +576,30 @@ class COOData:
 
         # Check if the rows are sorted
         if not all(row[i] <= row[i + 1] for i in range(len(row) - 1)):
-            raise ValueError("liac-arff can only output COO matrices with sorted rows.")
+            raise ValueError("liac-arff can only output COO matrices with "
+                             "sorted rows.")
 
         for v, col, row in zip(data, col, row):
             if row > current_row:
                 # Add empty rows if necessary
                 while current_row < row:
-                    yield " ".join(["{", ",".join(new_data), "}"])
+                    yield " ".join(["{", ','.join(new_data), "}"])
                     new_data = []
                     current_row += 1
 
             if col >= num_attributes:
                 raise BadObject(
-                    "Instance %d has at least %d attributes, expected %d"
-                    % (current_row, col + 1, num_attributes)
+                    'Instance %d has at least %d attributes, expected %d' %
+                    (current_row, col + 1, num_attributes)
                 )
 
-            if v is None or v == "" or v != v:
-                s = "?"
+            if v is None or v == '' or v != v:
+                s = '?'
             else:
                 s = encode_string(str(v))
             new_data.append("%d %s" % (col, s))
 
-        yield " ".join(["{", ",".join(new_data), "}"])
-
+        yield " ".join(["{", ','.join(new_data), "}"])
 
 class LODGeneratorData:
     def decode_rows(self, stream, conversors):
@@ -642,12 +609,10 @@ class LODGeneratorData:
             if not isinstance(values, dict):
                 raise BadLayout()
             try:
-                yield {
-                    key: None if value is None else conversors[key](value)
-                    for key, value in values.items()
-                }
+                yield {key: None if value is None else conversors[key](value)
+                       for key, value in values.items()}
             except ValueError as exc:
-                if "float: " in str(exc):
+                if 'float: ' in str(exc):
                     raise BadNumericalValue()
                 raise
             except IndexError:
@@ -663,21 +628,20 @@ class LODGeneratorData:
 
             if len(row) > 0 and max(row) >= num_attributes:
                 raise BadObject(
-                    "Instance %d has %d attributes, expected %d"
-                    % (current_row, max(row) + 1, num_attributes)
+                    'Instance %d has %d attributes, expected %d' %
+                    (current_row, max(row) + 1, num_attributes)
                 )
 
             for col in sorted(row):
                 v = row[col]
-                if v is None or v == "" or v != v:
-                    s = "?"
+                if v is None or v == '' or v != v:
+                    s = '?'
                 else:
                     s = encode_string(str(v))
                 new_data.append("%d %s" % (col, s))
 
             current_row += 1
-            yield " ".join(["{", ",".join(new_data), "}"])
-
+            yield " ".join(["{", ','.join(new_data), "}"])
 
 class LODData(_DataListMixin, LODGeneratorData):
     pass
@@ -697,33 +661,31 @@ def _get_data_object_for_decoding(matrix_type):
     else:
         raise ValueError("Matrix type %s not supported." % str(matrix_type))
 
-
 def _get_data_object_for_encoding(matrix):
     # Probably a scipy.sparse
-    if hasattr(matrix, "format"):
-        if matrix.format == "coo":
+    if hasattr(matrix, 'format'):
+        if matrix.format == 'coo':
             return COOData()
         else:
-            raise ValueError("Cannot guess matrix format!")
+            raise ValueError('Cannot guess matrix format!')
     elif isinstance(matrix[0], dict):
         return LODData()
     else:
         return Data()
 
-
 # =============================================================================
 
 # ADVANCED INTERFACE ==========================================================
 class ArffDecoder:
-    """An ARFF decoder."""
+    '''An ARFF decoder.'''
 
     def __init__(self):
-        """Constructor."""
+        '''Constructor.'''
         self._conversors = []
         self._current_line = 0
 
     def _decode_comment(self, s):
-        """(INTERNAL) Decodes a comment line.
+        '''(INTERNAL) Decodes a comment line.
 
         Comments are single line strings starting, obligatorily, with the ``%``
         character, and can have any symbol, including whitespaces or special
@@ -734,12 +696,12 @@ class ArffDecoder:
 
         :param s: a normalized string.
         :return: a string with the decoded comment.
-        """
-        res = re.sub(r"^\%( )?", "", s)
+        '''
+        res = re.sub(r'^\%( )?', '', s)
         return res
 
     def _decode_relation(self, s):
-        """(INTERNAL) Decodes a relation line.
+        '''(INTERNAL) Decodes a relation line.
 
         The relation declaration is a line with the format ``@RELATION
         <relation-name>``, where ``relation-name`` is a string. The string must
@@ -751,18 +713,18 @@ class ArffDecoder:
 
         :param s: a normalized string.
         :return: a string with the decoded relation name.
-        """
-        _, v = s.split(" ", 1)
+        '''
+        _, v = s.split(' ', 1)
         v = v.strip()
 
         if not _RE_RELATION.match(v):
             raise BadRelationFormat()
 
-        res = str(v.strip("\"'"))
+        res = str(v.strip('"\''))
         return res
 
     def _decode_attribute(self, s):
-        """(INTERNAL) Decodes an attribute line.
+        '''(INTERNAL) Decodes an attribute line.
 
         The attribute is the most complex declaration in an arff file. All
         attributes must follow the template::
@@ -787,8 +749,8 @@ class ArffDecoder:
 
         :param s: a normalized string.
         :return: a tuple (ATTRIBUTE_NAME, TYPE_OR_VALUES).
-        """
-        _, v = s.split(" ", 1)
+        '''
+        _, v = s.split(' ', 1)
         v = v.strip()
 
         # Verify the general structure of declaration
@@ -800,12 +762,12 @@ class ArffDecoder:
         name, type_ = m.groups()
 
         # Extracts the final name
-        name = str(name.strip("\"'"))
+        name = str(name.strip('"\''))
 
         # Extracts the final type
         if type_[:1] == "{" and type_[-1:] == "}":
             try:
-                type_ = _parse_values(type_.strip("{} "))
+                type_ = _parse_values(type_.strip('{} '))
             except Exception:
                 raise BadAttributeType()
             if isinstance(type_, dict):
@@ -814,27 +776,27 @@ class ArffDecoder:
         else:
             # If not nominal, verify the type name
             type_ = str(type_).upper()
-            if type_ not in ["NUMERIC", "REAL", "INTEGER", "STRING"]:
+            if type_ not in ['NUMERIC', 'REAL', 'INTEGER', 'STRING']:
                 raise BadAttributeType()
 
         return (name, type_)
 
     def _decode(self, s, encode_nominal=False, matrix_type=DENSE):
-        """Do the job the ``encode``."""
+        '''Do the job the ``encode``.'''
 
         # Make sure this method is idempotent
         self._current_line = 0
 
         # If string, convert to a list of lines
         if isinstance(s, str):
-            s = s.strip("\r\n ").replace("\r\n", "\n").split("\n")
+            s = s.strip('\r\n ').replace('\r\n', '\n').split('\n')
 
         # Create the return object
         obj: ArffContainerType = {
-            "description": "",
-            "relation": "",
-            "attributes": [],
-            "data": [],
+            'description': '',
+            'relation': '',
+            'attributes': [],
+            'data': []
         }
         attribute_names = {}
 
@@ -847,15 +809,14 @@ class ArffDecoder:
         for row in s:
             self._current_line += 1
             # Ignore empty lines
-            row = row.strip(" \r\n")
-            if not row:
-                continue
+            row = row.strip(' \r\n')
+            if not row: continue
 
             u_row = row.upper()
 
             # DESCRIPTION -----------------------------------------------------
             if u_row.startswith(_TK_DESCRIPTION) and STATE == _TK_DESCRIPTION:
-                obj["description"] += self._decode_comment(row) + "\n"
+                obj['description'] += self._decode_comment(row) + '\n'
             # -----------------------------------------------------------------
 
             # RELATION --------------------------------------------------------
@@ -864,7 +825,7 @@ class ArffDecoder:
                     raise BadLayout()
 
                 STATE = _TK_RELATION
-                obj["relation"] = self._decode_relation(row)
+                obj['relation'] = self._decode_relation(row)
             # -----------------------------------------------------------------
 
             # ATTRIBUTE -------------------------------------------------------
@@ -879,7 +840,7 @@ class ArffDecoder:
                     raise BadAttributeName(attr[0], attribute_names[attr[0]])
                 else:
                     attribute_names[attr[0]] = self._current_line
-                obj["attributes"].append(attr)
+                obj['attributes'].append(attr)
 
                 if isinstance(attr[1], (list, tuple)):
                     if encode_nominal:
@@ -887,12 +848,10 @@ class ArffDecoder:
                     else:
                         conversor = NominalConversor(attr[1])
                 else:
-                    CONVERSOR_MAP = {
-                        "STRING": str,
-                        "INTEGER": lambda x: int(float(x)),
-                        "NUMERIC": float,
-                        "REAL": float,
-                    }
+                    CONVERSOR_MAP = {'STRING': str,
+                                     'INTEGER': lambda x: int(float(x)),
+                                     'NUMERIC': float,
+                                     'REAL': float}
                     conversor = CONVERSOR_MAP[attr[1]]
 
                 self._conversors.append(conversor)
@@ -923,14 +882,14 @@ class ArffDecoder:
                     yield row
 
         # Alter the data object
-        obj["data"] = data.decode_rows(stream(), self._conversors)
-        if obj["description"].endswith("\n"):
-            obj["description"] = obj["description"][:-1]
+        obj['data'] = data.decode_rows(stream(), self._conversors)
+        if obj['description'].endswith('\n'):
+            obj['description'] = obj['description'][:-1]
 
         return obj
 
     def decode(self, s, encode_nominal=False, return_type=DENSE):
-        """Returns the Python representation of a given ARFF file.
+        '''Returns the Python representation of a given ARFF file.
 
         When a file object is passed as an argument, this method reads lines
         iteratively, avoiding to load unnecessary information to the memory.
@@ -943,21 +902,20 @@ class ArffDecoder:
             `arff.DENSE_GEN` or `arff.LOD_GEN`.
             Consult the sections on `working with sparse data`_ and `loading
             progressively`_.
-        """
+        '''
         try:
-            return self._decode(
-                s, encode_nominal=encode_nominal, matrix_type=return_type
-            )
+            return self._decode(s, encode_nominal=encode_nominal,
+                                matrix_type=return_type)
         except ArffException as e:
             e.line = self._current_line
             raise e
 
 
 class ArffEncoder:
-    """An ARFF encoder."""
+    '''An ARFF encoder.'''
 
-    def _encode_comment(self, s=""):
-        """(INTERNAL) Encodes a comment line.
+    def _encode_comment(self, s=''):
+        '''(INTERNAL) Encodes a comment line.
 
         Comments are single line strings starting, obligatorily, with the ``%``
         character, and can have any symbol, including whitespaces or special
@@ -967,30 +925,30 @@ class ArffEncoder:
 
         :param s: (OPTIONAL) string.
         :return: a string with the encoded comment line.
-        """
+        '''
         if s:
-            return "%s %s" % (_TK_COMMENT, s)
+            return '%s %s'%(_TK_COMMENT, s)
         else:
-            return "%s" % _TK_COMMENT
+            return '%s' % _TK_COMMENT
 
     def _encode_relation(self, name):
-        """(INTERNAL) Decodes a relation line.
+        '''(INTERNAL) Decodes a relation line.
 
         The relation declaration is a line with the format ``@RELATION
         <relation-name>``, where ``relation-name`` is a string.
 
         :param name: a string.
         :return: a string with the encoded relation declaration.
-        """
-        for char in " %{},":
+        '''
+        for char in ' %{},':
             if char in name:
-                name = '"%s"' % name
+                name = '"%s"'%name
                 break
 
-        return "%s %s" % (_TK_RELATION, name)
+        return '%s %s'%(_TK_RELATION, name)
 
     def _encode_attribute(self, name, type_):
-        """(INTERNAL) Encodes an attribute line.
+        '''(INTERNAL) Encodes an attribute line.
 
         The attribute follow the template::
 
@@ -1011,99 +969,94 @@ class ArffEncoder:
         :param name: a string.
         :param type_: a string or a list of string.
         :return: a string with the encoded attribute declaration.
-        """
-        for char in " %{},":
+        '''
+        for char in ' %{},':
             if char in name:
-                name = '"%s"' % name
+                name = '"%s"'%name
                 break
 
         if isinstance(type_, (tuple, list)):
-            type_tmp = ["%s" % encode_string(type_k) for type_k in type_]
-            type_ = "{%s}" % ", ".join(type_tmp)
+            type_tmp = ['%s' % encode_string(type_k) for type_k in type_]
+            type_ = '{%s}'%(', '.join(type_tmp))
 
-        return "%s %s %s" % (_TK_ATTRIBUTE, name, type_)
+        return '%s %s %s'%(_TK_ATTRIBUTE, name, type_)
 
     def encode(self, obj):
-        """Encodes a given object to an ARFF file.
+        '''Encodes a given object to an ARFF file.
 
         :param obj: the object containing the ARFF information.
         :return: the ARFF file as an string.
-        """
+        '''
         data = [row for row in self.iter_encode(obj)]
 
-        return "\n".join(data)
+        return '\n'.join(data)
 
     def iter_encode(self, obj):
-        """The iterative version of `arff.ArffEncoder.encode`.
+        '''The iterative version of `arff.ArffEncoder.encode`.
 
         This encodes iteratively a given object and return, one-by-one, the
         lines of the ARFF file.
 
         :param obj: the object containing the ARFF information.
         :return: (yields) the ARFF file as strings.
-        """
+        '''
         # DESCRIPTION
-        if obj.get("description", None):
-            for row in obj["description"].split("\n"):
+        if obj.get('description', None):
+            for row in obj['description'].split('\n'):
                 yield self._encode_comment(row)
 
         # RELATION
-        if not obj.get("relation"):
-            raise BadObject("Relation name not found or with invalid value.")
+        if not obj.get('relation'):
+            raise BadObject('Relation name not found or with invalid value.')
 
-        yield self._encode_relation(obj["relation"])
-        yield ""
+        yield self._encode_relation(obj['relation'])
+        yield ''
 
         # ATTRIBUTES
-        if not obj.get("attributes"):
-            raise BadObject("Attributes not found.")
+        if not obj.get('attributes'):
+            raise BadObject('Attributes not found.')
 
         attribute_names = set()
-        for attr in obj["attributes"]:
+        for attr in obj['attributes']:
             # Verify for bad object format
-            if (
-                not isinstance(attr, (tuple, list))
-                or len(attr) != 2
-                or not isinstance(attr[0], str)
-            ):
-                raise BadObject('Invalid attribute declaration "%s"' % str(attr))
+            if not isinstance(attr, (tuple, list)) or \
+               len(attr) != 2 or \
+               not isinstance(attr[0], str):
+                raise BadObject('Invalid attribute declaration "%s"'%str(attr))
 
             if isinstance(attr[1], str):
                 # Verify for invalid types
                 if attr[1] not in _SIMPLE_TYPES:
-                    raise BadObject('Invalid attribute type "%s"' % str(attr))
+                    raise BadObject('Invalid attribute type "%s"'%str(attr))
 
             # Verify for bad object format
             elif not isinstance(attr[1], (tuple, list)):
-                raise BadObject('Invalid attribute type "%s"' % str(attr))
+                raise BadObject('Invalid attribute type "%s"'%str(attr))
 
             # Verify attribute name is not used twice
             if attr[0] in attribute_names:
-                raise BadObject(
-                    'Trying to use attribute name "%s" for the second time.'
-                    % str(attr[0])
-                )
+                raise BadObject('Trying to use attribute name "%s" for the '
+                                'second time.' % str(attr[0]))
             else:
                 attribute_names.add(attr[0])
 
             yield self._encode_attribute(attr[0], attr[1])
-        yield ""
-        attributes = obj["attributes"]
+        yield ''
+        attributes = obj['attributes']
 
         # DATA
         yield _TK_DATA
-        if "data" in obj:
-            data = _get_data_object_for_encoding(obj.get("data"))
-            yield from data.encode_data(obj.get("data"), attributes)
+        if 'data' in obj:
+            data = _get_data_object_for_encoding(obj.get('data'))
+            yield from data.encode_data(obj.get('data'), attributes)
 
-        yield ""
-
+        yield ''
 
 # =============================================================================
 
 # BASIC INTERFACE =============================================================
 def load(fp, encode_nominal=False, return_type=DENSE):
-    """Load a file-like object containing the ARFF document and convert it into
+    '''Load a file-like object containing the ARFF document and convert it into
     a Python object.
 
     :param fp: a file-like object.
@@ -1115,13 +1068,13 @@ def load(fp, encode_nominal=False, return_type=DENSE):
         Consult the sections on `working with sparse data`_ and `loading
         progressively`_.
     :return: a dictionary.
-    """
+     '''
     decoder = ArffDecoder()
-    return decoder.decode(fp, encode_nominal=encode_nominal, return_type=return_type)
-
+    return decoder.decode(fp, encode_nominal=encode_nominal,
+                          return_type=return_type)
 
 def loads(s, encode_nominal=False, return_type=DENSE):
-    """Convert a string instance containing the ARFF document into a Python
+    '''Convert a string instance containing the ARFF document into a Python
     object.
 
     :param s: a string object.
@@ -1133,38 +1086,35 @@ def loads(s, encode_nominal=False, return_type=DENSE):
         Consult the sections on `working with sparse data`_ and `loading
         progressively`_.
     :return: a dictionary.
-    """
+    '''
     decoder = ArffDecoder()
-    return decoder.decode(s, encode_nominal=encode_nominal, return_type=return_type)
-
+    return decoder.decode(s, encode_nominal=encode_nominal,
+                          return_type=return_type)
 
 def dump(obj, fp):
-    """Serialize an object representing the ARFF document to a given file-like
+    '''Serialize an object representing the ARFF document to a given file-like
     object.
 
     :param obj: a dictionary.
     :param fp: a file-like object.
-    """
+    '''
     encoder = ArffEncoder()
     generator = encoder.iter_encode(obj)
 
     last_row = next(generator)
     for row in generator:
-        fp.write(last_row + "\n")
+        fp.write(last_row + '\n')
         last_row = row
     fp.write(last_row)
 
     return fp
 
-
 def dumps(obj):
-    """Serialize an object representing the ARFF document, returning a string.
+    '''Serialize an object representing the ARFF document, returning a string.
 
     :param obj: a dictionary.
     :return: a string with the ARFF document.
-    """
+    '''
     encoder = ArffEncoder()
     return encoder.encode(obj)
-
-
 # =============================================================================


### PR DESCRIPTION
This is a fix such that we downcast to `int` or `float` values of nominal features instead of storing them always as strings.
It would be consistent with the behaviour of the future `pandas` parser implemented in #21938 

Indeed it is related to the following quirk: https://github.com/scikit-learn/scikit-learn/pull/21938/files#diff-c14ad6f3f0f87029a67f4cca75114754191e3d2db225bb895b30e4d48b662cf0R825-R838