### PR TITLE
TST Convert warnings into errors in test_affinity_propgation

### DIFF
--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -156,11 +156,11 @@ def test_affinity_propagation_equal_mutual_similarities():
     assert_array_equal([0, 0], labels)
 
     # setting different preferences
-    with warnings.catch_warnings(record=True) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
         cluster_center_indices, labels = affinity_propagation(
             S, preference=[-20, -10], random_state=37
         )
-    assert not [w.message for w in record]
 
     # expect one cluster, with highest-preference sample as exemplar
     assert_array_equal([1], cluster_center_indices)
@@ -247,9 +247,9 @@ def test_affinity_propagation_convergence_warning_dense_sparse(centers):
     ap = AffinityPropagation(random_state=46)
     ap.fit(X, y)
     ap.cluster_centers_ = centers
-    with warnings.catch_warnings(record=True) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ConvergenceWarning)
         assert_array_equal(ap.predict(X), np.zeros(X.shape[0], dtype=int))
-    assert not [w.message for w in record]
 
 
 def test_affinity_propagation_float32():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to https://github.com/scikit-learn/scikit-learn/pull/22819
Related to #22572
Towards https://github.com/scikit-learn/scikit-learn/issues/22396

#### What does this implement/fix? Explain your changes.
This PR follows the idea in https://github.com/scikit-learn/scikit-learn/issues/22572#issuecomment-1066284782. For places where we test for "no warnings", we can convert those errors into warnings and have it raise normally.

I think this is nicer because the warning is explicit.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
