### PR TITLE
FIX Remove validation from __init__ and set_params for ColumnTransformer

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -158,6 +158,13 @@ Changelog
   `-1` and the original warning message is shown.
   :pr:`22217` by :user:`Meekail Zain <micky774>`.
 
+:mod:`sklearn.compose`
+......................
+
+- |Fix| :class:`compose.ColumnTransformer` now removes validation errors from
+  `__init__` and `set_params` methods.
+  :pr:`22537` by :user:`iofall <iofall>` and :user:`Arisa Y. <arisayosh>`.
+
 :mod:`sklearn.cross_decomposition`
 ..................................
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -222,14 +222,20 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         of get_params via BaseComposition._get_params which expects lists
         of tuples of len 2.
         """
-        return [(name, trans) for name, trans, _ in self.transformers]
+        try:
+            return [(name, trans) for name, trans, _ in self.transformers]
+        except (TypeError, ValueError):
+            return self.transformers
 
     @_transformers.setter
     def _transformers(self, value):
-        self.transformers = [
-            (name, trans, col)
-            for ((name, trans), (_, _, col)) in zip(value, self.transformers)
-        ]
+        try:
+            self.transformers = [
+                (name, trans, col)
+                for ((name, trans), (_, _, col)) in zip(value, self.transformers)
+            ]
+        except (TypeError, ValueError):
+            self.transformers = value
 
     def get_params(self, deep=True):
         """Get parameters for this estimator.

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -415,7 +415,6 @@ def test_transformers_get_feature_names_out(transformer):
 
 
 VALIDATE_ESTIMATOR_INIT = [
-    "ColumnTransformer",
     "SGDOneClassSVM",
     "TheilSenRegressor",
     "TweedieRegressor",

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -437,7 +437,7 @@ def test_estimators_do_not_raise_errors_in_init_or_set_params(Estimator):
         if param.kind != Parameter.VAR_KEYWORD
     ]
 
-    smoke_test_values = [-1, 3.0, "helloworld", np.array([1.0, 4.0]), {}, []]
+    smoke_test_values = [-1, 3.0, "helloworld", np.array([1.0, 4.0]), [1], {}, []]
     for value in smoke_test_values:
         new_params = {key: value for key in params}
 

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -56,10 +56,13 @@ class _BaseComposition(BaseEstimator, metaclass=ABCMeta):
         items = getattr(self, attr)
         if isinstance(items, list) and items:
             # Get item names used to identify valid names in params
-            item_names, _ = zip(*items)
-            for name in list(params.keys()):
-                if "__" not in name and name in item_names:
-                    self._replace_estimator(attr, name, params.pop(name))
+            try:
+                item_names, _ = zip(*items)
+                for name in list(params.keys()):
+                    if "__" not in name and name in item_names:
+                        self._replace_estimator(attr, name, params.pop(name))
+            except TypeError:
+                pass
 
         # 3. Step parameters and other initialisation arguments
         super().set_params(**params)

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -8,6 +8,7 @@ from abc import ABCMeta, abstractmethod
 from operator import attrgetter
 from functools import update_wrapper
 import numpy as np
+from contextlib import suppress
 
 from ..utils import _safe_indexing
 from ..utils._tags import _safe_tags
@@ -56,13 +57,13 @@ class _BaseComposition(BaseEstimator, metaclass=ABCMeta):
         items = getattr(self, attr)
         if isinstance(items, list) and items:
             # Get item names used to identify valid names in params
-            try:
+            # `zip` raises a TypeError when `items` does not contains
+            # elements of length 2
+            with suppress(TypeError):
                 item_names, _ = zip(*items)
                 for name in list(params.keys()):
                     if "__" not in name and name in item_names:
                         self._replace_estimator(attr, name, params.pop(name))
-            except TypeError:
-                pass
 
         # 3. Step parameters and other initialisation arguments
         super().set_params(**params)


### PR DESCRIPTION
Addresses #21406

#### What does this implement/fix? Explain your changes.
1. Although no explicit validation was defined in the `__init__()` method or the `set_params()` method, due to the nature of `ColumnTransformer` and its internal implementation, for some smoke test values in `test_common.py`, we did not pass the test.
2. To solve this we used `try-except` to handle these input based errors.

#### Any other comments?
1. We pass all the tests for `test_common.py` and `test_column_transformer.py`
2. We already use the `try-except` handler in `metaestimators.py`, however since `set_params()` internally calls `get_params()` which is defined by iterating over `self.transformers` in `ColumnTransformer`, we need to handle the exception in cases where the `self.transformers` attribute does not have an iterator.

#### Questions:
1. I wonder in this case should we try to handle validation the way we have done above or would it be useful to keep the class as it already is. That way we are more explicit and users get an immediate error when they try to set the params in an improper format (Although this would mean going against our convention).

#### Other Contributors:
**CC:** @arisayosh 
