### PR TITLE
TST introducing the random_seed fixture

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,6 +147,7 @@ jobs:
         BLAS: 'mkl'
         COVERAGE: 'true'
         SHOW_SHORT_SUMMARY: 'true'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '42'  # default global random seed
 
 # Check compilation with Ubuntu bionic 18.04 LTS and scipy from conda-forge
 - template: build_tools/azure/posix.yml
@@ -168,6 +169,7 @@ jobs:
         BLAS: 'openblas'
         COVERAGE: 'false'
         BUILD_WITH_ICC: 'false'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '0'  # non-default seed
 
 - template: build_tools/azure/posix.yml
   parameters:
@@ -190,6 +192,7 @@ jobs:
         PANDAS_VERSION: 'none'
         THREADPOOLCTL_VERSION: 'min'
         COVERAGE: 'false'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '1'  # non-default seed
       # Linux + Python 3.8 build with OpenBLAS
       py38_conda_defaults_openblas:
         DISTRIB: 'conda'
@@ -201,6 +204,7 @@ jobs:
         MATPLOTLIB_VERSION: 'min'
         THREADPOOLCTL_VERSION: '2.2.0'
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '2'  # non-default seed
       # Linux environment to test the latest available dependencies.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:
@@ -210,6 +214,7 @@ jobs:
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '3'  # non-default seed
 
 - template: build_tools/azure/posix-docker.yml
   parameters:
@@ -231,6 +236,7 @@ jobs:
         PYTEST_XDIST_VERSION: 'none'
         PYTEST_VERSION: 'min'
         THREADPOOLCTL_VERSION: '2.2.0'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '4'  # non-default seed
 
 - template: build_tools/azure/posix.yml
   parameters:
@@ -249,12 +255,14 @@ jobs:
         BLAS: 'mkl'
         CONDA_CHANNEL: 'conda-forge'
         CPU_COUNT: '3'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '5'  # non-default seed
       pylatest_conda_mkl_no_openmp:
         DISTRIB: 'conda'
         BLAS: 'mkl'
         SKLEARN_TEST_NO_OPENMP: 'true'
         SKLEARN_SKIP_OPENMP_TEST: 'true'
         CPU_COUNT: '3'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '6'  # non-default seed
 
 - template: build_tools/azure/windows.yml
   parameters:
@@ -280,6 +288,8 @@ jobs:
         # Temporary fix for setuptools to use disutils from standard lib
         # https://github.com/numpy/numpy/issues/17216
         SETUPTOOLS_USE_DISTUTILS: 'stdlib'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '7'  # non-default seed
       py38_pip_openblas_32bit:
         PYTHON_VERSION: '3.8'
         PYTHON_ARCH: '32'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '8'  # non-default seed

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -15,6 +15,13 @@ if [[ "$BUILD_WITH_ICC" == "true" ]]; then
     source /opt/intel/oneapi/setvars.sh
 fi
 
+if [[ "$BUILD_REASON" == "Schedule" ]]; then
+    # Enable global random seed randomization to discover seed-sensitive tests
+    # only on nightly builds.
+    # https://scikit-learn.org/stable/computing/parallelism.html#environment-variables
+    export SKLEARN_TESTS_GLOBAL_RANDOM_SEED="any"
+fi
+
 mkdir -p $TEST_DIR
 cp setup.cfg $TEST_DIR
 cd $TEST_DIR

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -194,6 +194,50 @@ These environment variables should be set before importing scikit-learn.
     Sets the seed of the global random generator when running the tests,
     for reproducibility.
 
