### PR TITLE
ENH Add feature_names_out to voting estimators

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -343,10 +343,9 @@ Changelog
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
 
 - |API| Adds :meth:`get_feature_names_out` to
-  :class:`ensemble.VotingClassifier` and
-  :class:`ensemble.VotingRegressor`. :pr:`22697` by `Thomas Fan`_.
+  :class:`ensemble.VotingClassifier`, :class:`ensemble.VotingRegressor`,
   :class:`ensemble.StackingClassifier`, and
-  :class:`ensemble.StackingRegressor`. :pr:`22695` by `Thomas Fan`_.
+  :class:`ensemble.StackingRegressor`. :pr:`22695` and :pr:`22697`  by `Thomas Fan`_.
 
 - |Fix| Removed a potential source of CPU oversubscription in
   :class:`ensemble.HistGradientBoostingClassifier` and
@@ -506,7 +505,7 @@ Changelog
   :class:`kernel_approximation.RBFSampler`, and
   :class:`kernel_approximation.SkewedChi2Sampler`. :pr:`22694` by `Thomas Fan`_.
 
-- |API| Adds :term:`get_feature_names_out` to the following transformers 
+- |API| Adds :term:`get_feature_names_out` to the following transformers
   of the :mod:`~sklearn.kernel_approximation` module:
   :class:`~sklearn.kernel_approximation.AdditiveChi2Sampler`.
   :pr:`22137` by `Thomas Fan`_.

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -342,6 +342,10 @@ Changelog
   :class:`ensemble.ExtraTreesClassifier`.
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
 
+- |API| Adds :meth:`get_feature_names_out` to
+  :class:`ensemble.VotingClassifier` and
+  :class:`ensemble.VotingRegressor`. :pr:`xxxxx` by `Thomas Fan`_.
+
 - |Fix| Removed a potential source of CPU oversubscription in
   :class:`ensemble.HistGradientBoostingClassifier` and
   :class:`ensemble.HistGradientBoostingRegressor` when CPU resource usage is limited,

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -344,7 +344,7 @@ Changelog
 
 - |API| Adds :meth:`get_feature_names_out` to
   :class:`ensemble.VotingClassifier` and
-  :class:`ensemble.VotingRegressor`. :pr:`xxxxx` by `Thomas Fan`_.
+  :class:`ensemble.VotingRegressor`. :pr:`22697` by `Thomas Fan`_.
 
 - |Fix| Removed a potential source of CPU oversubscription in
   :class:`ensemble.HistGradientBoostingClassifier` and

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -16,6 +16,7 @@ This module contains:
 from abc import abstractmethod
 
 import numbers
+from itertools import chain
 import numpy as np
 
 from joblib import Parallel
@@ -31,6 +32,7 @@ from ..utils import Bunch
 from ..utils import check_scalar
 from ..utils.metaestimators import available_if
 from ..utils.validation import check_is_fitted
+from ..utils.validation import _check_feature_names_in
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import column_or_1d
 from ..exceptions import NotFittedError
@@ -442,6 +444,45 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         else:
             return self._predict(X)
 
+    def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str objects
+            Transformed feature names.
+        """
+        if self.voting == "soft" and not self.flatten_transform:
+            raise ValueError(
+                "get_feature_names_out is not supported when `voting='soft'` and "
+                "`flatten_transform=False`"
+            )
+
+        _check_feature_names_in(self, input_features, generate_names=False)
+        class_name = self.__class__.__name__.lower()
+
+        active_names = [name for name, est in self.estimators if est != "drop"]
+
+        if self.voting == "hard":
+            return np.asarray(
+                [f"{class_name}_{name}" for name in active_names], dtype=object
+            )
+
+        # voting == "soft"
+        n_classes = len(self.classes_)
+        names_out = chain.from_iterable(
+            [
+                [f"{class_name}_{name}{i}" for i in range(n_classes)]
+                for name in active_names
+            ]
+        )
+        return np.asarray(list(names_out), dtype=object)
+
 
 class VotingRegressor(RegressorMixin, _BaseVoting):
     """Prediction voting regressor for unfitted estimators.
@@ -598,3 +639,23 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         """
         check_is_fitted(self)
         return self._predict(X)
+
+    def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Not used, present here for API consistency by convention.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str objects
+            Transformed feature names.
+        """
+        _check_feature_names_in(self, input_features, generate_names=False)
+        class_name = self.__class__.__name__.lower()
+        return np.asarray(
+            [f"{class_name}_{name}" for name, est in self.estimators if est != "drop"],
+            dtype=object,
+        )

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -16,7 +16,6 @@ This module contains:
 from abc import abstractmethod
 
 import numbers
-from itertools import chain
 import numpy as np
 
 from joblib import Parallel
