### PR TITLE
FIX DBSCAN and TSNE are missing the pairwise estimator tag

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -458,3 +458,6 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         """
         self.fit(X, sample_weight=sample_weight)
         return self.labels_
+
+    def _more_tags(self):
+        return {"pairwise": self.metric == "precomputed"}

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -36,22 +36,27 @@ def dbscan(
     n_jobs=None,
 ):
     """Perform DBSCAN clustering from vector array or distance matrix.
+
     Read more in the :ref:`User Guide <dbscan>`.
+
     Parameters
     ----------
     X : {array-like, sparse (CSR) matrix} of shape (n_samples, n_features) or \
             (n_samples, n_samples)
         A feature array, or array of distances between samples if
         ``metric='precomputed'``.
+
     eps : float, default=0.5
         The maximum distance between two samples for one to be considered
         as in the neighborhood of the other. This is not a maximum bound
         on the distances of points within a cluster. This is the most
         important DBSCAN parameter to choose appropriately for your data set
         and distance function.
+
     min_samples : int, default=5
         The number of samples (or total weight) in a neighborhood for a point
         to be considered as a core point. This includes the point itself.
+
     metric : str or callable, default='minkowski'
         The metric to use when calculating distance between instances in a
         feature array. If metric is a string or callable, it must be one of
