### PR TITLE
FIX Preserve float32 in MiniBatchDictionaryLearning

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -893,7 +893,8 @@ def dict_learning_online(
         dictionary = dictionary[:n_components, :]
     else:
         dictionary = np.r_[
-            dictionary, np.zeros((n_components - r, dictionary.shape[1]))
+            dictionary,
+            np.zeros((n_components - r, dictionary.shape[1]), dtype=dictionary.dtype),
         ]
 
     if verbose == 1:
@@ -905,25 +906,23 @@ def dict_learning_online(
     else:
         X_train = X
 
-    # Fortran-order dict better suited for the sparse coding which is the
-    # bottleneck of this algorithm.
-    dictionary = check_array(
-        dictionary, order="F", dtype=[np.float64, np.float32], copy=False
-    )
-    dictionary = np.require(dictionary, requirements="W")
-
     X_train = check_array(
         X_train, order="C", dtype=[np.float64, np.float32], copy=False
     )
+
+    # Fortran-order dict better suited for the sparse coding which is the
+    # bottleneck of this algorithm.
+    dictionary = check_array(dictionary, order="F", dtype=X_train.dtype, copy=False)
+    dictionary = np.require(dictionary, requirements="W")
 
     batches = gen_batches(n_samples, batch_size)
     batches = itertools.cycle(batches)
 
     # The covariance of the dictionary
     if inner_stats is None:
-        A = np.zeros((n_components, n_components))
+        A = np.zeros((n_components, n_components), dtype=X_train.dtype)
         # The data approximation
-        B = np.zeros((n_features, n_components))
+        B = np.zeros((n_features, n_components), dtype=X_train.dtype)
     else:
         A = inner_stats[0].copy()
         B = inner_stats[1].copy()

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -740,6 +740,10 @@ def test_dictionary_learning_dtype_match(
     assert dict_learner.components_.dtype == expected_type
     assert dict_learner.transform(X.astype(data_type)).dtype == expected_type
 
+    if dictionary_learning_transformer is MiniBatchDictionaryLearning:
+        assert dict_learner.inner_stats_[0].dtype == expected_type
+        assert dict_learner.inner_stats_[1].dtype == expected_type
+
 
 @pytest.mark.parametrize("method", ("lars", "cd"))
 @pytest.mark.parametrize(
@@ -812,17 +816,19 @@ def test_dict_learning_numerical_consistency(method):
         (np.int64, np.float64),
     ),
 )
-def test_minibatch_dictionary_learning_dtype_match(data_type, expected_type, method):
+def test_dict_learning_online_dtype_match(data_type, expected_type, method):
     # Verify output matrix dtype
     rng = np.random.RandomState(0)
     n_components = 8
-    dl = MiniBatchDictionaryLearning(n_components=8, alpha=1, random_state=0, method=method)
-    code = dl.fit_transform(X.astype(data_type))
-
+    code, dictionary = dict_learning_online(
+        X.astype(data_type),
+        n_components=n_components,
+        alpha=1,
+        random_state=rng,
+        method=method,
+    )
     assert code.dtype == expected_type
-    assert dl.components_.dtype == expected_type
-    assert dl.inner_stats_[0].dtype == expected_type
-    assert dl.inner_stats_[1].dtype == expected_type
+    assert dictionary.dtype == expected_type
 
 
 @pytest.mark.parametrize("method", ("lars", "cd"))

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -812,19 +812,17 @@ def test_dict_learning_numerical_consistency(method):
         (np.int64, np.float64),
     ),
 )
-def test_dict_learning_online_dtype_match(data_type, expected_type, method):
+def test_minibatch_dictionary_learning_dtype_match(data_type, expected_type, method):
     # Verify output matrix dtype
     rng = np.random.RandomState(0)
     n_components = 8
-    code, dictionary = dict_learning_online(
-        X.astype(data_type),
-        n_components=n_components,
-        alpha=1,
-        random_state=rng,
-        method=method,
-    )
+    dl = MiniBatchDictionaryLearning(n_components=8, alpha=1, random_state=0, method=method)
+    code = dl.fit_transform(X.astype(data_type))
+
     assert code.dtype == expected_type
-    assert dictionary.dtype == expected_type
+    assert dl.components_.dtype == expected_type
+    assert dl.inner_stats_[0].dtype == expected_type
+    assert dl.inner_stats_[1].dtype == expected_type
 
 
 @pytest.mark.parametrize("method", ("lars", "cd"))


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/22426

MiniBatchDictionaryLearning is supposed to preserve float32 since https://github.com/scikit-learn/scikit-learn/pull/22002 but the inner_stats (A and B) are still initialized with float64 which causes a copy each time there's an operation between X (or dict) and A or B.

I updated a test to check the dtype of A and B, which fails on main as expected.