### PR TITLE
MNT More cleaning for 1.1

### DIFF
--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -351,7 +351,6 @@ def test_convergence_fail():
         pls_nipals.fit(X, Y)
 
 
-@pytest.mark.filterwarnings("ignore:.*`scores_` was deprecated")  # 1.1
 @pytest.mark.parametrize("Est", (PLSSVD, PLSRegression, PLSCanonical))
 def test_attibutes_shapes(Est):
     # Make sure attributes are of the correct shape depending on n_components

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -428,10 +428,7 @@ def test_set_estimator_drop():
         weights=[1, 1, 0.5],
     )
     with pytest.warns(None) as record:
-        with warnings.catch_warnings():
-            # scipy 1.3.0 uses tostring which is deprecated in numpy
-            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
-            eclf2.set_params(rf="drop").fit(X, y)
+        eclf2.set_params(rf="drop").fit(X, y)
 
     assert not [w.message for w in record]
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
@@ -445,10 +442,7 @@ def test_set_estimator_drop():
 
     eclf1.set_params(voting="soft").fit(X, y)
     with pytest.warns(None) as record:
-        with warnings.catch_warnings():
-            # scipy 1.3.0 uses tostring which is deprecated in numpy
-            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
-            eclf2.set_params(voting="soft").fit(X, y)
+        eclf2.set_params(voting="soft").fit(X, y)
 
     assert not [w.message for w in record]
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
@@ -476,10 +470,7 @@ def test_set_estimator_drop():
         flatten_transform=False,
     )
     with pytest.warns(None) as record:
