### PR TITLE
CI: remove misleading pytest-xdist comment

### DIFF
--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -31,7 +31,6 @@ jobs:
     PILLOW_VERSION: 'latest'
     MATPLOTLIB_VERSION: 'latest'
     PYTEST_VERSION: '6.2.5'
-    # Disable pytest-xdist as it can stall builds
     PYTEST_XDIST_VERSION: 'latest'
     THREADPOOLCTL_VERSION: 'latest'
     COVERAGE: 'true'

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -17,7 +17,6 @@ jobs:
     JUNITXML: 'test-data.xml'
     SKLEARN_SKIP_NETWORK_TESTS: '1'
     PYTEST_VERSION: '5.2.1'
-    # Disable pytest-xdist as it can stall builds
     PYTEST_XDIST_VERSION: 'latest'
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
     SHOW_SHORT_SUMMARY: 'false'


### PR DESCRIPTION
Since PYTEST_XDIST_VERSION='latest', pytest-xdist is not disabled contrary to what the comment is saying 

