### PR TITLE
FIX Fixes Stacking* HTML repr

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -454,6 +454,9 @@ Changelog
   fitting on a pandas DataFrame with a non-default `scoring` parameter and
   early_stopping enabled. :pr:`22908` by `Thomas Fan`_.
 
+- |Fix| Fixes HTML repr for :class:`ensemble.StackingClassifier` and
+  :class:`ensemble.StackingRegressor`. :pr:`23097` by `Thomas Fan`_.
+
 - |Efficiency| Fitting a :class:`ensemble.RandomForestClassifier`,
   :class:`ensemble.RandomForestRegressor`, :class:`ensemble.ExtraTreesClassifier`,
   :class:`ensemble.ExtraTreesRegressor`, and :class:`ensemble.RandomTreesEmbedding`

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -351,7 +351,7 @@ class _BaseStacking(TransformerMixin, _BaseHeterogeneousEnsemble, metaclass=ABCM
         final_block = _VisualBlock(
             "parallel", [final_estimator], names=["final_estimator"], dash_wrapped=False
         )
-        return _VisualBlock("serial", (parallel, final_block), dash_wrapped=False)
+        return _VisualBlock("serial", (parallel, final_block), dash_wrapped=True)
 
 
 class StackingClassifier(ClassifierMixin, _BaseStacking):

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -351,7 +351,7 @@ class _BaseStacking(TransformerMixin, _BaseHeterogeneousEnsemble, metaclass=ABCM
         final_block = _VisualBlock(
             "parallel", [final_estimator], names=["final_estimator"], dash_wrapped=False
         )
-        return _VisualBlock("serial", (parallel, final_block), dash_wrapped=True)
+        return _VisualBlock("serial", (parallel, final_block), dash_wrapped=False)
 
 
 class StackingClassifier(ClassifierMixin, _BaseStacking):

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -260,9 +260,10 @@ _STYLE = """
   position: absolute;
   border-left: 1px solid gray;
   box-sizing: border-box;
-  top: 2em;
+  top: 0;
   bottom: 0;
   left: 50%;
+  z-index: 0;
 }
 #$id div.sk-serial {
   display: flex;
@@ -271,8 +272,10 @@ _STYLE = """
   background-color: white;
   padding-right: 0.2em;
   padding-left: 0.2em;
+  position: relative;
 }
 #$id div.sk-item {
+  position: relative;
   z-index: 1;
 }
 #$id div.sk-parallel {
@@ -280,19 +283,22 @@ _STYLE = """
   align-items: stretch;
   justify-content: center;
   background-color: white;
+  position: relative;
 }
-#$id div.sk-parallel::before {
+#$id div.sk-item::before, #$id div.sk-parallel-item::before {
   content: "";
   position: absolute;
   border-left: 1px solid gray;
   box-sizing: border-box;
-  top: 2em;
+  top: 0;
   bottom: 0;
   left: 50%;
+  z-index: -1;
 }
 #$id div.sk-parallel-item {
   display: flex;
   flex-direction: column;
+  z-index: 1;
   position: relative;
   background-color: white;
 }
@@ -313,18 +319,14 @@ _STYLE = """
   box-sizing: border-box;
   padding-bottom: 0.4em;
   background-color: white;
-  position: relative;
 }
 #$id div.sk-label label {
   font-family: monospace;
   font-weight: bold;
-  background-color: white;
   display: inline-block;
   line-height: 1.2em;
 }
 #$id div.sk-label-container {
-  position: relative;
-  z-index: 2;
   text-align: center;
 }
 #$id div.sk-container {

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -193,7 +193,7 @@ _STYLE = """
 }
 #$id label.sk-toggleable__label {
   cursor: pointer;
-  display: flex;
+  display: block;
   width: 100%;
   margin-bottom: 0;
   padding: 0.3em;

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -178,7 +178,7 @@ _STYLE = """
 }
 #$id label.sk-toggleable__label {
   cursor: pointer;
-  display: block;
+  display: flex;
   width: 100%;
   margin-bottom: 0;
   padding: 0.3em;


### PR DESCRIPTION
This PR fixes the HTML repr for stacking. To fix it, I needed to rethink how the edges are shown. In summary, this PR moves all the z-index and `position: relative` styles into the `serial` and `parallel` selectors.

Looking at the [stacking example main](https://scikit-learn.org/dev/auto_examples/ensemble/plot_stack_predictors.html#sphx-glr-auto-examples-ensemble-plot-stack-predictors-py) there is a CSS bug: (There is a line through the center)

### main

![Screen Shot 2022-04-17 at 5 42 17 PM](https://user-images.githubusercontent.com/5402633/163733058-c7611b06-fb3d-44cf-bffb-c62a1ab090c7.jpg)

### This PR

![Screen Shot 2022-04-17 at 5 43 30 PM](https://user-images.githubusercontent.com/5402633/163733112-5fd339e1-f0ec-4b3c-8574-1da3da5418bc.jpg)

