### PR TITLE
MAINT use the default CPU_COUNT=2 for the macOS builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,14 +255,12 @@ jobs:
         DISTRIB: 'conda'
         BLAS: 'mkl'
         CONDA_CHANNEL: 'conda-forge'
-        CPU_COUNT: '3'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '5'  # non-default seed
       pylatest_conda_mkl_no_openmp:
         DISTRIB: 'conda'
         BLAS: 'mkl'
         SKLEARN_TEST_NO_OPENMP: 'true'
         SKLEARN_SKIP_OPENMP_TEST: 'true'
-        CPU_COUNT: '3'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '6'  # non-default seed
 
 - template: build_tools/azure/windows.yml

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -26,11 +26,7 @@ mkdir -p $TEST_DIR
 cp setup.cfg $TEST_DIR
 cd $TEST_DIR
 
-python -c "
-from joblib import cpu_count
-print(f'Number of cores: {cpu_count(only_physical_cores=False)}')
-print(f'Number of physical cores: {cpu_count(only_physical_cores=True)}')
-"
+python -c "import joblib; print(f'Number of cores: {joblib.cpu_count()}')"
 python -c "import sklearn; sklearn.show_versions()"
 
 show_installed_libraries

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -26,6 +26,11 @@ mkdir -p $TEST_DIR
 cp setup.cfg $TEST_DIR
 cd $TEST_DIR
 
+python -c "
+from joblib import cpu_count
+print(f'Number of cores: {cpu_count(only_physical_cores=False)}')
+print(f'Number of physical cores: {cpu_count(only_physical_cores=True)}')
+"
 python -c "import sklearn; sklearn.show_versions()"
 
 show_installed_libraries


### PR DESCRIPTION
I just noticed that the macOS builds might be slow because we use 3 pytest-xdist workers workers with just 2 CPUs for no apparent reason.

Let's try to see if using the default of 2 pytest-xdist workers improves the build time.