### PR TITLE
API Deprecate if_delegate_has_method

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1613,7 +1613,6 @@ Plotting
    utils.gen_even_slices
    utils.graph.single_source_shortest_path_length
    utils.indexable
-   utils.metaestimators.if_delegate_has_method
    utils.metaestimators.available_if
    utils.multiclass.type_of_target
    utils.multiclass.is_multilabel
@@ -1654,5 +1653,11 @@ Utilities from joblib:
 Recently deprecated
 ===================
 
-To be removed in 1.0 (renaming of 0.25)
----------------------------------------
+To be removed in 1.3
+--------------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   utils.metaestimators.if_delegate_has_method

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -859,6 +859,9 @@ Changelog
   when a class is present in `y` but not in `class_weight`. :pr:`22595` by
   `Thomas Fan`_.
 
+- |API| :func:`utils.metaestimators.if_delegate_has_method` is deprecated and will be
+  removed in version 1.3. Use :func:`utils.metaestimators.available_if` instead.
+  :pr:`` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -861,7 +861,7 @@ Changelog
 
 - |API| :func:`utils.metaestimators.if_delegate_has_method` is deprecated and will be
   removed in version 1.3. Use :func:`utils.metaestimators.available_if` instead.
-  :pr:`` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+  :pr:`22830` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -178,7 +178,7 @@ def available_if(check):
     return lambda fn: _AvailableIfDescriptor(fn, check, attribute_name=fn.__name__)
 
 
-# TODO remove in version 1.3
+# TODO(1.3) remove
 class _IffHasAttrDescriptor(_AvailableIfDescriptor):
     """Implements a conditional property using the descriptor protocol.
 
@@ -222,12 +222,16 @@ class _IffHasAttrDescriptor(_AvailableIfDescriptor):
         return True
 
 
-# TODO remove in version 1.3
+# TODO(1.3) remove
 def if_delegate_has_method(delegate):
     """Create a decorator for methods that are delegated to a sub-estimator
 
     This enables ducktyping by hasattr returning True according to the
     sub-estimator.
+
+    .. deprecated:: 1.3
+        `if_delegate_has_method` is deprecated in version 1.1 and will be removed in
+        version 1.3. Use `available_if` instead.
 
     Parameters
     ----------

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -203,7 +203,7 @@ class _IffHasAttrDescriptor(_AvailableIfDescriptor):
         warnings.warn(
             "if_delegate_has_method was deprecated in version 1.1 and will be "
             "removed in version 1.3. Use if_available instead.",
-            FutureWarning
+            FutureWarning,
         )
 
         delegate = None

--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -3,6 +3,7 @@
 #         Andreas Mueller
 # License: BSD
 from typing import List, Any
+import warnings
 
 from abc import ABCMeta, abstractmethod
 from operator import attrgetter
@@ -177,6 +178,7 @@ def available_if(check):
     return lambda fn: _AvailableIfDescriptor(fn, check, attribute_name=fn.__name__)
 
 
+# TODO remove in version 1.3
 class _IffHasAttrDescriptor(_AvailableIfDescriptor):
     """Implements a conditional property using the descriptor protocol.
 
@@ -198,6 +200,12 @@ class _IffHasAttrDescriptor(_AvailableIfDescriptor):
         self.delegate_names = delegate_names
 
     def _check(self, obj):
+        warnings.warn(
+            "if_delegate_has_method was deprecated in version 1.1 and will be "
+            "removed in version 1.3. Use if_available instead.",
+            FutureWarning
+        )
+
         delegate = None
         for delegate_name in self.delegate_names:
             try:
@@ -214,6 +222,7 @@ class _IffHasAttrDescriptor(_AvailableIfDescriptor):
         return True
 
 
+# TODO remove in version 1.3
 def if_delegate_has_method(delegate):
     """Create a decorator for methods that are delegated to a sub-estimator
 

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -151,7 +151,7 @@ def test_if_delegate_has_method_deprecated():
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
         decorator = if_delegate_has_method(delegate="predict")
-    
+
     # Only when calling it
     with pytest.warns(FutureWarning, match="if_delegate_has_method was deprecated"):
         hasattr(MetaEst(HasPredict()), "predict")

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -150,7 +150,7 @@ def test_if_delegate_has_method_deprecated():
     # don't warn when creating the decorator
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
-        decorator = if_delegate_has_method(delegate="predict")
+        _ = if_delegate_has_method(delegate="predict")
 
     # Only when calling it
     with pytest.warns(FutureWarning, match="if_delegate_has_method was deprecated"):

--- a/sklearn/utils/tests/test_metaestimators.py
+++ b/sklearn/utils/tests/test_metaestimators.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import warnings
 
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.metaestimators import available_if
@@ -21,6 +22,7 @@ class MockMetaEstimator:
         pass
 
 
+@pytest.mark.filterwarnings("ignore:if_delegate_has_method was deprecated")
 def test_delegated_docstring():
     assert "This is a mock delegated function" in str(
         MockMetaEstimator.__dict__["func"].__doc__
@@ -76,6 +78,7 @@ class HasPredictAsNDArray:
     predict = np.ones((10, 2), dtype=np.int64)
 
 
+@pytest.mark.filterwarnings("ignore:if_delegate_has_method was deprecated")
 def test_if_delegate_has_method():
     assert hasattr(MetaEst(HasPredict()), "predict")
     assert not hasattr(MetaEst(HasNoPredict()), "predict")
@@ -131,6 +134,7 @@ def test_available_if_unbound_method():
         AvailableParameterEstimator.available_func(est)
 
 
+@pytest.mark.filterwarnings("ignore:if_delegate_has_method was deprecated")
 def test_if_delegate_has_method_numpy_array():
     """Check that we can check for an attribute that is a NumPy array.
 
@@ -139,3 +143,15 @@ def test_if_delegate_has_method_numpy_array():
     """
     estimator = MetaEst(HasPredictAsNDArray())
     assert hasattr(estimator, "predict")
+
+
+def test_if_delegate_has_method_deprecated():
+    """Check the deprecation warning of if_delegate_has_method"""
+    # don't warn when creating the decorator
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        decorator = if_delegate_has_method(delegate="predict")
+    
+    # Only when calling it
+    with pytest.warns(FutureWarning, match="if_delegate_has_method was deprecated"):
+        hasattr(MetaEst(HasPredict()), "predict")

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -516,6 +516,7 @@ class MockMetaEstimatorDeprecatedDelegation:
         """Incorrect docstring but should not be tested"""
 
 
+@pytest.mark.filterwarnings("ignore:if_delegate_has_method was deprecated")
 @pytest.mark.parametrize(
     "mock_meta",
     [


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/20506

The decorator has been replaced by `available_if` everywhere.