### PR TITLE
TST Replaces pytest.warns in test_affinity_propagation

### DIFF
--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -5,6 +5,8 @@ Testing for Clustering methods
 
 import numpy as np
 import pytest
+import warnings
+
 from scipy.sparse import csr_matrix
 
 from sklearn.exceptions import ConvergenceWarning
@@ -154,7 +156,7 @@ def test_affinity_propagation_equal_mutual_similarities():
     assert_array_equal([0, 0], labels)
 
     # setting different preferences
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         cluster_center_indices, labels = affinity_propagation(
             S, preference=[-20, -10], random_state=37
         )
@@ -245,7 +247,7 @@ def test_affinity_propagation_convergence_warning_dense_sparse(centers):
     ap = AffinityPropagation(random_state=46)
     ap.fit(X, y)
     ap.cluster_centers_ = centers
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         assert_array_equal(ap.predict(X), np.zeros(X.shape[0], dtype=int))
     assert not [w.message for w in record]
 


### PR DESCRIPTION
#### Reference Issues/PRs
References #22572.

#### What does this implement/fix? Explain your changes.
Replaces the depreciating function **pytest.warns(None)** with **warnings.catch_warnings(record=True)**.
File Updated: test_affinity_propagation.py

#### Any other comments?
None
