### PR TITLE
DOC: get rid of matplotlib DeprecationWarning in plot_cluster_iris.py

### DIFF
--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 
 # Though the following import is not directly being used, it is required
 # for 3D projection to work with matplotlib < 3.2
-import mpl_toolkits.mplot3d
+import mpl_toolkits.mplot3d # noqa: E501
 
 from sklearn.cluster import KMeans
 from sklearn import datasets

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -45,7 +45,8 @@ fignum = 1
 titles = ["8 clusters", "3 clusters", "3 clusters, bad initialization"]
 for name, est in estimators:
     fig = plt.figure(fignum, figsize=(4, 3))
-    ax = fig.add_subplot(111, projection="3d", elev=48, azim=134)
+    ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134, auto_add_to_figure=False)
+    fig.add_axes(ax)
     est.fit(X)
     labels = est.labels_
 
@@ -63,7 +64,8 @@ for name, est in estimators:
 
 # Plot the ground truth
 fig = plt.figure(fignum, figsize=(4, 3))
-ax = fig.add_subplot(111, projection="3d", elev=48, azim=134)
+ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134, auto_add_to_figure=False)
+fig.add_axes(ax)
 
 for name, label in [("Setosa", 0), ("Versicolour", 1), ("Virginica", 2)]:
     ax.text3D(

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 
 # Though the following import is not directly being used, it is required
 # for 3D projection to work with matplotlib < 3.2
-import mpl_toolkits.mplot3d # noqa: E501
+import mpl_toolkits.mplot3d  # noqa: E501
 
 from sklearn.cluster import KMeans
 from sklearn import datasets

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -22,6 +22,9 @@ and finally the ground truth.
 import numpy as np
 import matplotlib.pyplot as plt
 
+# Though the following import is not directly being used, it is required
+# for 3D projection to work
+from mpl_toolkits.mplot3d import Axes3D
 
 from sklearn.cluster import KMeans
 from sklearn import datasets

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -45,8 +45,7 @@ fignum = 1
 titles = ["8 clusters", "3 clusters", "3 clusters, bad initialization"]
 for name, est in estimators:
     fig = plt.figure(fignum, figsize=(4, 3))
-    ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134, auto_add_to_figure=False)
-    fig.add_axes(ax)
+    ax = fig.add_subplot(111, projection="3d", elev=48, azim=134)
     est.fit(X)
     labels = est.labels_
 
@@ -64,8 +63,7 @@ for name, est in estimators:
 
 # Plot the ground truth
 fig = plt.figure(fignum, figsize=(4, 3))
-ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134, auto_add_to_figure=False)
-fig.add_axes(ax)
+ax = fig.add_subplot(111, projection="3d", elev=48, azim=134)
 
 for name, label in [("Setosa", 0), ("Versicolour", 1), ("Virginica", 2)]:
     ax.text3D(

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -23,8 +23,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # Though the following import is not directly being used, it is required
-# for 3D projection to work
-from mpl_toolkits.mplot3d import Axes3D
+# for 3D projection to work with matplotlib < 3.2
+import mpl_toolkits.mplot3d
 
 from sklearn.cluster import KMeans
 from sklearn import datasets

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -45,7 +45,7 @@ fignum = 1
 titles = ["8 clusters", "3 clusters", "3 clusters, bad initialization"]
 for name, est in estimators:
     fig = plt.figure(fignum, figsize=(4, 3))
-    ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134)
+    ax = fig.add_subplot(111, projection="3d", elev=48, azim=134)
     est.fit(X)
     labels = est.labels_
 
@@ -63,7 +63,7 @@ for name, est in estimators:
 
 # Plot the ground truth
 fig = plt.figure(fignum, figsize=(4, 3))
-ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134)
+ax = fig.add_subplot(111, projection="3d", elev=48, azim=134)
 
 for name, label in [("Setosa", 0), ("Versicolour", 1), ("Virginica", 2)]:
     ax.text3D(

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -43,6 +43,7 @@ titles = ["8 clusters", "3 clusters", "3 clusters, bad initialization"]
 for name, est in estimators:
     fig = plt.figure(fignum, figsize=(4, 3))
     ax = fig.add_subplot(111, projection="3d", elev=48, azim=134)
+    ax.set_position([0, 0, 0.95, 1])
     est.fit(X)
     labels = est.labels_
 
@@ -61,6 +62,7 @@ for name, est in estimators:
 # Plot the ground truth
 fig = plt.figure(fignum, figsize=(4, 3))
 ax = fig.add_subplot(111, projection="3d", elev=48, azim=134)
+ax.set_position([0, 0, 0.95, 1])
 
 for name, label in [("Setosa", 0), ("Versicolour", 1), ("Virginica", 2)]:
     ax.text3D(

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 
 # Though the following import is not directly being used, it is required
 # for 3D projection to work with matplotlib < 3.2
-import mpl_toolkits.mplot3d  # noqa: E501
+import mpl_toolkits.mplot3d  # noqa: F401
 
 from sklearn.cluster import KMeans
 from sklearn import datasets

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -22,9 +22,6 @@ and finally the ground truth.
 import numpy as np
 import matplotlib.pyplot as plt
 
-# Though the following import is not directly being used, it is required
-# for 3D projection to work
-from mpl_toolkits.mplot3d import Axes3D
 
 from sklearn.cluster import KMeans
 from sklearn import datasets


### PR DESCRIPTION
#### Reference Issues/PRs

part of #22586. 

#### What does this implement/fix? Explain your changes.

Removes the warning message produced by matplotlib in `examples/cluster/plot_cluster_iris.py`.

The warning states: "Pass the keyword argument auto_add_to_figure=False and use fig.add_axes(ax) to suppress this warning. The default value of auto_add_to_figure will change to False in mpl3.5 and True values will no longer work in 3.6."

I added the keyword argument `auto_add_to_figure=False` and added `fig.add_axes(ax)` in the line below each use of `Axes3D`. I believe it should maintain the perspective and size of the plots compared to the solution found in [#22547](https://github.com/scikit-learn/scikit-learn/pull/22547), which uses `matplotlib.figure.Figure.add_subplot`.