### PR TITLE
DOC Fix axes3d matplotlib deprecation warning

### DIFF
--- a/examples/decomposition/plot_pca_iris.py
+++ b/examples/decomposition/plot_pca_iris.py
@@ -16,7 +16,6 @@ information on this dataset.
 
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 
 
 from sklearn import decomposition

--- a/examples/decomposition/plot_pca_iris.py
+++ b/examples/decomposition/plot_pca_iris.py
@@ -30,7 +30,10 @@ y = iris.target
 
 fig = plt.figure(1, figsize=(4, 3))
 plt.clf()
-ax = Axes3D(fig, rect=[0, 0, 0.95, 1], elev=48, azim=134)
+
+ax = fig.add_subplot(111, projection="3d", elev=48, azim=134)
+ax.set_position([0, 0, 0.95, 1])
+
 
 plt.cla()
 pca = decomposition.PCA(n_components=3)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Part of #22586 

#### What does this implement/fix? Explain your changes.
Removes the warning message produced by matplotlib in examples/decomposition/plot_pca_iris.py.

The warning states: "Pass the keyword argument auto_add_to_figure=False and use fig.add_axes(ax) to suppress this warning. The default value of auto_add_to_figure will change to False in mpl3.5 and True values will no longer work in 3.6."

Replaced a line like this:

`ax = Axes3D(fig, elev=elev, azim=azim, rect=[0, 0, 0.95, 1])
`

by:

```
ax = fig.add_subplot(111, projection="3d", elev=elev, azim=azim)
ax.set_position([0, 0, 0.95, 1])
```

as this was the recommended change to make in the reference issue.

#### Any other comments?
This is my first PR, so I'm sorry if there was any mistake in my submission. Please let me know if there are any changes, and I'll try my best to update accordingly.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