@@ -61,67 +66,84 @@ def dbscan(
         must be square during fit.
         X may be a :term:`sparse graph <sparse graph>`,
         in which case only "nonzero" elements may be considered neighbors.
+
     metric_params : dict, default=None
         Additional keyword arguments for the metric function.
+
         .. versionadded:: 0.19
+
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
         The algorithm to be used by the NearestNeighbors module
         to compute pointwise distances and find nearest neighbors.
         See NearestNeighbors module documentation for details.
+
     leaf_size : int, default=30
         Leaf size passed to BallTree or cKDTree. This can affect the speed
         of the construction and query, as well as the memory required
         to store the tree. The optimal value depends
         on the nature of the problem.
+
     p : float, default=2
         The power of the Minkowski metric to be used to calculate distance
         between points.
+
     sample_weight : array-like of shape (n_samples,), default=None
         Weight of each sample, such that a sample with a weight of at least
         ``min_samples`` is by itself a core sample; a sample with negative
         weight may inhibit its eps-neighbor from being core.
         Note that weights are absolute, and default to 1.
+
     n_jobs : int, default=None
         The number of parallel jobs to run for neighbors search. ``None`` means
         1 unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
         using all processors. See :term:`Glossary <n_jobs>` for more details.
         If precomputed distance are used, parallel execution is not available
         and thus n_jobs will have no effect.
+
     Returns
     -------
     core_samples : ndarray of shape (n_core_samples,)
         Indices of core samples.
+
     labels : ndarray of shape (n_samples,)
         Cluster labels for each point.  Noisy samples are given the label -1.
+
     See Also
     --------
     DBSCAN : An estimator interface for this clustering algorithm.
     OPTICS : A similar estimator interface clustering at multiple values of
         eps. Our implementation is optimized for memory usage.
+
     Notes
     -----
     For an example, see :ref:`examples/cluster/plot_dbscan.py
     <sphx_glr_auto_examples_cluster_plot_dbscan.py>`.
+
     This implementation bulk-computes all neighborhood queries, which increases
     the memory complexity to O(n.d) where d is the average number of neighbors,
     while original DBSCAN had memory complexity O(n). It may attract a higher
     memory complexity when querying these nearest neighborhoods, depending
     on the ``algorithm``.
+
     One way to avoid the query complexity is to pre-compute sparse
     neighborhoods in chunks using
     :func:`NearestNeighbors.radius_neighbors_graph
     <sklearn.neighbors.NearestNeighbors.radius_neighbors_graph>` with
     ``mode='distance'``, then using ``metric='precomputed'`` here.
+
     Another way to reduce memory and computation time is to remove
     (near-)duplicate points and use ``sample_weight`` instead.
+
     :func:`cluster.optics <sklearn.cluster.optics>` provides a similar
     clustering with lower memory usage.
+
     References
     ----------
     Ester, M., H. P. Kriegel, J. Sander, and X. Xu, "A Density-Based
     Algorithm for Discovering Clusters in Large Spatial Databases with Noise".
     In: Proceedings of the 2nd International Conference on Knowledge Discovery
     and Data Mining, Portland, OR, AAAI Press, pp. 226-231. 1996
+
     Schubert, E., Sander, J., Ester, M., Kriegel, H. P., & Xu, X. (2017).
     DBSCAN revisited, revisited: why and how you should (still) use DBSCAN.
     ACM Transactions on Database Systems (TODS), 42(3), 19.
@@ -143,10 +165,13 @@ def dbscan(
 
 class DBSCAN(ClusterMixin, BaseEstimator):
     """Perform DBSCAN clustering from vector array or distance matrix.
+
     DBSCAN - Density-Based Spatial Clustering of Applications with Noise.
     Finds core samples of high density and expands clusters from them.
     Good for data which contains clusters of similar density.
+
     Read more in the :ref:`User Guide <dbscan>`.
+
     Parameters
     ----------
     eps : float, default=0.5
@@ -155,9 +180,11 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         on the distances of points within a cluster. This is the most
         important DBSCAN parameter to choose appropriately for your data set
         and distance function.
+
     min_samples : int, default=5
         The number of samples (or total weight) in a neighborhood for a point
         to be considered as a core point. This includes the point itself.
+
     metric : str, or callable, default='euclidean'
         The metric to use when calculating distance between instances in a
         feature array. If metric is a string or callable, it must be one of
@@ -166,76 +193,99 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         If metric is "precomputed", X is assumed to be a distance matrix and
         must be square. X may be a :term:`Glossary <sparse graph>`, in which
         case only "nonzero" elements may be considered neighbors for DBSCAN.
+
         .. versionadded:: 0.17
            metric *precomputed* to accept precomputed sparse matrix.
+
     metric_params : dict, default=None
         Additional keyword arguments for the metric function.
+
         .. versionadded:: 0.19
+
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
         The algorithm to be used by the NearestNeighbors module
         to compute pointwise distances and find nearest neighbors.
         See NearestNeighbors module documentation for details.
+
     leaf_size : int, default=30
         Leaf size passed to BallTree or cKDTree. This can affect the speed
         of the construction and query, as well as the memory required
         to store the tree. The optimal value depends
         on the nature of the problem.
+
     p : float, default=None
         The power of the Minkowski metric to be used to calculate distance
         between points. If None, then ``p=2`` (equivalent to the Euclidean
         distance).
+
     n_jobs : int, default=None
         The number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
+
     Attributes
     ----------
     core_sample_indices_ : ndarray of shape (n_core_samples,)
         Indices of core samples.
+
     components_ : ndarray of shape (n_core_samples, n_features)
         Copy of each core sample found by training.
+
     labels_ : ndarray of shape (n_samples)
         Cluster labels for each point in the dataset given to fit().
         Noisy samples are given the label -1.
+
     n_features_in_ : int
         Number of features seen during :term:`fit`.
+
         .. versionadded:: 0.24
+
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Defined only when `X`
         has feature names that are all strings.
+
         .. versionadded:: 1.0
+
     See Also
     --------
     OPTICS : A similar clustering at multiple values of eps. Our implementation
         is optimized for memory usage.
+
     Notes
     -----
     For an example, see :ref:`examples/cluster/plot_dbscan.py
     <sphx_glr_auto_examples_cluster_plot_dbscan.py>`.
+
     This implementation bulk-computes all neighborhood queries, which increases
     the memory complexity to O(n.d) where d is the average number of neighbors,
     while original DBSCAN had memory complexity O(n). It may attract a higher
     memory complexity when querying these nearest neighborhoods, depending
     on the ``algorithm``.
+
     One way to avoid the query complexity is to pre-compute sparse
     neighborhoods in chunks using
     :func:`NearestNeighbors.radius_neighbors_graph
     <sklearn.neighbors.NearestNeighbors.radius_neighbors_graph>` with
     ``mode='distance'``, then using ``metric='precomputed'`` here.
+
     Another way to reduce memory and computation time is to remove
     (near-)duplicate points and use ``sample_weight`` instead.
+
     :class:`cluster.OPTICS` provides a similar clustering with lower memory
     usage.
+
     References
     ----------
     Ester, M., H. P. Kriegel, J. Sander, and X. Xu, "A Density-Based
     Algorithm for Discovering Clusters in Large Spatial Databases with Noise".
     In: Proceedings of the 2nd International Conference on Knowledge Discovery
     and Data Mining, Portland, OR, AAAI Press, pp. 226-231. 1996
+
     Schubert, E., Sander, J., Ester, M., Kriegel, H. P., & Xu, X. (2017).
     DBSCAN revisited, revisited: why and how you should (still) use DBSCAN.
     ACM Transactions on Database Systems (TODS), 42(3), 19.
+
     Examples
     --------
     >>> from sklearn.cluster import DBSCAN
@@ -272,6 +322,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
 
     def fit(self, X, y=None, sample_weight=None):
         """Perform DBSCAN clustering from features, or distance matrix.
+
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features), or \
@@ -279,13 +330,16 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             Training instances to cluster, or distances between instances if
             ``metric='precomputed'``. If a sparse matrix is provided, it will
             be converted into a sparse ``csr_matrix``.
+
         y : Ignored
             Not used, present here for API consistency by convention.
+
         sample_weight : array-like of shape (n_samples,), default=None
             Weight of each sample, such that a sample with a weight of at least
             ``min_samples`` is by itself a core sample; a sample with a
             negative weight may inhibit its eps-neighbor from being core.
             Note that weights are absolute, and default to 1.
+
         Returns
         -------
         self : object
@@ -379,6 +433,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
 
     def fit_predict(self, X, y=None, sample_weight=None):
         """Compute clusters from a data or distance matrix and predict labels.
+
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features), or \
@@ -386,13 +441,16 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             Training instances to cluster, or distances between instances if
             ``metric='precomputed'``. If a sparse matrix is provided, it will
             be converted into a sparse ``csr_matrix``.
+
         y : Ignored
             Not used, present here for API consistency by convention.
+
         sample_weight : array-like of shape (n_samples,), default=None
             Weight of each sample, such that a sample with a weight of at least
             ``min_samples`` is by itself a core sample; a sample with a
             negative weight may inhibit its eps-neighbor from being core.
             Note that weights are absolute, and default to 1.
+
         Returns
         -------
         labels : ndarray of shape (n_samples,)
@@ -400,6 +458,3 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         """
         self.fit(X, sample_weight=sample_weight)
         return self.labels_
-
-    def _more_tags(self):
-        return {"pairwise": self.metric == "precomputed"}

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -23,17 +23,17 @@ from ._dbscan_inner import dbscan_inner
 
 
 def dbscan(
-    X,
-    eps=0.5,
-    *,
-    min_samples=5,
-    metric="minkowski",
-    metric_params=None,
-    algorithm="auto",
-    leaf_size=30,
-    p=2,
-    sample_weight=None,
-    n_jobs=None,
+        X,
+        eps=0.5,
+        *,
+        min_samples=5,
+        metric="minkowski",
+        metric_params=None,
+        algorithm="auto",
+        leaf_size=30,
+        p=2,
+        sample_weight=None,
+        n_jobs=None,
 ):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
@@ -300,16 +300,16 @@ class DBSCAN(ClusterMixin, BaseEstimator):
     """
 
     def __init__(
-        self,
-        eps=0.5,
-        *,
-        min_samples=5,
-        metric="euclidean",
-        metric_params=None,
-        algorithm="auto",
-        leaf_size=30,
-        p=None,
-        n_jobs=None,
+            self,
+            eps=0.5,
+            *,
+            min_samples=5,
+            metric="euclidean",
+            metric_params=None,
+            algorithm="auto",
+            leaf_size=30,
+            p=None,
+            n_jobs=None,
     ):
         self.eps = eps
         self.min_samples = min_samples
@@ -458,3 +458,6 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         """
         self.fit(X, sample_weight=sample_weight)
         return self.labels_
+
+    def _more_tags(self):
+        return {"pairwise": self.metric == "precomputed"}

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -23,40 +23,35 @@ from ._dbscan_inner import dbscan_inner
 
 
 def dbscan(
-        X,
-        eps=0.5,
-        *,
-        min_samples=5,
-        metric="minkowski",
-        metric_params=None,
-        algorithm="auto",
-        leaf_size=30,
-        p=2,
-        sample_weight=None,
-        n_jobs=None,
+    X,
+    eps=0.5,
+    *,
+    min_samples=5,
+    metric="minkowski",
+    metric_params=None,
+    algorithm="auto",
+    leaf_size=30,
+    p=2,
+    sample_weight=None,
+    n_jobs=None,
 ):
     """Perform DBSCAN clustering from vector array or distance matrix.
-
     Read more in the :ref:`User Guide <dbscan>`.
-
     Parameters
     ----------
     X : {array-like, sparse (CSR) matrix} of shape (n_samples, n_features) or \
             (n_samples, n_samples)
         A feature array, or array of distances between samples if
         ``metric='precomputed'``.
-
     eps : float, default=0.5
         The maximum distance between two samples for one to be considered
         as in the neighborhood of the other. This is not a maximum bound
         on the distances of points within a cluster. This is the most
         important DBSCAN parameter to choose appropriately for your data set
         and distance function.
-
     min_samples : int, default=5
         The number of samples (or total weight) in a neighborhood for a point
         to be considered as a core point. This includes the point itself.
-
     metric : str or callable, default='minkowski'
         The metric to use when calculating distance between instances in a
         feature array. If metric is a string or callable, it must be one of
@@ -66,84 +61,67 @@ def dbscan(
         must be square during fit.
         X may be a :term:`sparse graph <sparse graph>`,
         in which case only "nonzero" elements may be considered neighbors.
-
     metric_params : dict, default=None
         Additional keyword arguments for the metric function.
-
         .. versionadded:: 0.19
-
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
         The algorithm to be used by the NearestNeighbors module
         to compute pointwise distances and find nearest neighbors.
         See NearestNeighbors module documentation for details.
-
     leaf_size : int, default=30
         Leaf size passed to BallTree or cKDTree. This can affect the speed
         of the construction and query, as well as the memory required
         to store the tree. The optimal value depends
         on the nature of the problem.
-
     p : float, default=2
         The power of the Minkowski metric to be used to calculate distance
         between points.
-
     sample_weight : array-like of shape (n_samples,), default=None
         Weight of each sample, such that a sample with a weight of at least
         ``min_samples`` is by itself a core sample; a sample with negative
         weight may inhibit its eps-neighbor from being core.
         Note that weights are absolute, and default to 1.
-
     n_jobs : int, default=None
         The number of parallel jobs to run for neighbors search. ``None`` means
         1 unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
         using all processors. See :term:`Glossary <n_jobs>` for more details.
         If precomputed distance are used, parallel execution is not available
         and thus n_jobs will have no effect.
-
     Returns
     -------
     core_samples : ndarray of shape (n_core_samples,)
         Indices of core samples.
-
     labels : ndarray of shape (n_samples,)
         Cluster labels for each point.  Noisy samples are given the label -1.
-
     See Also
     --------
     DBSCAN : An estimator interface for this clustering algorithm.
     OPTICS : A similar estimator interface clustering at multiple values of
         eps. Our implementation is optimized for memory usage.
-
     Notes
     -----
     For an example, see :ref:`examples/cluster/plot_dbscan.py
     <sphx_glr_auto_examples_cluster_plot_dbscan.py>`.
-
     This implementation bulk-computes all neighborhood queries, which increases
     the memory complexity to O(n.d) where d is the average number of neighbors,
     while original DBSCAN had memory complexity O(n). It may attract a higher
     memory complexity when querying these nearest neighborhoods, depending
     on the ``algorithm``.
-
     One way to avoid the query complexity is to pre-compute sparse
     neighborhoods in chunks using
     :func:`NearestNeighbors.radius_neighbors_graph
     <sklearn.neighbors.NearestNeighbors.radius_neighbors_graph>` with
     ``mode='distance'``, then using ``metric='precomputed'`` here.
-
     Another way to reduce memory and computation time is to remove
     (near-)duplicate points and use ``sample_weight`` instead.
-
     :func:`cluster.optics <sklearn.cluster.optics>` provides a similar
     clustering with lower memory usage.
-
     References
     ----------
     Ester, M., H. P. Kriegel, J. Sander, and X. Xu, "A Density-Based
     Algorithm for Discovering Clusters in Large Spatial Databases with Noise".
     In: Proceedings of the 2nd International Conference on Knowledge Discovery
     and Data Mining, Portland, OR, AAAI Press, pp. 226-231. 1996
-
     Schubert, E., Sander, J., Ester, M., Kriegel, H. P., & Xu, X. (2017).
     DBSCAN revisited, revisited: why and how you should (still) use DBSCAN.
     ACM Transactions on Database Systems (TODS), 42(3), 19.
@@ -165,13 +143,10 @@ def dbscan(
 
 class DBSCAN(ClusterMixin, BaseEstimator):
     """Perform DBSCAN clustering from vector array or distance matrix.
-
     DBSCAN - Density-Based Spatial Clustering of Applications with Noise.
     Finds core samples of high density and expands clusters from them.
     Good for data which contains clusters of similar density.
-
     Read more in the :ref:`User Guide <dbscan>`.
-
     Parameters
     ----------
     eps : float, default=0.5
@@ -180,11 +155,9 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         on the distances of points within a cluster. This is the most
         important DBSCAN parameter to choose appropriately for your data set
         and distance function.
-
     min_samples : int, default=5
         The number of samples (or total weight) in a neighborhood for a point
         to be considered as a core point. This includes the point itself.
-
     metric : str, or callable, default='euclidean'
         The metric to use when calculating distance between instances in a
         feature array. If metric is a string or callable, it must be one of
@@ -193,99 +166,76 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         If metric is "precomputed", X is assumed to be a distance matrix and
         must be square. X may be a :term:`Glossary <sparse graph>`, in which
         case only "nonzero" elements may be considered neighbors for DBSCAN.
-
         .. versionadded:: 0.17
            metric *precomputed* to accept precomputed sparse matrix.
-
     metric_params : dict, default=None
         Additional keyword arguments for the metric function.
-
         .. versionadded:: 0.19
-
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
         The algorithm to be used by the NearestNeighbors module
         to compute pointwise distances and find nearest neighbors.
         See NearestNeighbors module documentation for details.
-
     leaf_size : int, default=30
         Leaf size passed to BallTree or cKDTree. This can affect the speed
         of the construction and query, as well as the memory required
         to store the tree. The optimal value depends
         on the nature of the problem.
-
     p : float, default=None
         The power of the Minkowski metric to be used to calculate distance
         between points. If None, then ``p=2`` (equivalent to the Euclidean
         distance).
-
     n_jobs : int, default=None
         The number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
-
     Attributes
     ----------
     core_sample_indices_ : ndarray of shape (n_core_samples,)
         Indices of core samples.
-
     components_ : ndarray of shape (n_core_samples, n_features)
         Copy of each core sample found by training.
-
     labels_ : ndarray of shape (n_samples)
         Cluster labels for each point in the dataset given to fit().
         Noisy samples are given the label -1.
-
     n_features_in_ : int
         Number of features seen during :term:`fit`.
-
         .. versionadded:: 0.24
-
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Defined only when `X`
         has feature names that are all strings.
-
         .. versionadded:: 1.0
-
     See Also
     --------
     OPTICS : A similar clustering at multiple values of eps. Our implementation
         is optimized for memory usage.
-
     Notes
     -----
     For an example, see :ref:`examples/cluster/plot_dbscan.py
     <sphx_glr_auto_examples_cluster_plot_dbscan.py>`.
-
     This implementation bulk-computes all neighborhood queries, which increases
     the memory complexity to O(n.d) where d is the average number of neighbors,
     while original DBSCAN had memory complexity O(n). It may attract a higher
     memory complexity when querying these nearest neighborhoods, depending
     on the ``algorithm``.
-
     One way to avoid the query complexity is to pre-compute sparse
     neighborhoods in chunks using
     :func:`NearestNeighbors.radius_neighbors_graph
     <sklearn.neighbors.NearestNeighbors.radius_neighbors_graph>` with
     ``mode='distance'``, then using ``metric='precomputed'`` here.
-
     Another way to reduce memory and computation time is to remove
     (near-)duplicate points and use ``sample_weight`` instead.
-
     :class:`cluster.OPTICS` provides a similar clustering with lower memory
     usage.
-
     References
     ----------
     Ester, M., H. P. Kriegel, J. Sander, and X. Xu, "A Density-Based
     Algorithm for Discovering Clusters in Large Spatial Databases with Noise".
     In: Proceedings of the 2nd International Conference on Knowledge Discovery
     and Data Mining, Portland, OR, AAAI Press, pp. 226-231. 1996
-
     Schubert, E., Sander, J., Ester, M., Kriegel, H. P., & Xu, X. (2017).
     DBSCAN revisited, revisited: why and how you should (still) use DBSCAN.
     ACM Transactions on Database Systems (TODS), 42(3), 19.
-
     Examples
     --------
     >>> from sklearn.cluster import DBSCAN
@@ -300,16 +250,16 @@ class DBSCAN(ClusterMixin, BaseEstimator):
     """
 
     def __init__(
-            self,
-            eps=0.5,
-            *,
-            min_samples=5,
-            metric="euclidean",
-            metric_params=None,
-            algorithm="auto",
-            leaf_size=30,
-            p=None,
-            n_jobs=None,
+        self,
+        eps=0.5,
+        *,
+        min_samples=5,
+        metric="euclidean",
+        metric_params=None,
+        algorithm="auto",
+        leaf_size=30,
+        p=None,
+        n_jobs=None,
     ):
         self.eps = eps
         self.min_samples = min_samples
@@ -322,7 +272,6 @@ class DBSCAN(ClusterMixin, BaseEstimator):
 
     def fit(self, X, y=None, sample_weight=None):
         """Perform DBSCAN clustering from features, or distance matrix.
-
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features), or \
@@ -330,16 +279,13 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             Training instances to cluster, or distances between instances if
             ``metric='precomputed'``. If a sparse matrix is provided, it will
             be converted into a sparse ``csr_matrix``.
