### PR TITLE
FIX LinearRegression sparse + intercept + sample_weight

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -594,6 +594,10 @@ Changelog
   :class:`linear_model.ARDRegression` now preserve float32 dtype. :pr:`9087` by
   :user:`Arthur Imbert <Henley13>` and :pr:`22525` by :user:`Meekail Zain <micky774>`.
 
+- |Fix| The `intercept_` attribute of :class:`LinearRegression` is now correctly
+  computed in the presence of sample weights when the input is sparse.
+  :pr:`22891` by :user:`Jérémie du Boisberranger <jeremiedbb>`. 
+
 :mod:`sklearn.manifold`
 .......................
 

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -330,6 +330,9 @@ def _rescale_data(X, y, sample_weight, square_root=True):
 
     For many linear models, this enables easy support for sample_weight.
 
+    Set square_root=False if the square root of the sample weights has already been
+    done prior to calling this function.
+
     Returns
     -------
     X_rescaled : {array-like, sparse matrix}

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -4,6 +4,8 @@
 #
 # License: BSD 3 clause
 
+from os import confstr_names
+from random import sample
 import pytest
 import warnings
 
@@ -55,45 +57,47 @@ def test_linear_regression():
     assert_array_almost_equal(reg.predict(X), [0])
 
 
-def test_linear_regression_sample_weights():
-    # TODO: loop over sparse data as well
-
+@pytest.mark.parametrize("array_constr", [np.array, sparse.csr_matrix])
+@pytest.mark.parametrize("fit_intercept", [True, False])
+def test_linear_regression_sample_weights(array_constr, fit_intercept):
     rng = np.random.RandomState(0)
 
     # It would not work with under-determined systems
-    for n_samples, n_features in ((6, 5),):
+    n_samples, n_features = 6, 5
 
-        y = rng.randn(n_samples)
-        X = rng.randn(n_samples, n_features)
-        sample_weight = 1.0 + rng.rand(n_samples)
+    X = array_constr(rng.normal(size=(n_samples, n_features)))
+    y = rng.normal(size=n_samples)
 
-        for intercept in (True, False):
+    sample_weight = 1.0 + rng.uniform(size=n_samples)
 
-            # LinearRegression with explicit sample_weight
-            reg = LinearRegression(fit_intercept=intercept)
-            reg.fit(X, y, sample_weight=sample_weight)
-            coefs1 = reg.coef_
-            inter1 = reg.intercept_
+    # LinearRegression with explicit sample_weight
+    reg = LinearRegression(fit_intercept=fit_intercept)
+    reg.fit(X, y, sample_weight=sample_weight)
+    coefs1 = reg.coef_
+    inter1 = reg.intercept_
 
-            assert reg.coef_.shape == (X.shape[1],)  # sanity checks
-            assert reg.score(X, y) > 0.5
+    assert reg.coef_.shape == (X.shape[1],)  # sanity checks
+    assert reg.score(X, y) > 0.5
 
-            # Closed form of the weighted least square
-            # theta = (X^T W X)^(-1) * X^T W y
-            W = np.diag(sample_weight)
-            if intercept is False:
-                X_aug = X
-            else:
-                dummy_column = np.ones(shape=(n_samples, 1))
-                X_aug = np.concatenate((dummy_column, X), axis=1)
+    # Closed form of the weighted least square
+    # theta = (X^T W X)^(-1) @ X^T W y
+    W = np.diag(sample_weight)
+    if not fit_intercept:
+        X_aug = X
+    else:
+        hstack = sparse.hstack if sparse.issparse(X) else np.hstack
+        dummy_column = np.ones(shape=(n_samples, 1))
+        X_aug = hstack((dummy_column, X))
 
-            coefs2 = linalg.solve(X_aug.T.dot(W).dot(X_aug), X_aug.T.dot(W).dot(y))
+    Xw = X_aug.T @ W @ X_aug
+    yw = X_aug.T @ W @ y
+    coefs2 = linalg.solve(Xw, yw)
 
-            if intercept is False:
-                assert_array_almost_equal(coefs1, coefs2)
-            else:
-                assert_array_almost_equal(coefs1, coefs2[1:])
-                assert_almost_equal(inter1, coefs2[0])
+    if not fit_intercept:
+        assert_allclose(coefs1, coefs2)
+    else:
+        assert_allclose(coefs1, coefs2[1:])
+        assert_allclose(inter1, coefs2[0])
 
 
 def test_raises_value_error_if_positive_and_sparse():

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -25,6 +25,7 @@ from sklearn.datasets import make_sparse_uncorrelated
 from sklearn.datasets import make_regression
 from sklearn.datasets import load_iris
 from sklearn.preprocessing import StandardScaler
+from sklearn.preprocessing import add_dummy_feature
 
 rng = np.random.RandomState(0)
 rtol = 1e-6
@@ -79,12 +80,7 @@ def test_linear_regression_sample_weights(array_constr, fit_intercept):
     # Closed form of the weighted least square
     # theta = (X^T W X)^(-1) @ X^T W y
     W = np.diag(sample_weight)
-    if not fit_intercept:
-        X_aug = X
-    else:
-        hstack = sparse.hstack if sparse.issparse(X) else np.hstack
-        dummy_column = np.ones(shape=(n_samples, 1))
-        X_aug = hstack((dummy_column, X))
+    X_aug = X if not fit_intercept else add_dummy_feature(X)
 
     Xw = X_aug.T @ W @ X_aug
     yw = X_aug.T @ W @ y

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -4,8 +4,6 @@
 #
 # License: BSD 3 clause
 
-from os import confstr_names
-from random import sample
 import pytest
 import warnings
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -13,7 +13,6 @@ from scipy import linalg
 
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
-from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_allclose
 from sklearn.utils import check_random_state
 


### PR DESCRIPTION
Partial fix for #15438
Fixes https://github.com/scikit-learn/scikit-learn/issues/19578

This PR fixes the issue for LinearRegression only. I intend to check other linear models in separate PR(s).

To account for sample weight, we rescale X and y. When X is sparse we also need to rescale X_offset because the centering is implicit.

ping @agramfort 