### PR TITLE
TST replace pytest.warns(None) in test_label_propagation.py

### DIFF
--- a/sklearn/covariance/_elliptic_envelope.py
+++ b/sklearn/covariance/_elliptic_envelope.py
@@ -160,7 +160,7 @@ class EllipticEnvelope(OutlierMixin, MinCovDet):
 
         Parameters
         ----------
-        X : {array-like} of shape (n_samples, n_features)
+        X : array-like of shape (n_samples, n_features)
             Training data.
 
         y : Ignored

--- a/sklearn/covariance/_elliptic_envelope.py
+++ b/sklearn/covariance/_elliptic_envelope.py
@@ -160,11 +160,7 @@ class EllipticEnvelope(OutlierMixin, MinCovDet):
 
         Parameters
         ----------
-<<<<<<< HEAD
-        X : {array-like} of shape (n_samples, n_features)
-=======
         X : array-like of shape (n_samples, n_features)
->>>>>>> upstream/main
             Training data.
 
         y : Ignored

--- a/sklearn/covariance/_elliptic_envelope.py
+++ b/sklearn/covariance/_elliptic_envelope.py
@@ -160,7 +160,7 @@ class EllipticEnvelope(OutlierMixin, MinCovDet):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        X : {array-like} of shape (n_samples, n_features)
             Training data.
 
         y : Ignored

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+import warnings
 
 from scipy.sparse import issparse
 from sklearn.semi_supervised import _label_propagation as label_propagation
@@ -151,14 +152,16 @@ def test_convergence_warning():
     assert mdl.n_iter_ == mdl.max_iter
 
     mdl = label_propagation.LabelSpreading(kernel="rbf", max_iter=500)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         mdl.fit(X, y)
-    assert not [w.message for w in record]
+    
 
     mdl = label_propagation.LabelPropagation(kernel="rbf", max_iter=500)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         mdl.fit(X, y)
-    assert not [w.message for w in record]
+    
 
 
 @pytest.mark.parametrize(
@@ -173,9 +176,8 @@ def test_label_propagation_non_zero_normalizer(LabelPropagationCls):
     X = np.array([[100.0, 100.0], [100.0, 100.0], [0.0, 0.0], [0.0, 0.0]])
     y = np.array([0, 1, -1, -1])
     mdl = LabelPropagationCls(kernel="knn", max_iter=100, n_neighbors=1)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
         mdl.fit(X, y)
-    assert not [w.message for w in record]
 
 
 def test_predict_sparse_callable_kernel():


### PR DESCRIPTION
#### Reference Issues/PRs

Part of issue #22572 (Specifically `sklearn/semi_supervised/tests/test_label_propagation.py` part)


#### What does this implement/fix? Explain your changes.

Refactored `pytest.warns(None)` to use `warnings.catch_warnings()` and `warnings.simplefilter("error")`.  This was done because of a deprecation warning from Pytest for using `pytest.warns(None)`