### PR TITLE
TST replace pytest.warns(None) in linear_model test_base.py

### DIFF
--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -5,6 +5,7 @@
 # License: BSD 3 clause
 
 import pytest
+import warnings
 
 import numpy as np
 from scipy import sparse
@@ -358,9 +359,9 @@ def test_linear_regression_pd_sparse_dataframe_warning():
     df["0"] = pd.arrays.SparseArray(df["0"], fill_value=0)
     assert hasattr(df, "sparse")
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
         reg.fit(df.iloc[:, 0:2], df.iloc[:, 3])
-    assert not [w.message for w in record]
 
 
 def test_preprocess_data():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Related to #22572


#### What does this implement/fix? Explain your changes.
In this file, the `pytest.warns(None)` was being used to test that the model fit didn't raise a `UserWarning` when an entire pandas dataframe was sparse (in contrast to the case above it in the test where it does produce a `UserWarning` when only some columns are sparse. This PR replaces the deprecated usage of `pytest.warns(None)` with a specific warnings filter.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
