### PR TITLE
Add sample_weight to the calculation of alphas in enet_path and LinearModelCV

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -20,6 +20,7 @@ from ..base import RegressorMixin, MultiOutputMixin
 from ._base import _preprocess_data, _deprecate_normalize
 from ..utils import check_array
 from ..utils import check_scalar
+from ..utils.sparsefuncs import mean_variance_axis
 from ..utils.validation import check_random_state
 from ..model_selection import check_cv
 from ..utils.extmath import safe_sparse_dot
@@ -86,12 +87,12 @@ def _alpha_grid(
     X,
     y,
     Xy=None,
+    sample_weight=None,
     l1_ratio=1.0,
     fit_intercept=True,
     eps=1e-3,
     n_alphas=100,
     normalize=False,
-    copy_X=True,
 ):
     """Compute the grid of alpha values for elastic net parameter search
 
@@ -107,6 +108,8 @@ def _alpha_grid(
     Xy : array-like of shape (n_features,) or (n_features, n_outputs),\
          default=None
         Xy = np.dot(X.T, y) that can be precomputed.
+
+    sample_weight: ndarray of shape (n_samples,)
 
     l1_ratio : float, default=1.0
         The elastic net mixing parameter, with ``0 < l1_ratio <= 1``.
@@ -135,9 +138,6 @@ def _alpha_grid(
         .. deprecated:: 1.0
             ``normalize`` was deprecated in version 1.0 and will be removed in
             1.2.
-
-    copy_X : bool, default=True
-        If ``True``, X will be copied; else, it may be overwritten.
     """
     if l1_ratio == 0:
         raise ValueError(
@@ -146,47 +146,43 @@ def _alpha_grid(
             "your estimator with the appropriate `alphas=` "
             "argument."
         )
+
     n_samples = len(y)
+    if not fit_intercept:
+        if (Xy is None) or (normalize):
+            product = safe_sparse_dot(X.T, y) / n_samples
+        else:
+            product = Xy / n_samples
+    else:
+        if (sample_weight is None) and (Xy is None):
+            product = safe_sparse_dot(X.T, y - y.mean())
+            product /= n_samples
+        elif sample_weight is None:
+            product = Xy - y.mean() * X.sum(axis=0)
+            product /= n_samples
+        else:
+            w = sample_weight / sample_weight.sum()
+            sw = np.sqrt(w)
+            sw_matrix = sparse.dia_matrix((sw, 0), shape=(n_samples, n_samples))
+            z = (y - w.dot(y)) * sw
+            mu = z.mean()
+            z = (z - mu) * (1 - mu)
+            product = z @ safe_sparse_dot(sw_matrix, X)
+            product -= z.dot(sw) * safe_sparse_dot(sw, X)
 
-    sparse_center = False
-    if Xy is None:
-        X_sparse = sparse.isspmatrix(X)
-        sparse_center = X_sparse and (fit_intercept or normalize)
-        X = check_array(
-            X, accept_sparse="csc", copy=(copy_X and fit_intercept and not X_sparse)
-        )
-        if not X_sparse:
-            # X can be touched inplace thanks to the above line
-            X, y, _, _, _ = _preprocess_data(X, y, fit_intercept, normalize, copy=False)
-        Xy = safe_sparse_dot(X.T, y, dense_output=True)
+    if normalize:
+        if sparse.issparse(X):
+            _, var = mean_variance_axis(X, axis=0)
+            X_scale = var**0.5
+        else:
+            X_scale = X.std(axis=0)
+        X_scale = np.where(X_scale != 0, X_scale, 1.0)
+        product /= X_scale
 
-        if sparse_center:
-            # Workaround to find alpha_max for sparse matrices.
-            # since we should not destroy the sparsity of such matrices.
-            _, _, X_offset, _, X_scale = _preprocess_data(
-                X, y, fit_intercept, normalize, return_mean=True
-            )
-            mean_dot = X_offset * np.sum(y)
-
-    if Xy.ndim == 1:
-        Xy = Xy[:, np.newaxis]
-
-    if sparse_center:
-        if fit_intercept:
-            Xy -= mean_dot[:, np.newaxis]
-        if normalize:
-            Xy /= X_scale[:, np.newaxis]
-
-    alpha_max = np.sqrt(np.sum(Xy**2, axis=1)).max() / (n_samples * l1_ratio)
-
+    alpha_max = np.max(np.abs(product)) / l1_ratio
     if alpha_max <= np.finfo(float).resolution:
-        alphas = np.empty(n_alphas)
-        alphas.fill(np.finfo(float).resolution)
-        return alphas
-
-    return np.logspace(np.log10(alpha_max * eps), np.log10(alpha_max), num=n_alphas)[
-        ::-1
-    ]
+        return np.full(n_alphas, np.finfo(float).resolution)
+    return np.logspace(np.log10(alpha_max), np.log10(alpha_max * eps), num=n_alphas)
 
 
 def lasso_path(
@@ -576,7 +572,6 @@ def enet_path(
             eps=eps,
             n_alphas=n_alphas,
             normalize=False,
-            copy_X=False,
         )
     else:
         alphas = np.sort(alphas)[::-1]  # make sure alphas are properly ordered
@@ -1654,12 +1649,12 @@ class LinearModelCV(MultiOutputMixin, LinearModel, ABC):
                 _alpha_grid(
                     X,
                     y,
+                    sample_weight=sample_weight,
                     l1_ratio=l1_ratio,
                     fit_intercept=self.fit_intercept,
                     eps=self.eps,
                     n_alphas=self.n_alphas,
                     normalize=_normalize,
-                    copy_X=self.copy_X,
                 )
                 for l1_ratio in l1_ratios
             ]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #22914.

#### What does this implement/fix? Explain your changes.
Modifies `_alpha_grid` function in `linear_model._coordinate_descent` to accept a `sample_weight` argument.
In addition to adding this argument, I have removed the argument `copy_X`, which no longer seems to be needed.

The function `_alpha_grid` is called in two places, `enet_path` and `LinearModelCV`.
The new `sample_weight` argument is not used by `enet_path`, but it is used by `LinearModelCV`.

#### Any other comments?
Thanks for your patience, this is my first PR on Github and I'm trying my best.
