### PR TITLE
MNT Update to black 22.3.0 to resolve click error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
         versionSpec: '3.9'
     - bash: |
         # Include pytest compatibility with mypy
-        pip install pytest flake8 mypy==0.782 black==22.1.0
+        pip install pytest flake8 mypy==0.782 black==22.3.0
       displayName: Install linters
     - bash: |
         black --check --diff .

--- a/benchmarks/bench_plot_neighbors.py
+++ b/benchmarks/bench_plot_neighbors.py
@@ -102,7 +102,7 @@ def barplot_neighbors(
 
     plt.figure(figsize=(8, 11))
 
-    for (sbplt, vals, quantity, build_time, query_time) in [
+    for sbplt, vals, quantity, build_time, query_time in [
         (311, Nrange, "N", N_results_build, N_results_query),
         (312, Drange, "D", D_results_build, D_results_query),
         (313, krange, "k", k_results_build, k_results_query),

--- a/benchmarks/bench_rcv1_logreg_convergence.py
+++ b/benchmarks/bench_rcv1_logreg_convergence.py
@@ -102,7 +102,7 @@ def bench(clfs):
 
 def plot_train_losses(clfs):
     plt.figure()
-    for (name, _, _, train_losses, _, _, durations) in clfs:
+    for name, _, _, train_losses, _, _, durations in clfs:
         plt.plot(durations, train_losses, "-o", label=name)
         plt.legend(loc=0)
         plt.xlabel("seconds")
@@ -111,7 +111,7 @@ def plot_train_losses(clfs):
 
 def plot_train_scores(clfs):
     plt.figure()
-    for (name, _, _, _, train_scores, _, durations) in clfs:
+    for name, _, _, _, train_scores, _, durations in clfs:
         plt.plot(durations, train_scores, "-o", label=name)
         plt.legend(loc=0)
         plt.xlabel("seconds")
@@ -121,7 +121,7 @@ def plot_train_scores(clfs):
 
 def plot_test_scores(clfs):
     plt.figure()
-    for (name, _, _, _, _, test_scores, durations) in clfs:
+    for name, _, _, _, _, test_scores, durations in clfs:
         plt.plot(durations, test_scores, "-o", label=name)
         plt.legend(loc=0)
         plt.xlabel("seconds")
@@ -132,13 +132,13 @@ def plot_test_scores(clfs):
 def plot_dloss(clfs):
     plt.figure()
     pobj_final = []
-    for (name, _, _, train_losses, _, _, durations) in clfs:
+    for name, _, _, train_losses, _, _, durations in clfs:
         pobj_final.append(train_losses[-1])
 
     indices = np.argsort(pobj_final)
     pobj_best = pobj_final[indices[0]]
 
-    for (name, _, _, train_losses, _, _, durations) in clfs:
+    for name, _, _, train_losses, _, _, durations in clfs:
         log_pobj = np.log(abs(np.array(train_losses) - pobj_best)) / np.log(10)
 
         plt.plot(durations, log_pobj, "-o", label=name)

--- a/benchmarks/bench_saga.py
+++ b/benchmarks/bench_saga.py
@@ -112,7 +112,7 @@ def fit_single(
         train_time = time.clock() - t0
 
         scores = []
-        for (X, y) in [(X_train, y_train), (X_test, y_test)]:
+        for X, y in [(X_train, y_train), (X_test, y_test)]:
             try:
                 y_pred = lr.predict_proba(X)
             except NotImplementedError:

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -254,7 +254,7 @@ how to set up your git repository:
 
    .. prompt:: bash $
 
-        pip install pytest pytest-cov flake8 mypy numpydoc black==22.1.0
+        pip install pytest pytest-cov flake8 mypy numpydoc black==22.3.0
 
 .. _upstream:
 

--- a/examples/linear_model/plot_lasso_coordinate_descent_path.py
+++ b/examples/linear_model/plot_lasso_coordinate_descent_path.py
@@ -77,7 +77,7 @@ plt.axis("tight")
 
 plt.figure(3)
 neg_log_alphas_positive_enet = -np.log10(alphas_positive_enet)
-for (coef_e, coef_pe, c) in zip(coefs_enet, coefs_positive_enet, colors):
+for coef_e, coef_pe, c in zip(coefs_enet, coefs_positive_enet, colors):
     l1 = plt.plot(neg_log_alphas_enet, coef_e, c=c)
     l2 = plt.plot(neg_log_alphas_positive_enet, coef_pe, linestyle="--", c=c)
 

--- a/examples/mixture/plot_concentration_prior.py
+++ b/examples/mixture/plot_concentration_prior.py
@@ -141,7 +141,7 @@ X = np.vstack(
 y = np.concatenate([np.full(samples[j], j, dtype=int) for j in range(n_components)])
 
 # Plot results in two different figures
-for (title, estimator, concentrations_prior) in estimators:
+for title, estimator, concentrations_prior in estimators:
     plt.figure(figsize=(4.7 * 3, 8))
     plt.subplots_adjust(
         bottom=0.04, top=0.90, hspace=0.05, wspace=0.05, left=0.03, right=0.99

--- a/examples/semi_supervised/plot_self_training_varying_threshold.py
+++ b/examples/semi_supervised/plot_self_training_varying_threshold.py
@@ -57,7 +57,7 @@ scores = np.empty((x_values.shape[0], n_splits))
 amount_labeled = np.empty((x_values.shape[0], n_splits))
 amount_iterations = np.empty((x_values.shape[0], n_splits))
 
-for (i, threshold) in enumerate(x_values):
+for i, threshold in enumerate(x_values):
     self_training_clf = SelfTrainingClassifier(base_classifier, threshold=threshold)
 
     # We need manual cross validation so that we don't treat -1 as a separate

--- a/examples/svm/plot_rbf_parameters.py
+++ b/examples/svm/plot_rbf_parameters.py
@@ -174,7 +174,7 @@ import matplotlib.pyplot as plt
 
 plt.figure(figsize=(8, 6))
 xx, yy = np.meshgrid(np.linspace(-3, 3, 200), np.linspace(-3, 3, 200))
-for (k, (C, gamma, clf)) in enumerate(classifiers):
+for k, (C, gamma, clf) in enumerate(classifiers):
     # evaluate decision function in a grid
     Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
     Z = Z.reshape(xx.shape)

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -37,7 +37,7 @@ dependent_packages = {
     "pytest": (PYTEST_MIN_VERSION, "tests"),
     "pytest-cov": ("2.9.0", "tests"),
     "flake8": ("3.8.2", "tests"),
-    "black": ("22.1.0", "tests"),
+    "black": ("22.3.0", "tests"),
     "mypy": ("0.770", "tests"),
     "pyamg": ("4.0.0", "tests"),
     "sphinx": ("4.0.1", "docs"),

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -605,7 +605,7 @@ def test_ward_linkage_tree_return_distance():
 
     linkage_options = ["complete", "average", "single"]
     X_linkage_truth = [linkage_X_complete, linkage_X_average]
-    for (linkage, X_truth) in zip(linkage_options, X_linkage_truth):
+    for linkage, X_truth in zip(linkage_options, X_linkage_truth):
         out_X_unstructured = linkage_tree(X, return_distance=True, linkage=linkage)
         out_X_structured = linkage_tree(
             X, connectivity=connectivity_X, linkage=linkage, return_distance=True

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -657,7 +657,7 @@ def test_make_moons_unbalanced():
 def test_make_circles():
     factor = 0.3
 
-    for (n_samples, n_outer, n_inner) in [(7, 3, 4), (8, 4, 4)]:
+    for n_samples, n_outer, n_inner in [(7, 3, 4), (8, 4, 4)]:
         # Testing odd and even case, because in the past make_circles always
         # created an even number of samples.
         X, y = make_circles(n_samples, shuffle=False, noise=None, factor=factor)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
@@ -19,8 +19,8 @@ X_regression, y_regression = make_regression(random_state=0)
 def _assert_predictor_equal(gb_1, gb_2, X):
     """Assert that two HistGBM instances are identical."""
     # Check identical nodes for each tree
-    for (pred_ith_1, pred_ith_2) in zip(gb_1._predictors, gb_2._predictors):
-        for (predictor_1, predictor_2) in zip(pred_ith_1, pred_ith_2):
+    for pred_ith_1, pred_ith_2 in zip(gb_1._predictors, gb_2._predictors):
+        for predictor_1, predictor_2 in zip(pred_ith_1, pred_ith_2):
             assert_array_equal(predictor_1.nodes, predictor_2.nodes)
 
     # Check identical predictions

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -317,7 +317,7 @@ def test_extract_patches_strided():
     expected_views = expected_views_1D + expected_views_2D + expected_views_3D
     last_patches = last_patch_1D + last_patch_2D + last_patch_3D
 
-    for (image_shape, patch_size, patch_step, expected_view, last_patch) in zip(
+    for image_shape, patch_size, patch_step, expected_view, last_patch in zip(
         image_shapes, patch_sizes, patch_steps, expected_views, last_patches
     ):
         image = np.arange(np.prod(image_shape)).reshape(image_shape)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1309,7 +1309,7 @@ def test_saga_vs_liblinear():
     )
     X_sparse = sparse.csr_matrix(X_sparse)
 
-    for (X, y) in ((X_bin, y_bin), (X_sparse, y_sparse)):
+    for X, y in ((X_bin, y_bin), (X_sparse, y_sparse)):
         for penalty in ["l1", "l2"]:
             n_samples = X.shape[0]
             # alpha=1e-3 is time consuming

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -189,7 +189,7 @@ def test_ridge_sample_weights():
         X = rng.randn(n_samples, n_features)
         sample_weight = 1.0 + rng.rand(n_samples)
 
-        for (alpha, intercept, solver) in param_grid:
+        for alpha, intercept, solver in param_grid:
 
             # Ridge with explicit sample_weight
             est = Ridge(alpha=alpha, fit_intercept=intercept, solver=solver, tol=1e-12)

--- a/sklearn/linear_model/tests/test_theil_sen.py
+++ b/sklearn/linear_model/tests/test_theil_sen.py
@@ -111,9 +111,7 @@ def test_modweiszfeld_step_1d():
     assert_array_less(new_y, y)
     # Check that a single vector is identity
     X = np.array([1.0, 2.0, 3.0]).reshape(1, 3)
-    y = X[
-        0,
-    ]
+    y = X[0]
     new_y = _modified_weiszfeld_step(X, y)
     assert_array_equal(y, new_y)
 

--- a/sklearn/metrics/cluster/tests/test_common.py
+++ b/sklearn/metrics/cluster/tests/test_common.py
@@ -190,7 +190,7 @@ def test_format_invariance(metric_name):
         score_1 = metric(X, y_true)
         assert score_1 == metric(X.astype(float), y_true)
         y_true_gen = generate_formats(y_true)
-        for (y_true_fmt, fmt_name) in y_true_gen:
+        for y_true_fmt, fmt_name in y_true_gen:
             assert score_1 == metric(X, y_true_fmt)
 
 

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -423,7 +423,7 @@ def test_suffstat_sk_diag():
     covars_pred_diag = _estimate_gaussian_covariances_diag(resp, X, nk, xk, 0)
 
     ecov = EmpiricalCovariance()
-    for (cov_full, cov_diag) in zip(covars_pred_full, covars_pred_diag):
+    for cov_full, cov_diag in zip(covars_pred_full, covars_pred_diag):
         ecov.covariance_ = np.diag(np.diag(cov_full))
         cov_diag = np.diag(cov_diag)
         assert_almost_equal(ecov.error_norm(cov_diag, norm="frobenius"), 0)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -460,7 +460,7 @@ def check_cross_validate_single_metric(clf, X, y, scores):
         fitted_estimators,
     ) = scores
     # Test single metric evaluation when scoring is string or singleton list
-    for (return_train_score, dict_len) in ((True, 4), (False, 3)):
+    for return_train_score, dict_len in ((True, 4), (False, 3)):
         # Single metric passed as a string
         if return_train_score:
             mse_scores_dict = cross_validate(

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -536,7 +536,7 @@ def test_unsupervised_radius_neighbors(
             # sort the results: this is not done automatically for
             # radius searches
             dist, ind = neigh.radius_neighbors(test, return_distance=True)
-            for (d, i, i1) in zip(dist, ind, ind1):
+            for d, i, i1 in zip(dist, ind, ind1):
                 j = d.argsort()
                 d[:] = d[j]
                 i[:] = i[j]

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -319,7 +319,7 @@ class Pipeline(_BaseComposition):
 
         fit_transform_one_cached = memory.cache(_fit_transform_one)
 
-        for (step_idx, name, transformer) in self._iter(
+        for step_idx, name, transformer in self._iter(
             with_final=False, filter_passthrough=False
         ):
             if transformer is None or transformer == "passthrough":

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -515,14 +515,14 @@ def test_lda_dimension_warning(n_classes, n_features):
     ],
 )
 def test_lda_dtype_match(data_type, expected_type):
-    for (solver, shrinkage) in solver_shrinkage:
+    for solver, shrinkage in solver_shrinkage:
         clf = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
         clf.fit(X.astype(data_type), y.astype(data_type))
         assert clf.coef_.dtype == expected_type
 
 
 def test_lda_numeric_consistency_float32_float64():
-    for (solver, shrinkage) in solver_shrinkage:
+    for solver, shrinkage in solver_shrinkage:
         clf_32 = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
         clf_32.fit(X.astype(np.float32), y.astype(np.float32))
         clf_64 = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2128,7 +2128,7 @@ def check_classifiers_train(
     if not tags["binary_only"]:
         problems.append((X_m, y_m))
 
-    for (X, y) in problems:
+    for X, y in problems:
         classes = np.unique(y)
         n_classes = len(classes)
         n_samples, n_features = X.shape


### PR DESCRIPTION
Fixes linting issue with [CI on main](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=40247&view=logs&j=32e2e1bb-a28f-5b18-6cfc-3f01273f5609&t=fc67071d-c3d4-58b8-d38e-cafc0d3c731a) where `black==22.1.0` was not compatible with `click==8.1.0`.

<s>Due to black's [stability policy](https://black.readthedocs.io/en/stable/the_black_code_style/index.html) this is safe to do and there are no changes to formatting.</s> The stability policy does not apply to `--preview`. 

XREF: https://github.com/psf/black/issues/2964