### PR TITLE
ENH save memory with LinearLoss

### DIFF
--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -272,7 +272,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
                 coef = np.zeros(n_features, dtype=loss_dtype)
 
         # To save some memory, we preallocate a ndarray used as per row loss and
-        # gradient inside od LinearLoss, e.g. by LinearLoss.base_loss.gradient (and
+        # gradient inside of LinearLoss, e.g. by LinearLoss.base_loss.gradient (and
         # others).
         per_sample_loss_out = np.empty_like(y)
         per_sample_gradient_out = np.empty_like(y)
@@ -301,10 +301,8 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
                     sample_weight,
                     l2_reg_strength,
                     n_threads,
-                    {
-                        "per_sample_loss_out": per_sample_loss_out,
-                        "per_sample_gradient_out": per_sample_gradient_out,
-                    },
+                    per_sample_loss_out,
+                    per_sample_gradient_out,
                 ),
             )
             self.n_iter_ = _check_optimize_result("lbfgs", opt_res)

--- a/sklearn/linear_model/_linear_loss.py
+++ b/sklearn/linear_model/_linear_loss.py
@@ -120,7 +120,7 @@ class LinearModelLoss:
         sample_weight=None,
         l2_reg_strength=0.0,
         n_threads=1,
-        temporary_array_dict=None,
+        per_sample_loss_out=None,
     ):
         """Compute the loss as sum over point-wise losses.
 
@@ -141,12 +141,10 @@ class LinearModelLoss:
             L2 regularization strength
         n_threads : int, default=1
             Number of OpenMP threads to use.
-        temporary_array_dict: None or dict, default=None
-            Providing such an array can save a little memory. Possible entry:
-
-            "per_sample_loss_out" : C-contiguous array of shape (n_samples,)
-                A location into which the per sample loss is stored. If None, a new
-                array might be created.
+        per_sample_loss_out : None or C-contiguous array of shape (n_samples,), \
+            default=None
+            A location into which the per sample loss is stored. If None, a new array
+            might be created. Providing such an array can save a little memory.
 
         Returns
         -------
@@ -154,10 +152,6 @@ class LinearModelLoss:
             Sum of losses per sample plus penalty.
         """
         weights, intercept, raw_prediction = self._w_intercept_raw(coef, X)
-        if temporary_array_dict is not None:
-            per_sample_loss_out = temporary_array_dict.get("per_sample_loss_out", None)
-        else:
-            per_sample_loss_out = None
 
         loss = self.base_loss.loss(
             y_true=y,
@@ -179,7 +173,8 @@ class LinearModelLoss:
         sample_weight=None,
         l2_reg_strength=0.0,
         n_threads=1,
-        temporary_array_dict=None,
+        per_sample_loss_out=None,
+        per_sample_gradient_out=None,
     ):
         """Computes the sum of loss and gradient w.r.t. coef.
 
@@ -200,17 +195,14 @@ class LinearModelLoss:
             L2 regularization strength
         n_threads : int, default=1
             Number of OpenMP threads to use.
-        temporary_array_dict: None or dict, default=None
-            Providing such arrays can save a little memory. Possible entry:
-
-            "per_sample_loss_out" : C-contiguous array of shape (n_samples,)
-                A location into which the per sample loss is stored. If None, a new
-                array might be created.
-
-            "per_sample_gradient_out" : None or C-contiguous array of shape
-                (n_samples,) or array of shape (n_samples, n_classes)
-                A location into which the per sample gradient is stored. If None, a
-                new array might be created.
+        per_sample_loss_out : None or C-contiguous array of shape (n_samples,), \
+            default=None
+            A location into which the per sample loss is stored. If None, a new array
+            might be created. Providing such an array can save a little memory.
+        per_sample_gradient_out : None or C-contiguous array of shape (n_samples,) or
+            array of shape (n_samples, n_classes), default=None
+            A location into which the per sample gradient is stored. If None, a new
+            array might be created. Providing such an array can save a little memory.
 
         Returns
         -------
@@ -223,14 +215,6 @@ class LinearModelLoss:
         n_features, n_classes = X.shape[1], self.base_loss.n_classes
         n_dof = n_features + int(self.fit_intercept)
         weights, intercept, raw_prediction = self._w_intercept_raw(coef, X)
-        if temporary_array_dict is not None:
-            per_sample_loss_out = temporary_array_dict.get("per_sample_loss_out", None)
-            per_sample_gradient_out = temporary_array_dict.get(
-                "per_sample_gradient_out", None
-            )
-        else:
-            per_sample_loss_out = None
-            per_sample_gradient_out = None
 
         loss, grad_per_sample = self.base_loss.loss_gradient(
             y_true=y,
@@ -268,7 +252,7 @@ class LinearModelLoss:
         sample_weight=None,
         l2_reg_strength=0.0,
         n_threads=1,
-        temporary_array_dict=None,
+        per_sample_gradient_out=None,
     ):
         """Computes the gradient w.r.t. coef.
 
