### PR TITLE
MNT remove artifact_path file now unused

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,1 +1,0 @@
-0/doc/_changed.html


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/pull/22991

This file was used by the gh app. The action doesn't need it.