### PR TITLE
DOC Ensures that precision_recall_curve passes numpydoc

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -859,7 +859,6 @@ def precision_recall_curve(y_true, probas_pred, *, pos_label=None, sample_weight
     array([1. , 0.5, 0.5, 0. ])
     >>> thresholds
     array([0.35, 0.4 , 0.8 ])
-
     """
     fps, tps, thresholds = _binary_clf_curve(
         y_true, probas_pred, pos_label=pos_label, sample_weight=sample_weight

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -72,7 +72,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics._ranking.dcg_score",
     "sklearn.metrics._ranking.label_ranking_average_precision_score",
     "sklearn.metrics._ranking.label_ranking_loss",
-    "sklearn.metrics._ranking.precision_recall_curve",
     "sklearn.metrics._ranking.roc_auc_score",
     "sklearn.metrics._ranking.roc_curve",
     "sklearn.metrics._ranking.top_k_accuracy_score",


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #21350

#### What does this implement/fix? Explain your changes.

Fixing docs to ensure that `sklearn.metrics._ranking.precision_recall_curve` passes numpydoc validation

#### Any other comments?

None