### PR TITLE
DOC Ensures that paired_euclidean_distances passes numpydoc validation

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -992,20 +992,23 @@ def cosine_distances(X, Y=None):
 
 # Paired distances
 def paired_euclidean_distances(X, Y):
-    """
-    Computes the paired euclidean distances between X and Y.
+    """Compute the paired euclidean distances between X and Y.
 
     Read more in the :ref:`User Guide <metrics>`.
 
     Parameters
     ----------
     X : array-like of shape (n_samples, n_features)
+        Input array/matrix X.
 
     Y : array-like of shape (n_samples, n_features)
+        Input array/matrix Y.
 
     Returns
     -------
     distances : ndarray of shape (n_samples,)
+        Output array/matrix containing the calculated paired euclidian
+        distances.
     """
     X, Y = check_paired_arrays(X, Y)
     return row_norms(X - Y)

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -95,7 +95,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.haversine_distances",
     "sklearn.metrics.pairwise.kernel_metrics",
     "sklearn.metrics.pairwise.laplacian_kernel",
-    "sklearn.metrics.pairwise.paired_euclidean_distances",
     "sklearn.metrics.pairwise.paired_manhattan_distances",
     "sklearn.metrics.pairwise.pairwise_distances_argmin",
     "sklearn.metrics.pairwise.pairwise_distances_argmin_min",


### PR DESCRIPTION
#### Reference Issues/PRs
towards #21350

#### What does this implement/fix? Explain your changes.
Ensures sklearn.metrics.pairwise.paired_euclidean_distances docstring to be consistent with the numpydoc validation.

#### Any other comments?
#pariswimlds
