### PR TITLE
MNT return array instead of memory view in coordinate descent

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -387,7 +387,9 @@ class LinearModel(BaseEstimator, metaclass=ABCMeta):
     def _set_intercept(self, X_offset, y_offset, X_scale):
         """Set the intercept_"""
         if self.fit_intercept:
-            self.coef_ = self.coef_ / X_scale
+            # We always want coef_.dtype=X.dtype. For instance, X.dtype can differ from
+            # coef_.dtype if warm_start=True.
+            self.coef_ = np.divide(self.coef_, X_scale, dtype=X_offset.dtype)
             self.intercept_ = y_offset - np.dot(X_offset, self.coef_.T)
         else:
             self.intercept_ = 0.0

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -389,7 +389,7 @@ class LinearModel(BaseEstimator, metaclass=ABCMeta):
         if self.fit_intercept:
             # We always want coef_.dtype=X.dtype. For instance, X.dtype can differ from
             # coef_.dtype if warm_start=True.
-            self.coef_ = np.divide(self.coef_, X_scale, dtype=X_offset.dtype)
+            self.coef_ = np.divide(self.coef_, X_scale, dtype=X_scale.dtype)
             self.intercept_ = y_offset - np.dot(X_offset, self.coef_.T)
         else:
             self.intercept_ = 0.0

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -115,7 +115,8 @@ def enet_coordinate_descent(
 
     Returns
     -------
-    w : ndarray of shape (n_features)
+    w : ndarray of shape (n_features,)
+        ElasticNet coefficients.
     gap : float
         Achieved dual gap.
     tol : float
@@ -307,7 +308,8 @@ def sparse_enet_coordinate_descent(
 
     Returns
     -------
-    w : ndarray of shape (n_features)
+    w : ndarray of shape (n_features,)
+        ElasticNet coefficients.
     gap : float
         Achieved dual gap.
     tol : float
@@ -590,7 +592,8 @@ def enet_coordinate_descent_gram(
 
     Returns
     -------
-    w : ndarray of shape (n_features)
+    w : ndarray of shape (n_features,)
+        ElasticNet coefficients.
     gap : float
         Achieved dual gap.
     tol : float
@@ -738,8 +741,9 @@ def enet_coordinate_descent_multi_task(
     floating[::1, :] W,
     floating l1_reg,
     floating l2_reg,
-    np.ndarray[floating, ndim=2, mode='fortran'] X,  # TODO: use views with Cython 3.0
-    np.ndarray[floating, ndim=2, mode='fortran'] Y,  # hopefully with skl 1.0
+    # TODO: use const qualified fused-typed memoryview when Cython 3.0 is used.
+    np.ndarray[floating, ndim=2, mode='fortran'] X,
+    np.ndarray[floating, ndim=2, mode='fortran'] Y,
     int max_iter,
     floating tol,
     object rng,
@@ -755,6 +759,7 @@ def enet_coordinate_descent_multi_task(
     Returns
     -------
     W : ndarray of shape (n_tasks, n_features)
+        ElasticNet coefficients.
     gap : float
         Achieved dual gap.
     tol : float

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -94,12 +94,18 @@ cdef floating diff_abs_max(int n, floating* a, floating* b) nogil:
     return m
 
 
-def enet_coordinate_descent(floating[::1] w,
-                            floating alpha, floating beta,
-                            floating[::1, :] X,
-                            floating[::1] y,
-                            int max_iter, floating tol,
-                            object rng, bint random=0, bint positive=0):
+def enet_coordinate_descent(
+    floating[::1] w,
+    floating alpha,
+    floating beta,
+    floating[::1, :] X,
+    floating[::1] y,
+    int max_iter,
+    floating tol,
+    object rng,
+    bint random=0,
+    bint positive=0
+):
     """Cython version of the coordinate descent algorithm
         for Elastic-Net regression
 
@@ -558,13 +564,19 @@ def sparse_enet_coordinate_descent(
     return w, gap, tol, n_iter + 1
 
 
-def enet_coordinate_descent_gram(floating[::1] w,
-                                 floating alpha, floating beta,
-                                 np.ndarray[floating, ndim=2, mode='c'] Q,
-                                 np.ndarray[floating, ndim=1, mode='c'] q,
-                                 np.ndarray[floating, ndim=1] y,
-                                 int max_iter, floating tol, object rng,
-                                 bint random=0, bint positive=0):
+def enet_coordinate_descent_gram(
+    floating[::1] w,
+    floating alpha,
+    floating beta,
+    np.ndarray[floating, ndim=2, mode='c'] Q,
+    np.ndarray[floating, ndim=1, mode='c'] q,
+    np.ndarray[floating, ndim=1] y,
+    int max_iter,
+    floating tol,
+    object rng,
+    bint random=0,
+    bint positive=0
+):
     """Cython version of the coordinate descent algorithm
         for Elastic-Net regression
 
@@ -723,10 +735,16 @@ def enet_coordinate_descent_gram(floating[::1] w,
 
 
 def enet_coordinate_descent_multi_task(
-        floating[::1, :] W, floating l1_reg, floating l2_reg,
-        np.ndarray[floating, ndim=2, mode='fortran'] X,  # TODO: use views with Cython 3.0
-        np.ndarray[floating, ndim=2, mode='fortran'] Y,  # hopefully with skl 1.0
-        int max_iter, floating tol, object rng, bint random=0):
+    floating[::1, :] W,
+    floating l1_reg,
+    floating l2_reg,
+    np.ndarray[floating, ndim=2, mode='fortran'] X,  # TODO: use views with Cython 3.0
+    np.ndarray[floating, ndim=2, mode='fortran'] Y,  # hopefully with skl 1.0
+    int max_iter,
+    floating tol,
+    object rng,
+    bint random=0
+):
     """Cython version of the coordinate descent algorithm
         for Elastic-Net mult-task regression
 

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -107,6 +107,15 @@ def enet_coordinate_descent(floating[::1] w,
 
         (1/2) * norm(y - X w, 2)^2 + alpha norm(w, 1) + (beta/2) norm(w, 2)^2
 
+    Returns
+    -------
+    w : ndarray of shape (n_features)
+    gap : float
+        Achieved dual gap.
+    tol : float
+        Equals input `tol` times `np.dot(y, y)`. The tolerance used for the dual gap.
+    n_iter : int
+        Number of coordinate descent iterations.
     """
 
     if floating is float:
@@ -289,6 +298,16 @@ def sparse_enet_coordinate_descent(
         + (beta/2) * norm(w, 2)^2
 
     and X_mean is the weighted average of X (per column).
+
+    Returns
+    -------
+    w : ndarray of shape (n_features)
+    gap : float
+        Achieved dual gap.
+    tol : float
+        Equals input `tol` times `np.dot(y, y)`. The tolerance used for the dual gap.
+    n_iter : int
+        Number of coordinate descent iterations.
     """
     # Notes for sample_weight:
     # For dense X, one centers X and y and then rescales them by sqrt(sample_weight).
@@ -556,6 +575,16 @@ def enet_coordinate_descent_gram(floating[::1] w,
         which amount to the Elastic-Net problem when:
         Q = X^T X (Gram matrix)
         q = X^T y
+
+    Returns
+    -------
+    w : ndarray of shape (n_features)
+    gap : float
+        Achieved dual gap.
+    tol : float
+        Equals input `tol` times `np.dot(y, y)`. The tolerance used for the dual gap.
+    n_iter : int
+        Number of coordinate descent iterations.
     """
 
     if floating is float:
@@ -705,6 +734,15 @@ def enet_coordinate_descent_multi_task(
 
         0.5 * norm(Y - X W.T, 2)^2 + l1_reg ||W.T||_21 + 0.5 * l2_reg norm(W.T, 2)^2
 
+    Returns
+    -------
+    W : ndarray of shape (n_tasks, n_features)
+    gap : float
+        Achieved dual gap.
+    tol : float
+        Equals input `tol` times `np.dot(y, y)`. The tolerance used for the dual gap.
+    n_iter : int
+        Number of coordinate descent iterations.
     """
 
     if floating is float:

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -272,7 +272,7 @@ def enet_coordinate_descent(
                     )
                 warnings.warn(message, ConvergenceWarning)
 
-    return w, gap, tol, n_iter + 1
+    return np.asarray(w), gap, tol, n_iter + 1
 
 
 def sparse_enet_coordinate_descent(
@@ -561,7 +561,7 @@ def sparse_enet_coordinate_descent(
                               "gap: {}, tolerance: {}".format(gap, tol),
                               ConvergenceWarning)
 
-    return w, gap, tol, n_iter + 1
+    return np.asarray(w), gap, tol, n_iter + 1
 
 
 def enet_coordinate_descent_gram(

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1083,9 +1083,6 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
         self._set_intercept(X_offset, y_offset, X_scale)
 
-        # workaround since _set_intercept will cast self.coef_ into X.dtype
-        self.coef_ = np.asarray(self.coef_, dtype=X.dtype)
-
         # check for finiteness of coefficients
         if not all(np.isfinite(w).all() for w in [self.coef_, self.intercept_]):
             raise ValueError(


### PR DESCRIPTION
#### Reference Issues/PRs
None.

#### What does this implement/fix? Explain your changes.
This PR does a little maintenance. All coordinate descent solvers return ndarray instead of memory views. Docstring is improved and handling of dtype of coef is done.