### PR TITLE
MNT handle warnings in plot_manifold_sphere.py

### DIFF
--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -134,11 +134,15 @@ ax.xaxis.set_major_formatter(NullFormatter())
 ax.yaxis.set_major_formatter(NullFormatter())
 plt.axis("tight")
 
+import warnings  # TODO(1.3) Remove.
+
 # Perform t-distributed stochastic neighbor embedding.
-t0 = time()
-tsne = manifold.TSNE(n_components=2, init="pca", learning_rate="auto", random_state=0)
-trans_data = tsne.fit_transform(sphere_data).T
-t1 = time()
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", FutureWarning)
+    t0 = time()
+    tsne = manifold.TSNE(n_components=2, init="pca", random_state=0)
+    trans_data = tsne.fit_transform(sphere_data).T
+    t1 = time()
 print("t-SNE: %.2g sec" % (t1 - t0))
 
 ax = fig.add_subplot(2, 5, 10)

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -136,7 +136,7 @@ plt.axis("tight")
 
 # Perform t-distributed stochastic neighbor embedding.
 t0 = time()
-tsne = manifold.TSNE(n_components=2, init="pca", random_state=0)
+tsne = manifold.TSNE(n_components=2, init="pca", learning_rate="auto", random_state=0)
 trans_data = tsne.fit_transform(sphere_data).T
 t1 = time()
 print("t-SNE: %.2g sec" % (t1 - t0))

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -36,8 +36,9 @@ from matplotlib.ticker import NullFormatter
 from sklearn import manifold
 from sklearn.utils import check_random_state
 
-# unused but required import for doing 3d projections with matplotlib < 3.2
+# Unused but required import for doing 3d projections with matplotlib < 3.2
 import mpl_toolkits.mplot3d  # noqa: F401
+import warnings  # TODO(1.2) Remove.
 
 # Variables for manifold learning.
 n_neighbors = 10
@@ -137,13 +138,15 @@ ax.xaxis.set_major_formatter(NullFormatter())
 ax.yaxis.set_major_formatter(NullFormatter())
 plt.axis("tight")
 
-import warnings  # TODO(1.2) Remove.
-
 # Perform t-distributed stochastic neighbor embedding.
 with warnings.catch_warnings():
-    warnings.simplefilter("ignore", FutureWarning)
+    warnings.filterwarnings(
+        "ignore", message="The PCA initialization", category=FutureWarning
+    )
     t0 = time()
-    tsne = manifold.TSNE(n_components=2, init="pca", random_state=0)
+    tsne = manifold.TSNE(
+        n_components=2, init="pca", random_state=0, learning_rate="auto"
+    )
     trans_data = tsne.fit_transform(sphere_data).T
     t1 = time()
 print("t-SNE: %.2g sec" % (t1 - t0))

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -38,7 +38,7 @@ from sklearn.utils import check_random_state
 
 # Unused but required import for doing 3d projections with matplotlib < 3.2
 import mpl_toolkits.mplot3d  # noqa: F401
-import warnings  # TODO(1.2) Remove.
+import warnings
 
 # Variables for manifold learning.
 n_neighbors = 10
@@ -139,7 +139,7 @@ ax.yaxis.set_major_formatter(NullFormatter())
 plt.axis("tight")
 
 # Perform t-distributed stochastic neighbor embedding.
-with warnings.catch_warnings():
+with warnings.catch_warnings(): # TODO(1.2) Remove warning handling.
     warnings.filterwarnings(
         "ignore", message="The PCA initialization", category=FutureWarning
     )

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -139,7 +139,8 @@ ax.yaxis.set_major_formatter(NullFormatter())
 plt.axis("tight")
 
 # Perform t-distributed stochastic neighbor embedding.
-with warnings.catch_warnings(): # TODO(1.2) Remove warning handling.
+# TODO(1.2) Remove warning handling.
+with warnings.catch_warnings():
     warnings.filterwarnings(
         "ignore", message="The PCA initialization", category=FutureWarning
     )

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -134,7 +134,7 @@ ax.xaxis.set_major_formatter(NullFormatter())
 ax.yaxis.set_major_formatter(NullFormatter())
 plt.axis("tight")
 
-import warnings  # TODO(1.3) Remove.
+import warnings  # TODO(1.2) Remove.
 
 # Perform t-distributed stochastic neighbor embedding.
 with warnings.catch_warnings():

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -36,6 +36,9 @@ from matplotlib.ticker import NullFormatter
 from sklearn import manifold
 from sklearn.utils import check_random_state
 
+# unused but required import for doing 3d projections with matplotlib < 3.2
+import mpl_toolkits.mplot3d
+
 # Variables for manifold learning.
 n_neighbors = 10
 n_samples = 1000

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -30,17 +30,11 @@ that of representing a flat map of the Earth, as with
 # License: BSD 3 clause
 
 from time import time
-
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 from matplotlib.ticker import NullFormatter
-
 from sklearn import manifold
 from sklearn.utils import check_random_state
-
-# Next line to silence pyflakes.
-Axes3D
 
 # Variables for manifold learning.
 n_neighbors = 10

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -37,7 +37,7 @@ from sklearn import manifold
 from sklearn.utils import check_random_state
 
 # unused but required import for doing 3d projections with matplotlib < 3.2
-import mpl_toolkits.mplot3d
+import mpl_toolkits.mplot3d  # noqa: F401
 
 # Variables for manifold learning.
 n_neighbors = 10


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Close #22586 and followup on warnings introduced in #19491

#### What does this implement/fix? Explain your changes.
This PR removes the spurious use of Axes3D from [examples/manifold/plot_manifold_sphere.py](https://github.com/scikit-learn/scikit-learn/blob/main/examples/manifold/plot_manifold_sphere.py) and additionally catches the two FutureWarnings introduced in #19491

#### Any other comments?
I would be happy to convert this example to notebook style as well, but it may be better to do this in a separate PR.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
