### PR TITLE
TST Better info when checking for no warnings in tests

### DIFF
--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -158,7 +158,7 @@ def test_affinity_propagation_equal_mutual_similarities():
         cluster_center_indices, labels = affinity_propagation(
             S, preference=[-20, -10], random_state=37
         )
-    assert not len(record)
+    assert not [w.message for w in record]
 
     # expect one cluster, with highest-preference sample as exemplar
     assert_array_equal([1], cluster_center_indices)
@@ -247,7 +247,7 @@ def test_affinity_propagation_convergence_warning_dense_sparse(centers):
     ap.cluster_centers_ = centers
     with pytest.warns(None) as record:
         assert_array_equal(ap.predict(X), np.zeros(X.shape[0], dtype=int))
-    assert len(record) == 0, [w.message for w in record]
+    assert not [w.message for w in record]
 
 
 def test_affinity_propagation_float32():

--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -19,10 +19,11 @@ def test_feature_agglomeration():
     agglo_median = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.median)
     with pytest.warns(None) as record:
         agglo_mean.fit(X)
-    assert not len(record)
+    assert not [w.message for w in record]
     with pytest.warns(None) as record:
         agglo_median.fit(X)
-    assert not len(record)
+    assert not [w.message for w in record]
+
     assert np.size(np.unique(agglo_mean.labels_)) == n_clusters
     assert np.size(np.unique(agglo_median.labels_)) == n_clusters
     assert np.size(agglo_mean.labels_) == X.shape[1]

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -587,8 +587,7 @@ def test_loadings_converges():
     with pytest.warns(None) as record:
         cca.fit(X, y)
     # ConvergenceWarning should not be raised
-    if len(record) > 0:
-        pytest.fail(f"Unexpected warning: {str(record[0].message)}")
+    assert not [w.message for w in record]
 
     # Loadings converges to reasonable values
     assert np.all(np.abs(cca.x_loadings_) < 1)

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -116,7 +116,7 @@ def test_max_iter():
             D_multi, transform_algorithm=transform_algorithm, transform_max_iter=2000
         )
         model.fit_transform(X)
-    assert not record.list
+    assert not [w.message for w in record]
 
 
 def test_dict_learning_lars_positive_parameter():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -46,7 +46,7 @@ def test_no_empty_slice_warning():
     pca = PCA(n_components=n_components)
     with pytest.warns(None) as record:
         pca.fit(X)
-    assert not record.list
+    assert not [w.message for w in record]
 
 
 @pytest.mark.parametrize("copy", [True, False])

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -108,11 +108,12 @@ def test_iforest_error():
     with pytest.warns(None) as record:
         IsolationForest(max_samples="auto").fit(X)
     user_warnings = [each for each in record if issubclass(each.category, UserWarning)]
-    assert len(user_warnings) == 0
+    assert not user_warnings
+
     with pytest.warns(None) as record:
         IsolationForest(max_samples=np.int64(2)).fit(X)
     user_warnings = [each for each in record if issubclass(each.category, UserWarning)]
-    assert len(user_warnings) == 0
+    assert not user_warnings
 
     with pytest.raises(ValueError):
         IsolationForest(max_samples="foobar").fit(X)

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -433,7 +433,7 @@ def test_set_estimator_drop():
             warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
             eclf2.set_params(rf="drop").fit(X, y)
 
-    assert not record
+    assert not [w.message for w in record]
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
 
     assert dict(eclf2.estimators)["rf"] == "drop"
@@ -450,14 +450,14 @@ def test_set_estimator_drop():
             warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
             eclf2.set_params(voting="soft").fit(X, y)
 
-    assert not record
+    assert not [w.message for w in record]
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
     assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
     msg = "All estimators are dropped. At least one is required"
     with pytest.warns(None) as record:
         with pytest.raises(ValueError, match=msg):
             eclf2.set_params(lr="drop", rf="drop", nb="drop").fit(X, y)
-    assert not record
+    assert not [w.message for w in record]
 
     # Test soft voting transform
     X1 = np.array([[1], [2]])
