### PR TITLE
np docstrings format min_max_axis

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -159,7 +159,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.sparsefuncs.inplace_swap_row_csc",
     "sklearn.utils.sparsefuncs.inplace_swap_row_csr",
     "sklearn.utils.sparsefuncs.mean_variance_axis",
-    "sklearn.utils.sparsefuncs.min_max_axis",
     "sklearn.utils.validation.check_is_fitted",
     "sklearn.utils.validation.check_memory",
     "sklearn.utils.validation.check_random_state",

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -478,8 +478,7 @@ def _sparse_nan_min_max(X, axis):
 
 
 def min_max_axis(X, axis, ignore_nan=False):
-    """Compute minimum and maximum along an axis on a CSR or CSC matrix and
-    optionally ignore NaN values.
+    """Compute min and max along an axis on a CSR or CSC matrix (option: ignore NaN).
 
     Parameters
     ----------

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -478,7 +478,9 @@ def _sparse_nan_min_max(X, axis):
 
 
 def min_max_axis(X, axis, ignore_nan=False):
-    """Compute min and max along an axis on a CSR or CSC matrix (option: ignore NaN).
+    """Compute minimium and maximum along an axis on a CSR or CSC matrix.
+
+     Optionally ignore NaN values.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference Issues/PRs
#21350 

#### What does this implement/fix? Explain your changes.
Sum up the docstrings summary of sklearn.utils.sparsefuncs.min_max_axis to fit in a line

#pariswimlds
