### PR TITLE
ENH reduce memory usage in `make_blobs`

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -141,8 +141,9 @@ Changelog
   hole; when set to True, it returns the swiss-hole dataset. :pr:`21482` by
   :user:`Sebastian Pujalte <pujaltes>`.
 
-- |Enhancement| :func:`datasets.make_blobs` is optimized to use less memory. :pr:`22412` by
-  :user:`Zhehao Liu <MaxwellLZH>`.
+- |Enhancement| :func:`datasets.make_blobs` no longer copies data during the generation
+  process, therefore uses less memory. 
+  :pr:`22412` by :user:`Zhehao Liu <MaxwellLZH>`.
 
 - |Enhancement| :func:`datasets.load_diabetes` now accepts the parameter
   ``scaled``, to allow loading unscaled data. The scaled version of this

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -141,6 +141,9 @@ Changelog
   hole; when set to True, it returns the swiss-hole dataset. :pr:`21482` by
   :user:`Sebastian Pujalte <pujaltes>`.
 
+- |Enhancement| :func:`datasets.make_blobs` is optimized to use less memory. :pr:`22412` by
+  :user:`Zhehao Liu <MaxwellLZH>`.
+
 - |Enhancement| :func:`datasets.load_diabetes` now accepts the parameter
   ``scaled``, to allow loading unscaled data. The scaled version of this
   dataset is now computed from the unscaled data, and can produce slightly

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -941,7 +941,7 @@ def make_blobs(
 
     cum_sum_n_samples = np.cumsum(n_samples_per_center)
     X = np.empty(shape=(sum(n_samples_per_center), n_features), dtype=np.float64)
-    y = np.empty(shape=(sum(n_samples_per_center),), dtype=np.int64)
+    y = np.empty(shape=(sum(n_samples_per_center),), dtype=int)
 
     for i, (n, std) in enumerate(zip(n_samples_per_center, cluster_std)):
         start_idx = cum_sum_n_samples[i - 1] if i > 0 else 0

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -931,9 +931,6 @@ def make_blobs(
     if isinstance(cluster_std, numbers.Real):
         cluster_std = np.full(len(centers), cluster_std)
 
-    X = []
-    y = []
-
     if isinstance(n_samples, Iterable):
         n_samples_per_center = n_samples
     else:
@@ -942,19 +939,20 @@ def make_blobs(
         for i in range(n_samples % n_centers):
             n_samples_per_center[i] += 1
 
-    for i, (n, std) in enumerate(zip(n_samples_per_center, cluster_std)):
-        X.append(generator.normal(loc=centers[i], scale=std, size=(n, n_features)))
-        y += [i] * n
+    cum_sum_n_samples = np.cumsum(n_samples_per_center)
+    X = np.empty(shape=(sum(n_samples_per_center), n_features), dtype=np.float64)
+    y = np.empty(shape=(sum(n_samples_per_center),), dtype=np.int64)
 
-    X = np.concatenate(X)
-    y = np.array(y)
+    for i, (n, std) in enumerate(zip(n_samples_per_center, cluster_std)):
+        start_idx = cum_sum_n_samples[i - 1] if i > 0 else 0
+        end_idx = cum_sum_n_samples[i]
+        X[start_idx:end_idx] = generator.normal(
+            loc=centers[i], scale=std, size=(n, n_features)
+        )
+        y[start_idx:end_idx] = i
 
     if shuffle:
-        total_n_samples = np.sum(n_samples)
-        indices = np.arange(total_n_samples)
-        generator.shuffle(indices)
-        X = X[indices]
-        y = y[indices]
+        X, y = util_shuffle(X, y, random_state=generator)
 
     if return_centers:
         return X, y, centers

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -435,42 +435,6 @@ def test_make_blobs_error():
         make_blobs(n_samples, centers=3)
 
 
-def test_make_blobs_memory_usage():
-    try:
-        import memory_profiler
-
-        has_memory_profiler = True
-    except:
-        has_memory_profiler = False
-
-    if not has_memory_profiler:
-        pytest.skip("memory_profiler is not available.")
-
-    blobs_opts = {
-        "n_samples": 10 ** 4,
-        "n_features": 10 ** 4,
-        "centers": 10,
-        "random_state": 10,
-        "return_centers": True,
-        "shuffle": False,
-    }
-    # maximum memory usage in MB
-    actual_memory_usage, (X, y, c) = memory_profiler.memory_usage(
-        (partial(make_blobs, **blobs_opts), ()),
-        max_iterations=1,
-        max_usage=True,
-        retval=True,
-    )
-    memory_usage_X = (
-        blobs_opts["n_samples"] * blobs_opts["n_features"] * X.dtype.itemsize
-    )
-    memory_usage_y = blobs_opts["n_samples"] * y.dtype.itemsize
-    memory_usage_c = blobs_opts["centers"] * blobs_opts["n_features"] * c.dtype.itemsize
-    calc_memory_useage_mb = (memory_usage_X + memory_usage_y + memory_usage_c) / 1048576
-    # make sure actual memory usage is relatively close to theratical amount
-    assert actual_memory_usage < calc_memory_useage_mb * 1.3
-
-
 def test_make_friedman1():
     X, y = make_friedman1(n_samples=5, n_features=10, noise=0.0, random_state=0)
 

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -435,6 +435,42 @@ def test_make_blobs_error():
         make_blobs(n_samples, centers=3)
 
 
+def test_make_blobs_memory_usage():
+    try:
+        import memory_profiler
+
+        has_memory_profiler = True
+    except:
+        has_memory_profiler = False
+
+    if not has_memory_profiler:
+        pytest.skip("memory_profiler is not available.")
+
+    blobs_opts = {
+        "n_samples": 10 ** 4,
+        "n_features": 10 ** 4,
+        "centers": 10,
+        "random_state": 10,
+        "return_centers": True,
+        "shuffle": False,
+    }
+    # maximum memory usage in MB
+    actual_memory_usage, (X, y, c) = memory_profiler.memory_usage(
+        (partial(make_blobs, **blobs_opts), ()),
+        max_iterations=1,
+        max_usage=True,
+        retval=True,
+    )
+    memory_usage_X = (
+        blobs_opts["n_samples"] * blobs_opts["n_features"] * X.dtype.itemsize
+    )
+    memory_usage_y = blobs_opts["n_samples"] * y.dtype.itemsize
+    memory_usage_c = blobs_opts["centers"] * blobs_opts["n_features"] * c.dtype.itemsize
+    calc_memory_useage_mb = (memory_usage_X + memory_usage_y + memory_usage_c) / 1048576
+    # make sure actual memory usage is relatively close to theratical amount
+    assert actual_memory_usage < calc_memory_useage_mb * 1.3
+
+
 def test_make_friedman1():
     X, y = make_friedman1(n_samples=5, n_features=10, noise=0.0, random_state=0)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a fix to issue #22244. 

#### What does this implement/fix? Explain your changes.
Reduce memory usage in `make_blobs` by preallocating empty NumPy array instead of concatenating, as suggested by @glemaitre. 

Also adds a test case, using `memory_profiler` to track the memory usage of the function.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
