### PR TITLE
ENH Adds feature_names_out for most of kernel_approximation

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -491,7 +491,7 @@ Changelog
   :class:`kernel_approximation.Nystroem`,
   :class:`kernel_approximation.PolynomialCountSketch`,
   :class:`kernel_approximation.RBFSampler`, and
-  :class:`kernel_approximation.SkewedChi2Sampler`. :pr:`xxxxx` by `Thomas Fan`_.
+  :class:`kernel_approximation.SkewedChi2Sampler`. :pr:`22694` by `Thomas Fan`_.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -484,6 +484,15 @@ Changelog
 - |Enhancement| Adds :term:`get_feature_names_out` to `IsotonicRegression`.
   :pr:`22249` by `Thomas Fan`_.
 
+:mod:`sklearn.kernel_approximation`
+...................................
+
+- |API| Adds :meth:`get_feature_names_out` to
+  :class:`kernel_approximation.Nystroem`,
+  :class:`kernel_approximation.PolynomialCountSketch`,
+  :class:`kernel_approximation.RBFSampler`, and
+  :class:`kernel_approximation.SkewedChi2Sampler`. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -21,6 +21,7 @@ except ImportError:  # scipy < 1.4
 
 from .base import BaseEstimator
 from .base import TransformerMixin
+from .base import _ClassNamePrefixFeaturesOutMixin
 from .utils import check_random_state
 from .utils.extmath import safe_sparse_dot
 from .utils.validation import check_is_fitted
@@ -28,7 +29,9 @@ from .metrics.pairwise import pairwise_kernels, KERNEL_PARAMS
 from .utils.validation import check_non_negative
 
 
-class PolynomialCountSketch(BaseEstimator, TransformerMixin):
+class PolynomialCountSketch(
+    _ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
+):
     """Polynomial kernel approximation via Tensor Sketch.
 
     Implements Tensor Sketch, which approximates the feature map
@@ -158,6 +161,7 @@ class PolynomialCountSketch(BaseEstimator, TransformerMixin):
         )
 
         self.bitHash_ = random_state.choice(a=[-1, 1], size=(self.degree, n_features))
+        self._n_features_out = self.n_components
         return self
 
     def transform(self, X):
@@ -224,7 +228,7 @@ class PolynomialCountSketch(BaseEstimator, TransformerMixin):
         return data_sketch
 
 
-class RBFSampler(TransformerMixin, BaseEstimator):
+class RBFSampler(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
     """Approximate a RBF kernel feature map using random Fourier features.
 
     It implements a variant of Random Kitchen Sinks.[1]
@@ -337,6 +341,7 @@ class RBFSampler(TransformerMixin, BaseEstimator):
         )
 
         self.random_offset_ = random_state.uniform(0, 2 * np.pi, size=self.n_components)
+        self._n_features_out = self.n_components
         return self
 
     def transform(self, X):
@@ -363,7 +368,9 @@ class RBFSampler(TransformerMixin, BaseEstimator):
         return projection
 
 
-class SkewedChi2Sampler(TransformerMixin, BaseEstimator):
+class SkewedChi2Sampler(
+    _ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
+):
     """Approximate feature map for "skewed chi-squared" kernel.
 
     Read more in the :ref:`User Guide <skewed_chi_kernel_approx>`.
@@ -469,6 +476,7 @@ class SkewedChi2Sampler(TransformerMixin, BaseEstimator):
         # transform by inverse CDF of sech
         self.random_weights_ = 1.0 / np.pi * np.log(np.tan(np.pi / 2.0 * uniform))
         self.random_offset_ = random_state.uniform(0, 2 * np.pi, size=self.n_components)
+        self._n_features_out = self.n_components
         return self
 
     def transform(self, X):
@@ -715,7 +723,7 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
         return {"stateless": True, "requires_positive_X": True}
 
 
-class Nystroem(TransformerMixin, BaseEstimator):
+class Nystroem(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
     """Approximate a kernel map using a subset of the training data.
 
     Constructs an approximate feature map for an arbitrary kernel
@@ -909,6 +917,7 @@ class Nystroem(TransformerMixin, BaseEstimator):
         self.normalization_ = np.dot(U / np.sqrt(S), V)
         self.components_ = basis
         self.component_indices_ = basis_inds
+        self._n_features_out = n_components
         return self
 
     def transform(self, X):

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -346,3 +346,17 @@ def test_nystroem_component_indices():
     )
     feature_map_nystroem.fit(X)
     assert feature_map_nystroem.component_indices_.shape == (10,)
+
+
+@pytest.mark.parametrize(
+    "Estimator", [PolynomialCountSketch, RBFSampler, SkewedChi2Sampler, Nystroem]
+)
+def test_get_feature_names_out(Estimator):
+    """Check get_feature_names_out"""
+    est = Estimator().fit(X)
+    X_trans = est.transform(X)
+
+    names_out = est.get_feature_names_out()
+    class_name = Estimator.__name__.lower()
+    expected_names = [f"{class_name}{i}" for i in range(X_trans.shape[1])]
+    assert_array_equal(names_out, expected_names)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards https://github.com/scikit-learn/scikit-learn/issues/21308


#### What does this implement/fix? Explain your changes.
This PR adds `get_feature_names_out` to most of the kernel_approximation estimators. The remaining one is in https://github.com/scikit-learn/scikit-learn/pull/22137

#### Any other comments?
The `test_transformers_get_feature_names_out` common tests will run on these estimators because they define `get_feature_names_out`:

https://github.com/scikit-learn/scikit-learn/blob/1c24595c74e0bea246737b19f8fdfc8a1ffa2282/sklearn/tests/test_common.py#L394-L396

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
