### PR TITLE
DOC Ensures that sklearn.metrics._ranking.average_precision_score passes numpydoc validation

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -170,6 +170,7 @@ def average_precision_score(
     Returns
     -------
     average_precision : float
+        Summary of the precision-recall curve in a single value representing the average of all precisions.
 
     See Also
     --------

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -170,7 +170,7 @@ def average_precision_score(
     Returns
     -------
     average_precision : float
-        Summary of the precision-recall curve in a single value representing the average of all precisions.
+        Average precision score.
 
     See Also
     --------

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -66,7 +66,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics._plot.det_curve.plot_det_curve",
     "sklearn.metrics._plot.precision_recall_curve.plot_precision_recall_curve",
     "sklearn.metrics._ranking.auc",
-    "sklearn.metrics._ranking.average_precision_score",
     "sklearn.metrics._ranking.coverage_error",
     "sklearn.metrics._ranking.dcg_score",
     "sklearn.metrics._ranking.label_ranking_average_precision_score",


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses https://github.com/scikit-learn/scikit-learn/issues/21350

#### What does this implement/fix? Explain your changes.

This PR ensures sklearn.metrics._ranking.average_precision_score is compatible with numpydoc:

- Remove sklearn.metrics._classification.accuracy_score from DOCSTRING_IGNORE_LIST.
- Verify that all tests are passing.
