### PR TITLE
DOC Rewrite plot_document_clustering.py as notebook

### DIFF
--- a/examples/text/plot_document_clustering.py
+++ b/examples/text/plot_document_clustering.py
@@ -72,8 +72,9 @@ from sklearn import metrics
 from sklearn.cluster import MiniBatchKMeans
 
 
-def kmeans_pipeline(data, labels, n_clusters,
-                   idf=True, n_components=False, random_state=None):
+def kmeans_pipeline(
+    data, labels, n_clusters, idf=True, n_components=False, random_state=None
+):
     pipeline = []
 
     vectorizer = TfidfVectorizer(
@@ -107,7 +108,7 @@ def kmeans_pipeline(data, labels, n_clusters,
         init_size=1000,
         batch_size=1000,
         verbose=False,
-        random_state=random_state
+        random_state=random_state,
     )
 
     km.fit(X)
@@ -119,9 +120,7 @@ def kmeans_pipeline(data, labels, n_clusters,
     v_msr = metrics.v_measure_score(labels, km.labels_)
     rand_scr = metrics.adjusted_rand_score(labels, km.labels_)
     silhouette = metrics.silhouette_score(X, km.labels_, sample_size=1000)
-    print(
-        f"{homo:.3f}\t{complt:.3f}\t{v_msr:.3f}\t{rand_scr:.3f}\t{silhouette:.3f}"
-        )
+    print(f"{homo:.3f}\t{complt:.3f}\t{v_msr:.3f}\t{rand_scr:.3f}\t{silhouette:.3f}")
 
     return pipeline
 
@@ -139,7 +138,7 @@ def kmeans_pipeline(data, labels, n_clusters,
 # This improvement is not visible in the Silhouette Coefficient which is small
 # for both as this measure seem to suffer from the phenomenon called
 # "Concentration of Measure" or "Curse of Dimensionality" for high dimensional
-# datasets such as text data. The other measures are information theoretic 
+# datasets such as text data. The other measures are information theoretic
 # based evaluation scores: as they are only based
 # on cluster assignments rather than distances, hence not affected by the curse
 # of dimensionality.
@@ -161,16 +160,24 @@ print("         \thomo\tcomplet\tv-meas\trand-i\tsilhouette")
 print("-" * 58)
 
 print(f"{'Tf':9s}", end="\t")
-kmeans_pipeline(data=dataset.data, labels=labels, n_clusters=true_k,
-               idf=False, random_state=rseed)
+kmeans_pipeline(
+    data=dataset.data, labels=labels, n_clusters=true_k, idf=False, random_state=rseed
+)
 
 print(f"{'Tfidf':9s}", end="\t")
-kmeans_pipeline(data=dataset.data, labels=labels, n_clusters=true_k,
-               idf=True, random_state=rseed)
+kmeans_pipeline(
+    data=dataset.data, labels=labels, n_clusters=true_k, idf=True, random_state=rseed
+)
 
 print(f"{'Tfidf+LSA':9s}", end="\t")
-pipeline = kmeans_pipeline(data=dataset.data, labels=labels, n_clusters=true_k,
-                          idf=True, n_components=10, random_state=rseed)
+pipeline = kmeans_pipeline(
+    data=dataset.data,
+    labels=labels,
+    n_clusters=true_k,
+    idf=True,
+    n_components=10,
+    random_state=rseed,
+)
 
 
 # %%
@@ -193,20 +200,32 @@ order_centroids = original_space_centroids.argsort()[:, ::-1]
 
 terms = vectorizer.get_feature_names_out()
 
-fig, ax = plt.subplots(figsize=(10,5))
+fig, ax = plt.subplots(figsize=(10, 5))
 
 for i in range(true_k):
-    x_pos = .1 + .266 * i
-    ax.text(x_pos, .95, f"Cluster {i}",
-            fontsize=15, fontweight='bold',
-            ha='center', va='bottom')
+    x_pos = 0.1 + 0.266 * i
+    ax.text(
+        x_pos,
+        0.95,
+        f"Cluster {i}",
+        fontsize=15,
+        fontweight="bold",
+        ha="center",
+        va="bottom",
+    )
     for j, ind in enumerate(order_centroids[i, :10]):
-        scale = np.log(original_space_centroids[i, ind]+1)
-        y_pos = .77-.1*j
-        ax.text(x_pos, y_pos, terms[ind],
-                color=plt.cm.Set1(i),
-                fontsize=scale*130, fontweight=scale*1300,
-                ha='center', va='bottom')
+        scale = np.log(original_space_centroids[i, ind] + 1)
+        y_pos = 0.77 - 0.1 * j
+        ax.text(
+            x_pos,
+            y_pos,
+            terms[ind],
+            color=plt.cm.Set1(i),
+            fontsize=scale * 130,
+            fontweight=scale * 1300,
+            ha="center",
+            va="bottom",
+        )
 
 ax.set_title("Top terms per cluster", fontsize=20)
 ax.axis(False)

--- a/examples/text/plot_document_clustering.py
+++ b/examples/text/plot_document_clustering.py
@@ -228,5 +228,5 @@ for i in range(true_k):
         )
 
 ax.set_title("Top terms per cluster", fontsize=20)
-ax.axis(False)
+ax.axis("off")
 plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
For #22406.

#### What does this implement/fix? Explain your changes.
Rewrite of script to notebook-style example as suggested by @glemaitre in #22443.

Structured it as a comparison between k-means pipelines with weighted term frequency and dimensionality reduction and without. Also added a text plot at the end with the most frequent terms for each cluster.

#### Any other comments?
Alternatively, I could break the second cell with the `kmeans_pipeline` function into smaller ones and make it into a straightforward example. But I found the performance comparison interesting.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
