### PR TITLE
API Deprecate check_array dtype='numeric' + arrays of object

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -781,7 +781,7 @@ Changelog
   `dtype="numeric"` is deprecated. An error will be raised from version 1.3. Please
   convert your data to numeric values explicitly instead. Note that the already
   deprecated behavior of converting arrays of bytes/strings is extended to version 1.3.
-  :pr:`` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+  :pr:`22681` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -633,16 +633,6 @@ Changelog
 :mod:`sklearn.neighbors`
 ........................
 
-- |Enhancement| `utils.validation.check_array` and `utils.validation.type_of_target`
-  now accept an `input_name` parameter to make the error message more
-  informative when passed invalid input data (e.g. with NaN or infinite
-  values).
-  :pr:`21219` by :user:`Olivier Grisel <ogrisel>`.
-
-- |Enhancement| :func:`utils.validation.check_array` returns a float
-  ndarray with `np.nan` when passed a `Float32` or `Float64` pandas extension
-  array with `pd.NA`. :pr:`21278` by `Thomas Fan`_.
-
 - |Enhancement| Adds :term:`get_feature_names_out` to
   :class:`neighbors.RadiusNeighborsTransformer`, :class:`neighbors.KNeighborsTransformer`
   and :class:`neighbors.NeighborhoodComponentsAnalysis`. :pr:`22212` by
@@ -762,6 +752,16 @@ Changelog
   left corner of the HTML representation to show how the elements are
   clickable. :pr:`21298` by `Thomas Fan`_.
 
+- |Enhancement| `utils.validation.check_array` and `utils.validation.type_of_target`
+  now accept an `input_name` parameter to make the error message more
+  informative when passed invalid input data (e.g. with NaN or infinite
+  values).
+  :pr:`21219` by :user:`Olivier Grisel <ogrisel>`.
+
+- |Enhancement| :func:`utils.validation.check_array` returns a float
+  ndarray with `np.nan` when passed a `Float32` or `Float64` pandas extension
+  array with `pd.NA`. :pr:`21278` by `Thomas Fan`_.
+
 - |API| :func:`utils.estimator_checks.check_estimator`'s argument is now called
   `estimator` (previous name was `Estimator`). :pr:`22188` by
   :user:`Mathurin Massias <mathurinm>`.
@@ -776,6 +776,12 @@ Changelog
 - |Fix| Estimators with `non_deterministic` tag set to `True` will skip both
   `check_methods_sample_order_invariance` and `check_methods_subset_invariance` tests.
   :pr:`22318` by `Zhehao Liu <MaxwellLZH>`.
+
+- |API| Converting arrays of objects in :func:`utils.validation.check_array` with
+  `dtype="numeric"` is deprecated. An error will be raised from version 1.3. Please
+  convert your data to numeric values explicitly instead. Note that the already
+  deprecated behavior of converting arrays of bytes/strings is extended to version 1.3.
+  :pr:`` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -410,13 +410,15 @@ def test_check_array():
         np.array([["1", "2"], ["3", "4"]], dtype="S"),
         [[b"1", b"2"], [b"3", b"4"]],
         np.array([[b"1", b"2"], [b"3", b"4"]], dtype="V1"),
+        np.array([[1, 2], [3, 4]], dtype=object),
+        np.array([["1", "2"], ["3", "4"]], dtype=object),
     ],
 )
 def test_check_array_numeric_warns(X):
     """Test that check_array warns when it converts a bytes/string into a
     float."""
     expected_msg = (
-        r"Arrays of bytes/strings is being converted to decimal .*"
+        r"Arrays of objects/bytes/strings is being converted to decimal .*"
         r"deprecated in 0.24 and will be removed in 1.3"
     )
     with pytest.warns(FutureWarning, match=expected_msg):
@@ -432,11 +434,12 @@ def test_check_array_numeric_warns(X):
         np.array([["11", "12"], ["13", "xx"]], dtype="U"),
         np.array([["11", "12"], ["13", "xx"]], dtype="S"),
         [[b"a", b"b"], [b"c", b"d"]],
+        np.array([[11, "12"], [13, "xx"]], dtype=object),
     ],
 )
 def test_check_array_dtype_numeric_errors(X):
     """Error when string-ike array can not be converted"""
