### PR TITLE
CI Fixes job check-manifest dependency

### DIFF
--- a/.github/workflows/check-manifest.yml
+++ b/.github/workflows/check-manifest.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  check:
+  check-manifest:
     # Don't run on forks
     if: github.repository == 'scikit-learn/scikit-learn'
 


### PR DESCRIPTION
Quick fix to the job name. The `update-tracker` depends on the former job to be "check-manifest":

https://github.com/scikit-learn/scikit-learn/blob/35a679d181c5167fcc7f5fac1b7ea749fd70a8aa/.github/workflows/check-manifest.yml#L29-L31