### PR TITLE
TST replace pytest.warns(None) in metrics/cluster/test_unsupervised.py

### DIFF
--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import scipy.sparse as sp
 import pytest
@@ -10,6 +12,7 @@ from sklearn.metrics.cluster import silhouette_samples
 from sklearn.metrics import pairwise_distances
 from sklearn.metrics.cluster import calinski_harabasz_score
 from sklearn.metrics.cluster import davies_bouldin_score
+from sklearn.exceptions import UndefinedMetricWarning
 
 
 def test_silhouette():
@@ -341,14 +344,9 @@ def test_davies_bouldin_score():
     pytest.approx(davies_bouldin_score(X, labels), 2 * np.sqrt(0.5) / 3)
 
     # Ensure divide by zero warning is not raised in general case
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UndefinedMetricWarning)
         davies_bouldin_score(X, labels)
-    div_zero_warnings = [
-        warning
-        for warning in record
-        if "divide by zero encountered" in warning.message.args[0]
-    ]
-    assert len(div_zero_warnings) == 0
 
     # General case - cluster have one sample
     X = [[0, 0], [2, 2], [3, 3], [5, 5]]

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -12,7 +12,6 @@ from sklearn.metrics.cluster import silhouette_samples
 from sklearn.metrics import pairwise_distances
 from sklearn.metrics.cluster import calinski_harabasz_score
 from sklearn.metrics.cluster import davies_bouldin_score
-from sklearn.exceptions import UndefinedMetricWarning
 
 
 def test_silhouette():
@@ -345,7 +344,7 @@ def test_davies_bouldin_score():
 
     # Ensure divide by zero warning is not raised in general case
     with warnings.catch_warnings():
-        warnings.simplefilter("error", UndefinedMetricWarning)
+        warnings.simplefilter("error", RuntimeWarning)
         davies_bouldin_score(X, labels)
 
     # General case - cluster have one sample


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #22572


#### What does this implement/fix? Explain your changes.

- Removes the pytest.warns(None) replacing it with warnings.catch_warnings() and a simple filter("error")

#### Any other comments?

The comments refer to a zero division warning

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
