### PR TITLE
TST Replace pytest.warns

### DIFF
--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
-import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1135,7 +1134,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1155,7 +1154,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
+import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1134,7 +1135,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1154,7 +1155,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import warnings
 
 from sklearn.metrics.cluster import adjusted_mutual_info_score
 from sklearn.metrics.cluster import adjusted_rand_score
@@ -456,7 +457,7 @@ def test_adjusted_rand_score_overflow():
     rng = np.random.RandomState(0)
     y_true = rng.randint(0, 2, 100_000, dtype=np.int8)
     y_pred = rng.randint(0, 2, 100_000, dtype=np.int8)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         adjusted_rand_score(y_true, y_pred)
     assert not [w.message for w in record]
 

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 import pytest
+import warnings
 from scipy.sparse import csr_matrix
 
 from sklearn import datasets
@@ -341,7 +342,7 @@ def test_davies_bouldin_score():
     pytest.approx(davies_bouldin_score(X, labels), 2 * np.sqrt(0.5) / 3)
 
     # Ensure divide by zero warning is not raised in general case
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         davies_bouldin_score(X, labels)
     div_zero_warnings = [
         warning

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -589,12 +589,12 @@ def test_confusion_matrix_normalize_single_class():
     assert cm_true.sum() == pytest.approx(2.0)
 
     # additionally check that no warnings are raised due to a division by zero
-    with pytest.warns(None) as rec:
+    with warnings.catch_warnings(record=True) as rec:
         cm_pred = confusion_matrix(y_test, y_pred, normalize="pred")
     assert not rec
     assert cm_pred.sum() == pytest.approx(1.0)
 
-    with pytest.warns(None) as rec:
+    with warnings.catch_warnings(record=True) as rec:
         cm_pred = confusion_matrix(y_pred, y_test, normalize="true")
     assert not rec
 
@@ -1443,7 +1443,7 @@ def test_jaccard_score_zero_division_set_value(zero_division, expected_score):
     # check that we don't issue warning by passing the zero_division parameter
     y_true = np.array([[1, 0, 1], [0, 0, 0]])
     y_pred = np.array([[0, 0, 0], [0, 0, 0]])
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         score = jaccard_score(
             y_true, y_pred, average="samples", zero_division=zero_division
         )

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -17,6 +17,7 @@ except ImportError:
 from sklearn.utils.fixes import sp_version, parse_version
 
 import pytest
+import warnings
 
 from sklearn import config_context
 
@@ -192,7 +193,7 @@ def test_pairwise_boolean_distance(metric):
         pairwise_distances(X.astype(bool), Y=Y, metric=metric)
 
     # Check that no warning is raised if X is already boolean and Y is None:
-    with pytest.warns(None) as records:
+    with warnings.catch_warnings(record=True) as records:
         pairwise_distances(X.astype(bool), metric=metric)
     assert not [w.message for w in records]
 
@@ -201,7 +202,7 @@ def test_no_data_conversion_warning():
     # No warnings issued if metric is not a boolean distance function
     rng = np.random.RandomState(0)
     X = rng.randn(5, 4)
-    with pytest.warns(None) as records:
+    with warnings.catch_warnings(record=True) as records:
         pairwise_distances(X, metric="minkowski")
     assert not [w.message for w in records]
 

--- a/sklearn/preprocessing/tests/test_common.py
+++ b/sklearn/preprocessing/tests/test_common.py
@@ -68,7 +68,7 @@ def test_missing_value_handling(
     assert np.any(np.isnan(X_test), axis=0).all()
     X_test[:, 0] = np.nan  # make sure this boundary case is tested
 
-    with pytest.warns(None) as records:
+    with warnings.catch_warnings(record=True) as records:
         Xt = est.fit(X_train).transform(X_test)
     # ensure no warnings are raised
     assert not [w.message for w in records]
@@ -76,7 +76,7 @@ def test_missing_value_handling(
     assert_array_equal(np.isnan(Xt), np.isnan(X_test))
 
     # check that the function leads to the same results as the class
-    with pytest.warns(None) as records:
+    with warnings.catch_warnings(record=True) as records:
         Xt_class = est.transform(X_train)
     assert not [w.message for w in records]
     kwargs = est.get_params()
@@ -99,7 +99,7 @@ def test_missing_value_handling(
         # train only on non-NaN
         est.fit(_get_valid_samples_by_column(X_train, i))
         # check transforming with NaN works even when training without NaN
-        with pytest.warns(None) as records:
+        with warnings.catch_warnings(record=True) as records:
             Xt_col = est.transform(X_test[:, [i]])
         assert not [w.message for w in records]
         assert_allclose(Xt_col, Xt[:, [i]])
@@ -112,7 +112,7 @@ def test_missing_value_handling(
         est_dense = clone(est)
         est_sparse = clone(est)
 
-        with pytest.warns(None) as records:
+        with warnings.catch_warnings(record=True) as records:
             Xt_dense = est_dense.fit(X_train).transform(X_test)
             Xt_inv_dense = est_dense.inverse_transform(Xt_dense)
         assert not [w.message for w in records]
@@ -129,12 +129,12 @@ def test_missing_value_handling(
             # precompute the matrix to avoid catching side warnings
             X_train_sp = sparse_constructor(X_train)
             X_test_sp = sparse_constructor(X_test)
-            with pytest.warns(None) as records:
+            with warnings.catch_warnings(record=True) as records:
                 warnings.simplefilter("ignore", PendingDeprecationWarning)
                 Xt_sp = est_sparse.fit(X_train_sp).transform(X_test_sp)
             assert not [w.message for w in records]
             assert_allclose(Xt_sp.A, Xt_dense)
-            with pytest.warns(None) as records:
+            with warnings.catch_warnings(record=True) as records:
                 warnings.simplefilter("ignore", PendingDeprecationWarning)
                 Xt_inv_sp = est_sparse.inverse_transform(Xt_sp)
             assert not [w.message for w in records]

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -345,7 +345,7 @@ def test_standard_scaler_numerical_stability():
     x = np.full(8, np.log(1e-5), dtype=np.float64)
     # This does not raise a warning as the number of samples is too low
     # to trigger the problem in recent numpy
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         scale(x)
     assert not [w.message for w in record]
     assert_array_almost_equal(scale(x), np.zeros(8))
@@ -358,7 +358,7 @@ def test_standard_scaler_numerical_stability():
     assert_array_almost_equal(x_scaled, np.zeros(10))
 
     x = np.full(10, 1e-100, dtype=np.float64)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         x_small_scaled = scale(x)
     assert not [w.message for w in record]
     assert_array_almost_equal(x_small_scaled, np.zeros(10))

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 import numpy as np
 from scipy import sparse
 from sklearn.utils import _safe_indexing
@@ -152,7 +153,7 @@ def test_check_inverse():
             check_inverse=True,
             validate=True,
         )
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             Xt = trans.fit_transform(X)
         assert not [w.message for w in record]
         assert_allclose_dense_sparse(X, trans.inverse_transform(Xt))
@@ -162,13 +163,13 @@ def test_check_inverse():
     trans = FunctionTransformer(
         func=np.expm1, inverse_func=None, check_inverse=True, validate=True
     )
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         trans.fit(X_dense)
     assert not [w.message for w in record]
     trans = FunctionTransformer(
         func=None, inverse_func=np.expm1, check_inverse=True, validate=True
     )
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         trans.fit(X_dense)
     assert not [w.message for w in record]
 

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+import warnings 
 
 from scipy.sparse import issparse
 from sklearn.semi_supervised import _label_propagation as label_propagation
@@ -151,12 +152,12 @@ def test_convergence_warning():
     assert mdl.n_iter_ == mdl.max_iter
 
     mdl = label_propagation.LabelSpreading(kernel="rbf", max_iter=500)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         mdl.fit(X, y)
     assert not [w.message for w in record]
 
     mdl = label_propagation.LabelPropagation(kernel="rbf", max_iter=500)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         mdl.fit(X, y)
     assert not [w.message for w in record]
 
@@ -173,7 +174,7 @@ def test_label_propagation_non_zero_normalizer(LabelPropagationCls):
     X = np.array([[100.0, 100.0], [100.0, 100.0], [0.0, 0.0], [0.0, 0.0]])
     y = np.array([0, 1, -1, -1])
     mdl = LabelPropagationCls(kernel="knn", max_iter=100, n_neighbors=1)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         mdl.fit(X, y)
     assert not [w.message for w in record]
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -7,6 +7,7 @@ import numpy as np
 import itertools
 import pytest
 import re
+import warnings
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from numpy.testing import assert_almost_equal
@@ -1334,11 +1335,11 @@ def test_svc_ovr_tie_breaking(SVCClass):
 def test_gamma_auto():
     X, y = [[0.0, 1.2], [1.0, 1.3]], [0, 1]
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         svm.SVC(kernel="linear").fit(X, y)
     assert not [w.message for w in record]
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         svm.SVC(kernel="precomputed").fit(X, y)
     assert not [w.message for w in record]
 
@@ -1347,7 +1348,7 @@ def test_gamma_scale():
     X, y = [[0.0], [1.0]], [0, 1]
 
     clf = svm.SVC()
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         clf.fit(X, y)
     assert not [w.message for w in record]
     assert_almost_equal(clf._gamma, 4)
@@ -1355,7 +1356,7 @@ def test_gamma_scale():
     # X_var ~= 1 shouldn't raise warning, for when
     # gamma is not explicitly set.
     X, y = [[1, 2], [3, 2 * np.sqrt(6) / 3 + 2]], [0, 1]
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         clf.fit(X, y)
     assert not [w.message for w in record]
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -5,6 +5,7 @@ import re
 import numpy as np
 import scipy.sparse as sp
 import pytest
+import warnings
 
 import sklearn
 from sklearn.utils._testing import assert_array_equal
@@ -631,7 +632,7 @@ def test_feature_names_in():
     # fit on dataframe with all integer feature names works without warning
     df_int_names = pd.DataFrame(X_np)
     trans = NoOpTransformer()
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         trans.fit(df_int_names)
     assert not [w.message for w in record]
 
@@ -639,7 +640,7 @@ def test_feature_names_in():
     # -> do not warn on transform
     Xs = [X_np, df_int_names]
     for X in Xs:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             trans.transform(X)
         assert not [w.message for w in record]
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -367,7 +367,7 @@ column_name_estimators = list(
 def test_pandas_column_name_consistency(estimator):
     _set_checking_parameters(estimator)
     with ignore_warnings(category=(FutureWarning)):
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             check_dataframe_column_names_consistency(
                 estimator.__class__.__name__, estimator
             )

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import pytest
+import warnings
 
 from scipy import linalg
 
@@ -491,7 +492,7 @@ def test_lda_dimension_warning(n_classes, n_features):
     for n_components in [max_components - 1, None, max_components]:
         # if n_components <= min(n_classes - 1, n_features), no warning
         lda = LinearDiscriminantAnalysis(n_components=n_components)
-        with pytest.warns(None):
+        with warnings.catch_warnings(record=True):
             lda.fit(X, y)
 
     for n_components in [max_components + 1, max(n_features, n_classes - 1) + 1]:

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -42,7 +42,7 @@ def test_check_increasing_small_number_of_samples():
     x = [0, 1, 2]
     y = [1, 1.1, 1.05]
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         is_increasing = check_increasing(x, y)
     assert not [w.message for w in record]
 
@@ -54,7 +54,7 @@ def test_check_increasing_up():
     y = [0, 1.5, 2.77, 8.99, 8.99, 50]
 
     # Check that we got increasing=True and no warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         is_increasing = check_increasing(x, y)
     assert not [w.message for w in record]
 
@@ -66,7 +66,7 @@ def test_check_increasing_up_extreme():
     y = [0, 1, 2, 3, 4, 5]
 
     # Check that we got increasing=True and no warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         is_increasing = check_increasing(x, y)
     assert not [w.message for w in record]
 
@@ -78,7 +78,7 @@ def test_check_increasing_down():
     y = [0, -1.5, -2.77, -8.99, -8.99, -50]
 
     # Check that we got increasing=False and no warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         is_increasing = check_increasing(x, y)
     assert not [w.message for w in record]
 
@@ -90,7 +90,7 @@ def test_check_increasing_down_extreme():
     y = [0, -1, -2, -3, -4, -5]
 
     # Check that we got increasing=False and no warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         is_increasing = check_increasing(x, y)
     assert not [w.message for w in record]
 

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -3,6 +3,7 @@ import re
 import numpy as np
 import scipy.sparse
 import pytest
+import warnings
 
 from sklearn.datasets import load_digits, load_iris
 
@@ -513,7 +514,7 @@ def test_mnb_prior_unobserved_targets():
 
     clf = MultinomialNB()
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         clf.partial_fit(X, y, classes=[0, 1, 2])
     assert not [w.message for w in record]
 
@@ -522,7 +523,7 @@ def test_mnb_prior_unobserved_targets():
     assert clf.predict([[1, 1]]) == 0
 
     # add a training example with previously unobserved class
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         clf.partial_fit([[1, 1]], [2])
     assert not [w.message for w in record]
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -11,6 +11,7 @@ import pytest
 import numpy as np
 from scipy import sparse
 import joblib
+import warnings
 
 from sklearn.utils._testing import (
     assert_allclose,
@@ -227,7 +228,7 @@ def test_pipeline_invalid_parameters():
         pipe.set_params(anova__C=0.1)
 
     # Test clone
-    with pytest.warns(None):
+    with warnings.catch_warnings(record=True):
         pipe2 = clone(pipe)
     assert not pipe.named_steps["svc"] is pipe2.named_steps["svc"]
 
@@ -502,7 +503,7 @@ def test_feature_union():
     assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
 
     # Test clone
-    with pytest.warns(None):
+    with warnings.catch_warnings(record=True):
         fs2 = clone(fs)
     assert fs.transformer_list[0][1] is not fs2.transformer_list[0][1]
 
@@ -990,27 +991,27 @@ def test_set_feature_union_step_drop(get_names):
     assert_array_equal([[2, 3]], ft.fit_transform(X))
     assert_array_equal(["m2__x2", "m3__x3"], getattr(ft, get_names)())
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         ft.set_params(m2="drop")
         assert_array_equal([[3]], ft.fit(X).transform(X))
         assert_array_equal([[3]], ft.fit_transform(X))
     assert_array_equal(["m3__x3"], getattr(ft, get_names)())
     assert not [w.message for w in record]
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         ft.set_params(m3="drop")
         assert_array_equal([[]], ft.fit(X).transform(X))
         assert_array_equal([[]], ft.fit_transform(X))
     assert_array_equal([], getattr(ft, get_names)())
     assert not [w.message for w in record]
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         # check we can change back
         ft.set_params(m3=mult3)
         assert_array_equal([[3]], ft.fit(X).transform(X))
     assert not [w.message for w in record]
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         # Check 'drop' step at construction time
         ft = FeatureUnion([("m2", "drop"), ("m3", mult3)])
         assert_array_equal([[3]], ft.fit(X).transform(X))

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -472,7 +472,7 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
 
     X = pd.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
     subset = _safe_indexing(X, [0, 1], axis=0)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         subset.iloc[0, 0] = 10
     assert not [w.message for w in record]
     # The original dataframe is unaffected by the assignment on the subset:

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1088,7 +1088,7 @@ def test_retrieve_samples_from_non_standard_shape():
 def test_check_scalar_valid(x):
     """Test that check_scalar returns no error/warning if valid inputs are
     provided"""
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         scalar = check_scalar(
             x,
             "test_name",
@@ -1654,7 +1654,7 @@ def test_get_feature_names_pandas_with_ints_no_warning(names):
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame([[1, 2], [4, 5], [5, 6]], columns=names)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         names = _get_feature_names(X)
     assert not [w.message for w in record]
     assert names is None


### PR DESCRIPTION
Reference Issues/PRs
References https://github.com/scikit-learn/scikit-learn/issues/22572.

What does this implement/fix? Explain your changes.
Replaces the depreciating function **pytest.warns(None)** with **warnings.catch_warnings(record=True)**.

Files Updated: 
-  sklearn/manifold/tests/test_t_sne.py:
-  sklearn/metrics/cluster/tests/test_supervised.py:
-  sklearn/metrics/cluster/tests/test_unsupervised.py:
-  sklearn/metrics/tests/test_classification.py:
-  sklearn/metrics/tests/test_pairwise.py:
-  sklearn/preprocessing/tests/test_common.py:
-  sklearn/preprocessing/tests/test_data.py:
-  sklearn/preprocessing/tests/test_function_transformer.py:
-  sklearn/semi_supervised/tests/test_label_propagation.py:
-  sklearn/svm/tests/test_svm.py:
-  sklearn/tests/test_base.py:
-  sklearn/tests/test_common.py:
-  sklearn/tests/test_discriminant_analysis.py:
-  sklearn/tests/test_isotonic.py:
-  sklearn/tests/test_naive_bayes.py:
-  sklearn/tests/test_pipeline.py:
-  sklearn/utils/tests/test_utils.py:
-  sklearn/utils/tests/test_validation.py:

Any other comments?
Received 5 warnings when running Pytest on test_classification.py
Received 2 warnings when running Pytest on test_pairwise.py
Received 4 warnings when running Pytest on test_common.py
Received 12 warnings when running Pytest on test_data.py
Received 26 warnings when running Pytest on test_svm.py
Received 2046 warnings when running Pytest on sklearn/tests/test_common.py
Received 1 warning when running Pytest on test_discriminant_analysis.py
Received 2 warnings when running Pytest on test_naive_bayes.py
Received 3 warnings when running Pytest on test_pipeline.py
Received 14 warnings when running Pytest on test_utils.py
Received 29 warnings when running Pytest on test_validation.py