### PR TITLE
CI Adds upstream sync to check manifest

### DIFF
--- a/.github/workflows/check-manifest.yml
+++ b/.github/workflows/check-manifest.yml
@@ -22,3 +22,12 @@ jobs:
           pip install check-manifest scipy cython
       - run: |
           check-manifest -v
+
+  update-tracker:
+    uses: ./.github/workflows/update_tracking_issue.yml
+    if: ${{ always() }}
+    needs: [check-manifest]
+    with:
+      job_status: ${{ needs.check-manifest.result }}
+    secrets:
+      BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/update_tracking_issue.yml
+++ b/.github/workflows/update_tracking_issue.yml
@@ -1,0 +1,47 @@
+# For workflows to use this workflow include the following:
+#
+# update-tracker:
+#   uses: ./.github/workflows/update_tracking_issue.yml
+#   if: ${{ always() }}
+#   needs: [JOB_NAME]
+#   with:
+#     job_status: ${{ needs.JOB_NAME.result }}
+#   secrets:
+#     BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+# Where JOB_NAME is contains the status of the job you are interested in
+
+name: "Update tracking issue"
+on:
+  workflow_call:
+    inputs:
+      job_status:
+        required: true
+        type: string
+    secrets:
+      BOT_GITHUB_TOKEN:
+        required: true
+
+jobs:
+  update_tracking_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Update tracking issue on GitHub
+        run: |
+          set -ex
+          if [[ ${{ inputs.job_status }} == "success" ]]; then
+            TESTS_PASSED=true
+          else
+            TESTS_PASSED=false
+          fi
+
+          pip install defusedxml PyGithub
+          python maint_tools/update_tracking_issue.py \
+            ${{ secrets.BOT_GITHUB_TOKEN }} \
+            "$GITHUB_WORKFLOW" \
+            "$GITHUB_REPOSITORY" \
+            https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID \
+            --tests-passed $TESTS_PASSED

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -93,7 +93,12 @@ jobs:
         ISSUE_REPO="$BUILD_REPOSITORY_NAME"
 
         pip install defusedxml PyGithub
-        python maint_tools/create_issue_from_juint.py $(BOT_GITHUB_TOKEN) $CI_NAME $ISSUE_REPO $LINK_TO_RUN $JUNIT_FILE
+        python maint_tools/update_tracking_issue.py \
+          $(BOT_GITHUB_TOKEN) \
+          $CI_NAME \
+          $ISSUE_REPO \
+          $LINK_TO_RUN \
+          --junit-file $JUNIT_FILE
       displayName: 'Update issue tracker'
       env:
         JUNIT_FILE: $(TEST_DIR)/$(JUNITXML)

--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -27,9 +27,25 @@ parser.add_argument(
 parser.add_argument("ci_name", help="Name of CI run instance")
 parser.add_argument("issue_repo", help="Repo to track issues")
 parser.add_argument("link_to_ci_run", help="URL to link to")
-parser.add_argument("junit_file", help="JUnit file")
+parser.add_argument("--junit-file", help="JUnit file to determine if tests passed")
+parser.add_argument(
+    "--tests-passed",
+    help=(
+        "If --tests-passed is true, then the original issue is closed if the issue "
+        "exists. If tests-passed is false, then the an issue is updated or created."
+    ),
+)
 
 args = parser.parse_args()
+
+if args.junit_file is not None and args.tests_passed is not None:
+    print("--junit-file and --test-passed can not be set together")
+    sys.exit(1)
+
+if args.junit_file is None and args.tests_passed is None:
+    print("Either --junit-file or --test-passed must be passed in")
+    sys.exit(1)
+
 gh = Github(args.bot_github_token)
 issue_repo = gh.get_repo(args.issue_repo)
 title = f"⚠️ CI failed on {args.ci_name} ⚠️"
@@ -45,7 +61,7 @@ def get_issue():
     return first_page[0] if first_page else None
 
 
-def create_or_update_issue(body):
+def create_or_update_issue(body=""):
     # Interact with GitHub API to create issue
     header = f"**CI Failed on [{args.ci_name}]({args.link_to_ci_run})**"
     body_text = f"{header}\n{body}"
@@ -63,11 +79,31 @@ def create_or_update_issue(body):
         sys.exit()
 
 
+def close_issue_if_opened():
+    print("Test has no failures!")
+    issue = get_issue()
+    if issue is not None:
+        print(f"Closing issue #{issue.number}")
+        new_body = (
+            "## Closed issue because CI is no longer failing! ✅\n\n"
+            f"[Successful run]({args.link_to_ci_run})\n\n"
+            "## Previous failing issue\n\n"
+            f"{issue.body}"
+        )
+        issue.edit(state="closed", body=new_body)
+    sys.exit()
+
+
+if args.tests_passed is not None:
+    if args.tests_passed.lower() == "true":
+        close_issue_if_opened()
+    else:
+        create_or_update_issue()
+
 junit_path = Path(args.junit_file)
 if not junit_path.exists():
     body = "Unable to find junit file. Please see link for details."
     create_or_update_issue(body)
-    sys.exit()
 
 # Find failures in junit file
 tree = ET.parse(args.junit_file)
@@ -87,18 +123,7 @@ for item in tree.iter("testcase"):
     failure_cases.append(item.attrib["name"])
 
 if not failure_cases:
-    print("Test has no failures!")
-    issue = get_issue()
-    if issue is not None:
-        print(f"Closing issue #{issue.number}")
-        new_body = (
-            "## Closed issue because CI is no longer failing! ✅\n\n"
-            f"[Successful run]({args.link_to_ci_run})\n\n"
-            "## Previous failing issue\n\n"
-            f"{issue.body}"
-        )
-        issue.edit(state="closed", body=new_body)
-    sys.exit()
+    close_issue_if_opened()
 
 # Create content for issue
 body_list = [f"- {case}" for case in failure_cases]

--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -87,7 +87,7 @@ def close_issue_if_opened():
         new_body = (
             "## Closed issue because CI is no longer failing! ✅\n\n"
             f"[Successful run]({args.link_to_ci_run})\n\n"
-            "## Previous failing issue\n\n"
+            "## Previous failure report\n\n"
             f"{issue.body}"
         )
         issue.edit(state="closed", body=new_body)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #22638


#### What does this implement/fix? Explain your changes.
I update the script to be more generic and not need the junit file and can run in GitHub Actions. I think it would be good to have this update the tracker for the other nightly builds we have:

- Wheel building on GitHub actions
- Azure CI jobs: Intel ICC etc

#### Any other comments?
I tested these changes on my fork to make sure things work [on azure](https://github.com/thomasjpfan/scikit-learn/issues/106) and on [GitHub Actions](https://github.com/thomasjpfan/scikit-learn/issues/104).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
