### PR TITLE
CI Add conditional to only run check-manifest cronjob in scikit-learn repo

### DIFF
--- a/.github/workflows/check-manifest.yml
+++ b/.github/workflows/check-manifest.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check:
     # Don't run on forks
-    if: github.repo_owner == 'scikit-learn'
+    if: github.repository == 'scikit-learn/scikit-learn'
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-manifest.yml
+++ b/.github/workflows/check-manifest.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   check:
+    # Don't run on forks
+    if: github.repo_owner == 'scikit-learn'
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I recently updated my fork of `scikit-learn` and noticed that I was getting daily emails about a failed github workflow manifest check. This PR includes a suggestion to suppress the relevant action from running on forks. Of course, I could go to settings and disable actions on my fork, but given that GitHub automatically runs workflows on forks I suspect I'm not the only user to run into this issue.

Anyways - feel free to ignore in which case I'll just disable all actions on my fork. I just wanted to raise awareness that this was happening and propose the (seemingly) [recommended fix](https://github.community/t/stop-github-actions-running-on-a-fork/17965)