### PR TITLE
Using callable in RandomForest oob_score parameter to define the oob scoring strategy.

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -510,9 +510,13 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
                 )
 
             if self.oob_score is True:
-                self._set_oob_score_and_attributes(X, y, scoring_function=accuracy_score)
+                self._set_oob_score_and_attributes(
+                    X, y, scoring_function=accuracy_score
+                )
             else:
-                self._set_oob_score_and_attributes(X, y, scoring_function=self.oob_score)
+                self._set_oob_score_and_attributes(
+                    X, y, scoring_function=self.oob_score
+                )
 
         # Decapsulate classes_ attributes
         if hasattr(self, "classes_") and self.n_outputs_ == 1:

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1040,7 +1040,7 @@ class ForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
             y_pred = y_pred[:, np.newaxis, :]
         return y_pred
 
-    def _set_oob_score_and_attributes(self, X, y):
+    def _set_oob_score_and_attributes(self, X, y, scoring_function=r2_score):
         """Compute and set the OOB score and attributes.
 
         Parameters
@@ -1054,7 +1054,7 @@ class ForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
         if self.oob_prediction_.shape[-1] == 1:
             # drop the n_outputs axis if there is a single output
             self.oob_prediction_ = self.oob_prediction_.squeeze(axis=-1)
-        self.oob_score_ = r2_score(y, self.oob_prediction_)
+        self.oob_score_ = scoring_function(y, self.oob_prediction_)
 
     def _compute_partial_dependence_recursion(self, grid, target_features):
         """Fast partial dependence computation.

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -508,7 +508,11 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
                     "supported: continuous, continuous-multioutput, binary, "
                     "multiclass, multilabel-indicator."
                 )
-            self._set_oob_score_and_attributes(X, y)
+
+            if self.oob_score is True:
+                self._set_oob_score_and_attributes(X, y, scoring_function=accuracy_score)
+            else:
+                self._set_oob_score_and_attributes(X, y, scoring_function=self.oob_score)
 
         # Decapsulate classes_ attributes
         if hasattr(self, "classes_") and self.n_outputs_ == 1:
@@ -735,7 +739,7 @@ class ForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
             y_pred = np.rollaxis(y_pred, axis=0, start=3)
         return y_pred
 
-    def _set_oob_score_and_attributes(self, X, y):
+    def _set_oob_score_and_attributes(self, X, y, scoring_function=accuracy_score):
         """Compute and set the OOB score and attributes.
 
         Parameters
@@ -749,7 +753,7 @@ class ForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
         if self.oob_decision_function_.shape[-1] == 1:
             # drop the n_outputs axis if there is a single output
             self.oob_decision_function_ = self.oob_decision_function_.squeeze(axis=-1)
-        self.oob_score_ = accuracy_score(
+        self.oob_score_ = scoring_function(
             y, np.argmax(self.oob_decision_function_, axis=1)
         )
 

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -510,9 +510,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
                 )
 
             if self.oob_score is True:
-                self._set_oob_score_and_attributes(
-                    X, y, scoring_function=accuracy_score
-                )
+                self._set_oob_score_and_attributes(X, y)
             else:
                 self._set_oob_score_and_attributes(
                     X, y, scoring_function=self.oob_score


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #21521.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
In the random forest classifier and regression we could use callables for `oob_score` parameter. As suggested by @adrinjalali  in the issue #21521, the user could use any metric using the `partial` function, e.g. `partial(fbeta_score, beta=.7)`. If the `oob_score` parameter is set to `True` than the already used metric could be used to preserve backward compatibility.

#### Any other comments?
Is there any implementation constrain or any issue with this modification? 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
