### PR TITLE
DEBUG switch slow conda-forge macos build from mkl to openblas

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -244,9 +244,9 @@ jobs:
         ne(variables['Build.Reason'], 'Schedule')
       )
     matrix:
-      pylatest_conda_forge_mkl:
+      pylatest_conda_forge_openblas:
         DISTRIB: 'conda'
-        BLAS: 'mkl'
+        BLAS: 'openblas'
         CONDA_CHANNEL: 'conda-forge'
         CPU_COUNT: '3'
       pylatest_conda_mkl_no_openmp:


### PR DESCRIPTION
For some reason, the macos conda-forge MKL build is quite slow on the CI:

![image](https://user-images.githubusercontent.com/89061/158145195-223acadf-bea9-4e04-aad0-c550bcbcb3d0.png)

Let's see if this is related to the use of MKL. I have checked the output of threadpoolctl for that build and uses only 2 threads without having to set `MKL_NUM_THREADS` explicitly. Therefore I don't think it's caused by an oversubscription problem as I originally suspected.

Note that the coverage reporting is not enabled for that slowish build so this is not the cause either.

Let's see if using openblas instead of MKL would make that CI build run faster.