### PR TITLE
EXA: fix 3d projections in examples for matplotlib 3.1

### DIFF
--- a/examples/datasets/plot_iris_dataset.py
+++ b/examples/datasets/plot_iris_dataset.py
@@ -21,6 +21,10 @@ information on this dataset.
 # License: BSD 3 clause
 
 import matplotlib.pyplot as plt
+
+# unused but required import for doing 3d projections with matplotlib < 3.2
+import mpl_toolkits.mplot3d  # noqa: F401
+
 from sklearn import datasets
 from sklearn.decomposition import PCA
 

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -32,6 +32,9 @@ from numpy.random import RandomState
 import matplotlib.pyplot as plt
 from matplotlib import ticker
 
+# unused but required import for doing 3d projections with matplotlib < 3.2
+import mpl_toolkits.mplot3d  # noqa: F401
+
 from sklearn import manifold, datasets
 
 rng = RandomState(0)


### PR DESCRIPTION
See https://github.com/scikit-learn/scikit-learn/pull/22594#issuecomment-1050127303 for more details. The issue was observed in https://github.com/scikit-learn/scikit-learn/pull/23064. I think those are the only examples affected by this.

I assume they got through because the change were merged when matplotlib 2 was our min supported version and matplotlib 2 was OK without the import ...