### PR TITLE
DOC fix SciPy intersphinx link.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -303,7 +303,7 @@ trim_doctests_flags = True
 intersphinx_mapping = {
     "python": ("https://docs.python.org/{.major}".format(sys.version_info), None),
     "numpy": ("https://numpy.org/doc/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "matplotlib": ("https://matplotlib.org/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "joblib": ("https://joblib.readthedocs.io/en/latest/", None),


### PR DESCRIPTION
Fix the SciPy intersphinx link following our doc theme/`.htaccess` server changes. See: https://github.com/scipy/scipy/issues/15545#issuecomment-1032825234