### PR TITLE
FIX Fix DummyRegressor overriding constant

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -270,6 +270,12 @@ Changelog
   :class:`ensemble.ExtraTreesClassifier`.
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
 
+:mod:`sklearn.dummy`
+....................
+
+- |Fix| :class:`dummy.DummyRegressor` no longer overrides the `constant`
+  parameter during `fit`. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.feature_extraction`
 .................................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -274,7 +274,7 @@ Changelog
 ....................
 
 - |Fix| :class:`dummy.DummyRegressor` no longer overrides the `constant`
-  parameter during `fit`. :pr:`xxxxx` by `Thomas Fan`_.
+  parameter during `fit`. :pr:`22486` by `Thomas Fan`_.
 
 :mod:`sklearn.feature_extraction`
 .................................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -242,6 +242,12 @@ Changelog
   :class:`discriminant_analysis.LinearDiscriminantAnalysis`. :pr:`22120` by
   `Thomas Fan`_.
 
+:mod:`sklearn.dummy`
+....................
+
+- |Fix| :class:`dummy.DummyRegressor` no longer overrides the `constant`
+  parameter during `fit`. :pr:`22486` by `Thomas Fan`_.
+
 :mod:`sklearn.ensemble`
 .......................
 
@@ -269,12 +275,6 @@ Changelog
   changes are also applied for :class:`ensemble.ExtraTreesRegressor` and
   :class:`ensemble.ExtraTreesClassifier`.
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
-
-:mod:`sklearn.dummy`
-....................
-
-- |Fix| :class:`dummy.DummyRegressor` no longer overrides the `constant`
-  parameter during `fit`. :pr:`22486` by `Thomas Fan`_.
 
 :mod:`sklearn.feature_extraction`
 .................................

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -606,19 +606,17 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     "when the constant strategy is used."
                 )
 
-            self.constant = check_array(
+            self.constant_ = check_array(
                 self.constant,
                 accept_sparse=["csr", "csc", "coo"],
                 ensure_2d=False,
                 ensure_min_samples=0,
             )
 
-            if self.n_outputs_ != 1 and self.constant.shape[0] != y.shape[1]:
+            if self.n_outputs_ != 1 and self.constant_.shape[0] != y.shape[1]:
                 raise ValueError(
                     "Constant target value should have shape (%d, 1)." % y.shape[1]
                 )
-
-            self.constant_ = self.constant
 
         self.constant_ = np.reshape(self.constant_, (1, -1))
         return self

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -425,6 +425,9 @@ def test_constant_strategy_regressor():
     reg.fit(X, y)
     assert_array_equal(reg.predict(X), [43] * len(X))
 
+    # non-regression test for #22478
+    assert not isinstance(reg.constant, np.ndarray)
+
 
 def test_constant_strategy_multioutput_regressor():
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/22478


#### What does this implement/fix? Explain your changes.
This PR updates `DummyRegressor` to no longer override `constant` in `fit`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
