### PR TITLE
Fix rst title in support documentation

### DIFF
--- a/doc/support.rst
+++ b/doc/support.rst
@@ -78,7 +78,7 @@ push datafiles to them.
 .. _gitter:
 
 Gitter
-===
+======
 
 Some developers like to hang out on scikit-learn Gitter room:
 https://gitter.im/scikit-learn/scikit-learn.


### PR DESCRIPTION
https://scikit-learn.org/dev/support.html

Gitter is not a title and shows equal signs instead see snapshot below ...

![image](https://user-images.githubusercontent.com/1680079/163954651-85f3227d-b6f9-4c4f-934d-b651a02b82b7.png)
