### PR TITLE
FIX ColumnTransformer.get_feature_names_out with string slices

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -184,8 +184,8 @@ Changelog
 
 - |Fix| :term:`get_feature_names_out` functionality in
   :class:`compose.ColumnTransformer` was broken when columns were specified
-  using `slice`. This is fixed in :pr:`22775` by :user:`randomgeek78
-  <randomgeek78>`
+  using `slice`. This is fixed in :pr:`22775` and :pr:`22913` by
+  :user:`randomgeek78 <randomgeek78>`
 
 :mod:`sklearn.cross_decomposition`
 ..................................

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -7,7 +7,6 @@ different columns.
 #         Joris Van den Bossche
 # License: BSD
 from itertools import chain
-from typing import Iterable
 from collections import Counter
 
 import numpy as np

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -462,7 +462,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         if isinstance(column, slice) and _determine_key_type(column) == "str":
             # Assuming column and self._transformer_to_input_indices[name]
             # are matched. True if column generated from _iter
-            column = self._transformer_to_input_indices[name]            
+            column = self._transformer_to_input_indices[name]
         if isinstance(column, slice) or (
             isinstance(column, Iterable)
             and not all(isinstance(col, str) for col in column)

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -21,6 +21,7 @@ from ..preprocessing import FunctionTransformer
 from ..utils import Bunch
 from ..utils import _safe_indexing
 from ..utils import _get_column_indices
+from ..utils import _determine_key_type
 from ..utils.deprecation import deprecated
 from ..utils.metaestimators import _BaseComposition
 from ..utils.validation import check_array, check_is_fitted, _check_feature_names_in
@@ -444,6 +445,11 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             ):
                 # selection was already strings
                 return column
+            elif isinstance(column, slice) and _determine_key_type(column) == "str":
+                # Assuming column and self._transformer_to_input_indices[name]
+                # are matched. True if column generated from _iter
+                column = self._transformer_to_input_indices[name]
+                return feature_names_in[column]
             else:
                 return feature_names_in[column]
 
@@ -453,6 +459,10 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                 f"Transformer {name} (type {type(trans).__name__}) does "
                 "not provide get_feature_names_out."
             )
