### PR TITLE
TST Replaces pytest.warns(None) in test_fastica

### DIFF
--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -3,6 +3,7 @@ Test the fastica algorithm.
 """
 import itertools
 import pytest
+import warnings
 
 import numpy as np
 from scipy import stats
@@ -354,9 +355,9 @@ def test_fastica_whiten_backwards_compatibility():
     av_ica = FastICA(
         n_components=n_components, whiten="arbitrary-variance", random_state=0
     )
-    with pytest.warns(None) as warn_record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
         Xt_av = av_ica.fit_transform(X)
-        assert len(warn_record) == 0
 
     # The whitening strategy must be "arbitrary-variance" in all the cases.
     assert default_ica._whiten == "arbitrary-variance"

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
-import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1135,7 +1134,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1155,7 +1154,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
+import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1134,7 +1135,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1154,7 +1155,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 


### PR DESCRIPTION
#### Reference Issues/PRs
References #22572.

#### What does this implement/fix? Explain your changes.
Replaces the depreciating function **pytest.warns(None)**.
File Updated: sklearn/decomposition/tests/test_fastica.py

#### Any other comments?