### PR TITLE
MNT Uses memoryviews in tree criterion

### DIFF
--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -40,14 +40,6 @@ cdef class Criterion:
     cdef double weighted_n_left          # Weighted number of samples in the left node
     cdef double weighted_n_right         # Weighted number of samples in the right node
 
-    cdef double* sum_total          # For classification criteria, the sum of the
-                                    # weighted count of each label. For regression,
-                                    # the sum of w*y. sum_total[k] is equal to
-                                    # sum_{i=start}^{end-1} w[samples[i]]*y[samples[i], k],
-                                    # where k is output index.
-    cdef double* sum_left           # Same as above, but for the left side of the split
-    cdef double* sum_right          # same as above, but for the right side of the split
-
     # The criterion object is maintained such that left and right collected
     # statistics correspond to samples[start:pos] and samples[pos:end].
 
@@ -70,10 +62,18 @@ cdef class Criterion:
 cdef class ClassificationCriterion(Criterion):
     """Abstract criterion for classification."""
 
-    cdef SIZE_t* n_classes
-    cdef SIZE_t sum_stride
+    cdef SIZE_t[::1] n_classes
+    cdef SIZE_t max_n_classes
+
+    cdef double[:, ::1] sum_total   # The sum of the weighted count of each label.
+    cdef double[:, ::1] sum_left    # Same as above, but for the left side of the split
+    cdef double[:, ::1] sum_right   # Same as above, but for the right side of the split
 
 cdef class RegressionCriterion(Criterion):
     """Abstract regression criterion."""
 
     cdef double sq_sum_total
