### PR TITLE
TST Remove pytest.warns(None) and replace it with warnings.catch_warnings in test_pipeline.py

### DIFF
--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -502,9 +502,7 @@ def test_feature_union():
     assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
 
     # Test clone
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
-        fs2 = clone(fs)
+    fs2 = clone(fs)
     assert fs.transformer_list[0][1] is not fs2.transformer_list[0][1]
 
     # test setting parameters

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -8,7 +8,6 @@ import re
 import itertools
 
 import pytest
-import warnings
 import numpy as np
 from scipy import sparse
 import joblib
@@ -228,9 +227,7 @@ def test_pipeline_invalid_parameters():
         pipe.set_params(anova__C=0.1)
 
     # Test clone
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
-        pipe2 = clone(pipe)
+    pipe2 = clone(pipe)
     assert not pipe.named_steps["svc"] is pipe2.named_steps["svc"]
 
     # Check that apart from estimators, the parameters are the same
@@ -504,9 +501,7 @@ def test_feature_union():
     assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
 
     # Test clone
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
-        fs2 = clone(fs)
+    fs2 = clone(fs)
     assert fs.transformer_list[0][1] is not fs2.transformer_list[0][1]
 
     # test setting parameters

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -228,9 +228,7 @@ def test_pipeline_invalid_parameters():
         pipe.set_params(anova__C=0.1)
 
     # Test clone
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
-        pipe2 = clone(pipe)
+    pipe2 = clone(pipe)
     assert not pipe.named_steps["svc"] is pipe2.named_steps["svc"]
 
     # Check that apart from estimators, the parameters are the same

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -8,6 +8,7 @@ import re
 import itertools
 
 import pytest
+import warnings
 import numpy as np
 from scipy import sparse
 import joblib
@@ -227,7 +228,8 @@ def test_pipeline_invalid_parameters():
         pipe.set_params(anova__C=0.1)
 
     # Test clone
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
         pipe2 = clone(pipe)
     assert not pipe.named_steps["svc"] is pipe2.named_steps["svc"]
 
@@ -502,7 +504,8 @@ def test_feature_union():
     assert_array_almost_equal(X_transformed, X_sp_transformed.toarray())
 
     # Test clone
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
         fs2 = clone(fs)
     assert fs.transformer_list[0][1] is not fs2.transformer_list[0][1]
 


### PR DESCRIPTION
#### Reference Issues/PRs
Related to #22572 

#### What does this implement/fix? Explain your changes.
Replaces deprecated pytest.warns(None) in test_pipeline.py with a warnings.catch_warnings() context handler.

#### Any other comments?
・Replaced all deprecated pytest.warns(None) in test.pipeline.py.
・I think the original code checks if it raises a UserWarning, please correct me if I am wrong.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
