### PR TITLE
MAINT Disable PyPy nightly build for now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,10 +115,13 @@ jobs:
       and(
         succeeded(),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
-        or(
-          eq(variables['Build.Reason'], 'Schedule'),
-          contains(dependencies['git_commit']['outputs']['commit.message'], '[pypy]')
-        )
+        # TODO: re-enable the scheduled pypy build once it's possible to install pypy3.8
+        # https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2089
+        contains(dependencies['git_commit']['outputs']['commit.message'], '[pypy]')
+        # or(
+        #   eq(variables['Build.Reason'], 'Schedule'),
+        #   contains(dependencies['git_commit']['outputs']['commit.message'], '[pypy]')
+        # )
       )
     matrix:
       pypy3:


### PR DESCRIPTION
Temporarily disable the pypy scheduled build while we have no easy way to fix it (see #22646).