### PR TITLE
[WIP] FIX: Ignore key when present in `class_weight` and not in labels

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -58,9 +58,11 @@ def compute_class_weight(class_weight, *, classes, y):
             raise ValueError(
                 "class_weight must be dict, 'balanced', or None, got: %r" % class_weight
             )
-        for c in class_weight:
+
+        # Ignore class weights that are not in y
+        for c in y:
             i = np.searchsorted(classes, c)
-            if i >= len(classes) or classes[i] != c:
+            if i >= len(classes) or classes[i] != c or c not in class_weight:
                 raise ValueError("Class label {} not present.".format(c))
             else:
                 weight[i] = class_weight[c]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Fixes: #22413 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.

As mentioned in this comment https://github.com/scikit-learn/scikit-learn/issues/22413#issuecomment-1034134279, class weights not in `y` (labels) are now ignored. But class weights in `y` that are *not* present in `class_weight` will raise a ValueError.

#### Any other comments?

**TODO**:

- [ ] Implement non-regression test for issue
- [ ] Add test for `compute_sample_weight` 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
