### PR TITLE
CI Pin pytest version for stalled tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,6 +206,7 @@ jobs:
       pylatest_pip_openblas_pandas:
         DISTRIB: 'conda-pip-latest'
         PYTHON_VERSION: '3.9'
+        PYTEST_VERSION: '6.2.5'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
@@ -273,7 +274,8 @@ jobs:
         PYTHON_VERSION: '3.7'
         CHECK_WARNINGS: 'true'
         PYTHON_ARCH: '64'
-        PYTEST_VERSION: '*'
+        # Unpin when pytest stalling issue is fixed
+        PYTEST_VERSION: '6.2.5'
         COVERAGE: 'true'
         # Temporary fix for setuptools to use disutils from standard lib
         # https://github.com/numpy/numpy/issues/17216


### PR DESCRIPTION
On `main` and PRs, pytest 7.0 is causing [two CI instances to fail](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=37696&view=results). This PR pins the pytest version so unblock PRs.