### PR TITLE
DOC improve the random forest feature importance comparison example

### DIFF
--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -224,8 +224,8 @@ for name, data, target in zip(["train", "test"], [X_train, X_test], [y_train, y_
 importances = pd.concat(importances, names=["set", "permutation"])
 
 # %%
-axes = importances.reset_index(level="set").groupby("set").plot.box(vert=False, whis=10)
-for name, ax in axes.iteritems():
+for name, data in importances.reset_index(level="set").groupby("set"):
+    ax = data.plot.box(vert=False, whis=10)
     ax.set_title(f"Permutation Importances ({name} set)")
     ax.set_xlabel("Decrease in accuracy score")
     ax.axvline(x=0, color="k", linestyle="--")

--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -55,7 +55,7 @@ X = X[categorical_columns + numerical_columns]
 X_train, X_test, y_train, y_test = train_test_split(X, y, stratify=y, random_state=42)
 
 # %%
-# We define a predictive model based on random forest. Therefore, we will make
+# We define a predictive model based on a random forest. Therefore, we will make
 # the following preprocessing steps:
 #
 # - use :class:`~sklearn.preprocessing.OrdinaleEcnoder` to encode the

--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -146,10 +146,11 @@ mdi_importance = pd.Series(
 ).sort_values(ascending=True)
 
 # %%
-mdi_importance.plot.barh()
-plt.title("Random Forest Feature Importances (MDI)")
-plt.xlabel("Mean decrease in impurity")
-plt.tight_layout()
+ax = importances.plot.box(vert=False, whis=10)
+ax.set_title("Permutation Importances (test set)")
+ax.axvline(x=0, color="k", linestyle="--")
+ax.set_xlabel("Decrease in accuracy score")
+ax.figure.tight_layout()
 
 # %%
 # As an alternative, the permutation importances of ``rf`` are computed on a
@@ -171,11 +172,11 @@ importances = pd.DataFrame(
     result.importances[sorted_importances_idx].T,
     columns=X.columns[sorted_importances_idx],
 )
-importances.plot.box(vert=False, whis=10)
-plt.title("Permutation Importances (test set)")
-plt.axvline(x=0, color="k", linestyle="--")
-plt.xlabel("Decrease in accuracy score")
-plt.tight_layout()
+ax = importances.plot.box(vert=False, whis=10)
+ax.set_title("Permutation Importances (test set)")
+ax.axvline(x=0, color="k", linestyle="--")
+ax.set_xlabel("Decrease in accuracy score")
+ax.figure.tight_layout()
 
 # %%
 # It is also possible to compute the permutation importances on the training
@@ -192,11 +193,11 @@ importances = pd.DataFrame(
     result.importances[sorted_importances_idx].T,
     columns=X.columns[sorted_importances_idx],
 )
-importances.plot.box(vert=False, whis=10)
-plt.title("Permutation Importances (train set)")
-plt.axvline(x=0, color="k", linestyle="--")
-plt.xlabel("Decrease in accuracy score")
-plt.tight_layout()
+ax = importances.plot.box(vert=False, whis=10)
+ax.set_title("Permutation Importances (train set)")
+ax.axvline(x=0, color="k", linestyle="--")
+ax.set_xlabel("Decrease in accuracy score")
+ax.figure.tight_layout()
 
 # %%
 # We can further retry the experiment by limiting the capacity of the trees
@@ -235,7 +236,7 @@ for name, importances in zip(["train", "test"], [train_importances, test_importa
     ax.set_title(f"Permutation Importances ({name} set)")
     ax.set_xlabel("Decrease in accuracy score")
     ax.axvline(x=0, color="k", linestyle="--")
-    plt.tight_layout()
+    ax.figure.tight_layout()
 
 # %%
 # Now, we can observe that on both sets, the `random_num` and `random_cat`

--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -25,7 +25,6 @@ can mitigate those limitations.
 
 """
 # %%
-import matplotlib.pyplot as plt
 import numpy as np
 
 # %%
@@ -141,12 +140,12 @@ import pandas as pd
 
 feature_names = rf[:-1].get_feature_names_out()
 
-mdi_importance = pd.Series(
+mdi_importances = pd.Series(
     rf[-1].feature_importances_, index=feature_names
 ).sort_values(ascending=True)
 
 # %%
-ax = importances.plot.box(vert=False, whis=10)
+ax = mdi_importances.plot.box(vert=False, whis=10)
 ax.set_title("Permutation Importances (test set)")
 ax.axvline(x=0, color="k", linestyle="--")
 ax.set_xlabel("Decrease in accuracy score")

--- a/examples/inspection/plot_permutation_importance.py
+++ b/examples/inspection/plot_permutation_importance.py
@@ -146,8 +146,8 @@ mdi_importance = pd.Series(
 # %%
 mdi_importance.plot.barh()
 plt.title("Random Forest Feature Importances (MDI)")
-_ = plt.xlabel("Mean decrease in impurity")
-
+plt.xlabel("Mean decrease in impurity")
+plt.tight_layout()
 
 # %%
 # As an alternative, the permutation importances of ``rf`` are computed on a
@@ -161,18 +161,19 @@ _ = plt.xlabel("Mean decrease in impurity")
 from sklearn.inspection import permutation_importance
 
 result = permutation_importance(
-    rf[-1], rf[:-1].transform(X_test), y_test, n_repeats=10, random_state=42, n_jobs=2
+    rf, X_test, y_test, n_repeats=10, random_state=42, n_jobs=2
 )
 
 sorted_importances_idx = result.importances_mean.argsort()
 importances = pd.DataFrame(
     result.importances[sorted_importances_idx].T,
-    columns=feature_names[sorted_importances_idx],
+    columns=X.columns[sorted_importances_idx],
 )
 importances.plot.box(vert=False, whis=10)
 plt.title("Permutation Importances (test set)")
 plt.axvline(x=0, color="k", linestyle="--")
-_ = plt.xlabel("Decrease in accuracy score")
+plt.xlabel("Decrease in accuracy score")
+plt.tight_layout()
 
 # %%
 # It is also possible to compute the permutation importances on the training
@@ -181,18 +182,19 @@ _ = plt.xlabel("Decrease in accuracy score")
 # between those two plots is a confirmation that the RF model has enough
 # capacity to use that random numerical and categorical features to overfit.
 result = permutation_importance(
-    rf[-1], rf[:-1].transform(X_train), y_train, n_repeats=10, random_state=42, n_jobs=2
+    rf, X_train, y_train, n_repeats=10, random_state=42, n_jobs=2
 )
 
 sorted_importances_idx = result.importances_mean.argsort()
 importances = pd.DataFrame(
     result.importances[sorted_importances_idx].T,
-    columns=feature_names[sorted_importances_idx],
+    columns=X.columns[sorted_importances_idx],
 )
 importances.plot.box(vert=False, whis=10)
 plt.title("Permutation Importances (train set)")
 plt.axvline(x=0, color="k", linestyle="--")
-_ = plt.xlabel("Decrease in accuracy score")
+plt.xlabel("Decrease in accuracy score")
+plt.tight_layout()
 
 # %%
 # We can further retry the experiment by limiting the capacity of the trees
@@ -210,14 +212,14 @@ print(f"RF test accuracy: {rf.score(X_test, y_test):.3f}")
 importances = {}
 for name, data, target in zip(["train", "test"], [X_train, X_test], [y_train, y_test]):
     result = permutation_importance(
-        rf[-1], rf[:-1].transform(data), target, n_repeats=10, random_state=42, n_jobs=2
+        rf, data, target, n_repeats=10, random_state=42, n_jobs=2
     )
     if name == "train":
         sorted_importances_idx = result.importances_mean.argsort()
 
     importances[name] = pd.DataFrame(
         result.importances[sorted_importances_idx].T,
-        columns=rf[:-1].get_feature_names_out()[sorted_importances_idx],
+        columns=data.columns[sorted_importances_idx],
     )
 importances = pd.concat(importances, names=["set", "permutation"])
 
@@ -227,9 +229,10 @@ for name, ax in axes.iteritems():
     ax.set_title(f"Permutation Importances ({name} set)")
     ax.set_xlabel("Decrease in accuracy score")
     ax.axvline(x=0, color="k", linestyle="--")
+    plt.tight_layout()
 
 # %%
 # Now, we can observe that on both sets, the `random_num` and `random_cat`
-# features have a lower importance than with the overfitting random forest.
+# features have a lower importance compared to the overfitting random forest.
 # However, the conclusions regarding the importance of the other features are
 # still valid.


### PR DESCRIPTION
Improving slightly the example comparing the MDI and permutation importance example.

I replaced the `OneHotEncoder` with an `OrdinalEncoder` which is more reasonable and still shows the bias towards high cardinality features.

I also repeat the experiment with a random forest that does not overfit. It is not so computational intensive and we can show the resulting figure.

I also updated using the `get_feature_names_out` of the `ColumnTransformmer` that simplifies the example.