### PR TITLE
TST replace pytest.warns(None) in test_coordinate_descent.py

### DIFF
--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -103,7 +103,7 @@ def test_assure_warning_when_normalize(CoordinateDescentModel, normalize, n_warn
         warnings.simplefilter("always", FutureWarning)
         model.fit(X, y)
 
-    assert len(rec) == n_warnings
+    assert len([w.message for w in rec]) == n_warnings
 
 
 @pytest.mark.parametrize(

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -2,7 +2,6 @@
 #          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 # License: BSD 3 clause
 
-from asyncio import Future
 import numpy as np
 import pytest
 import warnings

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1429,7 +1429,7 @@ def test_convergence_warnings():
     with pytest.warns(ConvergenceWarning):
         MultiTaskElasticNet(max_iter=1, tol=-1).fit(X, y)
 
-    # check that the model converges w/o warnings
+    # check that the model converges w/o convergence warnings
     with warnings.catch_warnings():
         warnings.simplefilter("error", ConvergenceWarning)
         MultiTaskElasticNet().fit(X, y)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Relates to #22572 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Replaces three instances of `pytest.warns(None)` in `test_coordinate_descent.py`. Two of these were checking for absence of a `ConvergenceWarning`, and one was counting `FutureWarning`s related to the `normalize` keyword argument.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
