### PR TITLE
CI Removes manylinux2010 since SciPy does not support it in 1.8

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -86,18 +86,6 @@ jobs:
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
-          # Linux 64 bit manylinux2010
-          - os: ubuntu-latest
-            python: 38
-            bitness: 64
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2010
-          - os: ubuntu-latest
-            python: 39
-            bitness: 64
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2010
-
           # NumPy on Python 3.10 only supports 64bit and is only available with manylinux2014
           - os: ubuntu-latest
             python: 310


### PR DESCRIPTION
One of the reason the [wheel builds are failing](https://github.com/scikit-learn/scikit-learn/runs/5966007993?check_suite_focus=true) is because [SciPy 1.8.0](https://pypi.org/project/scipy/1.8.0/#files) does not have builds for manylinux2010.

This PR removes our manylinux2010 builds as well. I am placing this on the milestone since it is build related.