### PR TITLE
Fixing a documentation issue on SVC parameter decision_function_shape

### DIFF
--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -609,8 +609,7 @@ class SVC(BaseSVC):
         Whether to return a one-vs-rest ('ovr') decision function of shape
         (n_samples, n_classes) as all other classifiers, or the original
         one-vs-one ('ovo') decision function of libsvm which has shape
-        (n_samples, n_classes * (n_classes - 1) / 2). However, one-vs-one
-        ('ovo') is always used as multi-class strategy. The parameter is
+        (n_samples, n_classes * (n_classes - 1) / 2). The parameter is
         ignored for binary classification.
 
         .. versionchanged:: 0.19

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -609,8 +609,10 @@ class SVC(BaseSVC):
         Whether to return a one-vs-rest ('ovr') decision function of shape
         (n_samples, n_classes) as all other classifiers, or the original
         one-vs-one ('ovo') decision function of libsvm which has shape
-        (n_samples, n_classes * (n_classes - 1) / 2). The parameter is
-        ignored for binary classification.
+        (n_samples, n_classes * (n_classes - 1) / 2). However, note that 
+        internally, one-vs-one ('ovo') is always used as a multi-class strategy 
+        to train models; an ovr matrix is only constructed from the ovo matrix.
+        The parameter is ignored for binary classification.
 
         .. versionchanged:: 0.19
             decision_function_shape is 'ovr' by default.

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -609,8 +609,8 @@ class SVC(BaseSVC):
         Whether to return a one-vs-rest ('ovr') decision function of shape
         (n_samples, n_classes) as all other classifiers, or the original
         one-vs-one ('ovo') decision function of libsvm which has shape
-        (n_samples, n_classes * (n_classes - 1) / 2). However, note that 
-        internally, one-vs-one ('ovo') is always used as a multi-class strategy 
+        (n_samples, n_classes * (n_classes - 1) / 2). However, note that
+        internally, one-vs-one ('ovo') is always used as a multi-class strategy
         to train models; an ovr matrix is only constructed from the ovo matrix.
         The parameter is ignored for binary classification.
 


### PR DESCRIPTION
Fixes #22612. 

Fixing a documentation issue on SVC parameter decision_function_shape to reflect that one-vs-rest is also possible.

"Whether to return a one-vs-rest (‘ovr’) decision function of shape (n_samples, n_classes) as all other classifiers, or the original one-vs-one (‘ovo’) decision function of libsvm which has shape (n_samples, n_classes * (n_classes - 1) / 2). However, one-vs-one (‘ovo’) is always used as multi-class strategy. The parameter is ignored for binary classification."

to

"Whether to return a one-vs-rest (‘ovr’) decision function of shape (n_samples, n_classes) as all other classifiers, or the original one-vs-one (‘ovo’) decision function of libsvm which has shape (n_samples, n_classes * (n_classes - 1) / 2). The parameter is ignored for binary classification."

