### PR TITLE
TST Replaces pytest.warns in /cluster, /cross_decomposition, /decomposition, and /ensemble folders

### DIFF
--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -3,7 +3,6 @@ Tests for sklearn.cluster._feature_agglomeration
 """
 # Authors: Sergul Aydore 2017
 import numpy as np
-import pytest
 import warnings
 
 from numpy.testing import assert_array_equal

--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -18,10 +18,10 @@ def test_feature_agglomeration():
 
     agglo_mean = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.mean)
     agglo_median = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.median)
-    with warnings.catch_warnings(record=True)  as record:
+    with warnings.catch_warnings(record=True) as record:
         agglo_mean.fit(X)
     assert not [w.message for w in record]
-    with warnings.catch_warnings(record=True)  as record:
+    with warnings.catch_warnings(record=True) as record:
         agglo_median.fit(X)
     assert not [w.message for w in record]
 

--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -4,6 +4,7 @@ Tests for sklearn.cluster._feature_agglomeration
 # Authors: Sergul Aydore 2017
 import numpy as np
 import pytest
+import warnings
 
 from numpy.testing import assert_array_equal
 from sklearn.cluster import FeatureAgglomeration
@@ -17,10 +18,10 @@ def test_feature_agglomeration():
 
     agglo_mean = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.mean)
     agglo_median = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.median)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True)  as record:
         agglo_mean.fit(X)
     assert not [w.message for w in record]
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True)  as record:
         agglo_median.fit(X)
     assert not [w.message for w in record]
 

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -3,6 +3,7 @@
 # License: BSD 3 clause
 import numpy as np
 import pytest
+import warnings
 
 from sklearn.datasets import make_blobs
 from sklearn.cluster import OPTICS
@@ -224,7 +225,7 @@ def test_nowarn_if_metric_bool_data_bool():
     pairwise_metric = "rogerstanimoto"
     X = np.random.randint(2, size=(5, 2), dtype=bool)
 
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True)  as warn_record:
         OPTICS(metric=pairwise_metric).fit(X)
         assert len(warn_record) == 0
 
@@ -251,7 +252,7 @@ def test_nowarn_if_metric_no_bool():
     X_bool = np.random.randint(2, size=(5, 2), dtype=bool)
     X_num = np.random.randint(2, size=(5, 2), dtype=np.int32)
 
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True)  as warn_record:
         # fit boolean data
         OPTICS(metric=pairwise_metric).fit(X_bool)
         # fit numeric data

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -225,7 +225,7 @@ def test_nowarn_if_metric_bool_data_bool():
     pairwise_metric = "rogerstanimoto"
     X = np.random.randint(2, size=(5, 2), dtype=bool)
 
-    with warnings.catch_warnings(record=True)  as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         OPTICS(metric=pairwise_metric).fit(X)
         assert len(warn_record) == 0
 
@@ -252,7 +252,7 @@ def test_nowarn_if_metric_no_bool():
     X_bool = np.random.randint(2, size=(5, 2), dtype=bool)
     X_num = np.random.randint(2, size=(5, 2), dtype=np.int32)
 
-    with warnings.catch_warnings(record=True)  as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         # fit boolean data
         OPTICS(metric=pairwise_metric).fit(X_bool)
         # fit numeric data

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -1,5 +1,7 @@
 import pytest
 import numpy as np
+import warnings
+
 from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_allclose
 
 from sklearn.datasets import load_linnerud
@@ -560,7 +562,7 @@ def test_loadings_converges():
 
     cca = CCA(n_components=10, max_iter=500)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         cca.fit(X, y)
     # ConvergenceWarning should not be raised
     assert not [w.message for w in record]

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 import numpy as np
 from functools import partial
@@ -111,7 +112,7 @@ def test_max_iter():
         model.fit_transform(X)
 
     # check that the underlying model converges w/o warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         model = SparseCoder(
             D_multi, transform_algorithm=transform_algorithm, transform_max_iter=2000
         )

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -3,6 +3,7 @@ Test the fastica algorithm.
 """
 import itertools
 import pytest
+import warnings
 
 import numpy as np
 from scipy import stats
@@ -354,7 +355,7 @@ def test_fastica_whiten_backwards_compatibility():
     av_ica = FastICA(
         n_components=n_components, whiten="arbitrary-variance", random_state=0
     )
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True)  as warn_record:
         Xt_av = av_ica.fit_transform(X)
         assert len(warn_record) == 0
 

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -355,7 +355,7 @@ def test_fastica_whiten_backwards_compatibility():
     av_ica = FastICA(
         n_components=n_components, whiten="arbitrary-variance", random_state=0
     )
