### PR TITLE
FIX Make Ridge*CV warn about rescaling alphas with scaling

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -124,7 +124,7 @@ def _deprecate_normalize(normalize, default, estimator_name):
             "0. For other values of l1_ratio, no analytic formula is "
             "available."
         )
-    elif estimator_name == "RidgeCV" or estimator_name == "RidgeClassifierCV":
+    elif estimator_name in ("RidgeCV", "RidgeClassifierCV", "_RidgeGCV"):
         alpha_msg = "Set parameter alphas to: original_alphas * n_samples. "
     else:
         alpha_msg = ""

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1804,3 +1804,18 @@ def test_ridge_sample_weight_invariance(normalize, solver):
 
     assert_allclose(ridge_2sw.coef_, ridge_dup.coef_)
     assert_allclose(ridge_2sw.intercept_, ridge_dup.intercept_)
+
+
+@pytest.mark.parametrize("Estimator", [RidgeCV, RidgeClassifierCV], ids=["RidgeCV", "RidgeClassifierCV"])
+def test_ridgecv_normalize_deprecated(Estimator):
+    """Check that the normalize deprecation warning mentions the rescaling of alphas
+
+    Non-regression test for issue #22540
+    """
+    X = np.array([[1, -1], [1, 1]])
+    y = np.array([0, 1])
+
+    estimator = Estimator(normalize=True)
+
+    with pytest.warns(FutureWarning, match=r"Set parameter alphas to: original_alphas \* n_samples"):
+        estimator.fit(X, y)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1806,7 +1806,9 @@ def test_ridge_sample_weight_invariance(normalize, solver):
     assert_allclose(ridge_2sw.intercept_, ridge_dup.intercept_)
 
 
-@pytest.mark.parametrize("Estimator", [RidgeCV, RidgeClassifierCV], ids=["RidgeCV", "RidgeClassifierCV"])
+@pytest.mark.parametrize(
+    "Estimator", [RidgeCV, RidgeClassifierCV], ids=["RidgeCV", "RidgeClassifierCV"]
+)
 def test_ridgecv_normalize_deprecated(Estimator):
     """Check that the normalize deprecation warning mentions the rescaling of alphas
 
@@ -1817,5 +1819,7 @@ def test_ridgecv_normalize_deprecated(Estimator):
 
     estimator = Estimator(normalize=True)
 
-    with pytest.warns(FutureWarning, match=r"Set parameter alphas to: original_alphas \* n_samples"):
+    with pytest.warns(
+        FutureWarning, match=r"Set parameter alphas to: original_alphas \* n_samples"
+    ):
         estimator.fit(X, y)


### PR DESCRIPTION
For RidgeCV and RidgeClassifierCV the warning does not show the part regarding the alphas rescaling because they call _RidgeGCV internally which is from where the warning is raised.

Fixes #22540 