### PR TITLE
CI Fix scipy-dev for deprecation numpy.distutils [scipy-dev]

### DIFF
--- a/sklearn/_build_utils/pre_build_helpers.py
+++ b/sklearn/_build_utils/pre_build_helpers.py
@@ -12,6 +12,7 @@ import warnings
 from distutils.dist import Distribution
 from distutils.sysconfig import customize_compiler
 
+# NumPy 1.23 deprecates numpy.distutils
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     from numpy.distutils.ccompiler import new_compiler

--- a/sklearn/_build_utils/pre_build_helpers.py
+++ b/sklearn/_build_utils/pre_build_helpers.py
@@ -7,11 +7,15 @@ import tempfile
 import textwrap
 import setuptools  # noqa
 import subprocess
+import warnings
 
 from distutils.dist import Distribution
 from distutils.sysconfig import customize_compiler
-from numpy.distutils.ccompiler import new_compiler
-from numpy.distutils.command.config_compiler import config_cc
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from numpy.distutils.ccompiler import new_compiler
+    from numpy.distutils.command.config_compiler import config_cc
 
 
 def _get_compiler():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/22510

#### What does this implement/fix? Explain your changes.
This PR ignores the numpy.distutils warnings from the NumPy dev builds.

#### Any other comments?
I am planning to work toward https://github.com/scikit-learn/scikit-learn/issues/21499 soon. Looks like meson is almost ready for prime time. (SciPy have mostly switched over to it for their dev builds)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
