### PR TITLE
DOC Fix version of ConfusionMatrix.from_predictions

### DIFF
--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -342,7 +342,7 @@ class ConfusionMatrixDisplay:
 
         Read more in the :ref:`User Guide <confusion_matrix>`.
 
-        .. versionadded:: 0.24
+        .. versionadded:: 1.0
 
         Parameters
         ----------


### PR DESCRIPTION
From the commit: https://github.com/scikit-learn/scikit-learn/commit/8c6a045e46abe94e43a971d4f8042728addfd6a7 that added `from_prediction`, this feature was added in 1.0.