### PR TITLE
fixed typo error in  https://scikit-learn.org/stable/developers/contr…

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -394,7 +394,7 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    `sklearn/linear_model/logistic.py`, running the following commands will
    usually be enough:
 
-   - `pytest sklearn/linear_model/logistic.py` to make sure the doctest
+   - `pytest sklearn/linear_model/_logistic.py` to make sure the doctest
      examples are correct
    - `pytest sklearn/linear_model/tests/test_logistic.py` to run the tests
      specific to the file

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -391,7 +391,7 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    with `pytest`, but it is usually not recommended since it takes a long
    time. It is often enough to only run the test related to your changes:
    for example, if you changed something in
-   `sklearn/linear_model/logistic.py`, running the following commands will
+   `sklearn/linear_model/_logistic.py`, running the following commands will
    usually be enough:
 
    - `pytest sklearn/linear_model/_logistic.py` to make sure the doctest


### PR DESCRIPTION
Hi, @thomasjpfan I have changed logistic.py to _logistic.py which was a typo error in the scikit-learn.org/stable/developers/contributing.html file. Please review my pr and merge it. Thank you
Fixes #22813 