### PR TITLE
FIX Fix ColumnTransformer.get_feature_names_out with slices

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -182,6 +182,11 @@ Changelog
   `__init__` and `set_params` methods.
   :pr:`22537` by :user:`iofall <iofall>` and :user:`Arisa Y. <arisayosh>`.
 
+- |Fix| :term:`get_feature_names_out` functionality in
+  :class:`compose.ColumnTransformer` was broken when columns were specified
+  using `slice`. This is fixed in :pr:`22775` by :user:`randomgeek78
+  <randomgeek78>`
+
 :mod:`sklearn.cross_decomposition`
 ..................................
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -453,9 +453,8 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                 f"Transformer {name} (type {type(trans).__name__}) does "
                 "not provide get_feature_names_out."
             )
-        if isinstance(column, Iterable) and not all(
-            isinstance(col, str) for col in column
-        ):
+        if isinstance(column, slice) or (isinstance(column, Iterable) and
+                not all( isinstance(col, str) for col in column)):
             column = _safe_indexing(feature_names_in, column)
         return trans.get_feature_names_out(column)
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -453,8 +453,10 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                 f"Transformer {name} (type {type(trans).__name__}) does "
                 "not provide get_feature_names_out."
             )
-        if isinstance(column, slice) or (isinstance(column, Iterable) and
-                not all( isinstance(col, str) for col in column)):
+        if isinstance(column, slice) or (
+            isinstance(column, Iterable)
+            and not all(isinstance(col, str) for col in column)
+        ):
             column = _safe_indexing(feature_names_in, column)
         return trans.get_feature_names_out(column)
 

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1759,11 +1759,10 @@ class TransWithNames(Trans):
         ),
         (
             [
-                ("bycol1", TransWithNames(), slice(1, 2)),
-                ("bycol2", "drop", ["d"]),
+                ("bycol1", TransWithNames(), slice(1, 3)),
             ],
-            "passthrough",
-            ["bycol1__b", "remainder__a", "remainder__c"],
+            "drop",
+            ["bycol1__b", "bycol1__c"],
         ),
         (
             [
@@ -1875,10 +1874,10 @@ def test_verbose_feature_names_out_true(transformers, remainder, expected_names)
         (
             [
                 ("bycol1", TransWithNames(), ["d", "c"]),
-                ("bycol2", "passthrough", slice(0, 1)),
+                ("bycol2", "passthrough", slice(0, 2)),
             ],
             "drop",
-            ["d", "c", "a"],
+            ["d", "c", "a", "b"],
         ),
     ],
 )

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1757,6 +1757,30 @@ class TransWithNames(Trans):
             "drop",
             [],
         ),
+        (
+            [
+                ("bycol1", TransWithNames(), slice(1, 2)),
+                ("bycol2", "drop", ["d"]),
+            ],
+            "passthrough",
+            ["bycol1__b", "remainder__a", "remainder__c"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), ["b"]),
+                ("bycol2", "drop", slice(3, 4)),
+            ],
+            "passthrough",
+            ["bycol1__b", "remainder__a", "remainder__c"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), ["d", "c"]),
+                ("bycol2", "passthrough", slice(3, 4)),
+            ],
+            "passthrough",
+            ["bycol1__d", "bycol1__c", "bycol2__d", "remainder__a", "remainder__b"],
+        ),
     ],
 )
 def test_verbose_feature_names_out_true(transformers, remainder, expected_names):
@@ -1831,6 +1855,30 @@ def test_verbose_feature_names_out_true(transformers, remainder, expected_names)
             ],
             "drop",
             [],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), slice(1, 2)),
+                ("bycol2", "drop", ["d"]),
+            ],
+            "passthrough",
+            ["b", "a", "c"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), ["b"]),
+                ("bycol2", "drop", slice(3, 4)),
+            ],
+            "passthrough",
+            ["b", "a", "c"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), ["d", "c"]),
+                ("bycol2", "passthrough", slice(0, 1)),
+            ],
+            "drop",
+            ["d", "c", "a"],
         ),
     ],
 )
@@ -1919,6 +1967,24 @@ def test_verbose_feature_names_out_false(transformers, remainder, expected_names
             ],
             "passthrough",
             "['pca0', 'pca1', 'pca2', 'pca3', 'pca4', ...]",
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(["a", "b"]), slice(1, 2)),
+                ("bycol2", "passthrough", ["a"]),
+                ("bycol3", TransWithNames(["b"]), ["c"]),
+            ],
+            "passthrough",
+            "['a', 'b']",
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(["a", "b"]), ["b"]),
+                ("bycol2", "passthrough", slice(0, 1)),
+                ("bycol3", TransWithNames(["b"]), ["c"]),
+            ],
+            "passthrough",
+            "['a', 'b']",
         ),
     ],
 )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #22774
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Currently, ColumnTransformer's get_feature_names_out does not work when the columns are specified as slices. This fix makes get_feature_names_out work properly with slices as well.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
