### PR TITLE
MAINT Fix plot_gallery warning when building docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -392,6 +392,7 @@ sphinx_gallery_conf = {
     # avoid generating too many cross links
     "inspect_global_variables": False,
     "remove_config_comments": True,
+    "plot_gallery": "True",
 }
 
 


### PR DESCRIPTION
When building the docs with `make html-noplot` this warning appears:

```bash
WARNING: The config value `plot_gallery' has type `str', defaults to `bool'.
```

This PR removes the warning with the recommendation from https://github.com/sphinx-gallery/sphinx-gallery/issues/913