### PR TITLE
FIX relax criteria in failing test `test_poisson_vs_mse`

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2114,7 +2114,7 @@ def test_poisson_vs_mse():
         # test set.
         if val == "test":
             assert metric_poi < 0.5 * metric_mse
-        assert metric_poi < 0.75 * metric_dummy
+        assert metric_poi < 0.9 * metric_dummy
 
 
 @pytest.mark.parametrize("criterion", REG_CRITERIONS)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a fix to issue #22490 . 

#### What does this implement/fix? Explain your changes.
Relaxing the criteria from 0.75 to 0.9 in `sklearn/tree/tests/test_tree.py:test_poisson_vs_mse` as suggested. 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
