### PR TITLE
DOC remove unimplemented misclassification criterion from user guide

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -500,12 +500,6 @@ Entropy:
 
     H(Q_m) = - \sum_k p_{mk} \log(p_{mk})
 
-Misclassification:
-
-.. math::
-
-    H(Q_m) = 1 - \max(p_{mk})
-
 Regression criteria
 -------------------
 


### PR DESCRIPTION
We do not implement this criterion in scikit-learn.

This part of the scikit-learn user guide uses the notation and criterion presented page 309 of the [ESLII](https://hastie.su.domains/Papers/ESLII.pdf) but is it not aligned with the list of options actually implemented in scikit-learn.

If we ever decide to implement it, we can always re-add this doc but I suspect this is a YAGNI.