### PR TITLE
TST remove pytest.warns(None) in test_logistic.py

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy import sparse
 
 import pytest
-import warnings
 
 from sklearn.base import clone
 from sklearn.datasets import load_iris, make_classification
@@ -133,15 +132,6 @@ def test_logistic_cv_mock_scorer():
 
     assert custom_score == mock_scorer.scores[0]
     assert mock_scorer.calls == 1
-
-
-def test_logistic_cv_score_does_not_warn_by_default():
-    lr = LogisticRegressionCV(cv=2)
-    lr.fit(X, Y1)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        lr.score(X, lr.predict(X))
 
 
 @skip_if_no_parallel

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from scipy import sparse
 
 import pytest
+import warnings
 
 from sklearn.base import clone
 from sklearn.datasets import load_iris, make_classification
@@ -138,9 +139,9 @@ def test_logistic_cv_score_does_not_warn_by_default():
     lr = LogisticRegressionCV(cv=2)
     lr.fit(X, Y1)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         lr.score(X, lr.predict(X))
-    assert not [w.message for w in record]
 
 
 @skip_if_no_parallel


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Related to #22572
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Replaces deprecated `pytest.warns(None)` in `test_logistic.py` with a `warnings.catch_warnings()` context handler.

#### Any other comments?
Not clear what warning was being tested by the original code from a `git blame`, so this PR replaces like-for-like and will throw an error for any warning.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
