### PR TITLE
TST: replace pytest.warns(None) in test_plot_partial_dependence.py

### DIFF
--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -772,6 +772,7 @@ def test_partial_dependence_display_deprecation(
         disp.plot(pdp_lim=None)
     # case when constructor and method parameters are different
     with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
         disp.plot(pdp_lim=(0, 1))
     assert len(record) == 2
     for warning in record:

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -3,6 +3,7 @@ from scipy.stats.mstats import mquantiles
 
 import pytest
 from numpy.testing import assert_allclose
+import warnings
 
 from sklearn.datasets import load_diabetes
 from sklearn.datasets import load_iris
@@ -770,7 +771,7 @@ def test_partial_dependence_display_deprecation(
     with pytest.warns(FutureWarning, match=deprecation_msg):
         disp.plot(pdp_lim=None)
     # case when constructor and method parameters are different
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         disp.plot(pdp_lim=(0, 1))
     assert len(record) == 2
     for warning in record:

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -772,7 +772,7 @@ def test_partial_dependence_display_deprecation(
         disp.plot(pdp_lim=None)
     # case when constructor and method parameters are different
     with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
+        warnings.simplefilter("always", FutureWarning)
         disp.plot(pdp_lim=(0, 1))
     assert len(record) == 2
     for warning in record:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/issues/22572

#### What does this implement/fix? Explain your changes.
replaces `pytest.warns(None)` with `warnings.catch_warnings(record=True)` in test_plot_partial_dependence.py

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
