### PR TITLE
DOC fix the docstring of sklearn.datasets._samples_generator.make_biclusters

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1686,8 +1686,7 @@ def make_biclusters(
     shuffle=True,
     random_state=None,
 ):
-    """Generate an array with constant block diagonal structure for
-    biclustering.
+    """Generate a constant block diagonal structure array for biclustering.
 
     Read more in the :ref:`User Guide <sample_generators>`.
 
@@ -1727,6 +1726,10 @@ def make_biclusters(
     cols : ndarray of shape (n_clusters, X.shape[1])
         The indicators for cluster membership of each column.
 
+    See Also
+    --------
+    make_checkerboard: Generate an array with block checkerboard structure for biclustering.
+
     References
     ----------
 
@@ -1734,10 +1737,6 @@ def make_biclusters(
         words using bipartite spectral graph partitioning. In Proceedings
         of the seventh ACM SIGKDD international conference on Knowledge
         discovery and data mining (pp. 269-274). ACM.
-
-    See Also
-    --------
-    make_checkerboard
     """
     generator = check_random_state(random_state)
     n_rows, n_cols = shape

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1728,7 +1728,8 @@ def make_biclusters(
 
     See Also
     --------
-    make_checkerboard: Generate an array with block checkerboard structure for biclustering.
+    make_checkerboard: Generate an array with block checkerboard structure for
+        biclustering.
 
     References
     ----------

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -20,7 +20,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.datasets._kddcup99.fetch_kddcup99",
     "sklearn.datasets._lfw.fetch_lfw_pairs",
     "sklearn.datasets._lfw.fetch_lfw_people",
-    "sklearn.datasets._samples_generator.make_biclusters",
     "sklearn.datasets._samples_generator.make_classification",
     "sklearn.datasets._samples_generator.make_gaussian_quantiles",
     "sklearn.datasets._samples_generator.make_multilabel_classification",


### PR DESCRIPTION
#### Reference Issues/PRs
#21350 

#### What does this implement/fix? Explain your changes.
Fix the doctrings:
- Reference part after the See Also part
- Add the description of the function pointed in See Also
- The general description's length is one line

#### Any other comments?
#WiMLDS
