### PR TITLE
FIX Fixes KBinsDiscretizer for encode=ordinal

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -764,6 +764,9 @@ Changelog
 - |Fix| :class:`preprocessing.KBinDiscretizer` handles bin edges more consistently now.
   :pr:`14975` by `Andreas Müller`_ and :pr:`22526` by :user:`Meekail Zain <micky774>`.
 
+- |Fix| Adds :meth:`preprocessing.KBinDiscretizer.get_feature_names_out` support when
+  `encode="ordinal". :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.random_projection`
 ................................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -765,7 +765,7 @@ Changelog
   :pr:`14975` by `Andreas Müller`_ and :pr:`22526` by :user:`Meekail Zain <micky774>`.
 
 - |Fix| Adds :meth:`preprocessing.KBinDiscretizer.get_feature_names_out` support when
-  `encode="ordinal". :pr:`xxxxx` by `Thomas Fan`_.
+  `encode="ordinal". :pr:`22735` by `Thomas Fan`_.
 
 :mod:`sklearn.random_projection`
 ................................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -765,7 +765,7 @@ Changelog
   :pr:`14975` by `Andreas Müller`_ and :pr:`22526` by :user:`Meekail Zain <micky774>`.
 
 - |Fix| Adds :meth:`preprocessing.KBinDiscretizer.get_feature_names_out` support when