-
         y : Ignored
             Not used, present here for API consistency by convention.
-
         sample_weight : array-like of shape (n_samples,), default=None
             Weight of each sample, such that a sample with a weight of at least
             ``min_samples`` is by itself a core sample; a sample with a
             negative weight may inhibit its eps-neighbor from being core.
             Note that weights are absolute, and default to 1.
-
         Returns
         -------
         self : object
@@ -433,7 +379,6 @@ class DBSCAN(ClusterMixin, BaseEstimator):
 
     def fit_predict(self, X, y=None, sample_weight=None):
         """Compute clusters from a data or distance matrix and predict labels.
-
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features), or \
@@ -441,16 +386,13 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             Training instances to cluster, or distances between instances if
             ``metric='precomputed'``. If a sparse matrix is provided, it will
             be converted into a sparse ``csr_matrix``.
-
         y : Ignored
             Not used, present here for API consistency by convention.
-
         sample_weight : array-like of shape (n_samples,), default=None
             Weight of each sample, such that a sample with a weight of at least
             ``min_samples`` is by itself a core sample; a sample with a
             negative weight may inhibit its eps-neighbor from being core.
             Note that weights are absolute, and default to 1.
-
         Returns
         -------
         labels : ndarray of shape (n_samples,)

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -29,7 +29,6 @@ from . import _utils  # type: ignore
 # mypy error: Module 'sklearn.manifold' has no attribute '_barnes_hut_tsne'
 from . import _barnes_hut_tsne  # type: ignore
 
-
 MACHINE_EPSILON = np.finfo(np.double).eps
 
 
@@ -124,13 +123,13 @@ def _joint_probabilities_nn(distances, desired_perplexity, verbose):
 
 
 def _kl_divergence(
-    params,
-    P,
-    degrees_of_freedom,
-    n_samples,
-    n_components,
-    skip_num_points=0,
-    compute_error=True,
+        params,
+        P,
+        degrees_of_freedom,
+        n_samples,
+        n_components,
+        skip_num_points=0,
+        compute_error=True,
 ):
     """t-SNE objective function: gradient of the KL divergence
     of p_ijs and q_ijs and the absolute error.
