### PR TITLE
TST Replace pytest.warns

### DIFF
--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -3,7 +3,6 @@ Tests for sklearn.cluster._feature_agglomeration
 """
 # Authors: Sergul Aydore 2017
 import numpy as np
-import pytest
 import warnings
 
 from numpy.testing import assert_array_equal

--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -18,10 +18,10 @@ def test_feature_agglomeration():
 
     agglo_mean = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.mean)
     agglo_median = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.median)
-    with warnings.catch_warnings(record=True)  as record:
+    with warnings.catch_warnings(record=True) as record:
         agglo_mean.fit(X)
     assert not [w.message for w in record]
-    with warnings.catch_warnings(record=True)  as record:
+    with warnings.catch_warnings(record=True) as record:
         agglo_median.fit(X)
     assert not [w.message for w in record]
 

--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -4,6 +4,7 @@ Tests for sklearn.cluster._feature_agglomeration
 # Authors: Sergul Aydore 2017
 import numpy as np
 import pytest
+import warnings
 
 from numpy.testing import assert_array_equal
 from sklearn.cluster import FeatureAgglomeration
@@ -17,10 +18,10 @@ def test_feature_agglomeration():
 
     agglo_mean = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.mean)
     agglo_median = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.median)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True)  as record:
         agglo_mean.fit(X)
     assert not [w.message for w in record]
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True)  as record:
         agglo_median.fit(X)
     assert not [w.message for w in record]
 

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -3,6 +3,7 @@
 # License: BSD 3 clause
 import numpy as np
 import pytest
+import warnings
 
 from sklearn.datasets import make_blobs
 from sklearn.cluster import OPTICS
@@ -224,7 +225,7 @@ def test_nowarn_if_metric_bool_data_bool():
     pairwise_metric = "rogerstanimoto"
     X = np.random.randint(2, size=(5, 2), dtype=bool)
 
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True)  as warn_record:
         OPTICS(metric=pairwise_metric).fit(X)
         assert len(warn_record) == 0
 
@@ -251,7 +252,7 @@ def test_nowarn_if_metric_no_bool():
     X_bool = np.random.randint(2, size=(5, 2), dtype=bool)
     X_num = np.random.randint(2, size=(5, 2), dtype=np.int32)
 
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True)  as warn_record:
         # fit boolean data
         OPTICS(metric=pairwise_metric).fit(X_bool)
         # fit numeric data

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -225,7 +225,7 @@ def test_nowarn_if_metric_bool_data_bool():
     pairwise_metric = "rogerstanimoto"
     X = np.random.randint(2, size=(5, 2), dtype=bool)
 
-    with warnings.catch_warnings(record=True)  as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         OPTICS(metric=pairwise_metric).fit(X)
         assert len(warn_record) == 0
 
@@ -252,7 +252,7 @@ def test_nowarn_if_metric_no_bool():
     X_bool = np.random.randint(2, size=(5, 2), dtype=bool)
     X_num = np.random.randint(2, size=(5, 2), dtype=np.int32)
 
-    with warnings.catch_warnings(record=True)  as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         # fit boolean data
         OPTICS(metric=pairwise_metric).fit(X_bool)
         # fit numeric data

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -1,5 +1,7 @@
 import pytest
 import numpy as np
+import warnings
+
 from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_allclose
 
 from sklearn.datasets import load_linnerud
@@ -560,7 +562,7 @@ def test_loadings_converges():
 
     cca = CCA(n_components=10, max_iter=500)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         cca.fit(X, y)
     # ConvergenceWarning should not be raised
     assert not [w.message for w in record]

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 import numpy as np
 from functools import partial
@@ -111,7 +112,7 @@ def test_max_iter():
         model.fit_transform(X)
 
     # check that the underlying model converges w/o warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         model = SparseCoder(
             D_multi, transform_algorithm=transform_algorithm, transform_max_iter=2000
         )

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -3,6 +3,7 @@ Test the fastica algorithm.
 """
 import itertools
 import pytest
