### PR TITLE
MAINT: remove SKLEARN_SITE_JOBLIB doc which has been a noop since 0.21

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -190,7 +190,7 @@ jobs:
         PANDAS_VERSION: 'none'
         THREADPOOLCTL_VERSION: 'min'
         COVERAGE: 'false'
-      # Linux + Python 3.7 build with OpenBLAS and without SITE_JOBLIB
+      # Linux + Python 3.7 build with OpenBLAS
       py37_conda_defaults_openblas:
         DISTRIB: 'conda'
         CONDA_CHANNEL: 'defaults'  # Anaconda main channel

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -179,21 +179,6 @@ Environment variables
 
 These environment variables should be set before importing scikit-learn.
 
-:SKLEARN_SITE_JOBLIB:
-
-    When this environment variable is set to a non zero value,
-    scikit-learn uses the site joblib rather than its vendored version.
-    Consequently, joblib must be installed for scikit-learn to run.
-    Note that using the site joblib is at your own risks: the versions of
-    scikit-learn and joblib need to be compatible. Currently, joblib 0.11+
-    is supported. In addition, dumps from joblib.Memory might be incompatible,
-    and you might loose some caches and have to redownload some datasets.
-
-    .. deprecated:: 0.21
-
-       As of version 0.21 this parameter has no effect, vendored joblib was
-       removed and site joblib is always used.
-
 :SKLEARN_ASSUME_FINITE:
 
     Sets the default value for the `assume_finite` argument of


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

SKLEARN_SITE_JOBLIB has been doing nothing since 0.21, maybe it is time to remove it from the doc? I people google they probably find it on the documentation of previous scikit-learn versions.

I also cleaned up a misleading comment in the CI (this is actually the thing I bumped into and then I grepped to see whether SKLEARN_SITE_JOBLIB was still  mentioned somewhere).