### PR TITLE
MNT Replace pytest.warns(None) in linear_models tests

### DIFF
--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -184,14 +184,15 @@ def test_deprecate_normalize(normalize, default):
             expected = None
             warning_msg = []
 
-    with pytest.warns(expected) as record:
-        _normalize = _deprecate_normalize(normalize, default, "estimator")
-    assert _normalize == output
-
-    n_warnings = 0 if expected is None else 1
-    assert len(record) == n_warnings
-    if n_warnings:
+    if expected is None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            _normalize = _deprecate_normalize(normalize, default, "estimator")
+    else:
+        with pytest.warns(expected) as record:
+            _normalize = _deprecate_normalize(normalize, default, "estimator")
         assert all([warning in str(record[0].message) for warning in warning_msg])
+    assert _normalize == output
 
 
 def test_linear_regression_sparse(random_state=0):

--- a/sklearn/linear_model/tests/test_common.py
+++ b/sklearn/linear_model/tests/test_common.py
@@ -5,6 +5,7 @@
 import pytest
 
 import sys
+import warnings
 import numpy as np
 
 from sklearn.base import is_classifier
@@ -56,6 +57,12 @@ def test_linear_model_normalize_deprecation_message(
         y = np.sign(y)
 
     model = estimator(normalize=normalize)
+    if warning_category is None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            model.fit(X, y)
+        return
+
     with pytest.warns(warning_category) as record:
         model.fit(X, y)
     # Filter record in case other unrelated warnings are raised
@@ -67,6 +74,5 @@ def test_linear_model_normalize_deprecation_message(
             msg += "\n"
         raise AssertionError(msg)
     wanted = [r for r in record if r.category == warning_category]
-    if warning_category is not None:
-        assert "'normalize' was deprecated" in str(wanted[0].message)
+    assert "'normalize' was deprecated" in str(wanted[0].message)
     assert len(wanted) == n_warnings


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to https://github.com/scikit-learn/scikit-learn/issues/22572


#### What does this implement/fix? Explain your changes.
Given the context of the test, these tests are asserting that a `FutureWarning` is not raised for specific settings of `normalize`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
