### PR TITLE
DOC Fix matplotlib warning for plot_pca_3d.py

### DIFF
--- a/examples/decomposition/plot_pca_3d.py
+++ b/examples/decomposition/plot_pca_3d.py
@@ -17,7 +17,6 @@ comes in to choose a direction that is not flat.
 
 from sklearn.decomposition import PCA
 
-from mpl_toolkits.mplot3d import Axes3D
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import stats

--- a/examples/decomposition/plot_pca_3d.py
+++ b/examples/decomposition/plot_pca_3d.py
@@ -57,7 +57,7 @@ b /= norm
 def plot_figs(fig_num, elev, azim):
     fig = plt.figure(fig_num, figsize=(4, 3))
     plt.clf()
-    ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=elev, azim=azim)
+    ax = fig.add_subplot(111, projection="3d", elev=elev, azim=azim)
 
     ax.scatter(a[::10], b[::10], c[::10], c=density[::10], marker="+", alpha=0.4)
     Y = np.c_[a, b, c]

--- a/examples/decomposition/plot_pca_3d.py
+++ b/examples/decomposition/plot_pca_3d.py
@@ -54,9 +54,10 @@ b /= norm
 # #############################################################################
 # Plot the figures
 def plot_figs(fig_num, elev, azim):
-    fig = plt.figure(fig_num, figsize=(6, 4.5))
+    fig = plt.figure(fig_num, figsize=(4, 3))
     plt.clf()
     ax = fig.add_subplot(111, projection="3d", elev=elev, azim=azim)
+    ax.set_position([0, 0, 0.95, 1])
 
     ax.scatter(a[::10], b[::10], c[::10], c=density[::10], marker="+", alpha=0.4)
     Y = np.c_[a, b, c]

--- a/examples/decomposition/plot_pca_3d.py
+++ b/examples/decomposition/plot_pca_3d.py
@@ -54,7 +54,7 @@ b /= norm
 # #############################################################################
 # Plot the figures
 def plot_figs(fig_num, elev, azim):
-    fig = plt.figure(fig_num, figsize=(4, 3))
+    fig = plt.figure(fig_num, figsize=(6, 4.5))
     plt.clf()
     ax = fig.add_subplot(111, projection="3d", elev=elev, azim=azim)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a fix to issue #22586 

#### What does this implement/fix? Explain your changes.
Removes the warning message produced by matplotlib in `examples/decomposition/plot_pca_3d`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
