### PR TITLE
Add Blog to top menu bar in /stable (#22737)

### DIFF
--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -60,7 +60,7 @@ fi
 if [[ "$TEST_DOCSTRINGS" == "true" ]]; then
     # numpydoc requires sphinx
     mamba install --verbose -y sphinx
-    mamba install --verbose -y numpydoc
+    mamba install --verbose -y "numpydoc<1.2"
 fi
 
 python --version

--- a/doc/themes/scikit-learn-modern/nav.html
+++ b/doc/themes/scikit-learn-modern/nav.html
@@ -58,6 +58,9 @@
         <li class="nav-item">
           <a class="sk-nav-link nav-link" href="{{ pathto('auto_examples/index') }}">Examples</a>
         </li>
+        <li class="nav-item">
+          <a class="sk-nav-link nav-link" target="_blank" rel="noopener noreferrer" href="https://blog.scikit-learn.org/">Community</a>
+        </li>
         {%- for title, link in drop_down_navigation %}
         <li class="nav-item">
           <a class="sk-nav-link nav-link nav-more-item-mobile-items" href="{{ link }}">{{ title }}</a>


### PR DESCRIPTION
Co-authored-by: Thomas J. Fan <thomasjpfan@gmail.com>

#### Reference Issues/PRs
Improves #22737. 

#### What does this implement/fix? Explain your changes.
We want the ""Community" menu element to be accessible to as many people as possible.
That is why I suggest we show it on scikit-learn.org/stable and not only in the /dev version of the website.

#### Any other comments?
I cherry-picked the commit [d6984db](https://github.com/scikit-learn/scikit-learn/commit/d6984db4f2c8ff8c0b29413b40d53903f2123ce7)
 and pushed it to the 1.0.X branch. 
