### PR TITLE
DOC fix: update docstring to say onehotencoder handles missing values

### DIFF
--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -11,9 +11,9 @@ extraction pipelines to different subsets of features, using
 case of datasets that contain heterogeneous data types, since we may want to
 scale the numeric features and one-hot encode the categorical ones.
 
-In this example, the numeric data is standard-scaled after mean-imputation,
-while the categorical data is one-hot encoded after imputing missing values
-with a new category (``'missing'``).
+In this example, the numeric data is standard-scaled after mean-imputation. The
+categorical data is one-hot encoded via ``OneHotEncoder``, which
+creates a new category for missing values.
 
 In addition, we show two different ways to dispatch the columns to the
 particular pre-processor: by column names and by column data types.

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -75,12 +75,7 @@ numeric_transformer = Pipeline(
 )
 
 categorical_features = ["embarked", "sex", "pclass"]
-categorical_transformer = Pipeline(
-    steps=[
-        ("imputer", SimpleImputer(strategy="constant", fill_value="missing")),
-        ("encoder", OneHotEncoder(handle_unknown="ignore")),
-    ]
-)
+categorical_transformer = OneHotEncoder(handle_unknown="ignore")
 
 preprocessor = ColumnTransformer(
     transformers=[

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -75,7 +75,12 @@ numeric_transformer = Pipeline(
 )
 
 categorical_features = ["embarked", "sex", "pclass"]
-categorical_transformer = OneHotEncoder(handle_unknown="ignore")
+categorical_transformer = Pipeline(
+    steps=[
+        ("imputer", SimpleImputer(strategy="constant", fill_value="missing")),
+        ("encoder", OneHotEncoder(handle_unknown="ignore")),
+    ]
+)
 
 preprocessor = ColumnTransformer(
     transformers=[


### PR DESCRIPTION
Adds a missing SimpleImputer to the 
`compose/plot_column_transformer_mixed_types.ipynb` example

#### Reference Issues/PRs
Fixes #23053 

#### What does this implement/fix? Explain your changes.

Adds a missing SimpleImputer that the example description implied would be present.
