### PR TITLE
DOC Move model persistence up into user guide

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -253,6 +253,7 @@ redirects = {
     "auto_examples/feature_selection/plot_permutation_test_for_classification": (
         "auto_examples/model_selection/plot_permutation_tests_for_classification"
     ),
+    "modules/model_persistence": "model_persistence",
 }
 html_context["redirects"] = redirects
 for old_link in redirects:

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -1,3 +1,7 @@
+.. Places parent toc into the sidebar
+
+:parenttoc: True
+
 .. _model_persistence:
 
 =================

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -28,5 +28,5 @@ User Guide
    data_transforms.rst
    datasets.rst
    computing.rst
-   modules/model_persistence.rst
+   model_persistence.rst
    common_pitfalls.rst


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/22473


#### What does this implement/fix? Explain your changes.
This PR:

1. Moves `model_persistence` up a level so that the user guide always shows the TOC on the side bar. 
2. Redirects the old `model_persistence` page to the new one.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
