### PR TITLE
Fix wrong link title for PCA in "Dim. red." block

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -92,7 +92,7 @@
           <p class="card-text">Reducing the number of random variables to consider.</p>
           <p class="card-text"><strong>Applications:</strong> Visualization, Increased efficiency</br>
           <strong>Algorithms:</strong>
-          <a href="modules/decomposition.html#pca">k-Means</a>,
+          <a href="modules/decomposition.html#pca">PCA</a>,
           <a href="modules/feature_selection.html#feature-selection">feature selection</a>,
           <a href="modules/decomposition.html#nmf">non-negative matrix factorization</a>,
           and <a href="modules/decomposition.html#decompositions">more...</a></p>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Fixes #22834.


#### What does this implement/fix? Explain your changes.
This is a very simple fix, but this documentation problem was misleading students.

On the main website page, there is a "K-Means" link (which points to the PCA page) inside the "Dimentionality reduction" block.
This is an obvious copy paste mistrake, as K-Means is already referenced and the link target is correct.

I simply updated the template, I hope this will be sufficient.

#### Any other comments?
Sorry for such a small patch, but it should fix a very visible documentation mistake.  