-    with warnings.catch_warnings(record=True)  as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         Xt_av = av_ica.fit_transform(X)
         assert len(warn_record) == 0
 

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 import pytest
+import warnings
 
 from sklearn.utils._testing import (
     assert_array_almost_equal,
@@ -234,7 +235,7 @@ def test_leave_zero_eig():
     X_fit = np.array([[1, 1], [0, 0]])
 
     # Assert that even with all np warnings on, there is no div by zero warning
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         with np.errstate(all="warn"):
             k = KernelPCA(n_components=2, remove_zero_eig=False, eigen_solver="dense")
             # Fit, then transform

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -3,6 +3,7 @@ import scipy as sp
 from numpy.testing import assert_array_equal
 
 import pytest
+import warnings
 
 from sklearn.utils._testing import assert_allclose
 
@@ -44,7 +45,7 @@ def test_no_empty_slice_warning():
     n_features = n_components + 2  # anything > n_comps triggered it in 0.16
     X = np.random.uniform(-1, 1, size=(n_components, n_features))
     pca = PCA(n_components=n_components)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         pca.fit(X)
     assert not [w.message for w in record]
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -7,6 +7,7 @@ Testing for Isolation Forest algorithm (sklearn.ensemble.iforest).
 # License: BSD 3 clause
 
 import pytest
+import warnings
 
 import numpy as np
 
@@ -105,12 +106,12 @@ def test_iforest_error():
     # note that assert_no_warnings does not apply since it enables a
     # PendingDeprecationWarning triggered by scipy.sparse's use of
     # np.matrix. See issue #11251.
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         IsolationForest(max_samples="auto").fit(X)
     user_warnings = [each for each in record if issubclass(each.category, UserWarning)]
     assert not user_warnings
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         IsolationForest(max_samples=np.int64(2)).fit(X)
     user_warnings = [each for each in record if issubclass(each.category, UserWarning)]
     assert not user_warnings

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -469,7 +469,7 @@ def test_set_estimator_drop():
         weights=[1, 0.5],
         flatten_transform=False,
     )
-    with warnings.catch_warnings(record=True)  as record:
+    with warnings.catch_warnings(record=True) as record:
         eclf2.set_params(rf="drop").fit(X1, y1)
     assert not [w.message for w in record]
     assert_array_almost_equal(

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -1,6 +1,7 @@
 """Testing for the VotingClassifier and VotingRegressor"""
 
 import pytest
+import warnings
 import re
 import numpy as np
 
@@ -426,7 +427,7 @@ def test_set_estimator_drop():
         voting="hard",
         weights=[1, 1, 0.5],
     )
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         eclf2.set_params(rf="drop").fit(X, y)
 
     assert not [w.message for w in record]
@@ -440,14 +441,14 @@ def test_set_estimator_drop():
     assert eclf2.get_params()["rf"] == "drop"
 
     eclf1.set_params(voting="soft").fit(X, y)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         eclf2.set_params(voting="soft").fit(X, y)
 
     assert not [w.message for w in record]
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
     assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
     msg = "All estimators are dropped. At least one is required"
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         with pytest.raises(ValueError, match=msg):
             eclf2.set_params(lr="drop", rf="drop", nb="drop").fit(X, y)
     assert not [w.message for w in record]
@@ -468,7 +469,7 @@ def test_set_estimator_drop():
         weights=[1, 0.5],
         flatten_transform=False,
     )
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True)  as record:
         eclf2.set_params(rf="drop").fit(X1, y1)
     assert not [w.message for w in record]
     assert_array_almost_equal(
@@ -560,7 +561,7 @@ def test_none_estimator_with_weights(X, y, voter):
     voter = clone(voter)
     voter.fit(X, y, sample_weight=np.ones(y.shape))
     voter.set_params(lr="drop")
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         voter.fit(X, y, sample_weight=np.ones(y.shape))
     assert not [w.message for w in record]
     y_pred = voter.predict(X)


### PR DESCRIPTION
Reference Issues/PRs
References https://github.com/scikit-learn/scikit-learn/issues/22572.

What does this implement/fix? Explain your changes.
Replaces the depreciating function **pytest.warns(None)** with **warnings.catch_warnings(record=True)**.

Files Updated: 
- test_feature_agglomeration.py
- test_optics.py
- sklearn/cross_decomposition/tests/test_pls.py
- sklearn/decomposition/tests/test_dict_learning.py
- sklearn/decomposition/tests/test_fastica.py
- sklearn/decomposition/tests/test_kernel_pca.py
- sklearn/decomposition/tests/test_pca.py
- sklearn/ensemble/tests/test_iforest.py
- sklearn/ensemble/tests/test_voting.py

Any other comments?
- Received 6 warnings when running Pytest on test_dict_learning.py
- Received 28 warnings when running Pytest on test_kernel_pca.py
- Received 17 warnings when running Pytest on test_voting.py

Unsure if these warnings are related to my updates or were preexisting...

