### PR TITLE
DOC use notebook-style for plot_faces_decomposition

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -529,7 +529,7 @@ dictionary fixed, and then updating the dictionary to best fit the sparse code.
    :target: ../auto_examples/decomposition/plot_faces_decomposition.html
    :scale: 60%
 
-.. |dict_img2| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_006.png
+.. |dict_img2| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_007.png
    :target: ../auto_examples/decomposition/plot_faces_decomposition.html
    :scale: 60%
 
@@ -548,19 +548,19 @@ different positivity constraints applied. Red indicates negative values, blue
 indicates positive values, and white represents zeros.
 
 
-.. |dict_img_pos1| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_011.png
+.. |dict_img_pos1| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_010.png
     :target: ../auto_examples/decomposition/plot_image_denoising.html
     :scale: 60%
 
-.. |dict_img_pos2| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_012.png
+.. |dict_img_pos2| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_011.png
     :target: ../auto_examples/decomposition/plot_image_denoising.html
     :scale: 60%
 
-.. |dict_img_pos3| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_013.png
+.. |dict_img_pos3| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_012.png
     :target: ../auto_examples/decomposition/plot_image_denoising.html
     :scale: 60%
 
-.. |dict_img_pos4| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_014.png
+.. |dict_img_pos4| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_013.png
     :target: ../auto_examples/decomposition/plot_image_denoising.html
     :scale: 60%
 
@@ -689,7 +689,7 @@ about these components (e.g. whether they are orthogonal):
     :target: ../auto_examples/decomposition/plot_faces_decomposition.html
     :scale: 60%
 
-.. |fa_img3| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_009.png
+.. |fa_img3| image:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_008.png
     :target: ../auto_examples/decomposition/plot_faces_decomposition.html
     :scale: 60%
 
@@ -699,7 +699,7 @@ The main advantage for Factor Analysis over :class:`PCA` is that
 it can model the variance in every direction of the input space independently
 (heteroscedastic noise):
 
-.. figure:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_008.png
+.. figure:: ../auto_examples/decomposition/images/sphx_glr_plot_faces_decomposition_009.png
     :target: ../auto_examples/decomposition/plot_faces_decomposition.html
     :align: center
     :scale: 75%

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -6,7 +6,7 @@ Faces dataset decompositions
 This example applies to :ref:`olivetti_faces_dataset` different unsupervised
 matrix decomposition (dimension reduction) methods from the module
 :py:mod:`sklearn.decomposition` (see the documentation chapter
-:ref:`decompositions`) .
+:ref:`decompositions`).
 
 
 - Authors: Vlad Niculae, Alexandre Gramfort
@@ -15,12 +15,11 @@ matrix decomposition (dimension reduction) methods from the module
 
 # %%
 # Dataset preparation
-# ---------------------------------------------------
+# --------------------
 #
 # Loading and preprocessing the Olivetti faces dataset.
 
 import logging
-from time import time
 
 from numpy.random import RandomState
 import matplotlib.pyplot as plt
@@ -55,12 +54,11 @@ image_shape = (64, 64)
 
 
 def plot_gallery(title, images, n_col=n_col, n_row=n_row, cmap=plt.cm.gray):
-    if n_col * n_row == 1:
-        figsize = (3.5, 3.6)
-    else:
-        figsize = (2.0 * n_col, 2.26 * n_row)
-
-    fig = plt.figure(figsize=figsize, facecolor="white", tight_layout={"pad": 0.3})
+    fig = plt.figure(
+        figsize=(2.0 * n_col, 2.26 * n_row),
+        facecolor="white",
+        tight_layout={"pad": 0.3},
+    )
     fig.suptitle(title, size=16, wrap=True)
     for i, comp in enumerate(images):
         plt.subplot(n_row, n_col, i + 1)
@@ -72,8 +70,8 @@ def plot_gallery(title, images, n_col=n_col, n_row=n_row, cmap=plt.cm.gray):
             vmin=-vmax,
             vmax=vmax,
         )
-        plt.xticks(())
-        plt.yticks(())
+        plt.axis("off")
+    plt.show()
 
 
 # %%
@@ -84,73 +82,20 @@ plot_gallery("Faces from dataset", faces_centered[:n_components])
 
 # %%
 # Decomposition
-# ---------------------------------------------------
+# --------------
 #
