### PR TITLE
FIX accept NumPy arrays for alphas in GraphicalLassoCV

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -145,7 +145,7 @@ Changelog
 
 - |Fix| :class:`covariance.GraphicalLassoCV` now accepts NumPy array for the
   parameter `alphas`.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`22493` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.datasets`
 .......................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -140,6 +140,13 @@ Changelog
   :class:`cross_decomposition.PLSRegression`,
   and :class:`cross_decomposition.PLSCanonical`. :pr:`22119` by `Thomas Fan`_.
 
+:mod:`sklearn.covariance`
+.........................
+
+- |Fix| :class:`covariance.GraphicalLassoCV` now accepts NumPy array for the
+  parameter `alphas`.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.datasets`
 .......................
 

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -5,7 +5,6 @@ estimator.
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
 # License: BSD 3 clause
 # Copyright: INRIA
-from collections.abc import Iterable
 import warnings
 import operator
 import sys
@@ -18,7 +17,7 @@ from joblib import Parallel
 from . import empirical_covariance, EmpiricalCovariance, log_likelihood
 
 from ..exceptions import ConvergenceWarning
-from ..utils.validation import check_random_state
+from ..utils.validation import _is_arraylike_not_scalar, check_random_state
 from ..utils.fixes import delayed
 
 # mypy error: Module 'sklearn.linear_model' has no attribute '_cd_fast'
@@ -857,7 +856,7 @@ class GraphicalLassoCV(GraphicalLasso):
         n_alphas = self.alphas
         inner_verbose = max(0, self.verbose - 1)
 
-        if isinstance(n_alphas, Iterable):
+        if _is_arraylike_not_scalar(n_alphas):
             alphas = self.alphas
             n_refinements = 1
         else:
@@ -933,7 +932,7 @@ class GraphicalLassoCV(GraphicalLasso):
                 alpha_1 = path[best_index - 1][0]
                 alpha_0 = path[best_index + 1][0]
 
-            if not isinstance(n_alphas, Iterable):
+            if not _is_arraylike_not_scalar(n_alphas):
                 alphas = np.logspace(np.log10(alpha_1), np.log10(alpha_0), n_alphas + 2)
                 alphas = alphas[1:-1]
 

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -5,7 +5,7 @@ estimator.
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
 # License: BSD 3 clause
 # Copyright: INRIA
-from collections.abc import Sequence
+from collections.abc import Iterable
 import warnings
 import operator
 import sys
@@ -857,7 +857,7 @@ class GraphicalLassoCV(GraphicalLasso):
         n_alphas = self.alphas
         inner_verbose = max(0, self.verbose - 1)
 
-        if isinstance(n_alphas, Sequence):
+        if isinstance(n_alphas, Iterable):
             alphas = self.alphas
             n_refinements = 1
         else:
@@ -933,7 +933,7 @@ class GraphicalLassoCV(GraphicalLasso):
                 alpha_1 = path[best_index - 1][0]
                 alpha_0 = path[best_index + 1][0]
 
-            if not isinstance(n_alphas, Sequence):
+            if not isinstance(n_alphas, Iterable):
                 alphas = np.logspace(np.log10(alpha_1), np.log10(alpha_0), n_alphas + 2)
                 alphas = alphas[1:-1]
 


### PR DESCRIPTION
closes #22489 

I checked and it was the only location where we had this issue with `collections.abc.Sequence`.