### PR TITLE
make test_ridge_regression_vstacked_X less sensitive

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -273,7 +273,7 @@ def test_ridge_regression_vstacked_X(
     coef = coef[:-1]
 
     assert model.intercept_ == pytest.approx(intercept)
-    assert_allclose(model.coef_, coef)
+    assert_allclose(model.coef_, coef, atol=1e-3)
 
 
 @pytest.mark.parametrize("solver", SOLVERS)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -273,7 +273,7 @@ def test_ridge_regression_vstacked_X(
     coef = coef[:-1]
 
     assert model.intercept_ == pytest.approx(intercept)
-    assert_allclose(model.coef_, coef, atol=1e-3)
+    assert_allclose(model.coef_, coef, atol=1e-8)
 
 
 @pytest.mark.parametrize("solver", SOLVERS)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a fix to issue #23151 .

#### What does this implement/fix? Explain your changes.
The test error is raised due to the relative difference on a small coefficient, this PR sets `atol=1e-3` to avoid such cases.
```
AssertionError:
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 1 / 3 (33.3%)
Max absolute difference: 7.17563786e-11
Max relative difference: 3.62417193e-06
x: array([-3.677719e+00, -9.925325e-06,  3.448643e+00])
y: array([-3.677719e+00, -9.925289e-06,  3.448643e+00])
```
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
