### PR TITLE
ENH Support cardinality filtering of columns in `make_column_selector`

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -200,7 +200,7 @@ Changelog
 
 - |Enhancement| :func:`compose.make_column_selector` now supports selecting
   columns by their cardinality (number of unique values) using the keyword
-  arguments `cardinality` and `cardinality_threshold`. Implemented in
+  arguments `min_cardinality` and `max_cardinality`. Implemented in
   :pr:`22923` by :user:`richardt94 <richardt94>`.
 
 :mod:`sklearn.cross_decomposition`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -198,6 +198,11 @@ Changelog
   using `slice`. This is fixed in :pr:`22775` by :user:`randomgeek78
   <randomgeek78>`
 
+- |Enhancement| :func:`compose.make_column_selector` now supports selecting
+  columns by their cardinality (number of unique values) using the keyword
+  arguments `cardinality` and `cardinality_threshold`. Implemented in
+  :pr:`22923` by :user:`richardt94 <richardt94>`.
+
 :mod:`sklearn.cross_decomposition`
 ..................................
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1072,7 +1072,7 @@ class make_column_selector:
             cols = cols[cols.str.contains(self.pattern, regex=True)]
 
         if self.cardinality:
-            cols_cardinality = df.nunique()[cols]
+            cols_cardinality = df[cols].nunique()
         if self.cardinality == "high":
             cols = cols[cols_cardinality > self.cardinality_threshold]
         elif self.cardinality == "low":

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1395,7 +1395,7 @@ def test_make_column_selector_with_select_dtypes(cols, pattern, include, exclude
         (["col_high"], 7, None),
         (["col_low", "col_mid", "col_high"], None, 7),
         (["col_mid"], 2, 6),
-        ([], 2,3),
+        ([], 2, 3),
     ],
 )
 def test_make_column_selector_with_cardinality(cols, min_cardinality, max_cardinality):

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1385,6 +1385,35 @@ def test_make_column_selector_with_select_dtypes(cols, pattern, include, exclude
     assert_array_equal(selector(X_df), cols)
 
 
+@pytest.mark.parametrize(
+    "cols, cardinality, threshold",
+    [
+        (["col_high"], "high", 5),
+        (["col_low", "col_mid"], "low", 5),
+        (["col_mid", "col_high"], "high", 2),
+        (["col_low"], "low", 1),
+        ([], "high", 7),
+        (["col_low", "col_mid", "col_high"], None, 7),
+    ],
+)
+def test_make_column_selector_with_cardinality(cols, cardinality, threshold):
+    pd = pytest.importorskip("pandas")
+    X_df = pd.DataFrame(
+        {
+            "col_low": np.array([1, 1, 1, 1, 1, 1, 1], dtype=int),
+            "col_mid": np.array([1, 2, 3, 4, 5, 5, 5], dtype=int),
+            "col_high": np.array([1, 2, 3, 4, 5, 6, 7], dtype=int),
+        },
+        columns=["col_low", "col_mid", "col_high"],
+    )
+
+    selector = make_column_selector(
+        cardinality=cardinality, cardinality_threshold=threshold
+    )
+
+    assert_array_equal(selector(X_df), cols)
+
+
 def test_column_transformer_with_make_column_selector():
     # Functional test for column transformer + column selector
     pd = pytest.importorskip("pandas")

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1386,17 +1386,19 @@ def test_make_column_selector_with_select_dtypes(cols, pattern, include, exclude
 
 
 @pytest.mark.parametrize(
-    "cols, cardinality, threshold",
+    "cols, min_cardinality, max_cardinality",
     [
-        (["col_high"], "high", 5),
-        (["col_low", "col_mid"], "low", 5),
-        (["col_mid", "col_high"], "high", 2),
-        (["col_low"], "low", 1),
-        ([], "high", 7),
+        (["col_low","col_mid", "col_high"], None, None),
+        (["col_low", "col_mid"], None, 5),
+        (["col_mid", "col_high"], 2, None),
+        (["col_low"], None, 1),
+        (["col_high"], 7, None),
         (["col_low", "col_mid", "col_high"], None, 7),
+        (["col_mid"], 2, 6),
+        ([], 2,3),
     ],
 )
-def test_make_column_selector_with_cardinality(cols, cardinality, threshold):
+def test_make_column_selector_with_cardinality(cols, min_cardinality, max_cardinality):
     pd = pytest.importorskip("pandas")
     X_df = pd.DataFrame(
         {
@@ -1408,7 +1410,7 @@ def test_make_column_selector_with_cardinality(cols, cardinality, threshold):
     )
 
     selector = make_column_selector(
-        cardinality=cardinality, cardinality_threshold=threshold
+        min_cardinality=min_cardinality, max_cardinality=max_cardinality
     )
 
     assert_array_equal(selector(X_df), cols)

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1388,7 +1388,7 @@ def test_make_column_selector_with_select_dtypes(cols, pattern, include, exclude
 @pytest.mark.parametrize(
     "cols, min_cardinality, max_cardinality",
     [
-        (["col_low","col_mid", "col_high"], None, None),
+        (["col_low", "col_mid", "col_high"], None, None),
         (["col_low", "col_mid"], None, 5),
         (["col_mid", "col_high"], 2, None),
         (["col_low"], None, 1),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Resolves #15873.

#### What does this implement/fix? Explain your changes.
Implemented the functionality in the PR (selecting columns with cardinality > or <= some threshold), and a test in the test suite to check it works as expected.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
