### PR TITLE
[MAINT] Separate unit tests in `test_tree.py` for pickling and min_impurity_decrease

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1697,6 +1697,8 @@ def test_max_samples_boundary_regressors(name):
     assert ms_1_ms == pytest.approx(ms_None_ms)
 
 
+# TODO: Trees do not preserve dtype when fitting/predicting.
+# Add `global_dtype` when Trees have this ability.
 @pytest.mark.parametrize("name", FOREST_CLASSIFIERS)
 def test_max_samples_boundary_classifiers(name):
     X_train, X_test, y_train, _ = train_test_split(

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1697,8 +1697,6 @@ def test_max_samples_boundary_regressors(name):
     assert ms_1_ms == pytest.approx(ms_None_ms)
 
 
-# TODO: Trees do not preserve dtype when fitting/predicting.
-# Add `global_dtype` when Trees have this ability.
 @pytest.mark.parametrize("name", FOREST_CLASSIFIERS)
 def test_max_samples_boundary_classifiers(name):
     X_train, X_test, y_train, _ = train_test_split(

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -259,8 +259,6 @@ def test_weighted_classification_toy():
         assert_array_equal(clf.predict(T), true_result, "Failed with {0}".format(name))
 
 
-# TODO: Trees do not preserve dtype when fitting/predicting.
-# Add `global_dtype` when Trees have this ability.
 @pytest.mark.parametrize("Tree", REG_TREES.values())
 @pytest.mark.parametrize("criterion", REG_CRITERIONS)
 def test_regression_toy(Tree, criterion):
@@ -2140,8 +2138,6 @@ def test_poisson_vs_mse():
         assert metric_poi < 0.75 * metric_dummy
 
 
-# TODO: Trees do not preserve dtype when fitting/predicting.
-# Add `global_dtype` when Trees have this ability.
 @pytest.mark.parametrize("criterion", REG_CRITERIONS)
 def test_decision_tree_regressor_sample_weight_consistentcy(criterion):
     """Test that the impact of sample_weight is consistent."""

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -990,16 +990,12 @@ def test_pickle():
         est = TreeEstimator(random_state=0)
         est.fit(X, y)
         score = est.score(X, y)
-        fitted_attribute = dict()
-        for attribute in ["max_depth", "node_count", "capacity"]:
-            fitted_attribute[attribute] = getattr(est.tree_, attribute)
-
-        serialized_object = pickle.dumps(est)
-        est2 = pickle.loads(serialized_object)
-        assert type(est2) == est.__class__
 
         # test that all class properties are maintained
-        for prop_name in [
+        attributes = [
+            "max_depth",
+            "node_count",
+            "capacity",
             "n_classes",
             "children_left",
             "children_right",
@@ -1010,21 +1006,27 @@ def test_pickle():
             "n_node_samples",
             "weighted_n_node_samples",
             "value",
-        ]:
-            est_prop = getattr(est.tree_, prop_name)
-            est2_prop = getattr(est.tree_, prop_name)
-            assert_array_equal(est_prop, est2_prop)
+        ]
+        fitted_attribute = {
+            attribute: getattr(est.tree_, attribute) for attribute in attributes
+        }
+
+        serialized_object = pickle.dumps(est)
+        est2 = pickle.loads(serialized_object)
+        assert type(est2) == est.__class__
 
         score2 = est2.score(X, y)
         assert (
             score == score2
         ), "Failed to generate same score  after pickling with {0}".format(name)
-
         for attribute in fitted_attribute:
-            assert (
-                getattr(est2.tree_, attribute) == fitted_attribute[attribute]
-            ), "Failed to generate same attribute {0} after pickling with {1}".format(
-                attribute, name
+            assert_array_equal(
+                getattr(est2.tree_, attribute),
+                fitted_attribute[attribute],
+                err_msg=(
+                    f"Failed to generate same attribute {attribute} after pickling with"
+                    f" {name}"
+                ),
             )
 
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -259,6 +259,8 @@ def test_weighted_classification_toy():
         assert_array_equal(clf.predict(T), true_result, "Failed with {0}".format(name))
 
 
+# TODO: Trees do not preserve dtype when fitting/predicting.
+# Add `global_dtype` when Trees have this ability.
 @pytest.mark.parametrize("Tree", REG_TREES.values())
 @pytest.mark.parametrize("criterion", REG_CRITERIONS)
 def test_regression_toy(Tree, criterion):
@@ -2138,6 +2140,8 @@ def test_poisson_vs_mse():
         assert metric_poi < 0.75 * metric_dummy
 
 
+# TODO: Trees do not preserve dtype when fitting/predicting.
+# Add `global_dtype` when Trees have this ability.
 @pytest.mark.parametrize("criterion", REG_CRITERIONS)
 def test_decision_tree_regressor_sample_weight_consistentcy(criterion):
     """Test that the impact of sample_weight is consistent."""

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -978,6 +978,9 @@ def test_min_impurity_decrease():
                         actual_decrease, expected_decrease
                     )
 
+
+def test_pickle():
+    """Test pickling preserves Tree properties and performance."""
     for name, TreeEstimator in ALL_TREES.items():
         if "Classifier" in name:
             X, y = iris.data, iris.target
@@ -994,6 +997,24 @@ def test_min_impurity_decrease():
         serialized_object = pickle.dumps(est)
         est2 = pickle.loads(serialized_object)
         assert type(est2) == est.__class__
+
+        # test that all class properties are maintained
+        for prop_name in [
+            "n_classes",
+            "children_left",
+            "children_right",
+            "n_leaves",
+            "feature",
+            "threshold",
+            "impurity",
+            "n_node_samples",
+            "weighted_n_node_samples",
+            "value",
+        ]:
+            est_prop = getattr(est.tree_, prop_name)
+            est2_prop = getattr(est.tree_, prop_name)
+            assert_array_equal(est_prop, est2_prop)
+
         score2 = est2.score(X, y)
         assert (
             score == score2


### PR DESCRIPTION
#### Reference Issues/PRs
Discussed in OH today, but the pickling test should be separate from `min_impurity_decrease`


#### What does this implement/fix? Explain your changes.
I separated the two tests. I also added additional lines to test the properties of each Tree, which should be done imo as well.

#### Any other comments?
I don't think this needs a change log, or should I add one?

cc: @ogrisel and @glemaitre 