### PR TITLE
[WIP] Using callable in RandomForest oob_score parameter to defining the oob scoring strategy.

### DIFF
--- a/benchmarks/bench_hist_gradient_boosting_threading.py
+++ b/benchmarks/bench_hist_gradient_boosting_threading.py
@@ -239,7 +239,7 @@ def one_run(n_threads, n_samples):
 
 
 max_threads = os.cpu_count()
-n_threads_list = [2**i for i in range(8) if (2**i) < max_threads]
+n_threads_list = [2 ** i for i in range(8) if (2 ** i) < max_threads]
 n_threads_list.append(max_threads)
 
 sklearn_scores = []

--- a/benchmarks/bench_isotonic.py
+++ b/benchmarks/bench_isotonic.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
 
     timings = []
     for exponent in range(args.log_min_problem_size, args.log_max_problem_size):
-        n = 10**exponent
+        n = 10 ** exponent
         Y = DATASET_GENERATORS[args.dataset](n)
         time_per_iteration = [
             bench_isotonic_regression(Y) for i in range(args.iterations)

--- a/benchmarks/bench_lasso.py
+++ b/benchmarks/bench_lasso.py
@@ -39,7 +39,7 @@ def compute_bench(alpha, n_samples, n_features, precompute):
                 coef=True,
             )
 
-            X /= np.sqrt(np.sum(X**2, axis=0))  # Normalize data
+            X /= np.sqrt(np.sum(X ** 2, axis=0))  # Normalize data
 
             gc.collect()
             print("- benchmarking Lasso")

