### PR TITLE
Import setuptools before pip in sklearn.show_versions()

### DIFF
--- a/sklearn/utils/_show_versions.py
+++ b/sklearn/utils/_show_versions.py
@@ -44,8 +44,8 @@ def _get_deps_info():
 
     """
     deps = [
-        "pip",
         "setuptools",
+        "pip",
         "sklearn",
         "numpy",
         "scipy",


### PR DESCRIPTION
Fix #22614. An alternative since `import pip` is frowned upon would be to do it in a subprocess.

Putting this in draft because reintroducing `import distutils` in joblib may be the most pragmatic thing to do ...