### PR TITLE
FIX Typos in .github/workflows/check-changelog.yml

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -61,8 +61,8 @@ jobs:
             echo "If you see this error and there is already a changelog entry,"
             echo "check that the PR number is correct."
             echo ""
-            echo "If you believe that this PR does no warrant a changelog"
-            echo "entry, say so in a comment so that a maintainer will label "
+            echo "If you believe that this PR does not warrant a changelog"
+            echo "entry, say so in a comment so that a maintainer will label"
             echo "the PR with 'No Changelog Needed' to bypass this check."
             exit 1
           fi


### PR DESCRIPTION
There were two minor typos in a message for the changelog check workflow: 

1. A missing t in _does no**t** warrant_ 
2. An extra space at the end of a line after _label_

Observed [here](https://github.com/scikit-learn/scikit-learn/runs/5226991198?check_suite_focus=true#step:4:24599) in lines `24599` (missing t) and `24600` (extra space).

#### What does this implement/fix? Explain your changes.

Fixing typos in the workflow message

#### Any other comments?

None