### PR TITLE
MNT Replace pytest.warns(None) in test_neighbors

### DIFF
--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1556,7 +1556,7 @@ def test_neighbors_metrics(
 
 
 # TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn*")
+@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize(
     "metric", sorted(set(neighbors.VALID_METRICS["brute"]) - set(["precomputed"]))
 )
@@ -1597,7 +1597,6 @@ def test_kneighbors_brute_backend(
         )
 
         neigh.fit(X_train)
-
         with warn_context_manager:
             with config_context(enable_cython_pairwise_dist=False):
                 # Use the legacy backend for brute
@@ -1609,8 +1608,9 @@ def test_kneighbors_brute_backend(
                 pdr_brute_dst, pdr_brute_idx = neigh.kneighbors(
                     X_test, return_distance=True
                 )
-            assert_allclose(legacy_brute_dst, pdr_brute_dst)
-            assert_array_equal(legacy_brute_idx, pdr_brute_idx)
+
+        assert_allclose(legacy_brute_dst, pdr_brute_dst)
+        assert_array_equal(legacy_brute_idx, pdr_brute_idx)
 
 
 def test_callable_metric():
@@ -2119,7 +2119,6 @@ def test_radius_neighbors_brute_backend(
         )
 
         neigh.fit(X_train)
-
         with warn_context_manager:
             with config_context(enable_cython_pairwise_dist=False):
                 # Use the legacy backend for brute
@@ -2131,9 +2130,10 @@ def test_radius_neighbors_brute_backend(
                 pdr_brute_dst, pdr_brute_idx = neigh.radius_neighbors(
                     X_test, return_distance=True
                 )
-            assert_radius_neighborhood_results_equality(
-                legacy_brute_dst, pdr_brute_dst, legacy_brute_idx, pdr_brute_idx
-            )
+
+        assert_radius_neighborhood_results_equality(
+            legacy_brute_dst, pdr_brute_dst, legacy_brute_idx, pdr_brute_idx
+        )
 
 
 def test_valid_metrics_has_no_duplicate():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #22572

#### What does this implement/fix? Explain your changes.
This PR removes the use of `pytest.warns` in `test_neighbors` that was in `pytest.parameterize`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
