### PR TITLE
DOC Ensures that orthogonal_mp passes numpydoc validation

### DIFF
--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -342,7 +342,7 @@ def orthogonal_mp(
         Coefficients of the OMP solution. If `return_path=True`, this contains
         the whole coefficient path. In this case its shape is
         (n_features, n_features) or (n_features, n_targets, n_features) and
-        iterating over the last axis returns coefficients in increasing order
+        iterating over the last axis generates coefficients in increasing order
         of active features.
 
     n_iters : array-like or int

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -352,7 +352,7 @@ def orthogonal_mp(
     See Also
     --------
     OrthogonalMatchingPursuit : Orthogonal Matching Pursuit model.
-    orthogonal_mp_gram : Solves OMP problems using the Gram matrix and the product X.T * y.
+    orthogonal_mp_gram : Solve OMP problems using Gram matrix and the product X.T * y.
     lars_path : Compute Least Angle Regression or Lasso path using LARS algorithm.
     sklearn.decomposition.sparse_encode : Sparse coding.
 

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -342,7 +342,7 @@ def orthogonal_mp(
         Coefficients of the OMP solution. If `return_path=True`, this contains
         the whole coefficient path. In this case its shape is
         (n_features, n_features) or (n_features, n_targets, n_features) and
-        iterating over the last axis yields coefficients in increasing order
+        iterating over the last axis returns coefficients in increasing order
         of active features.
 
     n_iters : array-like or int
@@ -351,10 +351,10 @@ def orthogonal_mp(
 
     See Also
     --------
-    OrthogonalMatchingPursuit
-    orthogonal_mp_gram
-    lars_path
-    sklearn.decomposition.sparse_encode
+    OrthogonalMatchingPursuit : Orthogonal Matching Pursuit model.
+    orthogonal_mp_gram : Solves OMP problems using the Gram matrix and the product X.T * y.
+    lars_path : Compute Least Angle Regression or Lasso path using LARS algorithm.
+    sklearn.decomposition.sparse_encode : Sparse coding.
 
     Notes
     -----
@@ -367,7 +367,6 @@ def orthogonal_mp(
     M., Efficient Implementation of the K-SVD Algorithm using Batch Orthogonal
     Matching Pursuit Technical Report - CS Technion, April 2008.
     https://www.cs.technion.ac.il/~ronrubin/Publications/KSVD-OMP-v2.pdf
-
     """
     X = check_array(X, order="F", copy=copy_X)
     copy_X = False

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -52,7 +52,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.inspection._plot.partial_dependence.plot_partial_dependence",
     "sklearn.linear_model._least_angle.lars_path",
     "sklearn.linear_model._least_angle.lars_path_gram",
-    "sklearn.linear_model._omp.orthogonal_mp",
     "sklearn.linear_model._omp.orthogonal_mp_gram",
     "sklearn.linear_model._ridge.ridge_regression",
     "sklearn.manifold._locally_linear.locally_linear_embedding",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses https://github.com/scikit-learn/scikit-learn/issues/21350

#### What does this implement/fix? Explain your changes.

Fixing docs to allow  sklearn.linear_model._omp.orthogonal_mp to pass numpydoc validation



#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
