### PR TITLE
NOMRG remove redundant finiteness check in pairwise_distances_argmin(_min)

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -842,7 +842,7 @@ def pairwise_distances_argmin(X, Y, *, axis=1, metric="euclidean", metric_kwargs
     return indices
 
 
-def haversine_distances(X, Y=None):
+def haversine_distances(X, Y=None, force_all_finite=True):
     """Compute the Haversine distance between samples in X and Y.
 
     The Haversine (or great circle) distance is the angular distance between
@@ -889,6 +889,7 @@ def haversine_distances(X, Y=None):
     """
     from ..metrics import DistanceMetric
 
+    X, Y = check_pairwise_arrays(X, Y, force_all_finite=force_all_finite)
     return DistanceMetric.get_metric("haversine").pairwise(X, Y)
 
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -699,7 +699,12 @@ def pairwise_distances_argmin_min(
         with config_context(assume_finite=True):
             indices, values = zip(
                 *pairwise_distances_chunked(
-                    X, Y, reduce_func=_argmin_min_reduce, metric=metric, **metric_kwargs
+                    X,
+                    Y,
+                    reduce_func=_argmin_min_reduce,
+                    metric=metric,
+                    force_all_finite=False,
+                    **metric_kwargs,
                 )
             )
         indices = np.concatenate(indices)
@@ -812,7 +817,12 @@ def pairwise_distances_argmin(X, Y, *, axis=1, metric="euclidean", metric_kwargs
                     # This returns a np.ndarray generator whose arrays we need
                     # to flatten into one.
                     pairwise_distances_chunked(
-                        X, Y, reduce_func=_argmin_reduce, metric=metric, **metric_kwargs
+                        X,
+                        Y,
+                        reduce_func=_argmin_reduce,
+                        metric=metric,
+                        force_all_finite=False,
+                        **metric_kwargs,
                     )
                 )
             )

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -396,7 +396,7 @@ def nan_euclidean_distances(
     squared=False,
     missing_values=np.nan,
     copy=True,
-    force_all_finite="allow-nan",
+    force_all_finite=True,  # automatically relaxed for NaN missing_values
 ):
     """Calculate the euclidean distances in the presence of missing values.
 


### PR DESCRIPTION
While reviewing the results of #22590 I realized that the existing code had redundant finiteness checks.

This PR aims to investigate why skipping this redundant check would bring from a performance point of view.

I used the following benchmark script to evaluate the impact of this redundant checks:

```python
from time import perf_counter
import numpy as np
from sklearn.metrics import pairwise_distances_argmin_min

n_samples_1 = 10_000
n_samples_2 = 10_000
n_features = 100

X = np.random.randn(n_samples_1, n_features).astype(np.float32)
Y = np.random.randn(n_samples_2, n_features).astype(np.float32)

durations = []
for i in range(5):
    t0 = perf_counter()
    pairwise_distances_argmin_min(X, Y)
    d = perf_counter() - t0
    print(
        f"pairwise_argmin_min {n_samples_1=}, {n_samples_2=}, "
        f"{n_features=}: {d:.3f}s"
    )
    durations.append(d)

print(f"truncated mean: {np.mean(sorted(durations)[:-2]):.3f}s")
```

However I was surprised that this PR does not seem to make the code run faster.

Profiling the `main` branch with `viztracer` confirmed that the redundant chunk-wise finiteness checks seem negligible compared to the actual computation of the Euclidean distances. I should have started with the profiling.

I will post some screenshots of the profiling in the comments.

Note that this PR has also broken some tests for some reason I don't really understand but this is probably not important because I don't think it's useful to merge it.

Also note: to propagate the `force_all_finite=False` flag, I needed to introduce an additional `functools.partial` call in the chunked distance call. But since the chunks in the Python implementation of `pairwise_distances_chunked` are large, this is not likely to impact the performance significantly.

Other note: if we were to decide to allow of an option to skip the redundant checks as this PR is attempting we would need to:
- fix the broken tests;
- document the new parameters in the docstrings.