### PR TITLE
TST Replaces pytest.warns(None) in test_feature_agglomeration

### DIFF
--- a/sklearn/cluster/tests/test_feature_agglomeration.py
+++ b/sklearn/cluster/tests/test_feature_agglomeration.py
@@ -3,7 +3,6 @@ Tests for sklearn.cluster._feature_agglomeration
 """
 # Authors: Sergul Aydore 2017
 import numpy as np
-import pytest
 
 from numpy.testing import assert_array_equal
 from sklearn.cluster import FeatureAgglomeration
@@ -17,12 +16,8 @@ def test_feature_agglomeration():
 
     agglo_mean = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.mean)
     agglo_median = FeatureAgglomeration(n_clusters=n_clusters, pooling_func=np.median)
-    with pytest.warns(None) as record:
-        agglo_mean.fit(X)
-    assert not [w.message for w in record]
-    with pytest.warns(None) as record:
-        agglo_median.fit(X)
-    assert not [w.message for w in record]
+    agglo_mean.fit(X)
+    agglo_median.fit(X)
 
     assert np.size(np.unique(agglo_mean.labels_)) == n_clusters
     assert np.size(np.unique(agglo_median.labels_)) == n_clusters

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
-import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1135,7 +1134,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1155,7 +1154,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.warns(None) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
+import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -1134,7 +1135,7 @@ def test_tsne_init_futurewarning(init):
         with pytest.warns(FutureWarning, match="The PCA initialization.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 
@@ -1154,7 +1155,7 @@ def test_tsne_learning_rate_futurewarning(learning_rate):
         with pytest.warns(FutureWarning, match="The default learning rate.*"):
             tsne.fit_transform(X)
     else:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             tsne.fit_transform(X)
         assert not [w.message for w in record]
 


### PR DESCRIPTION
#### Reference Issues/PRs
Related to https://github.com/scikit-learn/scikit-learn/issues/22572.
See also https://github.com/scikit-learn/scikit-learn/pull/11537, https://github.com/scikit-learn/scikit-learn/pull/19437
Towards https://github.com/scikit-learn/scikit-learn/issues/22396

#### What does this implement/fix? Explain your changes.
Replaces the depreciating function **pytest.warns(None)**.
test_feature_agglomeration also no longer raises a DeprecationWarning- Assertion to check for no warnings is no longer needed.

#### Any other comments?
Removed unused pytest import
