### PR TITLE
WIP CI circleci artifact redirector as an action

### DIFF
--- a/.github/workflows/artifact-redirector.yml
+++ b/.github/workflows/artifact-redirector.yml
@@ -1,0 +1,14 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        id: step1
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/doc/_changed.html
+          circleci-jobs: doc
+          job-title: Check the rendered docs here!


### PR DESCRIPTION
We are currently using circleci-artifact-redirector as a github app.
It was suggested by its author that we should switch to using it as an action (https://github.com/larsoner/circleci-artifacts-redirector/issues/8).