### PR TITLE
CI don't run check_manifest on forks

### DIFF
--- a/.github/workflows/check-manifest.yml
+++ b/.github/workflows/check-manifest.yml
@@ -25,7 +25,7 @@ jobs:
 
   update-tracker:
     uses: ./.github/workflows/update_tracking_issue.yml
-    if: github.repository == 'scikit-learn/scikit-learn'
+    if: ${{ always() }}
     needs: [check-manifest]
     with:
       job_status: ${{ needs.check-manifest.result }}

--- a/.github/workflows/check-manifest.yml
+++ b/.github/workflows/check-manifest.yml
@@ -25,7 +25,7 @@ jobs:
 
   update-tracker:
     uses: ./.github/workflows/update_tracking_issue.yml
-    if: ${{ always() }}
+    if: github.repository == 'scikit-learn/scikit-learn'
     needs: [check-manifest]
     with:
       job_status: ${{ needs.check-manifest.result }}

--- a/.github/workflows/update_tracking_issue.yml
+++ b/.github/workflows/update_tracking_issue.yml
@@ -2,7 +2,7 @@
 #
 # update-tracker:
 #   uses: ./.github/workflows/update_tracking_issue.yml
-#   if: github.repository == 'scikit-learn/scikit-learn'
+#   if: ${{ always() }}
 #   needs: [JOB_NAME]
 #   with:
 #     job_status: ${{ needs.JOB_NAME.result }}
@@ -24,6 +24,7 @@ on:
 jobs:
   update_tracking_issue:
     runs-on: ubuntu-latest
+    if: github.repository == 'scikit-learn/scikit-learn'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/update_tracking_issue.yml
+++ b/.github/workflows/update_tracking_issue.yml
@@ -2,7 +2,7 @@
 #
 # update-tracker:
 #   uses: ./.github/workflows/update_tracking_issue.yml
-#   if: ${{ always() }}
+#   if: github.repository == 'scikit-learn/scikit-learn'
 #   needs: [JOB_NAME]
 #   with:
 #     job_status: ${{ needs.JOB_NAME.result }}


### PR DESCRIPTION
The `check` part doesn't run of forks already, but the `update-tracker` part does (and fails).

cc @thomasjpfan 