### PR TITLE
ENH optimize memory usage for `datasets.make_s_curve`

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1561,13 +1561,11 @@ def make_s_curve(n_samples=100, *, noise=0.0, random_state=None):
     generator = check_random_state(random_state)
 
     t = 3 * np.pi * (generator.uniform(size=(1, n_samples)) - 0.5)
-    x = np.sin(t)
-    y = 2.0 * generator.uniform(size=(1, n_samples))
-    z = np.sign(t) * (np.cos(t) - 1)
-
-    X = np.concatenate((x, y, z))
-    X += noise * generator.standard_normal(size=(3, n_samples))
-    X = X.T
+    X = np.empty(shape=(n_samples, 3), dtype=np.float64)
+    X[:, 0] = np.sin(t)
+    X[:, 1] = 2.0 * generator.uniform(size=n_samples)
+    X[:, 2] = np.sign(t) * (np.cos(t) - 1)
+    X += noise * generator.standard_normal(size=(3, n_samples)).T
     t = np.squeeze(t)
 
     return X, t


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a follow up to PR #22412 , memory usage of `datasets.make_s_curve` is reduced by preallocating empty NumPy array.

#### Other Comments
- I've tested on my machine this indeed uses less memory (from 694MiB to 541MiB when n_samples = 10000000).
- I've tested the generated sample is the same as before.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
