### PR TITLE
ENH Adds better error message for GitHub in html repr

### DIFF
--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -377,7 +377,9 @@ def estimator_html_repr(estimator):
         # The reverse logic applies to HTML repr div.sk-container.
         # div.sk-container is hidden by default and the loading the CSS displays it.
         fallback_msg = (
-            "Please rerun this cell to show the HTML repr or trust the notebook."
+            "In a Jupyter environment, please rerun this cell to show the HTML"
+            " representation or trust the notebook. <br />GitHub cannot render the HTML"
+            " representation, please try loading this page with nbviewer.org."
         )
         out.write(
             f"<style>{style_with_id}</style>"

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -378,8 +378,9 @@ def estimator_html_repr(estimator):
         # div.sk-container is hidden by default and the loading the CSS displays it.
         fallback_msg = (
             "In a Jupyter environment, please rerun this cell to show the HTML"
-            " representation or trust the notebook. <br />GitHub cannot render the HTML"
-            " representation, please try loading this page with nbviewer.org."
+            " representation or trust the notebook. <br />On GitHub, the"
+            " HTML representation is unable to render, please try loading this page"
+            " with nbviewer.org."
         )
         out.write(
             f"<style>{style_with_id}</style>"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards https://github.com/scikit-learn/scikit-learn/issues/21285


#### What does this implement/fix? Explain your changes.
This PR extends the fallback message describing the GitHub rendering issue. [Here](https://gist.github.com/thomasjpfan/c7ebe504f61e7b5597d1f49376b002bf) is what the repr looks like on GitHub.  The render is shown correctly on [nbviewer.org](https://nbviewer.org/gist/thomasjpfan/c7ebe504f61e7b5597d1f49376b002bf) and in jupyter notebooks.

CC @jnothman @jeremiedbb 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
