### PR TITLE
TST Replace pytest.warns(None) in utils/tests/test_utils.py

### DIFF
--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -7,7 +7,6 @@ import timeit
 import pytest
 import numpy as np
 import scipy.sparse as sp
-from pandas.core.common import SettingWithCopyWarning
 
 from sklearn.utils._testing import (
     assert_array_equal,
@@ -474,7 +473,7 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
     X = pd.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
     subset = _safe_indexing(X, [0, 1], axis=0)
     with warnings.catch_warnings():
-        warnings.simplefilter("error", SettingWithCopyWarning)
+        warnings.simplefilter("error", pd.core.common.SettingWithCopyWarning)
         subset.iloc[0, 0] = 10
     # The original dataframe is unaffected by the assignment on the subset:
     assert X.iloc[0, 0] == 1

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -7,6 +7,7 @@ import timeit
 import pytest
 import numpy as np
 import scipy.sparse as sp
+from pandas.core.common import SettingWithCopyWarning
 
 from sklearn.utils._testing import (
     assert_array_equal,
@@ -472,9 +473,9 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
 
     X = pd.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
     subset = _safe_indexing(X, [0, 1], axis=0)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SettingWithCopyWarning)
         subset.iloc[0, 0] = 10
-    assert not [w.message for w in record]
     # The original dataframe is unaffected by the assignment on the subset:
     assert X.iloc[0, 0] == 1
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #22572 

#### What does this implement/fix? Explain your changes.

- Removes the pytest.warns(None) replacing it with warnings.catch_warnings() and a simple filter("error", SettingWithCopyWarning)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
