### PR TITLE
MAINT Run tests against pypy3.8

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -69,7 +69,7 @@ python_environment_install() {
         fi
 
         if [[ "$DISTRIB" == *"pypy"* ]]; then
-            TO_INSTALL="$TO_INSTALL pypy"
+            TO_INSTALL="$TO_INSTALL pypy3.8"
         else
             TO_INSTALL="$TO_INSTALL python=$PYTHON_VERSION"
         fi


### PR DESCRIPTION
Try to run the `[pypy]` nightly build against `pypy3.8` explicitly (`pypy` is still pointing to `pypy3.7` at this time).

The `sklearn.show_versions()` fails (and probably other Python tests will fail because of this).