### PR TITLE
DOC correct position of changes in changelog

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -559,20 +559,6 @@ Changelog
   values in the training set.
   :pr:`21617` by :user:`Christian Ritter <chritter>`.
 
-- |Enhancement| :class:`linear_model.RidgeClassifier` is now supporting
-  multilabel classification.
-  :pr:`19689` by :user:`Guillaume Lemaitre <glemaitre>`.
-
-- |Enhancement| :class:`linear_model.RidgeCV` and
-  :class:`linear_model.RidgeClassifierCV` now raise consistent error message
-  when passed invalid values for `alphas`.
-  :pr:`21606` by :user:`Arturo Amor <ArturoAmorQ>`.
-
-- |Enhancement| :class:`linear_model.Ridge` and :class:`linear_model.RidgeClassifier`
-  now raise consistent error message when passed invalid values for `alpha`,
-  `max_iter` and `tol`.
-  :pr:`21341` by :user:`Arturo Amor <ArturoAmorQ>`.
-
 :mod:`sklearn.inspection`
 .........................
 
@@ -702,6 +688,20 @@ Changelog
   `fit_intercept=True`.
   :pr:`22950` by :user:`Christian Lorentzen <lorentzenchr>`.
 
+- |Enhancement| :class:`linear_model.RidgeClassifier` is now supporting
+  multilabel classification.
+  :pr:`19689` by :user:`Guillaume Lemaitre <glemaitre>`.
+
+- |Enhancement| :class:`linear_model.RidgeCV` and
+  :class:`linear_model.RidgeClassifierCV` now raise consistent error message
+  when passed invalid values for `alphas`.
+  :pr:`21606` by :user:`Arturo Amor <ArturoAmorQ>`.
+
+- |Enhancement| :class:`linear_model.Ridge` and :class:`linear_model.RidgeClassifier`
+  now raise consistent error message when passed invalid values for `alpha`,
+  `max_iter` and `tol`.
+  :pr:`21341` by :user:`Arturo Amor <ArturoAmorQ>`.
+
 :mod:`sklearn.manifold`
 .......................
 
@@ -826,16 +826,6 @@ Changelog
 
 :mod:`sklearn.neighbors`
 ........................
-
-- |Enhancement| `utils.validation.check_array` and `utils.validation.type_of_target`
-  now accept an `input_name` parameter to make the error message more
-  informative when passed invalid input data (e.g. with NaN or infinite
-  values).
-  :pr:`21219` by :user:`Olivier Grisel <ogrisel>`.
-
-- |Enhancement| :func:`utils.validation.check_array` returns a float
-  ndarray with `np.nan` when passed a `Float32` or `Float64` pandas extension
-  array with `pd.NA`. :pr:`21278` by `Thomas Fan`_.
 
 - |Enhancement| Adds :term:`get_feature_names_out` to
   :class:`neighbors.RadiusNeighborsTransformer`, :class:`neighbors.KNeighborsTransformer`
@@ -986,6 +976,16 @@ Changelog
 
 :mod:`sklearn.utils`
 ....................
+
+- |Enhancement| `utils.validation.check_array` and `utils.validation.type_of_target`
+  now accept an `input_name` parameter to make the error message more
+  informative when passed invalid input data (e.g. with NaN or infinite
+  values).
+  :pr:`21219` by :user:`Olivier Grisel <ogrisel>`.
+
+- |Enhancement| :func:`utils.validation.check_array` returns a float
+  ndarray with `np.nan` when passed a `Float32` or `Float64` pandas extension
+  array with `pd.NA`. :pr:`21278` by `Thomas Fan`_.
 
 - |Enhancement| :func:`utils.estimator_html_repr` shows a more helpful error
   message when running in a jupyter notebook that is not trusted. :pr:`21316`


### PR DESCRIPTION
#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.
I noticed that some changes in the changelog were listed under the wrong module. A few changes related to `sklearn.linear_model` were listed under `sklearn.impute` and some changes related to `sklearn.utils` were listed under `sklearn.neighbors`. I corrected that. 

#### Any other comments?
