### PR TITLE
TST remove tests for default change warnings in test_svm.py

### DIFF
--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1331,33 +1331,12 @@ def test_svc_ovr_tie_breaking(SVCClass):
     assert np.all(pred == np.argmax(dv, axis=1))
 
 
-def test_gamma_auto():
-    X, y = [[0.0, 1.2], [1.0, 1.3]], [0, 1]
-
-    with pytest.warns(None) as record:
-        svm.SVC(kernel="linear").fit(X, y)
-    assert not [w.message for w in record]
-
-    with pytest.warns(None) as record:
-        svm.SVC(kernel="precomputed").fit(X, y)
-    assert not [w.message for w in record]
-
-
 def test_gamma_scale():
     X, y = [[0.0], [1.0]], [0, 1]
 
     clf = svm.SVC()
-    with pytest.warns(None) as record:
-        clf.fit(X, y)
-    assert not [w.message for w in record]
+    clf.fit(X, y)
     assert_almost_equal(clf._gamma, 4)
-
-    # X_var ~= 1 shouldn't raise warning, for when
-    # gamma is not explicitly set.
-    X, y = [[1, 2], [3, 2 * np.sqrt(6) / 3 + 2]], [0, 1]
-    with pytest.warns(None) as record:
-        clf.fit(X, y)
-    assert not [w.message for w in record]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs
Related to https://github.com/scikit-learn/scikit-learn/issues/22572

#### What does this implement/fix? Explain your changes.

These tests were added in https://github.com/scikit-learn/scikit-learn/pull/10331 to warn users about a change in the default value for gamma. The code has since been removed, so I think the tests could go, too.

#### Any other comments?
I left in the check that tested the computed gamma value, since i could not find another test for that. Maybe ti would be better to add a more rigorous test for this, though, and replace the `test_gamma_scale` that I left.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
