### PR TITLE
ENH Include entire range in check_scalar error message

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1477,13 +1477,13 @@ def check_scalar(
         operator.lt if include_boundaries in ("left", "both") else operator.le
     )
     if min_val is not None and comparison_operator(x, min_val):
-        raise ValueError(f"{name} == {x}, must be in the range {boundary}")
+        raise ValueError(f"{name} == {x}, must be in the range {boundary}.")
 
     comparison_operator = (
         operator.gt if include_boundaries in ("right", "both") else operator.ge
     )
     if max_val is not None and comparison_operator(x, max_val):
-        raise ValueError(f"{name} == {x}, must be in the range {boundary}")
+        raise ValueError(f"{name} == {x}, must be in the range {boundary}.")
 
     return x
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1459,23 +1459,31 @@ def check_scalar(
             "is inconsistent."
         )
 
+    boundary = (
+        (
+            "(-inf"
+            if min_val is None
+            else f"{'[' if include_boundaries in ('left', 'both') else '('}{min_val}"
+        )
+        + ", "
+        + (
+            "inf)"
+            if max_val is None
+            else f"{max_val}{']' if include_boundaries in ('right', 'both') else ')'}"
+        )
+    )
+
     comparison_operator = (
         operator.lt if include_boundaries in ("left", "both") else operator.le
     )
     if min_val is not None and comparison_operator(x, min_val):
-        raise ValueError(
-            f"{name} == {x}, must be"
-            f" {'>=' if include_boundaries in ('left', 'both') else '>'} {min_val}."
-        )
+        raise ValueError(f"{name} == {x}, must be in the range {boundary}")
 
     comparison_operator = (
         operator.gt if include_boundaries in ("right", "both") else operator.ge
     )
     if max_val is not None and comparison_operator(x, max_val):
-        raise ValueError(
-            f"{name} == {x}, must be"
-            f" {'<=' if include_boundaries in ('right', 'both') else '<'} {max_val}."
-        )
+        raise ValueError(f"{name} == {x}, must be in the range {boundary}")
 
     return x
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a PR to address issue #22691 , where the entire boundary will be shown in the error message within `check_scalar`.




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
