### PR TITLE
DOC Ensures that load_linnerud passes numpydoc validation

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1101,9 +1101,8 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
 
     (data, target) : tuple if ``return_X_y`` is True
         Returns a tuple of two ndarrays or dataframe of shape
-        `(n_samples, n_features)`. Each row represents one sample and
-        each column represents the features in `X` and a target in `y` of a
-        given sample.
+        `(20, 3)`. Each row represents one sample and  each column represents the
+        features in `X` and a target in `y` of a given sample.
 
         .. versionadded:: 0.18
     """

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1100,6 +1100,9 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
             .. versionadded:: 0.20
 
     (data, target) : tuple if ``return_X_y`` is True
+        Returns a tuple of two ndarray of shape (n_samples, n_features)
+        A 2D array with each row representing one sample and each column
+        representing the features and/or target of a given sample.
 
         .. versionadded:: 0.18
     """

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1100,9 +1100,10 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
             .. versionadded:: 0.20
 
     (data, target) : tuple if ``return_X_y`` is True
-        Returns a tuple of two ndarray of shape (n_samples, n_features)
-        A 2D array with each row representing one sample and each column
-        representing the features and/or target of a given sample.
+        Returns a tuple of two ndarrays or dataframe of shape
+        `(n_samples, n_features)`. Each row represents one sample and
+        each column represents the features in `X` and a target in `y` of a
+        given sample.
 
         .. versionadded:: 0.18
     """

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1101,7 +1101,7 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
 
     (data, target) : tuple if ``return_X_y`` is True
         Returns a tuple of two ndarrays or dataframe of shape
-        `(20, 3)`. Each row represents one sample and  each column represents the
+        `(20, 3)`. Each row represents one sample and each column represents the
         features in `X` and a target in `y` of a given sample.
 
         .. versionadded:: 0.18

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -14,7 +14,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.covariance._shrunk_covariance.ledoit_wolf",
     "sklearn.covariance._shrunk_covariance.ledoit_wolf_shrinkage",
-    "sklearn.datasets._base.load_linnerud",
     "sklearn.datasets._base.load_sample_image",
     "sklearn.datasets._base.load_wine",
     "sklearn.datasets._california_housing.fetch_california_housing",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
1. Removed sklearn.datasets._base.load_linnerud from function_docstring_ignore_list.
2. Added description to (data, target).


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
