### PR TITLE
DOC Fix the formatting for environment variables in docs

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -163,14 +163,16 @@ Python runtime
 
 :func:`sklearn.set_config` controls the following behaviors:
 
-:assume_finite:
+`assume_finite`
+~~~~~~~~~~~~~~~
 
-    used to skip validation, which enables faster computations but may
-    lead to segmentation faults if the data contains NaNs.
+Used to skip validation, which enables faster computations but may lead to
+segmentation faults if the data contains NaNs.
 
-:working_memory:
+`working_memory`
+~~~~~~~~~~~~~~~~
 
-    the optimal size of temporary arrays used by some algorithms.
+The optimal size of temporary arrays used by some algorithms.
 
 .. _environment_variable:
 
@@ -179,83 +181,91 @@ Environment variables
 
 These environment variables should be set before importing scikit-learn.
 
-:SKLEARN_ASSUME_FINITE:
+`SKLEARN_ASSUME_FINITE`
+~~~~~~~~~~~~~~~~~~~~~~~
 
-    Sets the default value for the `assume_finite` argument of
-    :func:`sklearn.set_config`.
+Sets the default value for the `assume_finite` argument of
+:func:`sklearn.set_config`.
 
-:SKLEARN_WORKING_MEMORY:
+`SKLEARN_WORKING_MEMORY`
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Sets the default value for the `working_memory` argument of
-    :func:`sklearn.set_config`.
+Sets the default value for the `working_memory` argument of
+:func:`sklearn.set_config`.
 
-:SKLEARN_SEED:
+`SKLEARN_SEED`
+~~~~~~~~~~~~~~
 
-    Sets the seed of the global random generator when running the tests,
-    for reproducibility.
+Sets the seed of the global random generator when running the tests, for
+reproducibility.
 
-    Note that scikit-learn tests are expected to run deterministically with
-    explicit seeding of their own independent RNG instances instead of relying
-    on the numpy or Python standard library RNG singletons to make sure that
-    test results are independent of the test execution order. However some
-    tests might forget to use explicit seeding and this variable is a way to
-    control the intial state of the aforementioned singletons.
+Note that scikit-learn tests are expected to run deterministically with
+explicit seeding of their own independent RNG instances instead of relying on
+the numpy or Python standard library RNG singletons to make sure that test
+results are independent of the test execution order. However some tests might
+forget to use explicit seeding and this variable is a way to control the intial
+state of the aforementioned singletons.
 
-:SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
+`SKLEARN_TESTS_GLOBAL_RANDOM_SEED`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Controls the seeding of the random number generator used in tests that
-    rely on the `global_random_seed`` fixture.
+Controls the seeding of the random number generator used in tests that rely on
+the `global_random_seed`` fixture.
 
-    All tests that use this fixture accept the contract that they should
-    deterministically pass for any seed value from 0 to 99 included.
+All tests that use this fixture accept the contract that they should
+deterministically pass for any seed value from 0 to 99 included.
 
-    If the SKLEARN_TESTS_GLOBAL_RANDOM_SEED environment variable is set to
-    "any" (which should be the case on nightly builds on the CI), the fixture
-    will choose an arbitrary seed in the above range (based on the BUILD_NUMBER
-    or the current day) and all fixtured tests will run for that specific seed.
-    The goal is to ensure that, over time, our CI will run all tests with
-    different seeds while keeping the test duration of a single run of the full
-    test suite limited. This will check that the assertions of tests
-    written to use this fixture are not dependent on a specific seed value.
+If the `SKLEARN_TESTS_GLOBAL_RANDOM_SEED` environment variable is set to
+`"any"` (which should be the case on nightly builds on the CI), the fixture
+will choose an arbitrary seed in the above range (based on the BUILD_NUMBER or
+the current day) and all fixtured tests will run for that specific seed. The
+goal is to ensure that, over time, our CI will run all tests with different
+seeds while keeping the test duration of a single run of the full test suite
+limited. This will check that the assertions of tests written to use this
+fixture are not dependent on a specific seed value.
 
-    The range of admissible seed values is limited to [0, 99] because it is
-    often not possible to write a test that can work for any possible seed and
-    we want to avoid having tests that randomly fail on the CI.
+The range of admissible seed values is limited to [0, 99] because it is often
+not possible to write a test that can work for any possible seed and we want to
+avoid having tests that randomly fail on the CI.
 
