### PR TITLE
DOC Ensures that haversine_distances passes numpydoc validation

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -836,7 +836,7 @@ def haversine_distances(X, Y=None):
         A feature array.
 
     Y : array-like of shape (n_samples_Y, 2), default=None
-        If `None`, uses `Y=X`.
+        An optional second feature array. If `None`, uses `Y=X`.
 
     Returns
     -------

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -833,7 +833,7 @@ def haversine_distances(X, Y=None):
     Parameters
     ----------
     X : array-like of shape (n_samples_X, 2)
-        A feature array_like object.
+        A feature array.
 
     Y : array-like of shape (n_samples_Y, 2), default=None
         If `None`, uses `Y=X`.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -833,6 +833,7 @@ def haversine_distances(X, Y=None):
     Parameters
     ----------
     X : array-like of shape (n_samples_X, 2)
+        A feature array_like object.
 
     Y : array-like of shape (n_samples_Y, 2), default=None
         If `None`, uses `Y=X`.
@@ -840,6 +841,7 @@ def haversine_distances(X, Y=None):
     Returns
     -------
     distance : ndarray of shape (n_samples_X, n_samples_Y)
+        The distance matrix.
 
     Notes
     -----

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -74,7 +74,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.cosine_distances",
     "sklearn.metrics.pairwise.cosine_similarity",
     "sklearn.metrics.pairwise.distance_metrics",
-    "sklearn.metrics.pairwise.haversine_distances",
     "sklearn.metrics.pairwise.kernel_metrics",
     "sklearn.metrics.pairwise.laplacian_kernel",
     "sklearn.metrics.pairwise.paired_manhattan_distances",


### PR DESCRIPTION
Addresses #21350

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Modifications on metrics.pairwise.haversine_distance for docstring acceptance by the numpydoc criteria.


#### What does this implement/fix? Explain your changes.
Remove sklearn.metrics.pairwise.haversine_distances from test_doctrings.py FUNCTION_DOCSTRING_IGNORE_LIST
Necessary modifications for the resolution of errors:
              - PR07: Parameter "X" has no description
              - RT03: Return value has no description
#### Any other comments?
No

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
