### PR TITLE
CI Run all CI jobs on azure nightly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,6 @@ jobs:
         # Tests that require large downloads over the networks are skipped in CI.
         # Here we make sure, that they are still run on a regular basis.
         SKLEARN_SKIP_NETWORK_TESTS: '0'
-        CREATE_ISSUE_ON_TRACKER: 'true'
 
 # Check compilation with intel C++ compiler (ICC)
 - template: build_tools/azure/posix.yml
@@ -126,7 +125,6 @@ jobs:
         DOCKER_CONTAINER: 'condaforge/mambaforge-pypy3:4.10.3-5'
         PILLOW_VERSION: 'none'
         PANDAS_VERSION: 'none'
-        CREATE_ISSUE_ON_TRACKER: 'true'
 
 # Will run all the time regardless of linting outcome.
 - template: build_tools/azure/posix.yml
@@ -158,8 +156,7 @@ jobs:
     condition: |
       and(
         succeeded(),
-        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
-        ne(variables['Build.Reason'], 'Schedule')
+        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
       py38_conda_forge_openblas_ubuntu_1804:
@@ -179,8 +176,7 @@ jobs:
     condition: |
       and(
         succeeded(),
-        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
-        ne(variables['Build.Reason'], 'Schedule')
+        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
       # Linux environment to test that scikit-learn can be built against
@@ -225,8 +221,7 @@ jobs:
     condition: |
       and(
         succeeded(),
-        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
-        ne(variables['Build.Reason'], 'Schedule')
+        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
       debian_atlas_32bit:
@@ -247,8 +242,7 @@ jobs:
     condition: |
       and(
         succeeded(),
-        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
-        ne(variables['Build.Reason'], 'Schedule')
+        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
       pylatest_conda_forge_mkl:
@@ -271,8 +265,7 @@ jobs:
     condition: |
       and(
         succeeded(),
-        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
-        ne(variables['Build.Reason'], 'Schedule')
+        not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
       py38_conda_forge_mkl:

--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -37,7 +37,7 @@ jobs:
     DISTRIB: ''
     DOCKER_CONTAINER: ''
     SHOW_SHORT_SUMMARY: 'false'
-    CREATE_ISSUE_ON_TRACKER: 'false'
+    CREATE_ISSUE_ON_TRACKER: 'true'
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     CCACHE_COMPRESS: '1'
   strategy:

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -35,7 +35,7 @@ jobs:
     THREADPOOLCTL_VERSION: 'latest'
     COVERAGE: 'true'
     TEST_DOCSTRINGS: 'false'
-    CREATE_ISSUE_ON_TRACKER: 'false'
+    CREATE_ISSUE_ON_TRACKER: 'true'
     SHOW_SHORT_SUMMARY: 'false'
   strategy:
     matrix:

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -49,9 +49,6 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
 
     # Python 3.10 deprecates distutils, which is imported by numpy internally
     TEST_CMD="$TEST_CMD -Wignore:The\ distutils:DeprecationWarning"
-
-    # Ignore distutils deprecation warning, used by joblib interally
-    TEST_CMD="$TEST_CMD -Wignore:distutils\ Version\ classes\ are\ deprecated:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -49,6 +49,9 @@ if [[ -n "$CHECK_WARNINGS" ]]; then
 
     # Python 3.10 deprecates distutils, which is imported by numpy internally
     TEST_CMD="$TEST_CMD -Wignore:The\ distutils:DeprecationWarning"
+
+    # Ignore distutils deprecation warning, used by joblib interally
+    TEST_CMD="$TEST_CMD -Wignore:distutils\ Version\ classes\ are\ deprecated:DeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/pull/23110


#### What does this implement/fix? Explain your changes.
I think it makes sense to run all the CI jobs on azure nightly. This PR also sets the default `CREATE_ISSUE_ON_TRACKER` to true so that nightly errors create issues on the tracker automatically. Note that `CREATE_ISSUE_ON_TRACKER` is only active for nightly builds:

https://github.com/scikit-learn/scikit-learn/blob/28db3497a4babb47159923e07f266790164b5e47/build_tools/azure/posix.yml#L82-L83

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
