### PR TITLE
[FAILED] CI Enable cython coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 branch = True
 source = sklearn
 parallel = True
-plugins = Cython.Coverage
+plugins = ${SKLEARN_CYTHON_COVERAGE}
 omit =
     */sklearn/externals/*
     */sklearn/_build_utils/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 source = sklearn
 parallel = True
+plugins = Cython.Coverage
 omit =
     */sklearn/externals/*
     */sklearn/_build_utils/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 branch = True
 source = sklearn
 parallel = True
-plugins = ${SKLEARN_CYTHON_COVERAGE}
+plugins = ${CYTHON_COVERAGE_PLUGIN}
 omit =
     */sklearn/externals/*
     */sklearn/_build_utils/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,7 +201,8 @@ jobs:
         MATPLOTLIB_VERSION: 'min'
         THREADPOOLCTL_VERSION: '2.2.0'
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
-        SKLEARN_CYTHON_COVERAGE: 'Cython.Coverage'
+        SKLEARN_ENABLE_CYTHON_TRACE: '1'
+        CYTHON_COVERAGE_PLUGIN: 'Cython.Coverage'
       # Linux environment to test the latest available dependencies.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,6 +210,7 @@ jobs:
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
+        SKLEARN_ENABLE_CYTHON_COVERAGE: '1'
 
 - template: build_tools/azure/posix-docker.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,7 +201,7 @@ jobs:
         MATPLOTLIB_VERSION: 'min'
         THREADPOOLCTL_VERSION: '2.2.0'
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
-        SKLEARN_ENABLE_CYTHON_COVERAGE: '1'
+        SKLEARN_CYTHON_COVERAGE: 'Cython.Coverage'
       # Linux environment to test the latest available dependencies.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,6 +201,7 @@ jobs:
         MATPLOTLIB_VERSION: 'min'
         THREADPOOLCTL_VERSION: '2.2.0'
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
+        SKLEARN_ENABLE_CYTHON_COVERAGE: '1'
       # Linux environment to test the latest available dependencies.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:
@@ -210,7 +211,6 @@ jobs:
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
-        SKLEARN_ENABLE_CYTHON_COVERAGE: '1'
 
 - template: build_tools/azure/posix-docker.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,6 +201,7 @@ jobs:
         MATPLOTLIB_VERSION: 'min'
         THREADPOOLCTL_VERSION: '2.2.0'
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
+        PYTEST_XDIST_VERSION: 'none'
         SKLEARN_ENABLE_CYTHON_TRACE: '1'
         CYTHON_COVERAGE_PLUGIN: 'Cython.Coverage'
       # Linux environment to test the latest available dependencies.

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -72,7 +72,7 @@ def cythonize_extensions(top_path, config):
     )
 
     enable_cython_coverage = (
-        os.environ.get("SKLEARN_ENABLE_CYTHON_COVERAGE", "0") != "0"
+        os.environ.get("SKLEARN_CYTHON_COVERAGE", "0") != "0"
     )
 
     # To enable cython coverage, we need to

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -86,8 +86,10 @@ def cythonize_extensions(top_path, config):
                 # we ignore this extension for now.
                 continue
 
-            if "CYTHON_TRACE_NOGIL" not in [m[0] for m in extension.define_macros]:
-                extension.define_macros.append(("CYTHON_TRACE_NOGIL", "1"))
+            if "CYTHON_TRACE" not in [m[0] for m in extension.define_macros]:
+                # We could also define CYTHON_TRACE_NOGIL to cover nogil blocks but it
+                # makes the execution of the tests way too slow.
+                extension.define_macros.append(("CYTHON_TRACE", "1"))
 
     config.ext_modules = cythonize(
         config.ext_modules,

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -71,19 +71,18 @@ def cythonize_extensions(top_path, config):
         os.environ.get("SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES", "0") != "0"
     )
 
-    enable_cython_coverage = (
-        os.environ.get("SKLEARN_CYTHON_COVERAGE", "0") != "0"
-    )
+    # Enabling cython line tracing is util for profiling and coverage
+    cython_enable_trace = os.environ.get("SKLEARN_ENABLE_CYTHON_TRACE", "0") != "0"
 
-    # To enable cython coverage, we need to
+    # To enable cython line tracing, we need to
     # - set the cython directive linetrace=True (can be done globally in cythonize)
     # - set the C macro CYTHON_TRACE_NOGIL=1 (has to be done per extension)
     #   It's a bit hackish but instead of defining the macro in every setup file, we
     #   manually update the defined macros of every extension here.
