### PR TITLE
MAINT Import from public SciPy in pubilc namespace

### DIFF
--- a/benchmarks/bench_sparsify.py
+++ b/benchmarks/bench_sparsify.py
@@ -43,7 +43,7 @@ Line #      Hits         Time  Per Hit   % Time  Line Contents
     60       300       381409   1271.4     97.1          clf.predict(X_test_sparse)
 """
 
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 import numpy as np
 from sklearn.linear_model import SGDRegressor
 from sklearn.metrics import r2_score

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -152,7 +152,7 @@ also referred to as connected components) when clustering an image.
 ::
 
     >>> from skimage.data import coins
-    >>> from scipy.ndimage.filters import gaussian_filter
+    >>> from scipy.ndimage import gaussian_filter
     >>> from skimage.transform import rescale
     >>> rescaled_coins = rescale(
     ...     gaussian_filter(coins(), sigma=2),

--- a/examples/cluster/plot_coin_segmentation.py
+++ b/examples/cluster/plot_coin_segmentation.py
@@ -28,7 +28,7 @@ There are three options to assign labels:
 import time
 
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 import matplotlib.pyplot as plt
 from skimage.data import coins
 from skimage.transform import rescale

--- a/examples/cluster/plot_coin_ward_segmentation.py
+++ b/examples/cluster/plot_coin_ward_segmentation.py
@@ -16,7 +16,7 @@ for each segmented region to be in one piece.
 import time as time
 
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 import matplotlib.pyplot as plt
 

--- a/sklearn/datasets/_olivetti_faces.py
+++ b/sklearn/datasets/_olivetti_faces.py
@@ -17,7 +17,7 @@ from os.path import exists
 from os import makedirs, remove
 
 import numpy as np
-from scipy.io.matlab import loadmat
+from scipy.io import loadmat
 import joblib
 
 from . import get_data_home

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -851,7 +851,7 @@ def test_random_trees_dense_type():
     X, y = datasets.make_circles(factor=0.5)
     X_transformed = hasher.fit_transform(X)
 
-    # Assert that type is ndarray, not scipy.sparse.csr.csr_matrix
+    # Assert that type is ndarray, not scipy.sparse.csr_matrix
     assert type(X_transformed) == np.ndarray
 
 


### PR DESCRIPTION
SciPy 1.8.0 has deprecated some import namespaces and made them private: https://docs.scipy.org/doc/scipy/release.1.8.0.html#clear-split-between-public-and-private-api

This PR imports the function in the corresponding public namespace.