### PR TITLE
FIX: fetch covtype dataset concurrent-safe

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -281,6 +281,10 @@ Changelog
   :pr:`19747` by :user:`Tony Attalla <tonyattalla>` and :pr:`22498` by
   :user:`Meekail Zain <micky774>`.
 
+- |Fix| :func:`datasets.fetch_covtype` is now concurrent-safe: data is downloaded
+  to a temporary directory before being moved to the data directory.
+  :pr:`23113` by :user:`Ilion Beyst <iasoon>`
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/sklearn/datasets/_covtype.py
+++ b/sklearn/datasets/_covtype.py
@@ -158,7 +158,7 @@ def fetch_covtype(
         # guarantees that both reside on the same filesystem, so that we can use
         # os.rename to atomically move the data files to their target location.
         with TemporaryDirectory(dir=covtype_dir) as temp_dir:
-            logger.info("Downloading %s" % ARCHIVE.url)
+            logger.info(f"Downloading {ARCHIVE.url}")
             archive_path = _fetch_remote(ARCHIVE, dirname=temp_dir)
             Xy = np.genfromtxt(GzipFile(filename=archive_path), delimiter=",")
 

--- a/sklearn/datasets/_covtype.py
+++ b/sklearn/datasets/_covtype.py
@@ -17,7 +17,8 @@ Courtesy of Jock A. Blackard and Colorado State University.
 from gzip import GzipFile
 import logging
 from os.path import exists, join
-from os import remove, makedirs
+import os
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import joblib
@@ -148,23 +149,29 @@ def fetch_covtype(
     covtype_dir = join(data_home, "covertype")
     samples_path = _pkl_filepath(covtype_dir, "samples")
     targets_path = _pkl_filepath(covtype_dir, "targets")
-    available = exists(samples_path)
+    available = exists(samples_path) and exists(targets_path)
 
     if download_if_missing and not available:
-        if not exists(covtype_dir):
-            makedirs(covtype_dir)
-        logger.info("Downloading %s" % ARCHIVE.url)
+        os.makedirs(covtype_dir, exist_ok=True)
 
-        archive_path = _fetch_remote(ARCHIVE, dirname=covtype_dir)
-        Xy = np.genfromtxt(GzipFile(filename=archive_path), delimiter=",")
-        # delete archive
-        remove(archive_path)
+        # Creating temp_dir as a direct subdirectory of the target directory
+        # guarantees that both reside on the same filesystem, so that we can use
+        # os.rename to atomically move the data files to their target location.
+        with TemporaryDirectory(dir=covtype_dir) as temp_dir:
+            logger.info("Downloading %s" % ARCHIVE.url)
+            archive_path = _fetch_remote(ARCHIVE, dirname=temp_dir)
+            Xy = np.genfromtxt(GzipFile(filename=archive_path), delimiter=",")
 
-        X = Xy[:, :-1]
-        y = Xy[:, -1].astype(np.int32, copy=False)
+            X = Xy[:, :-1]
+            y = Xy[:, -1].astype(np.int32, copy=False)
 
-        joblib.dump(X, samples_path, compress=9)
-        joblib.dump(y, targets_path, compress=9)
+            samples_tmp_path = _pkl_filepath(temp_dir, "samples")
+            joblib.dump(X, samples_tmp_path, compress=9)
+            os.rename(samples_tmp_path, samples_path)
+
+            targets_tmp_path = _pkl_filepath(temp_dir, "targets")
+            joblib.dump(y, targets_tmp_path, compress=9)
+            os.rename(targets_tmp_path, targets_path)
 
     elif not available and not download_if_missing:
         raise IOError("Data not found and `download_if_missing` is False")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #23048.


#### What does this implement/fix? Explain your changes.
When fetching the dataset, write the data files to a temporary first, then atomically rename to their target location. (similar to https://github.com/scikit-learn/scikit-learn/pull/21833)
This approach avoids trouble with concurrent runs and partially written data.

#### Any other comments?

It looks like most dataset fetchers don't currently implement a mechanism like this. Would it be worthwhile to apply the same procedure to the others? If so, would separate PRs be prefered or do I tack it on to this one?
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
