### PR TITLE
DOC fix docstring of EllipticEnvelope.fit

### DIFF
--- a/sklearn/covariance/_elliptic_envelope.py
+++ b/sklearn/covariance/_elliptic_envelope.py
@@ -160,7 +160,7 @@ class EllipticEnvelope(OutlierMixin, MinCovDet):
 
         Parameters
         ----------
-        X : {array-like} of shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features)
             Training data.
 
         y : Ignored

--- a/sklearn/covariance/_elliptic_envelope.py
+++ b/sklearn/covariance/_elliptic_envelope.py
@@ -160,7 +160,7 @@ class EllipticEnvelope(OutlierMixin, MinCovDet):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        X : {array-like} of shape (n_samples, n_features)
             Training data.
 
         y : Ignored


### PR DESCRIPTION
This commit updates the `fit(X, y)` definition, in the docs, of the `sklearn.covariance.EllipticEnvelope` class.  The original definition stated that parameter X could be of type `'array-like'` or `'sparse matrix'`, however, an error would be thrown if a 'sparse matrix' is passed (`TypeError: A sparse matrix was passed, but dense data is required.`).  To resolve this, `'sparse matrix'` was removed from the list of types X could be, in the docstring.

Fixes #14613 