### PR TITLE
DOC Ensures that isotonic_regression passes numpydoc validation

### DIFF
--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -103,7 +103,7 @@ def isotonic_regression(
 
     increasing : bool, default=True
         Whether to compute ``y_`` is increasing (if set to True) or decreasing
-        (if set to False)
+        (if set to False).
 
     Returns
     -------

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -52,7 +52,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.feature_selection._univariate_selection.r_regression",
     "sklearn.inspection._partial_dependence.partial_dependence",
     "sklearn.inspection._plot.partial_dependence.plot_partial_dependence",
-    "sklearn.isotonic.isotonic_regression",
     "sklearn.linear_model._least_angle.lars_path",
     "sklearn.linear_model._least_angle.lars_path_gram",
     "sklearn.linear_model._omp.orthogonal_mp",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #21350

#### What does this implement/fix? Explain your changes.
Fixing docs to allow sklearn.isotonic.isotonic_regression docstring to pass numpydoc validation

#### Any other comments?
This is my first PR in the project :) 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
