### PR TITLE
CI Fixes CI for pyamg using deprecated SciPy API

### DIFF
--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -41,6 +41,9 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
 
     # Python 3.10 deprecates disutils and is imported by numpy interally during import time
     TEST_CMD="$TEST_CMD -Wignore:The\ distutils:DeprecationWarning"
+
+    # pyamg uses upcast from scipy.sparse.sputils which is deprecated in 1.8.0
+    TEST_CMD="$TEST_CMD -Wignore:Please\ use\ `upcast`\ from:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then


### PR DESCRIPTION
CI is failing because pyamg is using `scipy.sparse.sputils` which was deprecated in SciPy 1.8.0.