### PR TITLE
MNT Adjust setup.cfg to warn only for sklearn warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ addopts =
 
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning
+    error::FutureWarning:sklearn*
+    error::DeprecationWarning:sklearn*
 
 [flake8]
 # max line length for black

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,12 +14,12 @@ addopts =
     # correctly on the CI when running `pytest --pyargs sklearn` from the
     # source folder.
     -p sklearn.tests.random_seed
+    -Werror::FutureWarning:sklearn
+    -Werror::DeprecationWarning:sklearn
     -rN
 
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning
-    error::FutureWarning:sklearn*
-    error::DeprecationWarning:sklearn*
 
 [flake8]
 # max line length for black


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/13396


#### What does this implement/fix? Explain your changes.
This PR adjusts `setup.cfg` to error for `FutureWarnings` and `DeprecationWarning` from sklearn itself. This means that warnings from other modules will not raise an error.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
