### PR TITLE
Modifications to LinearRegression documentation.

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -43,7 +43,7 @@ and will store the coefficients :math:`w` of the linear model in its
 
     >>> from sklearn import linear_model
     >>> reg = linear_model.LinearRegression()
-    >>> reg.fit([[0, 0], [1, 1], [2, 2]], [0, 1, 3])
+    >>> reg.fit([[0, 0], [1, 1], [2, 2]], [1, 2, 3])
     LinearRegression()
     >>> reg.coef_
     array([0.5, 0.5])

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -13,7 +13,7 @@ value.
 
 .. math::    \hat{y}(w, x) = w_0 + w_1 x_1 + ... + w_p x_p
 
-Across the module, we designate the vector :math:`w = (w_1,
+Across the module, we designate the vector :math:`(w_1,
 ..., w_p)` as ``coef_`` and :math:`w_0` as ``intercept_``.
 
 To perform classification with generalized linear models, see
@@ -25,7 +25,7 @@ Ordinary Least Squares
 =======================
 
 :class:`LinearRegression` fits a linear model with coefficients
-:math:`w = (w_1, ..., w_p)` to minimize the residual sum
+:math:`w = (w_0, ..., w_p)` to minimize the residual sum
 of squares between the observed targets in the dataset, and the
 targets predicted by the linear approximation. Mathematically it
 solves a problem of the form:
@@ -39,7 +39,7 @@ solves a problem of the form:
 
 :class:`LinearRegression` will take in its ``fit`` method arrays X, y
 and will store the coefficients :math:`w` of the linear model in its
-``coef_`` member::
+``coef_`` and ``intercept_`` members::
 
     >>> from sklearn import linear_model
     >>> reg = linear_model.LinearRegression()
@@ -47,6 +47,8 @@ and will store the coefficients :math:`w` of the linear model in its
     LinearRegression()
     >>> reg.coef_
     array([0.5, 0.5])
+    >>> reg.intercept_
+    1.1102230246251565e-16
 
 The coefficient estimates for Ordinary Least Squares rely on the
 independence of the features. When features are correlated and the

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -43,12 +43,12 @@ and will store the coefficients :math:`w` of the linear model in its
 
     >>> from sklearn import linear_model
     >>> reg = linear_model.LinearRegression()
-    >>> reg.fit([[0, 0], [1, 1], [2, 2]], [0, 1, 2])
+    >>> reg.fit([[0, 0], [1, 1], [2, 2]], [0, 1, 3])
     LinearRegression()
     >>> reg.coef_
     array([0.5, 0.5])
     >>> reg.intercept_
-    1.1102230246251565e-16
+    1.0
 
 The coefficient estimates for Ordinary Least Squares rely on the
 independence of the features. When features are correlated and the


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #22551.

#### What does this implement/fix? Explain your changes.

From the documentation of https://scikit-learn.org/stable/modules/linear_model.html#ordinary-least-squares, one could understand that LinearRegression fits a model where the intercept $w_0$ is absent, that is, where $w_0=0$.

To prevent this misinterpretation, the present PR rephrases:

1. "Across the module, we designate the vector $w = (w_1, ..., w_p)$ as coef_ and $w_0$ as intercept_." as "Across the module, we designate the vector $(w_1, ..., w_p)$ as coef_ and $w_0$ as intercept_." 
2. "LinearRegression fits a linear model with coefficients $w = (w_1, ..., w_p)" as "LinearRegression fits a linear model with coefficients $w = (w_0, w_1, ..., w_p)" 
3. "and will store the coefficients of the linear model in its coef_ member" as "and will store the coefficients of the linear model in its coef_ and intercept_ members"

#### Any other comments?