### PR TITLE
MNT Removes _linear_loss attribute in GLMs

### DIFF
--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -230,12 +230,12 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         n_samples, n_features = X.shape
         self._base_loss = self._get_loss()
 
-        self._linear_loss = LinearModelLoss(
+        _linear_loss = LinearModelLoss(
             base_loss=self._base_loss,
             fit_intercept=self.fit_intercept,
         )
 
-        if not self._linear_loss.base_loss.in_y_true_range(y):
+        if not _linear_loss.base_loss.in_y_true_range(y):
             raise ValueError(
                 "Some value(s) of y are out of the valid range of the loss"
                 f" {self._base_loss.__class__.__name__!r}."
@@ -265,7 +265,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         else:
             if self.fit_intercept:
                 coef = np.zeros(n_features + 1, dtype=loss_dtype)
-                coef[-1] = self._linear_loss.base_loss.link.link(
+                coef[-1] = _linear_loss.base_loss.link.link(
                     np.average(y, weights=sample_weight)
                 )
             else:
@@ -274,7 +274,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         # Algorithms for optimization:
         # Note again that our losses implement 1/2 * deviance.
         if solver == "lbfgs":
-            func = self._linear_loss.loss_gradient
+            func = _linear_loss.loss_gradient
             l2_reg_strength = self.alpha
             n_threads = _openmp_effective_n_threads()
 
@@ -345,7 +345,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         """
         # check_array is done in _linear_predictor
         raw_prediction = self._linear_predictor(X)
-        y_pred = self._linear_loss.base_loss.link.inverse(raw_prediction)
+        y_pred = self._base_loss.link.inverse(raw_prediction)
         return y_pred
 
     def score(self, X, y, sample_weight=None):
@@ -394,12 +394,12 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
             # losses.
             sample_weight = _check_sample_weight(sample_weight, X, dtype=y.dtype)
 
-        base_loss = self._linear_loss.base_loss
+        base_loss = self._base_loss
 
         if not base_loss.in_y_true_range(y):
             raise ValueError(
                 "Some value(s) of y are out of the valid range of the loss"
-                f" {self._base_loss.__name__}."
+                f" {base_loss.__name__}."
             )
 
         # Note that constant_to_optimal_zero is already multiplied by sample_weight.

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -230,12 +230,12 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         n_samples, n_features = X.shape
         self._base_loss = self._get_loss()
 
-        _linear_loss = LinearModelLoss(
+        linear_loss = LinearModelLoss(
             base_loss=self._base_loss,
             fit_intercept=self.fit_intercept,
         )
 
-        if not _linear_loss.base_loss.in_y_true_range(y):
+        if not linear_loss.base_loss.in_y_true_range(y):
             raise ValueError(
                 "Some value(s) of y are out of the valid range of the loss"
                 f" {self._base_loss.__class__.__name__!r}."
@@ -265,7 +265,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         else:
             if self.fit_intercept:
                 coef = np.zeros(n_features + 1, dtype=loss_dtype)
-                coef[-1] = _linear_loss.base_loss.link.link(
+                coef[-1] = linear_loss.base_loss.link.link(
                     np.average(y, weights=sample_weight)
                 )
             else:
@@ -274,7 +274,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         # Algorithms for optimization:
         # Note again that our losses implement 1/2 * deviance.
         if solver == "lbfgs":
-            func = _linear_loss.loss_gradient
+            func = linear_loss.loss_gradient
             l2_reg_strength = self.alpha
             n_threads = _openmp_effective_n_threads()
 

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -402,7 +402,7 @@ def test_tweedie_link_argument(name, link_class):
     y = np.array([0.1, 0.5])  # in range of all distributions
     X = np.array([[1], [2]])
     glm = TweedieRegressor(power=1, link=name).fit(X, y)
-    assert isinstance(glm._linear_loss.base_loss.link, link_class)
+    assert isinstance(glm._base_loss.link, link_class)
 
     glm = TweedieRegressor(power=1, link="not a link")
     with pytest.raises(
@@ -426,7 +426,7 @@ def test_tweedie_link_auto(power, expected_link_class):
     y = np.array([0.1, 0.5])  # in range of all distributions
     X = np.array([[1], [2]])
     glm = TweedieRegressor(link="auto", power=power).fit(X, y)
-    assert isinstance(glm._linear_loss.base_loss.link, expected_link_class)
+    assert isinstance(glm._base_loss.link, expected_link_class)
 
 
 @pytest.mark.parametrize("power", [0, 1, 1.5, 2, 3])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #23090

#### What does this implement/fix? Explain your changes.
Coming from https://github.com/scikit-learn/scikit-learn/pull/23090#issuecomment-1097690778, I do not think we need to store `_linear_loss` at all. 

CC @lorentzenchr @ogrisel 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