+    Note that scikit-learn tests are expected to run deterministically with
+    explicit seeding of their own independent RNG instances instead of relying
+    on the numpy or Python standard library RNG singletons to make sure that
+    test results are independent of the test execution order. However some
+    tests might forget to use explicit seeding and this variable is a way to
+    control the intial state of the aforementioned singletons.
+
+:SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
+
+    Controls the seeding of the random number generator used in tests that
+    rely on the `global_random_seed`` fixture.
+
+    All tests that use this fixture accept the contract that they should
+    deterministically pass for any seed value from 0 to 99 included.
+
+    If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is not set
+    (which should be the default, in particular on the CI), the fixture will
+    choose an arbitrary seed in the above range and all fixtured tests will run
+    for that specific seed. This ensures that over time, our CI will run all
+    tests with different seeds while keeping the test duration of a single run
+    of the full test suite limited. This will enforce that the tests assertions
+    of tests written to use this fixture are not dependent on a specific seed
+    value.
+
+    The range of admissible seed values is limited to [0, 99] because it is
+    often not possible to write a test that can work for any possible seed
+    and we want to avoid having tests that randomly fail on the CI.
+
+    Valid values for SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
+
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="0,1,42": run tests for seeds of 0, 1
+      and 42
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": integers between 40 and 42
+      included
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": integers between 0 and 99
+      included
+
+    When writing a new test function that uses this fixture, please use the
+    following command to make sure that it passes deterministically for all
+    admissible seeds on your local machine:
+
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
+
 :SKLEARN_SKIP_NETWORK_TESTS:
 
     When this environment variable is set to a non zero value, the tests

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -215,7 +215,7 @@ These environment variables should be set before importing scikit-learn.
     or the current day) and all fixtured tests will run for that specific seed.
     The goal is to ensure that, over time, our CI will run all tests with
     different seeds while keeping the test duration of a single run of the full
-    test suite limited. This will check that the tests assertions of tests
+    test suite limited. This will check that the assertions of tests
     written to use this fixture are not dependent on a specific seed value.
 
     The range of admissible seed values is limited to [0, 99] because it is

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -225,12 +225,10 @@ These environment variables should be set before importing scikit-learn.
     Valid values for SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
 
     - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="0,1,42": run tests for seeds of 0, 1
-      and 42
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": integers between 40 and 42
-      included
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": integers between 0 and 99
-      included
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": run the tests with all seeds
+      between 40 and 42 included
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": run the tests with all seeds
+      between 0 and 99 included
 
     When writing a new test function that uses this fixture, please use the
     following command to make sure that it passes deterministically for all

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -233,14 +233,14 @@ These environment variables should be set before importing scikit-learn.
       between 0 and 99 included
 
     If the variable is not set, then 42 is used as the global seed in a
-    deterministic manner. This will make sure by default, the scikit-learn test
-    suite is as deterministic as possible which is useful to avoid disruption
-    of friendly third-party package maintainers. Similarly, this variable
-    should not be set in the CI config of pull-request runs to make sure that
-    our friendly contributors are not the first people to encounter a
-    seed-sensitivity regression in a test unrelated to the changes of their PR.
-    Only the scikit-learn maintainers who watch the results of the nightly
-    builds are expected to be annoyed by this.
+    deterministic manner. This ensures that, by default, the scikit-learn test
+    suite is as deterministic as possible to avoid disrupting our friendly
+    third-party package maintainers. Similarly, this variable should not be set
+    in the CI config of pull-requests to make sure that our friendly
+    contributors are not the first people to encounter a seed-sensitivity
+    regression in a test unrelated to the changes of their own PR. Only the
+    scikit-learn maintainers who watch the results of the nightly builds are
+    expected to be annoyed by this.
 
     When writing a new test function that uses this fixture, please use the
     following command to make sure that it passes deterministically for all

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -209,26 +209,38 @@ These environment variables should be set before importing scikit-learn.
     All tests that use this fixture accept the contract that they should
     deterministically pass for any seed value from 0 to 99 included.
 
-    If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is not set
-    (which should be the default, in particular on the CI), the fixture will
-    choose an arbitrary seed in the above range and all fixtured tests will run
-    for that specific seed. This ensures that over time, our CI will run all
-    tests with different seeds while keeping the test duration of a single run
-    of the full test suite limited. This will enforce that the tests assertions
-    of tests written to use this fixture are not dependent on a specific seed
-    value.
+    If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is set to
+    "any" (which should be the case on nightly builds on the CI), the fixture
+    will choose an arbitrary seed in the above range (based on the BUILD_NUMBER
+    or the current day) and all fixtured tests will run for that specific seed.
+    The goal is to ensure that, over time, our CI will run all tests with
+    different seeds while keeping the test duration of a single run of the full
+    test suite limited. This will check that the tests assertions of tests
+    written to use this fixture are not dependent on a specific seed value.
 
     The range of admissible seed values is limited to [0, 99] because it is
-    often not possible to write a test that can work for any possible seed
-    and we want to avoid having tests that randomly fail on the CI.
+    often not possible to write a test that can work for any possible seed and
+    we want to avoid having tests that randomly fail on the CI.
 
     Valid values for SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
 
     - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
     - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": run the tests with all seeds
       between 40 and 42 included
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="any": run the tests with an arbitrary
+      seed selected between 0 and 99 included
     - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": run the tests with all seeds
       between 0 and 99 included
+
+    If the variable is not set, then 42 is used as the global seed in a
+    deterministic manner. This will make sure by default, the scikit-learn test
+    suite is as deterministic as possible which is useful to avoid disruption
+    of friendly third-party package maintainers. Similarly, this variable
+    should not be set in the CI config of pull-request runs to make sure that
+    our friendly contributors are not the first people to encounter a
+    seed-sensitivity regression in a test unrelated to the changes of their PR.
+    Only the scikit-learn maintainers who watch the results of the nightly
+    builds are expected to be annoyed by this.
 
     When writing a new test function that uses this fixture, please use the
     following command to make sure that it passes deterministically for all

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,9 @@ addopts =
     --doctest-modules
     --disable-pytest-warnings
     --color=yes
+    # Activate the plugin explicitly to ensure that the seed is reported
+    # correctly on the CI when running `pytest --pyargs sklearn` from the
+    # source folder.
     -p sklearn.tests.random_seed
     -rN
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ addopts =
     --doctest-modules
     --disable-pytest-warnings
     --color=yes
+    -p sklearn.tests.random_seed
     -rN
 
 filterwarnings =

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -148,9 +148,9 @@ def test_relocate_empty_clusters(array_constr):
     "array_constr", [np.array, sp.csr_matrix], ids=["dense", "sparse"]
 )
 @pytest.mark.parametrize("tol", [1e-2, 1e-8, 1e-100, 0])
-def test_kmeans_elkan_results(distribution, array_constr, tol, random_seed):
+def test_kmeans_elkan_results(distribution, array_constr, tol, global_random_seed):
     # Check that results are identical between lloyd and elkan algorithms
-    rnd = np.random.RandomState(random_seed)
+    rnd = np.random.RandomState(global_random_seed)
     if distribution == "normal":
         X = rnd.normal(size=(5000, 10))
     else:

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -148,9 +148,9 @@ def test_relocate_empty_clusters(array_constr):
     "array_constr", [np.array, sp.csr_matrix], ids=["dense", "sparse"]
 )
 @pytest.mark.parametrize("tol", [1e-2, 1e-8, 1e-100, 0])
-def test_kmeans_elkan_results(distribution, array_constr, tol):
+def test_kmeans_elkan_results(distribution, array_constr, tol, random_seed):
     # Check that results are identical between lloyd and elkan algorithms
-    rnd = np.random.RandomState(0)
+    rnd = np.random.RandomState(random_seed)
     if distribution == "normal":
         X = rnd.normal(size=(5000, 10))
     else:

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -21,6 +21,10 @@ from sklearn.datasets import fetch_olivetti_faces
 from sklearn.datasets import fetch_rcv1
 
 
+# This plugin is necessary to define the random seed fixture
+pytest_plugins = ("sklearn.tests.random_seed",)
+
+
 if parse_version(pytest.__version__) < parse_version(PYTEST_MIN_VERSION):
     raise ImportError(
         "Your version of pytest is too old, you should have "

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -2,8 +2,6 @@ from os import environ
 from functools import wraps
 import platform
 import sys
-from random import Random
-from datetime import datetime
 
 import pytest
 from threadpoolctl import threadpool_limits
@@ -229,77 +227,3 @@ def pytest_configure(config):
         matplotlib.use("agg")
     except ImportError:
         pass
-
-
-# Definition of the random_seed fixture. See the docstring of the fixture for
-# more information.
-
-RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
-random_seed_var = environ.get("SKLEARN_TESTS_RANDOM_SEED")
-if random_seed_var is None:
-    # If the environment variable is not defined, pick-up one seed at random in
-    # the range of admissible random seeds. Note, to make sure that all
-    # pytest-xdist workers see the same seed, we seed the meta-random number
-    # generator with a value derived from the year and the day.
-    rng = Random(int(datetime.now().strftime("%Y%j")))
-    random_seeds = [rng.choice(RANDOM_SEED_RANGE)]
-elif random_seed_var == "all":
-    random_seeds = RANDOM_SEED_RANGE
-else:
-    if "-" in random_seed_var:
-        start, stop = random_seed_var.split("-")
-        random_seeds = list(range(int(start), int(stop) + 1))
-    else:
-        random_seeds = [int(s) for s in random_seed_var.split(",")]
-
-    if min(random_seeds) < 0 or max(random_seeds) > 99:
-        raise ValueError(
-            "The value(s) of the environment variable SKLEARN_TESTS_RANDOM_SEED "
-            f"must be in the range [0, 99] (or 'all'), got: {random_seed_var}"
-        )
-
-
-def pytest_report_header(config):
-    if random_seeds == RANDOM_SEED_RANGE:
-        seed_values = "all"
-    else:
-        seed_values = ",".join(str(s) for s in random_seeds)
-    return [
-        "To reproduce this test run, set the following environment variable:",
-        f'    SKLEARN_TESTS_RANDOM_SEED="{seed_values}"',
-    ]
-
-
-@pytest.fixture(params=random_seeds)
-def random_seed(request):
-    """Fixture to ask for a random yet controllable random seed.
-
-    All tests that use this fixture accept the contract that they should
-    deterministically pass for any seed value from 0 to 99 included.
-
-    If the SKLEARN_TESTS_RANDOM_SEED environment variable is not set (which
-    should be the default, in particular on the CI), the fixture will choose an
-    arbitrary seed in the above range and all fixtured tests will run for that
-    specific seed. This ensures that over time, our CI will run all tests with
-    different seeds while keeping the test duration of a single run of the full
-    test suite limited. This will enforce that the tests assertions of tests
-    written to use this fixture are not dependent on a specific seed value.
-
-    The range of admissible seed values is limited to [0, 99] because it is
-    often not possible to write a test that can work for any possible seed
-    and we want to avoid having tests that randomly fail on the CI.
-
-    Valid values for SKLEARN_TESTS_RANDOM_SEED:
-
-    - SKLEARN_TESTS_RANDOM_SEED="42": run tests with a fixed seed of 42
-    - SKLEARN_TESTS_RANDOM_SEED="0,1,42": run tests for seeds of 0, 1 and 42
-    - SKLEARN_TESTS_RANDOM_SEED="40-42": integers between 40 and 42 included
-    - SKLEARN_TESTS_RANDOM_SEED="all": integers between 0 and 99 included
-
-    When writing a new test function that uses this fixture, please use the
-    following command to make sure that it passes deterministically for all
-    admissible seeds on your local machine:
-
-        SKLEARN_TESTS_RANDOM_SEED="all" pytest -v -k test_your_test_name
-    """
-    yield request.param

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -2,7 +2,8 @@ from os import environ
 from functools import wraps
 import platform
 import sys
-import random
+from random import Random
+from datetime import datetime
 
 import pytest
 from threadpoolctl import threadpool_limits
@@ -237,8 +238,11 @@ RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
 random_seed_var = environ.get("SKLEARN_TESTS_RANDOM_SEED")
 if random_seed_var is None:
     # If the environment variable is not defined, pick-up one seed at random in
-    # the range of admissible random seeds.
-    random_seeds = [random.choice(RANDOM_SEED_RANGE)]
+    # the range of admissible random seeds. Note, to make sure that all
+    # pytest-xdist workers see the same seed, we seed the meta-random number
+    # generator with a value derived from the year and the day.
+    rng = Random(int(datetime.now().strftime("%Y%j")))
+    random_seeds = [rng.choice(RANDOM_SEED_RANGE)]
 elif random_seed_var == "all":
     random_seeds = RANDOM_SEED_RANGE
 else:

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -252,11 +252,11 @@ else:
     else:
         random_seeds = [int(s) for s in random_seed_var.split(",")]
 
-if min(random_seeds) < 0 or max(random_seeds) > 99:
-    raise ValueError(
-        "The value(s) of the environment variable SKLEARN_TESTS_RANDOM_SEED "
-        f"must be in the range [0, 99] (or 'all'), got: {random_seed_var}"
-    )
+    if min(random_seeds) < 0 or max(random_seeds) > 99:
+        raise ValueError(
+            "The value(s) of the environment variable SKLEARN_TESTS_RANDOM_SEED "
+            f"must be in the range [0, 99] (or 'all'), got: {random_seed_var}"
+        )
 
 
 def pytest_report_header(config):

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -264,10 +264,10 @@ def pytest_report_header(config):
         seed_values = "all"
     else:
         seed_values = ",".join(str(s) for s in random_seeds)
-    return (
-        "To reproduce this test run, set the following environment variable:\n"
-        f'    SKLEARN_TESTS_RANDOM_SEED="{seed_values}"'
-    )
+    return [
+        "To reproduce this test run, set the following environment variable:",
+        f'    SKLEARN_TESTS_RANDOM_SEED="{seed_values}"',
+    ]
 
 
 @pytest.fixture(params=random_seeds)

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -286,7 +286,8 @@ def random_seed(request):
     written to use this fixture are not dependent on a specific seed value.
 
     The range of admissible seed values is limited to [0, 99] because it is
-    often not possible to write a test that can work for any possible seed.
+    often not possible to write a test that can work for any possible seed
+    and we want to avoid having tests that randomly fail on the CI.
 
     Valid values for SKLEARN_TESTS_RANDOM_SEED:
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -248,9 +248,9 @@ elif random_seed_var == "all":
 else:
     if "-" in random_seed_var:
         start, stop = random_seed_var.split("-")
-        random_seeds = list(range(int(start.strip()), int(stop.strip()) + 1))
+        random_seeds = list(range(int(start), int(stop) + 1))
     else:
-        random_seeds = [int(s.strip()) for s in random_seed_var.split(",")]
+        random_seeds = [int(s) for s in random_seed_var.split(",")]
 
 if min(random_seeds) < 0 or max(random_seeds) > 99:
     raise ValueError(

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -298,7 +298,7 @@ def random_seed(request):
 
     When writing a new test function that uses this fixture, please use the
     following command to make sure that it passes deterministically for all
-    adminissible seeds on your local machine:
+    admissible seeds on your local machine:
 
         SKLEARN_TESTS_RANDOM_SEED="all" pytest -v -k test_your_test_name
     """

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -278,8 +278,8 @@ def random_seed(request):
     deterministically pass for any seed value from 0 to 99 included.
 
     If the SKLEARN_TESTS_RANDOM_SEED environment variable is not set (which
-    should be the default, in particular on the CI), the fixture will randomly
-    choose on seed in the above range and all fixtured tests will run for that
+    should be the default, in particular on the CI), the fixture will choose an
+    arbitrary seed in the above range and all fixtured tests will run for that
     specific seed. This ensures that over time, our CI will run all tests with
     different seeds while keeping the test duration of a single run of the full
     test suite limited. This will enforce that the tests assertions of tests

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -2,6 +2,7 @@ from os import environ
 from functools import wraps
 import platform
 import sys
+import random
 
 import pytest
 from threadpoolctl import threadpool_limits
@@ -227,3 +228,73 @@ def pytest_configure(config):
         matplotlib.use("agg")
     except ImportError:
         pass
+
+
+# Definition of the random_seed fixture. See the docstring of the fixture for
+# more information.
+
+RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
+random_seed_var = environ.get("SKLEARN_TESTS_RANDOM_SEED")
+if random_seed_var is None:
+    # If the environment variable is not defined, pick-up one seed at random in
+    # the range of admissible random seeds.
+    random_seeds = [random.choice(RANDOM_SEED_RANGE)]
+elif random_seed_var == "all":
+    random_seeds = RANDOM_SEED_RANGE
+else:
+    if "-" in random_seed_var:
+        start, stop = random_seed_var.split("-")
+        random_seeds = list(range(int(start.strip()), int(stop.strip()) + 1))
+    else:
+        random_seeds = [int(s.strip()) for s in random_seed_var.split(",")]
+
+if min(random_seeds) < 0 or max(random_seeds) > 99:
+    raise ValueError(
+        "The value(s) of the environment variable SKLEARN_TESTS_RANDOM_SEED "
+        f"must be in the range [0, 99] (or 'all'), got: {random_seed_var}"
+    )
+
+
+def pytest_report_header(config):
+    if random_seeds == RANDOM_SEED_RANGE:
+        seed_values = "all"
+    else:
+        seed_values = ",".join(str(s) for s in random_seeds)
+    return (
+        "To reproduce this test run, set the following environment variable:\n"
+        f'    SKLEARN_TESTS_RANDOM_SEED="{seed_values}"'
+    )
+
+
+@pytest.fixture(params=random_seeds)
+def random_seed(request):
+    """Fixture to ask for a random yet controllable random seed.
+
+    All tests that use this fixture accept the contract that they should
+    deterministically pass for any seed value from 0 to 99 included.
+
+    If the SKLEARN_TESTS_RANDOM_SEED environment variable is not set (which
+    should be the default, in particular on the CI), the fixture will randomly
+    choose on seed in the above range and all fixtured tests will run for that
+    specific seed. This ensures that over time, our CI will run all tests with
+    different seeds while keeping the test duration of a single run of the full
+    test suite limited. This will enforce that the tests assertions of tests
+    written to use this fixture are not dependent on a specific seed value.
+
+    The range of admissible seed values is limited to [0, 99] because it is
+    often not possible to write a test that can work for any possible seed.
+
+    Valid values for SKLEARN_TESTS_RANDOM_SEED:
+
+    - SKLEARN_TESTS_RANDOM_SEED="42": run tests with a fixed seed of 42
+    - SKLEARN_TESTS_RANDOM_SEED="0,1,42": run tests for seeds of 0, 1 and 42
+    - SKLEARN_TESTS_RANDOM_SEED="40-42": integers between 40 and 42 included
+    - SKLEARN_TESTS_RANDOM_SEED="all": integers between 0 and 99 included
+
+    When writing a new test function that uses this fixture, please use the
+    following command to make sure that it passes deterministically for all
+    adminissible seeds on your local machine:
+
+        SKLEARN_TESTS_RANDOM_SEED="all" pytest -v -k test_your_test_name
+    """
+    yield request.param

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -1,0 +1,77 @@
+import pytest
+from os import environ
+from random import Random
+from datetime import datetime
+
+# Definition of the random_seed fixture. See the docstring of the fixture for
+# more information.
+
+RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
+random_seed_var = environ.get("SKLEARN_TESTS_RANDOM_SEED")
+if random_seed_var is None:
+    # If the environment variable is not defined, pick-up one seed at random in
+    # the range of admissible random seeds. Note, to make sure that all
+    # pytest-xdist workers see the same seed, we seed the meta-random number
+    # generator with a value derived from the year and the day.
+    rng = Random(int(datetime.now().strftime("%Y%j")))
+    random_seeds = [rng.choice(RANDOM_SEED_RANGE)]
+elif random_seed_var == "all":
+    random_seeds = RANDOM_SEED_RANGE
+else:
+    if "-" in random_seed_var:
+        start, stop = random_seed_var.split("-")
+        random_seeds = list(range(int(start), int(stop) + 1))
+    else:
+        random_seeds = [int(s) for s in random_seed_var.split(",")]
+
+    if min(random_seeds) < 0 or max(random_seeds) > 99:
+        raise ValueError(
+            "The value(s) of the environment variable SKLEARN_TESTS_RANDOM_SEED "
+            f"must be in the range [0, 99] (or 'all'), got: {random_seed_var}"
+        )
+
+
+def pytest_report_header(config):
+    if random_seeds == RANDOM_SEED_RANGE:
+        seed_values = "all"
+    else:
+        seed_values = ",".join(str(s) for s in random_seeds)
+    return [
+        "To reproduce this test run, set the following environment variable:",
+        f'    SKLEARN_TESTS_RANDOM_SEED="{seed_values}"',
+    ]
+
+
+@pytest.fixture(params=random_seeds)
+def random_seed(request):
+    """Fixture to ask for a random yet controllable random seed.
+
+    All tests that use this fixture accept the contract that they should
+    deterministically pass for any seed value from 0 to 99 included.
+
+    If the SKLEARN_TESTS_RANDOM_SEED environment variable is not set (which
+    should be the default, in particular on the CI), the fixture will choose an
+    arbitrary seed in the above range and all fixtured tests will run for that
+    specific seed. This ensures that over time, our CI will run all tests with
+    different seeds while keeping the test duration of a single run of the full
+    test suite limited. This will enforce that the tests assertions of tests
+    written to use this fixture are not dependent on a specific seed value.
+
+    The range of admissible seed values is limited to [0, 99] because it is
+    often not possible to write a test that can work for any possible seed
+    and we want to avoid having tests that randomly fail on the CI.
+
+    Valid values for SKLEARN_TESTS_RANDOM_SEED:
+
+    - SKLEARN_TESTS_RANDOM_SEED="42": run tests with a fixed seed of 42
+    - SKLEARN_TESTS_RANDOM_SEED="0,1,42": run tests for seeds of 0, 1 and 42
+    - SKLEARN_TESTS_RANDOM_SEED="40-42": integers between 40 and 42 included
+    - SKLEARN_TESTS_RANDOM_SEED="all": integers between 0 and 99 included
+
+    When writing a new test function that uses this fixture, please use the
+    following command to make sure that it passes deterministically for all
+    admissible seeds on your local machine:
+
+        SKLEARN_TESTS_RANDOM_SEED="all" pytest -v -k test_your_test_name
+    """
+    yield request.param

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -10,11 +10,16 @@ RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
 random_seed_var = environ.get("SKLEARN_TESTS_GLOBAL_RANDOM_SEED")
 if random_seed_var is None:
     # If the environment variable is not defined, pick-up one seed at random in
-    # the range of admissible random seeds. Note, to make sure that all
-    # pytest-xdist workers see the same seed, we seed the meta-random number
-    # generator with a value derived from the year and the day.
-    rng = Random(int(datetime.now().strftime("%Y%j")))
-    random_seeds = [rng.choice(RANDOM_SEED_RANGE)]
+    # the range of admissible random seeds.
+    #
+    # Note, to make sure that all pytest-xdist workers see the same seed, we
+    # seed the meta-random number generator with a value derived either from a
+    # CI build number variables, or from the year and the day for local builds
+    try:
+        meta_seed = int(environ["BUILD_NUMBER"])
+    except (KeyError, ValueError):
+        meta_seed = int(datetime.now().strftime("%Y%j"))
+    random_seeds = [Random(meta_seed).choice(RANDOM_SEED_RANGE)]
 elif random_seed_var == "all":
     random_seeds = RANDOM_SEED_RANGE
 else:

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -80,14 +80,14 @@ def global_random_seed(request):
       between 0 and 99 included
 
     If the variable is not set, then 42 is used as the global seed in a
-    deterministic manner. This will make sure by default, the scikit-learn test
-    suite is as deterministic as possible which is useful to avoid disruption
-    of friendly third-party package maintainers. Similarly, this variable
-    should not be set in the CI config of pull-request runs to make sure that
-    our friendly contributors are not the first people to encounter a
-    seed-sensitivity regression in a test unrelated to the changes of their PR.
-    Only the scikit-learn maintainers who watch the results of the nightly
-    builds are expected to be annoyed by this.
+    deterministic manner. This ensures that, by default, the scikit-learn test
+    suite is as deterministic as possible to avoid disrupting our friendly
+    third-party package maintainers. Similarly, this variable should not be set
+    in the CI config of pull-requests to make sure that our friendly
+    contributors are not the first people to encounter a seed-sensitivity
+    regression in a test unrelated to the changes of their own PR. Only the
+    scikit-learn maintainers who watch the results of the nightly builds are
+    expected to be annoyed by this.
 
     When writing a new test function that uses this fixture, please use the
     following command to make sure that it passes deterministically for all

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -1,3 +1,13 @@
+"""global_random_seed fixture
+
+The goal of this fixture is to prevent tests that use it to be sensitive
+to a specific seed value while still being deterministic by default.
+
+See the documentation for the SKLEARN_TESTS_GLOBAL_RANDOM_SEED
+variable for insrtuctions on how to use this fixture.
+
+https://scikit-learn.org/dev/computing/parallelism.html#environment-variables
+"""
 import pytest
 from os import environ
 from random import Random
@@ -15,8 +25,6 @@ def pytest_configure(config):
     if config.pluginmanager.hasplugin("xdist"):
         config.pluginmanager.register(XDistHooks())
 
-    # Definition of the random_seed fixture. See the docstring of the fixture for
-    # more information.
     RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
     random_seed_var = environ.get("SKLEARN_TESTS_GLOBAL_RANDOM_SEED")
     if hasattr(config, "workinput"):
@@ -54,44 +62,10 @@ def pytest_configure(config):
             All tests that use this fixture accept the contract that they should
             deterministically pass for any seed value from 0 to 99 included.
 
-            If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is set to
-            "any" (which should be the case on nightly builds on the CI), the fixture
-            will choose an arbitrary seed in the above range (based on the BUILD_NUMBER
-            or the current day) and all fixtured tests will run for that specific seed.
-            The goal is to ensure that, over time, our CI will run all tests with
-            different seeds while keeping the test duration of a single run of the full
-            test suite limited. This will check that the tests assertions of tests
-            written to use this fixture are not dependent on a specific seed value.
+            See the documentation for the SKLEARN_TESTS_GLOBAL_RANDOM_SEED
+            variable for insrtuctions on how to use this fixture.
 
-            The range of admissible seed values is limited to [0, 99] because it is
-            often not possible to write a test that can work for any possible seed and
-            we want to avoid having tests that randomly fail on the CI.
-
-            Valid values for SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
-
-            - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
-            - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": run the tests with all seeds
-            between 40 and 42 included
-            - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="any": run the tests with an arbitrary
-            seed selected between 0 and 99 included
-            - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": run the tests with all seeds
-            between 0 and 99 included
-
-            If the variable is not set, then 42 is used as the global seed in a
-            deterministic manner. This ensures that, by default, the scikit-learn test
-            suite is as deterministic as possible to avoid disrupting our friendly
-            third-party package maintainers. Similarly, this variable should not be set
-            in the CI config of pull-requests to make sure that our friendly
-            contributors are not the first people to encounter a seed-sensitivity
-            regression in a test unrelated to the changes of their own PR. Only the
-            scikit-learn maintainers who watch the results of the nightly builds are
-            expected to be annoyed by this.
-
-            When writing a new test function that uses this fixture, please use the
-            following command to make sure that it passes deterministically for all
-            admissible seeds on your local machine:
-
-                SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
+            https://scikit-learn.org/dev/computing/parallelism.html#environment-variables
             """
             yield request.param
 

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -7,7 +7,7 @@ from datetime import datetime
 # more information.
 
 RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
-random_seed_var = environ.get("SKLEARN_TESTS_RANDOM_SEED")
+random_seed_var = environ.get("SKLEARN_TESTS_GLOBAL_RANDOM_SEED")
 if random_seed_var is None:
     # If the environment variable is not defined, pick-up one seed at random in
     # the range of admissible random seeds. Note, to make sure that all
@@ -26,8 +26,9 @@ else:
 
     if min(random_seeds) < 0 or max(random_seeds) > 99:
         raise ValueError(
-            "The value(s) of the environment variable SKLEARN_TESTS_RANDOM_SEED "
-            f"must be in the range [0, 99] (or 'all'), got: {random_seed_var}"
+            "The value(s) of the environment variable "
+            "SKLEARN_TESTS_GLOBAL_RANDOM_SEED must be in the range [0, 99] "
+            f"(or 'all'), got: {random_seed_var}"
         )
 
 
@@ -38,12 +39,12 @@ def pytest_report_header(config):
         seed_values = ",".join(str(s) for s in random_seeds)
     return [
         "To reproduce this test run, set the following environment variable:",
-        f'    SKLEARN_TESTS_RANDOM_SEED="{seed_values}"',
+        f'    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="{seed_values}"',
     ]
 
 
 @pytest.fixture(params=random_seeds)
-def random_seed(request):
+def global_random_seed(request):
     """Fixture to ask for a random yet controllable random seed.
 
     All tests that use this fixture accept the contract that they should
@@ -58,20 +59,23 @@ def random_seed(request):
     written to use this fixture are not dependent on a specific seed value.
 
     The range of admissible seed values is limited to [0, 99] because it is
-    often not possible to write a test that can work for any possible seed
-    and we want to avoid having tests that randomly fail on the CI.
+    often not possible to write a test that can work for any possible seed and
+    we want to avoid having tests that randomly fail on the CI.
 
-    Valid values for SKLEARN_TESTS_RANDOM_SEED:
+    Valid values for SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
 
-    - SKLEARN_TESTS_RANDOM_SEED="42": run tests with a fixed seed of 42
-    - SKLEARN_TESTS_RANDOM_SEED="0,1,42": run tests for seeds of 0, 1 and 42
-    - SKLEARN_TESTS_RANDOM_SEED="40-42": integers between 40 and 42 included
-    - SKLEARN_TESTS_RANDOM_SEED="all": integers between 0 and 99 included
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="0,1,42": run tests for seeds of 0, 1
+      and 42
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": integers between 40 and 42
+      included
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": integers between 0 and 99
+      included
 
     When writing a new test function that uses this fixture, please use the
     following command to make sure that it passes deterministically for all
     admissible seeds on your local machine:
 
-        SKLEARN_TESTS_RANDOM_SEED="all" pytest -v -k test_your_test_name
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
     """
     yield request.param

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -3,96 +3,107 @@ from os import environ
 from random import Random
 from datetime import datetime
 
-# Definition of the random_seed fixture. See the docstring of the fixture for
-# more information.
 
-RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
-random_seed_var = environ.get("SKLEARN_TESTS_GLOBAL_RANDOM_SEED")
-if random_seed_var is None:
-    # This is the way.
-    random_seeds = [42]
-elif random_seed_var == "any":
-    # Pick-up one seed at random in the range of admissible random seeds.
-    #
-    # Note, to make sure that all pytest-xdist workers see the same seed, we
-    # seed the meta-random number generator with a value derived either from a
-    # CI build number variables, or from the year and the day for local builds
-    try:
-        meta_seed = int(environ["BUILD_NUMBER"])
-    except (KeyError, ValueError):
+# Passes the main worker's random seeds to workers
+class XDistHooks:
+    def pytest_configure_node(self, node) -> None:
+        random_seeds = node.config.getoption("random_seeds")
+        node.workerinput["random_seeds"] = random_seeds
+
+
+def pytest_configure(config):
+    if config.pluginmanager.hasplugin("xdist"):
+        config.pluginmanager.register(XDistHooks())
+
+    # Definition of the random_seed fixture. See the docstring of the fixture for
+    # more information.
+    RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
+    random_seed_var = environ.get("SKLEARN_TESTS_GLOBAL_RANDOM_SEED")
+    if hasattr(config, "workinput"):
+        # Set worker random seed from seed generated from main process
+        random_seeds = config.workerinput["random_seeds"]
+    elif random_seed_var is None:
+        # This is the way.
+        random_seeds = [42]
+    elif random_seed_var == "any":
+        # Pick-up one seed at random in the range of admissible random seeds.
         meta_seed = int(datetime.now().strftime("%Y%j"))
-    random_seeds = [Random(meta_seed).choice(RANDOM_SEED_RANGE)]
-elif random_seed_var == "all":
-    random_seeds = RANDOM_SEED_RANGE
-else:
-    if "-" in random_seed_var:
-        start, stop = random_seed_var.split("-")
-        random_seeds = list(range(int(start), int(stop) + 1))
+        random_seeds = [Random(meta_seed).choice(RANDOM_SEED_RANGE)]
+    elif random_seed_var == "all":
+        random_seeds = RANDOM_SEED_RANGE
     else:
-        random_seeds = [int(random_seed_var)]
+        if "-" in random_seed_var:
+            start, stop = random_seed_var.split("-")
+            random_seeds = list(range(int(start), int(stop) + 1))
+        else:
+            random_seeds = [int(random_seed_var)]
 
-    if min(random_seeds) < 0 or max(random_seeds) > 99:
-        raise ValueError(
-            "The value(s) of the environment variable "
-            "SKLEARN_TESTS_GLOBAL_RANDOM_SEED must be in the range [0, 99] "
-            f"(or 'any' or 'all'), got: {random_seed_var}"
-        )
+        if min(random_seeds) < 0 or max(random_seeds) > 99:
+            raise ValueError(
+                "The value(s) of the environment variable "
+                "SKLEARN_TESTS_GLOBAL_RANDOM_SEED must be in the range [0, 99] "
+                f"(or 'any' or 'all'), got: {random_seed_var}"
+            )
+    config.option.random_seeds = random_seeds
+
+    class GlobalRandomSeedPlugin:
+        @pytest.fixture(params=random_seeds)
+        def global_random_seed(self, request):
+            """Fixture to ask for a random yet controllable random seed.
+
+            All tests that use this fixture accept the contract that they should
+            deterministically pass for any seed value from 0 to 99 included.
+
+            If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is set to
+            "any" (which should be the case on nightly builds on the CI), the fixture
+            will choose an arbitrary seed in the above range (based on the BUILD_NUMBER
+            or the current day) and all fixtured tests will run for that specific seed.
+            The goal is to ensure that, over time, our CI will run all tests with
+            different seeds while keeping the test duration of a single run of the full
+            test suite limited. This will check that the tests assertions of tests
+            written to use this fixture are not dependent on a specific seed value.
+
+            The range of admissible seed values is limited to [0, 99] because it is
+            often not possible to write a test that can work for any possible seed and
+            we want to avoid having tests that randomly fail on the CI.
+
+            Valid values for SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
+
+            - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
+            - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": run the tests with all seeds
+            between 40 and 42 included
+            - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="any": run the tests with an arbitrary
+            seed selected between 0 and 99 included
+            - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": run the tests with all seeds
+            between 0 and 99 included
+
+            If the variable is not set, then 42 is used as the global seed in a
+            deterministic manner. This ensures that, by default, the scikit-learn test
+            suite is as deterministic as possible to avoid disrupting our friendly
+            third-party package maintainers. Similarly, this variable should not be set
+            in the CI config of pull-requests to make sure that our friendly
+            contributors are not the first people to encounter a seed-sensitivity
+            regression in a test unrelated to the changes of their own PR. Only the
+            scikit-learn maintainers who watch the results of the nightly builds are
+            expected to be annoyed by this.
+
+            When writing a new test function that uses this fixture, please use the
+            following command to make sure that it passes deterministically for all
+            admissible seeds on your local machine:
+
+                SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
+            """
+            yield request.param
+
+    config.pluginmanager.register(GlobalRandomSeedPlugin())
 
 
 def pytest_report_header(config):
+    random_seed_var = environ.get("SKLEARN_TESTS_GLOBAL_RANDOM_SEED")
     if random_seed_var == "any":
         return [
             "To reproduce this test run, set the following environment variable:",
-            f'    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="{random_seeds[0]}"',
+            f'    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="{config.option.random_seeds[0]}"',
             "See: https://scikit-learn.org/dev/computing/parallelism.html"
             "#environment-variables",
         ]
-
-
-@pytest.fixture(params=random_seeds)
-def global_random_seed(request):
-    """Fixture to ask for a random yet controllable random seed.
-
-    All tests that use this fixture accept the contract that they should
-    deterministically pass for any seed value from 0 to 99 included.
-
-    If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is set to
-    "any" (which should be the case on nightly builds on the CI), the fixture
-    will choose an arbitrary seed in the above range (based on the BUILD_NUMBER
-    or the current day) and all fixtured tests will run for that specific seed.
-    The goal is to ensure that, over time, our CI will run all tests with
-    different seeds while keeping the test duration of a single run of the full
-    test suite limited. This will check that the tests assertions of tests
-    written to use this fixture are not dependent on a specific seed value.
-
-    The range of admissible seed values is limited to [0, 99] because it is
-    often not possible to write a test that can work for any possible seed and
-    we want to avoid having tests that randomly fail on the CI.
-
-    Valid values for SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
-
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": run the tests with all seeds
-      between 40 and 42 included
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="any": run the tests with an arbitrary
-      seed selected between 0 and 99 included
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": run the tests with all seeds
-      between 0 and 99 included
-
-    If the variable is not set, then 42 is used as the global seed in a
-    deterministic manner. This ensures that, by default, the scikit-learn test
-    suite is as deterministic as possible to avoid disrupting our friendly
-    third-party package maintainers. Similarly, this variable should not be set
-    in the CI config of pull-requests to make sure that our friendly
-    contributors are not the first people to encounter a seed-sensitivity
-    regression in a test unrelated to the changes of their own PR. Only the
-    scikit-learn maintainers who watch the results of the nightly builds are
-    expected to be annoyed by this.
-
-    When writing a new test function that uses this fixture, please use the
-    following command to make sure that it passes deterministically for all
-    admissible seeds on your local machine:
-
-        SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
-    """
-    yield request.param

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -9,8 +9,10 @@ from datetime import datetime
 RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
 random_seed_var = environ.get("SKLEARN_TESTS_GLOBAL_RANDOM_SEED")
 if random_seed_var is None:
-    # If the environment variable is not defined, pick-up one seed at random in
-    # the range of admissible random seeds.
+    # This is the way.
+    random_seeds = [42]
+elif random_seed_var == "any":
+    # Pick-up one seed at random in the range of admissible random seeds.
     #
     # Note, to make sure that all pytest-xdist workers see the same seed, we
     # seed the meta-random number generator with a value derived either from a
@@ -33,19 +35,18 @@ else:
         raise ValueError(
             "The value(s) of the environment variable "
             "SKLEARN_TESTS_GLOBAL_RANDOM_SEED must be in the range [0, 99] "
-            f"(or 'all'), got: {random_seed_var}"
+            f"(or 'any' or 'all'), got: {random_seed_var}"
         )
 
 
 def pytest_report_header(config):
-    if len(random_seeds) == 1:
-        repro_value = random_seeds[0]
-    else:
-        repro_value = random_seed_var
-    return [
-        "To reproduce this test run, set the following environment variable:",
-        f'    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="{repro_value}"',
-    ]
+    if random_seed_var == "any":
+        return [
+            "To reproduce this test run, set the following environment variable:",
+            f'    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="{random_seeds[0]}"',
+            "See: https://scikit-learn.org/dev/computing/parallelism.html"
+            "#environment-variables",
+        ]
 
 
 @pytest.fixture(params=random_seeds)
@@ -55,14 +56,14 @@ def global_random_seed(request):
     All tests that use this fixture accept the contract that they should
     deterministically pass for any seed value from 0 to 99 included.
 
-    If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is not set
-    (which should be the default, in particular on the CI), the fixture will
-    choose an arbitrary seed in the above range and all fixtured tests will run
-    for that specific seed. This ensures that over time, our CI will run all
-    tests with different seeds while keeping the test duration of a single run
-    of the full test suite limited. This will enforce that the tests assertions
-    of tests written to use this fixture are not dependent on a specific seed
-    value.
+    If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is set to
+    "any" (which should be the case on nightly builds on the CI), the fixture
+    will choose an arbitrary seed in the above range (based on the BUILD_NUMBER
+    or the current day) and all fixtured tests will run for that specific seed.
+    The goal is to ensure that, over time, our CI will run all tests with
+    different seeds while keeping the test duration of a single run of the full
+    test suite limited. This will check that the tests assertions of tests
+    written to use this fixture are not dependent on a specific seed value.
 
     The range of admissible seed values is limited to [0, 99] because it is
     often not possible to write a test that can work for any possible seed and
@@ -73,8 +74,20 @@ def global_random_seed(request):
     - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
     - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": run the tests with all seeds
       between 40 and 42 included
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="any": run the tests with an arbitrary
+      seed selected between 0 and 99 included
     - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": run the tests with all seeds
       between 0 and 99 included
+
+    If the variable is not set, then 42 is used as the global seed in a
+    deterministic manner. This will make sure by default, the scikit-learn test
+    suite is as deterministic as possible which is useful to avoid disruption
+    of friendly third-party package maintainers. Similarly, this variable
+    should not be set in the CI config of pull-request runs to make sure that
+    our friendly contributors are not the first people to encounter a
+    seed-sensitivity regression in a test unrelated to the changes of their PR.
+    Only the scikit-learn maintainers who watch the results of the nightly
+    builds are expected to be annoyed by this.
 
     When writing a new test function that uses this fixture, please use the
     following command to make sure that it passes deterministically for all

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -11,7 +11,6 @@ https://scikit-learn.org/dev/computing/parallelism.html#environment-variables
 import pytest
 from os import environ
 from random import Random
-from datetime import datetime
 
 
 # Passes the main worker's random seeds to workers
@@ -35,8 +34,7 @@ def pytest_configure(config):
         random_seeds = [42]
     elif random_seed_var == "any":
         # Pick-up one seed at random in the range of admissible random seeds.
-        meta_seed = int(datetime.now().strftime("%Y%j"))
-        random_seeds = [Random(meta_seed).choice(RANDOM_SEED_RANGE)]
+        random_seeds = [Random().choice(RANDOM_SEED_RANGE)]
     elif random_seed_var == "all":
         random_seeds = RANDOM_SEED_RANGE
     else:

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -22,7 +22,7 @@ else:
         start, stop = random_seed_var.split("-")
         random_seeds = list(range(int(start), int(stop) + 1))
     else:
-        random_seeds = [int(s) for s in random_seed_var.split(",")]
+        random_seeds = [int(random_seed_var)]
 
     if min(random_seeds) < 0 or max(random_seeds) > 99:
         raise ValueError(
@@ -33,13 +33,13 @@ else:
 
 
 def pytest_report_header(config):
-    if random_seeds == RANDOM_SEED_RANGE:
-        seed_values = "all"
+    if len(random_seeds) == 1:
+        repro_value = random_seeds[0]
     else:
-        seed_values = ",".join(str(s) for s in random_seeds)
+        repro_value = random_seed_var
     return [
         "To reproduce this test run, set the following environment variable:",
-        f'    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="{seed_values}"',
+        f'    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="{repro_value}"',
     ]
 
 
@@ -50,13 +50,14 @@ def global_random_seed(request):
     All tests that use this fixture accept the contract that they should
     deterministically pass for any seed value from 0 to 99 included.
 
-    If the SKLEARN_TESTS_RANDOM_SEED environment variable is not set (which
-    should be the default, in particular on the CI), the fixture will choose an
-    arbitrary seed in the above range and all fixtured tests will run for that
-    specific seed. This ensures that over time, our CI will run all tests with
-    different seeds while keeping the test duration of a single run of the full
-    test suite limited. This will enforce that the tests assertions of tests
-    written to use this fixture are not dependent on a specific seed value.
+    If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is not set
+    (which should be the default, in particular on the CI), the fixture will
+    choose an arbitrary seed in the above range and all fixtured tests will run
+    for that specific seed. This ensures that over time, our CI will run all
+    tests with different seeds while keeping the test duration of a single run
+    of the full test suite limited. This will enforce that the tests assertions
+    of tests written to use this fixture are not dependent on a specific seed
+    value.
 
     The range of admissible seed values is limited to [0, 99] because it is
     often not possible to write a test that can work for any possible seed and
@@ -65,12 +66,10 @@ def global_random_seed(request):
     Valid values for SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
 
     - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="0,1,42": run tests for seeds of 0, 1
-      and 42
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": integers between 40 and 42
-      included
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": integers between 0 and 99
-      included
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": run the tests with all seeds
+      between 40 and 42 included
+    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": run the tests with all seeds
+      between 0 and 99 included
 
     When writing a new test function that uses this fixture, please use the
     following command to make sure that it passes deterministically for all


### PR DESCRIPTION
Closes #13913

This is a new fixture similar to what is being developed in #22690 that will make it possible to ensure that (some of) our tests do no rely on a specific value of a random seed while giving full control to make it possible to reproduce CI runs locally or to make it possible to use 

The docstring of the fixture should be quite explicit. I tested it locally and it seems to work as expected:

```
dev ❯ SKLEARN_TESTS_GLOBAL_RANDOM_SEED='0-2' pytest -v -k "test_kmeans_elkan_results and 0.01-dense-normal" sklearn/cluster/tests/
======================================================================================== test session starts =========================================================================================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /Users/ogrisel/mambaforge/envs/dev/bin/python
cachedir: .pytest_cache
To reproduce this test run, set the following environment variable:
    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="0-2"
