### PR TITLE
FIX better handle limit cases in normalized_mutual_info_score

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -598,22 +598,6 @@ Changelog
 - |Fix| Fixed a bug in :func:`metrics.normalized_mutual_info_score` which could return
   unbounded values. :pr:`22635` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
-:mod:`sklearn.manifold`
-.......................
-
-- |Enhancement| :func:`manifold.spectral_embedding` and
-  :class:`manifold.SpectralEmbedding` supports `np.float32` dtype and will
-  preserve this dtype.
-  :pr:`21534` by :user:`Andrew Knyazev <lobpcg>`.
-
-- |Enhancement| Adds `get_feature_names_out` to :class:`manifold.Isomap`
-  and :class:`manifold.LocallyLinearEmbedding`. :pr:`22254` by `Thomas Fan`_.
-
-- |Fix| :func:`manifold.spectral_embedding` now uses Gaussian instead of
-  the previous uniform on [0, 1] random initial approximations to eigenvectors
-  in eigen_solvers `lobpcg` and `amg` to improve their numerical stability.
-  :pr:`21565` by :user:`Andrew Knyazev <lobpcg>`.
-
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -575,6 +575,9 @@ Changelog
   in the multiclass case when ``multiclass='ovr'`` which will return the score
   per class. :pr:`19158` by :user:`Nicki Skafte <SkafteNicki>`.
 
+- |Fix| Fixed a bug in :func:`metrics.normalized_mutual_info_score` which could return
+  unbounded values. :pr:`22635` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 :mod:`sklearn.manifold`
 .......................
 

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -25,6 +25,11 @@ def expected_mutual_information(contingency, int n_samples):
     N = <DOUBLE>n_samples
     a = np.ravel(contingency.sum(axis=1).astype(np.int32, copy=False))
     b = np.ravel(contingency.sum(axis=0).astype(np.int32, copy=False))
+
+    # any labelling with zero entropy implies EMI = 0
+    if a.size == 1 or b.size == 1:
+        return 0.0
+
     # There are three major terms to the EMI equation, which are multiplied to
     # and then summed over varying nij values.
     # While nijs[0] will never be used, having it simplifies the indexing.

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -801,6 +801,12 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
     contingency_sum = contingency.sum()
     pi = np.ravel(contingency.sum(axis=1))
     pj = np.ravel(contingency.sum(axis=0))
+
+    # Since MI <= min(H(X), H(Y)), any labelling with zero entropy, i.e. containing a
+    # single cluster, implies MI = 0
+    if pi.size == 1 or pj.size == 1:
+        return 0.0
+
     log_contingency_nm = np.log(nz_val)
     contingency_nm = nz_val / contingency_sum
     # Don't need to calculate the full outer product, just for non-zeroes
