### PR TITLE
ENH Verbosity for OneVsRestClassifier

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -542,6 +542,13 @@ Changelog
   its square root.
   :pr:`22058` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+:mod:`sklearn.multiclass`
+.........................
+
+- |Enhancement| :class:`multiclass.OneVsRestClassifier` now supports a `verbose`
+  parameter so progress on fitting can be seen.
+  :pr:`22508` by :user:`Chris Combs <combscCode>`.
+
 :mod:`sklearn.neighbors`
 ........................
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -220,7 +220,8 @@ class OneVsRestClassifier(
         The verbosity level, if non zero, progress messages are printed.
         Below 50, the output is sent to stderr. Otherwise, the output is sent
         to stdout. The frequency of the messages increases with the verbosity
-        level, reporting all iterations at 10.
+        level, reporting all iterations at 10. See joblib.Parallel for more
+        details.
 
     Attributes
     ----------
@@ -258,6 +259,7 @@ class OneVsRestClassifier(
         multilabel classification.
     sklearn.preprocessing.MultiLabelBinarizer : Transform iterable of iterables
         to binary indicator matrix.
+    joblib.Parallel : Class used for parallel training.
 
     Examples
     --------

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -222,8 +222,8 @@ class OneVsRestClassifier(
         to stdout. The frequency of the messages increases with the verbosity
         level, reporting all iterations at 10. See :class:`joblib.Parallel` for
         more details.
-        
-            .. versionadded:: 1.1
+
+        .. versionadded:: 1.1
 
     Attributes
     ----------

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -222,6 +222,8 @@ class OneVsRestClassifier(
         to stdout. The frequency of the messages increases with the verbosity
         level, reporting all iterations at 10. See :class:`joblib.Parallel` for
         more details.
+        
+            .. versionadded:: 1.1
 
     Attributes
     ----------

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -216,6 +216,12 @@ class OneVsRestClassifier(
         .. versionchanged:: 0.20
            `n_jobs` default changed from 1 to None
 
+    verbose : int, default=0
+        The verbosity level, if non zero, progress messages are printed.
+        Below 50, the output is sent to stderr. Otherwise, the output is sent
+        to stdout. The frequency of the messages increases with the verbosity
+        level, reporting all iterations at 10.
+
     Attributes
     ----------
     estimators_ : list of `n_classes` estimators
@@ -272,9 +278,10 @@ class OneVsRestClassifier(
     array([2, 0, 1])
     """
 
-    def __init__(self, estimator, *, n_jobs=None):
+    def __init__(self, estimator, *, n_jobs=None, verbose=0):
         self.estimator = estimator
         self.n_jobs = n_jobs
+        self.verbose = verbose
 
     def fit(self, X, y):
         """Fit underlying estimators.
@@ -305,7 +312,7 @@ class OneVsRestClassifier(
         # In cases where individual estimators are very fast to train setting
         # n_jobs > 1 in can results in slower performance due to the overhead
         # of spawning threads.  See joblib issue #112.
-        self.estimators_ = Parallel(n_jobs=self.n_jobs)(
+        self.estimators_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
             delayed(_fit_binary)(
                 self.estimator,
                 X,

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -220,8 +220,8 @@ class OneVsRestClassifier(
         The verbosity level, if non zero, progress messages are printed.
         Below 50, the output is sent to stderr. Otherwise, the output is sent
         to stdout. The frequency of the messages increases with the verbosity
-        level, reporting all iterations at 10. See joblib.Parallel for more
-        details.
+        level, reporting all iterations at 10. See :class:`joblib.Parallel` for
+        more details.
 
     Attributes
     ----------
@@ -259,7 +259,6 @@ class OneVsRestClassifier(
         multilabel classification.
     sklearn.preprocessing.MultiLabelBinarizer : Transform iterable of iterables
         to binary indicator matrix.
-    joblib.Parallel : Class used for parallel training.
 
     Examples
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #22441


#### What does this implement/fix? Explain your changes.

Adds a verbose parameter to `sklearn.multiclass.OneVsRestClassifier` so progress can be seen while the model is fitting.

#### Any other comments?

I'm not familiar with the best way to link to external libraries. I mention `joblib.Parallel` in documentation but I'm not sure if there's a better way to directly link to it using Sphinx. LMK if there's a better way to do this!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
