### PR TITLE
[MAINT] Improve extensibility of the Tree/Splitter code

### DIFF
--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -91,3 +91,42 @@ cdef class Splitter:
     cdef void node_value(self, double* dest) nogil
 
     cdef double node_impurity(self) nogil
+
+cdef inline void sort(DTYPE_t* Xf, SIZE_t* samples, SIZE_t n) nogil
+cdef inline void swap(DTYPE_t* Xf, SIZE_t* samples, SIZE_t i, SIZE_t j) nogil
+cdef inline DTYPE_t median3(DTYPE_t* Xf, SIZE_t n) nogil
+cdef void introsort(DTYPE_t* Xf, SIZE_t *samples, SIZE_t n, int maxd) nogil
+cdef inline void sift_down(DTYPE_t* Xf, SIZE_t* samples,
+                        SIZE_t start, SIZE_t end) nogil
+cdef void heapsort(DTYPE_t* Xf, SIZE_t* samples, SIZE_t n) nogil
+cdef int compare_SIZE_t(const void* a, const void* b) nogil
+cdef inline void binary_search(INT32_t* sorted_array,
+                            INT32_t start, INT32_t end,
+                            SIZE_t value, SIZE_t* index,
+                            INT32_t* new_start) nogil
+cdef inline void extract_nnz_index_to_samples(INT32_t* X_indices,
+                                            DTYPE_t* X_data,
+                                            INT32_t indptr_start,
+                                            INT32_t indptr_end,
+                                            SIZE_t* samples,
+                                            SIZE_t start,
+                                            SIZE_t end,
+                                            SIZE_t* index_to_samples,
+                                            DTYPE_t* Xf,
+                                            SIZE_t* end_negative,
+                                            SIZE_t* start_positive) nogil
+cdef inline void extract_nnz_binary_search(INT32_t* X_indices,
+                                        DTYPE_t* X_data,
+                                        INT32_t indptr_start,
+                                        INT32_t indptr_end,
+                                        SIZE_t* samples,
+                                        SIZE_t start,
+                                        SIZE_t end,
+                                        SIZE_t* index_to_samples,
+                                        DTYPE_t* Xf,
+                                        SIZE_t* end_negative,
+                                        SIZE_t* start_positive,
+                                        SIZE_t* sorted_samples,
+                                        bint* is_samples_sorted) nogil
+cdef inline void sparse_swap(SIZE_t* index_to_samples, SIZE_t* samples,
+                            SIZE_t pos_1, SIZE_t pos_2) nogil 

--- a/sklearn/tree/_tree.pxd
+++ b/sklearn/tree/_tree.pxd
@@ -56,9 +56,13 @@ cdef class Tree:
 
     # Methods
     cdef SIZE_t _add_node(self, SIZE_t parent, bint is_left, bint is_leaf,
-                          SIZE_t feature, double threshold, double impurity,
+                          SplitRecord split_node, double impurity,
                           SIZE_t n_node_samples,
                           double weighted_n_node_samples) nogil except -1
+    cdef int _set_node_values(self, SplitRecord split_node,
+                              Node *node)  nogil except -1
+    cdef DTYPE_t _compute_feature(self, const DTYPE_t[:] X_ndarray,
+                            Node *node) nogil
     cdef int _resize(self, SIZE_t capacity) nogil except -1
     cdef int _resize_c(self, SIZE_t capacity=*) nogil except -1
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes: #22753 


#### What does this implement/fix? Explain your changes.
- Moves splitter utility functions to `_splitter.pxd` definition file
- Modularize `Tree` class to enable easier extensions

#### Any other comments?
N/a