-    Valid values for SKLEARN_TESTS_GLOBAL_RANDOM_SEED:
+Valid values for `SKLEARN_TESTS_GLOBAL_RANDOM_SEED`:
 
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42": run tests with a fixed seed of 42
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42": run the tests with all seeds
-      between 40 and 42 included
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="any": run the tests with an arbitrary
-      seed selected between 0 and 99 included
-    - SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all": run the tests with all seeds
-      between 0 and 99 included
+- `SKLEARN_TESTS_GLOBAL_RANDOM_SEED="42"`: run tests with a fixed seed of 42
+- `SKLEARN_TESTS_GLOBAL_RANDOM_SEED="40-42"`: run the tests with all seeds
+  between 40 and 42 included
+- `SKLEARN_TESTS_GLOBAL_RANDOM_SEED="any"`: run the tests with an arbitrary
+  seed selected between 0 and 99 included
+- `SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all"`: run the tests with all seeds
+  between 0 and 99 included. This can take a long time: only use for individual
+  tests, not the full test suite!
 
-    If the variable is not set, then 42 is used as the global seed in a
-    deterministic manner. This ensures that, by default, the scikit-learn test
-    suite is as deterministic as possible to avoid disrupting our friendly
-    third-party package maintainers. Similarly, this variable should not be set
-    in the CI config of pull-requests to make sure that our friendly
-    contributors are not the first people to encounter a seed-sensitivity
-    regression in a test unrelated to the changes of their own PR. Only the
-    scikit-learn maintainers who watch the results of the nightly builds are
-    expected to be annoyed by this.
+If the variable is not set, then 42 is used as the global seed in a
+deterministic manner. This ensures that, by default, the scikit-learn test
+suite is as deterministic as possible to avoid disrupting our friendly
+third-party package maintainers. Similarly, this variable should not be set in
+the CI config of pull-requests to make sure that our friendly contributors are
+not the first people to encounter a seed-sensitivity regression in a test
+unrelated to the changes of their own PR. Only the scikit-learn maintainers who
+watch the results of the nightly builds are expected to be annoyed by this.
 
-    When writing a new test function that uses this fixture, please use the
-    following command to make sure that it passes deterministically for all
-    admissible seeds on your local machine:
+When writing a new test function that uses this fixture, please use the
+following command to make sure that it passes deterministically for all
+admissible seeds on your local machine:
 
-        SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
+.. prompt:: bash $
 
-:SKLEARN_SKIP_NETWORK_TESTS:
+    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
 
-    When this environment variable is set to a non zero value, the tests
-    that need network access are skipped. When this environment variable is
-    not set then network tests are skipped.
+`SKLEARN_SKIP_NETWORK_TESTS`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES:
+When this environment variable is set to a non zero value, the tests that need
+network access are skipped. When this environment variable is not set then
+network tests are skipped.
 
-    When this environment variable is set to a non zero value, the `Cython`
-    derivative, `boundscheck` is set to `True`. This is useful for finding
-    segfaults.
+`SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When this environment variable is set to a non zero value, the `Cython`
+derivative, `boundscheck` is set to `True`. This is useful for finding
+segfaults.

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -48,6 +48,10 @@ h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
   background-color: transparent;
 }
 
+h4 .section-number, h5 .section-number, h6 .section-number {
+  display: none;
+}
+
 h1:hover a.headerlink,
 h2:hover a.headerlink,
 h3:hover a.headerlink,

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -6,7 +6,7 @@ to a specific seed value while still being deterministic by default.
 See the documentation for the SKLEARN_TESTS_GLOBAL_RANDOM_SEED
 variable for insrtuctions on how to use this fixture.
 
-https://scikit-learn.org/dev/computing/parallelism.html#environment-variables
+https://scikit-learn.org/dev/computing/parallelism.html#sklearn-tests-global-random-seed
 """
 import pytest
 from os import environ
@@ -63,7 +63,7 @@ def pytest_configure(config):
             See the documentation for the SKLEARN_TESTS_GLOBAL_RANDOM_SEED
             variable for insrtuctions on how to use this fixture.
 
-            https://scikit-learn.org/dev/computing/parallelism.html#environment-variables
+            https://scikit-learn.org/dev/computing/parallelism.html#sklearn-tests-global-random-seed
             """
             yield request.param
 
@@ -77,5 +77,5 @@ def pytest_report_header(config):
             "To reproduce this test run, set the following environment variable:",
             f'    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="{config.option.random_seeds[0]}"',
             "See: https://scikit-learn.org/dev/computing/parallelism.html"
-            "#environment-variables",
+            "#sklearn-tests-global-random-seed",
         ]


### PR DESCRIPTION
I noticed that is was unreadable when working on #22749.

- before:

![image](https://user-images.githubusercontent.com/89061/158204670-db9ce628-a395-48e8-8660-a0b37230cfc4.png)


- after:

![image](https://user-images.githubusercontent.com/89061/158204453-6b78ee0f-d25b-444f-bcc9-2ff06b8d99c8.png)

In addition to making the potentially long variable names readable, it also makes it possible to do a direct link to the documentation of a specific variable as done in the second commit for the `sklearn/tests/random_seed.py` file.