### PR TITLE
MAINT Adapt scheduling of `PairwiseDistancesRadiusNeighborhood`

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction.pyx
+++ b/sklearn/metrics/_pairwise_distances_reduction.pyx
@@ -1570,8 +1570,7 @@ cdef class PairwiseDistancesRadiusNeighborhood(PairwiseDistancesReduction):
             # This is done in parallel sample-wise (no need for locks)
             # using dynamic scheduling because we might not have
             # the same number of neighbors for each query vector.
-            # TODO: compare 'dynamic' vs 'static' vs 'guided'
-            for idx in prange(self.n_samples_X, schedule='dynamic'):
+            for idx in prange(self.n_samples_X, schedule='static'):
                 self._merge_vectors(idx, self.chunks_n_threads)
 
             # The content of the vector have been std::moved.
@@ -1595,7 +1594,7 @@ cdef class PairwiseDistancesRadiusNeighborhood(PairwiseDistancesReduction):
         cdef:
             ITYPE_t i, j
 
-        for i in prange(self.n_samples_X, nogil=True, schedule='dynamic',
+        for i in prange(self.n_samples_X, nogil=True, schedule='static',
                         num_threads=self.effective_n_threads):
             for j in range(deref(self.neigh_indices)[i].size()):
                 deref(self.neigh_distances)[i][j] = (


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Follow-up of #22320


#### What does this implement/fix? Explain your changes.

Test various configuration of scheduling for OpenMP and pick the best one using [this script](https://gist.github.com/jjerphan/e834bf6d8e567612b6a43a2d9a059b27) with mimalloc.

#### Results

##### main

![6eb25ca8db](https://user-images.githubusercontent.com/13029839/158161138-924a8c91-430a-4434-b844-9679cacf93ce.png)


<details>
<summary>Raw results</summary>

```
    n_threads  n_train  n_test  n_features  mean_runtime  stderr_runtime
0           1   100000  100000          50     49.852703               0
1           2   100000  100000          50     25.524960               0
2           4   100000  100000          50     13.016662               0
3           8   100000  100000          50      6.593470               0
4          16   100000  100000          50      3.460975               0
5          32   100000  100000          50      1.926909               0
6          64   100000  100000          50      1.190385               0
7         128   100000  100000          50      3.591503               0
8           1   100000  100000         100     81.334735               0
9           2   100000  100000         100     42.853891               0
10          4   100000  100000         100     21.615465               0
11          8   100000  100000         100     10.993820               0
12         16   100000  100000         100      5.942740               0
13         32   100000  100000         100      3.217021               0
14         64   100000  100000         100      2.211893               0
15        128   100000  100000         100      4.553800               0
16          1   100000  100000         500    266.815465               0
17          2   100000  100000         500    136.234599               0
18          4   100000  100000         500     68.475497               0
19          8   100000  100000         500     34.828070               0
20         16   100000  100000         500     18.272350               0
21         32   100000  100000         500     10.241434               0
22         64   100000  100000         500      6.827677               0
23        128   100000  100000         500     12.496416               0
```

</details>


##### bce219e

![bce219e](https://user-images.githubusercontent.com/13029839/158161152-ab64da7a-72f3-42b4-b2e5-8fcfc20bbae6.png)

<details>
<summary>Raw results</summary>

```
    n_threads  n_train  n_test  n_features  mean_runtime  stderr_runtime
0           1   100000  100000          50     49.647817               0
1           2   100000  100000          50     25.303432               0
2           4   100000  100000          50     13.012075               0
3           8   100000  100000          50      6.557708               0
4          16   100000  100000          50      3.449857               0
5          32   100000  100000          50      1.995586               0
6          64   100000  100000          50      1.379598               0
7         128   100000  100000          50      3.237672               0
8           1   100000  100000         100     81.184791               0
9           2   100000  100000         100     43.860247               0
10          4   100000  100000         100     21.843178               0
11          8   100000  100000         100     10.951101               0
12         16   100000  100000         100      5.777386               0
13         32   100000  100000         100      3.126215               0
14         64   100000  100000         100      2.094214               0
15        128   100000  100000         100      4.396689               0
16          1   100000  100000         500    266.283220               0
17          2   100000  100000         500    136.463786               0
18          4   100000  100000         500     68.596914               0
19          8   100000  100000         500     34.902744               0
20         16   100000  100000         500     18.462613               0
21         32   100000  100000         500     10.252221               0
22         64   100000  100000         500      7.240885               0
23        128   100000  100000         500     12.582132               0
```

</details>