### PR TITLE
[Fix] a typo in doc

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1402,8 +1402,8 @@ def precision_recall_fscore_support(
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
     true positives and ``fp`` the number of false positives. The precision is
-    intuitively the ability of the classifier not to label as positive a sample
-    that is negative.
+    intuitively the ability of the classifier not to label a negative sample as 
+    positive.
 
     The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
     true positives and ``fn`` the number of false negatives. The recall is

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1402,7 +1402,7 @@ def precision_recall_fscore_support(
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
     true positives and ``fp`` the number of false positives. The precision is
-    intuitively the ability of the classifier not to label a negative sample as 
+    intuitively the ability of the classifier not to label a negative sample as
     positive.
 
     The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of


### PR DESCRIPTION
```
The precision is intuitively the ability of the classifier not to label as positive a sample that is negative.
```
is modified to
```
The precision is intuitively the ability of the classifier not to label a negative sample as positive.
```