### PR TITLE
replaced depreciated pytest warning syntax

### DIFF
--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -55,7 +55,7 @@ def test_check_increasing_up():
 
     # Check that we got increasing=True and no warnings
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", UserWarning)
         is_increasing = check_increasing(x, y)
 
     assert is_increasing
@@ -67,7 +67,7 @@ def test_check_increasing_up_extreme():
 
     # Check that we got increasing=True and no warnings
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", UserWarning)
         is_increasing = check_increasing(x, y)
 
     assert is_increasing
@@ -79,7 +79,7 @@ def test_check_increasing_down():
 
     # Check that we got increasing=False and no warnings
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", UserWarning)
         is_increasing = check_increasing(x, y)
 
     assert not is_increasing
@@ -91,7 +91,7 @@ def test_check_increasing_down_extreme():
 
     # Check that we got increasing=False and no warnings
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", UserWarning)
         is_increasing = check_increasing(x, y)
 
     assert not is_increasing

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -42,9 +42,9 @@ def test_check_increasing_small_number_of_samples():
     x = [0, 1, 2]
     y = [1, 1.1, 1.05]
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         is_increasing = check_increasing(x, y)
-    assert not [w.message for w in record]
 
     assert is_increasing
 
@@ -54,9 +54,9 @@ def test_check_increasing_up():
     y = [0, 1.5, 2.77, 8.99, 8.99, 50]
 
     # Check that we got increasing=True and no warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         is_increasing = check_increasing(x, y)
-    assert not [w.message for w in record]
 
     assert is_increasing
 
@@ -66,9 +66,9 @@ def test_check_increasing_up_extreme():
     y = [0, 1, 2, 3, 4, 5]
 
     # Check that we got increasing=True and no warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         is_increasing = check_increasing(x, y)
-    assert not [w.message for w in record]
 
     assert is_increasing
 
@@ -78,9 +78,9 @@ def test_check_increasing_down():
     y = [0, -1.5, -2.77, -8.99, -8.99, -50]
 
     # Check that we got increasing=False and no warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         is_increasing = check_increasing(x, y)
-    assert not [w.message for w in record]
 
     assert not is_increasing
 
@@ -90,9 +90,9 @@ def test_check_increasing_down_extreme():
     y = [0, -1, -2, -3, -4, -5]
 
     # Check that we got increasing=False and no warnings
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         is_increasing = check_increasing(x, y)
-    assert not [w.message for w in record]
 
     assert not is_increasing
 

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -43,7 +43,7 @@ def test_check_increasing_small_number_of_samples():
     y = [1, 1.1, 1.05]
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", UserWarning)
         is_increasing = check_increasing(x, y)
 
     assert is_increasing


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Fixes #22572

#### What does this implement/fix? Explain your changes.
Replaces depreciated pytest warning syntax with the updated one.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
