### PR TITLE
class_pairs_ stores which estimator is trained for what classes

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -681,6 +681,10 @@ Changelog
 :mod:`sklearn.multiclass`
 .........................
 
+- |Enhancement| :class:`sklearn.multiclass.OneVsOneClassifier` now have a cached_property
+  `class_pairs_` storing classes for which each estimator is trained with.
+  :pr:`22549` by :user:`Diwakar-Gupta`.
+
 - |Enhancement| :class:`multiclass.OneVsRestClassifier` now supports a `verbose`
   parameter so progress on fitting can be seen.
   :pr:`22508` by :user:`Chris Combs <combscCode>`.

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -38,6 +38,7 @@ import numpy as np
 import warnings
 import scipy.sparse as sp
 import itertools
+from functools import cached_property
 
 from .base import BaseEstimator, ClassifierMixin, clone, is_classifier
 from .base import MultiOutputMixin
@@ -603,6 +604,11 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         Indices of samples used when training the estimators.
         ``None`` when ``estimator``'s `pairwise` tag is False.
 
+    class_pairs_ : a cached_property containing an
+        ndarray of shape ``(n_classes * (n_classes - 1) // 2, 2)``.
+        Store pairs of classes used to train each estimator.
+        .. versionadded:: 1.1
+
     n_features_in_ : int
         Number of features seen during :term:`fit`.
 
@@ -685,6 +691,18 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         self.pairwise_indices_ = estimators_indices[1] if pairwise else None
 
         return self
+
+    @cached_property
+    def class_pairs_(self):
+        n_classes = self.classes_.shape[0]
+        return np.array(
+            [
+                [self.classes_[i], self.classes_[j]]
+                for i in range(n_classes)
+                for j in range(i + 1, n_classes)
+            ],
+            dtype=self.classes_.dtype,
+        )
 
     @available_if(_estimators_has("partial_fit"))
     def partial_fit(self, X, y, classes=None):

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -906,3 +906,33 @@ def test_constant_int_target(make_y):
     expected = np.zeros((X.shape[0], 2))
     expected[:, 0] = 1
     assert_allclose(y_pred, expected)
+
+
+def test_ovo_store_class_pairs():
+    # Check that class_pairs_ is created and has correct pairs.
+
+    X = iris.data
+
+    # Check with y of type int and string
+    y_int_string = [iris.target, iris.target_names[iris.target]]
+
+    for y in y_int_string:
+        clf = OneVsOneClassifier(LinearSVC(random_state=0)).fit(X, y)
+
+        classes = np.unique(y)
+        n_classes = classes.shape[0]
+
+        # Check dtype and shape is correct.
+        assert clf.class_pairs_.dtype == y.dtype
+        assert clf.class_pairs_.shape == (n_classes * (n_classes - 1) // 2, 2)
+
+        # Check pairs are correct or not.
+        correct_pairs = np.array(
+            [
+                [classes[i], classes[j]]
+                for i in range(n_classes)
+                for j in range(i + 1, n_classes)
+            ],
+            dtype=y.dtype,
+        )
+        assert np.all(clf.class_pairs_ == correct_pairs)


### PR DESCRIPTION
Store pairs of classes used to train each estimator in estimators attribute. In this case, it will be easier to map each estimator to its target.

#### Reference Issues/PRs
 Fixes #22366


#### What does this implement/fix? Explain your changes.
created a `cached_property`  `class_pairs_` to store labels each estimator is trained with.

This is done by 

            np.array(
                [self.classes_[i], self.classes_[j]] 
                for i in range(n_classes)
                for j in range(i + 1, n_classes)
            )

#### Any other comments?
Please tell me if there is any improvement that has to be done.