+
+    cdef double[::1] sum_total   # The sum of w*y.
+    cdef double[::1] sum_left    # Same as above, but for the left side of the split
+    cdef double[::1] sum_right   # Same as above, but for the right side of the split

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -39,13 +39,6 @@ cdef class Criterion:
     This object stores methods on how to calculate how good a split is using
     different metrics.
     """
-
-    def __dealloc__(self):
-        """Destructor."""
-        free(self.sum_total)
-        free(self.sum_left)
-        free(self.sum_right)
-
     def __getstate__(self):
         return {}
 
@@ -232,46 +225,29 @@ cdef class ClassificationCriterion(Criterion):
         self.weighted_n_left = 0.0
         self.weighted_n_right = 0.0
 
-        # Count labels for each output
-        self.sum_total = NULL
-        self.sum_left = NULL
-        self.sum_right = NULL
-        self.n_classes = NULL
-
-        safe_realloc(&self.n_classes, n_outputs)
+        self.n_classes = np.empty(n_outputs, dtype=np.intp)
 
         cdef SIZE_t k = 0
-        cdef SIZE_t sum_stride = 0
+        cdef SIZE_t max_n_classes = 0
 
         # For each target, set the number of unique classes in that target,
         # and also compute the maximal stride of all targets
         for k in range(n_outputs):
             self.n_classes[k] = n_classes[k]
 
-            if n_classes[k] > sum_stride:
-                sum_stride = n_classes[k]
+            if n_classes[k] > max_n_classes:
+                max_n_classes = n_classes[k]
 
-        self.sum_stride = sum_stride
+        self.max_n_classes = max_n_classes
 
-        cdef SIZE_t n_elements = n_outputs * sum_stride
-        self.sum_total = <double*> calloc(n_elements, sizeof(double))
-        self.sum_left = <double*> calloc(n_elements, sizeof(double))
-        self.sum_right = <double*> calloc(n_elements, sizeof(double))
-
-        if (self.sum_total == NULL or
-                self.sum_left == NULL or
-                self.sum_right == NULL):
-            raise MemoryError()
-
-    def __dealloc__(self):
-        """Destructor."""
-        free(self.n_classes)
+        # Count labels for each output
+        self.sum_total = np.zeros((n_outputs, max_n_classes), dtype=np.float64)
+        self.sum_left = np.zeros((n_outputs, max_n_classes), dtype=np.float64)
+        self.sum_right = np.zeros((n_outputs, max_n_classes), dtype=np.float64)
 
     def __reduce__(self):
         return (type(self),
-                (self.n_outputs,
-                 sizet_ptr_to_ndarray(self.n_classes, self.n_outputs)),
-                self.__getstate__())
+                (self.n_outputs, np.asarray(self.n_classes)), self.__getstate__())
 
     cdef int init(self, const DOUBLE_t[:, ::1] y,
                   DOUBLE_t* sample_weight, double weighted_n_samples,
@@ -308,9 +284,6 @@ cdef class ClassificationCriterion(Criterion):
         self.weighted_n_samples = weighted_n_samples
         self.weighted_n_node_samples = 0.0
 
-        cdef SIZE_t* n_classes = self.n_classes
-        cdef double* sum_total = self.sum_total
-
         cdef SIZE_t i
         cdef SIZE_t p
         cdef SIZE_t k
@@ -319,8 +292,7 @@ cdef class ClassificationCriterion(Criterion):
         cdef SIZE_t offset = 0
 
         for k in range(self.n_outputs):
-            memset(sum_total + offset, 0, n_classes[k] * sizeof(double))
-            offset += self.sum_stride
+            memset(&self.sum_total[k, 0], 0, self.n_classes[k] * sizeof(double))
 
         for p in range(start, end):
             i = samples[p]
@@ -333,7 +305,7 @@ cdef class ClassificationCriterion(Criterion):
             # Count weighted class frequency for each target
             for k in range(self.n_outputs):
                 c = <SIZE_t> self.y[i, k]
-                sum_total[k * self.sum_stride + c] += w
+                self.sum_total[k, c] += w
 
             self.weighted_n_node_samples += w
 
@@ -351,21 +323,11 @@ cdef class ClassificationCriterion(Criterion):
 
         self.weighted_n_left = 0.0
         self.weighted_n_right = self.weighted_n_node_samples
-
-        cdef double* sum_total = self.sum_total
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
-
-        cdef SIZE_t* n_classes = self.n_classes
         cdef SIZE_t k
 
         for k in range(self.n_outputs):
-            memset(sum_left, 0, n_classes[k] * sizeof(double))
-            memcpy(sum_right, sum_total, n_classes[k] * sizeof(double))
-
-            sum_total += self.sum_stride
-            sum_left += self.sum_stride
-            sum_right += self.sum_stride
+            memset(&self.sum_left[k, 0], 0, self.n_classes[k] * sizeof(double))
+            memcpy(&self.sum_right[k, 0], &self.sum_total[k, 0], self.n_classes[k] * sizeof(double))
         return 0
 
     cdef int reverse_reset(self) nogil except -1:
@@ -378,21 +340,11 @@ cdef class ClassificationCriterion(Criterion):
 
         self.weighted_n_left = self.weighted_n_node_samples
         self.weighted_n_right = 0.0
-
-        cdef double* sum_total = self.sum_total
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
-
-        cdef SIZE_t* n_classes = self.n_classes
         cdef SIZE_t k
 
         for k in range(self.n_outputs):
-            memset(sum_right, 0, n_classes[k] * sizeof(double))
-            memcpy(sum_left, sum_total, n_classes[k] * sizeof(double))
-
-            sum_total += self.sum_stride
-            sum_left += self.sum_stride
-            sum_right += self.sum_stride
+            memset(&self.sum_right[k, 0], 0, self.n_classes[k] * sizeof(double))
+            memcpy(&self.sum_left[k, 0],  &self.sum_total[k, 0], self.n_classes[k] * sizeof(double))
         return 0
 
     cdef int update(self, SIZE_t new_pos) nogil except -1:
@@ -410,11 +362,6 @@ cdef class ClassificationCriterion(Criterion):
         cdef SIZE_t pos = self.pos
         cdef SIZE_t end = self.end
 
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
-        cdef double* sum_total = self.sum_total
-
-        cdef SIZE_t* n_classes = self.n_classes
         cdef SIZE_t* samples = self.samples
         cdef DOUBLE_t* sample_weight = self.sample_weight
 
@@ -440,8 +387,7 @@ cdef class ClassificationCriterion(Criterion):
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
-                    label_index = k * self.sum_stride + <SIZE_t> self.y[i, k]
-                    sum_left[label_index] += w
+                    self.sum_left[k, <SIZE_t> self.y[i, k]] += w
 
                 self.weighted_n_left += w
 
@@ -455,20 +401,15 @@ cdef class ClassificationCriterion(Criterion):
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
-                    label_index = k * self.sum_stride + <SIZE_t> self.y[i, k]
-                    sum_left[label_index] -= w
+                    self.sum_left[k, <SIZE_t> self.y[i, k]] -= w
 
                 self.weighted_n_left -= w
 
         # Update right part statistics
         self.weighted_n_right = self.weighted_n_node_samples - self.weighted_n_left
         for k in range(self.n_outputs):
-            for c in range(n_classes[k]):
-                sum_right[c] = sum_total[c] - sum_left[c]
-
-            sum_right += self.sum_stride
-            sum_left += self.sum_stride
-            sum_total += self.sum_stride
+            for c in range(self.n_classes[k]):
+                self.sum_right[k, c] = self.sum_total[k, c] - self.sum_left[k, c]
 
         self.pos = new_pos
         return 0
@@ -488,14 +429,11 @@ cdef class ClassificationCriterion(Criterion):
         dest : double pointer
             The memory address which we will save the node value into.
         """
