### PR TITLE
MNT Replace pytest.warns(None) in test_ridge.py

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -4,6 +4,7 @@ from scipy import linalg
 from itertools import product
 
 import pytest
+import warnings
 
 from sklearn.utils import _IS_32BIT
 from sklearn.utils._testing import assert_almost_equal
@@ -1384,9 +1385,9 @@ def test_ridge_fit_intercept_sparse(solver):
     dense_ridge = Ridge(solver="sparse_cg", tol=1e-12)
     sparse_ridge = Ridge(solver=solver, tol=1e-12, positive=positive)
     dense_ridge.fit(X, y)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
         sparse_ridge.fit(X_csr, y)
-    assert not [w.message for w in record]
     assert np.allclose(dense_ridge.intercept_, sparse_ridge.intercept_)
     assert np.allclose(dense_ridge.coef_, sparse_ridge.coef_)
 
@@ -1413,9 +1414,9 @@ def test_ridge_fit_intercept_sparse_sag():
     dense_ridge = Ridge(**params)
     sparse_ridge = Ridge(**params)
     dense_ridge.fit(X, y)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
         sparse_ridge.fit(X_csr, y)
-    assert not [w.message for w in record]
     assert np.allclose(dense_ridge.intercept_, sparse_ridge.intercept_, rtol=1e-4)
     assert np.allclose(dense_ridge.coef_, sparse_ridge.coef_, rtol=1e-4)
     with pytest.warns(UserWarning, match='"sag" solver requires.*'):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Partially addresses #22572.

#### What does this implement/fix? Explain your changes.
Replaces `pytest.warns(None)` in `test_ridge.py` with `warnings.catch_warnings()` filters that error on `UserWarning` - based on review of commit history, the tests are intended to catch a previous `UserWarning` for solvers that could not fit intercepts for sparse inputs.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