@@ -475,13 +474,10 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
 
         # voting == "soft"
         n_classes = len(self.classes_)
-        names_out = chain.from_iterable(
-            [
-                [f"{class_name}_{name}{i}" for i in range(n_classes)]
-                for name in active_names
-            ]
-        )
-        return np.asarray(list(names_out), dtype=object)
+        names_out = [
+            f"{class_name}_{name}{i}" for name in active_names for i in range(n_classes)
+        ]
+        return np.asarray(names_out, dtype=object)
 
 
 class VotingRegressor(RegressorMixin, _BaseVoting):

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -629,7 +629,7 @@ def test_voting_verbose(estimator, capsys):
 
 
 def test_get_features_names_out_regressor():
-    """Check that get_feature_names_out output for regressor."""
+    """Check get_feature_names_out output for regressor."""
 
     X = [[1, 2], [3, 4], [5, 6]]
     y = [0, 1, 2]
@@ -666,7 +666,7 @@ def test_get_features_names_out_regressor():
     ],
 )
 def test_get_features_names_out_classifier(kwargs, expected_names):
-    """Check get_feature_names_out for different settings."""
+    """Check get_feature_names_out for classifier for different settings."""
     X = [[1, 2], [3, 4], [5, 6], [1, 1.2]]
     y = [0, 1, 2, 0]
 

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -666,7 +666,7 @@ def test_get_features_names_out_regressor():
     ],
 )
 def test_get_features_names_out_classifier(kwargs, expected_names):
-    """Check that get_feature_names_out for differnet settings."""
+    """Check get_feature_names_out for different settings."""
     X = [[1, 2], [3, 4], [5, 6], [1, 1.2]]
     y = [0, 1, 2, 0]
 

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -626,3 +626,83 @@ def test_voting_verbose(estimator, capsys):
 
     estimator.fit(X, y)
     assert re.match(pattern, capsys.readouterr()[0])
+
+
+def test_get_features_names_out_regressor():
+    """Check that get_feature_names_out output for regressor."""
+
+    X = [[1, 2], [3, 4], [5, 6]]
+    y = [0, 1, 2]
+
+    voting = VotingRegressor(
+        estimators=[
+            ("lr", LinearRegression()),
+            ("tree", DecisionTreeRegressor(random_state=0)),
+            ("ignore", "drop"),
+        ]
+    )
+    voting.fit(X, y)
+
+    names_out = voting.get_feature_names_out()
+    expected_names = ["votingregressor_lr", "votingregressor_tree"]
+    assert_array_equal(names_out, expected_names)
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_names",
+    [
+        (
+            {"voting": "soft", "flatten_transform": True},
+            [
+                "votingclassifier_lr0",
+                "votingclassifier_lr1",
+                "votingclassifier_lr2",
+                "votingclassifier_tree0",
+                "votingclassifier_tree1",
+                "votingclassifier_tree2",
+            ],
+        ),
+        ({"voting": "hard"}, ["votingclassifier_lr", "votingclassifier_tree"]),
+    ],
+)
+def test_get_features_names_out_classifier(kwargs, expected_names):
+    """Check that get_feature_names_out for differnet settings."""
+    X = [[1, 2], [3, 4], [5, 6], [1, 1.2]]
+    y = [0, 1, 2, 0]
+
+    voting = VotingClassifier(
+        estimators=[
+            ("lr", LogisticRegression(random_state=0)),
+            ("tree", DecisionTreeClassifier(random_state=0)),
+        ],
+        **kwargs,
+    )
+    voting.fit(X, y)
+    X_trans = voting.transform(X)
+    names_out = voting.get_feature_names_out()
+
+    assert X_trans.shape[1] == len(expected_names)
+    assert_array_equal(names_out, expected_names)
+
+
+def test_get_features_names_out_classifier_error():
+    """Check that error is raised when voting="soft" and flatten_transform=False."""
+    X = [[1, 2], [3, 4], [5, 6]]
+    y = [0, 1, 2]
+
+    voting = VotingClassifier(
+        estimators=[
+            ("lr", LogisticRegression(random_state=0)),
+            ("tree", DecisionTreeClassifier(random_state=0)),
+        ],
+        voting="soft",
+        flatten_transform=False,
+    )
+    voting.fit(X, y)
+
+    msg = (
+        "get_feature_names_out is not supported when `voting='soft'` and "
+        "`flatten_transform=False`"
+    )
+    with pytest.raises(ValueError, match=msg):
+        voting.get_feature_names_out()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards https://github.com/scikit-learn/scikit-learn/issues/21308

#### What does this implement/fix? Explain your changes.
This PR adds `get_feature_names_out` to voting classifiers. Note that `voting='soft'` and `flatten_transform=False` has no feature names because the transform is 3d.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
