### PR TITLE
[MRG] Set the target of datasets to be pandas categoricals

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -568,6 +568,15 @@ Changelog
   in favor of ``n_dim``. ``dim`` will be removed in version 1.6.
   :pr:`27718` by :user:`Adam Li <adam2392>`.
 
+:mod:`sklearn.datasets`
+.......................
+
+- |Enhancement| :func:`datasets.load_wine`, :func:`datasets.load_iris`,
+  :func:`datasets.load_breast_cancer` and :func:`datasets.load_digits`
+  now return the target as a pandas categorical dtype when ``as_frame``
+  is set to ``True``.
+  :pr:`22733` by :user:`Matt Williams <milliams>`.
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -602,6 +602,7 @@ def load_wine(*, return_X_y=False, as_frame=False):
         frame, data, target = _convert_data_dataframe(
             "load_wine", data, target, feature_names, target_columns
         )
+        target = target.astype("category")
 
     if return_X_y:
         return data, target
@@ -730,6 +731,7 @@ def load_iris(*, return_X_y=False, as_frame=False):
         frame, data, target = _convert_data_dataframe(
             "load_iris", data, target, feature_names, target_columns
         )
+        target = target.astype("category")
 
     if return_X_y:
         return data, target
@@ -883,6 +885,7 @@ def load_breast_cancer(*, return_X_y=False, as_frame=False):
         frame, data, target = _convert_data_dataframe(
             "load_breast_cancer", data, target, feature_names, target_columns
         )
+        target = target.astype("category")
 
     if return_X_y:
         return data, target
@@ -1025,6 +1028,7 @@ def load_digits(*, n_class=10, return_X_y=False, as_frame=False):
         frame, flat_data, target = _convert_data_dataframe(
             "load_digits", flat_data, target, feature_names, target_columns
         )
+        target = target.astype("category")
 
     if return_X_y:
         return flat_data, target

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -311,12 +311,12 @@ def test_loader(loader_func, data_shape, target_shape, n_target, has_descr, file
 @pytest.mark.parametrize(
     "loader_func, data_dtype, target_dtype",
     [
-        (load_breast_cancer, np.float64, int),
+        (load_breast_cancer, np.float64, "category"),
         (load_diabetes, np.float64, np.float64),
-        (load_digits, np.float64, int),
-        (load_iris, np.float64, int),
+        (load_digits, np.float64, "category"),
+        (load_iris, np.float64, "category"),
         (load_linnerud, np.float64, np.float64),
-        (load_wine, np.float64, int),
+        (load_wine, np.float64, "category"),
     ],
 )
 def test_toy_dataset_frame_dtype(loader_func, data_dtype, target_dtype):


### PR DESCRIPTION
Currently the `datasets` functions `load_wine`, `load_iris`, `load_breast_cancer` and `load_digits` have the option of returning their data as a pandas `DataFrame`. In this case, the data returned as the `target` has the data type `int`:

```python
from sklearn.datasets import load_wine
wine = load_wines(as_frame=True)
assert wine.target.dtype == "int64"
```

This PR changes this so that the target is set to be a [pandas categorical](https://pandas.pydata.org/docs/user_guide/categorical.html) so that now:

```python
assert wine.target.dtype == pd.CategoricalDtype(categories=[0, 1, 2])
```

This allows a number of niceties. Firstly, those who are used to using Pandas will expect categories to be `CategoricalDtype` as it is conceptually different to an integer. Secondly, it allows the option of:

```python
y = wine.target.cat.rename_categories(wine.target_names)
```

which allows the rows to be labelled, making plotting and visualisation legends easier:

```
0         setosa
1         setosa
         ...    
176    virginica
177    virginica
Name: target, Length: 178, dtype: category
Categories (3, object): ['setosa', 'versicolor', 'virginica']
```

Finally, some tools (like seaborn) treat `int` dtype as a continuous variable when plotting and will set a continuous colour palette:
```python
sns.relplot(data=wine.data, x="alcohol", y="proline", hue=wine.target)
```
![int](https://user-images.githubusercontent.com/61316/157282513-8cf2f757-0bcf-470c-82b1-5f0d1951da50.png)
but if the target is a category then it looks like:
![cat](https://user-images.githubusercontent.com/61316/157282665-9e172934-dcfe-4069-887e-01bf348d97d1.png)

A category containing integers is represented in the underlying numpy array in the same way as before so scikit-learn will train on it the same.

In the future, functions like `sklearn.datasets.make_classification` could do the same, but at the moment they do not have the option of returning a `DataFrame`. We could also call the `rename_categories` function on the data for the user, but I'm not sure if all scikit-learn models will work with non-integer values for the target category?
