### PR TITLE
MNT Removes duplicates in neighbors.VALID_METRICS["brute"]

### DIFF
--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -43,7 +43,7 @@ VALID_METRICS = dict(
     # The following list comes from the
     # sklearn.metrics.pairwise doc string
     brute=sorted(
-        set(PAIRWISE_DISTANCE_FUNCTIONS.keys()).union(
+        set(PAIRWISE_DISTANCE_FUNCTIONS).union(
             [
                 "braycurtis",
                 "canberra",

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -42,7 +42,7 @@ VALID_METRICS = dict(
     kd_tree=KDTree.valid_metrics,
     # The following list comes from the
     # sklearn.metrics.pairwise doc string
-    brute=list(
+    brute=sorted(
         set(PAIRWISE_DISTANCE_FUNCTIONS.keys()).union(
             [
                 "braycurtis",

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -42,29 +42,30 @@ VALID_METRICS = dict(
     kd_tree=KDTree.valid_metrics,
     # The following list comes from the
     # sklearn.metrics.pairwise doc string
-    brute=(
-        list(PAIRWISE_DISTANCE_FUNCTIONS.keys())
-        + [
-            "braycurtis",
-            "canberra",
-            "chebyshev",
-            "correlation",
-            "cosine",
-            "dice",
-            "hamming",
-            "jaccard",
-            "kulsinski",
-            "mahalanobis",
-            "matching",
-            "minkowski",
-            "rogerstanimoto",
-            "russellrao",
-            "seuclidean",
-            "sokalmichener",
-            "sokalsneath",
-            "sqeuclidean",
-            "yule",
-        ]
+    brute=list(
+        set(PAIRWISE_DISTANCE_FUNCTIONS.keys()).union(
+            [
+                "braycurtis",
+                "canberra",
+                "chebyshev",
+                "correlation",
+                "cosine",
+                "dice",
+                "hamming",
+                "jaccard",
+                "kulsinski",
+                "mahalanobis",
+                "matching",
+                "minkowski",
+                "rogerstanimoto",
+                "russellrao",
+                "seuclidean",
+                "sokalmichener",
+                "sokalsneath",
+                "sqeuclidean",
+                "yule",
+            ]
+        )
     ),
 )
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2033,3 +2033,8 @@ def test_neighbors_distance_metric_deprecation():
         dist_metric = DistanceMetric.get_metric("euclidean")
 
     assert isinstance(dist_metric, ActualDistanceMetric)
+
+
+def test_valid_metrics_has_no_duplicate():
+    for val in neighbors.VALID_METRICS.values():
+        assert len(val) == len(set(val))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #22584

#### What does this implement/fix? Explain your changes.

This PR ensures that the constant list:`sklearn.neighbors.VALID_METRICS["brute"]` has no duplicate.

Since the `VALID_METRICS["brute"]` is defined as a concatenation of different lists, the resulting list can unintentionally contain duplicate values. The PR continue to ensures the resulting list is unique by replacing `list1 + list2` with `list(set(list1).union(list2))`.

#### Any other comments?

No.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
