### PR TITLE
TST Removes pytest.warns(None) in test_iforest

### DIFF
--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -7,6 +7,7 @@ Testing for Isolation Forest algorithm (sklearn.ensemble.iforest).
 # License: BSD 3 clause
 
 import pytest
+import warnings
 
 import numpy as np
 
@@ -102,9 +103,12 @@ def test_iforest_error():
     warn_msg = "max_samples will be set to n_samples for estimation"
     with pytest.warns(UserWarning, match=warn_msg):
         IsolationForest(max_samples=1000).fit(X)
-
-    IsolationForest(max_samples="auto").fit(X)
-    IsolationForest(max_samples=np.int64(2)).fit(X)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        IsolationForest(max_samples="auto").fit(X)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        IsolationForest(max_samples=np.int64(2)).fit(X)
 
     with pytest.raises(ValueError):
         IsolationForest(max_samples="foobar").fit(X)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -102,18 +102,9 @@ def test_iforest_error():
     warn_msg = "max_samples will be set to n_samples for estimation"
     with pytest.warns(UserWarning, match=warn_msg):
         IsolationForest(max_samples=1000).fit(X)
-    # note that assert_no_warnings does not apply since it enables a
-    # PendingDeprecationWarning triggered by scipy.sparse's use of
-    # np.matrix. See issue #11251.
-    with pytest.warns(None) as record:
-        IsolationForest(max_samples="auto").fit(X)
-    user_warnings = [each for each in record if issubclass(each.category, UserWarning)]
-    assert not user_warnings
 
-    with pytest.warns(None) as record:
-        IsolationForest(max_samples=np.int64(2)).fit(X)
-    user_warnings = [each for each in record if issubclass(each.category, UserWarning)]
-    assert not user_warnings
+    IsolationForest(max_samples="auto").fit(X)
+    IsolationForest(max_samples=np.int64(2)).fit(X)
 
     with pytest.raises(ValueError):
         IsolationForest(max_samples="foobar").fit(X)


### PR DESCRIPTION
#### Reference Issues/PRs
Related to https://github.com/scikit-learn/scikit-learn/issues/22572.
See also https://github.com/scikit-learn/scikit-learn/pull/5678, https://github.com/scikit-learn/scikit-learn/pull/6814, https://github.com/scikit-learn/scikit-learn/pull/11251, [scipy.sparse documentation](https://docs.scipy.org/doc/scipy/reference/sparse.html)
Towards https://github.com/scikit-learn/scikit-learn/issues/22396

#### What does this implement/fix? Explain your changes.
Removes the depreciating function **pytest.warns(None)**.

Scipy.sparse no longer seems to leverage numpy.matrix - As a result, the PendingDeprecationWarning should no longer occur. Please correct me if I'm wrong here.

#### Any other comments?
Not sure if there were other UserWarnings to check for.