### PR TITLE
DOC Fixes sphinx warnings when building docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,7 +91,7 @@ source_suffix = ".rst"
 # source_encoding = 'utf-8'
 
 # The main toctree document.
-main_doc = "contents"
+root_doc = "contents"
 
 # General information about the project.
 project = "scikit-learn"

--- a/examples/miscellaneous/plot_outlier_detection_bench.py
+++ b/examples/miscellaneous/plot_outlier_detection_bench.py
@@ -23,7 +23,7 @@ print(__doc__)
 
 # %%
 # Define a data preprocessing function
-# ----------------------------------
+# ------------------------------------
 #
 # The example uses real-world datasets available in
 # :class:`sklearn.datasets` and the sample size of some datasets is reduced


### PR DESCRIPTION
This PR fixes two sphinx warnings when building the docs:

```bash
WARNING: Since v2.0, Sphinx uses "index" as root_doc by default. Please add "root_doc = 'contents'" to your conf.py.
/Users/thomasfan/Repos/scikit-learn-3/doc/auto_examples/miscellaneous/plot_outlier_detection_bench.rst:56: WARNING: Title underline too short.

Define a data preprocessing function
----------------------------------
```