-# Initialise different estimators for decomposition and organise them all
-# in a simple structure. Each tuple has the name and instance of the
-# estimator and boolean flag if this estimator will be used
-# on centred (preprocessed) data.
-
-estimators = [
-    (
-        "Eigenfaces - PCA using randomized SVD",
-        decomposition.PCA(
-            n_components=n_components, svd_solver="randomized", whiten=True
-        ),
-        True,
-    ),
-    (
-        "Non-negative components - NMF",
-        decomposition.NMF(n_components=n_components, tol=5e-3),
-        False,
-    ),
-    (
-        "Independent components - FastICA",
-        decomposition.FastICA(n_components=n_components, whiten=True),
-        True,
-    ),
-    (
-        "Sparse comp. - MiniBatchSparsePCA",
-        decomposition.MiniBatchSparsePCA(
-            n_components=n_components,
-            alpha=0.8,
-            n_iter=100,
-            batch_size=3,
-            random_state=rng,
-        ),
-        True,
-    ),
-    (
-        "MiniBatchDictionaryLearning",
-        decomposition.MiniBatchDictionaryLearning(
-            n_components=15, alpha=0.1, n_iter=50, batch_size=3, random_state=rng
-        ),
-        True,
-    ),
-    (
-        "Cluster centers - MiniBatchKMeans",
-        MiniBatchKMeans(
-            n_clusters=n_components,
-            tol=1e-3,
-            batch_size=20,
-            max_iter=50,
-            random_state=rng,
-        ),
-        True,
-    ),
-    (
-        "Factor Analysis components - FA",
-        decomposition.FactorAnalysis(n_components=n_components, max_iter=20),
-        True,
-    ),
-]
-
+# Initialise different estimators for decomposition and fit each
+# of them on all images and plot some results. Each estimator extracts
+# 6 components as vectors :math:`h \in \mathbf{R}^{4096}`.
+# We just displayed these vectors in human-friendly visualisation as 64x64 pixel images.
+#
 
 # %%
-# Next, fit each estimator on all images and plot some results.
-# Each estimator extracts 6 components as vectors
-# :math:`h \in \mathbf{R}^{4096}`. We just displayed these vectors
-# in human-friendly visualisation as 64x64 pixel images.
+# Eigenfaces - PCA using randomized SVD
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Linear dimensionality reduction using Singular Value Decomposition (SVD) of the data
+# to project it to a lower dimensional space.
+# Read more in the :ref:`User Guide <PCA>`.
 #
 # .. note::
 #
