### PR TITLE
MNT Refactor KMeans and MiniBatchKMeans to inherit from a common base class

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1088,7 +1088,7 @@ class _BaseKMeans(
         _, scores = _labels_inertia_threadpool_limit(
             X, sample_weight, x_squared_norms, self.cluster_centers_, self._n_threads
         )
-        return - scores
+        return -scores
 
     def _more_tags(self):
         return {

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -772,9 +772,304 @@ def _labels_inertia_threadpool_limit(
     return labels, inertia
 
 
-class KMeans(
+class _BaseKMeans(
     _ClassNamePrefixFeaturesOutMixin, TransformerMixin, ClusterMixin, BaseEstimator
 ):
+    """Base class for KMeans and MiniBatchKMeans"""
+
+    def __init__(
+        self,
+        n_clusters,
+        *,
+        init,
+        n_init,
+        max_iter,
+        tol,
+        verbose,
+        random_state,
+    ):
+        self.n_clusters = n_clusters
+        self.init = init
+        self.max_iter = max_iter
+        self.tol = tol
+        self.n_init = n_init
+        self.verbose = verbose
+        self.random_state = random_state
+
+    def _check_params(self, X):
+        # n_init
+        if self.n_init <= 0:
+            raise ValueError(f"n_init should be > 0, got {self.n_init} instead.")
+        self._n_init = self.n_init
+
+        # max_iter
+        if self.max_iter <= 0:
+            raise ValueError(f"max_iter should be > 0, got {self.max_iter} instead.")
+
+        # n_clusters
+        if X.shape[0] < self.n_clusters:
+            raise ValueError(
+                f"n_samples={X.shape[0]} should be >= n_clusters={self.n_clusters}."
+            )
+
+        # tol
+        self._tol = _tolerance(X, self.tol)
+
+        # init
+        if not (
+            _is_arraylike_not_scalar(self.init)
+            or callable(self.init)
+            or (isinstance(self.init, str) and self.init in ["k-means++", "random"])
+        ):
+            raise ValueError(
+                "init should be either 'k-means++', 'random', an array-like or a "
+                f"callable, got '{self.init}' instead."
+            )
+
+        if _is_arraylike_not_scalar(self.init) and self._n_init != 1:
+            warnings.warn(
+                "Explicit initial center position passed: performing only"
+                f" one init in {self.__class__.__name__} instead of "
+                f"n_init={self._n_init}.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            self._n_init = 1
+
+    def _check_mkl_vcomp(self, X, n_samples):
+        """Warns when vcomp and mkl are both present"""
+        # The BLAS call inside a prange in lloyd_iter_chunked_dense is known to
+        # cause a small memory leak when there are less chunks than the number
+        # of available threads. It only happens when the OpenMP library is
+        # vcomp (microsoft OpenMP) and the BLAS library is MKL. see #18653
+        if sp.issparse(X):
+            return
+
+        active_threads = int(np.ceil(n_samples / CHUNK_SIZE))
+        if active_threads < self._n_threads:
+            modules = threadpool_info()
+            has_vcomp = "vcomp" in [module["prefix"] for module in modules]
+            has_mkl = ("mkl", "intel") in [
+                (module["internal_api"], module.get("threading_layer", None))
+                for module in modules
+            ]
+            if has_vcomp and has_mkl:
+                if not hasattr(self, "batch_size"):  # KMeans
+                    warnings.warn(
+                        "KMeans is known to have a memory leak on Windows "
+                        "with MKL, when there are less chunks than available "
+                        "threads. You can avoid it by setting the environment"
+                        f" variable OMP_NUM_THREADS={active_threads}."
+                    )
+                else:  # MiniBatchKMeans
+                    warnings.warn(
+                        "MiniBatchKMeans is known to have a memory leak on "
+                        "Windows with MKL, when there are less chunks than "
+                        "available threads. You can prevent it by setting "
+                        f"batch_size >= {self._n_threads * CHUNK_SIZE} or by "
+                        "setting the environment variable "
+                        f"OMP_NUM_THREADS={active_threads}"
+                    )
+
+    def _validate_center_shape(self, X, centers):
+        """Check if centers is compatible with X and n_clusters."""
+        if centers.shape[0] != self.n_clusters:
+            raise ValueError(
+                f"The shape of the initial centers {centers.shape} does not "
+                f"match the number of clusters {self.n_clusters}."
+            )
+        if centers.shape[1] != X.shape[1]:
+            raise ValueError(
+                f"The shape of the initial centers {centers.shape} does not "
+                f"match the number of features of the data {X.shape[1]}."
+            )
+
+    def _check_test_data(self, X):
+        X = self._validate_data(
+            X,
+            accept_sparse="csr",
+            reset=False,
+            dtype=[np.float64, np.float32],
+            order="C",
+            accept_large_sparse=False,
+        )
+        return X
+
+    def _init_centroids(self, X, x_squared_norms, init, random_state, init_size=None):
+        """Compute the initial centroids.
+
+        Parameters
+        ----------
+        X : {ndarray, sparse matrix} of shape (n_samples, n_features)
+            The input samples.
+
+        x_squared_norms : ndarray of shape (n_samples,)
+            Squared euclidean norm of each data point. Pass it if you have it
+            at hands already to avoid it being recomputed here.
+
+        init : {'k-means++', 'random'}, callable or ndarray of shape \
+                (n_clusters, n_features)
+            Method for initialization.
+
+        random_state : RandomState instance
+            Determines random number generation for centroid initialization.
+            See :term:`Glossary <random_state>`.
+
+        init_size : int, default=None
+            Number of samples to randomly sample for speeding up the
+            initialization (sometimes at the expense of accuracy).
+
+        Returns
+        -------
+        centers : ndarray of shape (n_clusters, n_features)
+        """
+        n_samples = X.shape[0]
+        n_clusters = self.n_clusters
+
+        if init_size is not None and init_size < n_samples:
+            init_indices = random_state.randint(0, n_samples, init_size)
+            X = X[init_indices]
+            x_squared_norms = x_squared_norms[init_indices]
+            n_samples = X.shape[0]
+
+        if isinstance(init, str) and init == "k-means++":
+            centers, _ = _kmeans_plusplus(
+                X,
+                n_clusters,
+                random_state=random_state,
+                x_squared_norms=x_squared_norms,
+            )
+        elif isinstance(init, str) and init == "random":
+            seeds = random_state.permutation(n_samples)[:n_clusters]
+            centers = X[seeds]
+        elif _is_arraylike_not_scalar(self.init):
+            centers = init
+        elif callable(init):
+            centers = init(X, n_clusters, random_state=random_state)
+            centers = check_array(centers, dtype=X.dtype, copy=False, order="C")
+            self._validate_center_shape(X, centers)
+
+        if sp.issparse(centers):
+            centers = centers.toarray()
+
+        return centers
+
+    def fit_predict(self, X, y=None, sample_weight=None):
+        """Compute cluster centers and predict cluster index for each sample.
+
+        Convenience method; equivalent to calling fit(X) followed by
+        predict(X).
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            New data to transform.
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
+        sample_weight : array-like of shape (n_samples,), default=None
+            The weights for each observation in X. If None, all observations
+            are assigned equal weight.
+
+        Returns
+        -------
+        labels : ndarray of shape (n_samples,)
+            Index of the cluster each sample belongs to.
+        """
+        return self.fit(X, sample_weight=sample_weight).labels_
+
+    def fit_transform(self, X, y=None, sample_weight=None):
+        """Compute clustering and transform X to cluster-distance space.
+
+        Equivalent to fit(X).transform(X), but more efficiently implemented.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            New data to transform.
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
+        sample_weight : array-like of shape (n_samples,), default=None
+            The weights for each observation in X. If None, all observations
+            are assigned equal weight.
+
+        Returns
+        -------
+        X_new : ndarray of shape (n_samples, n_clusters)
+            X transformed in the new space.
+        """
+        return self.fit(X, sample_weight=sample_weight)._transform(X)
+
+    def transform(self, X):
+        """Transform X to a cluster-distance space.
+
+        In the new space, each dimension is the distance to the cluster
+        centers. Note that even if X is sparse, the array returned by
+        `transform` will typically be dense.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            New data to transform.
+
+        Returns
+        -------
+        X_new : ndarray of shape (n_samples, n_clusters)
+            X transformed in the new space.
+        """
+        check_is_fitted(self)
+
+        X = self._check_test_data(X)
+        return self._transform(X)
+
+    def _transform(self, X):
+        """Guts of transform method; no input validation."""
+        return euclidean_distances(X, self.cluster_centers_)
+
+    def score(self, X, y=None, sample_weight=None):
+        """Opposite of the value of X on the K-means objective.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            New data.
+
+        y : Ignored
+            Not used, present here for API consistency by convention.
+
+        sample_weight : array-like of shape (n_samples,), default=None
+            The weights for each observation in X. If None, all observations
+            are assigned equal weight.
+
+        Returns
+        -------
+        score : float
+            Opposite of the value of X on the K-means objective.
+        """
+        check_is_fitted(self)
+
+        X = self._check_test_data(X)
+        x_squared_norms = row_norms(X, squared=True)
+        sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
+
+        return -_labels_inertia_threadpool_limit(
+            X, sample_weight, x_squared_norms, self.cluster_centers_, self._n_threads
+        )[1]
+
+    def _more_tags(self):
+        return {
+            "_xfail_checks": {
+                "check_sample_weights_invariance": (
+                    "zero sample_weight is not equivalent to removing samples"
+                ),
+            },
+        }
+
+
+class KMeans(_BaseKMeans):
     """K-Means clustering.
 
     Read more in the :ref:`User Guide <k_means>`.
@@ -939,35 +1234,21 @@ class KMeans(
         copy_x=True,
         algorithm="lloyd",
     ):
+        super().__init__(
+            n_clusters=n_clusters,
+            init=init,
+            n_init=n_init,
+            max_iter=max_iter,
+            tol=tol,
+            verbose=verbose,
+            random_state=random_state,
+        )
 
-        self.n_clusters = n_clusters
-        self.init = init
-        self.max_iter = max_iter
-        self.tol = tol
-        self.n_init = n_init
-        self.verbose = verbose
-        self.random_state = random_state
         self.copy_x = copy_x
         self.algorithm = algorithm
 
     def _check_params(self, X):
-        # n_init
-        if self.n_init <= 0:
-            raise ValueError(f"n_init should be > 0, got {self.n_init} instead.")
-        self._n_init = self.n_init
-
-        # max_iter
-        if self.max_iter <= 0:
-            raise ValueError(f"max_iter should be > 0, got {self.max_iter} instead.")
-
-        # n_clusters
-        if X.shape[0] < self.n_clusters:
-            raise ValueError(
-                f"n_samples={X.shape[0]} should be >= n_clusters={self.n_clusters}."
-            )
-
-        # tol
-        self._tol = _tolerance(X, self.tol)
+        super()._check_params(X)
 
         # algorithm
         if self.algorithm not in ("lloyd", "elkan", "auto", "full"):
@@ -991,145 +1272,6 @@ class KMeans(
                 RuntimeWarning,
             )
             self._algorithm = "lloyd"
-
-        # init
-        if not (
-            _is_arraylike_not_scalar(self.init)
-            or callable(self.init)
-            or (isinstance(self.init, str) and self.init in ["k-means++", "random"])
-        ):
-            raise ValueError(
-                "init should be either 'k-means++', 'random', an array-like or a "
-                f"callable, got '{self.init}' instead."
-            )
-
-        if _is_arraylike_not_scalar(self.init) and self._n_init != 1:
-            warnings.warn(
-                "Explicit initial center position passed: performing only"
-                f" one init in {self.__class__.__name__} instead of "
-                f"n_init={self._n_init}.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-            self._n_init = 1
-
-    def _validate_center_shape(self, X, centers):
-        """Check if centers is compatible with X and n_clusters."""
-        if centers.shape[0] != self.n_clusters:
-            raise ValueError(
-                f"The shape of the initial centers {centers.shape} does not "
-                f"match the number of clusters {self.n_clusters}."
-            )
-        if centers.shape[1] != X.shape[1]:
-            raise ValueError(
-                f"The shape of the initial centers {centers.shape} does not "
-                f"match the number of features of the data {X.shape[1]}."
-            )
-
-    def _check_test_data(self, X):
-        X = self._validate_data(
-            X,
-            accept_sparse="csr",
-            reset=False,
-            dtype=[np.float64, np.float32],
-            order="C",
-            accept_large_sparse=False,
-        )
-        return X
-
-    def _check_mkl_vcomp(self, X, n_samples):
-        """Warns when vcomp and mkl are both present"""
-        # The BLAS call inside a prange in lloyd_iter_chunked_dense is known to
-        # cause a small memory leak when there are less chunks than the number
-        # of available threads. It only happens when the OpenMP library is
-        # vcomp (microsoft OpenMP) and the BLAS library is MKL. see #18653
-        if sp.issparse(X):
-            return
-
-        active_threads = int(np.ceil(n_samples / CHUNK_SIZE))
-        if active_threads < self._n_threads:
-            modules = threadpool_info()
-            has_vcomp = "vcomp" in [module["prefix"] for module in modules]
-            has_mkl = ("mkl", "intel") in [
-                (module["internal_api"], module.get("threading_layer", None))
-                for module in modules
-            ]
-            if has_vcomp and has_mkl:
-                if not hasattr(self, "batch_size"):  # KMeans
-                    warnings.warn(
-                        "KMeans is known to have a memory leak on Windows "
-                        "with MKL, when there are less chunks than available "
-                        "threads. You can avoid it by setting the environment"
-                        f" variable OMP_NUM_THREADS={active_threads}."
-                    )
-                else:  # MiniBatchKMeans
-                    warnings.warn(
-                        "MiniBatchKMeans is known to have a memory leak on "
-                        "Windows with MKL, when there are less chunks than "
-                        "available threads. You can prevent it by setting "
-                        f"batch_size >= {self._n_threads * CHUNK_SIZE} or by "
-                        "setting the environment variable "
-                        f"OMP_NUM_THREADS={active_threads}"
-                    )
-
-    def _init_centroids(self, X, x_squared_norms, init, random_state, init_size=None):
-        """Compute the initial centroids.
-
-        Parameters
-        ----------
-        X : {ndarray, sparse matrix} of shape (n_samples, n_features)
-            The input samples.
-
-        x_squared_norms : ndarray of shape (n_samples,)
-            Squared euclidean norm of each data point. Pass it if you have it
-            at hands already to avoid it being recomputed here.
-
-        init : {'k-means++', 'random'}, callable or ndarray of shape \
-                (n_clusters, n_features)
-            Method for initialization.
-
-        random_state : RandomState instance
-            Determines random number generation for centroid initialization.
-            See :term:`Glossary <random_state>`.
-
-        init_size : int, default=None
-            Number of samples to randomly sample for speeding up the
-            initialization (sometimes at the expense of accuracy).
-
-        Returns
-        -------
-        centers : ndarray of shape (n_clusters, n_features)
-        """
-        n_samples = X.shape[0]
-        n_clusters = self.n_clusters
-
-        if init_size is not None and init_size < n_samples:
-            init_indices = random_state.randint(0, n_samples, init_size)
-            X = X[init_indices]
-            x_squared_norms = x_squared_norms[init_indices]
-            n_samples = X.shape[0]
-
-        if isinstance(init, str) and init == "k-means++":
-            centers, _ = _kmeans_plusplus(
-                X,
-                n_clusters,
-                random_state=random_state,
-                x_squared_norms=x_squared_norms,
-            )
-        elif isinstance(init, str) and init == "random":
-            seeds = random_state.permutation(n_samples)[:n_clusters]
-            centers = X[seeds]
-        elif _is_arraylike_not_scalar(self.init):
-            centers = init
-        elif callable(init):
-            centers = init(X, n_clusters, random_state=random_state)
-            centers = check_array(centers, dtype=X.dtype, copy=False, order="C")
-            self._validate_center_shape(X, centers)
-
-        if sp.issparse(centers):
-            centers = centers.toarray()
-
-        return centers
 
     def fit(self, X, y=None, sample_weight=None):
         """Compute k-means clustering.
@@ -1254,81 +1396,6 @@ class KMeans(
         self.n_iter_ = best_n_iter
         return self
 
-    def fit_predict(self, X, y=None, sample_weight=None):
-        """Compute cluster centers and predict cluster index for each sample.
-
-        Convenience method; equivalent to calling fit(X) followed by
-        predict(X).
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            New data to transform.
-
-        y : Ignored
-            Not used, present here for API consistency by convention.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            The weights for each observation in X. If None, all observations
-            are assigned equal weight.
-
-        Returns
-        -------
-        labels : ndarray of shape (n_samples,)
-            Index of the cluster each sample belongs to.
-        """
-        return self.fit(X, sample_weight=sample_weight).labels_
-
-    def fit_transform(self, X, y=None, sample_weight=None):
-        """Compute clustering and transform X to cluster-distance space.
-
-        Equivalent to fit(X).transform(X), but more efficiently implemented.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            New data to transform.
-
-        y : Ignored
-            Not used, present here for API consistency by convention.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            The weights for each observation in X. If None, all observations
-            are assigned equal weight.
-
-        Returns
-        -------
-        X_new : ndarray of shape (n_samples, n_clusters)
-            X transformed in the new space.
-        """
-        return self.fit(X, sample_weight=sample_weight)._transform(X)
-
-    def transform(self, X):
-        """Transform X to a cluster-distance space.
-
-        In the new space, each dimension is the distance to the cluster
-        centers. Note that even if X is sparse, the array returned by
-        `transform` will typically be dense.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            New data to transform.
-
-        Returns
-        -------
-        X_new : ndarray of shape (n_samples, n_clusters)
-            X transformed in the new space.
-        """
-        check_is_fitted(self)
-
-        X = self._check_test_data(X)
-        return self._transform(X)
-
-    def _transform(self, X):
-        """Guts of transform method; no input validation."""
-        return euclidean_distances(X, self.cluster_centers_)
-
     def predict(self, X, sample_weight=None):
         """Predict the closest cluster each sample in X belongs to.
 
@@ -1359,45 +1426,6 @@ class KMeans(
         return _labels_inertia_threadpool_limit(
             X, sample_weight, x_squared_norms, self.cluster_centers_, self._n_threads
         )[0]
-
-    def score(self, X, y=None, sample_weight=None):
-        """Opposite of the value of X on the K-means objective.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            New data.
-
-        y : Ignored
-            Not used, present here for API consistency by convention.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            The weights for each observation in X. If None, all observations
-            are assigned equal weight.
-
-        Returns
-        -------
-        score : float
-            Opposite of the value of X on the K-means objective.
-        """
-        check_is_fitted(self)
-
-        X = self._check_test_data(X)
-        x_squared_norms = row_norms(X, squared=True)
-        sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
-
-        return -_labels_inertia_threadpool_limit(
-            X, sample_weight, x_squared_norms, self.cluster_centers_, self._n_threads
-        )[1]
-
-    def _more_tags(self):
-        return {
-            "_xfail_checks": {
-                "check_sample_weights_invariance": (
-                    "zero sample_weight is not equivalent to removing samples"
-                ),
-            },
-        }
 
 
 def _mini_batch_step(
@@ -1524,7 +1552,7 @@ def _mini_batch_step(
     return inertia
 
 
-class MiniBatchKMeans(KMeans):
+class MiniBatchKMeans(_BaseKMeans):
     """
     Mini-Batch K-Means clustering.
 
@@ -2146,12 +2174,3 @@ class MiniBatchKMeans(KMeans):
         )
 
         return labels
-
-    def _more_tags(self):
-        return {
-            "_xfail_checks": {
-                "check_sample_weights_invariance": (
-                    "zero sample_weight is not equivalent to removing samples"
-                ),
-            }
-        }

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1085,7 +1085,7 @@ class _BaseKMeans(
         x_squared_norms = row_norms(X, squared=True)
         sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 
-        _, scores = labels_inertia_threadpool_limit(
+        _, scores = _labels_inertia_threadpool_limit(
             X, sample_weight, x_squared_norms, self.cluster_centers_, self._n_threads
         )
         return - scores

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1085,9 +1085,10 @@ class _BaseKMeans(
         x_squared_norms = row_norms(X, squared=True)
         sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 
-        return -_labels_inertia_threadpool_limit(
+        _, scores = labels_inertia_threadpool_limit(
             X, sample_weight, x_squared_norms, self.cluster_centers_, self._n_threads
-        )[1]
+        )
+        return - scores
 
     def _more_tags(self):
         return {

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -843,7 +843,6 @@ class _BaseKMeans(
 
         This method is called by `_check_mkl_vcomp`.
         """
-        pass
 
     def _check_mkl_vcomp(self, X, n_samples):
         """Check when vcomp and mkl are both present"""


### PR DESCRIPTION
Currently MiniBatchKMeans inherits from KMeans but it does not use `algorithm` and `copy_x` that KMeans defines. This means that MiniBatchKMeans holds 2 unexpected attributes. It's more appropriate to make both inherit from a base class that only defines the common attributes.

In addition it might (didn't check) make it easier to include future KMeans alternatives like BisectKMeans or BreathingKMeans.