### PR TITLE
DOC fix shape of output in _BaseNB._joint_log_likelihood docstring

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -51,7 +51,7 @@ class _BaseNB(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         """Compute the unnormalized posterior log probability of X
 
         I.e. ``log P(c) + log P(x|c)`` for all rows x of X, as an array-like of
-        shape (n_classes, n_samples).
+        shape (n_samples, n_classes).
 
         Input is passed to _joint_log_likelihood as-is by predict,
         predict_proba and predict_log_proba.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
I am not aware of any issue for this PR.

#### What does this implement/fix? Explain your changes.
No actual code has been changed.

Corrects the docstring for `_joint_log_likelihood` method of `_BaseNB` abstract class. Namely, the return value's shape is corrected to `(n_samples, n_classes)` (was `(n_classes, n_samples)`, which is wrong).

```
>>> from sklearn.tests.test_naive_bayes import X1, y1
>>> from sklearn.naive_bayes import GaussianNB
>>> clf = GaussianNB().fit(X1, y1)
>>> clf._joint_log_likelihood(X1).shape
(10, 2)
>>> X1.shape
(10, 3)
>>> clf.predict_log_proba(X1).shape
(10, 2)
```

#### Any other comments?
This PR is primarily for me to learn about the pull request procedure before I contribute something real (currently working on it).

Please approve it as soon as convenient.