### PR TITLE
DEP deviance in favor of log_loss for GradientBoostingClassifier

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -724,9 +724,9 @@ homogeneous to a prediction: it cannot be a class, since the trees predict
 continuous values.
 
 The mapping from the value :math:`F_M(x_i)` to a class or a probability is
-loss-dependent. For the deviance (or log-loss), the probability that
+loss-dependent. For the log-loss, the probability that
 :math:`x_i` belongs to the positive class is modeled as :math:`p(y_i = 1 |
-x_i) = \sigma(F_M(x_i))` where :math:`\sigma` is the sigmoid function.
+x_i) = \sigma(F_M(x_i))` where :math:`\sigma` is the sigmoid or expit function.
 
 For multiclass classification, K trees (for K classes) are built at each of
 the :math:`M` iterations. The probability that :math:`x_i` belongs to class
@@ -764,11 +764,11 @@ the parameter ``loss``:
 
   * Classification
 
-    * Binomial deviance (``'deviance'``): The binomial
-      negative log-likelihood loss function for binary classification (provides
-      probability estimates).  The initial model is given by the
+    * Binary log-loss (``'log-loss'``): The binomial
+      negative log-likelihood loss function for binary classification. It provides
+      probability estimates.  The initial model is given by the
       log odds-ratio.
-    * Multinomial deviance (``'deviance'``): The multinomial
+    * Multi-class log-loss (``'log-loss'``): The multinomial
       negative log-likelihood loss function for multi-class classification with
       ``n_classes`` mutually exclusive classes. It provides
       probability estimates.  The initial model is given by the
@@ -777,7 +777,7 @@ the parameter ``loss``:
       inefficient for data sets with a large number of classes.
     * Exponential loss (``'exponential'``): The same loss function
       as :class:`AdaBoostClassifier`. Less robust to mislabeled
-      examples than ``'deviance'``; can only be used for binary
+      examples than ``'log-loss'``; can only be used for binary
       classification.
 
 .. _gradient_boosting_shrinkage:

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -93,8 +93,9 @@ Changelog
   produce the same models, but are deprecated and will be removed in version
   1.3.
 
-  - For :class:`ensemble.GradientBoostingClassifier`, `loss="deviance"` is deprecated,
-    use `"log_loss"` instead which is now the default.
+  - For :class:`ensemble.GradientBoostingClassifier`, The `loss` parameter name
+    "deviance" is deprecated in favor of the new name "log_loss", which is now the
+    default.
     :pr:`23036` by :user:`Christian Lorentzen <lorentzenchr>`.
 
 - |Efficiency| Low-level routines for reductions on pairwise distances

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -88,8 +88,8 @@ Changelog
     where 123456 is the *pull request* number, not the issue number.
 
 - |API| The option for using the log loss, aka binomial or multinomial deviance, via
-  the ``loss` parameters was made more consistent. The preferred way is by
-  setting the value to `"log_loss"`. Old option names are still valid,
+  the `loss` parameters was made more consistent. The preferred way is by
+  setting the value to `"log_loss"`. Old option names are still valid and
   produce the same models, but are deprecated and will be removed in version
   1.3.
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -87,6 +87,16 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+- |API| The option for using the log loss, aka binomial or multinomial deviance, via
+  the ``loss` parameters was made more consistent. The preferred way is by
+  setting the value to `"log_loss"`. Old option names are still valid,
+  produce the same models, but are deprecated and will be removed in version
+  1.3.
+
+  - For :class:`ensemble.GradientBoostingClassifier`, `loss="deviance"` is deprecated,
+    use `"log_loss"` instead which is now the default.
+    :pr:`23036` by :user:`Christian Lorentzen <lorentzenchr>`.
+
 - |Efficiency| Low-level routines for reductions on pairwise distances
   for dense float64 datasets have been refactored. The following functions
   and estimators now benefit from improved performances in terms of hardware
@@ -284,7 +294,7 @@ Changelog
     deprecated.
   - the default value of the `batch_size` parameter of both will change from 3 to 256
     in version 1.3.
-  
+
   :pr:`18975` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 - |Enhancement| :func:`decomposition.dict_learning`, :func:`decomposition.dict_learning_online`

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -308,8 +308,9 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         # TODO(1.3): Remove
         if self.loss == "deviance":
             warnings.warn(
-                "The loss 'deviance' was deprecated in v1.1 and will be removed in "
-                "version 1.3. Use 'log_loss' which is equivalent.",
+                "The loss parameter name 'deviance' was deprecated in v1.1 and will be
+                removed in version 1.3. Use the new parameter name 'log_loss' which is
+                equivalent.",
                 FutureWarning,
             )
             loss_class = (

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -994,7 +994,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
     ----------
     loss : {'log_loss', 'exponential'}, default='log_loss'
         The loss function to be optimized. 'log_loss' refers to binomial and
-        multinomial deviance, the same as used in linear logistic regression.
+        multinomial deviance, the same as used in logistic regression.
         It is a good choice for classification with probabilistic outputs.
         For loss 'exponential', gradient boosting recovers the AdaBoost algorithm.
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -992,7 +992,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
 
     Parameters
     ----------
-    loss : {'log_loss', 'exponential'}, default='log_loss'
+    loss : {'log_loss', 'deviance', 'exponential'}, default='log_loss'
         The loss function to be optimized. 'log_loss' refers to binomial and
         multinomial deviance, the same as used in logistic regression.
         It is a good choice for classification with probabilistic outputs.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -308,9 +308,9 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         # TODO(1.3): Remove
         if self.loss == "deviance":
             warnings.warn(
-                "The loss parameter name 'deviance' was deprecated in v1.1 and will be
-                removed in version 1.3. Use the new parameter name 'log_loss' which is
-                equivalent.",
+                "The loss parameter name 'deviance' was deprecated in v1.1 and will be "
+                "removed in version 1.3. Use the new parameter name 'log_loss' which "
+                "is equivalent.",
                 FutureWarning,
             )
             loss_class = (

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -289,7 +289,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         ):
             raise ValueError(f"Loss {self.loss!r} not supported. ")
 
-        # TODO: Remove in v1.2
+        # TODO(1.2): Remove
         if self.loss == "ls":
             warnings.warn(
                 "The loss 'ls' was deprecated in v1.0 and "
@@ -305,7 +305,19 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 FutureWarning,
             )
 
+        # TODO(1.3): Remove
         if self.loss == "deviance":
+            warnings.warn(
+                "The loss 'deviance' was deprecated in v1.1 and will be removed in "
+                "version 1.3. Use 'log_loss' which is equivalent.",
+                FutureWarning,
+            )
+            loss_class = (
+                _gb_losses.MultinomialDeviance
+                if len(self.classes_) > 2
+                else _gb_losses.BinomialDeviance
+            )
+        elif self.loss == "log_loss":
             loss_class = (
                 _gb_losses.MultinomialDeviance
                 if len(self.classes_) > 2
@@ -525,7 +537,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             )
 
         if self.criterion == "mse":
-            # TODO: Remove in v1.2. By then it should raise an error.
+            # TODO(1.2): Remove. By then it should raise an error.
             warnings.warn(
                 "Criterion 'mse' was deprecated in v1.0 and will be "
                 "removed in version 1.2. Use `criterion='squared_error'` "
@@ -955,7 +967,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
 
         return leaves
 
-    # TODO: Remove in 1.2
+    # TODO(1.2): Remove
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute `n_features_` was deprecated in version 1.0 and will be "
@@ -972,19 +984,23 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
     GB builds an additive model in a
     forward stage-wise fashion; it allows for the optimization of
     arbitrary differentiable loss functions. In each stage ``n_classes_``
-    regression trees are fit on the negative gradient of the
-    binomial or multinomial deviance loss function. Binary classification
+    regression trees are fit on the negative gradient of the loss function,
+    e.g. binary or multiclass log loss. Binary classification
     is a special case where only a single regression tree is induced.
 
     Read more in the :ref:`User Guide <gradient_boosting>`.
 
     Parameters
     ----------
-    loss : {'deviance', 'exponential'}, default='deviance'
-        The loss function to be optimized. 'deviance' refers to
-        deviance (= logistic regression) for classification
-        with probabilistic outputs. For loss 'exponential' gradient
-        boosting recovers the AdaBoost algorithm.
+    loss : {'log_loss', 'exponential'}, default='log_loss'
+        The loss function to be optimized. 'log_loss' refers to binomial and
+        multinomial deviance, the same as used in linear logistic regression.
+        It is a good choice for classification with probabilistic outputs.
+        For loss 'exponential', gradient boosting recovers the AdaBoost algorithm.
+
+        .. deprecated:: 1.1
+            The loss 'deviance' was deprecated in v1.1 and will be removed in
+            version 1.3. Use `loss='log_loss'` which is equivalent.
 
     learning_rate : float, default=0.1
         Learning rate shrinks the contribution of each tree by `learning_rate`.
@@ -1284,12 +1300,13 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
     0.913...
     """
 
-    _SUPPORTED_LOSS = ("deviance", "exponential")
+    # TODO(1.3): remove "deviance"
+    _SUPPORTED_LOSS = ("log_loss", "deviance", "exponential")
 
     def __init__(
         self,
         *,
-        loss="deviance",
+        loss="log_loss",
         learning_rate=0.1,
         n_estimators=100,
         subsample=1.0,
@@ -1839,7 +1856,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     0.4...
     """
 
-    # TODO: remove "ls" in version 1.2
+    # TODO(1.2): remove "ls" and "lad"
     _SUPPORTED_LOSS = (
         "squared_error",
         "ls",

--- a/sklearn/ensemble/_gb_losses.py
+++ b/sklearn/ensemble/_gb_losses.py
@@ -995,5 +995,6 @@ LOSS_FUNCTIONS = {
     "huber": HuberLossFunction,
     "quantile": QuantileLossFunction,
     "deviance": None,  # for both, multinomial and binomial
+    "log_loss": None,  # for both, multinomial and binomial
     "exponential": ExponentialLoss,
 }

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1529,7 +1529,7 @@ def test_criterion_mse_deprecated(Estimator):
 def test_loss_deprecated(old_loss, new_loss, Estimator):
     est1 = Estimator(loss=old_loss, random_state=0)
 
-    with pytest.warns(FutureWarning, match=rf"The loss .* '{old_loss}' was deprecated"):
+    with pytest.warns(FutureWarning, match=rf"The loss.* '{old_loss}' was deprecated"):
         est1.fit(X, y)
 
     est2 = Estimator(loss=new_loss, random_state=0)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1529,7 +1529,7 @@ def test_criterion_mse_deprecated(Estimator):
 def test_loss_deprecated(old_loss, new_loss, Estimator):
     est1 = Estimator(loss=old_loss, random_state=0)
 
-    with pytest.warns(FutureWarning, match=f"The loss '{old_loss}' was deprecated"):
+    with pytest.warns(FutureWarning, match=rf"The loss .* '{old_loss}' was deprecated"):
         est1.fit(X, y)
 
     est2 = Estimator(loss=new_loss, random_state=0)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -58,7 +58,7 @@ iris.data = iris.data[perm]
 iris.target = iris.target[perm]
 
 
-@pytest.mark.parametrize("loss", ("deviance", "exponential"))
+@pytest.mark.parametrize("loss", ("log_loss", "exponential"))
 def test_classification_toy(loss):
     # Check classification on a toy dataset.
     clf = GradientBoostingClassifier(loss=loss, n_estimators=10, random_state=1)
@@ -70,8 +70,8 @@ def test_classification_toy(loss):
     assert_array_equal(clf.predict(T), true_result)
     assert 10 == len(clf.estimators_)
 
-    deviance_decrease = clf.train_score_[:-1] - clf.train_score_[1:]
-    assert np.any(deviance_decrease >= 0.0)
+    log_loss_decrease = clf.train_score_[:-1] - clf.train_score_[1:]
+    assert np.any(log_loss_decrease >= 0.0)
 
     leaves = clf.apply(X)
     assert leaves.shape == (6, 10, 1)
@@ -249,7 +249,7 @@ def test_gbdt_loss_alpha_error(params, err_msg):
         (GradientBoostingClassifier, "absolute_error"),
         (GradientBoostingClassifier, "quantile"),
         (GradientBoostingClassifier, "huber"),
-        (GradientBoostingRegressor, "deviance"),
+        (GradientBoostingRegressor, "log_loss"),
         (GradientBoostingRegressor, "exponential"),
     ],
 )
@@ -260,7 +260,7 @@ def test_wrong_type_loss_function(GradientBoosting, loss):
         GradientBoosting(loss=loss).fit(X, y)
 
 
-@pytest.mark.parametrize("loss", ("deviance", "exponential"))
+@pytest.mark.parametrize("loss", ("log_loss", "exponential"))
 def test_classification_synthetic(loss):
     # Test GradientBoostingClassifier on synthetic dataset used by
     # Hastie et al. in ESLII Example 12.7.
@@ -343,7 +343,7 @@ def test_iris(subsample, sample_weight):
         sample_weight = np.ones(len(iris.target))
     # Check consistency on dataset iris.
     clf = GradientBoostingClassifier(
-        n_estimators=100, loss="deviance", random_state=1, subsample=subsample
+        n_estimators=100, loss="log_loss", random_state=1, subsample=subsample
     )
     clf.fit(iris.data, iris.target, sample_weight=sample_weight)
     score = clf.score(iris.data, iris.target)
@@ -475,8 +475,8 @@ def test_max_feature_regression():
         random_state=1,
     )
     gbrt.fit(X_train, y_train)
-    deviance = gbrt.loss_(y_test, gbrt.decision_function(X_test))
-    assert deviance < 0.5, "GB failed with deviance %.4f" % deviance
+    log_loss = gbrt.loss_(y_test, gbrt.decision_function(X_test))
+    assert log_loss < 0.5, "GB failed with deviance %.4f" % log_loss
 
 
 def test_feature_importance_regression(fetch_california_housing_fxt):
@@ -759,7 +759,7 @@ def test_oob_improvement_raise():
 def test_oob_multilcass_iris():
     # Check OOB improvement on multi-class dataset.
     clf = GradientBoostingClassifier(
-        n_estimators=100, loss="deviance", random_state=1, subsample=0.5
+        n_estimators=100, loss="log_loss", random_state=1, subsample=0.5
     )
     clf.fit(iris.data, iris.target)
     score = clf.score(iris.data, iris.target)
@@ -1226,7 +1226,7 @@ def test_non_uniform_weights_toy_edge_case_clf():
     y = [0, 0, 1, 0]
     # ignore the first 2 training samples by setting their weight to 0
     sample_weight = [0, 0, 1, 1]
-    for loss in ("deviance", "exponential"):
+    for loss in ("log_loss", "exponential"):
         gb = GradientBoostingClassifier(n_estimators=5, loss=loss)
         gb.fit(X, y, sample_weight=sample_weight)
         assert_array_equal(gb.predict([[1, 0]]), [1])
@@ -1516,20 +1516,22 @@ def test_criterion_mse_deprecated(Estimator):
         assert_allclose(est1.predict(X), est2.predict(X))
 
 
-# TODO: Remove in v1.2
 @pytest.mark.parametrize(
-    "old_loss, new_loss",
+    "old_loss, new_loss, Estimator",
     [
-        ("ls", "squared_error"),
-        ("lad", "absolute_error"),
+        # TODO(1.2): Remove
+        ("ls", "squared_error", GradientBoostingRegressor),
+        ("lad", "absolute_error", GradientBoostingRegressor),
+        # TODO(1.3): Remove
+        ("deviance", "log_loss", GradientBoostingClassifier),
     ],
 )
-def test_loss_deprecated(old_loss, new_loss):
-    est1 = GradientBoostingRegressor(loss=old_loss, random_state=0)
+def test_loss_deprecated(old_loss, new_loss, Estimator):
+    est1 = Estimator(loss=old_loss, random_state=0)
 
     with pytest.warns(FutureWarning, match=f"The loss '{old_loss}' was deprecated"):
         est1.fit(X, y)
 
-    est2 = GradientBoostingRegressor(loss=new_loss, random_state=0)
+    est2 = Estimator(loss=new_loss, random_state=0)
     est2.fit(X, y)
     assert_allclose(est1.predict(X), est2.predict(X))


### PR DESCRIPTION
#### Reference Issues/PRs
Partially addresses #18248

#### What does this implement/fix? Explain your changes.
This PR deprecates `loss="deviance"` in favor of `loss="log_loss"` in `GradientBoostingClassifier`. The default is changed accordingly.