### PR TITLE
DOC Update notebook style for plot_bayesian_ridge_curvefit

### DIFF
--- a/examples/linear_model/plot_bayesian_ridge_curvefit.py
+++ b/examples/linear_model/plot_bayesian_ridge_curvefit.py
@@ -28,18 +28,15 @@ It can be concluded that the model with larger L is more likely.
 
 # Author: Yoshihiro Uchida <nimbus1after2a1sun7shower@gmail.com>
 
+# %%
+# Generate sinusoidal data with noise
+# -----------------------------------
 import numpy as np
 import matplotlib.pyplot as plt
-
-from sklearn.linear_model import BayesianRidge
-
 
 def func(x):
     return np.sin(2 * np.pi * x)
 
-
-# #############################################################################
-# Generate sinusoidal data with noise
 size = 25
 rng = np.random.RandomState(1234)
 x_train = rng.uniform(0.0, 1.0, size)
@@ -47,14 +44,18 @@ y_train = func(x_train) + rng.normal(scale=0.1, size=size)
 x_test = np.linspace(0.0, 1.0, 100)
 
 
-# #############################################################################
+# %%
 # Fit by cubic polynomial
+# -----------------------
 n_order = 3
 X_train = np.vander(x_train, n_order + 1, increasing=True)
 X_test = np.vander(x_test, n_order + 1, increasing=True)
 
-# #############################################################################
+# %%
 # Plot the true and predicted curves with log marginal likelihood (L)
+# -------------------------------------------------------------------
+from sklearn.linear_model import BayesianRidge
+
 reg = BayesianRidge(tol=1e-6, fit_intercept=False, compute_score=True)
 fig, axes = plt.subplots(1, 2, figsize=(8, 4))
 for i, ax in enumerate(axes):

--- a/examples/linear_model/plot_bayesian_ridge_curvefit.py
+++ b/examples/linear_model/plot_bayesian_ridge_curvefit.py
@@ -34,8 +34,10 @@ It can be concluded that the model with larger L is more likely.
 import numpy as np
 import matplotlib.pyplot as plt
 
+
 def func(x):
     return np.sin(2 * np.pi * x)
+
 
 size = 25
 rng = np.random.RandomState(1234)

--- a/examples/linear_model/plot_bayesian_ridge_curvefit.py
+++ b/examples/linear_model/plot_bayesian_ridge_curvefit.py
@@ -32,7 +32,6 @@ It can be concluded that the model with larger L is more likely.
 # Generate sinusoidal data with noise
 # -----------------------------------
 import numpy as np
-import matplotlib.pyplot as plt
 
 
 def func(x):
@@ -49,16 +48,18 @@ x_test = np.linspace(0.0, 1.0, 100)
 # %%
 # Fit by cubic polynomial
 # -----------------------
+from sklearn.linear_model import BayesianRidge
+
 n_order = 3
 X_train = np.vander(x_train, n_order + 1, increasing=True)
 X_test = np.vander(x_test, n_order + 1, increasing=True)
+reg = BayesianRidge(tol=1e-6, fit_intercept=False, compute_score=True)
 
 # %%
 # Plot the true and predicted curves with log marginal likelihood (L)
 # -------------------------------------------------------------------
-from sklearn.linear_model import BayesianRidge
+import matplotlib.pyplot as plt
 
-reg = BayesianRidge(tol=1e-6, fit_intercept=False, compute_score=True)
 fig, axes = plt.subplots(1, 2, figsize=(8, 4))
 for i, ax in enumerate(axes):
     # Bayesian ridge regression with different initial value pairs


### PR DESCRIPTION
DOC Update notebook style for plot_bayesian_ridge_curvefit

#### Reference Issues/PRs

Update [examples/linear_model/plot_bayesian_ridge_curvefit.py](https://github.com/scikit-learn/scikit-learn/blob/main/examples/linear_model/plot_bayesian_ridge_curvefit.py) to notebook style, Issue [#22406](https://github.com/scikit-learn/scikit-learn/issues/22406)


#### What does this implement/fix? Explain your changes.

Split into 3 sections

- Data generation
- Fitting
- Plotting

Moved the following code
- Sinusoidal data generating function to the data generation code block
- BayesianRidge import to fitting code block


