### PR TITLE
TST Fixes global random seed with pytest-xdist

### DIFF
--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -26,7 +26,7 @@ def pytest_configure(config):
 
     RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
     random_seed_var = environ.get("SKLEARN_TESTS_GLOBAL_RANDOM_SEED")
-    if hasattr(config, "workerinput"):
+    if hasattr(config, "workerinput") and "random_seeds" in config.workerinput:
         # Set worker random seed from seed generated from main process
         random_seeds = config.workerinput["random_seeds"]
     elif random_seed_var is None:

--- a/sklearn/tests/random_seed.py
+++ b/sklearn/tests/random_seed.py
@@ -26,7 +26,7 @@ def pytest_configure(config):
 
     RANDOM_SEED_RANGE = list(range(100))  # All seeds in [0, 99] should be valid.
     random_seed_var = environ.get("SKLEARN_TESTS_GLOBAL_RANDOM_SEED")
-    if hasattr(config, "workinput"):
+    if hasattr(config, "workerinput"):
         # Set worker random seed from seed generated from main process
         random_seeds = config.workerinput["random_seeds"]
     elif random_seed_var is None:


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/22843 by correcting a spelling mistake.

You can test locally by running:

```bash
SKLEARN_TESTS_GLOBAL_RANDOM_SEED=any pytest sklearn/tests/test_random_projection.py::test_inverse_transform -n 2
```