### PR TITLE
DOC Fix duplicated module entries in whats_new

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -372,6 +372,12 @@ Changelog
   calling `fit` or `fit_transform`.
   :pr:`22553` by :user:`Meekail Zain <micky774>`.
 
+- |API| :func:`decomposition.FastICA` now supports unit variance for whitening.
+  The default value of its `whiten` argument will change from `True`
+  (which behaves like `'arbitrary-variance'`) to `'unit-variance'` in version 1.3.
+  :pr:`19490` by :user:`Facundo Ferrin <fferrin>` and
+  :user:`Julien Jerphanion <jjerphan>`.
+
 :mod:`sklearn.discriminant_analysis`
 ....................................
 
@@ -446,22 +452,18 @@ Changelog
   `warm_start` enabled.
   :pr:`22106` by :user:`Pieter Gijsbers <PGijsbers>`.
 
+- |Enhancement| Adds support to use pre-fit models with `cv="prefit"`
+  in :class:`ensemble.StackingClassifier` and :class:`ensemble.StackingRegressor`.
+  :pr:`16748` by :user:`Siqi He <siqi-he>` and :pr:`22215` by
+  :user:`Meekail Zain <micky774>`.
+
+- |Enhancement| :class:`ensemble.RandomTreesEmbedding` now has an informative
+  :func:`get_feature_names_out` function that includes both tree index and leaf index in
+  the output feature names.
+  :pr:`21762` by :user:`Zhehao Liu <MaxwellLZH>` and `Thomas Fan`_.
+
 :mod:`sklearn.feature_extraction`
 .................................
-
-- |Feature| Added auto mode to
-  :class:`feature_selection.SequentialFeatureSelection`. If the argument
-  `n_features_to_select` is `'auto'`, select features until the score
-  improvement does not exceed the argument `tol`. The default value of
-  `n_features_to_select` changed from `None` to `'warn'` in 1.1 and will become
-  `'auto'` in 1.3. `None` and `'warn'` will be removed in 1.3. :pr:`20145` by
-  :user:`murata-yu`.
-
-- |API| :func:`decomposition.FastICA` now supports unit variance for whitening.
-  The default value of its `whiten` argument will change from `True`
-  (which behaves like `'arbitrary-variance'`) to `'unit-variance'` in version 1.3.
-  :pr:`19490` by :user:`Facundo Ferrin <fferrin>` and
-  :user:`Julien Jerphanion <jjerphan>`.
 
 - |Fix| :class:`feature_extraction.FeatureHasher` now validates input parameters
   in `transform` instead of `__init__`. :pr:`21573` by
@@ -478,6 +480,14 @@ Changelog
 :mod:`sklearn.feature_selection`
 ................................
 
+- |Feature| Added auto mode to
+  :class:`feature_selection.SequentialFeatureSelection`. If the argument
+  `n_features_to_select` is `'auto'`, select features until the score
+  improvement does not exceed the argument `tol`. The default value of
+  `n_features_to_select` changed from `None` to `'warn'` in 1.1 and will become
+  `'auto'` in 1.3. `None` and `'warn'` will be removed in 1.3. :pr:`20145` by
+  :user:`murata-yu`.
+
 - |Efficiency| Improve runtime performance of :func:`feature_selection.chi2`
   with boolean arrays. :pr:`22235` by `Thomas Fan`_.
 
@@ -491,11 +501,6 @@ Changelog
 - |Efficiency| Reduced memory usage of :func:`feature_selection.chi2`.
   :pr:`21837` by :user:`Louis Wagner <lrwagner>`.
 
-- |Enhancement| Adds support to use pre-fit models with `cv="prefit"`
-  in :class:`ensemble.StackingClassifier` and :class:`ensemble.StackingRegressor`.
-  :pr:`16748` by :user:`Siqi He <siqi-he>` and :pr:`22215` by
-  :user:`Meekail Zain <micky774>`.
-
 - |Enhancement| :class:`feature_selection.GenericUnivariateSelect` preserves
   float32 dtype. :pr:`18482` by :user:`Thierry Gameiro <titigmr>`
   and :user:`Daniel Kharsa <aflatoune>` and :pr:`22370` by
@@ -508,11 +513,6 @@ Changelog
   or that the feature and target are perfectly correlated (only for the
   F-statistic).
   :pr:`17819` by :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
-
-- |Enhancement| :class:`ensemble.RandomTreesEmbedding` now has an informative
-  :func:`get_feature_names_out` function that includes both tree index and leaf index in
-  the output feature names.
-  :pr:`21762` by :user:`Zhehao Liu <MaxwellLZH>` and `Thomas Fan`_.
 
 :mod:`sklearn.gaussian_process`
 ...............................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -450,44 +450,6 @@ Changelog
   `'auto'` in 1.3. `None` and `'warn'` will be removed in 1.3. :pr:`20145` by
   :user:`murata-yu`.
 
