### PR TITLE
Fix verbosity regression in cross-validation grid search

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -788,7 +788,11 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         base_estimator = clone(self.estimator)
 
-        parallel = Parallel(n_jobs=self.n_jobs, pre_dispatch=self.pre_dispatch)
+        parallel = Parallel(
+            n_jobs=self.n_jobs,
+            verbose=self.verbose if self.n_jobs is not None and self.n_jobs > 1 else 0,
+            pre_dispatch=self.pre_dispatch,
+        )
 
         fit_and_score_kwargs = dict(
             scorer=scorers,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.
In https://github.com/scikit-learn/scikit-learn/pull/16935, the possibility of setting the verbosity level of `joblib.Parallel` in `GridSearchCV` was removed ([L703](https://github.com/scikit-learn/scikit-learn/pull/16935/files#diff-44602c6feb13bfed0cd07fbdb69462a92b7015c13e6b3fe966318cf24af89517L703)). Likely because the newly created output formatting was deemed better, but that is not used when `n_jobs > 1`. This PR restores the old behaviour for the latter case.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
