### PR TITLE
TST Replaces pytest.warns(None) in test_pca

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -3,6 +3,7 @@ import scipy as sp
 from numpy.testing import assert_array_equal
 
 import pytest
+import warnings
 
 from sklearn.utils._testing import assert_allclose
 
@@ -44,9 +45,9 @@ def test_no_empty_slice_warning():
     n_features = n_components + 2  # anything > n_comps triggered it in 0.16
     X = np.random.uniform(-1, 1, size=(n_components, n_features))
     pca = PCA(n_components=n_components)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
         pca.fit(X)
-    assert not [w.message for w in record]
 
 
 @pytest.mark.parametrize("copy", [True, False])


### PR DESCRIPTION
#### Reference Issues/PRs
Related to https://github.com/scikit-learn/scikit-learn/issues/22572.
See also https://github.com/scikit-learn/scikit-learn/pull/5336, https://github.com/scikit-learn/scikit-learn/pull/14138, [Example Empty Slice Warning](https://github.com/numpy/numpy/issues/10709)
Towards https://github.com/scikit-learn/scikit-learn/issues/22396

#### What does this implement/fix? Explain your changes.
Replaces the depreciating function **pytest.warns(None)**.
I believe the expected warning to avoid here would be numpy's "RuntimeWarning: Mean of empty slice"

#### Any other comments?