@@ -158,89 +103,136 @@ estimators = [
 #     also provides a scalar `noise_variance_` (the mean of pixelwise variance)
 #     that cannot be displayed as an image.
 
-for name, estimator, center in estimators:
-    print("- Extracting the top %d '%s'..." % (n_components, name))
-    t0 = time()
-    if center:
-        data = faces_centered
-    else:
-        data = faces
-    estimator.fit(data)
-    train_time = time() - t0
-    print("  done in %0.3fs" % train_time)
-    if hasattr(estimator, "cluster_centers_"):
-        components_ = estimator.cluster_centers_
-    else:
-        components_ = estimator.components_
+# %%
+pca_estimator = decomposition.PCA(
+    n_components=n_components, svd_solver="randomized", whiten=True
+)
+pca_estimator.fit(faces_centered)
+plot_gallery(
+    "Eigenfaces - PCA using randomized SVD", pca_estimator.components_[:n_components]
+)
 
-    if (
-        hasattr(estimator, "noise_variance_") and estimator.noise_variance_.ndim > 0
-    ):  # skip the Eigenfaces case
-        plot_gallery(
-            "Pixelwise variance from \n %s" % name,
-            estimator.noise_variance_.reshape(1, -1),
-            n_col=1,
-            n_row=1,
-        )
+# %%
+# Non-negative components - NMF
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Estimate non- negative original data as production of two non-negative matrices.
 
-    plot_gallery(name, components_[:n_components])
+# %%
+nmf_estimator = decomposition.NMF(n_components=n_components, tol=5e-3)
+nmf_estimator.fit(faces)  # original non- negative dataset
+plot_gallery("Non-negative components - NMF", nmf_estimator.components_[:n_components])
 
+# %%
+# Independent components - FastICA
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Independent component analysis separates a multivariate vectors into additive
+# subcomponents that are maximally independent.
+
+# %%
+ica_estimator = decomposition.FastICA(n_components=n_components, whiten=True)
+ica_estimator.fit(faces_centered)
+plot_gallery(
+    "Independent components - FastICA", ica_estimator.components_[:n_components]
+)
+
+# %%
+# Sparse comp. - MiniBatchSparsePCA
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Mini-batch sparse PCA (`MiniBatchSparsePCA`) extracts the set of sparse
+# components that best reconstruct the data. This variant is faster but
+# less accurate than the similar :py:mod:`sklearn.decomposition.SparsePCA`.
+
+# %%
+batch_pca_estimator = decomposition.MiniBatchSparsePCA(
+    n_components=n_components,
+    alpha=0.8,
+    n_iter=100,
+    batch_size=3,
+    random_state=rng,
+)
+batch_pca_estimator.fit(faces_centered)
+plot_gallery(
+    "Sparse comp. - MiniBatchSparsePCA", batch_pca_estimator.components_[:n_components]
+)
+
+# %%
+# Dictionary learning
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# By default, :class:`MiniBatchDictionaryLearning` divides the data into
+# mini-batches and optimizes in an online manner by cycling over the
+# mini-batches for the specified number of iterations.
+
+# %%
+batch_dict_estimator = decomposition.MiniBatchDictionaryLearning(
+    n_components=15, alpha=0.1, n_iter=50, batch_size=3, random_state=rng
+)
+batch_dict_estimator.fit(faces_centered)
+plot_gallery("Dictionary learning", batch_dict_estimator.components_[:n_components])
+
+# %%
+# Cluster centers - MiniBatchKMeans
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# `MiniBatchKMeans` is computationally efficient and implements on-line
+# learning with a partial_fit method. That is why it could be beneficial
+# to enhance some time-consuming algorithms with  `MiniBatchKMeans`.
+
+# %%
+kmeans_estimator = MiniBatchKMeans(
+    n_clusters=n_components,
+    tol=1e-3,
+    batch_size=20,
+    max_iter=50,
+    random_state=rng,
+)
+kmeans_estimator.fit(faces_centered)
+plot_gallery(
+    "Cluster centers - MiniBatchKMeans",
+    kmeans_estimator.cluster_centers_[:n_components],
+)
+
+
+# %%
+# Factor Analysis components - FA
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# `Factor Analysis` is similar to `PCA` but has the advantage of modelling the
+# variance in every direction of the input space independently
+# (heteroscedastic noise).
+# Read more in the :ref:`User Guide <FA>`.
+
+# %%
+fa_estimator = decomposition.FactorAnalysis(n_components=n_components, max_iter=20)
+fa_estimator.fit(faces_centered)
+plot_gallery("Factor Analysis (FA)", fa_estimator.components_[:n_components])
+
+# --- Pixelwise variance
+plt.figure(figsize=(3.2, 3.6), facecolor="white", tight_layout=True)
+vec = fa_estimator.noise_variance_
+vmax = max(vec.max(), -vec.min())
+plt.imshow(
+    vec.reshape(image_shape),
+    cmap=plt.cm.gray,
+    interpolation="nearest",
+    vmin=-vmax,
+    vmax=vmax,
+)
+plt.axis("off")
+plt.title("Pixelwise variance from \n Factor Analysis (FA)", size=16, wrap=True)
 plt.show()
+
 # %%
 # Decomposition: Dictionary learning
-# ---------------------------------------------------
+# -----------------------------------
 #
 # In the further section, let's consider :ref:`DictionaryLearning` more precisely.
 # Dictionary learning is a problem that amounts to finding a sparse representation
 # of the input data as a combination of simple elements. These simple elements form
 # a dictionary. It is possible to constrain the dictionary and/or code to be positive
 # to match constraints that may be present in the data.
-
-dict_estimators = [
-    (
-        "Dictionary learning",
-        decomposition.MiniBatchDictionaryLearning(
-            n_components=15, alpha=0.1, n_iter=50, batch_size=3, random_state=rng
-        ),
-    ),
-    (
-        "Dictionary learning - positive dictionary",
-        decomposition.MiniBatchDictionaryLearning(
-            n_components=15,
-            alpha=0.1,
-            n_iter=50,
-            batch_size=3,
-            random_state=rng,
-            positive_dict=True,
-        ),
-    ),
-    (
-        "Dictionary learning - positive code",
-        decomposition.MiniBatchDictionaryLearning(
-            n_components=15,
-            alpha=0.1,
-            n_iter=50,
-            batch_size=3,
-            fit_algorithm="cd",
-            random_state=rng,
-            positive_code=True,
-        ),
-    ),
-    (
-        "Dictionary learning - positive dictionary & code",
-        decomposition.MiniBatchDictionaryLearning(
-            n_components=15,
-            alpha=0.1,
-            n_iter=50,
-            batch_size=3,
-            fit_algorithm="cd",
-            random_state=rng,
-            positive_dict=True,
-            positive_code=True,
-        ),
-    ),
-]
-
 
 # %%
 # Plot the same samples from our dataset but with another colormap.
@@ -250,17 +242,72 @@ dict_estimators = [
 plot_gallery("Faces from dataset", faces_centered[:n_components], cmap=plt.cm.RdBu)
 
 # %%
-# Similar to the previous example, we train each estimator on all images.
+# Similar to the previous examples, we cahnge parameters and train
+# `MiniBatchDictionaryLearning` estimator on all images. The results
+# of the different positivity constraints are presented below.
+
+# %%
+# Dictionary learning - positive dictionary
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# The results of the different positivity constraints are presented below.
 
-for name, estimator in dict_estimators:
-    print("- Extracting the top %d '%s'..." % (n_components, name))
-    t0 = time()
-    data = faces_centered
-    estimator.fit(data)
-    train_time = time() - t0
-    print("  done in %0.3fs" % train_time)
-    plot_gallery(name, estimator.components_[:n_components], cmap=plt.cm.RdBu)
+# %%
+dict_pos_dict_estimator = decomposition.MiniBatchDictionaryLearning(
+    n_components=15,
+    alpha=0.1,
+    n_iter=50,
+    batch_size=3,
+    random_state=rng,
+    positive_dict=True,
+)
+dict_pos_dict_estimator.fit(faces_centered)
+plot_gallery(
+    "Dictionary learning - positive dictionary",
+    dict_pos_dict_estimator.components_[:n_components],
+    cmap=plt.cm.RdBu,
+)
 
-plt.show()
+# %%
+# Dictionary learning - positive code
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+
+# %%
+dict_pos_code_estimator = decomposition.MiniBatchDictionaryLearning(
+    n_components=15,
+    alpha=0.1,
+    n_iter=50,
+    batch_size=3,
+    fit_algorithm="cd",
+    random_state=rng,
+    positive_code=True,
+)
+dict_pos_code_estimator.fit(faces_centered)
+plot_gallery(
+    "Dictionary learning - positive code",
+    dict_pos_code_estimator.components_[:n_components],
+    cmap=plt.cm.RdBu,
+)
+
+# %%
+# Dictionary learning - positive dictionary & code
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+
+# %%
+dict_pos_estimator = decomposition.MiniBatchDictionaryLearning(
+    n_components=15,
+    alpha=0.1,
+    n_iter=50,
+    batch_size=3,
+    fit_algorithm="cd",
+    random_state=rng,
+    positive_dict=True,
+    positive_code=True,
+)
+dict_pos_estimator.fit(faces_centered)
+plot_gallery(
+    "Dictionary learning - positive dictionary & code",
+    dict_pos_estimator.components_[:n_components],
+    cmap=plt.cm.RdBu,
+)

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -157,7 +157,8 @@ batch_pca_estimator = decomposition.MiniBatchSparsePCA(
 )
 batch_pca_estimator.fit(faces_centered)
 plot_gallery(
-    "Sparse comp. - MiniBatchSparsePCA", batch_pca_estimator.components_[:n_components]
+    "Sparse components - MiniBatchSparsePCA",
+    batch_pca_estimator.components_[:n_components],
 )
 
 # %%

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -90,7 +90,7 @@ plot_gallery("Faces from dataset", faces_centered[:n_components])
 #
 # Initialise different estimators for decomposition and fit each
 # of them on all images and plot some results. Each estimator extracts
-# 6 components as vectors :math:`h \in \R^{4096}`.
+# 6 components as vectors :math:`h \in \mathbb{R}^{4096}`.
 # We just displayed these vectors in human-friendly visualisation as 64x64 pixel images.
 #
 # Read more in the :ref:`User Guide <decompositions>`.
@@ -121,7 +121,7 @@ plot_gallery(
 # Non-negative components - NMF
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Estimate non- negative original data as production of two non-negative matrices.
+# Estimate non-negative original data as production of two non-negative matrices.
 
 # %%
 nmf_estimator = decomposition.NMF(n_components=n_components, tol=5e-3)
@@ -258,8 +258,8 @@ plot_gallery("Faces from dataset", faces_centered[:n_components], cmap=plt.cm.Rd
 # the dictionary learning and sparse encoding decompose input data
 # into the dictionary and the coding coefficients matrices.
 # :math:`X \approx UV`, where :math:`X = [x_1, . . . , x_n]`,
-# :math:`X \in R^{m×n}`, dictionary :math:`U \in R^{m×k}`, coding
-# coefficients :math:`V \in R^{k×n}`.
+# :math:`X \in \mathbb{R}^{m×n}`, dictionary :math:`U \in \mathbb{R}^{m×k}`, coding
+# coefficients :math:`V \in \mathbb{R}^{k×n}`.
 #
 # Also below are the results when the dictionary and coding
 # coefficients are positively constrained.
@@ -269,6 +269,7 @@ plot_gallery("Faces from dataset", faces_centered[:n_components], cmap=plt.cm.Rd
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # In the following section we enforce positivity when finding the dictionary.
+
 # %%
 dict_pos_dict_estimator = decomposition.MiniBatchDictionaryLearning(
     n_components=n_components,

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -15,7 +15,7 @@ matrix decomposition (dimension reduction) methods from the module
 
 # %%
 # Dataset preparation
-# --------------------
+# -------------------
 #
 # Loading and preprocessing the Olivetti faces dataset.
 
@@ -25,7 +25,7 @@ from numpy.random import RandomState
 import matplotlib.pyplot as plt
 
 from sklearn.datasets import fetch_olivetti_faces
-from sklearn.cluster import MiniBatchKMeans
+from sklearn import cluster
 from sklearn import decomposition
 
 rng = RandomState(0)
@@ -44,7 +44,6 @@ faces_centered -= faces_centered.mean(axis=1).reshape(n_samples, -1)
 
 print("Dataset consists of %d faces" % n_samples)
 
-
 # %%
 # Define a base function to plot the gallery of faces.
 
@@ -54,23 +53,28 @@ image_shape = (64, 64)
 
 
 def plot_gallery(title, images, n_col=n_col, n_row=n_row, cmap=plt.cm.gray):
-    fig = plt.figure(
-        figsize=(2.0 * n_col, 2.26 * n_row),
+    fig, axs = plt.subplots(
+        nrows=n_row,
+        ncols=n_col,
+        figsize=(2.0 * n_col, 2.3 * n_row),
         facecolor="white",
-        tight_layout={"pad": 0.3},
+        constrained_layout=True,
     )
-    fig.suptitle(title, size=16, wrap=True)
-    for i, comp in enumerate(images):
-        plt.subplot(n_row, n_col, i + 1)
-        vmax = max(comp.max(), -comp.min())
-        plt.imshow(
-            comp.reshape(image_shape),
+    fig.set_constrained_layout_pads(w_pad=0.01, h_pad=0.02, hspace=0, wspace=0)
+    fig.set_edgecolor("black")
+    fig.suptitle(title, size=16)
+    for ax, vec in zip(axs.flat, images):
+        vmax = max(vec.max(), -vec.min())
+        im = ax.imshow(
+            vec.reshape(image_shape),
             cmap=cmap,
             interpolation="nearest",
             vmin=-vmax,
             vmax=vmax,
         )
-        plt.axis("off")
+        ax.axis("off")
+
+    fig.colorbar(im, ax=axs, orientation="horizontal", shrink=0.99, aspect=40, pad=0.01)
     plt.show()
 
 
@@ -82,18 +86,18 @@ plot_gallery("Faces from dataset", faces_centered[:n_components])
 
 # %%
 # Decomposition
-# --------------
+# -------------
 #
 # Initialise different estimators for decomposition and fit each
 # of them on all images and plot some results. Each estimator extracts
-# 6 components as vectors :math:`h \in \mathbf{R}^{4096}`.
+# 6 components as vectors :math:`h \in \R^{4096}`.
 # We just displayed these vectors in human-friendly visualisation as 64x64 pixel images.
 #
 # Read more in the :ref:`User Guide <decompositions>`.
 
 # %%
 # Eigenfaces - PCA using randomized SVD
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Linear dimensionality reduction using Singular Value Decomposition (SVD) of the data
 # to project it to a lower dimensional space.
 #
@@ -115,7 +119,7 @@ plot_gallery(
 
 # %%
 # Non-negative components - NMF
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # Estimate non- negative original data as production of two non-negative matrices.
 
@@ -126,20 +130,22 @@ plot_gallery("Non-negative components - NMF", nmf_estimator.components_[:n_compo
 
 # %%
 # Independent components - FastICA
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Independent component analysis separates a multivariate vectors into additive
 # subcomponents that are maximally independent.
 
 # %%
-ica_estimator = decomposition.FastICA(n_components=n_components, whiten=True)
+ica_estimator = decomposition.FastICA(
+    n_components=n_components, max_iter=400, whiten="arbitrary-variance", tol=15e-5
+)
 ica_estimator.fit(faces_centered)
 plot_gallery(
     "Independent components - FastICA", ica_estimator.components_[:n_components]
 )
 
 # %%
-# Sparse comp. - MiniBatchSparsePCA
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Sparse components - MiniBatchSparsePCA
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # Mini-batch sparse PCA (`MiniBatchSparsePCA`) extracts the set of sparse
 # components that best reconstruct the data. This variant is faster but
@@ -147,11 +153,7 @@ plot_gallery(
 
 # %%
 batch_pca_estimator = decomposition.MiniBatchSparsePCA(
-    n_components=n_components,
-    alpha=0.8,
-    n_iter=100,
-    batch_size=3,
-    random_state=rng,
+    n_components=n_components, alpha=0.1, n_iter=100, batch_size=3, random_state=rng
 )
 batch_pca_estimator.fit(faces_centered)
 plot_gallery(
@@ -160,7 +162,7 @@ plot_gallery(
 
 # %%
 # Dictionary learning
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^
 #
 # By default, :class:`MiniBatchDictionaryLearning` divides the data into
 # mini-batches and optimizes in an online manner by cycling over the
@@ -168,21 +170,21 @@ plot_gallery(
 
 # %%
 batch_dict_estimator = decomposition.MiniBatchDictionaryLearning(
-    n_components=15, alpha=0.1, n_iter=50, batch_size=3, random_state=rng
+    n_components=n_components, alpha=0.1, n_iter=50, batch_size=3, random_state=rng
 )
 batch_dict_estimator.fit(faces_centered)
 plot_gallery("Dictionary learning", batch_dict_estimator.components_[:n_components])
 
 # %%
 # Cluster centers - MiniBatchKMeans
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # `MiniBatchKMeans` is computationally efficient and implements on-line
-# learning with a partial_fit method. That is why it could be beneficial
+# learning with a `partial_fit` method. That is why it could be beneficial
 # to enhance some time-consuming algorithms with  `MiniBatchKMeans`.
 
 # %%
-kmeans_estimator = MiniBatchKMeans(
+kmeans_estimator = cluster.MiniBatchKMeans(
     n_clusters=n_components,
     tol=1e-3,
     batch_size=20,
@@ -198,7 +200,7 @@ plot_gallery(
 
 # %%
 # Factor Analysis components - FA
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # `Factor Analysis` is similar to `PCA` but has the advantage of modelling the
 # variance in every direction of the input space independently
@@ -223,17 +225,24 @@ plt.imshow(
 )
 plt.axis("off")
 plt.title("Pixelwise variance from \n Factor Analysis (FA)", size=16, wrap=True)
+plt.colorbar(orientation="horizontal", shrink=0.8, pad=0.03)
 plt.show()
 
 # %%
 # Decomposition: Dictionary learning
-# -----------------------------------
+# ----------------------------------
 #
 # In the further section, let's consider :ref:`DictionaryLearning` more precisely.
 # Dictionary learning is a problem that amounts to finding a sparse representation
 # of the input data as a combination of simple elements. These simple elements form
-# a dictionary. It is possible to constrain the dictionary and/or code to be positive
-# to match constraints that may be present in the data.
+# a dictionary. It is possible to constrain the dictionary and/or coding coefficients
+# to be positive to match constraints that may be present in the data.
+#
+# :class:`MiniBatchDictionaryLearning` implements a faster, but less accurate
+# version of the dictionary learning algorithm that is better suited for large
+# datasets.
+#
+# Read more in the :ref:`User Guide <_MiniBatchDictionaryLearning>`.
 
 # %%
 # Plot the same samples from our dataset but with another colormap.
@@ -243,18 +252,25 @@ plt.show()
 plot_gallery("Faces from dataset", faces_centered[:n_components], cmap=plt.cm.RdBu)
 
 # %%
-# Similar to the previous examples, we cahnge parameters and train
-# `MiniBatchDictionaryLearning` estimator on all images. The results
-# of the different positivity constraints are presented below.
+# Similar to the previous examples, we change parameters and train
+# `MiniBatchDictionaryLearning` estimator on all images. Generally,
+# the dictionary learning and sparse encoding decompose input data
+# into the dictionary and the coding coefficients matrices.
+# :math:`X \approx UV`, where :math:`X = [x_1, . . . , x_n]`,
+# :math:`X \in R^{m×n}`, dictionary :math:`U \in R^{m×k}`, coding
+# coefficients :math:`V \in R^{k×n}`.
+#
+# Also below are the results when the dictionary and coding
+# coefficients are positively constrained.
 
 # %%
 # Dictionary learning - positive dictionary
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-
+# In the following section we enforce positivity when finding the dictionary.
 # %%
 dict_pos_dict_estimator = decomposition.MiniBatchDictionaryLearning(
-    n_components=15,
+    n_components=n_components,
     alpha=0.1,
     n_iter=50,
     batch_size=3,
@@ -270,12 +286,13 @@ plot_gallery(
 
 # %%
 # Dictionary learning - positive code
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
+# Below we constrain the coding coefficients as a positive matrix.
 
 # %%
 dict_pos_code_estimator = decomposition.MiniBatchDictionaryLearning(
-    n_components=15,
+    n_components=n_components,
     alpha=0.1,
     n_iter=50,
     batch_size=3,
@@ -292,12 +309,14 @@ plot_gallery(
 
 # %%
 # Dictionary learning - positive dictionary & code
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
+# Also below are the results if the dictionary values and coding
+# coefficients are positively constrained.
 
 # %%
 dict_pos_estimator = decomposition.MiniBatchDictionaryLearning(
-    n_components=15,
+    n_components=n_components,
     alpha=0.1,
     n_iter=50,
     batch_size=3,

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -89,13 +89,14 @@ plot_gallery("Faces from dataset", faces_centered[:n_components])
 # 6 components as vectors :math:`h \in \mathbf{R}^{4096}`.
 # We just displayed these vectors in human-friendly visualisation as 64x64 pixel images.
 #
+# Read more in the :ref:`User Guide <decompositions>`.
 
 # %%
 # Eigenfaces - PCA using randomized SVD
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Linear dimensionality reduction using Singular Value Decomposition (SVD) of the data
 # to project it to a lower dimensional space.
-# Read more in the :ref:`User Guide <PCA>`.
+#
 #
 # .. note::
 #

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -241,9 +241,7 @@ plt.show()
 #
 # :class:`MiniBatchDictionaryLearning` implements a faster, but less accurate
 # version of the dictionary learning algorithm that is better suited for large
-# datasets.
-#
-# Read more in the :ref:`User Guide <_MiniBatchDictionaryLearning>`.
+# datasets. Read more in the :ref:`User Guide <MiniBatchDictionaryLearning>`.
 
 # %%
 # Plot the same samples from our dataset but with another colormap.


### PR DESCRIPTION
#### Reference Issues/PRs

- #22406 
   - [x] [examples/decomposition/plot_faces_decomposition.py](https://github.com/scikit-learn/scikit-learn/blob/main/examples/decomposition/plot_faces_decomposition.py)

#### What does this implement/fix? Explain your changes.

- fix notebook-style and add more descriptions
- small refactoring  for the plot function

#### Any other comments?
- [HTML in the doc](https://scikit-learn.org/stable/auto_examples/decomposition/plot_faces_decomposition.html)