### PR TITLE
TST Replaces pytest.warns(None) in test_dict_learning

### DIFF
--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 import numpy as np
 from functools import partial
@@ -111,12 +112,12 @@ def test_max_iter():
         model.fit_transform(X)
 
     # check that the underlying model converges w/o warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ConvergenceWarning)
         model = SparseCoder(
             D_multi, transform_algorithm=transform_algorithm, transform_max_iter=2000
         )
         model.fit_transform(X)
-    assert not [w.message for w in record]
 
 
 def test_dict_learning_lars_positive_parameter():

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
-import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1135,7 +1134,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1155,7 +1154,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
+import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1134,7 +1135,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1154,7 +1155,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 


### PR DESCRIPTION
#### Reference Issues/PRs
References #22572.

#### What does this implement/fix? Explain your changes.
Replaces the depreciating function **pytest.warns(None)**.
File Updated: sklearn/decomposition/tests/test_dict_learning.py

#### Any other comments?
Received 6 warnings from pytest