@@ -289,13 +273,10 @@ class LinearModelLoss:
             L2 regularization strength
         n_threads : int, default=1
             Number of OpenMP threads to use.
-        temporary_array_dict: None or dict, default=None
-            Providing such an array can save a little memory. Possible entry:
-
-            "per_sample_gradient_out" : None or C-contiguous array of shape
-                (n_samples,) or array of shape (n_samples, n_classes)
-                A location into which the per sample gradient is stored. If None, a new
-                array might be created.
+        per_sample_gradient_out : None or C-contiguous array of shape (n_samples,) or
+            array of shape (n_samples, n_classes), default=None
+            A location into which the per sample gradient is stored. If None, a new
+            array might be created. Providing such an array can save a little memory.
 
         Returns
         -------
@@ -305,12 +286,6 @@ class LinearModelLoss:
         n_features, n_classes = X.shape[1], self.base_loss.n_classes
         n_dof = n_features + int(self.fit_intercept)
         weights, intercept, raw_prediction = self._w_intercept_raw(coef, X)
-        if temporary_array_dict is not None:
-            per_sample_gradient_out = temporary_array_dict.get(
-                "per_sample_gradient_out", None
-            )
-        else:
-            per_sample_gradient_out = None
 
         grad_per_sample = self.base_loss.gradient(
             y_true=y,
@@ -345,7 +320,8 @@ class LinearModelLoss:
         sample_weight=None,
         l2_reg_strength=0.0,
         n_threads=1,
-        temporary_array_dict=None,
+        per_sample_gradient_out=None,
+        per_sample_hessian_out=None,
     ):
         """Computes gradient and hessp (hessian product function) w.r.t. coef.
 
@@ -366,17 +342,14 @@ class LinearModelLoss:
             L2 regularization strength
         n_threads : int, default=1
             Number of OpenMP threads to use.
-        temporary_array_dict: None or dict, default=None
-            Providing such an array can save a little memory. Possible entry:
-
-            "per_sample_gradient_out" : None or C-contiguous array of shape
-                (n_samples,) or array of shape (n_samples, n_classes)
-                A location into which the per sample gradient is stored. If None, a new
-                array might be created.
-            "per_sample_hessian_out" : None or C-contiguous array of shape (n_samples,)
-                or array of shape (n_samples, n_classes)
-                A location into which the per sample hessian is stored. If None, a new
-                array might be created.
+        per_sample_gradient_out : None or C-contiguous array of shape (n_samples,) or
+            array of shape (n_samples, n_classes), default=None
+            A location into which the per sample gradient is stored. If None, a new
+            array might be created. Providing such an array can save a little memory.
+        per_sample_hessian_out : None or C-contiguous array of shape (n_samples,) or
+            array of shape (n_samples, n_classes), default=None
+            A location into which the per sample hessian is stored. If None, a new
+            array might be created. Providing such an array can save a little memory.
 
         Returns
         -------
@@ -390,16 +363,6 @@ class LinearModelLoss:
         (n_samples, n_features), n_classes = X.shape, self.base_loss.n_classes
         n_dof = n_features + int(self.fit_intercept)
         weights, intercept, raw_prediction = self._w_intercept_raw(coef, X)
-        if temporary_array_dict is not None:
-            per_sample_gradient_out = temporary_array_dict.get(
-                "per_sample_gradient_out", None
-            )
-            per_sample_hessian_out = temporary_array_dict.get(
-                "per_sample_hessian_out", None
-            )
-        else:
-            per_sample_gradient_out = None
-            per_sample_hessian_out = None
 
         if not self.base_loss.is_multiclass:
             gradient, hessian = self.base_loss.gradient_hessian(


### PR DESCRIPTION
#### Reference Issues/PRs
Follow up of #21808 and #22548.

#### What does this implement/fix? Explain your changes.
This PR enables to allocate ndarrays an reuse them in `LinearModelLoss`. This improves memory footprint of:

- `LogisticRegression` with solver `"lbfgs"` and `"newton-cg"`
- `TweedieRegressor`, `PoissonRegressor`, `GammaRegressor`

#### Any other comments?
One could also provide pre-allocated arrays for the actual gradient (wrt the coefficients). This has one has `shape=coef.shape`.

If lbfgs, for instance, does 100 interations, then the current implementations allocates 2*100 temporary arrays for gradient and loss. In particular for multiclass problems, these gradient arrays have `shape=(n_samples, n_classes)`.