### PR TITLE
CI Pin environment.yml with auto updating script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,13 +196,7 @@ jobs:
       # Linux + Python 3.8 build with OpenBLAS
       py38_conda_defaults_openblas:
         DISTRIB: 'conda'
-        CONDA_CHANNEL: 'defaults'  # Anaconda main channel
-        PYTHON_VERSION: '3.8'
-        BLAS: 'openblas'
-        NUMPY_VERSION: 'min'
-        SCIPY_VERSION: 'min'
-        MATPLOTLIB_VERSION: 'min'
-        THREADPOOLCTL_VERSION: '2.2.0'
+        CONDA_ENV: 'build_tools/azure/lock_files/py38_conda_defaults_openblas.yml'
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '2'  # non-default seed
       # Linux environment to test the latest available dependencies.

--- a/build_tools/azure/env_files/py38_conda_defaults_openblas.yml
+++ b/build_tools/azure/env_files/py38_conda_defaults_openblas.yml
@@ -1,0 +1,21 @@
+channels:
+  - defaults
+dependencies:
+  - python=3.8
+  - numpy=1.17.3  # min
+  - blas[build=openblas]
+  - scipy=1.3.2  # min
+  - cython
+  - joblib
+  - threadpoolctl=2.2.0
+  - pandas
+  - matplotlib=3.1.2  # min
+  - pyamg
+  - pillow
+  - pytest=6.2.5
+  - pytest-xdist
+  - codecov
+  - pytest-cov
+  - coverage=6.2
+  - ccache
+  - pip

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -60,7 +60,11 @@ pre_python_environment_install() {
 }
 
 python_environment_install() {
-    if [[ "$DISTRIB" == "conda" || "$DISTRIB" == *"mamba"* ]]; then
+    if [[ "$CONDA_ENV" ]]; then
+        conda env create -n $VIRTUALENV -f $CONDA_ENV
+        source activate $VIRTUALENV
+
+    elif [[ "$DISTRIB" == "conda" || "$DISTRIB" == *"mamba"* ]]; then
 
         if [[ "$CONDA_CHANNEL" != "" ]]; then
             TO_INSTALL="--override-channels -c $CONDA_CHANNEL"

--- a/build_tools/azure/lock_files/py38_conda_defaults_openblas.yml
+++ b/build_tools/azure/lock_files/py38_conda_defaults_openblas.yml
@@ -1,0 +1,21 @@
+channels:
+- defaults
+dependencies:
+- python=3.8
+- numpy=1.17.3    # min
+- blas[build=openblas]
+- scipy=1.3.2    # min
+- cython=0.29.25
+- joblib=1.1.0
+- threadpoolctl=2.2.0
+- pandas=1.2.4
+- matplotlib=3.1.2    # min
+- pyamg=4.1.0
+- pillow=9.0.1
+- pytest=6.2.5
+- pytest-xdist=2.3.0
+- codecov=2.1.11
+- pytest-cov=3.0.0
+- coverage=6.2
+- ccache=3.7.9
+- pip=21.2.4

--- a/build_tools/ci_update_dependencies.py
+++ b/build_tools/ci_update_dependencies.py
@@ -1,0 +1,99 @@
+"""Update dependencies pinned environment variables.
+
+Requires conda-lock and ruamel.yaml to run. ruamel.yaml is used because handle comments.
+
+```bash
+pip install conda-lock ruamel.yaml
+```
+
+This script assumes that the platform environment file is in
+`build_tools/azure/env_files` and will place the pinned environment file into
+`build_tools/azure/lock_files`.
+
+Usage:
+
+python build_tools/ci_update_dependencies.py linux-64 py38_conda_defaults_openblas.yml
+"""
+import os
+from pathlib import Path
+import tempfile
+import subprocess
+import argparse
+import sys
+
+from ruamel.yaml import YAML
+from sklearn._min_dependencies import dependent_packages  # noqa
+
+
+parser = argparse.ArgumentParser(description="Update environment yaml")
+parser.add_argument("platform", help="platform to generate locked environment file")
+parser.add_argument("env_file", help="conda environment file")
+
+args = parser.parse_args()
+env_file = args.env_file
+
+env_path = Path("build_tools") / "azure" / "env_files" / env_file
+if not env_path.exists():
+    print(f"{env_file} does not exist")
+    sys.exit(1)
+
+yaml = YAML()
+with env_path.open("r") as f:
+    env_yaml = yaml.load(f)
+
+
+# Check that min dependencies are correct
+dependencies = env_yaml["dependencies"]
+dependencies_comments = dependencies.ca.items
+
+incorrect_mins = []
+for i, dependency in enumerate(dependencies):
+    comment = dependencies_comments.get(i)
+    if comment is not None and "min" in comment[0].value:
+        package, version = dependency.split("=")
+        min_version = dependent_packages[package][0]
+        if min_version != version:
+            incorrect_mins.append((package, version, min_version))
+
+if incorrect_mins:
+    print("Found incorrect minimum versions:")
+    for package, version, expected_min in incorrect_mins:
+        print(f"{package}={version} (expected {expected_min})")
+    sys.exit(1)
+
+# Use conda-lock to find pinned versions
+platform = args.platform
+with tempfile.TemporaryDirectory() as tmp_file:
+    tmp_path = os.path.join(tmp_file, "lock_file.yml")
+
+    subprocess.check_output(
+        ["conda-lock", "-f", str(env_path), "-p", platform, "--lockfile", tmp_path]
+    )
+    with open(tmp_path) as f:
+        lock_file_contents = f.read()
+        lock_file_yaml = yaml.load(lock_file_contents)
+
+
+# Create a environment.yml with pinned versions
+name_to_package = {package["name"]: package for package in lock_file_yaml["package"]}
+dependencies = env_yaml["dependencies"]
+pip_dependencies = None
+for i, dependency in enumerate(dependencies):
+    if isinstance(dependency, dict) and "pip" in dependency:
+        pip_dependencies = dependency["pip"]
+        continue
+
+    if dependency in name_to_package:
+        version = name_to_package[dependency]["version"]
+        dependencies[i] = f"{dependency}={version}"
+
+if pip_dependencies is not None:
+    for i, dependency in enumerate(pip_dependencies):
+        if dependency in name_to_package:
+            version = name_to_package[dependency]["version"]
+            pip_dependencies[i] = f"{dependency}=={version}"
+
+
+output_env_file = Path("build_tools") / "azure" / "lock_files" / env_file
+with output_env_file.open("w") as f:
+    yaml.dump(env_yaml, f)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards https://github.com/scikit-learn/scikit-learn/issues/22425
Alternative to https://github.com/scikit-learn/scikit-learn/pull/22448

#### What does this implement/fix? Explain your changes.
This PR use `conda-lock` to resolve the dependencies and then parse the yaml to create a new `environment.yml` file that matches the original one but with all packages pinned. The benefit of this PR over #22448 is:

1. We avoid the huge lock file generated by `conda-lock`
2. Only our direct dependencies are pinned in the `environment.yml` file.
3. The CI environment does not need to install conda-lock. Only the CI job that auto updates the "lock-files" will need conda-lock installed.

The downside of this PR is that we do not pin indirect dependencies. We can work around this by pinning our indirect dependency in the `environment.yml` if we need to.

This PR also contains a script to generate the "lock files" from the environment files and makes sure that the min dependencies are consistent with `_min_dependencies.py`.

#### Any other comments?
This PR only migrates over `py38_conda_defaults_openblas.yml` to demonstrate how this can work.

CC @lesteve @ogrisel 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
