### PR TITLE
DOC Clarifies comments and docstrings in _BaseDiscreteNB

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -53,8 +53,8 @@ class _BaseNB(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         I.e. ``log P(c) + log P(x|c)`` for all rows x of X, as an array-like of
         shape (n_samples, n_classes).
 
-        Input is handed over to _joint_log_likelihood by predict, predict_proba
-        and predict_log_proba after being passed through _check_X.
+        predict, predict_proba, and predict_log_proba passes the input through
+        _check_X and handles it over to _joint_log_likelihood
         """
 
     @abstractmethod

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -528,6 +528,7 @@ class _BaseDiscreteNB(_BaseNB):
         The class log priors are based on `class_prior`, class count or the
         number of classes. This method is called each time `fit` or
         `partial_fit` update the model.
+        """
         n_classes = len(self.classes_)
         if class_prior is not None:
             if len(class_prior) != n_classes:

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -512,36 +512,7 @@ class _BaseDiscreteNB(_BaseNB):
 
     __init__
     _joint_log_likelihood(X) as per _BaseNB
-    _update_feature_log_prob(alpha)
-    _count(X, Y)
     """
-
-    @abstractmethod
-    def _count(self, X, Y):
-        """Update counts that are used to calculate probabilities.
-
-        The counts make up a sufficient statistic extracted from the data.
-        Accordingly, this method is called each time ``fit`` or ``partial_fit``
-        update the model. The number and composition of counts depend on a
-        concrete model, but ``self.class_count`` must be updated in any case.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            The input samples.
-        Y : array-like of shape (n_samples, n_classes)
-            Binarized class labels."""
-
-    @abstractmethod
-    def _update_feature_log_prob(self, alpha):
-        """Update feature log probabilities based on counts.
-
-        This method is called each time ``fit`` or ``partial_fit`` update the
-        model.
-
-        Parameters
-        ----------
-        alpha : smoothing parameter. See :meth:`_check_alpha`."""
 
     def _check_X(self, X):
         """Validate X, used only in predict* methods."""

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -523,11 +523,11 @@ class _BaseDiscreteNB(_BaseNB):
         return self._validate_data(X, y, accept_sparse="csr", reset=reset)
 
     def _update_class_log_prior(self, class_prior=None):
-        """Update class log priors based `class_prior` (when provided) or class
-        counts.
+        """Update class log priors.
 
-        This method is called each time `fit` or `partial_fit` update the model.
-        """
+        The class log priors are based on `class_prior`, class count or the
+        number of classes. This method is called each time `fit` or
+        `partial_fit` update the model.
         n_classes = len(self.classes_)
         if class_prior is not None:
             if len(class_prior) != n_classes:

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -53,8 +53,8 @@ class _BaseNB(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         I.e. ``log P(c) + log P(x|c)`` for all rows x of X, as an array-like of
         shape (n_samples, n_classes).
 
-        predict, predict_proba, and predict_log_proba passes the input through
-        _check_X and handles it over to _joint_log_likelihood
+        predict, predict_proba, and predict_log_proba pass the input through
+        _check_X and handle it over to _joint_log_likelihood.
         """
 
     @abstractmethod


### PR DESCRIPTION
#### Reference Issues/PRs
As far as I know, there was no issue for that. I briefly mentioned what I had on my mind in #22502, where @glemaitre gave me a general guidance, which I am trying to follow.

#### What does this implement/fix? Explain your changes.
All changes are private.

1. Docstring for `_BaseNB._joint_log_likelihood` is corrected: I included a detail, which is important for implementation of a naive Bayes meta-estimators I am working on now (PR is coming within a day or so). I don't think this docstring appears in the documentation.
2. ~~Abstract methods `_count` and `_update_feature_log_prob` are added to the abstract class `_BaseDiscreteNB`, along with a minimal description of what these methods should do. I believe this addition will facilitate understanding and maintaining the code. Currently, the abstract methods aren't mentioned anywhere, but are called and their effects are expected by concrete methods of the same class.~~ **_Abstract methods will be added in a separated PR._**
3. Minor grammar in other commentaries.

#### Any other comments?
None.