### PR TITLE
DOC: Make plot_permutation_importance example run on VS code

### DIFF
--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -24,7 +24,7 @@ can mitigate those limitations.
        2001. https://doi.org/10.1023/A:1010933404324
 
 """
-
+# %%
 import matplotlib.pyplot as plt
 import numpy as np
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The imports of plot_permutation_example.py are not considered to be in a cell by VS code because it is missing # %%
We need this for this Saturday's sprint with WiMLDS Paris: https://github.com/scikit-learn-inria-fondation/WiMLDS-Paris-Sprint/blob/main/3.example.md 
plot_permutation_example.py is the example we are using there.

BEFORE
![example-vscode-before](https://user-images.githubusercontent.com/98105626/157730274-39d1fef7-00bd-4ffc-ac0d-563fae16f37b.png)

AFTER
![example-vscode-after](https://user-images.githubusercontent.com/98105626/157730334-b0c3759e-f2a8-4a26-88ca-7ac56ae1f61c.png)


#### Any other comments?
This is short fix but many other examples will require this same small edit. It will be worth to make a more exhaustive PR later on. 
