### PR TITLE
FIX Fixes KNeighborsRegressor.predict with array-likes

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -656,6 +656,11 @@ Changelog
   instead of `__init__`. :pr:`21430` by :user:`Desislava Vasileva <DessyVV>` and
   :user:`Lucy Jimenez <LucyJimenez>`.
 
+- |Fix| :func:`neighbors.KNeighborsRegressor.predict` now works properly when
+  given an array-like input if `KNeighborsRegressor` is first constructed with a
+  callable passed to the `weights` parameter. :pr:`22687` by
+  :user:`Meekail Zain <micky774>`
+
 :mod:`sklearn.neural_network`
 .............................
 

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -233,7 +233,7 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
         if weights is None:
             y_pred = np.mean(_y[neigh_ind], axis=1)
         else:
-            y_pred = np.empty((self.n_samples_fit_, _y.shape[1]), dtype=np.float64)
+            y_pred = np.empty((neigh_dist.shape[0], _y.shape[1]), dtype=np.float64)
             denom = np.sum(weights, axis=1)
 
             for j in range(_y.shape[1]):

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -233,7 +233,7 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
         if weights is None:
             y_pred = np.mean(_y[neigh_ind], axis=1)
         else:
-            y_pred = np.empty((len(X), _y.shape[1]), dtype=np.float64)
+            y_pred = np.empty((self.n_samples_fit_, _y.shape[1]), dtype=np.float64)
             denom = np.sum(weights, axis=1)
 
             for j in range(_y.shape[1]):

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -233,7 +233,7 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
         if weights is None:
             y_pred = np.mean(_y[neigh_ind], axis=1)
         else:
-            y_pred = np.empty((X.shape[0], _y.shape[1]), dtype=np.float64)
+            y_pred = np.empty((len(X), _y.shape[1]), dtype=np.float64)
             denom = np.sum(weights, axis=1)
 
             for j in range(_y.shape[1]):

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2102,11 +2102,9 @@ def test_valid_metrics_has_no_duplicate():
 
 
 def test_regressor_predict_on_arraylikes():
-    """
-    Ensures that `KNeighborsRegressor.predict` works for array-likes when
-    the `weights` parameter is passed a callable.
+    """Ensures that `predict` works for array-likes when `weights` is a callable.
 
-    Non-regression test for #22687
+    Non-regression test for #22687.
     """
     X = [[5, 1], [3, 1], [4, 3], [0, 3]]
     y = [2, 3, 5, 6]

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2045,14 +2045,12 @@ def test_valid_metrics_has_no_duplicate():
 
 def test_regressor_predict_on_arraylikes():
     """Non-regression test for #22687"""
-    x = [5, 6, 4, 3, 4, 3, 1]
-    x = [k for k in zip(x, x)]
-
-    y = [2, 5, 2, 3, 7, 6, 8]
+    X = [[5, 1], [3, 1], [4, 3], [0, 3]]
+    y = [2, 3, 5, 6]
 
     def _weights(dist):
-        return [[1] * dist.shape[0]]
+        return np.ones_like(dist)
 
-    est = KNeighborsRegressor(algorithm="brute", weights=_weights)
-    est.fit(x, y)
-    assert_allclose(est.predict([[2, 4]])[0], 20.0)
+    est = KNeighborsRegressor(n_neighbors=1, algorithm="brute", weights=_weights)
+    est.fit(X, y)
+    assert_allclose(est.predict([[0, 2.5]]), [6])

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2044,7 +2044,12 @@ def test_valid_metrics_has_no_duplicate():
 
 
 def test_regressor_predict_on_arraylikes():
-    """Non-regression test for #22687"""
+    """
+    Ensures that `KNeighborsRegressor.predict` works for array-likes when
+    the `weights` parameter is passed a callable.
+
+    Non-regression test for #22687
+    """
     X = [[5, 1], [3, 1], [4, 3], [0, 3]]
     y = [2, 3, 5, 6]
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -27,7 +27,10 @@ from sklearn.metrics.pairwise import pairwise_distances
 from sklearn.metrics.tests.test_dist_metrics import BOOL_METRICS
 from sklearn.model_selection import cross_val_score
 from sklearn.model_selection import train_test_split
-from sklearn.neighbors import VALID_METRICS_SPARSE
+from sklearn.neighbors import (
+    VALID_METRICS_SPARSE,
+    KNeighborsRegressor,
+)
 from sklearn.neighbors._base import (
     _is_sorted_by_data,
     _check_precomputed,
@@ -2038,3 +2041,18 @@ def test_neighbors_distance_metric_deprecation():
 def test_valid_metrics_has_no_duplicate():
     for val in neighbors.VALID_METRICS.values():
         assert len(val) == len(set(val))
+
+
+def test_regressor_predict_on_arraylikes():
+    """Non-regression test for #22687"""
+    x = [5, 6, 4, 3, 4, 3, 1]
+    x = [k for k in zip(x, x)]
+
+    y = [2, 5, 2, 3, 7, 6, 8]
+
+    def _weights(dist):
+        return [[1] * dist.shape[0]]
+
+    est = KNeighborsRegressor(algorithm="brute", weights=_weights)
+    est.fit(x, y)
+    assert_allclose(est.predict([[2, 4]])[0], 20.0)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #22683

#### What does this implement/fix? Explain your changes.
Previously `KenighborsRegressor.predict` was documented to accept "array-likes" however when `weights` is given as a callable, `predict(X)` calls `X.shape[0]`. To make `predict` compatible with array-likes this PR changes `X.shape[0]-->len(X)` and adds a non-regression test that fails on the main branch. 

#### Any other comments?