### PR TITLE
MNT remaining clean up for 1.1

### DIFF
--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -207,6 +207,11 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
         self : object
             Fitted estimator.
         """
+        if y is None:
+            raise ValueError(
+                f"This {self.__class__.__name__} estimator "
+                "requires y to be passed, but the target y is None."
+            )
         y = check_array(
             y,
             input_name="y",

--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -306,5 +306,4 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
     def _more_tags(self):
         return {
             "allow_nan": _safe_tags(self.estimator, key="allow_nan"),
-            "requires_y": True,
         }

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -14,7 +14,6 @@ from ...utils import deprecated
 from ...utils import check_matplotlib_support  # noqa
 from ...utils import check_random_state
 from ...utils import _safe_indexing
-from ...utils.validation import _deprecate_positional_args
 from ...utils.fixes import delayed
 
 
@@ -1267,7 +1266,6 @@ class PartialDependenceDisplay:
             ax.set_xlabel(self.feature_names[feature_idx[0]])
         ax.set_ylabel(self.feature_names[feature_idx[1]])
 
-    @_deprecate_positional_args(version="1.1")
     def plot(
         self,
         *,

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -37,7 +37,6 @@ from ..utils.validation import (
     _num_samples,
     column_or_1d,
     _check_sample_weight,
-    _deprecate_positional_args,
 )
 from ..utils.stats import _weighted_percentile
 
@@ -288,7 +287,6 @@ def mean_pinball_loss(
     return np.average(output_errors, weights=multioutput)
 
 
-@_deprecate_positional_args(version="1.1")
 def mean_absolute_percentage_error(
     y_true, y_pred, *, sample_weight=None, multioutput="uniform_average"
 ):

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -444,19 +444,6 @@ def test_regression_single_sample(metric):
         assert np.isnan(score)
 
 
-def test_deprecation_positional_arguments_mape():
-    y_true = [1, 1, 1]
-    y_pred = [1, 0, 1]
-    sample_weights = [0.5, 0.1, 0.2]
-    multioutput = "raw_values"
-
-    warning_msg = "passing these as positional arguments will result in an error"
-
-    # Trigger the warning
-    with pytest.warns(FutureWarning, match=warning_msg):
-        mean_absolute_percentage_error(y_true, y_pred, sample_weights, multioutput)
-
-
 def test_tweedie_deviance_continuity():
     n_samples = 100
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3636,20 +3636,8 @@ def check_n_features_in(name, estimator_orig):
 
     assert not hasattr(estimator, "n_features_in_")
     estimator.fit(X, y)
-    if hasattr(estimator, "n_features_in_"):
-        assert estimator.n_features_in_ == X.shape[1]
-    else:
-        warnings.warn(
-            "As of scikit-learn 0.23, estimators should expose a "
-            "n_features_in_ attribute, unless the 'no_validation' tag is "
-            "True. This attribute should be equal to the number of features "
-            "passed to the fit method. "
-            "An error will be raised from version 1.0 (renaming of 0.25) "
-            "when calling check_estimator(). "
-            "See SLEP010: "
-            "https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep010/proposal.html",  # noqa
-            FutureWarning,
-        )
+    assert hasattr(estimator, "n_features_in_")
+    assert estimator.n_features_in_ == X.shape[1]
 
 
 def check_requires_y_none(name, estimator_orig):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3661,7 +3661,6 @@ def check_requires_y_none(name, estimator_orig):
 
     try:
         estimator.fit(X, None)
-        print(estimator.__class__.__name__)
     except ValueError as ve:
         if not any(msg in str(ve) for msg in expected_err_msgs):
             raise ve

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3653,14 +3653,6 @@ def check_requires_y_none(name, estimator_orig):
     X = rng.normal(loc=100, size=(n_samples, 2))
     X = _pairwise_estimator_convert_X(X, estimator)
 
-    warning_msg = (
-        "As of scikit-learn 0.23, estimators should have a "
-        "'requires_y' tag set to the appropriate value. "
-        "The default value of the tag is False. "
-        "An error will be raised from version 1.0 when calling "
-        "check_estimator() if the tag isn't properly set."
-    )
-
     expected_err_msgs = (
         "requires y to be passed, but the target y is None",
         "Expected array-like (array or non-string sequence), got None",
@@ -3669,9 +3661,10 @@ def check_requires_y_none(name, estimator_orig):
 
     try:
         estimator.fit(X, None)
+        print(estimator.__class__.__name__)
     except ValueError as ve:
         if not any(msg in str(ve) for msg in expected_err_msgs):
-            warnings.warn(warning_msg, FutureWarning)
+            raise ve
 
 
 @ignore_warnings(category=FutureWarning)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -33,7 +33,10 @@ from ..exceptions import DataConversionWarning
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
 
 
-def _deprecate_positional_args(func=None, *, version="1.1 (renaming of 0.26)"):
+# This function is not used anymore at this moment in the code base but we keep it in
+# case that we merge a new public function without kwarg only by mistake, which would
+# require a deprecation cycle to fix.
+def _deprecate_positional_args(func=None, *, version="1.3"):
     """Decorator for methods that issues warnings for positional arguments.
 
     Using the keyword-only argument syntax in pep 3102, arguments after the
@@ -43,7 +46,7 @@ def _deprecate_positional_args(func=None, *, version="1.1 (renaming of 0.26)"):
     ----------
     func : callable, default=None
         Function to check arguments on.
-    version : callable, default="1.1 (renaming of 0.26)"
+    version : callable, default="1.3"
         The version when positional arguments will result in error.
     """
 


### PR DESCRIPTION
- Some warnings should have been transformed into errors in 1.0 in common tests but we forgot.
- The last deprecated positional args will end in 1.1.

There's no usage of ``_deprecate_positional_args anymore``. I wonder if we still want to keep this function around in case we merge a new public function without kwarg only by mistake. I left it for now but I'm not happy leaving dead code in the code base. What do you think ?