### PR TITLE
CI Do not auto close tracking issue if tests pass

### DIFF
--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -130,7 +130,8 @@ jobs:
           $CI_NAME \
           $ISSUE_REPO \
           $LINK_TO_RUN \
-          --junit-file $JUNIT_FILE
+          --junit-file $JUNIT_FILE \
+          --auto-close false
       displayName: 'Update issue tracker'
       env:
         JUNIT_FILE: $(TEST_DIR)/$(JUNITXML)

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -98,7 +98,8 @@ jobs:
           $CI_NAME \
           $ISSUE_REPO \
           $LINK_TO_RUN \
-          --junit-file $JUNIT_FILE
+          --junit-file $JUNIT_FILE \
+          --auto-close false
       displayName: 'Update issue tracker'
       env:
         JUNIT_FILE: $(TEST_DIR)/$(JUNITXML)

--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -81,27 +81,24 @@ def create_or_update_issue(body=""):
         print(f"Created issue in {args.issue_repo}#{issue.number}")
         sys.exit()
     else:
-        # Update existing issue
-        issue.edit(title=title, body=body_text)
-        print(f"Updated issue in {args.issue_repo}#{issue.number}")
+        # Add comment to existing issue
+        issue.create_comment(body=body_text)
+        print(f"Commented on issue: {args.issue_repo}#{issue.number}")
         sys.exit()
 
 
 def close_issue_if_opened():
     print("Test has no failures!")
-    if args.auto_close.lower() == "true":
-        issue = get_issue()
-        if issue is not None:
+    issue = get_issue()
+    if issue is not None:
+        comment = (
+            f"## CI is no longer failing! ✅\n\n[Successful run]({args.link_to_ci_run})"
+        )
+        print(f"Commented on issue #{issue.number}")
+        issue.create_comment(body=comment)
+        if args.auto_close.lower() == "true":
             print(f"Closing issue #{issue.number}")
-            new_body = (
-                "## Closed issue because CI is no longer failing! ✅\n\n"
-                f"[Successful run]({args.link_to_ci_run})\n\n"
-                "## Previous failure report\n\n"
-                f"{issue.body}"
-            )
-            issue.edit(state="closed", body=new_body)
-    else:
-        print("--auto-close is false, issue will not be closed.")
+            issue.edit(state="closed")
     sys.exit()
 
 

--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -35,6 +35,14 @@ parser.add_argument(
         "exists. If tests-passed is false, then the an issue is updated or created."
     ),
 )
+parser.add_argument(
+    "--auto-close",
+    help=(
+        "If --auto-close is false, then issues will not auto close even if the tests"
+        " pass."
+    ),
+    default="true",
+)
 
 args = parser.parse_args()
 
@@ -81,16 +89,19 @@ def create_or_update_issue(body=""):
 
 def close_issue_if_opened():
     print("Test has no failures!")
-    issue = get_issue()
-    if issue is not None:
-        print(f"Closing issue #{issue.number}")
-        new_body = (
-            "## Closed issue because CI is no longer failing! ✅\n\n"
-            f"[Successful run]({args.link_to_ci_run})\n\n"
-            "## Previous failure report\n\n"
-            f"{issue.body}"
-        )
-        issue.edit(state="closed", body=new_body)
+    if args.auto_close.lower() == "true":
+        issue = get_issue()
+        if issue is not None:
+            print(f"Closing issue #{issue.number}")
+            new_body = (
+                "## Closed issue because CI is no longer failing! ✅\n\n"
+                f"[Successful run]({args.link_to_ci_run})\n\n"
+                "## Previous failure report\n\n"
+                f"{issue.body}"
+            )
+            issue.edit(state="closed", body=new_body)
+    else:
+        print("--auto-close is false, issue will not be closed.")
     sys.exit()
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/issues/23151

#### What does this implement/fix? Explain your changes.
Now that the scheduled tests uses different random seeds, the test may fail for one seed and pass for another one. This PR updates the issue tracker script: 

1. To not auto close if all tests start to pass when `--auto-close false` is passed in
2. Leaves a comment instead of updating the original body. If a previous run failed because of a random seed and a current run failed because of another reason, I think we want to preserve all information.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->