-        cdef double* sum_total = self.sum_total
-        cdef SIZE_t* n_classes = self.n_classes
         cdef SIZE_t k
 
         for k in range(self.n_outputs):
-            memcpy(dest, sum_total, n_classes[k] * sizeof(double))
-            dest += self.sum_stride
-            sum_total += self.sum_stride
+            memcpy(dest, &self.sum_total[k, 0], self.n_classes[k] * sizeof(double))
+            dest += self.max_n_classes
 
 
 cdef class Entropy(ClassificationCriterion):
@@ -521,21 +459,17 @@ cdef class Entropy(ClassificationCriterion):
         i.e. the impurity of samples[start:end]. The smaller the impurity the
         better.
         """
-        cdef SIZE_t* n_classes = self.n_classes
-        cdef double* sum_total = self.sum_total
         cdef double entropy = 0.0
         cdef double count_k
         cdef SIZE_t k
         cdef SIZE_t c
 
         for k in range(self.n_outputs):
-            for c in range(n_classes[k]):
-                count_k = sum_total[c]
+            for c in range(self.n_classes[k]):
+                count_k = self.sum_total[k, c]
                 if count_k > 0.0:
                     count_k /= self.weighted_n_node_samples
                     entropy -= count_k * log(count_k)
-
-            sum_total += self.sum_stride
 
         return entropy / self.n_outputs
 
@@ -553,29 +487,29 @@ cdef class Entropy(ClassificationCriterion):
         impurity_right : double pointer
             The memory address to save the impurity of the right node
         """
-        cdef SIZE_t* n_classes = self.n_classes
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
         cdef double entropy_left = 0.0
         cdef double entropy_right = 0.0
         cdef double count_k
+        # Pointeres benchmark better than using the memorview directly
+        cdef double* sum_left_ptr = &self.sum_left[0, 0]
+        cdef double* sum_right_ptr = &self.sum_right[0, 0]
         cdef SIZE_t k
         cdef SIZE_t c
 
         for k in range(self.n_outputs):
-            for c in range(n_classes[k]):
-                count_k = sum_left[c]
+            for c in range(self.n_classes[k]):
+                count_k = sum_left_ptr[c]
                 if count_k > 0.0:
                     count_k /= self.weighted_n_left
                     entropy_left -= count_k * log(count_k)
 
-                count_k = sum_right[c]
+                count_k = sum_right_ptr[c]
                 if count_k > 0.0:
                     count_k /= self.weighted_n_right
                     entropy_right -= count_k * log(count_k)
 
-            sum_left += self.sum_stride
-            sum_right += self.sum_stride
+            sum_left_ptr += self.max_n_classes
+            sum_right_ptr += self.max_n_classes
 
         impurity_left[0] = entropy_left / self.n_outputs
         impurity_right[0] = entropy_right / self.n_outputs
