### PR TITLE
FIX Missing num_threads in some HGBT pranges

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -330,6 +330,12 @@ Changelog
   :class:`ensemble.ExtraTreesClassifier`.
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
 
+- |Fix| Removed a potential source of oversubscription in
+  :class:`ensemble.HistGradientBoostingClassifier` and
+  :class:`ensemble.HistGradientBoostingRegressor` when CPU resource usage is limited,
+  for instance using cgroups quota in a docker container. :pr:`22566` by
+  :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 :mod:`sklearn.feature_extraction`
 .................................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -330,7 +330,7 @@ Changelog
   :class:`ensemble.ExtraTreesClassifier`.
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
 
-- |Fix| Removed a potential source of oversubscription in
+- |Fix| Removed a potential source of CPU oversubscription in
   :class:`ensemble.HistGradientBoostingClassifier` and
   :class:`ensemble.HistGradientBoostingRegressor` when CPU resource usage is limited,
   for instance using cgroups quota in a docker container. :pr:`22566` by

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -335,7 +335,7 @@ cdef class Splitter:
 
             # map indices from sample_indices to left/right_indices_buffer
             for thread_idx in prange(n_threads, schedule='static',
-                                     chunksize=1):
+                                     chunksize=1, num_threads=n_threads):
                 left_count = 0
                 right_count = 0
 
@@ -377,7 +377,7 @@ cdef class Splitter:
             # sample_indices. This also updates self.partition since
             # sample_indices is a view.
             for thread_idx in prange(n_threads, schedule='static',
-                                     chunksize=1):
+                                     chunksize=1, num_threads=n_threads):
                 memcpy(
                     &sample_indices[left_offset[thread_idx]],
                     &left_indices_buffer[offset_in_buffers[thread_idx]],


### PR DESCRIPTION
Probably the reason of the performance issue reported in https://github.com/INRIA/scikit-learn-mooc/issues/586

in ``for thread_idx in prange(n_threads, schedule='static', chunksize=1)``, n_threads is the number of tasks but the number of threads stays unspecified. Like this, the number of tasks might be smaller than the number of threads, but openmp will still spawn all threads even if some of them are idle.