### PR TITLE
MNT remove merge=union gitattributes for whats_new files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-/doc/whats_new/v*.rst merge=union


### PR DESCRIPTION
Close #21516.

As noted in #21516 this does not seem that useful in practice (there are still conflicts to fix for users because Github has not implemented it: https://github.com/scikit-learn/scikit-learn/issues/21516#issuecomment-960826979) and cause caveats creating duplicated or weirdly ordered whats_new entries.