### PR TITLE
DOC Fixes plot_sgd example to be consistent with 0.24

### DIFF
--- a/examples/linear_model/plot_sgd_weighted_samples.py
+++ b/examples/linear_model/plot_sgd_weighted_samples.py
@@ -22,8 +22,8 @@ sample_weight[:10] *= 10
 
 # plot the weighted data points
 xx, yy = np.meshgrid(np.linspace(-4, 5, 500), np.linspace(-4, 5, 500))
-plt.figure()
-plt.scatter(
+fig, ax = plt.subplots()
+ax.scatter(
     X[:, 0],
     X[:, 1],
     c=y,
@@ -38,21 +38,18 @@ clf = linear_model.SGDClassifier(alpha=0.01, max_iter=100)
 clf.fit(X, y)
 Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
 Z = Z.reshape(xx.shape)
-no_weights = plt.contour(xx, yy, Z, levels=[0], linestyles=["solid"])
+no_weights = ax.contour(xx, yy, Z, levels=[0], linestyles=["solid"])
 
 # fit the weighted model
 clf = linear_model.SGDClassifier(alpha=0.01, max_iter=100)
 clf.fit(X, y, sample_weight=sample_weight)
 Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
 Z = Z.reshape(xx.shape)
-samples_weights = plt.contour(xx, yy, Z, levels=[0], linestyles=["dashed"])
+samples_weights = ax.contour(xx, yy, Z, levels=[0], linestyles=["dashed"])
 
-plt.legend(
-    [no_weights.collections[0], samples_weights.collections[0]],
-    ["no weights", "with weights"],
-    loc="lower left",
-)
+h1, _ = no_weights.legend_elements()
+h2, _ = samples_weights.legend_elements()
+ax.legend([h1[0], h2[0]], ["no weights", "with weights"], loc="lower left")
 
-plt.xticks(())
-plt.yticks(())
+ax.set(xticks=(), yticks=())
 plt.show()

--- a/examples/linear_model/plot_sgd_weighted_samples.py
+++ b/examples/linear_model/plot_sgd_weighted_samples.py
@@ -47,9 +47,13 @@ Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
 Z = Z.reshape(xx.shape)
 samples_weights = ax.contour(xx, yy, Z, levels=[0], linestyles=["dashed"])
 
-h1, _ = no_weights.legend_elements()
-h2, _ = samples_weights.legend_elements()
-ax.legend([h1[0], h2[0]], ["no weights", "with weights"], loc="lower left")
+no_weights_handles, _ = no_weights.legend_elements()
+weights_handles, _ = samples_weights.legend_elements()
+ax.legend(
+    [no_weights_handles[0], weights_handles[0]],
+    ["no weights", "with weights"],
+    loc="lower left",
+)
 
 ax.set(xticks=(), yticks=())
 plt.show()


### PR DESCRIPTION
This PR fixes the image so it is the same as the version on [0.24](https://scikit-learn.org/0.24/auto_examples/linear_model/plot_sgd_weighted_samples.html#sphx-glr-auto-examples-linear-model-plot-sgd-weighted-samples-py)

### main

![Screen Shot 2022-02-08 at 10 50 47 PM](https://user-images.githubusercontent.com/5402633/153118621-4d6991e3-922c-42bf-a01f-a1055fd4fc8e.jpg)

### PR

![Screen Shot 2022-02-08 at 10 54 05 PM](https://user-images.githubusercontent.com/5402633/153118829-8a8228d7-8a9e-47f3-a139-409cf5c43ed7.jpg)


