### PR TITLE
CI enable global_dtype fixture on nightly build jobs

### DIFF
--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -20,6 +20,11 @@ if [[ "$BUILD_REASON" == "Schedule" ]]; then
     # only on nightly builds.
     # https://scikit-learn.org/stable/computing/parallelism.html#environment-variables
     export SKLEARN_TESTS_GLOBAL_RANDOM_SEED="any"
+
+    # Enable global dtype fixture for all nightly builds to discover
+    # numerical-sensitive tests.
+    # https://scikit-learn.org/stable/computing/parallelism.html#environment-variables
+    export SKLEARN_RUN_FLOAT32_TESTS=1
 fi
 
 mkdir -p $TEST_DIR


### PR DESCRIPTION
The `globaly_dtype` fixture is currently only enabled on a single CI job. It means that the float32 tests are never run on windows or macos for instance. Since enabling the fixture makes the test suite longer we don't want to do it by default, but enabling it for the nighlty build is a good compromise imo.

It would also make me more comfortable with replacing some current [float64, float32] parametrization by the global_dtype fixture.