### PR TITLE
DOC Ensures that get_chunk_n_rows passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -142,7 +142,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.fixes.threadpool_limits",
     "sklearn.utils.gen_batches",
     "sklearn.utils.gen_even_slices",
-    "sklearn.utils.get_chunk_n_rows",
     "sklearn.utils.graph.graph_shortest_path",
     "sklearn.utils.graph.single_source_shortest_path_length",
     "sklearn.utils.is_scalar_nan",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -941,7 +941,7 @@ def _print_elapsed_time(source, message=None):
 
 
 def get_chunk_n_rows(row_bytes, *, max_n_rows=None, working_memory=None):
-    """Calculates how many rows can be processed within working_memory.
+    """Calculate how many rows can be processed within `working_memory`.
 
     Parameters
     ----------
@@ -951,17 +951,18 @@ def get_chunk_n_rows(row_bytes, *, max_n_rows=None, working_memory=None):
     max_n_rows : int, default=None
         The maximum return value.
     working_memory : int or float, default=None
-        The number of rows to fit inside this number of MiB will be returned.
-        When None (default), the value of
+        The number of rows to fit inside this number of MiB will be
+        returned. When None (default), the value of
         ``sklearn.get_config()['working_memory']`` is used.
 
     Returns
     -------
-    int or the value of n_samples
+    int
+        The number of rows which can be processed within `working_memory`.
 
     Warns
     -----
-    Issues a UserWarning if ``row_bytes`` exceeds ``working_memory`` MiB.
+    Issues a UserWarning if `row_bytes exceeds `working_memory` MiB.
     """
 
     if working_memory is None:


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #21350


#### What does this implement/fix? Explain your changes.
Updated sklearn.utils.get_chunk_n_rows docstring.
- Short summary now starts with infinitive verb.
- Variable names are back-tick quoted.
- The return value has a description.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
