### PR TITLE
CI use circleci artifact redirector GH action

### DIFF
--- a/.github/workflows/artifact-redirector.yml
+++ b/.github/workflows/artifact-redirector.yml
@@ -5,7 +5,6 @@ jobs:
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
-        id: step1
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/artifact-redirector.yml
+++ b/.github/workflows/artifact-redirector.yml
@@ -1,0 +1,14 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        id: step1
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/doc/_changed.html
+          circleci-jobs: doc
+          job-title: Check the rendered docs here!


### PR DESCRIPTION
Currently we are using the circleci-artifact-redirector github app https://github.com/larsoner/circleci-artifacts-redirector.
Its author suggested that we should use the circleci-artifact-redirector github action (see https://github.com/larsoner/circleci-artifacts-redirector/issues/8)

I think we can wait for https://github.com/larsoner/circleci-artifacts-redirector-action/issues/19 to be fixed before switching.
Note that the githib app also needs to be fixed, see https://github.com/scikit-learn/scikit-learn/issues/22931.