-    expected_warn_msg = "Unable to convert array of bytes/strings"
+    expected_warn_msg = "Unable to convert array of objects/bytes/strings"
     with pytest.raises(ValueError, match=expected_warn_msg):
         check_array(X, dtype="numeric")
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -401,7 +401,7 @@ def test_check_array():
     assert isinstance(result, np.ndarray)
 
 
-# TODO: Check for error in 1.1 when implicit conversion is removed
+# TODO: Check for error in 1.3 when implicit conversion is removed
 @pytest.mark.parametrize(
     "X",
     [
@@ -417,13 +417,13 @@ def test_check_array_numeric_warns(X):
     float."""
     expected_msg = (
         r"Arrays of bytes/strings is being converted to decimal .*"
-        r"deprecated in 0.24 and will be removed in 1.1"
+        r"deprecated in 0.24 and will be removed in 1.3"
     )
     with pytest.warns(FutureWarning, match=expected_msg):
         check_array(X, dtype="numeric")
 
 
-# TODO: remove in 1.1
+# TODO: remove in 1.3
 @ignore_warnings(category=FutureWarning)
 @pytest.mark.parametrize(
     "X",
@@ -481,7 +481,7 @@ def test_check_array_pandas_na_support(pd_dtype, dtype, expected_dtype):
         check_array(X, force_all_finite=True)
 
 
-# TODO: remove test in 1.1 once this behavior is deprecated
+# TODO: remove test in 1.3 once this behavior is deprecated
 def test_check_array_pandas_dtype_object_conversion():
     # test that data-frame like objects with dtype object
     # get converted

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -756,11 +756,7 @@ def check_array(
             dtype_orig = np.result_type(*dtypes_orig)
 
     if dtype_numeric:
-        if dtype_orig is not None and dtype_orig.kind == "O":
-            # if input is object, convert to float.
-            dtype = np.float64
-        else:
-            dtype = None
+        dtype = None
 
     if isinstance(dtype, (list, tuple)):
         if dtype_orig is not None and dtype_orig in dtype:
@@ -872,7 +868,7 @@ def check_array(
         # make sure we actually converted to numeric:
         if dtype_numeric and array.dtype.kind in "OUSV":
             warnings.warn(
-                "Arrays of bytes/strings is being converted to decimal "
+                "Arrays of objects/bytes/strings is being converted to decimal "
                 "numbers if dtype='numeric'. This behavior is deprecated in "
                 "0.24 and will be removed in 1.3. Please convert your data to numeric "
                 "values explicitly instead.",
@@ -883,7 +879,7 @@ def check_array(
                 array = array.astype(np.float64)
             except ValueError as e:
                 raise ValueError(
-                    "Unable to convert array of bytes/strings "
+                    "Unable to convert array of objects/bytes/strings "
                     "into decimal numbers with dtype='numeric'"
                 ) from e
         if not allow_nd and array.ndim >= 3:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -874,8 +874,8 @@ def check_array(
             warnings.warn(
                 "Arrays of bytes/strings is being converted to decimal "
                 "numbers if dtype='numeric'. This behavior is deprecated in "
-                "0.24 and will be removed in 1.1 (renaming of 0.26). Please "
-                "convert your data to numeric values explicitly instead.",
+                "0.24 and will be removed in 1.3. Please convert your data to numeric "
+                "values explicitly instead.",
                 FutureWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
Close #22589 

Currently `check_array(dtype='numeric')` tries to convert arrays of objects/bytes/string. This behavior has been deprecated for bytes/strings 2 releases ago and was planed to error in 1.1.

However, it was not deprecated for object arrays which leads to the following unexpected behavior:
``check_array([["1", "2"], ["3", "4"]], dtype="numeric")`` warns (error in 1.1)
``check_array(np.array([["1", "2"], ["3", "4"]], dtype=object), dtype="numeric")`` does not warn.

This PR deprecates the conversion for object arrays as well. It means that it also deprecates conversion in
``check_array(np.array([[1, 2], [3, 4]], dtype=object), dtype="numeric")``

As pointed out by @glemaitre, if we start to error in the first case we wouldn't have a consistent behavior for 2 more releases, so we propose to extend the deprecation of the first case and keep warning for bytes/string arrays until 1.3. In 1.3 we'll raise errors for all object/bytes/string arrays.

Remark: it does not mess up with dataframes with numerical extension arrays. It's tested in `test_check_array_pandas_na_support`