### PR TITLE
ENH Reduce copying when centering PDPs

### DIFF
--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -10,6 +10,7 @@ from joblib import Parallel
 
 from .. import partial_dependence
 from ...base import is_regressor
+from ...utils import Bunch
 from ...utils import check_array
 from ...utils import deprecated
 from ...utils import check_matplotlib_support  # noqa
@@ -1028,7 +1029,6 @@ class PartialDependenceDisplay:
         pd_plot_idx,
         n_total_lines_by_plot,
         individual_line_kw,
-        centered,
     ):
         """Plot the ICE lines.
 
@@ -1051,8 +1051,6 @@ class PartialDependenceDisplay:
             The total number of lines expected to be plot on the axis.
         individual_line_kw : dict
             Dict with keywords passed when plotting the ICE lines.
-        centered : bool
-            Whether or not to center the ICE lines to start at the origin.
         """
         rng = check_random_state(self.random_state)
         # subsample ice
@@ -1062,10 +1060,6 @@ class PartialDependenceDisplay:
             replace=False,
         )
         ice_lines_subsampled = preds[ice_lines_idx, :]
-        if centered:
-            # trigger a copy if we need to center the ICE lines
-            ice_lines_subsampled = ice_lines_subsampled.copy()
-            ice_lines_subsampled -= ice_lines_subsampled[:, [0]]
         # plot the subsampled ice
         for ice_idx, ice in enumerate(ice_lines_subsampled):
             line_idx = np.unravel_index(
@@ -1082,7 +1076,6 @@ class PartialDependenceDisplay:
         ax,
         pd_line_idx,
         line_kw,
-        centered,
     ):
         """Plot the average partial dependence.
 
@@ -1103,10 +1096,6 @@ class PartialDependenceDisplay:
         centered : bool
             Whether or not to center the average PD to start at the origin.
         """
-        if centered:
-            # trigger a copy to not make changes to the original array
-            avg_preds = avg_preds.copy()
-            avg_preds -= avg_preds[0]
         line_idx = np.unravel_index(pd_line_idx, self.lines_.shape)
         self.lines_[line_idx] = ax.plot(
             feature_values,
@@ -1129,7 +1118,6 @@ class PartialDependenceDisplay:
         ice_lines_kw,
         pd_line_kw,
         pdp_lim,
-        centered,
     ):
         """Plot 1-way partial dependence: ICE and PDP.
 
@@ -1167,8 +1155,6 @@ class PartialDependenceDisplay:
             Global min and max average predictions, such that all plots will
             have the same scale and y limits. `pdp_lim[1]` is the global min
             and max for single partial dependence curves.
-        centered : bool
-            Whether or not to center the PD and ICE plot to start at the origin.
         """
         from matplotlib import transforms  # noqa
 
@@ -1181,7 +1167,6 @@ class PartialDependenceDisplay:
                 pd_plot_idx,
                 n_lines,
                 ice_lines_kw,
-                centered,
             )
 
         if kind in ("average", "both"):
@@ -1196,7 +1181,6 @@ class PartialDependenceDisplay:
                 ax,
                 pd_line_idx,
                 pd_line_kw,
-                centered,
             )
 
         trans = transforms.blended_transform_factory(ax.transData, ax.transAxes)
@@ -1419,18 +1403,42 @@ class PartialDependenceDisplay:
                 )
             pdp_lim = self.pdp_lim
 
+        # Center results before plotting
+        if not centered:
+            pd_results_ = self.pd_results
+        else:
+            pd_results_ = []
+            for kind_plot, pd_result in zip(kind, self.pd_results):
+                current_results = {"values": pd_result["values"]}
+
+                if kind_plot == "individual":
+                    preds = pd_result.individual
+                    preds = preds - preds[self.target_idx, :, 0, None]
+                    current_results["individual"] = preds
+
+                elif kind_plot == "average":
+                    avg_preds = pd_result.average
+                    avg_preds = avg_preds - avg_preds[self.target_idx, 0, None]
+                    current_results["average"] = avg_preds
+
+                else:  # kind_plot == 'both'
+                    avg_preds = pd_result.average
+                    preds = pd_result.individual
+                    avg_preds = avg_preds - avg_preds[self.target_idx, 0, None]
+                    preds = preds - preds[self.target_idx, :, 0, None]
+                    current_results["average"] = avg_preds
+                    current_results["individual"] = preds
+
+                pd_results_.append(Bunch(**current_results))
+
         if pdp_lim is None:
             # get global min and max average predictions of PD grouped by plot type
             pdp_lim = {}
-            for idx, pdp in enumerate(self.pd_results):
+            for kind_plot, pdp in zip(kind, pd_results_):
                 values = pdp["values"]
-                preds = pdp.average if kind[idx] == "average" else pdp.individual
-                if centered and kind[idx] in ("both", "individual"):
-                    preds_offset = preds[self.target_idx, :, 0, None]
-                else:
-                    preds_offset = 0.0
-                min_pd = (preds[self.target_idx] - preds_offset).min()
-                max_pd = (preds[self.target_idx] - preds_offset).max()
+                preds = pdp.average if kind_plot == "average" else pdp.individual
+                min_pd = preds[self.target_idx].min()
+                max_pd = preds[self.target_idx].max()
                 n_fx = len(values)
                 old_min_pd, old_max_pd = pdp_lim.get(n_fx, (min_pd, max_pd))
                 min_pd = min(min_pd, old_min_pd)
