### PR TITLE
FIX Let classes be determined by y instead of class_weight

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -55,10 +55,8 @@ def compute_class_weight(class_weight, *, classes, y):
         # user-defined dictionary
         weight = np.ones(classes.shape[0], dtype=np.float64, order="C")
         remaining_classes = list(classes)
-        print(class_weight, classes, type(class_weight), type(classes))
         for c in class_weight:
             i = np.searchsorted(classes, c)
-            print(i, c)
             # ignore weights for classes not present in y
             if i < len(classes) and classes[i] == c:
                 weight[i] = class_weight[c]

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -51,19 +51,25 @@ def compute_class_weight(class_weight, *, classes, y):
 
         recip_freq = len(y) / (len(le.classes_) * np.bincount(y_ind).astype(np.float64))
         weight = recip_freq[le.transform(classes)]
-    else:
+    elif isinstance(class_weight, dict):
         # user-defined dictionary
         weight = np.ones(classes.shape[0], dtype=np.float64, order="C")
-        if not isinstance(class_weight, dict):
-            raise ValueError(
-                "class_weight must be dict, 'balanced', or None, got: %r" % class_weight
-            )
+        remaining_classes = list(classes)
+        print(class_weight, classes, type(class_weight), type(classes))
         for c in class_weight:
             i = np.searchsorted(classes, c)
-            if i >= len(classes) or classes[i] != c:
-                raise ValueError("Class label {} not present.".format(c))
-            else:
+            print(i, c)
+            # ignore weights for classes not present in y
+            if i < len(classes) and classes[i] == c:
                 weight[i] = class_weight[c]
+                remaining_classes.pop(0)
+        if remaining_classes:
+            raise ValueError("Class labels {} not present.".format(remaining_classes))
+
+    else:
+        raise ValueError(
+            "class_weight must be dict, 'balanced', or None, got: %r" % class_weight
+        )
 
     return weight
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -261,3 +261,16 @@ def test_compute_sample_weight_more_than_32():
     indices = np.arange(50)  # use subsampling
     weight = compute_sample_weight("balanced", y, indices=indices)
     assert_array_almost_equal(weight, np.ones(y.shape[0]))
+
+
+def test_compute_sample_weight_extra_weight():
+    # Test fix for #22413: extra class weight
+    class_weight = {"dog": 10, "cat": 1, "parrot": 5}
+    compute_sample_weight(class_weight, ["dog", "cat"])
+
+
+def test_compute_sample_weight_missing_weight():
+    # Regression test for #22413 fix: missing class weight
+    class_weight = {"dog": 10, "cat": 1}
+    with pytest.raises(ValueError):
+        compute_sample_weight(class_weight, ["dog", "cat", "parrot"])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #22413


#### What does this implement/fix? Explain your changes.
Let `y` determine the classes instead of `class_weight`.

#### Any other comments?
I had some issues running the tests - import errors when running `pytest sklearn/utils/tests/test_class_weight.py`. Running just my tests worked fine though.