### PR TITLE
CI Label PRs only when it is opened

### DIFF
--- a/.github/workflows/labeler-module.yml
+++ b/.github/workflows/labeler-module.yml
@@ -1,5 +1,7 @@
 name: "Pull Request Labeler"
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened]
 
 jobs:
   triage:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/22636


#### What does this implement/fix? Explain your changes.
This PR restricts the pull request labeler to run only when the PR gets opened.

CC @jeremiedbb

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
