### PR TITLE
DOC fix typo in log loss formula for trees

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -529,7 +529,7 @@ Entropy:
 
   .. math::
   
-      \mathrm{LL}(D, T) = -\sum_{m \in T} \frac{n_m}{n} H(Q_m)
+      \mathrm{LL}(D, T) = \sum_{m \in T} \frac{n_m}{n} H(Q_m)
 
 Regression criteria
 -------------------


### PR DESCRIPTION
All terms are positive in this equation. This evaded the scrutiny of the reviewers of #23081 which introduced this note yesterday.