-    if enable_cython_coverage:
+    if cython_enable_trace:
         for extension in config.ext_modules:
             if extension.name == "sklearn.tree._splitter":
-                # TODO enabling linetrace in _splitter.pyx makes compilation fail
+                # TODO setting linetrace=True in _splitter.pyx makes compilation fail
                 # we ignore this extension for now.
                 continue
 
@@ -103,7 +102,7 @@ def cythonize_extensions(top_path, config):
             "initializedcheck": False,
             "nonecheck": False,
             "cdivision": True,
-            "linetrace": enable_cython_coverage,
+            "linetrace": cython_enable_trace,
         },
     )
 

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -1,3 +1,7 @@
+# cython: linetrace=False
+# locally disable linetrace. It means we don't have coverage for this extension.
+# TODO: find why enabling linetrace for this extension breaks compilation.
+
 """This module contains routines and data structures to:
 
 - Find the best possible split of a node. For a given node, a split is


### PR DESCRIPTION
Fixes #8163

Linetracing makes the program run much slower so we don't want to always enable it (not even enable it in all CI jobs).
I added an env var to enable cython coverage and use it in a single CI job. Let's see how it goes.

I haven't been able to compile all scikit-learn with `cython: linetrace=True`. the `_splitter.pyx` extension breaks the compilation with this error:
```
sklearn/ensemble/_hist_gradient_boosting/splitting.c: In function ‘__pyx_pf_7sklearn_8ensemble_23_hist_gradient_boosting_9splitting_8Splitter_2split_indices’:
sklearn/ensemble/_hist_gradient_boosting/splitting.c:634:43: error: invalid entry to OpenMP structured block
  634 |     { __PYX_MARK_ERR_POS(f_index, lineno) goto Ln_error; }
      |                                           ^~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:1917:34: note: in definition of macro ‘__Pyx_TraceLine’
 1917 |               if (unlikely(ret)) goto_error;\
      |                                  ^~~~~~~~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:4890:35: note: in expansion of macro ‘__PYX_ERR’
 4890 |             __Pyx_TraceLine(342,1,__PYX_ERR(0, 342, __pyx_L13_error))
      |                                   ^~~~~~~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:634:43: error: invalid entry to OpenMP structured block
  634 |     { __PYX_MARK_ERR_POS(f_index, lineno) goto Ln_error; }
      |                                           ^~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:1923:34: note: in definition of macro ‘__Pyx_TraceLine’
 1923 |               if (unlikely(ret)) goto_error;\
      |                                  ^~~~~~~~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:4890:35: note: in expansion of macro ‘__PYX_ERR’
 4890 |             __Pyx_TraceLine(342,1,__PYX_ERR(0, 342, __pyx_L13_error))
      |                                   ^~~~~~~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:634:43: error: invalid entry to OpenMP structured block
  634 |     { __PYX_MARK_ERR_POS(f_index, lineno) goto Ln_error; }
      |                                           ^~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:1917:34: note: in definition of macro ‘__Pyx_TraceLine’
 1917 |               if (unlikely(ret)) goto_error;\
      |                                  ^~~~~~~~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:5323:35: note: in expansion of macro ‘__PYX_ERR’
 5323 |             __Pyx_TraceLine(384,1,__PYX_ERR(0, 384, __pyx_L26_error))
      |                                   ^~~~~~~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:634:43: error: invalid entry to OpenMP structured block
  634 |     { __PYX_MARK_ERR_POS(f_index, lineno) goto Ln_error; }
      |                                           ^~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:1923:34: note: in definition of macro ‘__Pyx_TraceLine’
 1923 |               if (unlikely(ret)) goto_error;\
      |                                  ^~~~~~~~~~
sklearn/ensemble/_hist_gradient_boosting/splitting.c:5323:35: note: in expansion of macro ‘__PYX_ERR’
 5323 |             __Pyx_TraceLine(384,1,__PYX_ERR(0, 384, __pyx_L26_error))
      |                                   ^~~~~~~~~
```
I haven't found yet how to solve it, seems related to OpenMP and `goto` not usable inside openmp section, but other extensions using openmp compile, so I don't understand what's going on :(
Anyway we can still enable the coverage for all other extension and solve this issue later.