-        with warnings.catch_warnings():
-            # scipy 1.3.0 uses tostring which is deprecated in numpy
-            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
-            eclf2.set_params(rf="drop").fit(X1, y1)
+        eclf2.set_params(rf="drop").fit(X1, y1)
     assert not [w.message for w in record]
     assert_array_almost_equal(
         eclf1.transform(X1),

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -1,6 +1,5 @@
 """Testing for the VotingClassifier and VotingRegressor"""
 
-import warnings
 import pytest
 import re
 import numpy as np

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -7,13 +7,11 @@ from .utils.deprecation import deprecated
 
 __all__ = [
     "NotFittedError",
-    "ChangedBehaviorWarning",
     "ConvergenceWarning",
     "DataConversionWarning",
     "DataDimensionalityWarning",
     "EfficiencyWarning",
     "FitFailedWarning",
-    "NonBLASDotWarning",
     "SkipTestWarning",
     "UndefinedMetricWarning",
     "PositiveSpectrumWarning",
@@ -39,15 +37,6 @@ class NotFittedError(ValueError, AttributeError):
 
     .. versionchanged:: 0.18
        Moved from sklearn.utils.validation.
-    """
-
-
-@deprecated("ChangedBehaviorWarning is deprecated in 0.24 and will be removed in 1.1")
-class ChangedBehaviorWarning(UserWarning):
-    """Warning class used to notify the user of any change in the behavior.
-
-    .. versionchanged:: 0.18
-       Moved from sklearn.base.
     """
 
 
@@ -111,18 +100,6 @@ class FitFailedWarning(RuntimeWarning):
 
     .. versionchanged:: 0.18
        Moved from sklearn.cross_validation.
-    """
-
-
-@deprecated("NonBLASDotWarning is deprecated in 0.24 and will be removed in 1.1")
-class NonBLASDotWarning(EfficiencyWarning):
-    """Warning used when the dot operation does not use BLAS.
-
-    This warning is used to notify the user that BLAS was not used for dot
-    operation and hence the efficiency may be affected.
-
-    .. versionchanged:: 0.18
-       Moved from sklearn.utils.validation, extends EfficiencyWarning.
     """
 
 

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -7,11 +7,13 @@ from .utils.deprecation import deprecated
 
 __all__ = [
     "NotFittedError",
+    "ChangedBehaviorWarning",
     "ConvergenceWarning",
     "DataConversionWarning",
     "DataDimensionalityWarning",
     "EfficiencyWarning",
     "FitFailedWarning",
+    "NonBLASDotWarning",
     "SkipTestWarning",
     "UndefinedMetricWarning",
     "PositiveSpectrumWarning",
@@ -37,6 +39,15 @@ class NotFittedError(ValueError, AttributeError):
 
     .. versionchanged:: 0.18
        Moved from sklearn.utils.validation.
+    """
+
+
+@deprecated("ChangedBehaviorWarning is deprecated in 0.24 and will be removed in 1.1")
+class ChangedBehaviorWarning(UserWarning):
+    """Warning class used to notify the user of any change in the behavior.
+
+    .. versionchanged:: 0.18
+       Moved from sklearn.base.
     """
 
 
@@ -100,6 +111,18 @@ class FitFailedWarning(RuntimeWarning):
 
     .. versionchanged:: 0.18
        Moved from sklearn.cross_validation.
+    """
+
+
+@deprecated("NonBLASDotWarning is deprecated in 0.24 and will be removed in 1.1")
+class NonBLASDotWarning(EfficiencyWarning):
+    """Warning used when the dot operation does not use BLAS.
+
+    This warning is used to notify the user that BLAS was not used for dot
+    operation and hence the efficiency may be affected.
+
+    .. versionchanged:: 0.18
+       Moved from sklearn.utils.validation, extends EfficiencyWarning.
     """
 
 

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -152,7 +152,6 @@ def test_hasher_zeros():
     assert X.data.shape == (0,)
 
 
-@ignore_warnings(category=FutureWarning)
 def test_hasher_alternate_sign():
     X = [list("Thequickbrownfoxjumped")]
 

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_array_equal
 import pytest
 
 from sklearn.feature_extraction import FeatureHasher
-from sklearn.utils._testing import ignore_warnings, fails_if_pypy
+from sklearn.utils._testing import fails_if_pypy
 
 pytestmark = fails_if_pypy
 

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -83,15 +83,8 @@ def test_grid_to_graph():
     assert A.dtype == np.float64
 
 
-@ignore_warnings(category=DeprecationWarning)  # scipy deprecation inside face
 def test_connect_regions():
-    try:
-        face = sp.face(gray=True)
-    except AttributeError:
-        # Newer versions of scipy have face in misc
-        from scipy import misc
-
-        face = misc.face(gray=True)
+    face = sp.misc.face(gray=True)
     # subsample by 4 to reduce run time
     face = face[::4, ::4]
     for thr in (50, 150):
@@ -100,15 +93,8 @@ def test_connect_regions():
         assert ndimage.label(mask)[1] == connected_components(graph)[0]
 
 
-@ignore_warnings(category=DeprecationWarning)  # scipy deprecation inside face
 def test_connect_regions_with_grid():
-    try:
-        face = sp.face(gray=True)
-    except AttributeError:
-        # Newer versions of scipy have face in misc
-        from scipy import misc
-
-        face = misc.face(gray=True)
+    face = sp.misc.face(gray=True)
 
     # subsample by 4 to reduce run time
     face = face[::4, ::4]

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -16,7 +16,6 @@ from sklearn.feature_extraction.image import (
     PatchExtractor,
     _extract_patches,
 )
-from sklearn.utils._testing import ignore_warnings
 
 
 def test_img_to_graph():

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -3,7 +3,6 @@
 # Author: Jan Hendrik Metzen <jhm@informatik.uni-bremen.de>
 # License: BSD 3 clause
 
-import warnings
 import numpy as np
 
 from scipy.optimize import approx_fprime

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -209,10 +209,7 @@ def test_warning_bounds():
     )
     gpc_sum = GaussianProcessClassifier(kernel=kernel_sum)
     with pytest.warns(None) as record:
-        with warnings.catch_warnings():
-            # scipy 1.3.0 uses tostring which is deprecated in numpy
-            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
-            gpc_sum.fit(X, y)
+        gpc_sum.fit(X, y)
 
     assert len(record) == 2
     assert (
@@ -240,10 +237,7 @@ def test_warning_bounds():
     gpc_dims = GaussianProcessClassifier(kernel=kernel_dims)
 
     with pytest.warns(None) as record:
-        with warnings.catch_warnings():
-            # scipy 1.3.0 uses tostring which is deprecated in numpy
-            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
-            gpc_dims.fit(X_tile, y)
+        gpc_dims.fit(X_tile, y)
 
     assert len(record) == 2
     assert (

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -7,7 +7,6 @@
 import sys
 import re
 import numpy as np
-import warnings
 
 from scipy.optimize import approx_fprime
 

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -480,10 +480,7 @@ def test_warning_bounds():
     )
     gpr_sum = GaussianProcessRegressor(kernel=kernel_sum)
     with pytest.warns(None) as record:
-        with warnings.catch_warnings():
-            # scipy 1.3.0 uses tostring which is deprecated in numpy
-            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
-            gpr_sum.fit(X, y)
+        gpr_sum.fit(X, y)
 
     assert len(record) == 2
     assert (
@@ -511,10 +508,7 @@ def test_warning_bounds():
     gpr_dims = GaussianProcessRegressor(kernel=kernel_dims)
 
     with pytest.warns(None) as record:
-        with warnings.catch_warnings():
-            # scipy 1.3.0 uses tostring which is deprecated in numpy
-            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
-            gpr_dims.fit(X_tile, y)
+        gpr_dims.fit(X_tile, y)
 
     assert len(record) == 2
     assert (

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -442,12 +442,9 @@ def test_logistic_regression_path_convergence_fail():
     # advice (scaling the data) and to the logistic regression specific
     # documentation that includes hints on the solver configuration.
     with pytest.warns(ConvergenceWarning) as record:
-        with warnings.catch_warnings():
-            # scipy 1.3.0 uses tostring which is deprecated in numpy
-            warnings.filterwarnings("ignore", "tostring", DeprecationWarning)
-            _logistic_regression_path(
-                X, y, Cs=Cs, tol=0.0, max_iter=1, random_state=0, verbose=0
-            )
+        _logistic_regression_path(
+            X, y, Cs=Cs, tol=0.0, max_iter=1, random_state=0, verbose=0
+        )
 
     assert len(record) == 1
     warn_msg = record[0].message.args[0]

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1,7 +1,6 @@
 import itertools
 import os
 import re
-import warnings
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 from numpy.testing import assert_array_almost_equal, assert_array_equal

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -34,7 +34,6 @@ score_funcs = [
 ]
 
 
-@ignore_warnings(category=FutureWarning)
 def test_error_messages_on_wrong_input():
     for score_func in score_funcs:
         expected = (
@@ -62,7 +61,6 @@ def test_generalized_average():
     assert means[0] == means[1] == means[2] == means[3]
 
 
-@ignore_warnings(category=FutureWarning)
 def test_perfect_matches():
     for score_func in score_funcs:
         assert score_func([], []) == pytest.approx(1.0)
@@ -165,7 +163,6 @@ def test_non_consecutive_labels():
     assert_almost_equal(ri_2, 0.66, 2)
 
 
-@ignore_warnings(category=FutureWarning)
 def uniform_labelings_scores(score_func, n_samples, k_range, n_runs=10, seed=42):
     # Compute score for random uniform cluster labelings
     random_labels = np.random.RandomState(seed).randint
@@ -178,7 +175,6 @@ def uniform_labelings_scores(score_func, n_samples, k_range, n_runs=10, seed=42)
     return scores
 
 
-@ignore_warnings(category=FutureWarning)
 def test_adjustment_for_chance():
     # Check that adjusted scores are almost zero on random labels
     n_clusters_range = [2, 10, 50, 90]
@@ -283,7 +279,6 @@ def test_contingency_matrix_sparse():
         contingency_matrix(labels_a, labels_b, eps=1e-10, sparse=True)
 
 
-@ignore_warnings(category=FutureWarning)
 def test_exactly_zero_info_score():
     # Check numerical stability when information is exactly zero
     for i in np.logspace(1, 4, 4).astype(int):

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -19,7 +19,7 @@ from sklearn.metrics.cluster._supervised import _generalized_average
 from sklearn.metrics.cluster._supervised import check_clusterings
 
 from sklearn.utils import assert_all_finite
-from sklearn.utils._testing import assert_almost_equal, ignore_warnings
+from sklearn.utils._testing import assert_almost_equal
 from numpy.testing import assert_array_equal, assert_array_almost_equal, assert_allclose
 
 

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -14,7 +14,6 @@ from sklearn.utils._testing import (
     assert_array_almost_equal,
     assert_almost_equal,
     assert_array_equal,
-    ignore_warnings,
 )
 from sklearn.utils.extmath import softmax
 from sklearn.exceptions import NotFittedError

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -491,7 +491,6 @@ def test_calibration_less_classes(ensemble):
             assert np.allclose(proba, 1 / proba.shape[0])
 
 
-@ignore_warnings(category=FutureWarning)
 @pytest.mark.parametrize(
     "X",
     [

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -115,8 +115,6 @@ def test_check_estimator_generate_only():
     assert isgenerator(all_instance_gen_checks)
 
 
-@ignore_warnings(category=(DeprecationWarning, FutureWarning))
-# ignore deprecated open(.., 'U') in numpy distutils
 def test_configure():
     # Smoke test the 'configure' step of setup, this tests all the
     # 'configure' functions in the setup.pys in scikit-learn

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -289,8 +289,6 @@ def test_NB_partial_fit_no_first_classes(NaiveBayes):
         clf.partial_fit(X2, y2, classes=np.arange(42))
 
 
-# TODO: Remove in version 1.1
-@ignore_warnings(category=FutureWarning)
 def test_discretenb_predict_proba():
     # Test discrete NB classes' probability scores
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -12,7 +12,6 @@ from sklearn.model_selection import cross_val_score
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
-from sklearn.utils._testing import ignore_warnings
 
 from sklearn.naive_bayes import GaussianNB, BernoulliNB
 from sklearn.naive_bayes import MultinomialNB, ComplementNB


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/pull/22643
I found a bunch of warning filters in the tests that correspond to old deprecations that have never been cleaned-up (and a couple for 1.1 also)