### PR TITLE
FIX Only raise feature name warning with mixed types and strings

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -45,6 +45,10 @@ random sampling procedures.
   `force_finite=False` if you really want to get non-finite values and keep
   the old behavior.
 
+- |Fix| Panda's DataFrames with all non-string columns such as a MultiIndex
+  will no longer warn when passed into an Estimator. :pr:`xxxxx` by
+  `Thomas Fan`_.
+
 Changelog
 ---------
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -46,8 +46,10 @@ random sampling procedures.
   the old behavior.
 
 - |Fix| Panda's DataFrames with all non-string columns such as a MultiIndex
-  will no longer warn when passed into an Estimator. :pr:`22410` by
-  `Thomas Fan`_.
+  no longer warns when passed into an Estimator. These non-string columns
+  will be supported in 1.3. Note that `feature_names_in_` will continue to
+  **not** be defined. For `feature_names_in_` to be defined, columns must be
+  all strings. :pr:`22410` by `Thomas Fan`_.
 
 Changelog
 ---------

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -45,11 +45,11 @@ random sampling procedures.
   `force_finite=False` if you really want to get non-finite values and keep
   the old behavior.
 
-- |Fix| Panda's DataFrames with all non-string columns such as a MultiIndex
-  no longer warns when passed into an Estimator. These non-string columns
-  will be supported in 1.3. Note that `feature_names_in_` will continue to
-  **not** be defined. For `feature_names_in_` to be defined, columns must be
-  all strings. :pr:`22410` by `Thomas Fan`_.
+- |Fix| Panda's DataFrames with all non-string columns such as a MultiIndex no
+  longer warns when passed into an Estimator. Estimators will continue to
+  ignore the column names in DataFrames with non-string columns. For
+  `feature_names_in_` to be defined, columns must be all strings. :pr:`22410` by
+  `Thomas Fan`_.
 
 Changelog
 ---------

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -46,7 +46,7 @@ random sampling procedures.
   the old behavior.
 
 - |Fix| Panda's DataFrames with all non-string columns such as a MultiIndex
-  will no longer warn when passed into an Estimator. :pr:`xxxxx` by
+  will no longer warn when passed into an Estimator. :pr:`22410` by
   `Thomas Fan`_.
 
 Changelog

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1613,11 +1613,14 @@ def test_check_array_deprecated_matrix():
 
 @pytest.mark.parametrize(
     "names",
-    [list(range(2)), range(2), None],
-    ids=["list-int", "range", "default"],
+    [list(range(2)), range(2), None, [["a", "b"], ["c", "d"]]],
+    ids=["list-int", "range", "default", "MultiIndex"],
 )
 def test_get_feature_names_pandas_with_ints_no_warning(names):
-    """Get feature names with pandas dataframes with ints without warning"""
+    """Get feature names with pandas dataframes without warning.
+
+    Column names with consistent dtypes will not warn, such as int or MultiIndex.
+    """
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame([[1, 2], [4, 5], [5, 6]], columns=names)
 
@@ -1648,10 +1651,10 @@ def test_get_feature_names_numpy():
 @pytest.mark.parametrize(
     "names, dtypes",
     [
-        ([["a", "b"], ["c", "d"]], "['tuple']"),
         (["a", 1], "['int', 'str']"),
+        (["pizza", ["a", "b"]], "['list', 'str']"),
     ],
-    ids=["multi-index", "mixed"],
+    ids=["int-str", "list-str"],
 )
 def test_get_feature_names_invalid_dtypes_warns(names, dtypes):
     """Get feature names warns when the feature names have mixed dtypes"""

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1810,9 +1810,8 @@ def _get_feature_names(X):
 
     types = sorted(t.__qualname__ for t in set(type(v) for v in feature_names))
 
-    # Warn when types are mixed.
-    # ints and strings do not warn
-    if len(types) > 1 or not (types[0].startswith("int") or types[0] == "str"):
+    # Warn when types are mixed and string is one of the types
+    if len(types) > 1 and "str" in types:
         # TODO: Convert to an error in 1.2
         warnings.warn(
             "Feature names only support names that are all strings. "
@@ -1823,7 +1822,7 @@ def _get_feature_names(X):
         return
 
     # Only feature names of all strings are supported
-    if types[0] == "str":
+    if len(types) == 1 and types[0] == "str":
         return feature_names
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/22399


#### What does this implement/fix? Explain your changes.
This PR adjusts the check to only raise a warning for feature names when there is a mixed dtype and a string is in it. 

#### Any other comments?
I think this is more consistent with the @ogrisel's comment here: https://github.com/scikit-learn/scikit-learn/pull/18010#issuecomment-896561811

CC @glemaitre 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
