### PR TITLE
STY Better paragraph styling for admonition p

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -832,8 +832,12 @@ div.admonition {
   background-color: #eee;
 }
 
-div.admonition p, div.admonition dl, div.admonition dd,
-div.deprecated p, div.versionchanged p, div.versionadded p{
+div.admonition p:last-child,
+div.admonition dl:last-child,
+div.admonition dd:last-child,
+div.deprecated p:last-child,
+div.versionchanged p:last-child,
+div.versionadded p:last-child{
   margin-bottom: 0
 }
 


### PR DESCRIPTION
I noticed how the CSS can be improved when reviewing: https://github.com/scikit-learn/scikit-learn/pull/23081

This PR improves the spacing of HTML elements inside of `.. notes` and other directives. For example, the [note in Ledoit-wolf](https://scikit-learn.org/stable/modules/covariance.html#ledoit-wolf-shrinkage) on main looks like:


![Screen Shot 2022-04-08 at 6 37 54 PM](https://user-images.githubusercontent.com/5402633/162542903-cfed30fa-c742-4e47-827d-412c03f8fbbe.jpg)

With this PR:

![Screen Shot 2022-04-08 at 6 38 18 PM](https://user-images.githubusercontent.com/5402633/162542938-c4998353-f069-4ab5-9289-479f787c3512.jpg)

(Basically the `p` tag inherits from the normal `p` tag, while only the last one sets the margin-bottom to 0.)