### PR TITLE
DOC Correct docstring for RocCurveDisplay.from_predictions

### DIFF
--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -301,7 +301,7 @@ class RocCurveDisplay:
 
         Returns
         -------
-        display : :class:`~sklearn.metrics.DetCurveDisplay`
+        display : :class:`~sklearn.metrics.RocCurveDisplay`
             Object that stores computed values.
 
         See Also


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The docs for `RocCurveDisplay.from_predictions`  erroneously describe the return type as a `DetCurveDisplay` when it should be a `RocCurveDisplay`.

