### PR TITLE
DOC Ensures that make_scorer passes numpydoc validation

### DIFF
--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -591,8 +591,8 @@ def make_scorer(
     :func:`~sklearn.model_selection.cross_val_score`.
     It takes a score function, such as :func:`~sklearn.metrics.accuracy_score`,
     :func:`~sklearn.metrics.mean_squared_error`,
-    :func:`~sklearn.metrics.adjusted_rand_index` or
-    :func:`~sklearn.metrics.average_precision`
+    :func:`~sklearn.metrics.adjusted_rand_score` or
+    :func:`~sklearn.metrics.average_precision_score`
     and returns a callable that scores an estimator's output.
     The signature of the call is `(estimator, X, y)` where `estimator`
     is the model to be evaluated, `X` is the data and `y` is the

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -604,51 +604,40 @@ def make_scorer(
     ----------
     score_func : callable
         Score function (or loss function) with signature
-        ``score_func(y, y_pred, **kwargs)``.
+        `score_func(y, y_pred, **kwargs)`.
 
     greater_is_better : bool, default=True
-        Whether score_func is a score function (default), meaning high is good,
-        or a loss function, meaning low is good. In the latter case, the
-        scorer object will sign-flip the outcome of the score_func.
+        Whether `score_func` is a score function (default), meaning high is
+        good, or a loss function, meaning low is good. In the latter case, the
+        scorer object will sign-flip the outcome of the `score_func`.
 
     needs_proba : bool, default=False
-        Whether score_func requires predict_proba to get probability estimates
-        out of a classifier.
+        Whether `score_func` requires `predict_proba` to get probability
+        estimates out of a classifier.
 
         If True, for binary `y_true`, the score function is supposed to accept
         a 1D `y_pred` (i.e., probability of the positive class, shape
         `(n_samples,)`).
 
     needs_threshold : bool, default=False
-        Whether score_func takes a continuous decision certainty.
+        Whether `score_func` takes a continuous decision certainty.
         This only works for binary classification using estimators that
-        have either a decision_function or predict_proba method.
+        have either a `decision_function` or `predict_proba` method.
 
         If True, for binary `y_true`, the score function is supposed to accept
         a 1D `y_pred` (i.e., probability of the positive class or the decision
         function, shape `(n_samples,)`).
 
-        For example ``average_precision`` or the area under the roc curve
+        For example `average_precision` or the area under the roc curve
         can not be computed using discrete predictions alone.
 
     **kwargs : additional arguments
-        Additional parameters to be passed to score_func.
+        Additional parameters to be passed to `score_func`.
 
     Returns
     -------
     scorer : callable
         Callable object that returns a scalar score; greater is better.
-
-    Examples
-    --------
-    >>> from sklearn.metrics import fbeta_score, make_scorer
-    >>> ftwo_scorer = make_scorer(fbeta_score, beta=2)
-    >>> ftwo_scorer
-    make_scorer(fbeta_score, beta=2)
-    >>> from sklearn.model_selection import GridSearchCV
-    >>> from sklearn.svm import LinearSVC
-    >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]},
-    ...                     scoring=ftwo_scorer)
 
     Notes
     -----
@@ -660,6 +649,17 @@ def make_scorer(
     `needs_threshold=True`, the score function is supposed to accept the
     output of :term:`decision_function` or :term:`predict_proba` when
     :term:`decision_function` is not present.
+
+    Examples
+    --------
+    >>> from sklearn.metrics import fbeta_score, make_scorer
+    >>> ftwo_scorer = make_scorer(fbeta_score, beta=2)
+    >>> ftwo_scorer
+    make_scorer(fbeta_score, beta=2)
+    >>> from sklearn.model_selection import GridSearchCV
+    >>> from sklearn.svm import LinearSVC
+    >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]},
+    ...                     scoring=ftwo_scorer)
     """
     sign = 1 if greater_is_better else -1
     if needs_proba and needs_threshold:

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -86,7 +86,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics._ranking.roc_curve",
     "sklearn.metrics._ranking.top_k_accuracy_score",
     "sklearn.metrics._regression.mean_pinball_loss",
-    "sklearn.metrics._scorer.make_scorer",
     "sklearn.metrics.cluster._bicluster.consensus_score",
     "sklearn.metrics.cluster._supervised.adjusted_mutual_info_score",
     "sklearn.metrics.cluster._supervised.adjusted_rand_score",


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #21350.


#### What does this implement/fix? Explain your changes.
This PR:
- Removes `make_scorer` from `FUNCTION_DOCSTRING_IGNORE_LIST`.
- Fixes numpydocs from `make_scorer`.
- Fixes broken links for `~sklearn.metrics.adjusted_rand_score` and `~sklearn.metrics.average_precision_score`