### PR TITLE
MAINT update black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ requires = [
 
 [tool.black]
 line-length = 88
-target_version = ['py37', 'py38', 'py39']
-experimental_string_processing = true
+target_version = ['py38', 'py39', 'py310']
+preview = true
 exclude = '''
 /(
     \.eggs         # exclude a few common directories in the


### PR DESCRIPTION
- do not need to support Python 3.7 compat;
- `experimental_string_processing` is deprecated and included in `preview`.