@@ -201,16 +200,16 @@ def _kl_divergence(
 
 
 def _kl_divergence_bh(
-    params,
-    P,
-    degrees_of_freedom,
-    n_samples,
-    n_components,
-    angle=0.5,
-    skip_num_points=0,
-    verbose=False,
-    compute_error=True,
-    num_threads=1,
+        params,
+        P,
+        degrees_of_freedom,
+        n_samples,
+        n_components,
+        angle=0.5,
+        skip_num_points=0,
+        verbose=False,
+        compute_error=True,
+        num_threads=1,
 ):
     """t-SNE objective function: KL divergence of p_ijs and q_ijs.
 
@@ -297,19 +296,19 @@ def _kl_divergence_bh(
 
 
 def _gradient_descent(
-    objective,
-    p0,
-    it,
-    n_iter,
-    n_iter_check=1,
-    n_iter_without_progress=300,
-    momentum=0.8,
-    learning_rate=200.0,
-    min_gain=0.01,
-    min_grad_norm=1e-7,
-    verbose=0,
-    args=None,
-    kwargs=None,
+        objective,
+        p0,
+        it,
+        n_iter,
+        n_iter_check=1,
+        n_iter_without_progress=300,
+        momentum=0.8,
+        learning_rate=200.0,
+        min_gain=0.01,
+        min_grad_norm=1e-7,
+        verbose=0,
+        args=None,
+        kwargs=None,
 ):
     """Batch gradient descent with momentum and individual gains.
 
@@ -502,8 +501,8 @@ def trustworthiness(X, X_embedded, *, n_neighbors=5, metric="euclidean"):
     # `ind_X[i]` is the index of sorted distances between i and other samples
     ind_X_embedded = (
         NearestNeighbors(n_neighbors=n_neighbors)
-        .fit(X_embedded)
-        .kneighbors(return_distance=False)
+            .fit(X_embedded)
+            .kneighbors(return_distance=False)
     )
 
     # We build an inverted index of neighbors in the input space: For sample i,
@@ -514,11 +513,11 @@ def trustworthiness(X, X_embedded, *, n_neighbors=5, metric="euclidean"):
     ordered_indices = np.arange(n_samples + 1)
     inverted_index[ordered_indices[:-1, np.newaxis], ind_X] = ordered_indices[1:]
     ranks = (
-        inverted_index[ordered_indices[:-1, np.newaxis], ind_X_embedded] - n_neighbors
+            inverted_index[ordered_indices[:-1, np.newaxis], ind_X_embedded] - n_neighbors
     )
     t = np.sum(ranks[ranks > 0])
     t = 1.0 - t * (
-        2.0 / (n_samples * n_neighbors * (2.0 * n_samples - 3.0 * n_neighbors - 1.0))
+            2.0 / (n_samples * n_neighbors * (2.0 * n_samples - 3.0 * n_neighbors - 1.0))
     )
     return t
 
@@ -739,24 +738,24 @@ class TSNE(BaseEstimator):
     _N_ITER_CHECK = 50
 
     def __init__(
-        self,
-        n_components=2,
-        *,
-        perplexity=30.0,
-        early_exaggeration=12.0,
-        learning_rate="warn",
-        n_iter=1000,
-        n_iter_without_progress=300,
-        min_grad_norm=1e-7,
-        metric="euclidean",
-        metric_params=None,
-        init="warn",
-        verbose=0,
-        random_state=None,
-        method="barnes_hut",
-        angle=0.5,
-        n_jobs=None,
-        square_distances="deprecated",
+            self,
+            n_components=2,
+            *,
+            perplexity=30.0,
+            early_exaggeration=12.0,
+            learning_rate="warn",
+            n_iter=1000,
+            n_iter_without_progress=300,
+            min_grad_norm=1e-7,
+            metric="euclidean",
+            metric_params=None,
+            init="warn",
+            verbose=0,
+            random_state=None,
+            method="barnes_hut",
+            angle=0.5,
+            n_jobs=None,
+            square_distances="deprecated",
     ):
         self.n_components = n_components
         self.perplexity = perplexity
@@ -1008,13 +1007,13 @@ class TSNE(BaseEstimator):
         )
 
     def _tsne(
-        self,
-        P,
-        degrees_of_freedom,
-        n_samples,
-        X_embedded,
-        neighbors=None,
-        skip_num_points=0,
+            self,
+            P,
+            degrees_of_freedom,
+            n_samples,
+            X_embedded,
+            neighbors=None,
+            skip_num_points=0,
     ):
         """Runs t-SNE."""
         # t-SNE minimizes the Kullback-Leiber divergence of the Gaussians P
