### PR TITLE
DEBUG swap coverage in windows azure builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -276,10 +276,10 @@ jobs:
         PYTHON_ARCH: '64'
         # Unpin when pytest stalling issue is fixed
         PYTEST_VERSION: '6.2.5'
-        COVERAGE: 'true'
         # Temporary fix for setuptools to use disutils from standard lib
         # https://github.com/numpy/numpy/issues/17216
         SETUPTOOLS_USE_DISTUTILS: 'stdlib'
       py38_pip_openblas_32bit:
         PYTHON_VERSION: '3.8'
         PYTHON_ARCH: '32'
+        COVERAGE: 'true'


### PR DESCRIPTION
Trying to understand why `py38_conda_forge_mkl` is significantly slower than `py38_pip_openblas_32bit`.

I suspect the coverage overhead that needs to do disk writes that might be slower on the Windows machines on Azure Pipelines. Let's see if this hypothesis holds.

For reference, here are the timings of those two builds on the last successful build in `main`:

![image](https://user-images.githubusercontent.com/89061/158144445-63c1876b-7ef0-4262-aa72-f951576ea3a7.png)