-:mod:`sklearn.feature_selection`
-................................
-
-- |Efficiency| Improve runtime performance of :func:`feature_selection.chi2`
-  with boolean arrays. :pr:`22235` by `Thomas Fan`_.
-
-- |Feature| Added the ability to pass callables to the `max_features` parameter
-  of :class:`feature_selection.SelectFromModel`. Also introduced new attribute
-  `max_features_` which is inferred from `max_features` and the data during
-  `fit`. If `max_features` is an integer, then `max_features_ = max_features`.
-  If `max_features` is a callable, then `max_features_ = max_features(X)`.
-  :pr:`22356` by :user:`Meekail Zain <micky774>`
-
-:mod:`sklearn.feature_selection`
-................................
-- |Efficiency| Reduced memory usage of :func:`feature_selection.chi2`.
-  :pr:`21837` by :user:`Louis Wagner <lrwagner>`.
-
-- |Efficiency|  Fitting a :class:`ensemble.RandomForestClassifier`,
-  :class:`ensemble.RandomForestRegressor`, :class:`ensemble.ExtraTreesClassifier`,
-  :class:`ensemble.ExtraTreesRegressor`, and :class:`ensemble.RandomTreesEmbedding`
-  is now faster in a multiprocessing setting, especially for subsequent fits with
-  `warm_start` enabled.
-  :pr:`22106` by :user:`Pieter Gijsbers <PGijsbers>`.
-
-- |Enhancement| Adds support to use pre-fit models with `cv="prefit"`
-  in :class:`ensemble.StackingClassifier` and :class:`ensemble.StackingRegressor`.
-  :pr:`16748` by :user:`Siqi He <siqi-he>` and :pr:`22215` by
-  :user:`Meekail Zain <micky774>`.
-
-- |Enhancement| :class:`feature_selection.GenericUnivariateSelect` preserves
-  float32 dtype. :pr:`18482` by :user:`Thierry Gameiro <titigmr>`
-  and :user:`Daniel Kharsa <aflatoune>` and :pr:`22370` by
-  :user:`Meekail Zain <micky774>`.
-
-:mod:`sklearn.feature_extraction`
-.................................
-
 - |API| :func:`decomposition.FastICA` now supports unit variance for whitening.
   The default value of its `whiten` argument will change from `True`
   (which behaves like `'arbitrary-variance'`) to `'unit-variance'` in version 1.3.
@@ -509,6 +471,36 @@ Changelog
 :mod:`sklearn.feature_selection`
 ................................
 
+- |Efficiency| Improve runtime performance of :func:`feature_selection.chi2`
+  with boolean arrays. :pr:`22235` by `Thomas Fan`_.
+
+- |Feature| Added the ability to pass callables to the `max_features` parameter
+  of :class:`feature_selection.SelectFromModel`. Also introduced new attribute
+  `max_features_` which is inferred from `max_features` and the data during
+  `fit`. If `max_features` is an integer, then `max_features_ = max_features`.
+  If `max_features` is a callable, then `max_features_ = max_features(X)`.
+  :pr:`22356` by :user:`Meekail Zain <micky774>`
+
+- |Efficiency| Reduced memory usage of :func:`feature_selection.chi2`.
+  :pr:`21837` by :user:`Louis Wagner <lrwagner>`.
+
+- |Efficiency|  Fitting a :class:`ensemble.RandomForestClassifier`,
+  :class:`ensemble.RandomForestRegressor`, :class:`ensemble.ExtraTreesClassifier`,
+  :class:`ensemble.ExtraTreesRegressor`, and :class:`ensemble.RandomTreesEmbedding`
+  is now faster in a multiprocessing setting, especially for subsequent fits with
+  `warm_start` enabled.
+  :pr:`22106` by :user:`Pieter Gijsbers <PGijsbers>`.
+
+- |Enhancement| Adds support to use pre-fit models with `cv="prefit"`
+  in :class:`ensemble.StackingClassifier` and :class:`ensemble.StackingRegressor`.
+  :pr:`16748` by :user:`Siqi He <siqi-he>` and :pr:`22215` by
+  :user:`Meekail Zain <micky774>`.
+
+- |Enhancement| :class:`feature_selection.GenericUnivariateSelect` preserves
+  float32 dtype. :pr:`18482` by :user:`Thierry Gameiro <titigmr>`
+  and :user:`Daniel Kharsa <aflatoune>` and :pr:`22370` by
+  :user:`Meekail Zain <micky774>`.
+
 - |Enhancement| Add a parameter `force_finite` to
   :func:`feature_selection.f_regression` and
   :func:`feature_selection.r_regression`. This parameter allows to force the