@@ -1128,3 +1127,6 @@ class TSNE(BaseEstimator):
         """
         self.fit_transform(X)
         return self
+
+    def _more_tags(self):
+        return {"pairwise": self.metric == "precomputed"}

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -29,6 +29,7 @@ from . import _utils  # type: ignore
 # mypy error: Module 'sklearn.manifold' has no attribute '_barnes_hut_tsne'
 from . import _barnes_hut_tsne  # type: ignore
 
+
 MACHINE_EPSILON = np.finfo(np.double).eps
 
 
@@ -123,13 +124,13 @@ def _joint_probabilities_nn(distances, desired_perplexity, verbose):
 
 
 def _kl_divergence(
-        params,
-        P,
-        degrees_of_freedom,
-        n_samples,
-        n_components,
-        skip_num_points=0,
-        compute_error=True,
+    params,
+    P,
+    degrees_of_freedom,
+    n_samples,
+    n_components,
+    skip_num_points=0,
+    compute_error=True,
 ):
     """t-SNE objective function: gradient of the KL divergence
     of p_ijs and q_ijs and the absolute error.
@@ -200,16 +201,16 @@ def _kl_divergence(
 
 
 def _kl_divergence_bh(
-        params,
-        P,
-        degrees_of_freedom,
-        n_samples,
-        n_components,
-        angle=0.5,
-        skip_num_points=0,
-        verbose=False,
-        compute_error=True,
-        num_threads=1,
+    params,
+    P,
+    degrees_of_freedom,
+    n_samples,
+    n_components,
+    angle=0.5,
+    skip_num_points=0,
+    verbose=False,
+    compute_error=True,
+    num_threads=1,
 ):
     """t-SNE objective function: KL divergence of p_ijs and q_ijs.
 
@@ -296,19 +297,19 @@ def _kl_divergence_bh(
 
 
 def _gradient_descent(
-        objective,
-        p0,
-        it,
-        n_iter,
-        n_iter_check=1,
-        n_iter_without_progress=300,
-        momentum=0.8,
-        learning_rate=200.0,
-        min_gain=0.01,
-        min_grad_norm=1e-7,
-        verbose=0,
-        args=None,
-        kwargs=None,
+    objective,
+    p0,
+    it,
+    n_iter,
+    n_iter_check=1,
+    n_iter_without_progress=300,
+    momentum=0.8,
+    learning_rate=200.0,
+    min_gain=0.01,
+    min_grad_norm=1e-7,
+    verbose=0,
+    args=None,
+    kwargs=None,
 ):
     """Batch gradient descent with momentum and individual gains.
 
@@ -501,8 +502,8 @@ def trustworthiness(X, X_embedded, *, n_neighbors=5, metric="euclidean"):
     # `ind_X[i]` is the index of sorted distances between i and other samples
     ind_X_embedded = (
         NearestNeighbors(n_neighbors=n_neighbors)
-            .fit(X_embedded)
-            .kneighbors(return_distance=False)
+        .fit(X_embedded)
+        .kneighbors(return_distance=False)
     )
 
     # We build an inverted index of neighbors in the input space: For sample i,
@@ -513,11 +514,11 @@ def trustworthiness(X, X_embedded, *, n_neighbors=5, metric="euclidean"):
     ordered_indices = np.arange(n_samples + 1)
     inverted_index[ordered_indices[:-1, np.newaxis], ind_X] = ordered_indices[1:]
     ranks = (
-            inverted_index[ordered_indices[:-1, np.newaxis], ind_X_embedded] - n_neighbors
+        inverted_index[ordered_indices[:-1, np.newaxis], ind_X_embedded] - n_neighbors
     )
     t = np.sum(ranks[ranks > 0])
     t = 1.0 - t * (
-            2.0 / (n_samples * n_neighbors * (2.0 * n_samples - 3.0 * n_neighbors - 1.0))
+        2.0 / (n_samples * n_neighbors * (2.0 * n_samples - 3.0 * n_neighbors - 1.0))
     )
     return t
 
@@ -738,24 +739,24 @@ class TSNE(BaseEstimator):
     _N_ITER_CHECK = 50
 
     def __init__(
-            self,
-            n_components=2,
-            *,
-            perplexity=30.0,
-            early_exaggeration=12.0,
-            learning_rate="warn",
-            n_iter=1000,
-            n_iter_without_progress=300,
-            min_grad_norm=1e-7,
-            metric="euclidean",
-            metric_params=None,
-            init="warn",
-            verbose=0,
-            random_state=None,
-            method="barnes_hut",
-            angle=0.5,
-            n_jobs=None,
-            square_distances="deprecated",
+        self,
+        n_components=2,
+        *,
+        perplexity=30.0,
+        early_exaggeration=12.0,
+        learning_rate="warn",
+        n_iter=1000,
+        n_iter_without_progress=300,
+        min_grad_norm=1e-7,
+        metric="euclidean",
+        metric_params=None,
+        init="warn",
+        verbose=0,
+        random_state=None,
+        method="barnes_hut",
+        angle=0.5,
+        n_jobs=None,
+        square_distances="deprecated",
     ):
         self.n_components = n_components
         self.perplexity = perplexity
@@ -1007,13 +1008,13 @@ class TSNE(BaseEstimator):
         )
 
     def _tsne(
-            self,
-            P,
-            degrees_of_freedom,
-            n_samples,
-            X_embedded,
-            neighbors=None,
-            skip_num_points=0,
+        self,
+        P,
+        degrees_of_freedom,
+        n_samples,
+        X_embedded,
+        neighbors=None,
+        skip_num_points=0,
     ):
         """Runs t-SNE."""
         # t-SNE minimizes the Kullback-Leiber divergence of the Gaussians P


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #22809

#### What does this implement/fix? Explain your changes.
Add `_more_tags` function to DBSCAN and TSNE classes.
In `_more_tags` I made pairwise=True when metric=precomputed.

#### Any other comments?