--- a/benchmarks/bench_plot_nmf.py
+++ b/benchmarks/bench_plot_nmf.py
@@ -162,7 +162,7 @@ def _fit_projected_gradient(X, W, H, tol, max_iter, nls_max_iter, alpha, l1_rati
         proj_grad_W = squared_norm(gradW * np.logical_or(gradW < 0, W > 0))
         proj_grad_H = squared_norm(gradH * np.logical_or(gradH < 0, H > 0))
 
-        if (proj_grad_W + proj_grad_H) / init_grad < tol**2:
+        if (proj_grad_W + proj_grad_H) / init_grad < tol ** 2:
             break
 
         # update W
@@ -260,8 +260,7 @@ class _PGNMF(NMF):
         if not isinstance(self.max_iter, numbers.Integral) or self.max_iter < 0:
             raise ValueError(
                 "Maximum number of iterations must be a positive "
-                "integer; got (max_iter=%r)"
-                % self.max_iter
+                "integer; got (max_iter=%r)" % self.max_iter
             )
         if not isinstance(self.tol, numbers.Number) or self.tol < 0:
             raise ValueError(
@@ -307,8 +306,7 @@ class _PGNMF(NMF):
         if n_iter == self.max_iter and self.tol > 0:
             warnings.warn(
                 "Maximum number of iteration %d reached. Increase it"
-                " to improve convergence."
-                % self.max_iter,
+                " to improve convergence." % self.max_iter,
                 ConvergenceWarning,
             )
 

--- a/benchmarks/bench_random_projections.py
+++ b/benchmarks/bench_random_projections.py
@@ -38,7 +38,7 @@ def type_auto_or_int(val):
 
 
 def compute_time(t_start, delta):
-    mu_second = 0.0 + 10**6  # number of microseconds in a second
+    mu_second = 0.0 + 10 ** 6  # number of microseconds in a second
 
     return delta.seconds + delta.microseconds / mu_second
 
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     op.add_option(
         "--n-features",
         dest="n_features",
-        default=10**4,
+        default=10 ** 4,
         type=int,
         help="Number of features in the benchmarks",
     )
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     op.add_option(
         "--ratio-nonzeros",
         dest="ratio_nonzeros",
-        default=10**-3,
+        default=10 ** -3,
         type=float,
         help="Number of features in the benchmarks",
     )

--- a/benchmarks/bench_rcv1_logreg_convergence.py
+++ b/benchmarks/bench_rcv1_logreg_convergence.py
@@ -149,7 +149,7 @@ def plot_dloss(clfs):
 
 def get_max_squared_sum(X):
     """Get the maximum row-wise sum of squares"""
-    return np.sum(X**2, axis=1).max()
+    return np.sum(X ** 2, axis=1).max()
 
 
 rcv1 = fetch_rcv1()

--- a/benchmarks/bench_saga.py
+++ b/benchmarks/bench_saga.py
@@ -119,7 +119,7 @@ def fit_single(
                 # Lightning predict_proba is not implemented for n_classes > 2
                 y_pred = _predict_proba(lr, X)
             score = log_loss(y, y_pred, normalize=False) / n_samples
-            score += 0.5 * alpha * np.sum(lr.coef_**2) + beta * np.sum(
+            score += 0.5 * alpha * np.sum(lr.coef_ ** 2) + beta * np.sum(
                 np.abs(lr.coef_)
             )
             scores.append(score)

--- a/benchmarks/bench_sample_without_replacement.py
+++ b/benchmarks/bench_sample_without_replacement.py
@@ -16,7 +16,7 @@ from sklearn.utils.random import sample_without_replacement
 
 
 def compute_time(t_start, delta):
-    mu_second = 0.0 + 10**6  # number of microseconds in a second
+    mu_second = 0.0 + 10 ** 6  # number of microseconds in a second
 
     return delta.seconds + delta.microseconds / mu_second
 

--- a/benchmarks/bench_tree.py
+++ b/benchmarks/bench_tree.py
@@ -22,7 +22,7 @@ from datetime import datetime
 scikit_classifier_results = []
 scikit_regressor_results = []
 
-mu_second = 0.0 + 10**6  # number of microseconds in a second
+mu_second = 0.0 + 10 ** 6  # number of microseconds in a second
 
 
 def bench_scikit_tree_classifier(X, Y):

--- a/examples/applications/plot_model_complexity_influence.py
+++ b/examples/applications/plot_model_complexity_influence.py
@@ -180,7 +180,7 @@ configurations = [
     },
     {
         "estimator": NuSVR,
-        "tuned_params": {"C": 1e3, "gamma": 2**-15},
+        "tuned_params": {"C": 1e3, "gamma": 2 ** -15},
         "changing_param": "nu",
         "changing_param_values": [0.05, 0.1, 0.2, 0.35, 0.5],
         "complexity_label": "n_support_vectors",

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -186,7 +186,7 @@ def stream_reuters_documents(data_path=None):
 # maximum
 
 vectorizer = HashingVectorizer(
-    decode_error="ignore", n_features=2**18, alternate_sign=False
+    decode_error="ignore", n_features=2 ** 18, alternate_sign=False
 )
 
 

--- a/examples/applications/plot_species_distribution_modeling.py
+++ b/examples/applications/plot_species_distribution_modeling.py
@@ -214,7 +214,7 @@ def plot_species_distribution(
         plt.scatter(
             species.pts_train["dd long"],
             species.pts_train["dd lat"],
-            s=2**2,
+            s=2 ** 2,
             c="black",
             marker="^",
             label="train",
@@ -222,7 +222,7 @@ def plot_species_distribution(
         plt.scatter(
             species.pts_test["dd long"],
             species.pts_test["dd lat"],
-            s=2**2,
+            s=2 ** 2,
             c="black",
             marker="x",
             label="test",

--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -207,7 +207,7 @@ non_zero = np.abs(np.triu(partial_correlations, k=1)) > 0.02
 
 # Plot the nodes using the coordinates of our embedding
 plt.scatter(
-    embedding[0], embedding[1], s=100 * d**2, c=labels, cmap=plt.cm.nipy_spectral
+    embedding[0], embedding[1], s=100 * d ** 2, c=labels, cmap=plt.cm.nipy_spectral
 )
 
 # Plot the edges

--- a/examples/applications/plot_tomography_l1_reconstruction.py
+++ b/examples/applications/plot_tomography_l1_reconstruction.py
@@ -81,7 +81,7 @@ def build_projection_operator(l_x, n_dir):
     X, Y = _generate_center_coordinates(l_x)
     angles = np.linspace(0, np.pi, n_dir, endpoint=False)
     data_inds, weights, camera_inds = [], [], []
-    data_unravel_indices = np.arange(l_x**2)
+    data_unravel_indices = np.arange(l_x ** 2)
     data_unravel_indices = np.hstack((data_unravel_indices, data_unravel_indices))
     for i, angle in enumerate(angles):
         Xrot = np.cos(angle) * X - np.sin(angle) * Y

--- a/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
+++ b/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
@@ -48,7 +48,7 @@ coef = np.zeros((size, size))
 coef[0:roi_size, 0:roi_size] = -1.0
 coef[-roi_size:, -roi_size:] = 1.0
 
-X = np.random.randn(n_samples, size**2)
+X = np.random.randn(n_samples, size ** 2)
 for x in X:  # smooth data
     x[:] = ndimage.gaussian_filter(x.reshape(size, size), sigma=1.0).ravel()
 X -= X.mean(axis=0)

--- a/examples/cluster/plot_kmeans_stability_low_dim_dense.py
+++ b/examples/cluster/plot_kmeans_stability_low_dim_dense.py
@@ -49,7 +49,7 @@ n_init_range = np.array([1, 5, 10, 15, 20])
 n_samples_per_center = 100
 grid_size = 3
 scale = 0.1
-n_clusters = grid_size**2
+n_clusters = grid_size ** 2
 
 
 def make_data(random_state, n_samples_per_center, grid_size, scale):

--- a/examples/cluster/plot_segmentation_toy.py
+++ b/examples/cluster/plot_segmentation_toy.py
@@ -46,10 +46,10 @@ center4 = (24, 70)
 
 radius1, radius2, radius3, radius4 = 16, 14, 15, 14
 
-circle1 = (x - center1[0]) ** 2 + (y - center1[1]) ** 2 < radius1**2
-circle2 = (x - center2[0]) ** 2 + (y - center2[1]) ** 2 < radius2**2
-circle3 = (x - center3[0]) ** 2 + (y - center3[1]) ** 2 < radius3**2
-circle4 = (x - center4[0]) ** 2 + (y - center4[1]) ** 2 < radius4**2
+circle1 = (x - center1[0]) ** 2 + (y - center1[1]) ** 2 < radius1 ** 2
+circle2 = (x - center2[0]) ** 2 + (y - center2[1]) ** 2 < radius2 ** 2
+circle3 = (x - center3[0]) ** 2 + (y - center3[1]) ** 2 < radius3 ** 2
+circle4 = (x - center4[0]) ** 2 + (y - center4[1]) ** 2 < radius4 ** 2
 
 # #############################################################################
 # 4 circles

--- a/examples/covariance/plot_robust_vs_empirical_covariance.py
+++ b/examples/covariance/plot_robust_vs_empirical_covariance.py
@@ -99,7 +99,7 @@ for i, n_outliers in enumerate(range_n_outliers):
         # fit a Minimum Covariance Determinant (MCD) robust estimator to data
         mcd = MinCovDet().fit(X)
         # compare raw robust estimates with the true location and covariance
-        err_loc_mcd[i, j] = np.sum(mcd.location_**2)
+        err_loc_mcd[i, j] = np.sum(mcd.location_ ** 2)
         err_cov_mcd[i, j] = mcd.error_norm(np.eye(n_features))
 
         # compare estimators learned from the full data set with true
@@ -114,7 +114,7 @@ for i, n_outliers in enumerate(range_n_outliers):
         pure_X = X[inliers_mask]
         pure_location = pure_X.mean(0)
         pure_emp_cov = EmpiricalCovariance().fit(pure_X)
-        err_loc_emp_pure[i, j] = np.sum(pure_location**2)
+        err_loc_emp_pure[i, j] = np.sum(pure_location ** 2)
         err_cov_emp_pure[i, j] = pure_emp_cov.error_norm(np.eye(n_features))
 
 # Display results

--- a/examples/datasets/plot_random_multilabel_dataset.py
+++ b/examples/datasets/plot_random_multilabel_dataset.py
@@ -55,7 +55,7 @@ COLORS = np.array(
 
 # Use same random seed for multiple calls to make_multilabel_classification to
 # ensure same distributions
-RANDOM_SEED = np.random.randint(2**10)
+RANDOM_SEED = np.random.randint(2 ** 10)
 
 
 def plot_2d(ax, n_labels=1, n_classes=3, length=50):
@@ -79,7 +79,7 @@ def plot_2d(ax, n_labels=1, n_classes=3, length=50):
         marker="*",
         linewidth=0.5,
         edgecolor="black",
-        s=20 + 1500 * p_c**2,
+        s=20 + 1500 * p_c ** 2,
         color=COLORS.take([1, 2, 4]),
     )
     ax.set_xlabel("Feature 0 count")

--- a/examples/decomposition/plot_image_denoising.py
+++ b/examples/decomposition/plot_image_denoising.py
@@ -78,7 +78,7 @@ def show_with_diff(image, reference, title):
     plt.subplot(1, 2, 2)
     difference = image - reference
 
-    plt.title("Difference (norm: %.2f)" % np.sqrt(np.sum(difference**2)))
+    plt.title("Difference (norm: %.2f)" % np.sqrt(np.sum(difference ** 2)))
     plt.imshow(
         difference, vmin=-0.5, vmax=0.5, cmap=plt.cm.PuOr, interpolation="nearest"
     )

--- a/examples/decomposition/plot_sparse_coding.py
+++ b/examples/decomposition/plot_sparse_coding.py
@@ -26,9 +26,9 @@ def ricker_function(resolution, center, width):
     """Discrete sub-sampled Ricker (Mexican hat) wavelet"""
     x = np.linspace(0, resolution - 1, resolution)
     x = (
-        (2 / (np.sqrt(3 * width) * np.pi**0.25))
-        * (1 - (x - center) ** 2 / width**2)
-        * np.exp(-((x - center) ** 2) / (2 * width**2))
+        (2 / (np.sqrt(3 * width) * np.pi ** 0.25))
+        * (1 - (x - center) ** 2 / width ** 2)
+        * np.exp(-((x - center) ** 2) / (2 * width ** 2))
     )
     return x
 
@@ -39,7 +39,7 @@ def ricker_matrix(width, resolution, n_components):
     D = np.empty((n_components, resolution))
     for i, center in enumerate(centers):
         D[i] = ricker_function(resolution, center, width)
-    D /= np.sqrt(np.sum(D**2, axis=1))[:, np.newaxis]
+    D /= np.sqrt(np.sum(D ** 2, axis=1))[:, np.newaxis]
     return D
 
 

--- a/examples/ensemble/plot_bias_variance.py
+++ b/examples/ensemble/plot_bias_variance.py
@@ -95,7 +95,7 @@ n_estimators = len(estimators)
 def f(x):
     x = x.ravel()
 
-    return np.exp(-(x**2)) + 1.5 * np.exp(-((x - 2) ** 2))
+    return np.exp(-(x ** 2)) + 1.5 * np.exp(-((x - 2) ** 2))
 
 
 def generate(n_samples, noise, n_repeat=1):

--- a/examples/ensemble/plot_gradient_boosting_quantile.py
+++ b/examples/ensemble/plot_gradient_boosting_quantile.py
@@ -35,7 +35,7 @@ expected_y = f(X).ravel()
 # The lognormal distribution is non-symmetric and long tailed: observing large
 # outliers is likely but it is impossible to observe small outliers.
 sigma = 0.5 + X.ravel() / 10
-noise = rng.lognormal(sigma=sigma) - np.exp(sigma**2 / 2)
+noise = rng.lognormal(sigma=sigma) - np.exp(sigma ** 2 / 2)
 y = expected_y + noise
 
 # %%

--- a/examples/gaussian_process/plot_gpr_co2.py
+++ b/examples/gaussian_process/plot_gpr_co2.py
@@ -100,7 +100,7 @@ y = co2_data["co2"].to_numpy()
 # specific length-scale and the amplitude are free hyperparameters.
 from sklearn.gaussian_process.kernels import RBF
 
-long_term_trend_kernel = 50.0**2 * RBF(length_scale=50.0)
+long_term_trend_kernel = 50.0 ** 2 * RBF(length_scale=50.0)
 
 # %%
 # The seasonal variation is explained by the periodic exponential sine squared
@@ -113,7 +113,7 @@ long_term_trend_kernel = 50.0**2 * RBF(length_scale=50.0)
 from sklearn.gaussian_process.kernels import ExpSineSquared
 
 seasonal_kernel = (
-    2.0**2
+    2.0 ** 2
     * RBF(length_scale=100.0)
     * ExpSineSquared(length_scale=1.0, periodicity=1.0, periodicity_bounds="fixed")
 )
@@ -126,7 +126,7 @@ seasonal_kernel = (
 # better accommodate the different irregularities.
 from sklearn.gaussian_process.kernels import RationalQuadratic
 
-irregularities_kernel = 0.5**2 * RationalQuadratic(length_scale=1.0, alpha=1.0)
+irregularities_kernel = 0.5 ** 2 * RationalQuadratic(length_scale=1.0, alpha=1.0)
 
 # %%
 # Finally, the noise in the dataset can be accounted with a kernel consisting
@@ -136,8 +136,8 @@ irregularities_kernel = 0.5**2 * RationalQuadratic(length_scale=1.0, alpha=1.0)
 # further free parameters.
 from sklearn.gaussian_process.kernels import WhiteKernel
 
-noise_kernel = 0.1**2 * RBF(length_scale=0.1) + WhiteKernel(
-    noise_level=0.1**2, noise_level_bounds=(1e-5, 1e5)
+noise_kernel = 0.1 ** 2 * RBF(length_scale=0.1) + WhiteKernel(
+    noise_level=0.1 ** 2, noise_level_bounds=(1e-5, 1e5)
 )
 
 # %%

--- a/examples/gaussian_process/plot_gpr_noisy_targets.py
+++ b/examples/gaussian_process/plot_gpr_noisy_targets.py
@@ -114,7 +114,7 @@ y_train_noisy = y_train + rng.normal(loc=0.0, scale=noise_std, size=y_train.shap
 # time, we specify the parameter `alpha` which can be interpreted as the
 # variance of a Gaussian noise.
 gaussian_process = GaussianProcessRegressor(
-    kernel=kernel, alpha=noise_std**2, n_restarts_optimizer=9
+    kernel=kernel, alpha=noise_std ** 2, n_restarts_optimizer=9
 )
 gaussian_process.fit(X_train, y_train_noisy)
 mean_prediction, std_prediction = gaussian_process.predict(X, return_std=True)

--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -113,7 +113,7 @@ K = kernel(X)
 D = kernel.diag(X)
 
 plt.figure(figsize=(8, 5))
-plt.imshow(np.diag(D**-0.5).dot(K).dot(np.diag(D**-0.5)))
+plt.imshow(np.diag(D ** -0.5).dot(K).dot(np.diag(D ** -0.5)))
 plt.xticks(np.arange(len(X)), X)
 plt.yticks(np.arange(len(X)), X)
 plt.title("Sequence similarity under the kernel")

--- a/examples/linear_model/plot_sgd_penalties.py
+++ b/examples/linear_model/plot_sgd_penalties.py
@@ -21,7 +21,7 @@ elastic_net_color = "darkorange"
 line = np.linspace(-1.5, 1.5, 1001)
 xx, yy = np.meshgrid(line, line)
 
-l2 = xx**2 + yy**2
+l2 = xx ** 2 + yy ** 2
 l1 = np.abs(xx) + np.abs(yy)
 rho = 0.5
 elastic_net = rho * l1 + (1 - rho) * l2

--- a/examples/manifold/plot_mds.py
+++ b/examples/manifold/plot_mds.py
@@ -61,8 +61,8 @@ nmds = manifold.MDS(
 npos = nmds.fit_transform(similarities, init=pos)
 
 # Rescale the data
-pos *= np.sqrt((X_true**2).sum()) / np.sqrt((pos**2).sum())
-npos *= np.sqrt((X_true**2).sum()) / np.sqrt((npos**2).sum())
+pos *= np.sqrt((X_true ** 2).sum()) / np.sqrt((pos ** 2).sum())
+npos *= np.sqrt((X_true ** 2).sum()) / np.sqrt((npos ** 2).sum())
 
 # Rotate the data
 clf = PCA(n_components=2)

--- a/examples/svm/plot_svm_margin.py
+++ b/examples/svm/plot_svm_margin.py
@@ -47,9 +47,9 @@ for name, penalty in (("unreg", 1), ("reg", 0.05)):
     # support vectors (margin away from hyperplane in direction
     # perpendicular to hyperplane). This is sqrt(1+a^2) away vertically in
     # 2-d.
-    margin = 1 / np.sqrt(np.sum(clf.coef_**2))
-    yy_down = yy - np.sqrt(1 + a**2) * margin
-    yy_up = yy + np.sqrt(1 + a**2) * margin
+    margin = 1 / np.sqrt(np.sum(clf.coef_ ** 2))
+    yy_down = yy - np.sqrt(1 + a ** 2) * margin
+    yy_up = yy + np.sqrt(1 + a ** 2) * margin
 
     # plot the line, the points, and the nearest vectors to the plane
     plt.figure(fignum, figsize=(4, 3))

--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -28,7 +28,7 @@ automatically downloaded, then cached.
 USE_HASHING = False
 
 # Number of features used by `HashingVectorizer`
-N_FEATURES = 2**16
+N_FEATURES = 2 ** 16
 
 # Optional feature selection: either False, or an integer: the number of
 # features to select

--- a/examples/text/plot_hashing_vs_dict_vectorizer.py
+++ b/examples/text/plot_hashing_vs_dict_vectorizer.py
@@ -72,7 +72,7 @@ print()
 try:
     n_features = int(sys.argv[1])
 except IndexError:
-    n_features = 2**18
+    n_features = 2 ** 18
 except ValueError:
     print("not a valid number of features: %r" % sys.argv[1])
     sys.exit(1)

--- a/sklearn/_loss/tests/test_glm_distribution.py
+++ b/sklearn/_loss/tests/test_glm_distribution.py
@@ -115,9 +115,12 @@ def test_deviance_derivative(family):
     dev_derivative = family.deviance_derivative(y_true, y_pred)
     assert dev_derivative.shape == y_pred.shape
 
-    err = check_grad(
-        lambda y_pred: family.deviance(y_true, y_pred),
-        lambda y_pred: family.deviance_derivative(y_true, y_pred),
-        y_pred,
-    ) / np.linalg.norm(dev_derivative)
+    err = (
+        check_grad(
+            lambda y_pred: family.deviance(y_true, y_pred),
+            lambda y_pred: family.deviance_derivative(y_true, y_pred),
+            y_pred,
+        )
+        / np.linalg.norm(dev_derivative)
+    )
     assert abs(err) < 1e-6

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -228,10 +228,10 @@ def test_loss_boundary_y_pred(loss, y_pred_success, y_pred_fail):
         (PinballLoss(quantile=0.25), 5.0, 1.0, 4 * 0.25),
         (HalfPoissonLoss(), 2.0, np.log(4), 4 - 2 * np.log(4)),
         (HalfGammaLoss(), 2.0, np.log(4), np.log(4) + 2 / 4),
-        (HalfTweedieLoss(power=3), 2.0, np.log(4), -1 / 4 + 1 / 4**2),
+        (HalfTweedieLoss(power=3), 2.0, np.log(4), -1 / 4 + 1 / 4 ** 2),
         (HalfTweedieLossIdentity(power=1), 2.0, 4.0, 2 - 2 * np.log(2)),
         (HalfTweedieLossIdentity(power=2), 2.0, 4.0, np.log(2) - 1 / 2),
-        (HalfTweedieLossIdentity(power=3), 2.0, 4.0, -1 / 4 + 1 / 4**2 + 1 / 2 / 2),
+        (HalfTweedieLossIdentity(power=3), 2.0, 4.0, -1 / 4 + 1 / 4 ** 2 + 1 / 2 / 2),
         (HalfBinomialLoss(), 0.25, np.log(4), np.log(5) - 0.25 * np.log(4)),
         (
             HalfMultinomialLoss(n_classes=3),
@@ -1169,5 +1169,5 @@ def test_tweedie_log_identity_consistency(p):
     )
     assert_allclose(gradient_log, y_pred * gradient_identity)
     assert_allclose(
-        hessian_log, y_pred * gradient_identity + y_pred**2 * hessian_identity
+        hessian_log, y_pred * gradient_identity + y_pred ** 2 * hessian_identity
     )

--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -328,7 +328,7 @@ class _CFSubcluster:
         #   r^2 = sum_i ||x_i||^2 / n - ||c||^2
         sq_radius = new_ss / new_n - new_sq_norm
 
-        if sq_radius <= threshold**2:
+        if sq_radius <= threshold ** 2:
             (
                 self.n_samples_,
                 self.linear_sum_,

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -528,7 +528,7 @@ def _kmeans_single_elkan(
             break
         else:
             # No strict convergence, check for tol based convergence.
-            center_shift_tot = (center_shift**2).sum()
+            center_shift_tot = (center_shift ** 2).sum()
             if center_shift_tot <= tol:
                 if verbose:
                     print(
@@ -671,7 +671,7 @@ def _kmeans_single_lloyd(
                 break
             else:
                 # No strict convergence, check for tol based convergence.
-                center_shift_tot = (center_shift**2).sum()
+                center_shift_tot = (center_shift ** 2).sum()
                 if center_shift_tot <= tol:
                     if verbose:
                         print(

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -130,7 +130,7 @@ def discretize(
     # Normalize the rows of the eigenvectors.  Samples should lie on the unit
     # hypersphere centered at the origin.  This transforms the samples in the
     # embedding space to the space of partition matrices.
-    vectors = vectors / np.sqrt((vectors**2).sum(axis=1))[:, np.newaxis]
+    vectors = vectors / np.sqrt((vectors ** 2).sum(axis=1))[:, np.newaxis]
 
     svd_restarts = 0
     has_converged = False

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -218,7 +218,7 @@ def test_minibatch_update_consistency():
     weight_sums = np.zeros(centers_old.shape[0], dtype=X.dtype)
     weight_sums_csr = np.zeros(centers_old.shape[0], dtype=X.dtype)
 
-    x_squared_norms = (X**2).sum(axis=1)
+    x_squared_norms = (X ** 2).sum(axis=1)
     x_squared_norms_csr = row_norms(X_csr, squared=True)
 
     sample_weight = np.ones(X.shape[0], dtype=X.dtype)
@@ -993,7 +993,7 @@ def test_euclidean_distance(dtype, squared):
     )
     a_dense = a_sparse.toarray().reshape(-1)
     b = rng.randn(100).astype(dtype, copy=False)
-    b_squared_norm = (b**2).sum()
+    b_squared_norm = (b ** 2).sum()
 
     expected = ((a_dense - b) ** 2).sum()
     expected = expected if squared else np.sqrt(expected)

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -321,8 +321,8 @@ def test_spectral_clustering_with_arpack_amg_solvers():
     center1, center2 = (14, 12), (20, 25)
     radius1, radius2 = 8, 7
 
-    circle1 = (x - center1[0]) ** 2 + (y - center1[1]) ** 2 < radius1**2
-    circle2 = (x - center2[0]) ** 2 + (y - center2[1]) ** 2 < radius2**2
+    circle1 = (x - center1[0]) ** 2 + (y - center1[1]) ** 2 < radius1 ** 2
+    circle2 = (x - center2[0]) ** 2 + (y - center2[1]) ** 2 < radius2 ** 2
 
     circles = circle1 | circle2
     mask = circles.copy()

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -370,8 +370,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         if self.remainder not in ("drop", "passthrough") and not is_transformer:
             raise ValueError(
                 "The remainder keyword needs to be one of 'drop', "
-                "'passthrough', or estimator. '%s' was passed instead"
-                % self.remainder
+                "'passthrough', or estimator. '%s' was passed instead" % self.remainder
             )
 
         self._n_features = X.shape[1]

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -297,7 +297,7 @@ class EmpiricalCovariance(BaseEstimator):
         error = comp_cov - self.covariance_
         # compute the error norm
         if norm == "frobenius":
-            squared_norm = np.sum(error**2)
+            squared_norm = np.sum(error ** 2)
         elif norm == "spectral":
             squared_norm = np.amax(linalg.svdvals(np.dot(error.T, error)))
         else:

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -240,7 +240,7 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
 
     # number of blocks to split the covariance matrix into
     n_splits = int(n_features / block_size)
-    X2 = X**2
+    X2 = X ** 2
     emp_cov_trace = np.sum(X2, axis=0) / n_samples
     mu = np.sum(emp_cov_trace) / n_features
     beta_ = 0.0  # sum of the coefficients of <X2.T, X2>
@@ -262,14 +262,14 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
     delta_ += np.sum(
         np.dot(X.T[block_size * n_splits :], X[:, block_size * n_splits :]) ** 2
     )
-    delta_ /= n_samples**2
+    delta_ /= n_samples ** 2
     beta_ += np.sum(
         np.dot(X2.T[block_size * n_splits :], X2[:, block_size * n_splits :])
     )
     # use delta_ to compute beta
     beta = 1.0 / (n_features * n_samples) * (beta_ / n_samples - delta_)
     # delta is the sum of the squared coefficients of (<X.T,X> - mu*Id) / p
-    delta = delta_ - 2.0 * mu * emp_cov_trace.sum() + n_features * mu**2
+    delta = delta_ - 2.0 * mu * emp_cov_trace.sum() + n_features * mu ** 2
     delta /= n_features
     # get final beta as the min between beta and delta
     # We do this to prevent shrinking more than "1", which would invert
@@ -322,7 +322,7 @@ def ledoit_wolf(X, *, assume_centered=False, block_size=1000):
     if len(X.shape) == 2 and X.shape[1] == 1:
         if not assume_centered:
             X = X - X.mean()
-        return np.atleast_2d((X**2).mean()), 0.0
+        return np.atleast_2d((X ** 2).mean()), 0.0
     if X.ndim == 1:
         X = np.reshape(X, (1, -1))
         warnings.warn(
@@ -524,7 +524,7 @@ def oas(X, *, assume_centered=False):
     if len(X.shape) == 2 and X.shape[1] == 1:
         if not assume_centered:
             X = X - X.mean()
-        return np.atleast_2d((X**2).mean()), 0.0
+        return np.atleast_2d((X ** 2).mean()), 0.0
     if X.ndim == 1:
         X = np.reshape(X, (1, -1))
         warnings.warn(
@@ -539,9 +539,9 @@ def oas(X, *, assume_centered=False):
     mu = np.trace(emp_cov) / n_features
 
     # formula from Chen et al.'s **implementation**
-    alpha = np.mean(emp_cov**2)
-    num = alpha + mu**2
-    den = (n_samples + 1.0) * (alpha - (mu**2) / n_features)
+    alpha = np.mean(emp_cov ** 2)
+    num = alpha + mu ** 2
+    den = (n_samples + 1.0) * (alpha - (mu ** 2) / n_features)
 
     shrinkage = 1.0 if den == 0 else min(num / den, 1.0)
     shrunk_cov = (1.0 - shrinkage) * emp_cov

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -143,7 +143,7 @@ def test_ledoit_wolf():
     lw_cov_from_mle, lw_shrinkage_from_mle = ledoit_wolf(X_1d, assume_centered=True)
     assert_array_almost_equal(lw_cov_from_mle, lw.covariance_, 4)
     assert_almost_equal(lw_shrinkage_from_mle, lw.shrinkage_)
-    assert_array_almost_equal((X_1d**2).sum() / n_samples, lw.covariance_, 4)
+    assert_array_almost_equal((X_1d ** 2).sum() / n_samples, lw.covariance_, 4)
 
     # test shrinkage coeff on a simple data set (without saving precision)
     lw = LedoitWolf(store_precision=False, assume_centered=True)
@@ -207,12 +207,12 @@ def _naive_ledoit_wolf_shrinkage(X):
     mu = np.trace(emp_cov) / n_features
     delta_ = emp_cov.copy()
     delta_.flat[:: n_features + 1] -= mu
-    delta = (delta_**2).sum() / n_features
-    X2 = X**2
+    delta = (delta_ ** 2).sum() / n_features
+    X2 = X ** 2
     beta_ = (
         1.0
         / (n_features * n_samples)
-        * np.sum(np.dot(X2.T, X2) / n_samples - emp_cov**2)
+        * np.sum(np.dot(X2.T, X2) / n_samples - emp_cov ** 2)
     )
 
     beta = min(beta_, delta)
@@ -279,7 +279,7 @@ def test_oas():
     oa_cov_from_mle, oa_shrinkage_from_mle = oas(X_1d, assume_centered=True)
     assert_array_almost_equal(oa_cov_from_mle, oa.covariance_, 4)
     assert_almost_equal(oa_shrinkage_from_mle, oa.shrinkage_)
-    assert_array_almost_equal((X_1d**2).sum() / n_samples, oa.covariance_, 4)
+    assert_array_almost_equal((X_1d ** 2).sum() / n_samples, oa.covariance_, 4)
 
     # test shrinkage coeff on a simple data set (without saving precision)
     oa = OAS(store_precision=False, assume_centered=True)

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -30,7 +30,7 @@ def _generate_hypercube(samples, dimensions, rng):
                 _generate_hypercube(samples, 30, rng),
             ]
         )
-    out = sample_without_replacement(2**dimensions, samples, random_state=rng).astype(
+    out = sample_without_replacement(2 ** dimensions, samples, random_state=rng).astype(
         dtype=">u4", copy=False
     )
     out = np.unpackbits(out.view(">u1")).reshape((-1, 32))[:, -dimensions:]
@@ -186,7 +186,7 @@ def make_classification(
         msg += " smaller or equal 2**n_informative({})={}"
         raise ValueError(
             msg.format(
-                n_classes, n_clusters_per_class, n_informative, 2**n_informative
+                n_classes, n_clusters_per_class, n_informative, 2 ** n_informative
             )
         )
 
@@ -496,7 +496,7 @@ def make_hastie_10_2(n_samples=12000, *, random_state=None):
 
     shape = (n_samples, 10)
     X = rs.normal(size=shape).reshape(shape)
-    y = ((X**2.0).sum(axis=1) > 9.34).astype(np.float64, copy=False)
+    y = ((X ** 2.0).sum(axis=1) > 9.34).astype(np.float64, copy=False)
     y[y == 0.0] = -1.0
 
     return X, y
@@ -1303,7 +1303,7 @@ def make_sparse_coded_signal(
 
     # generate dictionary
     D = generator.standard_normal(size=(n_features, n_components))
-    D /= np.sqrt(np.sum((D**2), axis=0))
+    D /= np.sqrt(np.sum((D ** 2), axis=0))
 
     # generate code
     X = np.zeros((n_components, n_samples))

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -241,7 +241,7 @@ def test_load_diabetes_raw():
     diabetes_default = load_diabetes()
 
     np.testing.assert_allclose(
-        scale(diabetes_raw.data) / (442**0.5), diabetes_default.data, atol=1e-04
+        scale(diabetes_raw.data) / (442 ** 0.5), diabetes_default.data, atol=1e-04
     )
 
 

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -1238,8 +1238,7 @@ def test_fetch_openml_cache(monkeypatch, gzip_response, tmpdir):
         raise ValueError(
             "This mechanism intends to test correct cache"
             "handling. As such, urlopen should never be "
-            "accessed. URL: %s"
-            % request.get_full_url()
+            "accessed. URL: %s" % request.get_full_url()
         )
 
     data_id = 2

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -505,7 +505,7 @@ def test_make_sparse_coded_signal():
     for row in X:
         assert len(np.flatnonzero(row)) == 3, "Non-zero coefs mismatch"
     assert_allclose(Y, X @ D)
-    assert_allclose(np.sqrt((D**2).sum(axis=1)), np.ones(D.shape[0]))
+    assert_allclose(np.sqrt((D ** 2).sum(axis=1)), np.ones(D.shape[0]))
 
 
 def test_make_sparse_coded_signal_transposed():
@@ -523,7 +523,7 @@ def test_make_sparse_coded_signal_transposed():
     for col in X.T:
         assert len(np.flatnonzero(col)) == 3, "Non-zero coefs mismatch"
     assert_allclose(Y, D @ X)
-    assert_allclose(np.sqrt((D**2).sum(axis=0)), np.ones(D.shape[1]))
+    assert_allclose(np.sqrt((D ** 2).sum(axis=0)), np.ones(D.shape[1]))
 
 
 # TODO(1.3): remove
@@ -666,8 +666,8 @@ def test_make_circles():
         center = [0.0, 0.0]
         for x, label in zip(X, y):
             dist_sqr = ((x - center) ** 2).sum()
-            dist_exp = 1.0 if label == 0 else factor**2
-            dist_exp = 1.0 if label == 0 else factor**2
+            dist_exp = 1.0 if label == 0 else factor ** 2
+            dist_exp = 1.0 if label == 0 else factor ** 2
             assert_almost_equal(
                 dist_sqr, dist_exp, err_msg="Point is not on expected circle"
             )

--- a/sklearn/decomposition/_base.py
+++ b/sklearn/decomposition/_base.py
@@ -75,7 +75,7 @@ class _BasePCA(
         precision = np.dot(components_, components_.T) / self.noise_variance_
         precision.flat[:: len(precision) + 1] += 1.0 / exp_var_diff
         precision = np.dot(components_.T, np.dot(linalg.inv(precision), components_))
-        precision /= -(self.noise_variance_**2)
+        precision /= -(self.noise_variance_ ** 2)
         precision.flat[:: len(precision) + 1] += 1.0 / self.noise_variance_
         return precision
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1089,7 +1089,7 @@ def dict_learning_online(
         if ii < batch_size - 1:
             theta = float((ii + 1) * batch_size)
         else:
-            theta = float(batch_size**2 + ii + 1 - batch_size)
+            theta = float(batch_size ** 2 + ii + 1 - batch_size)
         beta = (theta + 1 - batch_size) / (theta + 1)
 
         A *= beta
@@ -2102,7 +2102,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         if step < batch_size - 1:
             theta = (step + 1) * batch_size
         else:
-            theta = batch_size**2 + step + 1 - batch_size
+            theta = batch_size ** 2 + step + 1 - batch_size
         beta = (theta + 1 - batch_size) / (theta + 1)
 
         A, B = self._inner_stats

--- a/sklearn/decomposition/_factor_analysis.py
+++ b/sklearn/decomposition/_factor_analysis.py
@@ -285,7 +285,7 @@ class FactorAnalysis(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEst
                 break
             old_ll = ll
 
-            psi = np.maximum(var - np.sum(W**2, axis=0), SMALL)
+            psi = np.maximum(var - np.sum(W ** 2, axis=0), SMALL)
         else:
             warnings.warn(
                 "FactorAnalysis did not converge."
@@ -443,10 +443,10 @@ def _ortho_rotation(components, method="varimax", tol=1e-6, max_iter=100):
     for _ in range(max_iter):
         comp_rot = np.dot(components, rotation_matrix)
         if method == "varimax":
-            tmp = comp_rot * np.transpose((comp_rot**2).sum(axis=0) / nrow)
+            tmp = comp_rot * np.transpose((comp_rot ** 2).sum(axis=0) / nrow)
         elif method == "quartimax":
             tmp = 0
-        u, s, v = np.linalg.svd(np.dot(components.T, comp_rot**3 - tmp))
+        u, s, v = np.linalg.svd(np.dot(components.T, comp_rot ** 3 - tmp))
         rotation_matrix = np.dot(u, v)
         var_new = np.sum(s)
         if var != 0 and var_new < var * (1 + tol):

--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -76,7 +76,7 @@ def _ica_def(X, tol, g, fun_args, max_iter, w_init):
     # j is the index of the extracted component
     for j in range(n_components):
         w = w_init[j, :].copy()
-        w /= np.sqrt((w**2).sum())
+        w /= np.sqrt((w ** 2).sum())
 
         for i in range(max_iter):
             gwtx, g_wtx = g(np.dot(w.T, X), fun_args)
@@ -85,7 +85,7 @@ def _ica_def(X, tol, g, fun_args, max_iter, w_init):
 
             _gs_decorrelation(w1, W, j)
 
-            w1 /= np.sqrt((w1**2).sum())
+            w1 /= np.sqrt((w1 ** 2).sum())
 
             lim = np.abs(np.abs((w1 * w).sum()) - 1)
             w = w1
@@ -136,19 +136,19 @@ def _logcosh(x, fun_args=None):
     g_x = np.empty(x.shape[0], dtype=x.dtype)
     # XXX compute in chunks to avoid extra allocation
     for i, gx_i in enumerate(gx):  # please don't vectorize.
-        g_x[i] = (alpha * (1 - gx_i**2)).mean()
+        g_x[i] = (alpha * (1 - gx_i ** 2)).mean()
     return gx, g_x
 
 
 def _exp(x, fun_args):
-    exp = np.exp(-(x**2) / 2)
+    exp = np.exp(-(x ** 2) / 2)
     gx = x * exp
-    g_x = (1 - x**2) * exp
+    g_x = (1 - x ** 2) * exp
     return gx, g_x.mean(axis=-1)
 
 
 def _cube(x, fun_args):
-    return x**3, (3 * x**2).mean(axis=-1)
+    return x ** 3, (3 * x ** 2).mean(axis=-1)
 
 
 def fastica(
@@ -526,8 +526,7 @@ class FastICA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
             exc = ValueError if isinstance(self.fun, str) else TypeError
             raise exc(
                 "Unknown function %r;"
-                " should be one of 'logcosh', 'exp', 'cube' or callable"
-                % self.fun
+                " should be one of 'logcosh', 'exp', 'cube' or callable" % self.fun
             )
 
         n_features, n_samples = XT.shape

--- a/sklearn/decomposition/_incremental_pca.py
+++ b/sklearn/decomposition/_incremental_pca.py
@@ -334,8 +334,8 @@ class IncrementalPCA(_BasePCA):
 
         U, S, Vt = linalg.svd(X, full_matrices=False, check_finite=False)
         U, Vt = svd_flip(U, Vt, u_based_decision=False)
-        explained_variance = S**2 / (n_total_samples - 1)
-        explained_variance_ratio = S**2 / np.sum(col_var * n_total_samples)
+        explained_variance = S ** 2 / (n_total_samples - 1)
+        explained_variance_ratio = S ** 2 / np.sum(col_var * n_total_samples)
 
         self.n_samples_seen_ = n_total_samples
         self.components_ = Vt[: self.n_components_]

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -158,10 +158,10 @@ def _beta_divergence(X, W, H, beta, square_root=False):
                 sum_WH_beta += np.sum(np.dot(W, H[:, i]) ** beta)
 
         else:
-            sum_WH_beta = np.sum(WH**beta)
+            sum_WH_beta = np.sum(WH ** beta)
 
         sum_X_WH = np.dot(X_data, WH_data ** (beta - 1))
-        res = (X_data**beta).sum() - beta * sum_X_WH
+        res = (X_data ** beta).sum() - beta * sum_X_WH
         res += sum_WH_beta * (beta - 1)
         res /= beta * (beta - 1)
 
@@ -1652,8 +1652,7 @@ class NMF(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         if n_iter == self.max_iter and self.tol > 0:
             warnings.warn(
                 "Maximum number of iterations %d reached. Increase "
-                "it to improve convergence."
-                % self.max_iter,
+                "it to improve convergence." % self.max_iter,
                 ConvergenceWarning,
             )
 

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -522,7 +522,7 @@ class PCA(_BasePCA):
         components_ = Vt
 
         # Get variance explained by singular values
-        explained_variance_ = (S**2) / (n_samples - 1)
+        explained_variance_ = (S ** 2) / (n_samples - 1)
         total_var = explained_variance_.sum()
         explained_variance_ratio_ = explained_variance_ / total_var
         singular_values_ = S.copy()  # Store the singular values.
@@ -618,7 +618,7 @@ class PCA(_BasePCA):
         self.n_components_ = n_components
 
         # Get variance explained by singular values
-        self.explained_variance_ = (S**2) / (n_samples - 1)
+        self.explained_variance_ = (S ** 2) / (n_samples - 1)
 
         # Workaround in-place variance calculation since at the time numpy
         # did not have a way to calculate variance in-place.

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -68,9 +68,9 @@ def test_max_iter():
         """Discrete sub-sampled Ricker (Mexican hat) wavelet"""
         x = np.linspace(0, resolution - 1, resolution)
         x = (
-            (2 / (np.sqrt(3 * width) * np.pi**0.25))
-            * (1 - (x - center) ** 2 / width**2)
-            * np.exp(-((x - center) ** 2) / (2 * width**2))
+            (2 / (np.sqrt(3 * width) * np.pi ** 0.25))
+            * (1 - (x - center) ** 2 / width ** 2)
+            * np.exp(-((x - center) ** 2) / (2 * width ** 2))
         )
         return x
 
@@ -80,7 +80,7 @@ def test_max_iter():
         D = np.empty((n_components, resolution))
         for i, center in enumerate(centers):
             D[i] = ricker_function(resolution, center, width)
-        D /= np.sqrt(np.sum(D**2, axis=1))[:, np.newaxis]
+        D /= np.sqrt(np.sum(D ** 2, axis=1))[:, np.newaxis]
         return D
 
     transform_algorithm = "lasso_cd"
@@ -493,7 +493,7 @@ def test_dict_learning_online_partial_fit():
     n_components = 12
     rng = np.random.RandomState(0)
     V = rng.randn(n_components, n_features)  # random init
-    V /= np.sum(V**2, axis=1)[:, np.newaxis]
+    V /= np.sum(V ** 2, axis=1)[:, np.newaxis]
     dict1 = MiniBatchDictionaryLearning(
         n_components,
         max_iter=10,
@@ -523,7 +523,7 @@ def test_sparse_encode_shapes():
     n_components = 12
     rng = np.random.RandomState(0)
     V = rng.randn(n_components, n_features)  # random init
-    V /= np.sum(V**2, axis=1)[:, np.newaxis]
+    V /= np.sum(V ** 2, axis=1)[:, np.newaxis]
     for algo in ("lasso_lars", "lasso_cd", "lars", "omp", "threshold"):
         code = sparse_encode(X, V, algorithm=algo)
         assert code.shape == (n_samples, n_components)
@@ -535,7 +535,7 @@ def test_sparse_encode_positivity(algo, positive):
     n_components = 12
     rng = np.random.RandomState(0)
     V = rng.randn(n_components, n_features)  # random init
-    V /= np.sum(V**2, axis=1)[:, np.newaxis]
+    V /= np.sum(V ** 2, axis=1)[:, np.newaxis]
     code = sparse_encode(X, V, algorithm=algo, positive=positive)
     if positive:
         assert (code >= 0).all()
@@ -548,7 +548,7 @@ def test_sparse_encode_unavailable_positivity(algo):
     n_components = 12
     rng = np.random.RandomState(0)
     V = rng.randn(n_components, n_features)  # random init
-    V /= np.sum(V**2, axis=1)[:, np.newaxis]
+    V /= np.sum(V ** 2, axis=1)[:, np.newaxis]
     err_msg = "Positive constraint not supported for '{}' coding method."
     err_msg = err_msg.format(algo)
     with pytest.raises(ValueError, match=err_msg):
@@ -559,7 +559,7 @@ def test_sparse_encode_input():
     n_components = 100
     rng = np.random.RandomState(0)
     V = rng.randn(n_components, n_features)  # random init
-    V /= np.sum(V**2, axis=1)[:, np.newaxis]
+    V /= np.sum(V ** 2, axis=1)[:, np.newaxis]
     Xf = check_array(X, order="F")
     for algo in ("lasso_lars", "lasso_cd", "lars", "omp", "threshold"):
         a = sparse_encode(X, V, algorithm=algo)
@@ -571,7 +571,7 @@ def test_sparse_encode_error():
     n_components = 12
     rng = np.random.RandomState(0)
     V = rng.randn(n_components, n_features)  # random init
-    V /= np.sum(V**2, axis=1)[:, np.newaxis]
+    V /= np.sum(V ** 2, axis=1)[:, np.newaxis]
     code = sparse_encode(X, V, alpha=0.001)
     assert not np.all(code == 0)
     assert np.sqrt(np.sum((np.dot(code, V) - X) ** 2)) < 0.1
@@ -597,7 +597,7 @@ def test_sparse_coder_estimator():
     n_components = 12
     rng = np.random.RandomState(0)
     V = rng.randn(n_components, n_features)  # random init
-    V /= np.sum(V**2, axis=1)[:, np.newaxis]
+    V /= np.sum(V ** 2, axis=1)[:, np.newaxis]
     coder = SparseCoder(
         dictionary=V, transform_algorithm="lasso_lars", transform_alpha=0.001
     ).transform(X)
@@ -609,7 +609,7 @@ def test_sparse_coder_estimator_clone():
     n_components = 12
     rng = np.random.RandomState(0)
     V = rng.randn(n_components, n_features)  # random init
-    V /= np.sum(V**2, axis=1)[:, np.newaxis]
+    V /= np.sum(V ** 2, axis=1)[:, np.newaxis]
     coder = SparseCoder(
         dictionary=V, transform_algorithm="lasso_lars", transform_alpha=0.001
     )
@@ -975,7 +975,7 @@ def test_dict_learning_numerical_consistency(method):
     # instead of comparing directly U and V.
     assert_allclose(np.matmul(U_64, V_64), np.matmul(U_32, V_32), rtol=rtol)
     assert_allclose(np.sum(np.abs(U_64)), np.sum(np.abs(U_32)), rtol=rtol)
-    assert_allclose(np.sum(V_64**2), np.sum(V_32**2), rtol=rtol)
+    assert_allclose(np.sum(V_64 ** 2), np.sum(V_32 ** 2), rtol=rtol)
     # verify an obtained solution is not degenerate
     assert np.mean(U_64 != 0.0) > 0.05
     assert np.count_nonzero(U_64 != 0.0) == np.count_nonzero(U_32 != 0.0)
@@ -1039,7 +1039,7 @@ def test_dict_learning_online_numerical_consistency(method):
     # instead of comparing directly U and V.
     assert_allclose(np.matmul(U_64, V_64), np.matmul(U_32, V_32), rtol=rtol)
     assert_allclose(np.sum(np.abs(U_64)), np.sum(np.abs(U_32)), rtol=rtol)
-    assert_allclose(np.sum(V_64**2), np.sum(V_32**2), rtol=rtol)
+    assert_allclose(np.sum(V_64 ** 2), np.sum(V_32 ** 2), rtol=rtol)
     # verify an obtained solution is not degenerate
     assert np.mean(U_64 != 0.0) > 0.05
     assert np.count_nonzero(U_64 != 0.0) == np.count_nonzero(U_32 != 0.0)

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -39,7 +39,7 @@ def test_gs():
     W, _, _ = np.linalg.svd(rng.randn(10, 10))
     w = rng.randn(10)
     _gs_decorrelation(w, W, 10)
-    assert (w**2).sum() < 1.0e-10
+    assert (w ** 2).sum() < 1.0e-10
     w = rng.randn(10)
     u = _gs_decorrelation(w, W, 5)
     tmp = np.dot(u, W.T)
@@ -99,7 +99,7 @@ def test_fastica_simple(add_noise, global_random_seed, global_dtype):
 
     # function as fun arg
     def g_test(x):
-        return x**3, (3 * x**2).mean(axis=-1)
+        return x ** 3, (3 * x ** 2).mean(axis=-1)
 
     algos = ["parallel", "deflation"]
     nls = ["logcosh", "exp", "cube", g_test]

--- a/sklearn/decomposition/tests/test_incremental_pca.py
+++ b/sklearn/decomposition/tests/test_incremental_pca.py
@@ -97,7 +97,7 @@ def test_incremental_pca_check_projection():
     Yt = IncrementalPCA(n_components=2).fit(X).transform(Xt)
 
     # Normalize
-    Yt /= np.sqrt((Yt**2).sum())
+    Yt /= np.sqrt((Yt ** 2).sum())
 
     # Make sure that the first element of Yt is ~1, this means
     # the reconstruction worked as expected
@@ -331,18 +331,18 @@ def test_singular_values():
     X_pca = pca.transform(X)
     X_ipca = ipca.transform(X)
     assert_array_almost_equal(
-        np.sum(pca.singular_values_**2.0), np.linalg.norm(X_pca, "fro") ** 2.0, 12
+        np.sum(pca.singular_values_ ** 2.0), np.linalg.norm(X_pca, "fro") ** 2.0, 12
     )
     assert_array_almost_equal(
-        np.sum(ipca.singular_values_**2.0), np.linalg.norm(X_ipca, "fro") ** 2.0, 2
+        np.sum(ipca.singular_values_ ** 2.0), np.linalg.norm(X_ipca, "fro") ** 2.0, 2
     )
 
     # Compare to the 2-norms of the score vectors
     assert_array_almost_equal(
-        pca.singular_values_, np.sqrt(np.sum(X_pca**2.0, axis=0)), 12
+        pca.singular_values_, np.sqrt(np.sum(X_pca ** 2.0, axis=0)), 12
     )
     assert_array_almost_equal(
-        ipca.singular_values_, np.sqrt(np.sum(X_ipca**2.0, axis=0)), 2
+        ipca.singular_values_, np.sqrt(np.sum(X_ipca ** 2.0, axis=0)), 2
     )
 
     # Set the singular values and see what we get back
@@ -358,7 +358,7 @@ def test_singular_values():
     ipca = IncrementalPCA(n_components=3, batch_size=100)
 
     X_pca = pca.fit_transform(X)
-    X_pca /= np.sqrt(np.sum(X_pca**2.0, axis=0))
+    X_pca /= np.sqrt(np.sum(X_pca ** 2.0, axis=0))
     X_pca[:, 0] *= 3.142
     X_pca[:, 1] *= 2.718
 

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -347,8 +347,8 @@ def _beta_divergence_dense(X, W, H, beta):
         div = X_nonzero / WH_Xnonzero
         res = np.sum(div) - X.size - np.sum(np.log(div))
     else:
-        res = (X_nonzero**beta).sum()
-        res += (beta - 1) * (WH**beta).sum()
+        res = (X_nonzero ** beta).sum()
+        res += (beta - 1) * (WH ** beta).sum()
         res -= beta * (X_nonzero * (WH_Xnonzero ** (beta - 1))).sum()
         res /= beta * (beta - 1)
 
@@ -636,8 +636,8 @@ def test_nmf_decreasing(solver):
                 nmf._beta_divergence(X, W, H, beta_loss)
                 + alpha * l1_ratio * n_features * W.sum()
                 + alpha * l1_ratio * n_samples * H.sum()
-                + alpha * (1 - l1_ratio) * n_features * (W**2).sum()
-                + alpha * (1 - l1_ratio) * n_samples * (H**2).sum()
+                + alpha * (1 - l1_ratio) * n_features * (W ** 2).sum()
+                + alpha * (1 - l1_ratio) * n_samples * (H ** 2).sum()
             )
             if previous_loss is not None:
                 assert previous_loss > loss

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -172,10 +172,10 @@ def test_pca_singular_values(svd_solver):
 
     # compare to the Frobenius norm
     assert_allclose(
-        np.sum(pca.singular_values_**2), np.linalg.norm(X_trans, "fro") ** 2
+        np.sum(pca.singular_values_ ** 2), np.linalg.norm(X_trans, "fro") ** 2
     )
     # Compare to the 2-norms of the score vectors
-    assert_allclose(pca.singular_values_, np.sqrt(np.sum(X_trans**2, axis=0)))
+    assert_allclose(pca.singular_values_, np.sqrt(np.sum(X_trans ** 2, axis=0)))
 
     # set the singular values and see what er get back
     n_samples, n_features = 100, 110
@@ -183,7 +183,7 @@ def test_pca_singular_values(svd_solver):
 
     pca = PCA(n_components=3, svd_solver=svd_solver, random_state=rng)
     X_trans = pca.fit_transform(X)
-    X_trans /= np.sqrt(np.sum(X_trans**2, axis=0))
+    X_trans /= np.sqrt(np.sum(X_trans ** 2, axis=0))
     X_trans[:, 0] *= 3.142
     X_trans[:, 1] *= 2.718
     X_hat = np.dot(X_trans, pca.components_)
@@ -201,7 +201,7 @@ def test_pca_check_projection(svd_solver):
     Xt = 0.1 * rng.randn(1, p) + np.array([3, 4, 5])
 
     Yt = PCA(n_components=2, svd_solver=svd_solver).fit(X).transform(Xt)
-    Yt /= np.sqrt((Yt**2).sum())
+    Yt /= np.sqrt((Yt ** 2).sum())
 
     assert_allclose(np.abs(Yt[0][0]), 1.0, rtol=5e-3)
 
@@ -413,7 +413,7 @@ def test_pca_score(svd_solver):
     pca.fit(X)
 
     ll1 = pca.score(X)
-    h = -0.5 * np.log(2 * np.pi * np.exp(1) * 0.1**2) * p
+    h = -0.5 * np.log(2 * np.pi * np.exp(1) * 0.1 ** 2) * p
     assert_allclose(ll1 / h, 1, rtol=5e-2)
 
     ll2 = pca.score(rng.randn(n, p) * 0.2 + np.array([3, 4, 5]))

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -146,14 +146,14 @@ def test_singular_values_consistency(solver):
     # Compare to the Frobenius norm
     X_pca = pca.transform(X)
     assert_allclose(
-        np.sum(pca.singular_values_**2.0),
+        np.sum(pca.singular_values_ ** 2.0),
         np.linalg.norm(X_pca, "fro") ** 2.0,
         rtol=1e-2,
     )
 
     # Compare to the 2-norms of the score vectors
     assert_allclose(
-        pca.singular_values_, np.sqrt(np.sum(X_pca**2.0, axis=0)), rtol=1e-2
+        pca.singular_values_, np.sqrt(np.sum(X_pca ** 2.0, axis=0)), rtol=1e-2
     )
 
 
@@ -169,7 +169,7 @@ def test_singular_values_expected(solver):
     pca = TruncatedSVD(n_components=3, algorithm=solver, random_state=rng)
     X_pca = pca.fit_transform(X)
 
-    X_pca /= np.sqrt(np.sum(X_pca**2.0, axis=0))
+    X_pca /= np.sqrt(np.sum(X_pca ** 2.0, axis=0))
     X_pca[:, 0] *= 3.142
     X_pca[:, 1] *= 2.718
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -513,14 +513,14 @@ class LinearDiscriminantAnalysis(
         if self._max_components == 0:
             self.explained_variance_ratio_ = np.empty((0,), dtype=S.dtype)
         else:
-            self.explained_variance_ratio_ = (S**2 / np.sum(S**2))[
+            self.explained_variance_ratio_ = (S ** 2 / np.sum(S ** 2))[
                 : self._max_components
             ]
 
         rank = np.sum(S > self.tol * S[0])
         self.scalings_ = np.dot(scalings, Vt.T[:, :rank])
         coef = np.dot(self.means_ - self.xbar_, self.scalings_)
-        self.intercept_ = -0.5 * np.sum(coef**2, axis=1) + np.log(self.priors_)
+        self.intercept_ = -0.5 * np.sum(coef ** 2, axis=1) + np.log(self.priors_)
         self.coef_ = np.dot(coef, self.scalings_.T)
         self.intercept_ -= np.dot(self.xbar_, self.coef_.T)
 
@@ -884,7 +884,7 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
             rank = np.sum(S > self.tol)
             if rank < n_features:
                 warnings.warn("Variables are collinear")
-            S2 = (S**2) / (len(Xg) - 1)
+            S2 = (S ** 2) / (len(Xg) - 1)
             S2 = ((1 - self.reg_param) * S2) + self.reg_param
             if self.store_covariance or store_covariance:
                 # cov = V * (S^2 / (n-1)) * V.T
@@ -909,7 +909,7 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
             S = self.scalings_[i]
             Xm = X - self.means_[i]
             X2 = np.dot(Xm, R * (S ** (-0.5)))
-            norm2.append(np.sum(X2**2, axis=1))
+            norm2.append(np.sum(X2 ** 2, axis=1))
         norm2 = np.array(norm2).T  # shape = [len(X), n_classes]
         u = np.asarray([np.sum(np.log(s)) for s in self.scalings_])
         return -0.5 * (norm2 + u) + np.log(self.priors_)

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -510,9 +510,13 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
                 )
 
             if self.oob_score is True:
-                self._set_oob_score_and_attributes(X, y, scoring_function=accuracy_score)
+                self._set_oob_score_and_attributes(
+                    X, y, scoring_function=accuracy_score
+                )
             else:
-                self._set_oob_score_and_attributes(X, y, scoring_function=self.oob_score)
+                self._set_oob_score_and_attributes(
+                    X, y, scoring_function=self.oob_score
+                )
 
         # Decapsulate classes_ attributes
         if hasattr(self, "classes_") and self.n_outputs_ == 1:
@@ -785,8 +789,7 @@ class ForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
                     raise ValueError(
                         "Valid presets for class_weight include "
                         '"balanced" and "balanced_subsample".'
-                        'Given "%s".'
-                        % self.class_weight
+                        'Given "%s".' % self.class_weight
                     )
                 if self.warm_start:
                     warn(

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -508,7 +508,11 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
                     "supported: continuous, continuous-multioutput, binary, "
                     "multiclass, multilabel-indicator."
                 )
-            self._set_oob_score_and_attributes(X, y)
+
+            if self.oob_score is True:
+                self._set_oob_score_and_attributes(X, y, scoring_function=accuracy_score)
+            else:
+                self._set_oob_score_and_attributes(X, y, scoring_function=self.oob_score)
 
         # Decapsulate classes_ attributes
         if hasattr(self, "classes_") and self.n_outputs_ == 1:
@@ -735,7 +739,7 @@ class ForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
             y_pred = np.rollaxis(y_pred, axis=0, start=3)
         return y_pred
 
-    def _set_oob_score_and_attributes(self, X, y):
+    def _set_oob_score_and_attributes(self, X, y, scoring_function=accuracy_score):
         """Compute and set the OOB score and attributes.
 
         Parameters
@@ -749,7 +753,7 @@ class ForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
         if self.oob_decision_function_.shape[-1] == 1:
             # drop the n_outputs axis if there is a single output
             self.oob_decision_function_ = self.oob_decision_function_.squeeze(axis=-1)
-        self.oob_score_ = accuracy_score(
+        self.oob_score_ = scoring_function(
             y, np.argmax(self.oob_decision_function_, axis=1)
         )
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -614,8 +614,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                         if (
                             "pass parameters to specific steps of "
                             "your pipeline using the "
-                            "stepname__parameter"
-                            in str(e)
+                            "stepname__parameter" in str(e)
                         ):  # pipeline
                             raise ValueError(msg) from e
                         else:  # regular estimator whose input checking failed
@@ -901,8 +900,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             warnings.warn(
                 "Using recursion method with a non-constant init predictor "
                 "will lead to incorrect partial dependence values. "
-                "Got init=%s."
-                % self.init,
+                "Got init=%s." % self.init,
                 UserWarning,
             )
         grid = np.asarray(grid, dtype=DTYPE, order="C")

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
@@ -424,16 +424,16 @@ def test_make_known_categories_bitsets():
     # first categorical feature: [2, 4, 10, 240]
     f_idx = 1
     mapped_f_idx = f_idx_map[f_idx]
-    expected_cat_bitset[mapped_f_idx, 0] = 2**2 + 2**4 + 2**10
+    expected_cat_bitset[mapped_f_idx, 0] = 2 ** 2 + 2 ** 4 + 2 ** 10
     # 240 = 32**7 + 16, therefore the 16th bit of the 7th array is 1.
-    expected_cat_bitset[mapped_f_idx, 7] = 2**16
+    expected_cat_bitset[mapped_f_idx, 7] = 2 ** 16
 
     # second categorical feature [30, 70, 180]
     f_idx = 2
     mapped_f_idx = f_idx_map[f_idx]
-    expected_cat_bitset[mapped_f_idx, 0] = 2**30
-    expected_cat_bitset[mapped_f_idx, 2] = 2**6
-    expected_cat_bitset[mapped_f_idx, 5] = 2**20
+    expected_cat_bitset[mapped_f_idx, 0] = 2 ** 30
+    expected_cat_bitset[mapped_f_idx, 2] = 2 ** 6
+    expected_cat_bitset[mapped_f_idx, 5] = 2 ** 20
 
     assert_allclose(expected_cat_bitset, known_cat_bitsets)
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_bitset.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_bitset.py
@@ -13,10 +13,10 @@ from sklearn.ensemble._hist_gradient_boosting.common import X_DTYPE
 @pytest.mark.parametrize(
     "values_to_insert, expected_bitset",
     [
-        ([0, 4, 33], np.array([2**0 + 2**4, 2**1, 0], dtype=np.uint32)),
+        ([0, 4, 33], np.array([2 ** 0 + 2 ** 4, 2 ** 1, 0], dtype=np.uint32)),
         (
             [31, 32, 33, 79],
-            np.array([2**31, 2**0 + 2**1, 2**15], dtype=np.uint32),
+            np.array([2 ** 31, 2 ** 0 + 2 ** 1, 2 ** 15], dtype=np.uint32),
         ),
     ],
 )
@@ -39,9 +39,9 @@ def test_set_get_bitset(values_to_insert, expected_bitset):
         (
             [3, 4, 5, 10, 31, 32, 43],
             [0, 2, 4, 5, 6],
-            [2**3 + 2**5 + 2**31, 2**0 + 2**11],
+            [2 ** 3 + 2 ** 5 + 2 ** 31, 2 ** 0 + 2 ** 11],
         ),
-        ([3, 33, 50, 52], [1, 3], [0, 2**1 + 2**20]),
+        ([3, 33, 50, 52], [1, 3], [0, 2 ** 1 + 2 ** 20]),
     ],
 )
 def test_raw_bitset_from_binned_bitset(

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
@@ -476,12 +476,12 @@ def test_grow_tree_categories():
     assert left["count"] >= right["count"]
 
     # check binned category value (1)
-    expected_binned_cat_bitset = [2**1] + [0] * 7
+    expected_binned_cat_bitset = [2 ** 1] + [0] * 7
     binned_cat_bitset = predictor.binned_left_cat_bitsets
     assert_array_equal(binned_cat_bitset[0], expected_binned_cat_bitset)
 
     # check raw category value (9)
-    expected_raw_cat_bitsets = [2**9] + [0] * 7
+    expected_raw_cat_bitsets = [2 ** 9] + [0] * 7
     raw_cat_bitsets = predictor.raw_left_cat_bitsets
     assert_array_equal(raw_cat_bitsets[0], expected_raw_cat_bitsets)
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -161,7 +161,7 @@ def test_categorical_predictor(bins_go_left, expected_predictions):
 
     # manually construct bitset
     known_cat_bitsets = np.zeros((1, 8), dtype=np.uint32)
-    known_cat_bitsets[0, 0] = np.sum(2**categories, dtype=np.uint32)
+    known_cat_bitsets[0, 0] = np.sum(2 ** categories, dtype=np.uint32)
     f_idx_map = np.array([0], dtype=np.uint32)
 
     # Check with un-binned data

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -279,8 +279,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
                 raise ValueError(
                     "max_samples (%s) is not supported."
                     'Valid choices are: "auto", int or'
-                    "float"
-                    % self.max_samples
+                    "float" % self.max_samples
                 )
 
         elif isinstance(self.max_samples, numbers.Integral):

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1256,7 +1256,7 @@ def check_class_weights(name):
 
     # Check that sample_weight and class_weight are multiplicative
     clf1 = ForestClassifier(random_state=0)
-    clf1.fit(iris.data, iris.target, sample_weight**2)
+    clf1.fit(iris.data, iris.target, sample_weight ** 2)
     clf2 = ForestClassifier(class_weight=class_weight, random_state=0)
     clf2.fit(iris.data, iris.target, sample_weight)
     assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -94,7 +94,7 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
 
     def __init__(
         self,
-        n_features=(2**20),
+        n_features=(2 ** 20),
         *,
         input_type="dict",
         dtype=np.float64,

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -27,7 +27,7 @@ def test_feature_hasher_strings():
     ]
 
     for lg_n_features in (7, 9, 11, 16, 22):
-        n_features = 2**lg_n_features
+        n_features = 2 ** lg_n_features
 
         it = (x for x in raw_X)  # iterable
 
@@ -56,15 +56,15 @@ def test_hashing_transform_seed():
     ]
 
     raw_X_ = (((f, 1) for f in x) for x in raw_X)
-    indices, indptr, _ = _hashing_transform(raw_X_, 2**7, str, False)
+    indices, indptr, _ = _hashing_transform(raw_X_, 2 ** 7, str, False)
 
     raw_X_ = (((f, 1) for f in x) for x in raw_X)
-    indices_0, indptr_0, _ = _hashing_transform(raw_X_, 2**7, str, False, seed=0)
+    indices_0, indptr_0, _ = _hashing_transform(raw_X_, 2 ** 7, str, False, seed=0)
     assert_array_equal(indices, indices_0)
     assert_array_equal(indptr, indptr_0)
 
     raw_X_ = (((f, 1) for f in x) for x in raw_X)
-    indices_1, _, _ = _hashing_transform(raw_X_, 2**7, str, False, seed=1)
+    indices_1, _, _ = _hashing_transform(raw_X_, 2 ** 7, str, False, seed=1)
     with pytest.raises(AssertionError):
         assert_array_equal(indices, indices_1)
 
@@ -129,7 +129,7 @@ def test_hasher_invalid_input():
     with pytest.raises(TypeError):
         feature_hasher.transform(raw_X)
 
-    feature_hasher = FeatureHasher(n_features=np.uint16(2**6))
+    feature_hasher = FeatureHasher(n_features=np.uint16(2 ** 6))
     with pytest.raises(ValueError):
         feature_hasher.transform([])
     with pytest.raises(Exception):

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -55,7 +55,7 @@ def test_grid_to_graph():
     mask = np.zeros((size, size), dtype=bool)
     mask[0:roi_size, 0:roi_size] = True
     mask[-roi_size:, -roi_size:] = True
-    mask = mask.reshape(size**2)
+    mask = mask.reshape(size ** 2)
     A = grid_to_graph(n_x=size, n_y=size, mask=mask, return_as=np.ndarray)
     assert connected_components(A)[0] == 2
 

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -473,7 +473,7 @@ def test_tf_idf_smoothing():
     assert (tfidf >= 0).all()
 
     # check normalization
-    assert_array_almost_equal((tfidf**2).sum(axis=1), [1.0, 1.0, 1.0])
+    assert_array_almost_equal((tfidf ** 2).sum(axis=1), [1.0, 1.0, 1.0])
 
     # this is robust to features with only zeros
     X = [[1, 1, 0], [1, 1, 0], [1, 0, 0]]
@@ -489,7 +489,7 @@ def test_tfidf_no_smoothing():
     assert (tfidf >= 0).all()
 
     # check normalization
-    assert_array_almost_equal((tfidf**2).sum(axis=1), [1.0, 1.0, 1.0])
+    assert_array_almost_equal((tfidf ** 2).sum(axis=1), [1.0, 1.0, 1.0])
 
     # the lack of smoothing make IDF fragile in the presence of feature with
     # only zeros
@@ -1065,7 +1065,7 @@ def test_vectorizer_unicode():
 
     vect = HashingVectorizer(norm=None, alternate_sign=False)
     X_hashed = vect.transform([document])
-    assert X_hashed.shape == (1, 2**20)
+    assert X_hashed.shape == (1, 2 ** 20)
 
     # No collisions on such a small dataset
     assert X_counted.nnz == X_hashed.nnz

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -395,8 +395,7 @@ class _VectorizerMixin:
                     "Your stop_words may be inconsistent with "
                     "your preprocessing. Tokenizing the stop "
                     "words generated tokens %r not in "
-                    "stop_words."
-                    % sorted(inconsistent)
+                    "stop_words." % sorted(inconsistent)
                 )
             return not inconsistent
         except Exception:
@@ -504,8 +503,7 @@ class _VectorizerMixin:
         if min_n > max_m:
             raise ValueError(
                 "Invalid value for ngram_range=%s "
-                "lower boundary larger than the upper boundary."
-                % str(self.ngram_range)
+                "lower boundary larger than the upper boundary." % str(self.ngram_range)
             )
 
     def _warn_for_unused_params(self):
@@ -737,7 +735,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         token_pattern=r"(?u)\b\w\w+\b",
         ngram_range=(1, 1),
         analyzer="word",
-        n_features=(2**20),
+        n_features=(2 ** 20),
         binary=False,
         norm="l2",
         alternate_sign=True,

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -96,7 +96,7 @@ def f_oneway(*args):
     ss_alldata = sum(safe_sqr(a).sum(axis=0) for a in args)
     sums_args = [np.asarray(a.sum(axis=0)) for a in args]
     square_of_sums_alldata = sum(sums_args) ** 2
-    square_of_sums_args = [s**2 for s in sums_args]
+    square_of_sums_args = [s ** 2 for s in sums_args]
     sstot = ss_alldata - square_of_sums_alldata / float(n_samples)
     ssbn = 0.0
     for k, _ in enumerate(args):
@@ -305,7 +305,7 @@ def r_regression(X, y, *, center=True, force_finite=True):
         else:
             X_means = X.mean(axis=0)
         # Compute the scaled standard deviations via moments
-        X_norms = np.sqrt(row_norms(X.T, squared=True) - n_samples * X_means**2)
+        X_norms = np.sqrt(row_norms(X.T, squared=True) - n_samples * X_means ** 2)
     else:
         X_norms = row_norms(X.T)
 
@@ -407,7 +407,7 @@ def f_regression(X, y, *, center=True, force_finite=True):
     )
     deg_of_freedom = y.size - (2 if center else 1)
 
-    corr_coef_squared = correlation_coefficient**2
+    corr_coef_squared = correlation_coefficient ** 2
 
     with np.errstate(divide="ignore", invalid="ignore"):
         f_statistic = corr_coef_squared / (1 - corr_coef_squared) * deg_of_freedom

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -37,8 +37,8 @@ def test_compute_mi_cc(global_dtype):
     corr = 0.5
     cov = np.array(
         [
-            [sigma_1**2, corr * sigma_1 * sigma_2],
-            [corr * sigma_1 * sigma_2, sigma_2**2],
+            [sigma_1 ** 2, corr * sigma_1 * sigma_2],
+            [corr * sigma_1 * sigma_2, sigma_2 ** 2],
         ]
     )
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -320,7 +320,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         gamma = LAMBDAS * f_star
         integrals = (
             np.sqrt(np.pi / alpha)
-            * erf(gamma * np.sqrt(alpha / (alpha + LAMBDAS**2)))
+            * erf(gamma * np.sqrt(alpha / (alpha + LAMBDAS ** 2)))
             / (2 * np.sqrt(var_f_star * 2 * np.pi))
         )
         pi_star = (COEFS * integrals).sum(axis=0) + 0.5 * COEFS.sum()

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -409,7 +409,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 y_cov = self.kernel_(X) - V.T @ V
 
                 # undo normalisation
-                y_cov = np.outer(y_cov, self._y_train_std**2).reshape(
+                y_cov = np.outer(y_cov, self._y_train_std ** 2).reshape(
                     *y_cov.shape, -1
                 )
                 # if y_cov has shape (n_samples, n_samples, 1), reshape to
@@ -436,7 +436,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     y_var[y_var_negative] = 0.0
 
                 # undo normalisation
-                y_var = np.outer(y_var, self._y_train_std**2).reshape(
+                y_var = np.outer(y_var, self._y_train_std ** 2).reshape(
                     *y_var.shape, -1
                 )
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1122,10 +1122,10 @@ class Exponentiation(Kernel):
         if eval_gradient:
             K, K_gradient = self.kernel(X, Y, eval_gradient=True)
             K_gradient *= self.exponent * K[:, :, np.newaxis] ** (self.exponent - 1)
-            return K**self.exponent, K_gradient
+            return K ** self.exponent, K_gradient
         else:
             K = self.kernel(X, Y, eval_gradient=False)
-            return K**self.exponent
+            return K ** self.exponent
 
     def diag(self, X):
         """Returns the diagonal of the kernel k(X, X).
@@ -1554,7 +1554,7 @@ class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             elif self.anisotropic:
                 # We need to recompute the pairwise dimension-wise distances
                 K_gradient = (X[:, np.newaxis, :] - X[np.newaxis, :, :]) ** 2 / (
-                    length_scale**2
+                    length_scale ** 2
                 )
                 K_gradient *= K[..., np.newaxis]
                 return K, K_gradient
@@ -1701,15 +1701,15 @@ class Matern(RBF):
             K = (1.0 + K) * np.exp(-K)
         elif self.nu == 2.5:
             K = dists * math.sqrt(5)
-            K = (1.0 + K + K**2 / 3.0) * np.exp(-K)
+            K = (1.0 + K + K ** 2 / 3.0) * np.exp(-K)
         elif self.nu == np.inf:
-            K = np.exp(-(dists**2) / 2.0)
+            K = np.exp(-(dists ** 2) / 2.0)
         else:  # general case; expensive to evaluate
             K = dists
             K[K == 0.0] += np.finfo(float).eps  # strict zeros result in nan
             tmp = math.sqrt(2 * self.nu) * K
             K.fill((2 ** (1.0 - self.nu)) / gamma(self.nu))
-            K *= tmp**self.nu
+            K *= tmp ** self.nu
             K *= kv(self.nu, tmp)
 
         if Y is None:
@@ -1726,10 +1726,10 @@ class Matern(RBF):
             # We need to recompute the pairwise dimension-wise distances
             if self.anisotropic:
                 D = (X[:, np.newaxis, :] - X[np.newaxis, :, :]) ** 2 / (
-                    length_scale**2
+                    length_scale ** 2
                 )
             else:
-                D = squareform(dists**2)[:, :, np.newaxis]
+                D = squareform(dists ** 2)[:, :, np.newaxis]
 
             if self.nu == 0.5:
                 denominator = np.sqrt(D.sum(axis=2))[:, :, np.newaxis]
@@ -1888,20 +1888,20 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
         X = np.atleast_2d(X)
         if Y is None:
             dists = squareform(pdist(X, metric="sqeuclidean"))
-            tmp = dists / (2 * self.alpha * self.length_scale**2)
+            tmp = dists / (2 * self.alpha * self.length_scale ** 2)
             base = 1 + tmp
-            K = base**-self.alpha
+            K = base ** -self.alpha
             np.fill_diagonal(K, 1)
         else:
             if eval_gradient:
                 raise ValueError("Gradient can only be evaluated when Y is None.")
             dists = cdist(X, Y, metric="sqeuclidean")
-            K = (1 + dists / (2 * self.alpha * self.length_scale**2)) ** -self.alpha
+            K = (1 + dists / (2 * self.alpha * self.length_scale ** 2)) ** -self.alpha
 
         if eval_gradient:
             # gradient with respect to length_scale
             if not self.hyperparameter_length_scale.fixed:
-                length_scale_gradient = dists * K / (self.length_scale**2 * base)
+                length_scale_gradient = dists * K / (self.length_scale ** 2 * base)
                 length_scale_gradient = length_scale_gradient[:, :, np.newaxis]
             else:  # l is kept fixed
                 length_scale_gradient = np.empty((K.shape[0], K.shape[1], 0))
@@ -1910,7 +1910,7 @@ class RationalQuadratic(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             if not self.hyperparameter_alpha.fixed:
                 alpha_gradient = K * (
                     -self.alpha * np.log(base)
-                    + dists / (2 * self.length_scale**2 * base)
+                    + dists / (2 * self.length_scale ** 2 * base)
                 )
                 alpha_gradient = alpha_gradient[:, :, np.newaxis]
             else:  # alpha is kept fixed
@@ -2048,14 +2048,14 @@ class ExpSineSquared(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
             cos_of_arg = np.cos(arg)
             # gradient with respect to length_scale
             if not self.hyperparameter_length_scale.fixed:
-                length_scale_gradient = 4 / self.length_scale**2 * sin_of_arg**2 * K
+                length_scale_gradient = 4 / self.length_scale ** 2 * sin_of_arg ** 2 * K
                 length_scale_gradient = length_scale_gradient[:, :, np.newaxis]
             else:  # length_scale is kept fixed
                 length_scale_gradient = np.empty((K.shape[0], K.shape[1], 0))
             # gradient with respect to p
             if not self.hyperparameter_periodicity.fixed:
                 periodicity_gradient = (
-                    4 * arg / self.length_scale**2 * cos_of_arg * sin_of_arg * K
+                    4 * arg / self.length_scale ** 2 * cos_of_arg * sin_of_arg * K
                 )
                 periodicity_gradient = periodicity_gradient[:, :, np.newaxis]
             else:  # p is kept fixed
@@ -2166,16 +2166,16 @@ class DotProduct(Kernel):
         """
         X = np.atleast_2d(X)
         if Y is None:
-            K = np.inner(X, X) + self.sigma_0**2
+            K = np.inner(X, X) + self.sigma_0 ** 2
         else:
             if eval_gradient:
                 raise ValueError("Gradient can only be evaluated when Y is None.")
-            K = np.inner(X, Y) + self.sigma_0**2
+            K = np.inner(X, Y) + self.sigma_0 ** 2
 
         if eval_gradient:
             if not self.hyperparameter_sigma_0.fixed:
                 K_gradient = np.empty((K.shape[0], K.shape[1], 1))
-                K_gradient[..., 0] = 2 * self.sigma_0**2
+                K_gradient[..., 0] = 2 * self.sigma_0 ** 2
                 return K, K_gradient
             else:
                 return K, np.empty((X.shape[0], X.shape[0], 0))
@@ -2199,7 +2199,7 @@ class DotProduct(Kernel):
         K_diag : ndarray of shape (n_samples_X,)
             Diagonal of kernel k(X, X).
         """
-        return np.einsum("ij,ij->i", X, X) + self.sigma_0**2
+        return np.einsum("ij,ij->i", X, X) + self.sigma_0 ** 2
 
     def is_stationary(self):
         """Returns whether the kernel is stationary."""

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -216,8 +216,7 @@ def test_warning_bounds():
 
         assert issubclass(record[0].category, ConvergenceWarning)
         assert (
-            record[0].message.args[0]
-            == "The optimal value found for "
+            record[0].message.args[0] == "The optimal value found for "
             "dimension 0 of parameter "
             "k1__noise_level is close to the "
             "specified upper bound 0.001. "
@@ -227,8 +226,7 @@ def test_warning_bounds():
 
         assert issubclass(record[1].category, ConvergenceWarning)
         assert (
-            record[1].message.args[0]
-            == "The optimal value found for "
+            record[1].message.args[0] == "The optimal value found for "
             "dimension 0 of parameter "
             "k2__length_scale is close to the "
             "specified lower bound 1000.0. "
@@ -248,8 +246,7 @@ def test_warning_bounds():
 
         assert issubclass(record[0].category, ConvergenceWarning)
         assert (
-            record[0].message.args[0]
-            == "The optimal value found for "
+            record[0].message.args[0] == "The optimal value found for "
             "dimension 0 of parameter "
             "length_scale is close to the "
             "specified upper bound 100.0. "
@@ -259,8 +256,7 @@ def test_warning_bounds():
 
         assert issubclass(record[1].category, ConvergenceWarning)
         assert (
-            record[1].message.args[0]
-            == "The optimal value found for "
+            record[1].message.args[0] == "The optimal value found for "
             "dimension 1 of parameter "
             "length_scale is close to the "
             "specified upper bound 100.0. "

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -50,7 +50,7 @@ non_fixed_kernels = [kernel for kernel in kernels if kernel != fixed_kernel]
 
 @pytest.mark.parametrize("kernel", kernels)
 def test_gpr_interpolation(kernel):
-    if sys.maxsize <= 2**32:
+    if sys.maxsize <= 2 ** 32:
         pytest.xfail("This test may fail on 32 bit Python")
 
     # Test the interpolating property for different kernels.
@@ -78,7 +78,7 @@ def test_gpr_interpolation_structured():
 
 @pytest.mark.parametrize("kernel", non_fixed_kernels)
 def test_lml_improving(kernel):
-    if sys.maxsize <= 2**32:
+    if sys.maxsize <= 2 ** 32:
         pytest.xfail("This test may fail on 32 bit Python")
 
     # Test that hyperparameter-tuning improves log-marginal likelihood.
@@ -191,7 +191,7 @@ def test_no_optimizer():
 @pytest.mark.parametrize("kernel", kernels)
 @pytest.mark.parametrize("target", [y, np.ones(X.shape[0], dtype=np.float64)])
 def test_predict_cov_vs_std(kernel, target):
-    if sys.maxsize <= 2**32:
+    if sys.maxsize <= 2 ** 32:
         pytest.xfail("This test may fail on 32 bit Python")
 
     # Test that predicted std.-dev. is consistent with cov's diagonal.
@@ -276,7 +276,7 @@ def test_y_normalization(kernel):
     assert_almost_equal(y_pred_std, y_pred_std_norm)
 
     _, y_cov = gpr.predict(X2, return_cov=True)
-    y_cov = y_cov * y_std**2
+    y_cov = y_cov * y_std ** 2
     _, y_cov_norm = gpr_norm.predict(X2, return_cov=True)
 
     assert_almost_equal(y_cov, y_cov_norm)
@@ -487,8 +487,7 @@ def test_warning_bounds():
 
         assert issubclass(record[0].category, ConvergenceWarning)
         assert (
-            record[0].message.args[0]
-            == "The optimal value found for "
+            record[0].message.args[0] == "The optimal value found for "
             "dimension 0 of parameter "
             "k1__noise_level is close to the "
             "specified upper bound 0.001. "
@@ -498,8 +497,7 @@ def test_warning_bounds():
 
         assert issubclass(record[1].category, ConvergenceWarning)
         assert (
-            record[1].message.args[0]
-            == "The optimal value found for "
+            record[1].message.args[0] == "The optimal value found for "
             "dimension 0 of parameter "
             "k2__length_scale is close to the "
             "specified lower bound 1000.0. "
@@ -519,8 +517,7 @@ def test_warning_bounds():
 
         assert issubclass(record[0].category, ConvergenceWarning)
         assert (
-            record[0].message.args[0]
-            == "The optimal value found for "
+            record[0].message.args[0] == "The optimal value found for "
             "dimension 0 of parameter "
             "length_scale is close to the "
             "specified lower bound 10.0. "
@@ -530,8 +527,7 @@ def test_warning_bounds():
 
         assert issubclass(record[1].category, ConvergenceWarning)
         assert (
-            record[1].message.args[0]
-            == "The optimal value found for "
+            record[1].message.args[0] == "The optimal value found for "
             "dimension 1 of parameter "
             "length_scale is close to the "
             "specified lower bound 10.0. "
@@ -544,7 +540,7 @@ def test_bound_check_fixed_hyperparameter():
     # Regression test for issue #17943
     # Check that having a hyperparameter with fixed bounds doesn't cause an
     # error
-    k1 = 50.0**2 * RBF(length_scale=50.0)  # long term smooth rising trend
+    k1 = 50.0 ** 2 * RBF(length_scale=50.0)  # long term smooth rising trend
     k2 = ExpSineSquared(
         length_scale=1.0, periodicity=1.0, periodicity_bounds="fixed"
     )  # seasonal component

--- a/sklearn/inspection/tests/test_permutation_importance.py
+++ b/sklearn/inspection/tests/test_permutation_importance.py
@@ -247,7 +247,7 @@ def test_permutation_importance_linear_regresssion():
     lr = LinearRegression().fit(X, y)
 
     # this relationship can be computed in closed form
-    expected_importances = 2 * lr.coef_**2
+    expected_importances = 2 * lr.coef_ ** 2
     results = permutation_importance(
         lr, X, y, n_repeats=50, scoring="neg_mean_squared_error"
     )
@@ -437,7 +437,7 @@ def test_permutation_importance_sample_weight():
     # the two features importance should equal to 2 on expectation (when using
     # mean absolutes error as the loss function).
     w = np.hstack(
-        [np.repeat(10.0**10, n_half_samples), np.repeat(1.0, n_half_samples)]
+        [np.repeat(10.0 ** 10, n_half_samples), np.repeat(1.0, n_half_samples)]
     )
     lr.fit(x, y, w)
     pi = permutation_importance(

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -132,9 +132,7 @@ def _deprecate_normalize(normalize, default, estimator_name):
     if default and normalize == "deprecated":
         warnings.warn(
             "The default of 'normalize' will be set to False in version 1.2 "
-            "and deprecated in version 1.4.\n"
-            + pipeline_msg
-            + alpha_msg,
+            "and deprecated in version 1.4.\n" + pipeline_msg + alpha_msg,
             FutureWarning,
         )
     elif normalize != "deprecated" and normalize and not default:

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -281,7 +281,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
 
         XT_y = np.dot(X.T, y)
         U, S, Vh = linalg.svd(X, full_matrices=False)
-        eigen_vals_ = S**2
+        eigen_vals_ = S ** 2
 
         # Convergence loop of the bayesian ridge regression
         for iter_ in range(self.n_iter):
@@ -300,7 +300,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
 
             # Update alpha and lambda according to (MacKay, 1992)
             gamma_ = np.sum((alpha_ * eigen_vals_) / (lambda_ + alpha_ * eigen_vals_))
-            lambda_ = (gamma_ + 2 * lambda_1) / (np.sum(coef_**2) + 2 * lambda_2)
+            lambda_ = (gamma_ + 2 * lambda_1) / (np.sum(coef_ ** 2) + 2 * lambda_2)
             alpha_ = (n_samples - gamma_ + 2 * alpha_1) / (rmse_ + 2 * alpha_2)
 
             # Check for convergence
@@ -417,7 +417,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
             n_features * log(lambda_)
             + n_samples * log(alpha_)
             - alpha_ * rmse
-            - lambda_ * np.sum(coef**2)
+            - lambda_ * np.sum(coef ** 2)
             + logdet_sigma
             - n_samples * log(2 * np.pi)
         )
@@ -689,7 +689,7 @@ class ARDRegression(RegressorMixin, LinearModel):
                     + n_samples * log(alpha_)
                     + np.sum(np.log(lambda_))
                 )
-                s -= 0.5 * (alpha_ * rmse_ + (lambda_ * coef_**2).sum())
+                s -= 0.5 * (alpha_ * rmse_ + (lambda_ * coef_ ** 2).sum())
                 self.scores_.append(s)
 
             # Check for convergence

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -177,7 +177,7 @@ def _alpha_grid(
         if normalize:
             Xy /= X_scale[:, np.newaxis]
 
-    alpha_max = np.sqrt(np.sum(Xy**2, axis=1)).max() / (n_samples * l1_ratio)
+    alpha_max = np.sqrt(np.sum(Xy ** 2, axis=1)).max() / (n_samples * l1_ratio)
 
     if alpha_max <= np.finfo(float).resolution:
         alphas = np.empty(n_alphas)
@@ -1448,9 +1448,9 @@ def _path_residuals(
     residues = X_test_coefs - y_test[:, :, np.newaxis]
     residues += intercepts
     if sample_weight is None:
-        this_mse = (residues**2).mean(axis=0)
+        this_mse = (residues ** 2).mean(axis=0)
     else:
-        this_mse = np.average(residues**2, weights=sw_test, axis=0)
+        this_mse = np.average(residues ** 2, weights=sw_test, axis=0)
 
     return this_mse.mean(axis=0)
 

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -76,7 +76,7 @@ def _huber_loss_and_gradient(w, X, y, epsilon, alpha, sample_weight=None):
     n_sw_outliers = np.sum(outliers_sw)
     outlier_loss = (
         2.0 * epsilon * np.sum(outliers_sw * outliers)
-        - sigma * n_sw_outliers * epsilon**2
+        - sigma * n_sw_outliers * epsilon ** 2
     )
 
     # Calculate the quadratic loss due to the non-outliers.-
@@ -110,7 +110,7 @@ def _huber_loss_and_gradient(w, X, y, epsilon, alpha, sample_weight=None):
 
     # Gradient due to sigma.
     grad[-1] = n_samples
-    grad[-1] -= n_sw_outliers * epsilon**2
+    grad[-1] -= n_sw_outliers * epsilon ** 2
     grad[-1] -= squared_loss / sigma
 
     # Gradient due to the intercept.

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -704,7 +704,7 @@ def _lars_path_solver(
                 i = 0
                 L_ = L[:n_active, :n_active].copy()
                 while not np.isfinite(AA):
-                    L_.flat[:: n_active + 1] += (2**i) * eps
+                    L_.flat[:: n_active + 1] += (2 ** i) * eps
                     least_squares, _ = solve_cholesky(
                         L_, sign_active[:n_active], lower=True
                     )
@@ -1447,7 +1447,7 @@ def _lars_path_residues(
         y_test -= y_mean
 
     if normalize:
-        norms = np.sqrt(np.sum(X_train**2, axis=0))
+        norms = np.sqrt(np.sum(X_train ** 2, axis=0))
         nonzeros = np.flatnonzero(norms)
         X_train[:, nonzeros] /= norms[nonzeros]
 
@@ -1684,8 +1684,7 @@ class LarsCV(Lars):
         if hasattr(Gram, "__array__"):
             warnings.warn(
                 'Parameter "precompute" cannot be an array in '
-                '%s. Automatically switch to "auto" instead.'
-                % self.__class__.__name__
+                '%s. Automatically switch to "auto" instead.' % self.__class__.__name__
             )
             Gram = "auto"
 
@@ -2219,7 +2218,7 @@ class LassoLarsIC(LassoLars):
             )
 
         residuals = y[:, np.newaxis] - np.dot(X, coef_path_)
-        residuals_sum_squares = np.sum(residuals**2, axis=0)
+        residuals_sum_squares = np.sum(residuals ** 2, axis=0)
         degrees_of_freedom = np.zeros(coef_path_.shape[1], dtype=int)
         for k, coef in enumerate(coef_path_.T):
             mask = np.abs(coef) > np.finfo(coef.dtype).eps

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1186,8 +1186,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             raise ValueError(
                 "This solver needs samples of at least 2 classes"
                 " in the data, but the data contains only one"
-                " class: %r"
-                % classes_[0]
+                " class: %r" % classes_[0]
             )
 
         if len(self.classes_) == 2:
@@ -1699,8 +1698,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
             ):
                 raise ValueError(
                     "l1_ratios must be a list of numbers between "
-                    "0 and 1; got (l1_ratios=%r)"
-                    % self.l1_ratios
+                    "0 and 1; got (l1_ratios=%r)" % self.l1_ratios
                 )
             l1_ratios_ = self.l1_ratios
         else:
@@ -1760,8 +1758,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
             raise ValueError(
                 "This solver needs samples of at least 2 classes"
                 " in the data, but the data contains only one"
-                " class: %r"
-                % classes[0]
+                " class: %r" % classes[0]
             )
 
         if n_classes == 2:

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -394,7 +394,7 @@ def orthogonal_mp(
         G = np.asfortranarray(G)
         Xy = np.dot(X.T, y)
         if tol is not None:
-            norms_squared = np.sum((y**2), axis=0)
+            norms_squared = np.sum((y ** 2), axis=0)
         else:
             norms_squared = None
         return orthogonal_mp_gram(
@@ -752,7 +752,7 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
                 return_n_iter=True,
             )
         else:
-            norms_sq = np.sum(y**2, axis=0) if self.tol is not None else None
+            norms_sq = np.sum(y ** 2, axis=0) if self.tol is not None else None
 
             coef_, self.n_iter_ = orthogonal_mp_gram(
                 Gram,
@@ -843,7 +843,7 @@ def _omp_path_residues(
         y_test -= y_mean
 
     if normalize:
-        norms = np.sqrt(np.sum(X_train**2, axis=0))
+        norms = np.sqrt(np.sum(X_train ** 2, axis=0))
         nonzeros = np.flatnonzero(norms)
         X_train[:, nonzeros] /= norms[nonzeros]
 

--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -174,11 +174,15 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
             "revised simplex",
         ):
             raise ValueError(f"Invalid value for argument solver, got {self.solver}")
-        elif self.solver in (
-            "highs-ds",
-            "highs-ipm",
-            "highs",
-        ) and sp_version < parse_version("1.6.0"):
+        elif (
+            self.solver
+            in (
+                "highs-ds",
+                "highs-ipm",
+                "highs",
+            )
+            and sp_version < parse_version("1.6.0")
+        ):
             raise ValueError(
                 f"Solver {self.solver} is only available "
                 f"with scipy>=1.6.0, got {sp_version}"

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -43,7 +43,7 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     """
     inlier_ratio = n_inliers / float(n_samples)
     nom = max(_EPSILON, 1 - probability)
-    denom = max(_EPSILON, 1 - inlier_ratio**min_samples)
+    denom = max(_EPSILON, 1 - inlier_ratio ** min_samples)
     if nom == 1:
         return 0
     if denom == 1:
@@ -400,8 +400,7 @@ class RANSACRegressor(
         else:
             raise ValueError(
                 "loss should be 'absolute_error', 'squared_error' or a "
-                "callable. Got %s. "
-                % self.loss
+                "callable. Got %s. " % self.loss
             )
 
         random_state = check_random_state(self.random_state)

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -287,7 +287,7 @@ def _solve_svd(X, y, alpha):
     s_nnz = s[idx][:, np.newaxis]
     UTy = np.dot(U.T, y)
     d = np.zeros((s.size, alpha.size), dtype=X.dtype)
-    d[idx] = s_nnz / (s_nnz**2 + alpha)
+    d[idx] = s_nnz / (s_nnz ** 2 + alpha)
     d_UT_y = d * UTy
     return np.dot(Vt.T, d_UT_y).T
 
@@ -1616,7 +1616,7 @@ class _RidgeGCV(LinearModel):
     @staticmethod
     def _decomp_diag(v_prime, Q):
         # compute diagonal of the matrix: dot(Q, dot(diag(v_prime), Q^T))
-        return (v_prime * Q**2).sum(axis=-1)
+        return (v_prime * Q ** 2).sum(axis=-1)
 
     @staticmethod
     def _diag_dot(D, B):
@@ -1898,7 +1898,7 @@ class _RidgeGCV(LinearModel):
             intercept_column = sqrt_sw[:, None]
             X = np.hstack((X, intercept_column))
         U, singvals, _ = linalg.svd(X, full_matrices=0)
-        singvals_sq = singvals**2
+        singvals_sq = singvals ** 2
         UT_y = np.dot(U.T, y)
         return X_mean, singvals_sq, U, UT_y
 
@@ -1908,15 +1908,15 @@ class _RidgeGCV(LinearModel):
         Used when we have an SVD decomposition of X
         (n_samples > n_features and X is dense).
         """
-        w = ((singvals_sq + alpha) ** -1) - (alpha**-1)
+        w = ((singvals_sq + alpha) ** -1) - (alpha ** -1)
         if self.fit_intercept:
             # detect intercept column
             normalized_sw = sqrt_sw / np.linalg.norm(sqrt_sw)
             intercept_dim = _find_smallest_angle(normalized_sw, U)
             # cancel the regularization for the intercept
-            w[intercept_dim] = -(alpha**-1)
-        c = np.dot(U, self._diag_dot(w, UT_y)) + (alpha**-1) * y
-        G_inverse_diag = self._decomp_diag(w, U) + (alpha**-1)
+            w[intercept_dim] = -(alpha ** -1)
+        c = np.dot(U, self._diag_dot(w, UT_y)) + (alpha ** -1) * y
+        G_inverse_diag = self._decomp_diag(w, U) + (alpha ** -1)
         if len(y.shape) != 1:
             # handle case where y is 2-d
             G_inverse_diag = G_inverse_diag[:, np.newaxis]

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1288,8 +1288,7 @@ class SGDClassifier(BaseSGDClassifier):
             raise NotImplementedError(
                 "predict_(log_)proba only supported when"
                 " loss='log' or loss='modified_huber' "
-                "(%r given)"
-                % self.loss
+                "(%r given)" % self.loss
             )
 
     @available_if(_check_proba)

--- a/sklearn/linear_model/_theil_sen.py
+++ b/sklearn/linear_model/_theil_sen.py
@@ -53,7 +53,7 @@ def _modified_weiszfeld_step(X, x_old):
       http://users.jyu.fi/~samiayr/pdf/ayramo_eurogen05.pdf
     """
     diff = X - x_old
-    diff_norm = np.sqrt(np.sum(diff**2, axis=1))
+    diff_norm = np.sqrt(np.sum(diff ** 2, axis=1))
     mask = diff_norm >= _EPSILON
     # x_old equals one of our samples
     is_x_old_in_X = int(mask.sum() < X.shape[0])

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -301,10 +301,10 @@ def test_lasso_dual_gap():
     clf = Lasso(alpha=alpha, fit_intercept=False).fit(X, y)
     w = clf.coef_
     R = y - X @ w
-    primal = 0.5 * np.mean(R**2) + clf.alpha * np.sum(np.abs(w))
+    primal = 0.5 * np.mean(R ** 2) + clf.alpha * np.sum(np.abs(w))
     # dual pt: R / n_samples, dual constraint: norm(X.T @ theta, inf) <= alpha
     R /= np.max(np.abs(X.T @ R) / (n_samples * alpha))
-    dual = 0.5 * (np.mean(y**2) - np.mean((y - R) ** 2))
+    dual = 0.5 * (np.mean(y ** 2) - np.mean((y - R) ** 2))
     assert_allclose(clf.dual_gap_, primal - dual)
 
 

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -172,7 +172,7 @@ def test_collinearity():
     _, _, coef_path_ = f(linear_model.lars_path)(X, y, alpha_min=0.01)
     assert not np.isnan(coef_path_).any()
     residual = np.dot(X, coef_path_[:, -1]) - y
-    assert (residual**2).sum() < 1.0  # just make sure it's bounded
+    assert (residual ** 2).sum() < 1.0  # just make sure it's bounded
 
     n_samples = 10
     X = rng.rand(n_samples, 5)
@@ -443,7 +443,7 @@ def test_lars_n_nonzero_coefs(verbose=False):
 @ignore_warnings
 def test_multitarget():
     # Assure that estimators receiving multidimensional y do the right thing
-    Y = np.vstack([y, y**2]).T
+    Y = np.vstack([y, y ** 2]).T
     n_targets = Y.shape[1]
     estimators = [
         linear_model.LassoLars(),
@@ -801,7 +801,7 @@ def test_lasso_lars_vs_R_implementation():
     # Let's rescale back the coefficients returned by sklearn before comparing
     # against the R result (read the note above)
     temp = X - np.mean(X, axis=0)
-    normx = np.sqrt(np.sum(temp**2, axis=0))
+    normx = np.sqrt(np.sum(temp ** 2, axis=0))
     skl_betas2 /= normx[:, np.newaxis]
 
     assert_array_almost_equal(r2, skl_betas2, decimal=12)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1020,8 +1020,7 @@ def test_logreg_intercept_scaling():
         msg = (
             "Intercept scaling is %r but needs to be greater than 0."
             " To disable fitting an intercept,"
-            " set fit_intercept=False."
-            % clf.intercept_scaling
+            " set fit_intercept=False." % clf.intercept_scaling
         )
         with pytest.raises(ValueError, match=msg):
             clf.fit(X, Y1)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -174,7 +174,7 @@ def test_ridge_regression(solver, fit_intercept, ols_ridge_dataset, global_rando
     # Calculate residuals and R2.
     res_null = y - np.mean(y)
     res_Ridge = y - X @ coef
-    R2_Ridge = 1 - np.sum(res_Ridge**2) / np.sum(res_null**2)
+    R2_Ridge = 1 - np.sum(res_Ridge ** 2) / np.sum(res_null ** 2)
 
     model = Ridge(**params)
     X = X[:, :-1]  # remove intercept
@@ -1330,7 +1330,7 @@ def test_class_weight_vs_sample_weight(reg):
 
     # Check that sample_weight and class_weight are multiplicative
     reg1 = reg()
-    reg1.fit(iris.data, iris.target, sample_weight**2)
+    reg1.fit(iris.data, iris.target, sample_weight ** 2)
     reg2 = reg(class_weight=class_weight)
     reg2.fit(iris.data, iris.target, sample_weight)
     assert_almost_equal(reg1.coef_, reg2.coef_)
@@ -1982,7 +1982,7 @@ def test_positive_ridge_loss(alpha):
             coef = model.coef_
 
         return 0.5 * np.sum((y - X @ coef - intercept) ** 2) + 0.5 * alpha * np.sum(
-            coef**2
+            coef ** 2
         )
 
     model = Ridge(alpha=alpha).fit(X, y)

--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -276,7 +276,7 @@ class Isomap(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
 
         self.dist_matrix_ = shortest_path(nbg, method=self.path_method, directed=False)
 
-        G = self.dist_matrix_**2
+        G = self.dist_matrix_ ** 2
         G *= -0.5
 
         self.embedding_ = self.kernel_pca_.fit_transform(G)
@@ -302,10 +302,10 @@ class Isomap(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
 
         ``K(D) = -0.5 * (I - 1/n_samples) * D^2 * (I - 1/n_samples)``
         """
-        G = -0.5 * self.dist_matrix_**2
+        G = -0.5 * self.dist_matrix_ ** 2
         G_center = KernelCenterer().fit_transform(G)
         evals = self.kernel_pca_.eigenvalues_
-        return np.sqrt(np.sum(G_center**2) - np.sum(evals**2)) / G.shape[0]
+        return np.sqrt(np.sum(G_center ** 2) - np.sum(evals ** 2)) / G.shape[0]
 
     def fit(self, X, y=None):
         """Compute the embedding vectors for data X.

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -113,7 +113,7 @@ def _smacof_single(
             disparities[sim_flat != 0] = disparities_flat
             disparities = disparities.reshape((n_samples, n_samples))
             disparities *= np.sqrt(
-                (n_samples * (n_samples - 1) / 2) / (disparities**2).sum()
+                (n_samples * (n_samples - 1) / 2) / (disparities ** 2).sum()
             )
 
         # Compute stress
@@ -126,7 +126,7 @@ def _smacof_single(
         B[np.arange(len(B)), np.arange(len(B))] += ratio.sum(axis=1)
         X = 1.0 / n_samples * np.dot(B, X)
 
-        dis = np.sqrt((X**2).sum(axis=1)).sum()
+        dis = np.sqrt((X ** 2).sum(axis=1)).sum()
         if verbose >= 2:
             print("it: %d, stress %s" % (it, stress))
         if old_stress is not None:

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -627,8 +627,7 @@ class SpectralEmbedding(BaseEstimator):
                 raise ValueError(
                     "%s is not a valid affinity. Expected "
                     "'precomputed', 'rbf', 'nearest_neighbors' "
-                    "or a callable."
-                    % self.affinity
+                    "or a callable." % self.affinity
                 )
         elif not callable(self.affinity):
             raise ValueError(

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -81,7 +81,7 @@ def test_isomap_reconstruction_error(n_neighbors, radius):
     else:
         G = neighbors.radius_neighbors_graph(X, radius, mode="distance").toarray()
     centerer = preprocessing.KernelCenterer()
-    K = centerer.fit_transform(-0.5 * G**2)
+    K = centerer.fit_transform(-0.5 * G ** 2)
 
     for eigen_solver in eigen_solvers:
         for path_method in path_methods:
@@ -104,7 +104,7 @@ def test_isomap_reconstruction_error(n_neighbors, radius):
                     clf.embedding_, radius, mode="distance"
                 )
             G_iso = G_iso.toarray()
-            K_iso = centerer.fit_transform(-0.5 * G_iso**2)
+            K_iso = centerer.fit_transform(-0.5 * G_iso ** 2)
 
             # make sure error agrees
             reconstruction_error = np.linalg.norm(K - K_iso) / n_pts
@@ -183,7 +183,7 @@ def test_pipeline_with_nearest_neighbors_transformer():
 def test_different_metric():
     # Test that the metric parameters work correctly, and default to euclidean
     def custom_metric(x1, x2):
-        return np.sqrt(np.sum(x1**2 + x2**2))
+        return np.sqrt(np.sum(x1 ** 2 + x2 ** 2))
 
     # metric, p, is_euclidean
     metrics = [

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -47,7 +47,7 @@ S, true_labels = make_blobs(
 def _assert_equal_with_sign_flipping(A, B, tol=0.0):
     """Check array A and B are equal with possible sign flipping on
     each columns"""
-    tol_squared = tol**2
+    tol_squared = tol ** 2
     for A_col, B_col in zip(A.T, B.T):
         assert (
             np.max((A_col - B_col) ** 2) <= tol_squared

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -549,8 +549,7 @@ def multilabel_confusion_matrix(
                 raise ValueError(
                     "All labels must be in [0, n labels) for "
                     "multilabel targets. "
-                    "Got %d < 0"
-                    % np.min(labels)
+                    "Got %d < 0" % np.min(labels)
                 )
 
         if n_labels is not None:
@@ -910,8 +909,8 @@ def matthews_corrcoef(y_true, y_pred, *, sample_weight=None):
     n_correct = np.trace(C, dtype=np.float64)
     n_samples = p_sum.sum()
     cov_ytyp = n_correct * n_samples - np.dot(t_sum, p_sum)
-    cov_ypyp = n_samples**2 - np.dot(p_sum, p_sum)
-    cov_ytyt = n_samples**2 - np.dot(t_sum, t_sum)
+    cov_ypyp = n_samples ** 2 - np.dot(p_sum, p_sum)
+    cov_ytyt = n_samples ** 2 - np.dot(t_sum, t_sum)
 
     if cov_ypyp * cov_ytyt == 0:
         return 0.0
@@ -1574,7 +1573,7 @@ def precision_recall_fscore_support(
         true_sum = np.array([true_sum.sum()])
 
     # Finally, we have all our sufficient statistics. Divide! #
-    beta2 = beta**2
+    beta2 = beta ** 2
 
     # Divide, and on zero-division, set scores and/or warn according to
     # zero_division:

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -356,7 +356,7 @@ def _binary_roc_auc_score(y_true, y_score, sample_weight=None, max_fpr=None):
 
     # McClish correction: standardize result to be 0.5 if non-discriminant
     # and 1 if maximal
-    min_area = 0.5 * max_fpr**2
+    min_area = 0.5 * max_fpr ** 2
     max_area = max_fpr
     return 0.5 * (1 + (partial_auc - min_area) / (max_area - min_area))
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -227,12 +227,12 @@ def pair_confusion_matrix(labels_true, labels_pred):
     )
     n_c = np.ravel(contingency.sum(axis=1))
     n_k = np.ravel(contingency.sum(axis=0))
-    sum_squares = (contingency.data**2).sum()
+    sum_squares = (contingency.data ** 2).sum()
     C = np.empty((2, 2), dtype=np.int64)
     C[1, 1] = sum_squares - n_samples
     C[0, 1] = contingency.dot(n_k).sum() - sum_squares
     C[1, 0] = contingency.transpose().dot(n_c).sum() - sum_squares
-    C[0, 0] = n_samples**2 - C[0, 1] - C[1, 0] - sum_squares
+    C[0, 0] = n_samples ** 2 - C[0, 1] - C[1, 0] - sum_squares
     return C
 
 

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -409,7 +409,7 @@ def test_pair_confusion_matrix_single_cluster():
 def test_pair_confusion_matrix():
     # regular case: different non-trivial clusterings
     n = 10
-    N = n**2
+    N = n ** 2
     clustering1 = np.hstack([[i + 1] * n for i in range(n)])
     clustering2 = np.hstack([[i + 1] * (n + 1) for i in range(n)])[:N]
     # basic quadratic implementation

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -530,7 +530,7 @@ def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None, batch_size=None):
                 + (x_density * n_samples_X * y_density * n_samples_Y)
             )
             / 10,
-            10 * 2**17,
+            10 * 2 ** 17,
         )
 
         # The increase amount of memory in 8-byte blocks is:
@@ -540,7 +540,7 @@ def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None, batch_size=None):
         # Hence x² + (xd+yd)kx = M, where x=batch_size, k=n_features, M=maxmem
         #                                 xd=x_density and yd=y_density
         tmp = (x_density + y_density) * n_features
-        batch_size = (-tmp + np.sqrt(tmp**2 + 4 * maxmem)) / 2
+        batch_size = (-tmp + np.sqrt(tmp ** 2 + 4 * maxmem)) / 2
         batch_size = max(int(batch_size), 1)
 
     x_batches = gen_batches(n_samples_X, batch_size)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -255,7 +255,7 @@ def test_precision_recall_f1_score_binary():
 
         assert_almost_equal(
             my_assert(fbeta_score, y_true, y_pred, beta=2, **kwargs),
-            (1 + 2**2) * ps * rs / (2**2 * ps + rs),
+            (1 + 2 ** 2) * ps * rs / (2 ** 2 * ps + rs),
             2,
         )
 
@@ -1960,8 +1960,7 @@ def test_recall_warnings(zero_division):
         )
         if zero_division == "warn":
             assert (
-                str(record.pop().message)
-                == "Recall is ill-defined and "
+                str(record.pop().message) == "Recall is ill-defined and "
                 "being set to 0.0 due to no true samples."
                 " Use `zero_division` parameter to control"
                 " this behavior."
@@ -1972,8 +1971,7 @@ def test_recall_warnings(zero_division):
         recall_score([0, 0], [0, 0])
         if zero_division == "warn":
             assert (
-                str(record.pop().message)
-                == "Recall is ill-defined and "
+                str(record.pop().message) == "Recall is ill-defined and "
                 "being set to 0.0 due to no true samples."
                 " Use `zero_division` parameter to control"
                 " this behavior."
@@ -1992,8 +1990,7 @@ def test_precision_warnings(zero_division):
         )
         if zero_division == "warn":
             assert (
-                str(record.pop().message)
-                == "Precision is ill-defined and "
+                str(record.pop().message) == "Precision is ill-defined and "
                 "being set to 0.0 due to no predicted samples."
                 " Use `zero_division` parameter to control"
                 " this behavior."
@@ -2004,8 +2001,7 @@ def test_precision_warnings(zero_division):
         precision_score([0, 0], [0, 0])
         if zero_division == "warn":
             assert (
-                str(record.pop().message)
-                == "Precision is ill-defined and "
+                str(record.pop().message) == "Precision is ill-defined and "
                 "being set to 0.0 due to no predicted samples."
                 " Use `zero_division` parameter to control"
                 " this behavior."
@@ -2050,8 +2046,7 @@ def test_fscore_warnings(zero_division):
             )
             if zero_division == "warn":
                 assert (
-                    str(record.pop().message)
-                    == "F-score is ill-defined and "
+                    str(record.pop().message) == "F-score is ill-defined and "
                     "being set to 0.0 due to no true nor predicted "
                     "samples. Use `zero_division` parameter to "
                     "control this behavior."

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -545,7 +545,7 @@ def test_pairwise_distances_chunked_reduce():
     # Reduced Euclidean distance
     S = pairwise_distances(X)[:, :100]
     S_chunks = pairwise_distances_chunked(
-        X, None, reduce_func=_reduce_func, working_memory=2**-16
+        X, None, reduce_func=_reduce_func, working_memory=2 ** -16
     )
     assert isinstance(S_chunks, GeneratorType)
     S_chunks = list(S_chunks)
@@ -559,7 +559,7 @@ def test_pairwise_distances_chunked_reduce_none():
     rng = np.random.RandomState(0)
     X = rng.random_sample((10, 4))
     S_chunks = pairwise_distances_chunked(
-        X, None, reduce_func=lambda dist, start: None, working_memory=2**-16
+        X, None, reduce_func=lambda dist, start: None, working_memory=2 ** -16
     )
     assert isinstance(S_chunks, GeneratorType)
     S_chunks = list(S_chunks)
@@ -630,11 +630,11 @@ def check_pairwise_distances_chunked(X, Y, working_memory, metric="euclidean"):
     assert isinstance(gen, GeneratorType)
     blockwise_distances = list(gen)
     Y = X if Y is None else Y
-    min_block_mib = len(Y) * 8 * 2**-20
+    min_block_mib = len(Y) * 8 * 2 ** -20
 
     for block in blockwise_distances:
         memory_used = block.nbytes
-        assert memory_used <= max(working_memory, min_block_mib) * 2**20
+        assert memory_used <= max(working_memory, min_block_mib) * 2 ** 20
 
     blockwise_distances = np.vstack(blockwise_distances)
     S = pairwise_distances(X, Y, metric=metric)
@@ -668,7 +668,7 @@ def test_pairwise_distances_chunked():
     # Test small amounts of memory
     for power in range(-16, 0):
         check_pairwise_distances_chunked(
-            X, None, working_memory=2**power, metric="euclidean"
+            X, None, working_memory=2 ** power, metric="euclidean"
         )
     # X as list
     check_pairwise_distances_chunked(
@@ -691,7 +691,7 @@ def test_pairwise_distances_chunked():
 
     # Test precomputed returns all at once
     D = pairwise_distances(X)
-    gen = pairwise_distances_chunked(D, working_memory=2**-16, metric="precomputed")
+    gen = pairwise_distances_chunked(D, working_memory=2 ** -16, metric="precomputed")
     assert isinstance(gen, GeneratorType)
     assert next(gen) is D
     with pytest.raises(StopIteration):
@@ -754,8 +754,8 @@ def test_euclidean_distances_norm_shapes():
     X = rng.random_sample((10, 10))
     Y = rng.random_sample((20, 10))
 
-    X_norm_squared = (X**2).sum(axis=1)
-    Y_norm_squared = (Y**2).sum(axis=1)
+    X_norm_squared = (X ** 2).sum(axis=1)
+    Y_norm_squared = (Y ** 2).sum(axis=1)
 
     D1 = euclidean_distances(
         X, Y, X_norm_squared=X_norm_squared, Y_norm_squared=Y_norm_squared
@@ -951,7 +951,7 @@ def test_nan_euclidean_distances_2x2(X, X_diag, missing_value):
     assert_allclose(exp_dist, dist)
 
     dist_sq = nan_euclidean_distances(X, squared=True, missing_values=missing_value)
-    assert_allclose(exp_dist**2, dist_sq)
+    assert_allclose(exp_dist ** 2, dist_sq)
 
     dist_two = nan_euclidean_distances(X, X, missing_values=missing_value)
     assert_allclose(exp_dist, dist_two)

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -71,7 +71,7 @@ def test_regression_metrics(n_samples=50):
     n = n_samples
     assert_almost_equal(
         mean_tweedie_deviance(y_true, y_pred, power=-1),
-        5 / 12 * n * (n**2 + 2 * n + 1),
+        5 / 12 * n * (n ** 2 + 2 * n + 1),
     )
     assert_almost_equal(
         mean_tweedie_deviance(y_true, y_pred, power=1), (n + 1) * (1 - np.log(2))

--- a/sklearn/mixture/_base.py
+++ b/sklearn/mixture/_base.py
@@ -79,15 +79,13 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         if self.n_components < 1:
             raise ValueError(
                 "Invalid value for 'n_components': %d "
-                "Estimation requires at least one component"
-                % self.n_components
+                "Estimation requires at least one component" % self.n_components
             )
 
         if self.tol < 0.0:
             raise ValueError(
                 "Invalid value for 'tol': %.5f "
-                "Tolerance used by the EM must be non-negative"
-                % self.tol
+                "Tolerance used by the EM must be non-negative" % self.tol
             )
 
         if self.n_init < 1:
@@ -99,16 +97,14 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         if self.max_iter < 1:
             raise ValueError(
                 "Invalid value for 'max_iter': %d "
-                "Estimation requires at least one iteration"
-                % self.max_iter
+                "Estimation requires at least one iteration" % self.max_iter
             )
 
         if self.reg_covar < 0.0:
             raise ValueError(
                 "Invalid value for 'reg_covar': %.5f "
                 "regularization on covariance must be "
-                "non-negative"
-                % self.reg_covar
+                "non-negative" % self.reg_covar
             )
 
         # Check all the parameters values of the derived class

--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -389,8 +389,7 @@ class BayesianGaussianMixture(BaseMixture):
             raise ValueError(
                 "Invalid value for 'covariance_type': %s "
                 "'covariance_type' should be in "
-                "['spherical', 'tied', 'diag', 'full']"
-                % self.covariance_type
+                "['spherical', 'tied', 'diag', 'full']" % self.covariance_type
             )
 
         if self.weight_concentration_prior_type not in [
@@ -438,8 +437,7 @@ class BayesianGaussianMixture(BaseMixture):
         else:
             raise ValueError(
                 "The parameter 'mean_precision_prior' should be "
-                "greater than 0., but got %.3f."
-                % self.mean_precision_prior
+                "greater than 0., but got %.3f." % self.mean_precision_prior
             )
 
         if self.mean_prior is None:
@@ -513,8 +511,7 @@ class BayesianGaussianMixture(BaseMixture):
         else:
             raise ValueError(
                 "The parameter 'spherical covariance_prior' "
-                "should be greater than 0., but got %.3f."
-                % self.covariance_prior
+                "should be greater than 0., but got %.3f." % self.covariance_prior
             )
 
     def _initialize(self, X, resp):
@@ -893,4 +890,4 @@ class BayesianGaussianMixture(BaseMixture):
                 self.precisions_cholesky_, self.precisions_cholesky_.T
             )
         else:
-            self.precisions_ = self.precisions_cholesky_**2
+            self.precisions_ = self.precisions_cholesky_ ** 2

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -229,7 +229,7 @@ def _estimate_gaussian_covariances_diag(resp, X, nk, means, reg_covar):
         The covariance vector of the current components.
     """
     avg_X2 = np.dot(resp.T, X * X) / nk[:, np.newaxis]
-    avg_means2 = means**2
+    avg_means2 = means ** 2
     avg_X_means = means * np.dot(resp.T, X) / nk[:, np.newaxis]
     return avg_X2 - 2 * avg_X_means + avg_means2 + reg_covar
 
@@ -434,17 +434,17 @@ def _estimate_log_gaussian_prob(X, means, precisions_chol, covariance_type):
             log_prob[:, k] = np.sum(np.square(y), axis=1)
 
     elif covariance_type == "diag":
-        precisions = precisions_chol**2
+        precisions = precisions_chol ** 2
         log_prob = (
-            np.sum((means**2 * precisions), 1)
+            np.sum((means ** 2 * precisions), 1)
             - 2.0 * np.dot(X, (means * precisions).T)
-            + np.dot(X**2, precisions.T)
+            + np.dot(X ** 2, precisions.T)
         )
 
     elif covariance_type == "spherical":
-        precisions = precisions_chol**2
+        precisions = precisions_chol ** 2
         log_prob = (
-            np.sum(means**2, 1) * precisions
+            np.sum(means ** 2, 1) * precisions
             - 2 * np.dot(X, means.T * precisions)
             + np.outer(row_norms(X, squared=True), precisions)
         )
@@ -672,8 +672,7 @@ class GaussianMixture(BaseMixture):
             raise ValueError(
                 "Invalid value for 'covariance_type': %s "
                 "'covariance_type' should be in "
-                "['spherical', 'tied', 'diag', 'full']"
-                % self.covariance_type
+                "['spherical', 'tied', 'diag', 'full']" % self.covariance_type
             )
 
         if self.weights_init is not None:
@@ -790,7 +789,7 @@ class GaussianMixture(BaseMixture):
                 self.precisions_cholesky_, self.precisions_cholesky_.T
             )
         else:
-            self.precisions_ = self.precisions_cholesky_**2
+            self.precisions_ = self.precisions_cholesky_ ** 2
 
     def _n_parameters(self):
         """Return the number of free parameters in the model."""

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -431,7 +431,7 @@ def test_suffstat_sk_diag():
 
     # check the precision computation
     precs_chol_pred = _compute_precision_cholesky(covars_pred_diag, "diag")
-    assert_almost_equal(covars_pred_diag, 1.0 / precs_chol_pred**2)
+    assert_almost_equal(covars_pred_diag, 1.0 / precs_chol_pred ** 2)
 
 
 def test_gaussian_suffstat_sk_spherical():
@@ -453,7 +453,7 @@ def test_gaussian_suffstat_sk_spherical():
 
     # check the precision computation
     precs_chol_pred = _compute_precision_cholesky(covars_pred_spherical, "spherical")
-    assert_almost_equal(covars_pred_spherical, 1.0 / precs_chol_pred**2)
+    assert_almost_equal(covars_pred_spherical, 1.0 / precs_chol_pred ** 2)
 
 
 def test_compute_log_det_cholesky():
@@ -470,7 +470,7 @@ def test_compute_log_det_cholesky():
         elif covar_type == "diag":
             predected_det = np.array([np.prod(cov) for cov in covariance])
         elif covar_type == "spherical":
-            predected_det = covariance**n_features
+            predected_det = covariance ** n_features
 
         # We compute the cholesky decomposition of the covariance matrix
         expected_det = _compute_log_det_cholesky(

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -438,8 +438,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         if self.scorer_ is None:
             raise ValueError(
                 "No score function explicitly defined, "
-                "and the estimator doesn't provide one %s"
-                % self.best_estimator_
+                "and the estimator doesn't provide one %s" % self.best_estimator_
             )
         if isinstance(self.scorer_, dict):
             if self.multimetric_:

--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -288,7 +288,7 @@ class BaseSuccessiveHalving(BaseSearchCV):
             last_iteration = n_required_iterations - 1
             self.min_resources_ = max(
                 self.min_resources_,
-                self.max_resources_ // self.factor**last_iteration,
+                self.max_resources_ // self.factor ** last_iteration,
             )
 
         # n_possible_iterations is the number of iterations that we can
@@ -327,7 +327,7 @@ class BaseSuccessiveHalving(BaseSearchCV):
                 # eliminated), and then go on as usual.
                 power = max(0, itr - n_required_iterations + n_possible_iterations)
 
-            n_resources = int(self.factor**power * self.min_resources_)
+            n_resources = int(self.factor ** power * self.min_resources_)
             # guard, probably not needed
             n_resources = min(n_resources, self.max_resources_)
             self.n_resources_.append(n_resources)

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -374,8 +374,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                 raise ValueError(
                     "kd_tree does not support callable metric '%s'"
                     "Function call overhead will result"
-                    "in very poor performance."
-                    % self.metric
+                    "in very poor performance." % self.metric
                 )
         elif self.metric not in VALID_METRICS[alg_check]:
             raise ValueError(
@@ -808,8 +807,7 @@ class KNeighborsMixin:
             if issparse(X):
                 raise ValueError(
                     "%s does not work with sparse matrices. Densify the data, "
-                    "or set algorithm='brute'"
-                    % self._fit_method
+                    "or set algorithm='brute'" % self._fit_method
                 )
             chunked_results = Parallel(n_jobs, prefer="threads")(
                 delayed(_tree_query_parallel_helper)(
@@ -1160,8 +1158,7 @@ class RadiusNeighborsMixin:
             if issparse(X):
                 raise ValueError(
                     "%s does not work with sparse matrices. Densify the data, "
-                    "or set algorithm='brute'"
-                    % self._fit_method
+                    "or set algorithm='brute'" % self._fit_method
                 )
 
             n_jobs = effective_n_jobs(self.n_jobs)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -127,7 +127,7 @@ def _weight_func(dist):
     # can be looped
     with np.errstate(divide="ignore"):
         retval = 1.0 / dist
-    return retval**2
+    return retval ** 2
 
 
 WEIGHTS = ["uniform", "distance", _weight_func]
@@ -579,7 +579,7 @@ def test_kneighbors_classifier(
     # Test k-neighbors classification
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features).astype(global_dtype, copy=False) - 1
-    y = ((X**2).sum(axis=1) < 0.5).astype(int)
+    y = ((X ** 2).sum(axis=1) < 0.5).astype(int)
     y_str = y.astype(str)
 
     knn = neighbors.KNeighborsClassifier(
@@ -606,7 +606,7 @@ def test_kneighbors_classifier_float_labels(
     # Test k-neighbors classification
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features).astype(global_dtype, copy=False) - 1
-    y = ((X**2).sum(axis=1) < 0.5).astype(int)
+    y = ((X ** 2).sum(axis=1) < 0.5).astype(int)
 
     knn = neighbors.KNeighborsClassifier(n_neighbors=n_neighbors)
     knn.fit(X, y.astype(float))
@@ -662,7 +662,7 @@ def test_radius_neighbors_classifier(
     # Test radius-based classification
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features).astype(global_dtype, copy=False) - 1
-    y = ((X**2).sum(axis=1) < radius).astype(int)
+    y = ((X ** 2).sum(axis=1) < radius).astype(int)
     y_str = y.astype(str)
 
     neigh = neighbors.RadiusNeighborsClassifier(
@@ -1049,7 +1049,7 @@ def test_kneighbors_classifier_sparse(
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
     X *= X > 0.2
-    y = ((X**2).sum(axis=1) < 0.5).astype(int)
+    y = ((X ** 2).sum(axis=1) < 0.5).astype(int)
 
     for sparsemat in SPARSE_TYPES:
         knn = neighbors.KNeighborsClassifier(n_neighbors=n_neighbors, algorithm="auto")
@@ -1111,7 +1111,7 @@ def test_kneighbors_regressor(
     # Test k-neighbors regression
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
-    y = np.sqrt((X**2).sum(1))
+    y = np.sqrt((X ** 2).sum(1))
     y /= y.max()
 
     y_target = y[:n_test_pts]
@@ -1160,7 +1160,7 @@ def test_kneighbors_regressor_multioutput(
     # Test k-neighbors in multi-output regression
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
-    y = np.sqrt((X**2).sum(1))
+    y = np.sqrt((X ** 2).sum(1))
     y /= y.max()
     y = np.vstack([y, y]).T
 
@@ -1185,7 +1185,7 @@ def test_radius_neighbors_regressor(
     # Test radius-based neighbors regression
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
-    y = np.sqrt((X**2).sum(1))
+    y = np.sqrt((X ** 2).sum(1))
     y /= y.max()
 
     y_target = y[:n_test_pts]
@@ -1252,7 +1252,7 @@ def test_RadiusNeighborsRegressor_multioutput(
     # Test k-neighbors in multi-output regression with various weight
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
-    y = np.sqrt((X**2).sum(1))
+    y = np.sqrt((X ** 2).sum(1))
     y /= y.max()
     y = np.vstack([y, y]).T
 
@@ -1277,7 +1277,7 @@ def test_kneighbors_regressor_sparse(
     # Like the above, but with various types of sparse matrices
     rng = np.random.RandomState(random_state)
     X = 2 * rng.rand(n_samples, n_features) - 1
-    y = ((X**2).sum(axis=1) < 0.25).astype(int)
+    y = ((X ** 2).sum(axis=1) < 0.25).astype(int)
 
     for sparsemat in SPARSE_TYPES:
         knn = neighbors.KNeighborsRegressor(n_neighbors=n_neighbors, algorithm="auto")
@@ -1615,7 +1615,7 @@ def test_kneighbors_brute_backend(
 
 def test_callable_metric():
     def custom_metric(x1, x2):
-        return np.sqrt(np.sum(x1**2 + x2**2))
+        return np.sqrt(np.sum(x1 ** 2 + x2 ** 2))
 
     X = np.random.RandomState(42).rand(20, 2)
     nbrs1 = neighbors.NearestNeighbors(

--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -126,7 +126,7 @@ def inplace_tanh_derivative(Z, delta):
     delta : {array-like}, shape (n_samples, n_features)
          The backpropagated error signal to be modified inplace.
     """
-    delta *= 1 - Z**2
+    delta *= 1 - Z ** 2
 
 
 def inplace_relu_derivative(Z, delta):

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -765,8 +765,7 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
         if self.solver not in _STOCHASTIC_SOLVERS:
             raise AttributeError(
                 "partial_fit is only available for stochastic"
-                " optimizers. %s is not stochastic."
-                % self.solver
+                " optimizers. %s is not stochastic." % self.solver
             )
         return True
 

--- a/sklearn/neural_network/_stochastic_optimizers.py
+++ b/sklearn/neural_network/_stochastic_optimizers.py
@@ -273,13 +273,13 @@ class AdamOptimizer(BaseOptimizer):
             for m, grad in zip(self.ms, grads)
         ]
         self.vs = [
-            self.beta_2 * v + (1 - self.beta_2) * (grad**2)
+            self.beta_2 * v + (1 - self.beta_2) * (grad ** 2)
             for v, grad in zip(self.vs, grads)
         ]
         self.learning_rate = (
             self.learning_rate_init
-            * np.sqrt(1 - self.beta_2**self.t)
-            / (1 - self.beta_1**self.t)
+            * np.sqrt(1 - self.beta_2 ** self.t)
+            / (1 - self.beta_1 ** self.t)
         )
         updates = [
             -self.learning_rate * m / (np.sqrt(v) + self.epsilon)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -754,8 +754,7 @@ def test_warm_start():
         message = (
             "warm_start can only be used where `y` has the same "
             "classes as in the previous call to fit."
-            " Previously got [0 1 2], `y` has %s"
-            % np.unique(y_i)
+            " Previously got [0 1 2], `y` has %s" % np.unique(y_i)
         )
         with pytest.raises(ValueError, match=re.escape(message)):
             clf.fit(X, y_i)

--- a/sklearn/neural_network/tests/test_stochastic_optimizers.py
+++ b/sklearn/neural_network/tests/test_stochastic_optimizers.py
@@ -12,7 +12,7 @@ shapes = [(4, 6), (6, 8), (7, 8, 9)]
 
 
 def test_base_optimizer():
-    for lr in [10**i for i in range(-3, 4)]:
+    for lr in [10 ** i for i in range(-3, 4)]:
         optimizer = BaseOptimizer(lr)
         assert optimizer.trigger_stopping("", False)
 
@@ -21,7 +21,7 @@ def test_sgd_optimizer_no_momentum():
     params = [np.zeros(shape) for shape in shapes]
     rng = np.random.RandomState(0)
 
-    for lr in [10**i for i in range(-3, 4)]:
+    for lr in [10 ** i for i in range(-3, 4)]:
         optimizer = SGDOptimizer(params, lr, momentum=0, nesterov=False)
         grads = [rng.random_sample(shape) for shape in shapes]
         expected = [param - lr * grad for param, grad in zip(params, grads)]
@@ -101,8 +101,8 @@ def test_adam_optimizer():
             grads = [rng.random_sample(shape) for shape in shapes]
 
             ms = [beta_1 * m + (1 - beta_1) * grad for m, grad in zip(ms, grads)]
-            vs = [beta_2 * v + (1 - beta_2) * (grad**2) for v, grad in zip(vs, grads)]
-            learning_rate = lr * np.sqrt(1 - beta_2**t) / (1 - beta_1**t)
+            vs = [beta_2 * v + (1 - beta_2) * (grad ** 2) for v, grad in zip(vs, grads)]
+            learning_rate = lr * np.sqrt(1 - beta_2 ** t) / (1 - beta_1 ** t)
             updates = [
                 -learning_rate * m / (np.sqrt(v) + epsilon) for m, v in zip(ms, vs)
             ]

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2558,15 +2558,13 @@ class QuantileTransformer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator
         if self.n_quantiles <= 0:
             raise ValueError(
                 "Invalid value for 'n_quantiles': %d. "
-                "The number of quantiles must be at least one."
-                % self.n_quantiles
+                "The number of quantiles must be at least one." % self.n_quantiles
             )
 
         if self.subsample <= 0:
             raise ValueError(
                 "Invalid value for 'subsample': %d. "
-                "The number of subsamples must be at least one."
-                % self.subsample
+                "The number of subsamples must be at least one." % self.subsample
             )
 
         if self.n_quantiles > self.subsample:

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -282,7 +282,7 @@ def test_standard_scaler_near_constant_features(
     # is considered constant and not scaled.
 
     scale_min, scale_max = -30, 19
-    scales = np.array([10**i for i in range(scale_min, scale_max + 1)], dtype=dtype)
+    scales = np.array([10 ** i for i in range(scale_min, scale_max + 1)], dtype=dtype)
 
     n_features = scales.shape[0]
     X = np.empty((n_samples, n_features), dtype=dtype)
@@ -299,8 +299,8 @@ def test_standard_scaler_near_constant_features(
 
     # if var < bound = N.eps.var + N².eps².mean², the feature is considered
     # constant and the scale_ attribute is set to 1.
-    bounds = n_samples * eps * scales**2 + n_samples**2 * eps**2 * average**2
-    within_bounds = scales**2 <= bounds
+    bounds = n_samples * eps * scales ** 2 + n_samples ** 2 * eps ** 2 * average ** 2
+    within_bounds = scales ** 2 <= bounds
 
     # Check that scale_min is small enough to have some scales below the
     # bound and therefore detected as constant:
@@ -321,7 +321,7 @@ def test_standard_scaler_near_constant_features(
     # The other features are scaled and scale_ is equal to sqrt(var_) assuming
     # that scales are large enough for average + scale and average - scale to
     # be distinct in X (depending on X's dtype).
-    common_mask = np.logical_and(scales**2 > bounds, representable_diff)
+    common_mask = np.logical_and(scales ** 2 > bounds, representable_diff)
     assert_allclose(scaler.scale_[common_mask], np.sqrt(scaler.var_)[common_mask])
 
 
@@ -2039,7 +2039,7 @@ def test_normalize():
                 if norm == "l1":
                     row_sums = np.abs(X_norm).sum(axis=1)
                 else:
-                    X_norm_squared = X_norm**2
+                    X_norm_squared = X_norm ** 2
                     row_sums = X_norm_squared.sum(axis=1)
 
                 assert_array_almost_equal(row_sums, ones)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -144,7 +144,7 @@ def test_numeric_stability(i):
     Xt_expected = np.array([0, 0, 1, 1, 1]).reshape(-1, 1)
 
     # Test up to discretizing nano units
-    X = X_init / 10**i
+    X = X_init / 10 ** i
     Xt = KBinsDiscretizer(n_bins=2, encode="ordinal").fit_transform(X)
     assert_array_equal(Xt_expected, Xt)
 

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -485,7 +485,7 @@ def test_polynomial_features_input_validation(params, err_msg):
 @pytest.fixture()
 def single_feature_degree3():
     X = np.arange(6)[:, np.newaxis]
-    P = np.hstack([np.ones_like(X), X, X**2, X**3])
+    P = np.hstack([np.ones_like(X), X, X ** 2, X ** 3])
     return X, P
 
 
@@ -536,16 +536,16 @@ def two_features_degree3():
     x2 = X[:, 1:]
     P = np.hstack(
         [
-            x1**0 * x2**0,  # 0
-            x1**1 * x2**0,  # 1
-            x1**0 * x2**1,  # 2
-            x1**2 * x2**0,  # 3
-            x1**1 * x2**1,  # 4
-            x1**0 * x2**2,  # 5
-            x1**3 * x2**0,  # 6
-            x1**2 * x2**1,  # 7
-            x1**1 * x2**2,  # 8
-            x1**0 * x2**3,  # 9
+            x1 ** 0 * x2 ** 0,  # 0
+            x1 ** 1 * x2 ** 0,  # 1
+            x1 ** 0 * x2 ** 1,  # 2
+            x1 ** 2 * x2 ** 0,  # 3
+            x1 ** 1 * x2 ** 1,  # 4
+            x1 ** 0 * x2 ** 2,  # 5
+            x1 ** 3 * x2 ** 0,  # 6
+            x1 ** 2 * x2 ** 1,  # 7
+            x1 ** 1 * x2 ** 2,  # 8
+            x1 ** 0 * x2 ** 3,  # 9
         ]
     )
     return X, P

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -128,7 +128,7 @@ def johnson_lindenstrauss_min_dim(n_samples, *, eps=0.1):
             % n_samples
         )
 
-    denominator = (eps**2 / 2) - (eps**3 / 3)
+    denominator = (eps ** 2 / 2) - (eps ** 3 / 3)
     return (4 * np.log(n_samples) / denominator).astype(np.int64)
 
 

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -156,8 +156,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             raise ValueError(
                 "%s is not a valid kernel. Only rbf and knn"
                 " or an explicit function "
-                " are supported at this time."
-                % self.kernel
+                " are supported at this time." % self.kernel
             )
 
     @abstractmethod

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -301,8 +301,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             warnings.warn(
                 "Solver terminated early (max_iter=%i)."
                 "  Consider pre-processing your data with"
-                " StandardScaler or MinMaxScaler."
-                % self.max_iter,
+                " StandardScaler or MinMaxScaler." % self.max_iter,
                 ConvergenceWarning,
             )
 
@@ -1162,8 +1161,7 @@ def _fit_liblinear(
             raise ValueError(
                 "This solver needs samples of at least 2 classes"
                 " in the data, but the data contains only one"
-                " class: %r"
-                % classes_[0]
+                " class: %r" % classes_[0]
             )
 
         class_weight_ = compute_class_weight(class_weight, classes=classes_, y=y)

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1195,8 +1195,7 @@ def test_linear_svc_intercept_scaling():
         msg = (
             "Intercept scaling is %r but needs to be greater than 0."
             " To disable fitting an intercept,"
-            " set fit_intercept=False."
-            % lsvc.intercept_scaling
+            " set fit_intercept=False." % lsvc.intercept_scaling
         )
         with pytest.raises(ValueError, match=msg):
             lsvc.fit(X, Y)

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -368,8 +368,8 @@ def test_lda_orthogonality():
 
     d1 = means_transformed[3] - means_transformed[0]
     d2 = means_transformed[2] - means_transformed[1]
-    d1 /= np.sqrt(np.sum(d1**2))
-    d2 /= np.sqrt(np.sum(d2**2))
+    d1 /= np.sqrt(np.sum(d1 ** 2))
+    d2 /= np.sqrt(np.sum(d2 ** 2))
 
     # the transformed within-class covariance should be the identity matrix
     assert_almost_equal(np.cov(clf.transform(scatter).T), np.eye(2))

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -495,7 +495,7 @@ def test_fast_predict():
     # affect out-of-sample predictions:
     # https://github.com/scikit-learn/scikit-learn/pull/6206
     rng = np.random.RandomState(123)
-    n_samples = 10**3
+    n_samples = 10 ** 3
     # X values over the -10,10 range
     X_train = 20.0 * rng.rand(n_samples) - 10
     y_train = (

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1279,7 +1279,7 @@ def check_class_weights(name):
 
     # Check that sample_weight and class_weight are multiplicative
     clf1 = TreeClassifier(random_state=0)
-    clf1.fit(iris.data, iris.target, sample_weight**2)
+    clf1.fit(iris.data, iris.target, sample_weight ** 2)
     clf2 = TreeClassifier(class_weight=class_weight, random_state=0)
     clf2.fit(iris.data, iris.target, sample_weight)
     assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
@@ -1397,7 +1397,7 @@ def test_with_only_one_non_constant_features():
 
 def test_big_input():
     # Test if the warning for too large inputs is appropriate.
-    X = np.repeat(10**40.0, 4).astype(np.float64).reshape(-1, 1)
+    X = np.repeat(10 ** 40.0, 4).astype(np.float64).reshape(-1, 1)
     clf = DecisionTreeClassifier()
     try:
         clf.fit(X, [0, 1, 0, 1])

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -675,7 +675,7 @@ def safe_sqr(X, *, copy=True):
         X.data **= 2
     else:
         if copy:
-            X = X**2
+            X = X ** 2
         else:
             X **= 2
     return X
@@ -965,14 +965,14 @@ def get_chunk_n_rows(row_bytes, *, max_n_rows=None, working_memory=None):
     if working_memory is None:
         working_memory = get_config()["working_memory"]
 
-    chunk_n_rows = int(working_memory * (2**20) // row_bytes)
+    chunk_n_rows = int(working_memory * (2 ** 20) // row_bytes)
     if max_n_rows is not None:
         chunk_n_rows = min(chunk_n_rows, max_n_rows)
     if chunk_n_rows < 1:
         warnings.warn(
             "Could not adhere to working_memory config. "
             "Currently %.0fMiB, %.0fMiB required."
-            % (working_memory, np.ceil(row_bytes * 2**-20))
+            % (working_memory, np.ceil(row_bytes * 2 ** -20))
         )
         chunk_n_rows = 1
     return chunk_n_rows
@@ -1256,8 +1256,7 @@ def all_estimators(type_filter=None):
                 "Parameter type_filter must be 'classifier', "
                 "'regressor', 'transformer', 'cluster' or "
                 "None, got"
-                " %s."
-                % repr(type_filter)
+                " %s." % repr(type_filter)
             )
 
     # drop duplicates, sort for reproducibility

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1239,8 +1239,7 @@ def check_dont_overwrite_parameters(name, estimator_orig):
         " the fit method."
         " Estimators are only allowed to add private attributes"
         " either started with _ or ended"
-        " with _ but %s added"
-        % ", ".join(attrs_added_by_fit)
+        " with _ but %s added" % ", ".join(attrs_added_by_fit)
     )
 
     # check that fit doesn't change any public attribute
@@ -1255,8 +1254,7 @@ def check_dont_overwrite_parameters(name, estimator_orig):
         " the fit method. Estimators are only allowed"
         " to change attributes started"
         " or ended with _, but"
-        " %s changed"
-        % ", ".join(attrs_changed_by_fit)
+        " %s changed" % ", ".join(attrs_changed_by_fit)
     )
 
 
@@ -2636,8 +2634,7 @@ def check_supervised_y_2d(name, estimator_orig):
         assert len(w) > 0, msg
         assert (
             "DataConversionWarning('A column-vector y"
-            " was passed when a 1d array was expected"
-            in msg
+            " was passed when a 1d array was expected" in msg
         )
     assert_allclose(y_pred.ravel(), y_pred_2d.ravel())
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -1002,7 +1002,7 @@ def _incremental_mean_and_var(
         # correction term of the corrected 2 pass algorithm.
         # See "Algorithms for computing the sample variance: analysis
         # and recommendations", by Chan, Golub, and LeVeque.
-        new_unnormalized_variance -= correction**2 / new_sample_count
+        new_unnormalized_variance -= correction ** 2 / new_sample_count
 
         last_unnormalized_variance = last_variance * last_sample_count
 

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -195,7 +195,7 @@ def test_compute_sample_weight():
     # Test with multi-output of unbalanced classes
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1], [3, -1]])
     sample_weight = compute_sample_weight("balanced", y)
-    assert_array_almost_equal(sample_weight, expected_balanced**2, decimal=3)
+    assert_array_almost_equal(sample_weight, expected_balanced ** 2, decimal=3)
 
 
 def test_compute_sample_weight_with_subsample():
@@ -224,7 +224,7 @@ def test_compute_sample_weight_with_subsample():
     # Test with a bootstrap subsample for multi-output
     y = np.asarray([[1, 0], [1, 0], [1, 0], [2, 1], [2, 1], [2, 1]])
     sample_weight = compute_sample_weight("balanced", y, indices=[0, 1, 1, 2, 2, 3])
-    assert_array_almost_equal(sample_weight, expected_balanced**2)
+    assert_array_almost_equal(sample_weight, expected_balanced ** 2)
 
     # Test with a missing class
     y = np.asarray([1, 1, 1, 2, 2, 2, 3])

--- a/sklearn/utils/tests/test_cython_blas.py
+++ b/sklearn/utils/tests/test_cython_blas.py
@@ -131,7 +131,7 @@ def test_rotg(dtype):
         if a == 0 and b == 0:
             c, s, r, z = (1, 0, 0, 0)
         else:
-            r = np.sqrt(a**2 + b**2) * (1 if roe >= 0 else -1)
+            r = np.sqrt(a ** 2 + b ** 2) * (1 if roe >= 0 else -1)
             c, s = a / r, b / r
             z = s if roe == a else (1 if c == 0 else 1 / c)
         return r, z, c, s

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -306,7 +306,7 @@ def test_row_norms(dtype):
         precision = 5
 
     X = X.astype(dtype, copy=False)
-    sq_norm = (X**2).sum(axis=1)
+    sq_norm = (X ** 2).sum(axis=1)
 
     assert_array_almost_equal(sq_norm, row_norms(X, squared=True), precision)
     assert_array_almost_equal(np.sqrt(sq_norm), row_norms(X), precision)
@@ -624,7 +624,7 @@ def test_incremental_weighted_mean_and_variance_simple(rng, dtype):
 
     expected_mean = np.average(X, weights=sample_weight, axis=0)
     expected_var = (
-        np.average(X**2, weights=sample_weight, axis=0) - expected_mean**2
+        np.average(X ** 2, weights=sample_weight, axis=0) - expected_mean ** 2
     )
     assert_almost_equal(mean, expected_mean)
     assert_almost_equal(var, expected_var)
@@ -776,7 +776,7 @@ def test_incremental_variance_numerical_stability():
     # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
     def one_pass_var(X):
         n = X.shape[0]
-        exp_x2 = (X**2).sum(axis=0) / n
+        exp_x2 = (X ** 2).sum(axis=0) / n
         expx_2 = (X.sum(axis=0) / n) ** 2
         return exp_x2 - expx_2
 

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -28,12 +28,12 @@ def test_object_dtype_isnan(dtype, val):
 
 @pytest.mark.parametrize("low,high,base", [(-1, 0, 10), (0, 2, np.exp(1)), (-1, 1, 2)])
 def test_loguniform(low, high, base):
-    rv = loguniform(base**low, base**high)
+    rv = loguniform(base ** low, base ** high)
     assert isinstance(rv, scipy.stats._distn_infrastructure.rv_frozen)
     rvs = rv.rvs(size=2000, random_state=0)
 
     # Test the basics; right bounds, right size
-    assert (base**low <= rvs).all() and (rvs <= base**high).all()
+    assert (base ** low <= rvs).all() and (rvs <= base ** high).all()
     assert len(rvs) == 2000
 
     # Test that it's actually (fairly) uniform
@@ -43,6 +43,6 @@ def test_loguniform(low, high, base):
     assert np.abs(counts - counts.mean()).max() <= 40
 
     # Test that random_state works
-    assert loguniform(base**low, base**high).rvs(random_state=0) == loguniform(
-        base**low, base**high
+    assert loguniform(base ** low, base ** high).rvs(random_state=0) == loguniform(
+        base ** low, base ** high
     ).rvs(random_state=0)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #21521.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
In the random forest classifier and regression we could use callables for `oob_score` parameter. As suggested by @adrinjalali  in the issue #21521, the user could use any metric using the `partial` function, e.g. `partial(fbeta_score, beta=.7)`. If the `oob_score` parameter is set to `True` than the already used metric could be used to preserve backward compatibility.

#### Any other comments?
Is there any implementation constrain or any issue with this modification? 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
