### PR TITLE
binary_clf_curve inverts y_true when pos_label=0.

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -754,7 +754,7 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     pos_label = _check_pos_label_consistency(pos_label, y_true)
 
     # make y_true a boolean vector
-    y_true = y_true == pos_label
+    y_true = y_true.astype(bool)
 
     # sort scores and corresponding truth values
     desc_score_indices = np.argsort(y_score, kind="mergesort")[::-1]


### PR DESCRIPTION
When calling roc_curve with pos_label=0, the results may be incorrect because binary_clf_curve inverts y_true. Fortunately, the author included a comment which stated they wanted to make y_true a boolean vector. Therefore, the fix is simple: use astype to perform the conversion instead of ==.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
