### PR TITLE
TST Replaces pytest.warns(None) in test_optics

### DIFF
--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -226,7 +226,6 @@ def test_nowarn_if_metric_bool_data_bool():
     X = np.random.randint(2, size=(5, 2), dtype=bool)
 
     with warnings.catch_warnings():
-        # DataConversionWarning should not be raised 
         warnings.simplefilter("error", DataConversionWarning)
 
         OPTICS(metric=pairwise_metric).fit(X)
@@ -255,7 +254,6 @@ def test_nowarn_if_metric_no_bool():
     X_num = np.random.randint(2, size=(5, 2), dtype=np.int32)
 
     with warnings.catch_warnings():
-        # DataConversionWarning should not be raised 
         warnings.simplefilter("error", DataConversionWarning)
 
         # fit boolean data

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -225,9 +225,11 @@ def test_nowarn_if_metric_bool_data_bool():
     pairwise_metric = "rogerstanimoto"
     X = np.random.randint(2, size=(5, 2), dtype=bool)
 
-    with warnings.catch_warnings(record=True) as warn_record:
+    with warnings.catch_warnings():
+        # DataConversionWarning should not be raised 
+        warnings.simplefilter("error", DataConversionWarning)
+
         OPTICS(metric=pairwise_metric).fit(X)
-        assert len(warn_record) == 0
 
 
 def test_warn_if_metric_bool_data_no_bool():
@@ -252,12 +254,14 @@ def test_nowarn_if_metric_no_bool():
     X_bool = np.random.randint(2, size=(5, 2), dtype=bool)
     X_num = np.random.randint(2, size=(5, 2), dtype=np.int32)
 
-    with warnings.catch_warnings(record=True) as warn_record:
+    with warnings.catch_warnings():
+        # DataConversionWarning should not be raised 
+        warnings.simplefilter("error", DataConversionWarning)
+
         # fit boolean data
         OPTICS(metric=pairwise_metric).fit(X_bool)
         # fit numeric data
         OPTICS(metric=pairwise_metric).fit(X_num)
-        assert len(warn_record) == 0
 
 
 def test_close_extract():

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -3,6 +3,7 @@
 # License: BSD 3 clause
 import numpy as np
 import pytest
+import warnings
 
 from sklearn.datasets import make_blobs
 from sklearn.cluster import OPTICS
@@ -224,7 +225,7 @@ def test_nowarn_if_metric_bool_data_bool():
     pairwise_metric = "rogerstanimoto"
     X = np.random.randint(2, size=(5, 2), dtype=bool)
 
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         OPTICS(metric=pairwise_metric).fit(X)
         assert len(warn_record) == 0
 
@@ -251,7 +252,7 @@ def test_nowarn_if_metric_no_bool():
     X_bool = np.random.randint(2, size=(5, 2), dtype=bool)
     X_num = np.random.randint(2, size=(5, 2), dtype=np.int32)
 
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings(record=True) as warn_record:
         # fit boolean data
         OPTICS(metric=pairwise_metric).fit(X_bool)
         # fit numeric data

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
-import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1135,7 +1134,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1155,7 +1154,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
+import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1134,7 +1135,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1154,7 +1155,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 


### PR DESCRIPTION
#### Reference Issues/PRs
References #22572.

#### What does this implement/fix? Explain your changes.
Replaces the depreciating function **pytest.warns(None)** with **warnings.catch_warnings(record=True)**.
File Updated: test_optics.py

#### Any other comments?
None