@@ -605,8 +539,6 @@ cdef class Gini(ClassificationCriterion):
         i.e. the impurity of samples[start:end]. The smaller the impurity the
         better.
         """
-        cdef SIZE_t* n_classes = self.n_classes
-        cdef double* sum_total = self.sum_total
         cdef double gini = 0.0
         cdef double sq_count
         cdef double count_k
@@ -616,14 +548,12 @@ cdef class Gini(ClassificationCriterion):
         for k in range(self.n_outputs):
             sq_count = 0.0
 
-            for c in range(n_classes[k]):
-                count_k = sum_total[c]
+            for c in range(self.n_classes[k]):
+                count_k = self.sum_total[k, c]
                 sq_count += count_k * count_k
 
             gini += 1.0 - sq_count / (self.weighted_n_node_samples *
                                       self.weighted_n_node_samples)
-
-            sum_total += self.sum_stride
 
         return gini / self.n_outputs
 
@@ -641,9 +571,6 @@ cdef class Gini(ClassificationCriterion):
         impurity_right : double pointer
             The memory address to save the impurity of the right node to
         """
-        cdef SIZE_t* n_classes = self.n_classes
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
         cdef double gini_left = 0.0
         cdef double gini_right = 0.0
         cdef double sq_count_left
@@ -656,11 +583,11 @@ cdef class Gini(ClassificationCriterion):
             sq_count_left = 0.0
             sq_count_right = 0.0
 
-            for c in range(n_classes[k]):
-                count_k = sum_left[c]
+            for c in range(self.n_classes[k]):
+                count_k = self.sum_left[k, c]
                 sq_count_left += count_k * count_k
 
