### PR TITLE
DOC use notebook-style for plot_train_error_vs_test_error

### DIFF
--- a/examples/model_selection/plot_train_error_vs_test_error.py
+++ b/examples/model_selection/plot_train_error_vs_test_error.py
@@ -20,19 +20,21 @@ measured using the explained variance a.k.a. R^2.
 # --------------------
 import numpy as np
 from sklearn import linear_model
+from sklearn.datasets import make_regression
+from sklearn.model_selection import train_test_split
 
 n_samples_train, n_samples_test, n_features = 75, 150, 500
-np.random.seed(0)
-coef = np.random.randn(n_features)
-coef[50:] = 0.0  # only the top 10 features are impacting the model
-X = np.random.randn(n_samples_train + n_samples_test, n_features)
-y = np.dot(X, coef)
-
-# %%
-# Split train and test data
-X_train, X_test = X[:n_samples_train], X[n_samples_train:]
-y_train, y_test = y[:n_samples_train], y[n_samples_train:]
-
+X, y, coef = make_regression(
+    n_samples=n_samples_train + n_samples_test,
+    n_features=n_features,
+    n_informative=50,
+    shuffle=False,
+    noise=1.0,
+    coef=True,
+)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, train_size=n_samples_train, test_size=n_samples_test, shuffle=False
+)
 # %%
 # Compute train and test errors
 # -----------------------------

--- a/examples/model_selection/plot_train_error_vs_test_error.py
+++ b/examples/model_selection/plot_train_error_vs_test_error.py
@@ -12,12 +12,12 @@ measured using the explained variance a.k.a. R^2.
 
 """
 
-# %%
-# Generate sample data
-# --------------------
 # Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 # License: BSD 3 clause
 
+# %%
+# Generate sample data
+# --------------------
 import numpy as np
 from sklearn import linear_model
 

--- a/examples/model_selection/plot_train_error_vs_test_error.py
+++ b/examples/model_selection/plot_train_error_vs_test_error.py
@@ -12,14 +12,15 @@ measured using the explained variance a.k.a. R^2.
 
 """
 
+# %%
+# Generate sample data
+# --------------------
 # Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>
 # License: BSD 3 clause
 
 import numpy as np
 from sklearn import linear_model
 
-# #############################################################################
-# Generate sample data
 n_samples_train, n_samples_test, n_features = 75, 150, 500
 np.random.seed(0)
 coef = np.random.randn(n_features)
@@ -27,12 +28,14 @@ coef[50:] = 0.0  # only the top 10 features are impacting the model
 X = np.random.randn(n_samples_train + n_samples_test, n_features)
 y = np.dot(X, coef)
 
+# %%
 # Split train and test data
 X_train, X_test = X[:n_samples_train], X[n_samples_train:]
 y_train, y_test = y[:n_samples_train], y[n_samples_train:]
 
-# #############################################################################
+# %%
 # Compute train and test errors
+# -----------------------------
 alphas = np.logspace(-5, 1, 60)
 enet = linear_model.ElasticNet(l1_ratio=0.7, max_iter=10000)
 train_errors = list()
@@ -51,8 +54,9 @@ print("Optimal regularization parameter : %s" % alpha_optim)
 enet.set_params(alpha=alpha_optim)
 coef_ = enet.fit(X, y).coef_
 
-# #############################################################################
+# %%
 # Plot results functions
+# ----------------------
 
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Update `examples/linear_model/plot_lasso_and_elasticnet.py` to notebook style, Issue https://github.com/scikit-learn/scikit-learn/issues/22406
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Slit example into:
- Generate Sample Data
- Compute train and test errors
- Plot results functions

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
