### PR TITLE
Add Blog to top menu bar

### DIFF
--- a/doc/themes/scikit-learn-modern/nav.html
+++ b/doc/themes/scikit-learn-modern/nav.html
@@ -58,6 +58,9 @@
         <li class="nav-item">
           <a class="sk-nav-link nav-link" href="{{ pathto('auto_examples/index') }}">Examples</a>
         </li>
+        <li class="nav-item">
+          <a class="sk-nav-link nav-link" href="https://blog.scikit-learn.org/">Community</a>
+        </li>
         {%- for title, link in drop_down_navigation %}
         <li class="nav-item">
           <a class="sk-nav-link nav-link nav-more-item-mobile-items" href="{{ link }}">{{ title }}</a>

--- a/doc/themes/scikit-learn-modern/nav.html
+++ b/doc/themes/scikit-learn-modern/nav.html
@@ -59,7 +59,7 @@
           <a class="sk-nav-link nav-link" href="{{ pathto('auto_examples/index') }}">Examples</a>
         </li>
         <li class="nav-item">
-          <a class="sk-nav-link nav-link" href="https://blog.scikit-learn.org/">Community</a>
+          <a class="sk-nav-link nav-link" target="_blank" rel="noopener noreferrer" href="https://blog.scikit-learn.org/">Community</a>
         </li>
         {%- for title, link in drop_down_navigation %}
         <li class="nav-item">


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #22337. See also #65.

#### What does this implement/fix? Explain your changes.
It is adding a "Community" element to the top menu bar of scikit-learn.org pointing to blog.scikit-learn.org
![Screenshot from 2022-03-09 16-51-14](https://user-images.githubusercontent.com/98105626/157478594-155cd3d0-c1ba-486f-a61f-0647aeb38319.png)
