### PR TITLE
[WIP] Elaborates on description of MaxAbsScaler in example.

### DIFF
--- a/examples/preprocessing/plot_all_scaling.py
+++ b/examples/preprocessing/plot_all_scaling.py
@@ -307,8 +307,12 @@ make_plot(2)
 #
 # :class:`~sklearn.preprocessing.MaxAbsScaler` is similar to
 # :class:`~sklearn.preprocessing.MinMaxScaler` except that the
-# values are mapped in the range [0, 1]. On positive only data, both scalers
-# behave similarly.
+# values are mapped across several ranges depending on whether negative
+# OR positive values are present. If only positive values are present, the
+# range is [0, 1]. If only negative values are present, the range is [-1, 0].
+# If both negative and positive values are present, the range is [-1, 1].
+# On positive only data, both :class:`~sklearn.preprocessing.MinMaxScaler`
+# and :class:`~sklearn.preprocessing.MaxAbsScaler` behave similarly.
 # :class:`~sklearn.preprocessing.MaxAbsScaler` therefore also suffers from
 # the presence of large outliers.
 


### PR DESCRIPTION
The original description in the [MaxAbsScaler example found here](https://scikit-learn.org/stable/auto_examples/preprocessing/plot_all_scaling.html#maxabsscaler) seemed like it was missing some nuances. I added a minor tweak to improve the clarity of the description especially related to how MaxAbsScaler is similar to and different from MinMaxScaler.

#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.
The original written description did not appear to address several valid use cases. The change adds more nuance to the description. Namely:

> [MaxAbsScaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MaxAbsScaler.html#sklearn.preprocessing.MaxAbsScaler) is similar to [MinMaxScaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MinMaxScaler.html#sklearn.preprocessing.MinMaxScaler) except that the values are mapped in the range [0, 1]. On positive only data, both scalers behave similarly. [MaxAbsScaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MaxAbsScaler.html#sklearn.preprocessing.MaxAbsScaler) therefore also suffers from the presence of large outliers.

Might be better written as:

> [MaxAbsScaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MaxAbsScaler.html#sklearn.preprocessing.MaxAbsScaler) is similar to [MinMaxScaler](https://scikit-learn.org/modules/generatedsklearn.preprocessing.MinMaxScaler.html#sklearn.preprocessing.MinMaxScaler) except that the values are mapped across several ranges depending on whether negative OR positive values are present. If only positive values are present, the range is [0, 1]. If only negative values are present, the range is [-1, 0]. If both negative and positive values are present, the range is [-1, 1]. On positive only data, both [MinMaxScaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MinMaxScaler.html#sklearn.preprocessing.MinMaxScaler) and [MaxAbsScaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MaxAbsScaler.html#sklearn.preprocessing.MaxAbsScaler) behave similarly. [MaxAbsScaler](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MaxAbsScaler.html#sklearn.preprocessing.MaxAbsScaler) therefore also suffers from the presence of large outliers.


#### Any other comments?
I am happy to refine the verbiage as needed.