### PR TITLE
DOC Fixes VotingClassifier.transform docstring

### DIFF
--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -422,9 +422,8 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         -------
         probabilities_or_labels
             If `voting='soft'` and `flatten_transform=True`:
-                returns ndarray of shape (n_classifiers, n_samples *
-                n_classes), being class probabilities calculated by each
-                classifier.
+                returns ndarray of shape (n_samples, n_classifiers * n_classes),
+                being class probabilities calculated by each classifier.
             If `voting='soft' and `flatten_transform=False`:
                 ndarray of shape (n_classifiers, n_samples, n_classes)
             If `voting='hard'`:


### PR DESCRIPTION
Docstring fix about the shape of `VotingClassifier.transform`. Here is a code snippet to demonstrate the relationship between `transform` and `predict_proba`:

```python
from sklearn.datasets import make_classification
from sklearn.ensemble import VotingClassifier
from sklearn.linear_model import LogisticRegression
from sklearn.ensemble import RandomForestClassifier
from numpy.testing import assert_allclose

n_samples = 140
n_classes = 3
X, y = make_classification(n_samples=n_samples, random_state=10, n_classes=n_classes,
                           n_clusters_per_class=1)

voting = VotingClassifier([
    ("lr", LogisticRegression()), ("rf", RandomForestClassifier(random_state=0))
], voting="soft", flatten_transform=True)
voting.fit(X, y)

lr_trans = voting.estimators_[0].predict_proba(X)
rf_trans = voting.estimators_[1].predict_proba(X)

X_trans = voting.transform(X)
assert X_trans.shape == (n_samples, 2 * n_classes)

assert_allclose(lr_trans, X_trans[:, :3])
assert_allclose(rf_trans, X_trans[:, 3:])
```