### PR TITLE
TST Adds common test for parameters set not in __init__

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -757,11 +757,11 @@ class _BaseRidge(LinearModel, metaclass=ABCMeta):
             sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 
         if self.max_iter is not None:
-            self.max_iter = check_scalar(
+            check_scalar(
                 self.max_iter, "max_iter", target_type=numbers.Integral, min_val=1
             )
 
-        self.tol = check_scalar(self.tol, "tol", target_type=numbers.Real, min_val=0.0)
+        check_scalar(self.tol, "tol", target_type=numbers.Real, min_val=0.0)
 
         # when X is sparse we only remove offset from y
         X, y, X_offset, y_offset, X_scale = self._preprocess_data(
@@ -2041,18 +2041,20 @@ class _BaseRidgeCV(LinearModel):
             include_boundaries="neither",
         )
 
-        if isinstance(self.alphas, (np.ndarray, list, tuple)):
-            n_alphas = 1 if np.ndim(self.alphas) == 0 else len(self.alphas)
+        alphas = self.alphas
+
+        if isinstance(alphas, (np.ndarray, list, tuple)):
+            n_alphas = 1 if np.ndim(alphas) == 0 else len(alphas)
             if n_alphas != 1:
-                for index, alpha in enumerate(self.alphas):
-                    alpha = check_scalar_alpha(alpha, f"alphas[{index}]")
+                for index, alpha in enumerate(alphas):
+                    check_scalar_alpha(alpha, f"alphas[{index}]")
             else:
-                self.alphas[0] = check_scalar_alpha(self.alphas[0], "alphas")
+                check_scalar_alpha(alphas[0], "alphas")
         else:
             # check for single non-iterable item
-            self.alphas = check_scalar_alpha(self.alphas, "alphas")
+            check_scalar_alpha(alphas, "alphas")
 
-        alphas = np.asarray(self.alphas)
+        alphas = np.asarray(alphas)
 
         if cv is None:
             estimator = _RidgeGCV(

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -195,7 +195,7 @@ class KNeighborsClassifier(KNeighborsMixin, ClassifierMixin, NeighborsBase):
         self : KNeighborsClassifier
             The fitted k-nearest neighbors classifier.
         """
-        self.weights = _check_weights(self.weights)
+        _check_weights(self.weights)
 
         return self._fit(X, y)
 
@@ -511,7 +511,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin, ClassifierMixin, Neighbors
         self : RadiusNeighborsClassifier
             The fitted radius neighbors classifier.
         """
-        self.weights = _check_weights(self.weights)
+        _check_weights(self.weights)
 
         self._fit(X, y)
 

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -198,7 +198,7 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
         self : KNeighborsRegressor
             The fitted k-nearest neighbors regressor.
         """
-        self.weights = _check_weights(self.weights)
+        _check_weights(self.weights)
 
         return self._fit(X, y)
 
@@ -411,7 +411,7 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin, RegressorMixin, NeighborsBa
         self : RadiusNeighborsRegressor
             The fitted radius neighbors regressor.
         """
-        self.weights = _check_weights(self.weights)
+        _check_weights(self.weights)
 
         return self._fit(X, y)
 

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -216,9 +216,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                         FutureWarning,
                     )
             else:
-                self.subsample = check_scalar(
-                    self.subsample, "subsample", numbers.Integral, min_val=1
-                )
+                check_scalar(self.subsample, "subsample", numbers.Integral, min_val=1)
                 rng = check_random_state(self.random_state)
                 if n_samples > self.subsample:
                     subsample_idx = rng.choice(

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -459,7 +459,7 @@ ESTIMATOR_PARAMETER_TO_XFAIL = {
     ("NeighborhoodComponentsAnalysis", "n_components"),
     ("PatchExtractor", "random_state"),
     ("Pipeline", "steps"),  # Expected behavior
-    ("RANSACRegressor", "estimator"),
+    ("RANSACRegressor", "estimator"),  # Expected behavior
     ("RidgeClassifier", "max_iter"),
     ("RidgeClassifierCV", "alphas"),
 }
@@ -476,10 +476,16 @@ def test_estimators_do_not_set_parameter_outside_of_init(name, Estimator):
         )
         for kls in Estimator.mro()
     )
+
+    # Regex for "self.a_string = " where "a_string" can not begin or end with "_"
     param_set_re = re.compile(r"self.(?!_)(\w+)(?<!_) = ")
 
     for f in functions:
-        source = getsource(f)
+        try:
+            source = getsource(f)
+        except TypeError:
+            continue
+
         match = param_set_re.search(source)
         if match is None:
             continue

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -471,14 +471,14 @@ def test_estimators_do_not_set_parameter_outside_of_init(name, Estimator):
     functions = chain.from_iterable(
         (
             f
-            for name, f in getmembers(kls, isfunction)
-            if f.__qualname__.startswith(kls.__name__) and name != "__init__"
+            for name, f in getmembers(Kls, isfunction)
+            if f.__qualname__.startswith(Kls.__name__) and name != "__init__"
         )
-        for kls in Estimator.mro()
+        for Kls in Estimator.mro()
     )
 
     # Regex for "self.a_string = " where "a_string" can not begin or end with "_"
-    param_set_re = re.compile(r"self.(?!_)(\w+)(?<!_) = ")
+    param_set_re = re.compile(r"self\.(?!_)(\w+)(?<!_) = ")
 
     for f in functions:
         try:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/pull/22486
Related to https://github.com/scikit-learn/scikit-learn/issues/22478

#### What does this implement/fix? Explain your changes.
This PR adds a new common test that inspects the source code to see if an attribute is set.

#### Any other comments?
I can see that `check_scalar` does not actually change the input, but using `self.parameter = check_scalar` makes it look like we are changing the parameter.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