@@ -911,13 +917,16 @@ def adjusted_mutual_info_score(
     n_samples = labels_true.shape[0]
     classes = np.unique(labels_true)
     clusters = np.unique(labels_pred)
+
     # Special limit cases: no clustering since the data is not split.
+    # It corresponds to both labellings having zero entropy.
     # This is a perfect match hence return 1.0.
     if (
         classes.shape[0] == clusters.shape[0] == 1
         or classes.shape[0] == clusters.shape[0] == 0
     ):
         return 1.0
+
     contingency = contingency_matrix(labels_true, labels_pred, sparse=True)
     contingency = contingency.astype(np.float64, **_astype_copy_false(contingency))
     # Calculate the MI for the two clusterings
@@ -1022,16 +1031,25 @@ def normalized_mutual_info_score(
     clusters = np.unique(labels_pred)
 
     # Special limit cases: no clustering since the data is not split.
+    # It corresponds to both labellings having zero entropy.
     # This is a perfect match hence return 1.0.
     if (
         classes.shape[0] == clusters.shape[0] == 1
         or classes.shape[0] == clusters.shape[0] == 0
     ):
         return 1.0
+
     contingency = contingency_matrix(labels_true, labels_pred, sparse=True)
     contingency = contingency.astype(np.float64, **_astype_copy_false(contingency))
     # Calculate the MI for the two clusterings
     mi = mutual_info_score(labels_true, labels_pred, contingency=contingency)
+
+    # At this point mi = 0 can't be a perfect match (the special case of a single
+    # cluster has been dealt with before). Hence, if mi = 0, the nmi must be 0 whatever
+    # the normalization.
+    if mi == 0:
+        return 0.0
+
     # Calculate the expected value for the mutual information
     # Calculate entropy for each labeling
     h_true, h_pred = entropy(labels_true), entropy(labels_pred)
@@ -1125,8 +1143,8 @@ def entropy(labels):
 
     Parameters
     ----------
-    labels : int array, shape = [n_samples]
-        The labels
+    labels : array-like of shape (n_samples,), dtype=int
+        The labels.
 
     Notes
     -----
@@ -1137,6 +1155,11 @@ def entropy(labels):
     label_idx = np.unique(labels, return_inverse=True)[1]
     pi = np.bincount(label_idx).astype(np.float64)
     pi = pi[pi > 0]
+
+    # single cluster => zero entropy
+    if pi.size == 1:
+        return 0.0
+
     pi_sum = np.sum(pi)
     # log(a / b) should be calculated as log(a) - log(b) for
     # possible loss of precision

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -16,6 +16,7 @@ better.
 # License: BSD 3 clause
 
 
+from tkinter import N
 import warnings
 from math import log
 
@@ -1050,14 +1051,11 @@ def normalized_mutual_info_score(
     if mi == 0:
         return 0.0
 
-    # Calculate the expected value for the mutual information
     # Calculate entropy for each labeling
     h_true, h_pred = entropy(labels_true), entropy(labels_pred)
+
     normalizer = _generalized_average(h_true, h_pred, average_method)
-    # Avoid 0.0 / 0.0 when either entropy is zero.
-    normalizer = max(normalizer, np.finfo("float64").eps)
-    nmi = mi / normalizer
-    return nmi
+    return mi / normalizer
 
 
 def fowlkes_mallows_score(labels_true, labels_pred, *, sparse=False):

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -16,7 +16,6 @@ better.
 # License: BSD 3 clause
 
 
-from tkinter import N
 import warnings
 from math import log
 

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -466,7 +466,8 @@ def test_adjusted_rand_score_overflow():
     assert not [w.message for w in record]
 
 
-def test_normalized_mutual_info_score_bounded():
+@pytest.mark.parametrize("average_method", ["min", "arithmetic", "geometric", "max"])
+def test_normalized_mutual_info_score_bounded(average_method):
     """Check that nmi returns a score between 0 (included) and 1 (excluded
     for non-perfect match)
 
@@ -477,7 +478,9 @@ def test_normalized_mutual_info_score_bounded():
     labels3 = [0, 1] + labels1[2:]
 
     # labels1 is constant. The mutual info between labels1 and any other labelling is 0.
-    assert normalized_mutual_info_score(labels1, labels2) == 0
+    nmi = normalized_mutual_info_score(labels1, labels2, average_method=average_method)
+    assert nmi == 0
 
     # non constant, non perfect matching labels
-    assert 0 <= normalized_mutual_info_score(labels2, labels3) < 1
+    nmi = normalized_mutual_info_score(labels2, labels3, average_method=average_method)
+    assert 0 <= nmi < 1

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -260,6 +260,7 @@ def test_entropy():
     ent = entropy([0, 0, 42.0])
     assert_almost_equal(ent, 0.6365141, 5)
     assert_almost_equal(entropy([]), 1)
+    assert entropy([1, 1, 1, 1]) == 0
 
 
 def test_contingency_matrix():
@@ -366,11 +367,13 @@ def test_fowlkes_mallows_score_properties():
         ([1] * 6, [1, 1, 0, 0, 1, 1]),
         ([1, 1, 0, 0, 1, 1], ["a"] * 6),
         ([1, 1, 0, 0, 1, 1], [1] * 6),
+        (["a"] * 6, ["a"] * 6),
     ],
 )
 def test_mutual_info_score_positive_constant_label(labels_true, labels_pred):
+    # Check that MI = 0 when one or both labelling are constant
     # non-regression test for #16355
-    assert mutual_info_score(labels_true, labels_pred) >= 0
+    assert mutual_info_score(labels_true, labels_pred) == 0
 
 
 def test_check_clustering_error():
@@ -461,3 +464,18 @@ def test_adjusted_rand_score_overflow():
     with pytest.warns(None) as record:
         adjusted_rand_score(y_true, y_pred)
     assert not [w.message for w in record]
+
+
+def test_normalized_mutual_info_score_bounded():
+    """Check that nmi returns a score between 0 (included) and 1 (excluded
+    for non-perfect match)
+    """
+    labels1 = [0] * 469
+    labels2 = [1] + labels1[1:]
+    labels3 = [0, 1] + labels1[2:]
+
+    # labels1 is constant. The mutual info between labels1 and any other labelling is 0.
+    assert normalized_mutual_info_score(labels1, labels2) == 0
+
+    # non constant, non perfect matching labels
+    assert 0 <= normalized_mutual_info_score(labels2, labels3) < 1

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -469,6 +469,8 @@ def test_adjusted_rand_score_overflow():
 def test_normalized_mutual_info_score_bounded():
     """Check that nmi returns a score between 0 (included) and 1 (excluded
     for non-perfect match)
+
+    Non-regression test for issue #13836
     """
     labels1 = [0] * 469
     labels2 = [1] + labels1[1:]


### PR DESCRIPTION
Fixes #13836 

by better handling of limit cases, i.e when 1 or both labelling are constant, i.e. there's a single cluster.