### PR TITLE
MAINT `PairwiseDistancesReduction`: Do correctly warn on unused metric kwargs

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction.pyx
+++ b/sklearn/metrics/_pairwise_distances_reduction.pyx
@@ -1101,9 +1101,13 @@ cdef class FastEuclideanPairwiseDistancesArgKmin(PairwiseDistancesArgKmin):
         strategy=None,
         metric_kwargs=None,
     ):
-        if metric_kwargs is not None and len(metric_kwargs) > 0:
+        if (
+            metric_kwargs is not None and
+            len(metric_kwargs) > 0 and
+            "Y_norm_squared" not in metric_kwargs
+        ):
             warnings.warn(
-                f"Some metric_kwargs have been passed ({metric_kwargs}) but aren't"
+                f"Some metric_kwargs have been passed ({metric_kwargs}) but aren't "
                 f"usable for this case ({self.__class__.__name__}) and will be ignored.",
                 UserWarning,
                 stacklevel=3,
@@ -1647,6 +1651,18 @@ cdef class FastEuclideanPairwiseDistancesRadiusNeighborhood(PairwiseDistancesRad
         sort_results=False,
         metric_kwargs=None,
     ):
+        if (
+            metric_kwargs is not None and
+            len(metric_kwargs) > 0 and
+            "Y_norm_squared" not in metric_kwargs
+        ):
+            warnings.warn(
+                f"Some metric_kwargs have been passed ({metric_kwargs}) but aren't "
+                f"usable for this case ({self.__class__.__name__}) and will be ignored.",
+                UserWarning,
+                stacklevel=3,
+            )
+
         super().__init__(
             # The datasets pair here is used for exact distances computations
             datasets_pair=DatasetsPair.get_for(X, Y, metric="euclidean"),

--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -166,6 +166,19 @@ def test_argkmin_factory_method_wrong_usages():
             X=np.asfortranarray(X), Y=Y, k=k, metric=metric
         )
 
+    unused_metric_kwargs = {"p": 3}
+
+    message = (
+        r"Some metric_kwargs have been passed \({'p': 3}\) but aren't usable for this"
+        r" case \("
+        r"FastEuclideanPairwiseDistancesArgKmin\) and will be ignored."
+    )
+
+    with pytest.warns(UserWarning, match=message):
+        PairwiseDistancesArgKmin.compute(
+            X=X, Y=Y, k=k, metric=metric, metric_kwargs=unused_metric_kwargs
+        )
+
 
 def test_radius_neighborhood_factory_method_wrong_usages():
     rng = np.random.RandomState(1)
@@ -214,6 +227,19 @@ def test_radius_neighborhood_factory_method_wrong_usages():
     with pytest.raises(ValueError, match="ndarray is not C-contiguous"):
         PairwiseDistancesRadiusNeighborhood.compute(
             X=np.asfortranarray(X), Y=Y, radius=radius, metric=metric
+        )
+
+    unused_metric_kwargs = {"p": 3}
+
+    message = (
+        r"Some metric_kwargs have been passed \({'p': 3}\) but aren't usable for this"
+        r" case \(FastEuclideanPairwiseDistancesRadiusNeighborhood\) and will be"
+        r" ignored."
+    )
+
+    with pytest.warns(UserWarning, match=message):
+        PairwiseDistancesRadiusNeighborhood.compute(
+            X=X, Y=Y, radius=radius, metric=metric, metric_kwargs=unused_metric_kwargs
         )
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.

This removes spurious warnings and check that `PairwiseDistancesReduction` correctly warns when unused metric kwargs are passed.

