### PR TITLE
BLD Exclude SECURITY.md from MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,4 +30,5 @@ exclude azure-pipelines.yml
 exclude lgtm.yml
 exclude CODE_OF_CONDUCT.md
 exclude CONTRIBUTING.md
+exclude SECURITY.md
 exclude PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
This PR fixes the failing [Check Manifest](https://github.com/scikit-learn/scikit-learn/runs/5353201525?check_suite_focus=true) test.