### PR TITLE
DOC label addition of QuantileRegressor as major feature

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -764,7 +764,7 @@ Changelog
 :mod:`sklearn.linear_model`
 ...........................
 
-- |Feature| Added :class:`linear_model.QuantileRegressor` which implements
+- |MajorFeature| Added :class:`linear_model.QuantileRegressor` which implements
   linear quantile regression with L1 penalty.
   :pr:`9978` by :user:`David Dale <avidale>` and
   :user:`Christian Lorentzen <lorentzenchr>`.


### PR DESCRIPTION
#### Reference Issues/PRs
The addition of the `QuantileRegressor` in v1.0 via #9978 should be marked as major feature in the changelog.