@@ -516,6 +508,11 @@ Changelog
   or that the feature and target are perfectly correlated (only for the
   F-statistic).
   :pr:`17819` by :user:`Juan Carlos Alfaro Jiménez <alfaro96>`.
+
+- |Enhancement| :class:`ensemble.RandomTreesEmbedding` now has an informative
+  :func:`get_feature_names_out` function that includes both tree index and leaf index in
+  the output feature names.
+  :pr:`21762` by :user:`Zhehao Liu <MaxwellLZH>` and `Thomas Fan`_.
 
 :mod:`sklearn.gaussian_process`
 ...............................
@@ -531,13 +528,6 @@ Changelog
 - |Fix| :class:`gaussian_process.GaussianProcessClassifier` raises
   a more informative error if `CompoundKernel` is passed via `kernel`.
   :pr:`22223` by :user:`MarcoM <marcozzxx810>`.
-
-:mod:`sklearn.ensemble`
-.......................
-- |Enhancement| :class:`ensemble.RandomTreesEmbedding` now has an informative
-  :func:`get_feature_names_out` function that includes both tree index and leaf index in
-  the output feature names.
-  :pr:`21762` by :user:`Zhehao Liu <MaxwellLZH>` and `Thomas Fan`_.
 
 :mod:`sklearn.impute`
 .....................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -486,7 +486,7 @@ Changelog
   improvement does not exceed the argument `tol`. The default value of
   `n_features_to_select` changed from `None` to `'warn'` in 1.1 and will become
   `'auto'` in 1.3. `None` and `'warn'` will be removed in 1.3. :pr:`20145` by
-  :user:`murata-yu`.
+  :user:`murata-yu <murata-yu>`.
 
 - |Efficiency| Improve runtime performance of :func:`feature_selection.chi2`
   with boolean arrays. :pr:`22235` by `Thomas Fan`_.

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -439,6 +439,13 @@ Changelog
   fitting on a pandas DataFrame with a non-default `scoring` parameter and
   early_stopping enabled. :pr:`22908` by `Thomas Fan`_.
 
+- |Efficiency| Fitting a :class:`ensemble.RandomForestClassifier`,
+  :class:`ensemble.RandomForestRegressor`, :class:`ensemble.ExtraTreesClassifier`,
+  :class:`ensemble.ExtraTreesRegressor`, and :class:`ensemble.RandomTreesEmbedding`
+  is now faster in a multiprocessing setting, especially for subsequent fits with
+  `warm_start` enabled.
+  :pr:`22106` by :user:`Pieter Gijsbers <PGijsbers>`.
+
 :mod:`sklearn.feature_extraction`
 .................................
 
@@ -483,13 +490,6 @@ Changelog
 
 - |Efficiency| Reduced memory usage of :func:`feature_selection.chi2`.
   :pr:`21837` by :user:`Louis Wagner <lrwagner>`.
-
-- |Efficiency|  Fitting a :class:`ensemble.RandomForestClassifier`,
-  :class:`ensemble.RandomForestRegressor`, :class:`ensemble.ExtraTreesClassifier`,
-  :class:`ensemble.ExtraTreesRegressor`, and :class:`ensemble.RandomTreesEmbedding`
-  is now faster in a multiprocessing setting, especially for subsequent fits with
-  `warm_start` enabled.
-  :pr:`22106` by :user:`Pieter Gijsbers <PGijsbers>`.
 
 - |Enhancement| Adds support to use pre-fit models with `cv="prefit"`
   in :class:`ensemble.StackingClassifier` and :class:`ensemble.StackingRegressor`.


### PR DESCRIPTION
It seems like the auto-merge functionality of whats_new files (xref #21516) is causing weird ordering of whats_new. Maybe this can happen without this auto-merge .gitattributes though.

This fixes it. I used this `git grep` to track duplicated modules in whats_new. Output is on main and shows some duplicated module entries:

```
❯ git grep -P '^:mod:' doc/whats_new/v1.1.rst | sort | uniq -c | sort -nr
      3 doc/whats_new/v1.1.rst::mod:`sklearn.feature_selection`
      2 doc/whats_new/v1.1.rst::mod:`sklearn.feature_extraction`
      2 doc/whats_new/v1.1.rst::mod:`sklearn.ensemble`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.utils`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.tree`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.svm`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.random_projection`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.preprocessing`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.pipeline`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.neural_network`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.neighbors`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.multiclass`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.model_selection`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.mixture`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.metrics`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.manifold`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.linear_model`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.kernel_approximation`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.isotonic`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.inspection`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.impute`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.gaussian_process`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.feature_extraction.text`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.dummy`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.discriminant_analysis`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.decomposition`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.datasets`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.cross_decomposition`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.covariance`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.compose`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.cluster`
      1 doc/whats_new/v1.1.rst::mod:`sklearn.calibration`
```