### PR TITLE
DOC Sphinx warnings.

### DIFF
--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -8,8 +8,6 @@ the stock market structure from variations in historical quotes.
 
 The quantity that we use is the daily variation in quote price: quotes
 that are linked tend to fluctuate in relation to each other during a day.
-
-.. _stock_market:
 """
 
 # Author: Gael Varoquaux gael.varoquaux@normalesup.org
@@ -107,6 +105,8 @@ open_prices = np.vstack([q["open"] for q in quotes])
 variation = close_prices - open_prices
 
 # %%
+# .. _stock_market:
+#
 # Learning a graph structure
 # --------------------------
 #

--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -21,7 +21,7 @@ can mitigate those limitations.
 .. topic:: References:
 
    * :doi:`L. Breiman, "Random Forests", Machine Learning, 45(1), 5-32,
-   2001. <10.1023/A:1010933404324>`
+     2001. <10.1023/A:1010933404324>`
 
 """
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This Pull Request fixes some sphinx warnings recently introduced
```
scikit-learn/doc/auto_examples/inspection/plot_permutation_importance.rst:42: WARNING: Inline interpreted text or phrase reference start-string without end-string.
scikit-learn/doc/auto_examples/inspection/plot_permutation_importance.rst:43: WARNING: Bullet list ends without a blank line; unexpected unindent.
scikit-learn/doc/tutorial/statistical_inference/putting_together.rst:62: WARNING: Failed to create a cross reference. A title or caption not found: stock_market
```
