### PR TITLE
CI fetch_openml retry on SSL timeout

### DIFF
--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -674,8 +674,9 @@ def fetch_openml(
            in 0.24.
 
     n_retries : int, default=3
-        Number of retries when HTTP errors are encountered. Error with status
-        code 412 won't be retried as they represent OpenML generic errors.
+        Number of retries when HTTP errors or network timeouts are encountered.
+        Error with status code 412 won't be retried as they represent OpenML
+        generic errors.
 
     delay : float, default=1.0
         Number of seconds between retries.

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -82,7 +82,7 @@ def _retry_on_network_error(
             while True:
                 try:
                     return f(*args, **kwargs)
-                except URLError as e:
+                except (URLError, TimeoutError) as e:
                     # 412 is a specific OpenML error code.
                     if isinstance(e, HTTPError) and e.code == 412:
                         raise


### PR DESCRIPTION
Hopefully, this can help make `fetch_openml` calls more stable. We recently observed the following on the CI:

<details>

```python-traceback
2022-02-18T02:53:44.1260595Z 215   >>> iris_version_3 = fetch_openml(name="iris", version=3)
2022-02-18T02:53:44.1261376Z UNEXPECTED EXCEPTION: TimeoutError('The read operation timed out')
2022-02-18T02:53:44.1262501Z Traceback (most recent call last):
2022-02-18T02:53:44.1263185Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 52, in wrapper
2022-02-18T02:53:44.1310032Z     return f(*args, **kw)
2022-02-18T02:53:44.1311040Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 224, in _load_json
2022-02-18T02:53:44.1311744Z     _open_openml_url(url, data_home, n_retries=n_retries, delay=delay)
2022-02-18T02:53:44.1312401Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 156, in _open_openml_url
2022-02-18T02:53:44.1313063Z     _retry_on_network_error(n_retries, delay, req.full_url)(urlopen)(
2022-02-18T02:53:44.1313703Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 84, in wrapper
2022-02-18T02:53:44.1314275Z     return f(*args, **kwargs)
2022-02-18T02:53:44.1314877Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 216, in urlopen
2022-02-18T02:53:44.1315516Z     return opener.open(url, data, timeout)
2022-02-18T02:53:44.1316124Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 519, in open
2022-02-18T02:53:44.1316739Z     response = self._open(req, data)
2022-02-18T02:53:44.1317349Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 536, in _open
2022-02-18T02:53:44.1318015Z     result = self._call_chain(self.handle_open, protocol, protocol +
2022-02-18T02:53:44.1318690Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 496, in _call_chain
2022-02-18T02:53:44.1319329Z     result = func(*args)
2022-02-18T02:53:44.1319931Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 1391, in https_open
2022-02-18T02:53:44.1320574Z     return self.do_open(http.client.HTTPSConnection, req,
2022-02-18T02:53:44.1321230Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 1352, in do_open
2022-02-18T02:53:44.1321831Z     r = h.getresponse()
2022-02-18T02:53:44.1322428Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/http/client.py", line 1368, in getresponse
2022-02-18T02:53:44.1323024Z     response.begin()
2022-02-18T02:53:44.1324168Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/http/client.py", line 317, in begin
2022-02-18T02:53:44.1325960Z     version, status, reason = self._read_status()
2022-02-18T02:53:44.1326686Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/http/client.py", line 278, in _read_status
2022-02-18T02:53:44.1327536Z     line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
2022-02-18T02:53:44.1328058Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/socket.py", line 705, in readinto
2022-02-18T02:53:44.1328516Z     return self._sock.recv_into(b)
2022-02-18T02:53:44.1328964Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/ssl.py", line 1273, in recv_into
2022-02-18T02:53:44.1329400Z     return self.read(nbytes, buffer)
2022-02-18T02:53:44.1329848Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/ssl.py", line 1129, in read
2022-02-18T02:53:44.1330303Z     return self._sslobj.read(len, buffer)
2022-02-18T02:53:44.1330695Z TimeoutError: The read operation timed out
2022-02-18T02:53:44.1331123Z During handling of the above exception, another exception occurred:
2022-02-18T02:53:44.1331529Z Traceback (most recent call last):
2022-02-18T02:53:44.1331985Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/doctest.py", line 1348, in __run
2022-02-18T02:53:44.1332457Z     exec(compile(example.source, filename, "single",
2022-02-18T02:53:44.1332928Z   File "<doctest loading_other_datasets.rst[27]>", line 1, in <module>
2022-02-18T02:53:44.1333415Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 745, in fetch_openml
2022-02-18T02:53:44.1333847Z     data_info = _get_data_info_by_name(
2022-02-18T02:53:44.1334305Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 305, in _get_data_info_by_name
2022-02-18T02:53:44.1334903Z     json_data = _get_json_content_from_openml_api(
2022-02-18T02:53:44.1335402Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 229, in _get_json_content_from_openml_api
2022-02-18T02:53:44.1335860Z     return _load_json()
2022-02-18T02:53:44.1336252Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 60, in wrapper
2022-02-18T02:53:44.1336671Z     return f(*args, **kw)
2022-02-18T02:53:44.1337086Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 224, in _load_json
2022-02-18T02:53:44.1337579Z     _open_openml_url(url, data_home, n_retries=n_retries, delay=delay)
2022-02-18T02:53:44.1338063Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 156, in _open_openml_url
2022-02-18T02:53:44.1338562Z     _retry_on_network_error(n_retries, delay, req.full_url)(urlopen)(
2022-02-18T02:53:44.1339046Z   File "/home/vsts/work/1/s/sklearn/datasets/_openml.py", line 84, in wrapper
2022-02-18T02:53:44.1339462Z     return f(*args, **kwargs)
2022-02-18T02:53:44.1339913Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 216, in urlopen
2022-02-18T02:53:44.1340369Z     return opener.open(url, data, timeout)
2022-02-18T02:53:44.1340834Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 519, in open
2022-02-18T02:53:44.1341291Z     response = self._open(req, data)
2022-02-18T02:53:44.1341746Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 536, in _open
2022-02-18T02:53:44.1342250Z     result = self._call_chain(self.handle_open, protocol, protocol +
2022-02-18T02:53:44.1342770Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 496, in _call_chain
2022-02-18T02:53:44.1343219Z     result = func(*args)
2022-02-18T02:53:44.1343666Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 1391, in https_open
2022-02-18T02:53:44.1344167Z     return self.do_open(http.client.HTTPSConnection, req,
2022-02-18T02:53:44.1344666Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/urllib/request.py", line 1352, in do_open
2022-02-18T02:53:44.1345109Z     r = h.getresponse()
2022-02-18T02:53:44.1345535Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/http/client.py", line 1368, in getresponse
2022-02-18T02:53:44.1345976Z     response.begin()
2022-02-18T02:53:44.1346400Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/http/client.py", line 317, in begin
2022-02-18T02:53:44.1346956Z     version, status, reason = self._read_status()
2022-02-18T02:53:44.1347426Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/http/client.py", line 278, in _read_status
2022-02-18T02:53:44.1348122Z     line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
2022-02-18T02:53:44.1348636Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/socket.py", line 705, in readinto
2022-02-18T02:53:44.1349089Z     return self._sock.recv_into(b)
2022-02-18T02:53:44.1349665Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/ssl.py", line 1273, in recv_into
2022-02-18T02:53:44.1350169Z     return self.read(nbytes, buffer)
2022-02-18T02:53:44.1350595Z   File "/usr/share/miniconda/envs/testvenv/lib/python3.10/ssl.py", line 1129, in read
2022-02-18T02:53:44.1351050Z     return self._sslobj.read(len, buffer)
2022-02-18T02:53:44.1351442Z TimeoutError: The read operation timed out
```

</details>

https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=38258&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=a5a438e1-a911-5517-158f-26a140e5cbbf