### PR TITLE
TST adapt tol for ridge tests to pass on all random seeds

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -256,7 +256,7 @@ def test_ridge_regression_vstacked_X(
         alpha=2 * alpha,
         fit_intercept=fit_intercept,
         solver=solver,
-        tol=1e-11,
+        tol=1e-15 if solver in ("sag", "saga") else 1e-10,
         random_state=global_random_seed,
     )
     X = X[:, :-1]  # remove intercept
@@ -1663,7 +1663,7 @@ def test_ridge_fit_intercept_sparse(solver, with_sample_weight, global_random_se
     sparse_ridge.fit(sp.csr_matrix(X), y, sample_weight=sample_weight)
 
     assert_allclose(dense_ridge.intercept_, sparse_ridge.intercept_)
-    assert_allclose(dense_ridge.coef_, sparse_ridge.coef_)
+    assert_allclose(dense_ridge.coef_, sparse_ridge.coef_, rtol=5e-7)
 
 
 @pytest.mark.parametrize("solver", ["saga", "svd", "cholesky"])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixed #23014.

#### What does this implement/fix? Explain your changes.
Adapts tolerances to let ridge tests pass on all random seeds

#### Any other comments?
On my machine, the following passes:
```
SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest sklearn/linear_model/tests/test_ridge.py
```


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
