### PR TITLE
FIX zero sample weight after bootstrap

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -168,11 +168,15 @@ def _parallel_build_trees(
         else:
             curr_sample_weight = sample_weight.copy()
 
-        indices = _generate_sample_indices(
-            tree.random_state, n_samples, n_samples_bootstrap
-        )
-        sample_counts = np.bincount(indices, minlength=n_samples)
-        curr_sample_weight *= sample_counts
+        while True:
+            indices = _generate_sample_indices(
+                tree.random_state, n_samples, n_samples_bootstrap
+            )
+            sample_counts = np.bincount(indices, minlength=n_samples)
+            curr_sample_weight *= sample_counts
+
+            if np.any(curr_sample_weight != 0):
+                break
 
         if class_weight == "subsample":
             with catch_warnings():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
When some zeroes are passed into the `sample_weight` of `RandomForestRegressor` or `RandomForestClaasifier`, the  samples from bootstrap can all weight 0, which makes no sample available in the `DecisionTree` and results in `nan` in the prediction value.
In order to prevent this, we can bootstrap again until not all of the sample weight is zero.

#### Any other comments?
Maybe we should not expect any zero sample weight and prevent it in the `_check_sample_weight` function?
