### PR TITLE
DOC Ensures ledoit_wolf_shrinkage passes numpydoc

### DIFF
--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -186,7 +186,7 @@ class ShrunkCovariance(EmpiricalCovariance):
 
 
 def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
-    """Estimates the shrunk Ledoit-Wolf covariance matrix.
+    """Estimate the shrunk Ledoit-Wolf covariance matrix.
 
     Read more in the :ref:`User Guide <shrunk_covariance>`.
 

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -13,7 +13,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 
 FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.covariance._shrunk_covariance.ledoit_wolf",
-    "sklearn.covariance._shrunk_covariance.ledoit_wolf_shrinkage",
     "sklearn.datasets._base.load_sample_image",
     "sklearn.datasets._base.load_wine",
     "sklearn.datasets._california_housing.fetch_california_housing",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#21350 

#### What does this implement/fix? Explain your changes.

This PR ensures that function `sklearn.covariance._shrunk_covariance.ledoit_wolf_shrinkage` passes numpydoc validation

* Remove sklearn.covariance._shrunk_covariance.ledoit_wolf_shrinkage from [FUNCTION_DOCSTRING_IGNORE_LIST](https://github.com/scikit-learn/scikit-learn/blob/5b04fe66e49f0a6409ee6701afba8a98d2ddcbc1/sklearn/tests/test_docstrings.py#L14) in sklearn.tests.test_docstrings.py
* Verify all tests are passing

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
