### PR TITLE
TST Replace pytest.warns(None) in test_gpc.py

### DIFF
--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -507,16 +507,6 @@ def test_warning_bounds():
             "fit again may find a better value."
         )
 
-    assert (
-        record[1].message.args[0]
-        == "The optimal value found for "
-        "dimension 0 of parameter "
-        "k2__length_scale is close to the "
-        "specified lower bound 1000.0. "
-        "Decreasing the bound and calling "
-        "fit again may find a better value."
-    )
-
     X_tile = np.tile(X, 2)
     kernel_dims = RBF(length_scale=[1.0, 2.0], length_scale_bounds=[1e1, 1e2])
     gpr_dims = GaussianProcessRegressor(kernel=kernel_dims)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -4,6 +4,7 @@
 # Modified by: Pete Green <p.l.green@liverpool.ac.uk>
 # License: BSD 3 clause
 
+import warnings
 import sys
 import re
 import numpy as np
@@ -478,19 +479,33 @@ def test_warning_bounds():
         length_scale_bounds=[1e3, 1e5]
     )
     gpr_sum = GaussianProcessRegressor(kernel=kernel_sum)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
         gpr_sum.fit(X, y)
 
-    assert len(record) == 2
-    assert (
-        record[0].message.args[0]
-        == "The optimal value found for "
-        "dimension 0 of parameter "
-        "k1__noise_level is close to the "
-        "specified upper bound 0.001. "
-        "Increasing the bound and calling "
-        "fit again may find a better value."
-    )
+        assert len(record) == 2
+
+        assert issubclass(record[0].category, ConvergenceWarning)
+        assert (
+            record[0].message.args[0]
+            == "The optimal value found for "
+            "dimension 0 of parameter "
+            "k1__noise_level is close to the "
+            "specified upper bound 0.001. "
+            "Increasing the bound and calling "
+            "fit again may find a better value."
+        )
+
+        assert issubclass(record[1].category, ConvergenceWarning)
+        assert (
+            record[1].message.args[0]
+            == "The optimal value found for "
+            "dimension 0 of parameter "
+            "k2__length_scale is close to the "
+            "specified lower bound 1000.0. "
+            "Decreasing the bound and calling "
+            "fit again may find a better value."
+        )
 
     assert (
         record[1].message.args[0]
@@ -506,29 +521,33 @@ def test_warning_bounds():
     kernel_dims = RBF(length_scale=[1.0, 2.0], length_scale_bounds=[1e1, 1e2])
     gpr_dims = GaussianProcessRegressor(kernel=kernel_dims)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
         gpr_dims.fit(X_tile, y)
 
-    assert len(record) == 2
-    assert (
-        record[0].message.args[0]
-        == "The optimal value found for "
-        "dimension 0 of parameter "
-        "length_scale is close to the "
-        "specified lower bound 10.0. "
-        "Decreasing the bound and calling "
-        "fit again may find a better value."
-    )
+        assert len(record) == 2
 
-    assert (
-        record[1].message.args[0]
-        == "The optimal value found for "
-        "dimension 1 of parameter "
-        "length_scale is close to the "
-        "specified lower bound 10.0. "
-        "Decreasing the bound and calling "
-        "fit again may find a better value."
-    )
+        assert issubclass(record[0].category, ConvergenceWarning)
+        assert (
+            record[0].message.args[0]
+            == "The optimal value found for "
+            "dimension 0 of parameter "
+            "length_scale is close to the "
+            "specified lower bound 10.0. "
+            "Decreasing the bound and calling "
+            "fit again may find a better value."
+        )
+
+        assert issubclass(record[1].category, ConvergenceWarning)
+        assert (
+            record[1].message.args[0]
+            == "The optimal value found for "
+            "dimension 1 of parameter "
+            "length_scale is close to the "
+            "specified lower bound 10.0. "
+            "Decreasing the bound and calling "
+            "fit again may find a better value."
+        )
 
 
 def test_bound_check_fixed_hyperparameter():


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes **pytest warnings due to deprecation of pytest.warns(None)** (#22572)


#### What does this implement/fix? Explain your changes.
This PR removes the ```pytest.warns(None)``` which is being deprecated. The behaviour of the test is to check that expected warnings are given to the user. This behaviour remains the same, but now uses the [warnings](https://docs.python.org/3/library/warnings.html#) library.

#### Any other comments?
I followed the documentation for testing warnings provided [here](https://docs.python.org/3/library/warnings.html#testing-warnings)

Please note, that I have created a similar PR for the file ```scikit-learn/sklearn/gaussian_process/tests/test_gpc.py```
