### PR TITLE
TST Replace pytest.warns(None) in feature_extraction/tests/test_text.py

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 import re
 
 import pytest
+import warnings
 from scipy import sparse
 
 from sklearn.feature_extraction.text import strip_tags
@@ -450,9 +451,9 @@ def test_countvectorizer_uppercase_in_vocab():
     with pytest.warns(UserWarning, match=message):
         vectorizer.fit(vocabulary)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
         vectorizer.transform(vocabulary)
-    assert not [w.message for w in record]
 
 
 def test_tf_transformer_feature_names_out():
@@ -1420,9 +1421,9 @@ def test_vectorizer_stop_words_inconsistent():
         assert _check_stop_words_consistency(vec) is False
 
     # Only one warning per stop list
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
         vec.fit_transform(["hello world"])
-    assert not [w.message for w in record]
     assert _check_stop_words_consistency(vec) is None
 
     # Test caching of inconsistency assessment


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to [#22572](https://github.com/scikit-learn/scikit-learn/issues/22572)
Towards [#22396](https://github.com/scikit-learn/scikit-learn/issues/22396)


#### What does this implement/fix? Explain your changes.
Removes the deprecated pytest.warns(None), and replaces it with warnings.catch_warnings().
I believe the expected warning is "UserWarning".


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
