### PR TITLE
CI Increases test time for pypy [pypy]

### DIFF
--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -9,6 +9,7 @@ jobs:
 - job: ${{ parameters.name }}
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.condition }}
+  timeoutInMinutes: 120
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:


### PR DESCRIPTION
The pypy build has been timing out on main: https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=40493&view=results

This PR updates the timeout to 120 minutes.