@@ -480,7 +480,7 @@ def test_set_estimator_drop():
             # scipy 1.3.0 uses tostring which is deprecated in numpy
             warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
             eclf2.set_params(rf="drop").fit(X1, y1)
-    assert not record
+    assert not [w.message for w in record]
     assert_array_almost_equal(
         eclf1.transform(X1),
         np.array([[[0.7, 0.3], [0.3, 0.7]], [[1.0, 0.0], [0.0, 1.0]]]),
@@ -572,7 +572,7 @@ def test_none_estimator_with_weights(X, y, voter):
     voter.set_params(lr="drop")
     with pytest.warns(None) as record:
         voter.fit(X, y, sample_weight=np.ones(y.shape))
-    assert not record
+    assert not [w.message for w in record]
     y_pred = voter.predict(X)
     assert y_pred.shape == y.shape
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -453,7 +453,7 @@ def test_countvectorizer_uppercase_in_vocab():
 
     with pytest.warns(None) as record:
         vectorizer.transform(vocabulary)
-    assert not record
+    assert not [w.message for w in record]
 
 
 def test_tf_transformer_feature_names_out():
@@ -1424,7 +1424,7 @@ def test_vectorizer_stop_words_inconsistent():
     # Only one warning per stop list
     with pytest.warns(None) as record:
         vec.fit_transform(["hello world"])
-    assert not len(record)
+    assert not [w.message for w in record]
     assert _check_stop_words_consistency(vec) is None
 
     # Test caching of inconsistency assessment

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -210,7 +210,7 @@ def test_r_regression_force_finite(X, y, expected_corr_coef, force_finite):
     """
     with pytest.warns(None) as records:
         corr_coef = r_regression(X, y, force_finite=force_finite)
-    assert not [str(w.message) for w in records]
+    assert not [w.message for w in records]
     np.testing.assert_array_almost_equal(corr_coef, expected_corr_coef)
 
 
@@ -293,7 +293,7 @@ def test_f_regression_corner_case(
     """
     with pytest.warns(None) as records:
         f_statistic, p_values = f_regression(X, y, force_finite=force_finite)
-    assert not [str(w.message) for w in records]
+    assert not [w.message for w in records]
     np.testing.assert_array_almost_equal(f_statistic, expected_f_statistic)
     np.testing.assert_array_almost_equal(p_values, expected_p_values)
 

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -455,4 +455,4 @@ def test_estimator_does_not_support_feature_names():
 
     with pytest.warns(None) as records:
         selector.transform(X.iloc[1:3])
-    assert not [str(record.message) for record in records]
+    assert not [w.message for w in records]

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -981,7 +981,7 @@ def test_iterative_imputer_catch_warning():
     imputer = IterativeImputer(n_nearest_features=5, sample_posterior=True)
     with pytest.warns(None) as record:
         X_fill = imputer.fit_transform(X, y)
-    assert not [w.message for w in record.list]
+    assert not [w.message for w in record]
     assert not np.any(np.isnan(X_fill))
 
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -364,7 +364,7 @@ def test_linear_regression_pd_sparse_dataframe_warning():
 
     with pytest.warns(None) as record:
         reg.fit(df.iloc[:, 0:2], df.iloc[:, 3])
-    assert not record
+    assert not [w.message for w in record]
 
 
 def test_preprocess_data():

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -103,7 +103,7 @@ def test_assure_warning_when_normalize(CoordinateDescentModel, normalize, n_warn
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]
-    assert len(record) == n_warnings
+    assert len(record) == n_warnings, [w.message for w in record]
 
 
 @pytest.mark.parametrize(
@@ -1404,7 +1404,7 @@ def test_convergence_warnings():
     with pytest.warns(None) as record:
         MultiTaskElasticNet().fit(X, y)
 
-    assert not record.list
+    assert not [w.message for w in record]
 
 
 def test_sparse_input_convergence_warning():
@@ -1417,7 +1417,7 @@ def test_sparse_input_convergence_warning():
     with pytest.warns(None) as record:
         Lasso().fit(sparse.csr_matrix(X, dtype=np.float32), y)
 
-    assert not record.list
+    assert not [w.message for w in record]
 
 
 @pytest.mark.parametrize(

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -103,7 +103,7 @@ def test_assure_warning_when_normalize(CoordinateDescentModel, normalize, n_warn
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]
-    assert len(record) == n_warnings, [w.message for w in record]
+    assert len(record) == n_warnings
 
 
 @pytest.mark.parametrize(

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -53,7 +53,7 @@ def test_assure_warning_when_normalize(LeastAngleModel, normalize, n_warnings):
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]
-    assert len(record) == n_warnings
+    assert len(record) == n_warnings, [w.message for w in record]
 
 
 def test_simple():

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -53,7 +53,7 @@ def test_assure_warning_when_normalize(LeastAngleModel, normalize, n_warnings):
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]
-    assert len(record) == n_warnings, [w.message for w in record]
+    assert len(record) == n_warnings
 
 
 def test_simple():

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -145,7 +145,7 @@ def test_logistic_cv_score_does_not_warn_by_default():
 
     with pytest.warns(None) as record:
         lr.score(X, lr.predict(X))
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
 
 @skip_if_no_parallel

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -57,7 +57,7 @@ def test_assure_warning_when_normalize(OmpModel, normalize, n_warnings):
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]
-    assert len(record) == n_warnings, [w.message for w in record]
+    assert len(record) == n_warnings
 
 
 def test_correct_shapes():

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -57,7 +57,7 @@ def test_assure_warning_when_normalize(OmpModel, normalize, n_warnings):
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]
-    assert len(record) == n_warnings
+    assert len(record) == n_warnings, [w.message for w in record]
 
 
 def test_correct_shapes():

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1388,7 +1388,7 @@ def test_ridge_fit_intercept_sparse(solver):
     dense_ridge.fit(X, y)
     with pytest.warns(None) as record:
         sparse_ridge.fit(X_csr, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
     assert np.allclose(dense_ridge.intercept_, sparse_ridge.intercept_)
     assert np.allclose(dense_ridge.coef_, sparse_ridge.coef_)
 
@@ -1417,7 +1417,7 @@ def test_ridge_fit_intercept_sparse_sag():
     dense_ridge.fit(X, y)
     with pytest.warns(None) as record:
         sparse_ridge.fit(X_csr, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
     assert np.allclose(dense_ridge.intercept_, sparse_ridge.intercept_, rtol=1e-4)
     assert np.allclose(dense_ridge.coef_, sparse_ridge.coef_, rtol=1e-4)
     with pytest.warns(UserWarning, match='"sag" solver requires.*'):

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -1136,7 +1136,7 @@ def test_tsne_init_futurewarning(init):
     else:
         with pytest.warns(None) as record:
             tsne.fit_transform(X)
-        assert not record
+        assert not [w.message for w in record]
 
 
 # TODO: Remove in 1.2
@@ -1156,7 +1156,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
     else:
         with pytest.warns(None) as record:
             tsne.fit_transform(X)
-        assert not record
+        assert not [w.message for w in record]
 
 
 @pytest.mark.filterwarnings("ignore:The default initialization in TSNE")

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -460,4 +460,4 @@ def test_adjusted_rand_score_overflow():
     y_pred = rng.randint(0, 2, 100_000, dtype=np.int8)
     with pytest.warns(None) as record:
         adjusted_rand_score(y_true, y_pred)
-    assert len(record) == 0
+    assert not [w.message for w in record]

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1448,7 +1448,7 @@ def test_jaccard_score_zero_division_set_value(zero_division, expected_score):
             y_true, y_pred, average="samples", zero_division=zero_division
         )
     assert score == pytest.approx(expected_score)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
 
 @ignore_warnings

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -194,7 +194,7 @@ def test_pairwise_boolean_distance(metric):
     # Check that no warning is raised if X is already boolean and Y is None:
     with pytest.warns(None) as records:
         pairwise_distances(X.astype(bool), metric=metric)
-    assert len(records) == 0
+    assert not [w.message for w in records]
 
 
 def test_no_data_conversion_warning():
@@ -203,7 +203,7 @@ def test_no_data_conversion_warning():
     X = rng.randn(5, 4)
     with pytest.warns(None) as records:
         pairwise_distances(X, metric="minkowski")
-    assert len(records) == 0
+    assert not [w.message for w in records]
 
 
 @pytest.mark.parametrize("func", [pairwise_distances, pairwise_kernels])

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2373,7 +2373,7 @@ def test_validation_pairwise():
     svm = SVC(kernel="precomputed")
     with pytest.warns(None) as record:
         cross_validate(svm, linear_kernel, y, cv=2)
-    assert not record
+    assert not [w.message for w in record]
 
     # pairwise tag is not consistent with pairwise attribute
     class IncorrectTagSVM(SVC):

--- a/sklearn/preprocessing/tests/test_common.py
+++ b/sklearn/preprocessing/tests/test_common.py
@@ -71,14 +71,14 @@ def test_missing_value_handling(
     with pytest.warns(None) as records:
         Xt = est.fit(X_train).transform(X_test)
     # ensure no warnings are raised
-    assert len(records) == 0
+    assert not [w.message for w in records]
     # missing values should still be missing, and only them
     assert_array_equal(np.isnan(Xt), np.isnan(X_test))
 
     # check that the function leads to the same results as the class
     with pytest.warns(None) as records:
         Xt_class = est.transform(X_train)
-    assert len(records) == 0
+    assert not [w.message for w in records]
     kwargs = est.get_params()
     # remove the parameters which should be omitted because they
     # are not defined in the sister function of the preprocessing class
@@ -101,7 +101,7 @@ def test_missing_value_handling(
         # check transforming with NaN works even when training without NaN
         with pytest.warns(None) as records:
             Xt_col = est.transform(X_test[:, [i]])
-        assert len(records) == 0
+        assert not [w.message for w in records]
         assert_allclose(Xt_col, Xt[:, [i]])
         # check non-NaN is handled as before - the 1st column is all nan
         if not np.isnan(X_test[:, i]).all():
@@ -115,7 +115,7 @@ def test_missing_value_handling(
         with pytest.warns(None) as records:
             Xt_dense = est_dense.fit(X_train).transform(X_test)
             Xt_inv_dense = est_dense.inverse_transform(Xt_dense)
-        assert len(records) == 0
+        assert not [w.message for w in records]
         for sparse_constructor in (
             sparse.csr_matrix,
             sparse.csc_matrix,
@@ -132,12 +132,12 @@ def test_missing_value_handling(
             with pytest.warns(None) as records:
                 warnings.simplefilter("ignore", PendingDeprecationWarning)
                 Xt_sp = est_sparse.fit(X_train_sp).transform(X_test_sp)
-            assert len(records) == 0
+            assert not [w.message for w in records]
             assert_allclose(Xt_sp.A, Xt_dense)
             with pytest.warns(None) as records:
                 warnings.simplefilter("ignore", PendingDeprecationWarning)
                 Xt_inv_sp = est_sparse.inverse_transform(Xt_sp)
-            assert len(records) == 0
+            assert not [w.message for w in records]
             assert_allclose(Xt_inv_sp.A, Xt_inv_dense)
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -346,7 +346,7 @@ def test_standard_scaler_numerical_stability():
     # to trigger the problem in recent numpy
     with pytest.warns(None) as record:
         scale(x)
-    assert len(record) == 0
+    assert not [w.message for w in record]
     assert_array_almost_equal(scale(x), np.zeros(8))
 
     # with 2 more samples, the std computation run into numerical issues:
@@ -359,7 +359,7 @@ def test_standard_scaler_numerical_stability():
     x = np.full(10, 1e-100, dtype=np.float64)
     with pytest.warns(None) as record:
         x_small_scaled = scale(x)
-    assert len(record) == 0
+    assert not [w.message for w in record]
     assert_array_almost_equal(x_small_scaled, np.zeros(10))
 
     # Large values can cause (often recoverable) numerical stability issues:

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -149,7 +149,7 @@ def test_check_inverse():
         )
         with pytest.warns(None) as record:
             Xt = trans.fit_transform(X)
-        assert len(record) == 0
+        assert not [w.message for w in record]
         assert_allclose_dense_sparse(X, trans.inverse_transform(Xt))
 
     # check that we don't check inverse when one of the func or inverse is not
@@ -159,13 +159,13 @@ def test_check_inverse():
     )
     with pytest.warns(None) as record:
         trans.fit(X_dense)
-    assert len(record) == 0
+    assert not [w.message for w in record]
     trans = FunctionTransformer(
         func=None, inverse_func=np.expm1, check_inverse=True, validate=True
     )
     with pytest.warns(None) as record:
         trans.fit(X_dense)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
 
 def test_function_transformer_frame():

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -153,12 +153,12 @@ def test_convergence_warning():
     mdl = label_propagation.LabelSpreading(kernel="rbf", max_iter=500)
     with pytest.warns(None) as record:
         mdl.fit(X, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
     mdl = label_propagation.LabelPropagation(kernel="rbf", max_iter=500)
     with pytest.warns(None) as record:
         mdl.fit(X, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
 
 @pytest.mark.parametrize(
@@ -175,7 +175,7 @@ def test_label_propagation_non_zero_normalizer(LabelPropagationCls):
     mdl = LabelPropagationCls(kernel="knn", max_iter=100, n_neighbors=1)
     with pytest.warns(None) as record:
         mdl.fit(X, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
 
 def test_predict_sparse_callable_kernel():

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1332,11 +1332,11 @@ def test_gamma_auto():
 
     with pytest.warns(None) as record:
         svm.SVC(kernel="linear").fit(X, y)
-    assert not len(record)
+    assert not [w.message for w in record]
 
     with pytest.warns(None) as record:
         svm.SVC(kernel="precomputed").fit(X, y)
-    assert not len(record)
+    assert not [w.message for w in record]
 
 
 def test_gamma_scale():
@@ -1345,7 +1345,7 @@ def test_gamma_scale():
     clf = svm.SVC()
     with pytest.warns(None) as record:
         clf.fit(X, y)
-    assert not len(record)
+    assert not [w.message for w in record]
     assert_almost_equal(clf._gamma, 4)
 
     # X_var ~= 1 shouldn't raise warning, for when
@@ -1353,7 +1353,7 @@ def test_gamma_scale():
     X, y = [[1, 2], [3, 2 * np.sqrt(6) / 3 + 2]], [0, 1]
     with pytest.warns(None) as record:
         clf.fit(X, y)
-    assert not len(record)
+    assert not [w.message for w in record]
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -566,7 +566,7 @@ def test_is_pairwise():
     pca = KernelPCA(kernel="precomputed")
     with pytest.warns(None) as record:
         assert _is_pairwise(pca)
-    assert not record
+    assert not [w.message for w in record]
 
     # pairwise attribute that is not consistent with the pairwise tag
     class IncorrectTagPCA(KernelPCA):
@@ -590,7 +590,7 @@ def test_is_pairwise():
     est = BaseEstimator()
     with pytest.warns(None) as record:
         assert not _is_pairwise(est)
-    assert not record
+    assert not [w.message for w in record]
 
 
 def test_n_features_in_validation():
@@ -667,7 +667,7 @@ def test_feature_names_in():
     trans = NoOpTransformer()
     with pytest.warns(None) as record:
         trans.fit(df_int_names)
-    assert not record
+    assert not [w.message for w in record]
 
     # fit on dataframe with no feature names or all integer feature names
     # -> do not warn on transform
@@ -675,7 +675,7 @@ def test_feature_names_in():
     for X in Xs:
         with pytest.warns(None) as record:
             trans.transform(X)
-        assert not record
+        assert not [w.message for w in record]
 
     # TODO: Convert to a error in 1.2
     # fit on dataframe with feature names that are mixed warns:

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -44,7 +44,7 @@ def test_check_increasing_small_number_of_samples():
 
     with pytest.warns(None) as record:
         is_increasing = check_increasing(x, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
     assert is_increasing
 
@@ -56,7 +56,7 @@ def test_check_increasing_up():
     # Check that we got increasing=True and no warnings
     with pytest.warns(None) as record:
         is_increasing = check_increasing(x, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
     assert is_increasing
 
@@ -68,7 +68,7 @@ def test_check_increasing_up_extreme():
     # Check that we got increasing=True and no warnings
     with pytest.warns(None) as record:
         is_increasing = check_increasing(x, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
     assert is_increasing
 
@@ -80,7 +80,7 @@ def test_check_increasing_down():
     # Check that we got increasing=False and no warnings
     with pytest.warns(None) as record:
         is_increasing = check_increasing(x, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
     assert not is_increasing
 
@@ -92,7 +92,7 @@ def test_check_increasing_down_extreme():
     # Check that we got increasing=False and no warnings
     with pytest.warns(None) as record:
         is_increasing = check_increasing(x, y)
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
     assert not is_increasing
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -518,7 +518,7 @@ def test_mnb_prior_unobserved_targets():
 
     with pytest.warns(None) as record:
         clf.partial_fit(X, y, classes=[0, 1, 2])
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
     assert clf.predict([[0, 1]]) == 0
     assert clf.predict([[1, 0]]) == 1
@@ -527,7 +527,7 @@ def test_mnb_prior_unobserved_targets():
     # add a training example with previously unobserved class
     with pytest.warns(None) as record:
         clf.partial_fit([[1, 1]], [2])
-    assert len(record) == 0
+    assert not [w.message for w in record]
 
     assert clf.predict([[0, 1]]) == 0
     assert clf.predict([[1, 0]]) == 1

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -996,20 +996,20 @@ def test_set_feature_union_step_drop(get_names):
         assert_array_equal([[3]], ft.fit(X).transform(X))
         assert_array_equal([[3]], ft.fit_transform(X))
     assert_array_equal(["m3__x3"], getattr(ft, get_names)())
-    assert not record
+    assert not [w.message for w in record]
 
     with pytest.warns(None) as record:
         ft.set_params(m3="drop")
         assert_array_equal([[]], ft.fit(X).transform(X))
         assert_array_equal([[]], ft.fit_transform(X))
     assert_array_equal([], getattr(ft, get_names)())
-    assert not record
+    assert not [w.message for w in record]
 
     with pytest.warns(None) as record:
         # check we can change back
         ft.set_params(m3=mult3)
         assert_array_equal([[3]], ft.fit(X).transform(X))
-    assert not record
+    assert not [w.message for w in record]
 
     with pytest.warns(None) as record:
         # Check 'drop' step at construction time
@@ -1017,7 +1017,7 @@ def test_set_feature_union_step_drop(get_names):
         assert_array_equal([[3]], ft.fit(X).transform(X))
         assert_array_equal([[3]], ft.fit_transform(X))
     assert_array_equal(["m3__x3"], getattr(ft, get_names)())
-    assert not record
+    assert not [w.message for w in record]
 
 
 def test_set_feature_union_passthrough():

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -479,7 +479,7 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
     subset = _safe_indexing(X, [0, 1], axis=0)
     with pytest.warns(None) as record:
         subset.iloc[0, 0] = 10
-    assert len(record) == 0, f"{[str(rec.message) for rec in record]}"
+    assert not [w.message for w in record]
     # The original dataframe is unaffected by the assignment on the subset:
     assert X.iloc[0, 0] == 1
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1092,7 +1092,7 @@ def test_check_scalar_valid(x):
             max_val=5,
             include_boundaries="both",
         )
-    assert len(record) == 0
+    assert not [w.message for w in record]
     assert scalar == x
 
 
@@ -1623,7 +1623,7 @@ def test_get_feature_names_pandas_with_ints_no_warning(names):
 
     with pytest.warns(None) as record:
         names = _get_feature_names(X)
-    assert not record
+    assert not [w.message for w in record]
     assert names is None
 
 


### PR DESCRIPTION
Related to https://github.com/scikit-learn/scikit-learn/pull/22361

Every time a new warning is raised it is hard to debug the `assert not record` check because the messages are hidden. This PR updates the assertion to:

```python
assert not [w.message for w in record]
```

so the actual warnings are shown in the error message.