+import warnings
 
 import numpy as np
 from scipy import stats
@@ -354,7 +355,7 @@ def test_fastica_whiten_backwards_compatibility():
     av_ica = FastICA(
         n_components=n_components, whiten="arbitrary-variance", random_state=0
     )
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True)  as warn_record:
         Xt_av = av_ica.fit_transform(X)
         assert len(warn_record) == 0
 

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -355,7 +355,7 @@ def test_fastica_whiten_backwards_compatibility():
     av_ica = FastICA(
         n_components=n_components, whiten="arbitrary-variance", random_state=0
     )
-    with warnings.catch_warnings(record=True)  as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         Xt_av = av_ica.fit_transform(X)
         assert len(warn_record) == 0
 

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 import pytest
+import warnings
 
 from sklearn.utils._testing import (
     assert_array_almost_equal,
@@ -234,7 +235,7 @@ def test_leave_zero_eig():
     X_fit = np.array([[1, 1], [0, 0]])
 
     # Assert that even with all np warnings on, there is no div by zero warning
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         with np.errstate(all="warn"):
             k = KernelPCA(n_components=2, remove_zero_eig=False, eigen_solver="dense")
             # Fit, then transform

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -3,6 +3,7 @@ import scipy as sp
 from numpy.testing import assert_array_equal
 
 import pytest
+import warnings
 
 from sklearn.utils._testing import assert_allclose
 
@@ -44,7 +45,7 @@ def test_no_empty_slice_warning():
     n_features = n_components + 2  # anything > n_comps triggered it in 0.16
     X = np.random.uniform(-1, 1, size=(n_components, n_features))
     pca = PCA(n_components=n_components)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         pca.fit(X)
     assert not [w.message for w in record]
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -7,6 +7,7 @@ Testing for Isolation Forest algorithm (sklearn.ensemble.iforest).
 # License: BSD 3 clause
 
 import pytest
+import warnings
 
 import numpy as np
 
@@ -105,12 +106,12 @@ def test_iforest_error():
     # note that assert_no_warnings does not apply since it enables a
     # PendingDeprecationWarning triggered by scipy.sparse's use of
     # np.matrix. See issue #11251.
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         IsolationForest(max_samples="auto").fit(X)
     user_warnings = [each for each in record if issubclass(each.category, UserWarning)]
     assert not user_warnings
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         IsolationForest(max_samples=np.int64(2)).fit(X)
     user_warnings = [each for each in record if issubclass(each.category, UserWarning)]
     assert not user_warnings

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -469,7 +469,7 @@ def test_set_estimator_drop():
         weights=[1, 0.5],
         flatten_transform=False,
     )
-    with warnings.catch_warnings(record=True)  as record:
+    with warnings.catch_warnings(record=True) as record:
         eclf2.set_params(rf="drop").fit(X1, y1)
     assert not [w.message for w in record]
     assert_array_almost_equal(

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -1,6 +1,7 @@
 """Testing for the VotingClassifier and VotingRegressor"""
 
 import pytest
+import warnings
 import re
 import numpy as np
 
@@ -426,7 +427,7 @@ def test_set_estimator_drop():
         voting="hard",
         weights=[1, 1, 0.5],
     )
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         eclf2.set_params(rf="drop").fit(X, y)
 
     assert not [w.message for w in record]
@@ -440,14 +441,14 @@ def test_set_estimator_drop():
     assert eclf2.get_params()["rf"] == "drop"
 
     eclf1.set_params(voting="soft").fit(X, y)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         eclf2.set_params(voting="soft").fit(X, y)
 
     assert not [w.message for w in record]
     assert_array_equal(eclf1.predict(X), eclf2.predict(X))
     assert_array_almost_equal(eclf1.predict_proba(X), eclf2.predict_proba(X))
     msg = "All estimators are dropped. At least one is required"
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         with pytest.raises(ValueError, match=msg):
             eclf2.set_params(lr="drop", rf="drop", nb="drop").fit(X, y)
     assert not [w.message for w in record]