@@ -1462,7 +1470,7 @@ class PartialDependenceDisplay:
             # we need to determine the number of ICE samples computed
             ice_plot_idx = is_average_plot.index(False)
             n_ice_lines = self._get_sample_count(
-                len(self.pd_results[ice_plot_idx].individual[0])
+                len(pd_results_[ice_plot_idx].individual[0])
             )
             if any([kind_plot == "both" for kind_plot in kind]):
                 n_lines = n_ice_lines + 1  # account for the average line
@@ -1530,7 +1538,7 @@ class PartialDependenceDisplay:
         self.deciles_hlines_ = np.empty_like(self.axes_, dtype=object)
 
         for pd_plot_idx, (axi, feature_idx, pd_result, kind_plot) in enumerate(
-            zip(self.axes_.ravel(), self.features, self.pd_results, kind)
+            zip(self.axes_.ravel(), self.features, pd_results_, kind)
         ):
             avg_preds = None
             preds = None
@@ -1597,7 +1605,6 @@ class PartialDependenceDisplay:
                     ice_lines_kw,
                     pd_line_kw,
                     pdp_lim,
-                    centered,
                 )
             else:
                 self._plot_two_way_partial_dependence(

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -1411,23 +1411,15 @@ class PartialDependenceDisplay:
             for kind_plot, pd_result in zip(kind, self.pd_results):
                 current_results = {"values": pd_result["values"]}
 
-                if kind_plot == "individual":
+                if kind_plot in ("individual", "both"):
                     preds = pd_result.individual
                     preds = preds - preds[self.target_idx, :, 0, None]
                     current_results["individual"] = preds
 
-                elif kind_plot == "average":
+                if kind_plot in ("average", "both"):
                     avg_preds = pd_result.average
                     avg_preds = avg_preds - avg_preds[self.target_idx, 0, None]
                     current_results["average"] = avg_preds
-
-                else:  # kind_plot == 'both'
-                    avg_preds = pd_result.average
-                    preds = pd_result.individual
-                    avg_preds = avg_preds - avg_preds[self.target_idx, 0, None]
-                    preds = preds - preds[self.target_idx, :, 0, None]
-                    current_results["average"] = avg_preds
-                    current_results["individual"] = preds
 
                 pd_results_.append(Bunch(**current_results))
 

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -803,7 +803,7 @@ def test_partial_dependence_plot_limits_one_way(
 
     disp.plot(centered=centered)
     # check that we anchor to zero x-axis when centering
-    y_lim = range_pd - range_pd[0] if centered and kind != "average" else range_pd
+    y_lim = range_pd - range_pd[0] if centered else range_pd
     for ax in disp.axes_.ravel():
         assert_allclose(ax.get_ylim(), y_lim)
 
@@ -828,9 +828,9 @@ def test_partial_dependence_plot_limits_two_way(
         pd["average"][0, 0] = range_pd[0]
 
     disp.plot(centered=centered)
-    # centering should not have any effect on the limits
     coutour = disp.contours_[0, 0]
-    expect_levels = np.linspace(*range_pd, num=8)
+    levels = range_pd - range_pd[0] if centered else range_pd
+    expect_levels = np.linspace(*levels, num=8)
     assert_allclose(coutour.levels, expect_levels)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to https://github.com/scikit-learn/scikit-learn/pull/18310


#### What does this implement/fix? Explain your changes.
Since `pdp_lim` already does the subtraction to compute the limits, I do not think we need to do the computation again in the private `_plot` methods.

Also I think kind="average" should center when `centered=True`, otherwise parts of the plot gets cut off. For example when running this:

<details><summary>Code snippet</summary>

from sklearn.datasets import fetch_california_housing
from sklearn.model_selection import train_test_split
from sklearn.pipeline import make_pipeline
from sklearn.preprocessing import QuantileTransformer
from sklearn.neural_network import MLPRegressor
from sklearn.inspection import PartialDependenceDisplay

X, y = fetch_california_housing(as_frame=True, return_X_y=True)
y -= y.mean()

X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=0)

est = make_pipeline(
    QuantileTransformer(),
    MLPRegressor(
        hidden_layer_sizes=(30, 15),
        learning_rate_init=0.01,
        early_stopping=True,
        random_state=0,
    ),
)
est.fit(X_train, y_train)


common_params = {
    "n_jobs": 2,
    "grid_resolution": 10,
    "centered": True,
    "random_state": 0,
}

display = PartialDependenceDisplay.from_estimator(
    est,
    X_train,
    features=["MedInc", "AveOccup", "HouseAge"],
    kind="average",
    **common_params,
)

display.figure_.suptitle("centered=True")
display.plot(centered=False)
_ = display.figure_.suptitle("centered=False")
</details>

Notice how on `main` the `centered=True` version has part of the plot cut offed.

### main

![Screen Shot 2022-04-07 at 4 51 54 PM](https://user-images.githubusercontent.com/5402633/162301105-7fef57e5-288a-496a-a782-195408cbf387.jpg)


### This PR


![Screen Shot 2022-04-07 at 4 52 26 PM](https://user-images.githubusercontent.com/5402633/162301152-1f11678e-941a-4156-97b5-1b068e911cdb.jpg)


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