+        if isinstance(column, slice) and _determine_key_type(column) == "str":
+            # Assuming column and self._transformer_to_input_indices[name]
+            # are matched. True if column generated from _iter
+            column = self._transformer_to_input_indices[name]            
         if isinstance(column, slice) or (
             isinstance(column, Iterable)
             and not all(isinstance(col, str) for col in column)

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -21,7 +21,6 @@ from ..preprocessing import FunctionTransformer
 from ..utils import Bunch
 from ..utils import _safe_indexing
 from ..utils import _get_column_indices
-from ..utils import _determine_key_type
 from ..utils.deprecation import deprecated
 from ..utils.metaestimators import _BaseComposition
 from ..utils.validation import check_array, check_is_fitted, _check_feature_names_in
@@ -430,14 +429,16 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             feature_names.extend([f"{name}__{f}" for f in trans.get_feature_names()])
         return feature_names
 
-    def _get_feature_name_out_for_transformer(self, name, trans, feature_names_in):
+    def _get_feature_name_out_for_transformer(
+        self, name, trans, column, feature_names_in
+    ):
         """Gets feature names of transformer.
 
         Used in conjunction with self._iter(fitted=True) in get_feature_names_out.
         """
         column_indices = self._transformer_to_input_indices[name]
         names = feature_names_in[column_indices]
-        if trans == "drop" or _is_empty_column_selection(names):
+        if trans == "drop" or _is_empty_column_selection(column):
             return
         elif trans == "passthrough":
             return names
@@ -475,9 +476,9 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
         # List of tuples (name, feature_names_out)
         transformer_with_feature_names_out = []
-        for name, trans, _, _ in self._iter(fitted=True):
+        for name, trans, column, _ in self._iter(fitted=True):
             feature_names_out = self._get_feature_name_out_for_transformer(
-                name, trans, input_features
+                name, trans, column, input_features
             )
             if feature_names_out is None:
                 continue

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -430,9 +430,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             feature_names.extend([f"{name}__{f}" for f in trans.get_feature_names()])
         return feature_names
 
-    def _get_feature_name_out_for_transformer(
-        self, name, trans, feature_names_in
-    ):
+    def _get_feature_name_out_for_transformer(self, name, trans, feature_names_in):
         """Gets feature names of transformer.
 
         Used in conjunction with self._iter(fitted=True) in get_feature_names_out.

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1790,18 +1790,18 @@ class TransWithNames(Trans):
         (
             [
                 ("bycol1", TransWithNames(), ["b"]),
-                ("bycol2", "drop", slice("d", "d")),
+                ("bycol2", "drop", slice("c", "d")),
             ],
             "passthrough",
-            ["bycol1__b", "remainder__a", "remainder__c"],
+            ["bycol1__b", "remainder__a"],
         ),
         (
             [
                 ("bycol1", TransWithNames(), ["d", "c"]),
-                ("bycol2", "passthrough", slice("d", "d")),
+                ("bycol2", "passthrough", slice("c", "d")),
             ],
             "passthrough",
-            ["bycol1__d", "bycol1__c", "bycol2__d", "remainder__a", "remainder__b"],
+            ["bycol1__d", "bycol1__c", "bycol2__c", "bycol2__d", "remainder__a", "remainder__b"],
         ),
     ],
 )
@@ -1904,19 +1904,19 @@ def test_verbose_feature_names_out_true(transformers, remainder, expected_names)
         ),
         (
             [
-                ("bycol1", TransWithNames(), slice("b", "b")),
+                ("bycol1", TransWithNames(), slice("a", "b")),
                 ("bycol2", "drop", ["d"]),
             ],
             "passthrough",
-            ["b", "a", "c"],
+            ["a", "b", "c"],
         ),
         (
             [
                 ("bycol1", TransWithNames(), ["b"]),
-                ("bycol2", "drop", slice("d", "d")),
+                ("bycol2", "drop", slice("c", "d")),
             ],
             "passthrough",
-            ["b", "a", "c"],
+            ["b", "a"],
         ),
         (
             [
@@ -1925,6 +1925,14 @@ def test_verbose_feature_names_out_true(transformers, remainder, expected_names)
             ],
             "drop",
             ["d", "c", "a", "b"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), ["d", "c"]),
+                ("bycol2", "passthrough", slice("b", "b")),
+            ],
+            "drop",
+            ["d", "c", "b"],
         ),
     ],
 )
@@ -2034,7 +2042,7 @@ def test_verbose_feature_names_out_false(transformers, remainder, expected_names
         ),
         (
             [
-                ("bycol1", TransWithNames(["a", "b"]), slice("b", "b")),
+                ("bycol1", TransWithNames(["a", "b"]), slice("b", "c")),
                 ("bycol2", "passthrough", ["a"]),
                 ("bycol3", TransWithNames(["b"]), ["c"]),
             ],

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1780,6 +1780,29 @@ class TransWithNames(Trans):
             "passthrough",
             ["bycol1__d", "bycol1__c", "bycol2__d", "remainder__a", "remainder__b"],
         ),
+        (
+            [
+                ("bycol1", TransWithNames(), slice("b", "c")),
+            ],
+            "drop",
+            ["bycol1__b", "bycol1__c"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), ["b"]),
+                ("bycol2", "drop", slice("d", "d")),
+            ],
+            "passthrough",
+            ["bycol1__b", "remainder__a", "remainder__c"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), ["d", "c"]),
+                ("bycol2", "passthrough", slice("d", "d")),
+            ],
+            "passthrough",
+            ["bycol1__d", "bycol1__c", "bycol2__d", "remainder__a", "remainder__b"],
+        ),
     ],
 )
 def test_verbose_feature_names_out_true(transformers, remainder, expected_names):
@@ -1875,6 +1898,30 @@ def test_verbose_feature_names_out_true(transformers, remainder, expected_names)
             [
                 ("bycol1", TransWithNames(), ["d", "c"]),
                 ("bycol2", "passthrough", slice(0, 2)),
+            ],
+            "drop",
+            ["d", "c", "a", "b"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), slice("b", "b")),
+                ("bycol2", "drop", ["d"]),
+            ],
+            "passthrough",
+            ["b", "a", "c"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), ["b"]),
+                ("bycol2", "drop", slice("d", "d")),
+            ],
+            "passthrough",
+            ["b", "a", "c"],
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(), ["d", "c"]),
+                ("bycol2", "passthrough", slice("a", "b")),
             ],
             "drop",
             ["d", "c", "a", "b"],
@@ -1980,6 +2027,24 @@ def test_verbose_feature_names_out_false(transformers, remainder, expected_names
             [
                 ("bycol1", TransWithNames(["a", "b"]), ["b"]),
                 ("bycol2", "passthrough", slice(0, 1)),
+                ("bycol3", TransWithNames(["b"]), ["c"]),
+            ],
+            "passthrough",
+            "['a', 'b']",
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(["a", "b"]), slice("b", "b")),
+                ("bycol2", "passthrough", ["a"]),
+                ("bycol3", TransWithNames(["b"]), ["c"]),
+            ],
+            "passthrough",
+            "['a', 'b']",
+        ),
+        (
+            [
+                ("bycol1", TransWithNames(["a", "b"]), ["b"]),
+                ("bycol2", "passthrough", slice("a", "a")),
                 ("bycol3", TransWithNames(["b"]), ["c"]),
             ],
             "passthrough",

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1801,7 +1801,14 @@ class TransWithNames(Trans):
                 ("bycol2", "passthrough", slice("c", "d")),
             ],
             "passthrough",
-            ["bycol1__d", "bycol1__c", "bycol2__c", "bycol2__d", "remainder__a", "remainder__b"],
+            [
+                "bycol1__d",
+                "bycol1__c",
+                "bycol2__c",
+                "bycol2__d",
+                "remainder__a",
+                "remainder__b",
+            ],
         ),
     ],
 )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->
The earlier PR (#22775) did not account for string slices. A string slice like `slice('col_A', 'col_B')` is a valid column specification format and was not handled in the earlier PR. This PR extends the earlier fix to include string slices.

#### Reference Issues/PRs
Extends Fix #22775 

Issue: #22774 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
It extends get_feature_names_out API to include cases where the column specification was using a string slice like `slice('col_A', 'col_B')`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