@@ -468,7 +469,7 @@ def test_set_estimator_drop():
         weights=[1, 0.5],
         flatten_transform=False,
     )
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True)  as record:
         eclf2.set_params(rf="drop").fit(X1, y1)
     assert not [w.message for w in record]
     assert_array_almost_equal(
@@ -560,7 +561,7 @@ def test_none_estimator_with_weights(X, y, voter):
     voter = clone(voter)
     voter.fit(X, y, sample_weight=np.ones(y.shape))
     voter.set_params(lr="drop")
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         voter.fit(X, y, sample_weight=np.ones(y.shape))
     assert not [w.message for w in record]
     y_pred = voter.predict(X)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -3,6 +3,8 @@ from collections.abc import Mapping
 import re
 
 import pytest
+import warnings
+
 from scipy import sparse
 
 from sklearn.feature_extraction.text import strip_tags
@@ -451,7 +453,7 @@ def test_countvectorizer_uppercase_in_vocab():
     with pytest.warns(UserWarning, match=message):
         vectorizer.fit(vocabulary)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         vectorizer.transform(vocabulary)
     assert not [w.message for w in record]
 
@@ -1421,7 +1423,7 @@ def test_vectorizer_stop_words_inconsistent():
         assert _check_stop_words_consistency(vec) is False
 
     # Only one warning per stop list
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         vec.fit_transform(["hello world"])
     assert not [w.message for w in record]
     assert _check_stop_words_consistency(vec) is None

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -208,7 +208,7 @@ def test_r_regression_force_finite(X, y, expected_corr_coef, force_finite):
     Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/15672
     """
-    with pytest.warns(None) as records:
+    with warnings.catch_warnings(record=True) as records:
         corr_coef = r_regression(X, y, force_finite=force_finite)
     assert not [w.message for w in records]
     np.testing.assert_array_almost_equal(corr_coef, expected_corr_coef)
@@ -291,7 +291,7 @@ def test_f_regression_corner_case(
     Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/15672
     """
-    with pytest.warns(None) as records:
+    with warnings.catch_warnings(record=True) as records:
         f_statistic, p_values = f_regression(X, y, force_finite=force_finite)
     assert not [w.message for w in records]
     np.testing.assert_array_almost_equal(f_statistic, expected_f_statistic)

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 import numpy as np
 
 from sklearn.utils._testing import assert_array_almost_equal
@@ -453,6 +454,6 @@ def test_estimator_does_not_support_feature_names():
     feature_names_out = set(selector.get_feature_names_out())
     assert feature_names_out < all_feature_names
 
-    with pytest.warns(None) as records:
+    with warnings.catch_warnings(record=True) as records:
         selector.transform(X.iloc[1:3])
     assert not [w.message for w in records]

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy.optimize import approx_fprime
 
 import pytest
+import warnings
 
 from sklearn.gaussian_process import GaussianProcessClassifier
 from sklearn.gaussian_process.kernels import (
@@ -207,7 +208,7 @@ def test_warning_bounds():
         length_scale_bounds=[1e3, 1e5]
     )
     gpc_sum = GaussianProcessClassifier(kernel=kernel_sum)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         gpc_sum.fit(X, y)
 
     assert len(record) == 2
@@ -235,7 +236,7 @@ def test_warning_bounds():
     kernel_dims = RBF(length_scale=[1.0, 2.0], length_scale_bounds=[1e1, 1e2])
     gpc_dims = GaussianProcessClassifier(kernel=kernel_dims)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         gpc_dims.fit(X_tile, y)
 
     assert len(record) == 2

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy.optimize import approx_fprime
 
 import pytest
+import warnings
 
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C, WhiteKernel
@@ -478,7 +479,7 @@ def test_warning_bounds():
         length_scale_bounds=[1e3, 1e5]
     )
     gpr_sum = GaussianProcessRegressor(kernel=kernel_sum)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         gpr_sum.fit(X, y)
 
     assert len(record) == 2
