### PR TITLE
CI Fixes bot for test collection failure

### DIFF
--- a/maint_tools/create_issue_from_juint.py
+++ b/maint_tools/create_issue_from_juint.py
@@ -77,7 +77,7 @@ failure_cases = []
 error = tree.find("./testsuite/testcase/error")
 if error is not None:
     # Get information for test collection error
-    failure_cases.append({"title": "Test Collection Failure", "body": error.text})
+    failure_cases.append("Test Collection Failure")
 
 for item in tree.iter("testcase"):
     failure = item.find("failure")


### PR DESCRIPTION
Noticed overly long message in https://github.com/scikit-learn/scikit-learn/issues/22510 for a test collection error.

This PR removes the body since it is not used anymore and goes with "Test Collection Error".