### PR TITLE
DOC Ensures that precision_recall_fscore_support passes numpydoc validation

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1489,7 +1489,7 @@ def precision_recall_fscore_support(
     -------
     precision : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
-        Estimated precision of data.
+        Precision score.
 
     recall : float (if average is not None) or array of float, shape =\
         [n_unique_labels]

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1493,7 +1493,7 @@ def precision_recall_fscore_support(
 
     recall : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
-        Estimated recall of data.
+        Recall score.
 
     fbeta_score : float (if average is not None) or array of float, shape =\
         [n_unique_labels]

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1497,7 +1497,7 @@ def precision_recall_fscore_support(
 
     fbeta_score : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
-        Estimated fbeta_score of data.
+        F-beta score.
 
     support : None (if average is not None) or array of int, shape =\
         [n_unique_labels]

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1489,12 +1489,15 @@ def precision_recall_fscore_support(
     -------
     precision : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
+        Estimated precision of data.
 
     recall : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
+        Estimated recall of data.
 
     fbeta_score : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
+        Estimated fbeta_score of data.
 
     support : None (if average is not None) or array of int, shape =\
         [n_unique_labels]

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -68,7 +68,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics._classification.hinge_loss",
     "sklearn.metrics._classification.jaccard_score",
     "sklearn.metrics._classification.log_loss",
-    "sklearn.metrics._classification.precision_recall_fscore_support",
     "sklearn.metrics._plot.confusion_matrix.plot_confusion_matrix",
     "sklearn.metrics._plot.det_curve.plot_det_curve",
     "sklearn.metrics._plot.precision_recall_curve.plot_precision_recall_curve",


### PR DESCRIPTION
#### Reference Issues/PRs
     Address #21350

#### What does this implement/fix? Explain your changes.

- Wrote missing return of precision, recall, and fscore in precision_recall_fscore_support function.
- Verify that all the test passes after fixing the issues.
- remove the function from FUNCTION_DOCSTRING_IGNORE_LIST.

#### Any other comments?

My first PR :). looking forward to contribute more