rootdir: /Users/ogrisel/code/scikit-learn, configfile: setup.cfg
plugins: anyio-3.3.0, xdist-2.3.0, timeout-1.4.2, forked-1.3.0, cov-3.0.0
collected 548 items / 545 deselected / 3 selected                                                                                                                                                    

sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[0-0.01-dense-normal] PASSED                                                                                                   [ 33%]
sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[1-0.01-dense-normal] PASSED                                                                                                   [ 66%]
sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[2-0.01-dense-normal] PASSED                                                                                                   [100%]

================================================================================= 3 passed, 545 deselected in 0.25s ==================================================================================

dev ❯ SKLEARN_TESTS_GLOAL_RANDOM_SEED='42' pytest -v -k "test_kmeans_elkan_results and 0.01-dense-normal" sklearn/cluster/tests/
======================================================================================== test session starts =========================================================================================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /Users/ogrisel/mambaforge/envs/dev/bin/python
cachedir: .pytest_cache
To reproduce this test run, set the following environment variable:
    SKLEARN_TESTS_GLOAL_RANDOM_SEED="42"
rootdir: /Users/ogrisel/code/scikit-learn, configfile: setup.cfg
plugins: anyio-3.3.0, xdist-2.3.0, timeout-1.4.2, forked-1.3.0, cov-3.0.0
collected 516 items / 515 deselected / 1 selected                                                                                                                                                    

sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[42-0.01-dense-normal] PASSED                                                                                                  [100%]

================================================================================= 1 passed, 515 deselected in 0.19s ==================================================================================

dev ❯ pytest -v -k "test_kmeans_elkan_results and 0.01-dense-normal" sklearn/cluster/tests/
======================================================================================== test session starts =========================================================================================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /Users/ogrisel/mambaforge/envs/dev/bin/python
cachedir: .pytest_cache
To reproduce this test run, set the following environment variable:
    SKLEARN_TESTS_GLOAL_RANDOM_SEED="94"
rootdir: /Users/ogrisel/code/scikit-learn, configfile: setup.cfg
plugins: anyio-3.3.0, xdist-2.3.0, timeout-1.4.2, forked-1.3.0, cov-3.0.0
collected 516 items / 515 deselected / 1 selected                                                                                                                                                    

sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[94-0.01-dense-normal] PASSED                                                                                                  [100%]

================================================================================= 1 passed, 515 deselected in 0.22s ==================================================================================

dev ❯ SKLEARN_TESTS_GLOAL_RANDOM_SEED='all' pytest -v -k "test_kmeans_elkan_results and 0.01-dense-normal" sklearn/cluster/tests/
======================================================================================== test session starts =========================================================================================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /Users/ogrisel/mambaforge/envs/dev/bin/python
cachedir: .pytest_cache
To reproduce this test run, set the following environment variable:
    SKLEARN_TESTS_GLOAL_RANDOM_SEED="all"
rootdir: /Users/ogrisel/code/scikit-learn, configfile: setup.cfg
plugins: anyio-3.3.0, xdist-2.3.0, timeout-1.4.2, forked-1.3.0, cov-3.0.0
collected 2100 items / 2000 deselected / 100 selected                                                                                                                                                

sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[0-0.01-dense-normal] PASSED                                                                                                   [  1%]
sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[1-0.01-dense-normal] PASSED                                                                                                   [  2%]
sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[2-0.01-dense-normal] PASSED                                                                                                   [  3%]
sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[3-0.01-dense-normal] PASSED                                                                                                   [  4%]
sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[4-0.01-dense-normal] PASSED                                                                                                   [  5%]
sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[5-0.01-dense-normal] PASSED                                                                                                   [  6%]
sklearn/cluster/tests/test_k_means.py::test_kmeans_elkan_results[6-0.01-dense-normal] PASSED                                                                                                   [  7%]
[...]
```

TODO:

- [x] find out if we can make the test pass even if the plugin is not installed or maybe force the activation of the plugin in `sklearn/conftests.py`?
- [x] document the new environment variable;
- [x] decide and implement the renaming of the fixture based on the discussion in https://github.com/scikit-learn/scikit-learn/pull/22749#discussion_r823977204