### PR TITLE
DOC Use proper tags for get_feature_names_out in whats_new

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -194,7 +194,7 @@ Changelog
   reconstruction of a `X` target when a `Y` parameter is given. :pr:`19680` by
   :user:`Robin Thibaut <robinthibaut>`.
 
-- |API| Adds :term:`get_feature_names_out` to all transformers in the
+- |Enhancement| Adds :term:`get_feature_names_out` to all transformers in the
   :mod:`~sklearn.cross_decomposition` module:
   :class:`cross_decomposition.CCA`,
   :class:`cross_decomposition.PLSSVD`,
@@ -258,7 +258,7 @@ Changelog
   `algorithm='randomized'`.
   :pr:`22181` by :user:`Zach Deane-Mayer <zachmayer>`.
 
-- |API| Adds :term:`get_feature_names_out` to all transformers in the
+- |Enhancement| Adds :term:`get_feature_names_out` to all transformers in the
   :mod:`~sklearn.decomposition` module:
   :class:`~sklearn.decomposition.DictionaryLearning`,
   :class:`~sklearn.decomposition.FactorAnalysis`,
@@ -320,7 +320,7 @@ Changelog
   behavior.:pr:`15984` by :user:`Okon Samuel <OkonSamuel>` :pr:`22696` by
   :user:`Meekail Zain <micky774>`.
 
-- |API| Adds :term:`get_feature_names_out` to
+- |Enhancement| Adds :term:`get_feature_names_out` to
   :class:`discriminant_analysis.LinearDiscriminantAnalysis`. :pr:`22120` by
   `Thomas Fan`_.
 
@@ -363,7 +363,7 @@ Changelog
   :class:`ensemble.ExtraTreesClassifier`.
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
 
-- |API| Adds :meth:`get_feature_names_out` to
+- |Enhancement| Adds :meth:`get_feature_names_out` to
   :class:`ensemble.VotingClassifier`, :class:`ensemble.VotingRegressor`,
   :class:`ensemble.StackingClassifier`, and
   :class:`ensemble.StackingRegressor`. :pr:`22695` and :pr:`22697`  by `Thomas Fan`_.
@@ -473,9 +473,10 @@ Changelog
 - |Enhancement| Added support for `pd.NA` in :class:`SimpleImputer`.
   :pr:`21114` by :user:`Ying Xiong <yxiong>`.
 
-- |API| Adds :meth:`get_feature_names_out` to :class:`impute.SimpleImputer`,
-  :class:`impute.KNNImputer`, :class:`impute.IterativeImputer`, and
-  :class:`impute.MissingIndicator`. :pr:`21078` by `Thomas Fan`_.
+- |Enhancement| Adds :meth:`get_feature_names_out` to
+  :class:`impute.SimpleImputer`, :class:`impute.KNNImputer`,
+  :class:`impute.IterativeImputer`, and :class:`impute.MissingIndicator`.
+  :pr:`21078` by `Thomas Fan`_.
 
 - |API| The `verbose` parameter was deprecated for :class:`impute.SimpleImputer`.
   A warning will always be raised upon the removal of empty columns.
@@ -520,16 +521,13 @@ Changelog
 :mod:`sklearn.kernel_approximation`
 ...................................
 
-- |API| Adds :meth:`get_feature_names_out` to
+- |Enhancement| Adds :meth:`get_feature_names_out` to
+  :class:`kernel_approximation.AdditiveChi2Sampler`.
   :class:`kernel_approximation.Nystroem`,
   :class:`kernel_approximation.PolynomialCountSketch`,
   :class:`kernel_approximation.RBFSampler`, and
-  :class:`kernel_approximation.SkewedChi2Sampler`. :pr:`22694` by `Thomas Fan`_.
-
-- |API| Adds :term:`get_feature_names_out` to the following transformers
-  of the :mod:`~sklearn.kernel_approximation` module:
-  :class:`~sklearn.kernel_approximation.AdditiveChi2Sampler`.
-  :pr:`22137` by `Thomas Fan`_.
+  :class:`kernel_approximation.SkewedChi2Sampler`.
+  :pr:`22137` and :pr:`22694` by `Thomas Fan`_.
 
 :mod:`sklearn.linear_model`
 ...........................
@@ -782,7 +780,7 @@ Changelog
   now provides informative error message when input has mixed dtypes. :pr:`19916` by
   :user:`Zhehao Liu <MaxwellLZH>`.
 
-- |API| Adds :meth:`get_feature_names_out` to
+- |Enhancement| Adds :meth:`get_feature_names_out` to
   :class:`preprocessing.Normalizer`,
   :class:`preprocessing.KernelCenterer`,
   :class:`preprocessing.OrdinalEncoder`, and
@@ -809,7 +807,7 @@ Changelog
   to True, the pseudo-inverse of the components is computed during `fit` and stored as
   `inverse_components_`. :pr:`21701` by `Aurélien Geron <ageron>`.
 
-- |API| Adds :term:`get_feature_names_out` to all transformers in the
+- |Enhancement| Adds :term:`get_feature_names_out` to all transformers in the
   :mod:`~sklearn.random_projection` module:
   :class:`~sklearn.random_projection.GaussianRandomProjection` and
   :class:`~sklearn.random_projection.SparseRandomProjection`. :pr:`21330` by


### PR DESCRIPTION
This PR uses the correct tags for `get_feature_names_out` related changelog entries. The `|API|` tag is used for "API Changes":

https://github.com/scikit-learn/scikit-learn/blob/b9bd2d524db520a8e8740025ce7aca2342d37f38/doc/whats_new/changelog_legend.inc#L11-L12