@@ -506,7 +507,7 @@ def test_warning_bounds():
     kernel_dims = RBF(length_scale=[1.0, 2.0], length_scale_bounds=[1e1, 1e2])
     gpr_dims = GaussianProcessRegressor(kernel=kernel_dims)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         gpr_dims.fit(X_tile, y)
 
     assert len(record) == 2

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 import numpy as np
 from scipy import sparse
@@ -979,7 +980,7 @@ def test_iterative_imputer_catch_warning():
         X[sample_idx, feat] = np.nan
 
     imputer = IterativeImputer(n_nearest_features=5, sample_posterior=True)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         X_fill = imputer.fit_transform(X, y)
     assert not [w.message for w in record]
     assert not np.any(np.isnan(X_fill))

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -5,7 +5,7 @@
 # License: BSD 3 clause
 
 import pytest
-
+import warnings
 import numpy as np
 from scipy import sparse
 from scipy import linalg
@@ -358,7 +358,7 @@ def test_linear_regression_pd_sparse_dataframe_warning():
     df["0"] = pd.arrays.SparseArray(df["0"], fill_value=0)
     assert hasattr(df, "sparse")
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         reg.fit(df.iloc[:, 0:2], df.iloc[:, 3])
     assert not [w.message for w in record]
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -99,7 +99,7 @@ def test_assure_warning_when_normalize(CoordinateDescentModel, normalize, n_warn
         y = np.stack((y, y), axis=1)
 
     model = CoordinateDescentModel(normalize=normalize)
-    with warnings.catch_warnings(record=True) as record:
+    with pytest.warns(None) as record:
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import pytest
+import warnings
 from scipy import interpolate, sparse
 from copy import deepcopy
 import joblib
@@ -98,7 +99,7 @@ def test_assure_warning_when_normalize(CoordinateDescentModel, normalize, n_warn
         y = np.stack((y, y), axis=1)
 
     model = CoordinateDescentModel(normalize=normalize)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]
@@ -1428,7 +1429,7 @@ def test_convergence_warnings():
         MultiTaskElasticNet(max_iter=1, tol=-1).fit(X, y)
 
     # check that the model converges w/o warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         MultiTaskElasticNet().fit(X, y)
 
     assert not [w.message for w in record]
@@ -1441,7 +1442,7 @@ def test_sparse_input_convergence_warning():
         ElasticNet(max_iter=1, tol=0).fit(sparse.csr_matrix(X, dtype=np.float32), y)
 
     # check that the model converges w/o warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         Lasso().fit(sparse.csr_matrix(X, dtype=np.float32), y)
 
     assert not [w.message for w in record]

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -47,7 +47,7 @@ def test_assure_warning_when_normalize(LeastAngleModel, normalize, n_warnings):
     y = rng.rand(n_samples)
 
     model = LeastAngleModel(normalize=normalize)
-    with warnings.catch_warnings(record=True) as record:
+    with pytest.warns(None) as record:
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pytest
 import warnings

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 import pytest
+import warnings
 from scipy import linalg
 from sklearn.base import clone
 from sklearn.model_selection import train_test_split
@@ -48,7 +49,7 @@ def test_assure_warning_when_normalize(LeastAngleModel, normalize, n_warnings):
     y = rng.rand(n_samples)
 
     model = LeastAngleModel(normalize=normalize)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy import sparse
 
 import pytest
+import warnings
 
 from sklearn.base import clone
 from sklearn.datasets import load_iris, make_classification
@@ -138,7 +139,7 @@ def test_logistic_cv_score_does_not_warn_by_default():
     lr = LogisticRegressionCV(cv=2)
     lr.fit(X, Y1)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         lr.score(X, lr.predict(X))
     assert not [w.message for w in record]
 

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pytest
+import warnings
 
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_equal
@@ -53,7 +54,7 @@ def test_assure_warning_when_normalize(OmpModel, normalize, n_warnings):
     y = rng.rand(n_samples)
 
     model = OmpModel(normalize=normalize)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import pytest
-import warnings
 
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils._testing import assert_array_equal
@@ -54,7 +53,7 @@ def test_assure_warning_when_normalize(OmpModel, normalize, n_warnings):
     y = rng.rand(n_samples)
 
     model = OmpModel(normalize=normalize)
-    with warnings.catch_warnings(record=True) as record:
+    with pytest.warns(None) as record:
         model.fit(X, y)
 
     record = [r for r in record if r.category == FutureWarning]

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -4,6 +4,7 @@ from scipy import linalg
 from itertools import product
 
 import pytest
+import warnings
 
 from sklearn.utils import _IS_32BIT
 from sklearn.utils._testing import assert_almost_equal
@@ -1384,7 +1385,7 @@ def test_ridge_fit_intercept_sparse(solver):
     dense_ridge = Ridge(solver="sparse_cg", tol=1e-12)
     sparse_ridge = Ridge(solver=solver, tol=1e-12, positive=positive)
     dense_ridge.fit(X, y)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         sparse_ridge.fit(X_csr, y)
     assert not [w.message for w in record]
     assert np.allclose(dense_ridge.intercept_, sparse_ridge.intercept_)
@@ -1413,7 +1414,7 @@ def test_ridge_fit_intercept_sparse_sag():
     dense_ridge = Ridge(**params)
     sparse_ridge = Ridge(**params)
     dense_ridge.fit(X, y)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         sparse_ridge.fit(X_csr, y)
     assert not [w.message for w in record]
     assert np.allclose(dense_ridge.intercept_, sparse_ridge.intercept_, rtol=1e-4)


### PR DESCRIPTION
**Reference Issues/PRs**
References https://github.com/scikit-learn/scikit-learn/issues/22572.

**What does this implement/fix? Explain your changes.**
Replaces the depreciating function pytest.warns(None) with warnings.catch_warnings(record=True).

**Files Updated:**
-  sklearn/cross_decomposition/tests/test_pls.py:
-  sklearn/decomposition/tests/test_dict_learning.py:
-  sklearn/decomposition/tests/test_fastica.py:
-  sklearn/decomposition/tests/test_kernel_pca.py:
-  sklearn/decomposition/tests/test_pca.py:
-  sklearn/ensemble/tests/test_iforest.py:
-  sklearn/ensemble/tests/test_voting.py:
-  sklearn/feature_extraction/tests/test_text.py:
-  sklearn/feature_selection/tests/test_feature_select.py:
-  sklearn/feature_selection/tests/test_from_model.py:
-  sklearn/gaussian_process/tests/test_gpc.py:
-  sklearn/gaussian_process/tests/test_gpr.py:
-  sklearn/impute/tests/test_impute.py:
-  sklearn/linear_model/tests/test_base.py:
-  sklearn/linear_model/tests/test_coordinate_descent.py:
-  sklearn/linear_model/tests/test_least_angle.py:
-  sklearn/linear_model/tests/test_logistic.py:
-  sklearn/linear_model/tests/test_omp.py:
-  sklearn/linear_model/tests/test_ridge.py:

**Any other comments?**

Received 6 warnings when running Pytest on test_dict_learning.py
Received 28 warnings when running Pytest on test_kernel_pca.py
Received 17 warnings when running Pytest on test_voting.py
Received 6 warnings when running Pytest on test_text.py
Received 3 warnings when running Pytest on test_from_model.py
Received 15 warnings when running Pytest on test_gpc.py
Received 49 warnings when running Pytest on test_gpr.py
Received 32 warnings when running Pytest on test_impute.py
Received 5 warnings when running Pytest on test_base.py
Received 264 warnings when running Pytest on test_coordinate_descent.py
Received 8 warnings when running Pytest on test_least_angle.py
Received 468 warnings when running Pytest on test_logistic.py
Received 5 warnings when running Pytest on test_omp.py
Received 82 warnings when running Pytest on test_ridge.py

Unsure if these warnings are related to my updates or were preexisting...