-  `encode="ordinal". :pr:`22735` by `Thomas Fan`_.
+  `encode="ordinal"`. :pr:`22735` by `Thomas Fan`_.
 
 :mod:`sklearn.random_projection`
 ................................

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -308,7 +308,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             )
             # Fit the OneHotEncoder with toy datasets
             # so that it's ready for use after the KBinsDiscretizer is fitted
-            self._encoder.fit(np.zeros((1, len(self.n_bins_)), dtype=np.int64))
+            self._encoder.fit(np.zeros((1, len(self.n_bins_))))
 
         return self
 

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -308,7 +308,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             )
             # Fit the OneHotEncoder with toy datasets
             # so that it's ready for use after the KBinsDiscretizer is fitted
-            self._encoder.fit(np.zeros((1, len(self.n_bins_))))
+            self._encoder.fit(np.zeros((1, len(self.n_bins_)), dtype=np.int64))
 
         return self
 
@@ -449,4 +449,8 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             Transformed feature names.
         """
         input_features = _check_feature_names_in(self, input_features)
-        return self._encoder.get_feature_names_out(input_features)
+        if hasattr(self, "_encoder"):
+            return self._encoder.get_feature_names_out(input_features)
+
+        # ordinal encoding
+        return input_features

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -308,7 +308,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             )
             # Fit the OneHotEncoder with toy datasets
             # so that it's ready for use after the KBinsDiscretizer is fitted
-            self._encoder.fit(np.zeros((1, len(self.n_bins_))))
+            self._encoder.fit(np.zeros((1, len(self.n_bins_)), dtype=np.int64))
 
         return self
 

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -439,13 +439,21 @@ def test_kbinsdiscretizer_subsample_values(subsample):
     [
         (
             "onehot",
-            [f"feat{i}_{j}" for i in range(3) for j in np.arange(4, dtype=np.float32)],
+            [
+                f"feat{col_id}_{bin_id}"
+                for col_id in range(3)
+                for bin_id in np.arange(4, dtype=np.float32)
+            ],
         ),
         (
             "onehot-dense",
-            [f"feat{i}_{j}" for i in range(3) for j in np.arange(4, dtype=np.float32)],
+            [
+                f"feat{col_id}_{bin_id}"
+                for col_id in range(3)
+                for bin_id in np.arange(4, dtype=np.float32)
+            ],
         ),
-        ("ordinal", [f"feat{i}" for i in range(3)]),
+        ("ordinal", [f"feat{col_id}" for col_id in range(3)]),
     ],
 )
 def test_kbinsdiscrtizer_get_feature_names_out(encode, expected_names):

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -439,19 +439,11 @@ def test_kbinsdiscretizer_subsample_values(subsample):
     [
         (
             "onehot",
-            [
-                f"feat{col_id}_{bin_id}"
-                for col_id in range(3)
-                for bin_id in np.arange(4, dtype=np.float32)
-            ],
+            [f"feat{col_id}_{bin_id}" for col_id in range(3) for bin_id in range(4)],
         ),
         (
             "onehot-dense",
-            [
-                f"feat{col_id}_{bin_id}"
-                for col_id in range(3)
-                for bin_id in np.arange(4, dtype=np.float32)
-            ],
+            [f"feat{col_id}_{bin_id}" for col_id in range(3) for bin_id in range(4)],
         ),
         ("ordinal", [f"feat{col_id}" for col_id in range(3)]),
     ],

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -439,11 +439,11 @@ def test_kbinsdiscretizer_subsample_values(subsample):
     [
         (
             "onehot",
-            [f"feat{i}_{j}" for i in range(3) for j in range(4)],
+            [f"feat{i}_{j}" for i in range(3) for j in np.arange(4, dtype=np.float32)],
         ),
         (
             "onehot-dense",
-            [f"feat{i}_{j}" for i in range(3) for j in range(4)],
+            [f"feat{i}_{j}" for i in range(3) for j in np.arange(4, dtype=np.float32)],
         ),
         ("ordinal", [f"feat{i}" for i in range(3)]),
     ],

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -439,11 +439,19 @@ def test_kbinsdiscretizer_subsample_values(subsample):
     [
         (
             "onehot",
-            [f"feat{col_id}_{bin_id}" for col_id in range(3) for bin_id in range(4)],
+            [
+                f"feat{col_id}_{float(bin_id)}"
+                for col_id in range(3)
+                for bin_id in range(4)
+            ],
         ),
         (
             "onehot-dense",
-            [f"feat{col_id}_{bin_id}" for col_id in range(3) for bin_id in range(4)],
+            [
+                f"feat{col_id}_{float(bin_id)}"
+                for col_id in range(3)
+                for bin_id in range(4)
+            ],
         ),
         ("ordinal", [f"feat{col_id}" for col_id in range(3)]),
     ],

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -432,3 +432,31 @@ def test_kbinsdiscretizer_subsample_values(subsample):
             kbd_default.bin_edges_[0] == kbd_with_subsampling.bin_edges_[0]
         )
         assert kbd_default.bin_edges_.shape == kbd_with_subsampling.bin_edges_.shape
+
+
+@pytest.mark.parametrize(
+    "encode, expected_names",
+    [
+        (
+            "onehot",
+            [f"feat{i}_{j}" for i in range(3) for j in range(4)],
+        ),
+        (
+            "onehot-dense",
+            [f"feat{i}_{j}" for i in range(3) for j in range(4)],
+        ),
+        ("ordinal", [f"feat{i}" for i in range(3)]),
+    ],
+)
+def test_kbinsdiscrtizer_get_feature_names_out(encode, expected_names):
+    """Check get_feature_names_out for different settings."""
+    X = [[-2, 1, -4], [-1, 2, -3], [0, 3, -2], [1, 4, -1]]
+
+    kbd = KBinsDiscretizer(n_bins=4, encode=encode).fit(X)
+    Xt = kbd.transform(X)
+
+    input_features = [f"feat{i}" for i in range(3)]
+    output_names = kbd.get_feature_names_out(input_features)
+    assert Xt.shape[1] == output_names.shape[0]
+
+    assert_array_equal(output_names, expected_names)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -457,7 +457,9 @@ def test_kbinsdiscretizer_subsample_values(subsample):
     ],
 )
 def test_kbinsdiscrtizer_get_feature_names_out(encode, expected_names):
-    """Check get_feature_names_out for different settings."""
+    """Check get_feature_names_out for different settings.
+    Non-regression test for #22731
+    """
     X = [[-2, 1, -4], [-1, 2, -3], [0, 3, -2], [1, 4, -1]]
 
     kbd = KBinsDiscretizer(n_bins=4, encode=encode).fit(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/22731

#### What does this implement/fix? Explain your changes.
This PR add feature names support to KBinsDiscretizer when `encode="ordinal"`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
