### PR TITLE
DOC Specify the meaning of y=None in metrics.pairwise.haversine_distances

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -837,6 +837,7 @@ def haversine_distances(X, Y=None):
     X : array-like of shape (n_samples_X, 2)
 
     Y : array-like of shape (n_samples_Y, 2), default=None
+        If `None`, uses `Y=X`.
 
     Returns
     -------


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #17295


#### What does this implement/fix? Explain your changes.
Added documentation to `haversine_distances` function in `/sklearn/metrics/pairwise.py` for case `Y=None`.

#### Any other comments?
#pariswimlds sprint