-                count_k = sum_right[c]
+                count_k = self.sum_right[k, c]
                 sq_count_right += count_k * count_k
 
             gini_left += 1.0 - sq_count_left / (self.weighted_n_left *
@@ -668,9 +595,6 @@ cdef class Gini(ClassificationCriterion):
 
             gini_right += 1.0 - sq_count_right / (self.weighted_n_right *
                                                   self.weighted_n_right)
-
-            sum_left += self.sum_stride
-            sum_right += self.sum_stride
 
         impurity_left[0] = gini_left / self.n_outputs
         impurity_right[0] = gini_right / self.n_outputs
@@ -716,21 +640,9 @@ cdef class RegressionCriterion(Criterion):
 
         self.sq_sum_total = 0.0
 
-        # Allocate accumulators. Make sure they are NULL, not uninitialized,
-        # before an exception can be raised (which triggers __dealloc__).
-        self.sum_total = NULL
-        self.sum_left = NULL
-        self.sum_right = NULL
-
-        # Allocate memory for the accumulators
-        self.sum_total = <double*> calloc(n_outputs, sizeof(double))
-        self.sum_left = <double*> calloc(n_outputs, sizeof(double))
-        self.sum_right = <double*> calloc(n_outputs, sizeof(double))
-
-        if (self.sum_total == NULL or
-                self.sum_left == NULL or
-                self.sum_right == NULL):
-            raise MemoryError()
+        self.sum_total = np.zeros(n_outputs, dtype=np.float64)
+        self.sum_left = np.zeros(n_outputs, dtype=np.float64)
+        self.sum_right = np.zeros(n_outputs, dtype=np.float64)
 
     def __reduce__(self):
         return (type(self), (self.n_outputs, self.n_samples), self.__getstate__())
@@ -759,9 +671,8 @@ cdef class RegressionCriterion(Criterion):
         cdef DOUBLE_t y_ik
         cdef DOUBLE_t w_y_ik
         cdef DOUBLE_t w = 1.0
-
         self.sq_sum_total = 0.0
-        memset(self.sum_total, 0, self.n_outputs * sizeof(double))
+        memset(&self.sum_total[0], 0, self.n_outputs * sizeof(double))
 
         for p in range(start, end):
             i = samples[p]
@@ -784,8 +695,8 @@ cdef class RegressionCriterion(Criterion):
     cdef int reset(self) nogil except -1:
         """Reset the criterion at pos=start."""
         cdef SIZE_t n_bytes = self.n_outputs * sizeof(double)
-        memset(self.sum_left, 0, n_bytes)
-        memcpy(self.sum_right, self.sum_total, n_bytes)
+        memset(&self.sum_left[0], 0, n_bytes)
+        memcpy(&self.sum_right[0], &self.sum_total[0], n_bytes)
 
         self.weighted_n_left = 0.0
         self.weighted_n_right = self.weighted_n_node_samples
@@ -795,8 +706,8 @@ cdef class RegressionCriterion(Criterion):
     cdef int reverse_reset(self) nogil except -1:
         """Reset the criterion at pos=end."""
         cdef SIZE_t n_bytes = self.n_outputs * sizeof(double)
-        memset(self.sum_right, 0, n_bytes)
-        memcpy(self.sum_left, self.sum_total, n_bytes)
+        memset(&self.sum_right[0], 0, n_bytes)
+        memcpy(&self.sum_left[0], &self.sum_total[0], n_bytes)
 
         self.weighted_n_right = 0.0
         self.weighted_n_left = self.weighted_n_node_samples
@@ -805,10 +716,6 @@ cdef class RegressionCriterion(Criterion):
 
     cdef int update(self, SIZE_t new_pos) nogil except -1:
         """Updated statistics by moving samples[pos:new_pos] to the left."""
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
-        cdef double* sum_total = self.sum_total
-
         cdef double* sample_weight = self.sample_weight
         cdef SIZE_t* samples = self.samples
 
@@ -834,7 +741,7 @@ cdef class RegressionCriterion(Criterion):
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
-                    sum_left[k] += w * self.y[i, k]
+                    self.sum_left[k] += w * self.y[i, k]
 
                 self.weighted_n_left += w
         else:
@@ -847,14 +754,14 @@ cdef class RegressionCriterion(Criterion):
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
-                    sum_left[k] -= w * self.y[i, k]
+                    self.sum_left[k] -= w * self.y[i, k]
 
                 self.weighted_n_left -= w
 
         self.weighted_n_right = (self.weighted_n_node_samples -
                                  self.weighted_n_left)
         for k in range(self.n_outputs):
-            sum_right[k] = sum_total[k] - sum_left[k]
+            self.sum_right[k] = self.sum_total[k] - self.sum_left[k]
 
         self.pos = new_pos
         return 0
@@ -887,13 +794,12 @@ cdef class MSE(RegressionCriterion):
         i.e. the impurity of samples[start:end]. The smaller the impurity the
         better.
         """
-        cdef double* sum_total = self.sum_total
         cdef double impurity
         cdef SIZE_t k
 
         impurity = self.sq_sum_total / self.weighted_n_node_samples
         for k in range(self.n_outputs):
-            impurity -= (sum_total[k] / self.weighted_n_node_samples)**2.0
+            impurity -= (self.sum_total[k] / self.weighted_n_node_samples)**2.0
 
         return impurity / self.n_outputs
 
@@ -917,16 +823,13 @@ cdef class MSE(RegressionCriterion):
 
             - 1/n_L * sum_{i left}(y_i)^2 - 1/n_R * sum_{i right}(y_i)^2
         """
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
-
         cdef SIZE_t k
         cdef double proxy_impurity_left = 0.0
         cdef double proxy_impurity_right = 0.0
 
         for k in range(self.n_outputs):
-            proxy_impurity_left += sum_left[k] * sum_left[k]
-            proxy_impurity_right += sum_right[k] * sum_right[k]
+            proxy_impurity_left += self.sum_left[k] * self.sum_left[k]
+            proxy_impurity_right += self.sum_right[k] * self.sum_right[k]
 
         return (proxy_impurity_left / self.weighted_n_left +
                 proxy_impurity_right / self.weighted_n_right)
@@ -943,8 +846,6 @@ cdef class MSE(RegressionCriterion):
         cdef SIZE_t pos = self.pos
         cdef SIZE_t start = self.start
 
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
         cdef DOUBLE_t y_ik
 
         cdef double sq_sum_left = 0.0
@@ -971,8 +872,8 @@ cdef class MSE(RegressionCriterion):
         impurity_right[0] = sq_sum_right / self.weighted_n_right
 
         for k in range(self.n_outputs):
-            impurity_left[0] -= (sum_left[k] / self.weighted_n_left) ** 2.0
-            impurity_right[0] -= (sum_right[k] / self.weighted_n_right) ** 2.0
+            impurity_left[0] -= (self.sum_left[k] / self.weighted_n_left) ** 2.0
+            impurity_right[0] -= (self.sum_right[k] / self.weighted_n_right) ** 2.0
 
         impurity_left[0] /= self.n_outputs
         impurity_right[0] /= self.n_outputs
@@ -984,13 +885,9 @@ cdef class MAE(RegressionCriterion):
        MAE = (1 / n)*(\sum_i |y_i - f_i|), where y_i is the true
        value and f_i is the predicted value."""
 
-    def __dealloc__(self):
-        """Destructor."""
-        free(self.node_medians)
-
     cdef np.ndarray left_child
     cdef np.ndarray right_child
-    cdef DOUBLE_t* node_medians
+    cdef DOUBLE_t[::1] node_medians
 
     def __cinit__(self, SIZE_t n_outputs, SIZE_t n_samples):
         """Initialize parameters for this criterion.
@@ -1018,12 +915,7 @@ cdef class MAE(RegressionCriterion):
         self.weighted_n_left = 0.0
         self.weighted_n_right = 0.0
 
-        # Allocate accumulators. Make sure they are NULL, not uninitialized,
-        # before an exception can be raised (which triggers __dealloc__).
-        self.node_medians = NULL
-
-        # Allocate memory for the accumulators
-        safe_realloc(&self.node_medians, n_outputs)
+        self.node_medians = np.zeros(n_outputs, dtype=np.float64)
 
         self.left_child = np.empty(n_outputs, dtype='object')
         self.right_child = np.empty(n_outputs, dtype='object')
@@ -1298,9 +1190,6 @@ cdef class FriedmanMSE(MSE):
         The absolute impurity improvement is only computed by the
         impurity_improvement method once the best split has been found.
         """
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
-
         cdef double total_sum_left = 0.0
         cdef double total_sum_right = 0.0
 
@@ -1308,8 +1197,8 @@ cdef class FriedmanMSE(MSE):
         cdef double diff = 0.0
 
         for k in range(self.n_outputs):
-            total_sum_left += sum_left[k]
-            total_sum_right += sum_right[k]
+            total_sum_left += self.sum_left[k]
+            total_sum_right += self.sum_right[k]
 
         diff = (self.weighted_n_right * total_sum_left -
                 self.weighted_n_left * total_sum_right)
@@ -1319,9 +1208,6 @@ cdef class FriedmanMSE(MSE):
     cdef double impurity_improvement(self, double impurity_parent, double
                                      impurity_left, double impurity_right) nogil:
         # Note: none of the arguments are used here
-        cdef double* sum_left = self.sum_left
-        cdef double* sum_right = self.sum_right
-
         cdef double total_sum_left = 0.0
         cdef double total_sum_right = 0.0
 
@@ -1329,8 +1215,8 @@ cdef class FriedmanMSE(MSE):
         cdef double diff = 0.0
 
         for k in range(self.n_outputs):
-            total_sum_left += sum_left[k]
-            total_sum_right += sum_right[k]
+            total_sum_left += self.sum_left[k]
+            total_sum_right += self.sum_right[k]
 
         diff = (self.weighted_n_right * total_sum_left -
                 self.weighted_n_left * total_sum_right) / self.n_outputs
@@ -1442,7 +1328,7 @@ cdef class Poisson(RegressionCriterion):
     cdef inline DOUBLE_t poisson_loss(self,
                                       SIZE_t start,
                                       SIZE_t end,
-                                      DOUBLE_t* y_sum,
+                                      double[::1] y_sum,
                                       DOUBLE_t weight_sum) nogil:
         """Helper function to compute Poisson loss (~deviance) of a given node.
         """

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -490,7 +490,8 @@ cdef class Entropy(ClassificationCriterion):
         cdef double entropy_left = 0.0
         cdef double entropy_right = 0.0
         cdef double count_k
-        # Pointeres benchmark better than using the memorview directly
+        # Pointers are being used here because benchmarks
+        # showed regression when using memory-views.
         cdef double* sum_left_ptr = &self.sum_left[0, 0]
         cdef double* sum_right_ptr = &self.sum_right[0, 0]
         cdef SIZE_t k

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -1329,7 +1329,7 @@ cdef class Poisson(RegressionCriterion):
     cdef inline DOUBLE_t poisson_loss(self,
                                       SIZE_t start,
                                       SIZE_t end,
-                                      double[::1] y_sum,
+                                      const double[::1] y_sum,
                                       DOUBLE_t weight_sum) nogil:
         """Helper function to compute Poisson loss (~deviance) of a given node.
         """

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -485,27 +485,20 @@ cdef class Entropy(ClassificationCriterion):
         cdef double entropy_left = 0.0
         cdef double entropy_right = 0.0
         cdef double count_k
-        # Pointers are being used here because benchmarks
-        # showed regression when using memory-views.
-        cdef double* sum_left_ptr = &self.sum_left[0, 0]
-        cdef double* sum_right_ptr = &self.sum_right[0, 0]
         cdef SIZE_t k
         cdef SIZE_t c
 
         for k in range(self.n_outputs):
             for c in range(self.n_classes[k]):
-                count_k = sum_left_ptr[c]
+                count_k = self.sum_left[k, c]
                 if count_k > 0.0:
                     count_k /= self.weighted_n_left
                     entropy_left -= count_k * log(count_k)
 
-                count_k = sum_right_ptr[c]
+                count_k = self.sum_right[k, c]
                 if count_k > 0.0:
                     count_k /= self.weighted_n_right
                     entropy_right -= count_k * log(count_k)
-
-            sum_left_ptr += self.max_n_classes
-            sum_right_ptr += self.max_n_classes
 
         impurity_left[0] = entropy_left / self.n_outputs
         impurity_right[0] = entropy_right / self.n_outputs

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -12,8 +12,6 @@
 #
 # License: BSD 3 clause
 
-from libc.stdlib cimport calloc
-from libc.stdlib cimport free
 from libc.string cimport memcpy
 from libc.string cimport memset
 from libc.math cimport fabs
@@ -26,8 +24,6 @@ from numpy.math cimport INFINITY
 from scipy.special.cython_special cimport xlogy
 
 from ._utils cimport log
-from ._utils cimport safe_realloc
-from ._utils cimport sizet_ptr_to_ndarray
 from ._utils cimport WeightedMedianCalculator
 
 # EPSILON is used in the Poisson criterion
@@ -289,7 +285,6 @@ cdef class ClassificationCriterion(Criterion):
         cdef SIZE_t k
         cdef SIZE_t c
         cdef DOUBLE_t w = 1.0
-        cdef SIZE_t offset = 0
 
         for k in range(self.n_outputs):
             memset(&self.sum_total[k, 0], 0, self.n_classes[k] * sizeof(double))


### PR DESCRIPTION
Continues #22868

This PR refactors `sklearn/tree/_criterion.pxd` to use memoryviews. This PR simplifies the code because strides are handled by the memoryview and Python can handle the memory. I ran [this benchmark](https://gist.github.com/thomasjpfan/c072ae5362928dea8e4a7da59d8961a0#file-benchmark-py) with every criterion and different n_samples and noticed no change in performance. [Here are the plots of the results](https://gist.github.com/thomasjpfan/c072ae5362928dea8e4a7da59d8961a0#file-bench_trees-ipynb) and here is the [raw results on main](https://gist.github.com/thomasjpfan/c072ae5362928dea8e4a7da59d8961a0#file-main_criterion-json) and [raw results for this PR](https://gist.github.com/thomasjpfan/c072ae5362928dea8e4a7da59d8961a0#file-pr_criterion-json).

Note that `memcpy` and `memset` are still used because they benchmark better when compared to their memoryview counter parts (`mv[:] = 0.0` or `mv[:] = other_mv`).