### PR TITLE
TST Replace pytest.warns(None) in test_discriminant_analysis.py

### DIFF
--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import pytest
-import warnings
 
 from scipy import linalg
 
@@ -492,9 +491,7 @@ def test_lda_dimension_warning(n_classes, n_features):
     for n_components in [max_components - 1, None, max_components]:
         # if n_components <= min(n_classes - 1, n_features), no warning
         lda = LinearDiscriminantAnalysis(n_components=n_components)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            lda.fit(X, y)
+        lda.fit(X, y)
 
     for n_components in [max_components + 1, max(n_features, n_classes - 1) + 1]:
         # if n_components > min(n_classes - 1, n_features), raise error.

--- a/sklearn/tests/test_discriminant_analysis.py
+++ b/sklearn/tests/test_discriminant_analysis.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import pytest
+import warnings
 
 from scipy import linalg
 
@@ -491,7 +492,8 @@ def test_lda_dimension_warning(n_classes, n_features):
     for n_components in [max_components - 1, None, max_components]:
         # if n_components <= min(n_classes - 1, n_features), no warning
         lda = LinearDiscriminantAnalysis(n_components=n_components)
-        with pytest.warns(None):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
             lda.fit(X, y)
 
     for n_components in [max_components + 1, max(n_features, n_classes - 1) + 1]:


### PR DESCRIPTION
#### Reference Issues/PRs
Part of issue #22572
Following to PR #22824 

#### What does this implement/fix? Explain your changes.
Removing the use of pytest.warns(None) from ```tests/test_discriminant_analysis.py``` due to the deprecation from Pytest.
Using warnings.catch_warnings() along with warnings.simplefilter("error", UserWarning) to replace pytest.warns(None)

#### Any other comments?
This is my first ever open source pull-request. Please let me know if I have made any mistakes.
