### PR TITLE
FIX Removes all random unique IDs in html repr

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -1017,7 +1017,7 @@ Changelog
 
 - |Enhancement| Removes random unique identifiers in the HTML representation.
   Jupyter notebooks are reproducable as long as the cells are run in the same order.
-  :pr:`xxxxx` by `Thomas Fan`_.
+  :pr:`23098` by `Thomas Fan`_.
 
 - |API| :func:`utils.estimator_checks.check_estimator`'s argument is now called
   `estimator` (previous name was `Estimator`). :pr:`22188` by

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -1016,8 +1016,8 @@ Changelog
   clickable. :pr:`21298` by `Thomas Fan`_.
 
 - |Enhancement| Removes random unique identifiers in the HTML representation.
-  Jupyter notebooks are reproducable as long as the cells are run in the same order.
-  :pr:`23098` by `Thomas Fan`_.
+  With this change, jupyter notebooks are reproducible as long as the cells are
+  run in the same order. :pr:`23098` by `Thomas Fan`_.
 
 - |API| :func:`utils.estimator_checks.check_estimator`'s argument is now called
   `estimator` (previous name was `Estimator`). :pr:`22188` by

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -1015,6 +1015,10 @@ Changelog
   left corner of the HTML representation to show how the elements are
   clickable. :pr:`21298` by `Thomas Fan`_.
 
+- |Enhancement| Removes random unique identifiers in the HTML representation.
+  Jupyter notebooks are reproducable as long as the cells are run in the same order.
+  :pr:`xxxxx` by `Thomas Fan`_.
+
 - |API| :func:`utils.estimator_checks.check_estimator`'s argument is now called
   `estimator` (previous name was `Estimator`). :pr:`22188` by
   :user:`Mathurin Massias <mathurinm>`.

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -2,10 +2,23 @@ from contextlib import closing
 from contextlib import suppress
 from io import StringIO
 from string import Template
-import uuid
 import html
 
 from .. import config_context
+
+
+class _Counter:
+    """Generate unique ids."""
+
+    def __init__(self):
+        self.count = -1
+
+    def get_id(self, prefix):
+        self.count += 1
+        return f"{prefix}{self.count}"
+
+
+_counter = _Counter()
 
 
 class _VisualBlock:
@@ -73,7 +86,7 @@ def _write_label_html(
         label_class = "sk-toggleable__label sk-toggleable__label-arrow"
 
         checked_str = "checked" if checked else ""
-        est_id = uuid.uuid4()
+        est_id = _counter.get_id("sk-estimator-id-")
         out.write(
             '<input class="sk-toggleable__control sk-hidden--visually" '
             f'id="{est_id}" type="checkbox" {checked_str}>'
@@ -362,7 +375,7 @@ def estimator_html_repr(estimator):
         HTML representation of estimator.
     """
     with closing(StringIO()) as out:
-        container_id = "sk-" + str(uuid.uuid4())
+        container_id = _counter.get_id("sk-container-id-")
         style_template = Template(_STYLE)
         style_with_id = style_template.substitute(id=container_id)
         estimator_str = str(estimator)

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -8,17 +8,19 @@ from .. import config_context
 
 
 class _IDCounter:
-    """Generate sequential ids."""
+    """Generate sequential ids with a prefix."""
 
-    def __init__(self):
+    def __init__(self, prefix):
+        self.prefix = prefix
         self.count = 0
 
-    def get_id(self, prefix):
+    def get_id(self):
         self.count += 1
-        return f"{prefix}{self.count}"
+        return f"{self.prefix}-{self.count}"
 
 
-_id_counter = _IDCounter()
+_CONTAINER_ID_COUNTER = _IDCounter("sk-container-id")
+_ESTIMATOR_ID_COUNTER = _IDCounter("sk-estimator-id")
 
 
 class _VisualBlock:
@@ -86,7 +88,7 @@ def _write_label_html(
         label_class = "sk-toggleable__label sk-toggleable__label-arrow"
 
         checked_str = "checked" if checked else ""
-        est_id = _id_counter.get_id("sk-estimator-id-")
+        est_id = _ESTIMATOR_ID_COUNTER.get_id()
         out.write(
             '<input class="sk-toggleable__control sk-hidden--visually" '
             f'id="{est_id}" type="checkbox" {checked_str}>'
@@ -375,7 +377,7 @@ def estimator_html_repr(estimator):
         HTML representation of estimator.
     """
     with closing(StringIO()) as out:
-        container_id = _id_counter.get_id("sk-container-id-")
+        container_id = _CONTAINER_ID_COUNTER.get_id()
         style_template = Template(_STYLE)
         style_with_id = style_template.substitute(id=container_id)
         estimator_str = str(estimator)

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -11,7 +11,7 @@ class _Counter:
     """Generate unique ids."""
 
     def __init__(self):
-        self.count = -1
+        self.count = 0
 
     def get_id(self, prefix):
         self.count += 1

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -7,8 +7,8 @@ import html
 from .. import config_context
 
 
-class _Counter:
-    """Generate unique ids."""
+class _IDCounter:
+    """Generate sequential ids."""
 
     def __init__(self):
         self.count = 0
@@ -18,7 +18,7 @@ class _Counter:
         return f"{prefix}{self.count}"
 
 
-_counter = _Counter()
+_id_counter = _IDCounter()
 
 
 class _VisualBlock:
@@ -86,7 +86,7 @@ def _write_label_html(
         label_class = "sk-toggleable__label sk-toggleable__label-arrow"
 
         checked_str = "checked" if checked else ""
-        est_id = _counter.get_id("sk-estimator-id-")
+        est_id = _id_counter.get_id("sk-estimator-id-")
         out.write(
             '<input class="sk-toggleable__control sk-hidden--visually" '
             f'id="{est_id}" type="checkbox" {checked_str}>'
@@ -375,7 +375,7 @@ def estimator_html_repr(estimator):
         HTML representation of estimator.
     """
     with closing(StringIO()) as out:
-        container_id = _counter.get_id("sk-container-id-")
+        container_id = _id_counter.get_id("sk-container-id-")
         style_template = Template(_STYLE)
         style_with_id = style_template.substitute(id=container_id)
         estimator_str = str(estimator)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/21486


#### What does this implement/fix? Explain your changes.
Now that HTML repr is the default, I think having random uuids in the HTML repr is worst developer experience. With this PR, Jupyter notebooks are reproducable as long as the cells are run in the same order.

#### Any other comments?
I tested this build out by building the scikit-learn mooc and it looks like everything renders correctly.

CC @lesteve 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->