### PR TITLE
Fixed multiple tar slips from using "extractall" which can lead to an exploit

### DIFF
--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -18,6 +18,7 @@ features (words) may appear in each batch.
 #          @FedericoV <https://github.com/FedericoV/>
 # License: BSD 3 clause
 
+from contextlib import closing
 from glob import glob
 import itertools
 import os.path
@@ -169,7 +170,9 @@ def stream_reuters_documents(data_path=None):
         if _not_in_sphinx():
             sys.stdout.write("\r")
         print("untarring Reuters dataset...")
-        tarfile.open(archive_path, "r:gz").extractall(data_path)
+        # calling extractall() can result in files outside destination directory to be overwritten, resulting in an arbitrary file write.
+        with closing(tarfile.open(archive_path, "r:gz")) as archive:
+            archive.extractall(path=data_path)
         print("done.")
 
     parser = ReutersParser()

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -170,7 +170,7 @@ def stream_reuters_documents(data_path=None):
         if _not_in_sphinx():
             sys.stdout.write("\r")
         print("untarring Reuters dataset...")
-        # calling extractall() can result in files outside destination directory to be overwritten, resulting in an arbitrary file write.
+        # extractall can cause a tar slip
         with closing(tarfile.open(archive_path, "r:gz")) as archive:
             archive.extractall(path=data_path)
         print("done.")

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -109,7 +109,7 @@ def _check_fetch_lfw(data_home=None, funneled=True, download_if_missing=True):
         import tarfile
 
         logger.debug("Decompressing the data archive to %s", data_folder_path)
-        # using extractall() can result in files outside destination directory to be overwritten, resulting in an arbitrary file write.
+        # extractall can cause a tar slip
         with closing(tarfile.open(archive_path, "r:gz")) as archive:
             archive.extractall(path=lfw_home)
         remove(archive_path)

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -8,6 +8,7 @@ over the internet, all details are available on the official website:
 # Copyright (c) 2011 Olivier Grisel <olivier.grisel@ensta.org>
 # License: BSD 3 clause
 
+from contextlib import closing
 from os import listdir, makedirs, remove
 from os.path import join, exists, isdir
 
@@ -108,7 +109,9 @@ def _check_fetch_lfw(data_home=None, funneled=True, download_if_missing=True):
         import tarfile
 
         logger.debug("Decompressing the data archive to %s", data_folder_path)
-        tarfile.open(archive_path, "r:gz").extractall(path=lfw_home)
+        # using extractall() can result in files outside destination directory to be overwritten, resulting in an arbitrary file write.
+        with closing(tarfile.open(archive_path, "r:gz")) as archive:
+            archive.extractall(path=lfw_home)
         remove(archive_path)
 
     return lfw_home, data_folder_path

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -24,6 +24,7 @@ uncompressed the train set is 52 MB and the test set is 34 MB.
 # Copyright (c) 2011 Olivier Grisel <olivier.grisel@ensta.org>
 # License: BSD 3 clause
 
+from contextlib import closing
 import os
 import logging
 import tarfile
@@ -74,7 +75,9 @@ def _download_20newsgroups(target_dir, cache_path):
     archive_path = _fetch_remote(ARCHIVE, dirname=target_dir)
 
     logger.debug("Decompressing %s", archive_path)
-    tarfile.open(archive_path, "r:gz").extractall(path=target_dir)
+    # using extractall() can result in files outside destination directory to be overwritten, resulting in an arbitrary file write.
+    with closing(tarfile.open(archive_path, "r:gz")) as archive:
+        archive.extractall(path=target_dir)
     os.remove(archive_path)
 
     # Store a zipped pickle

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -75,7 +75,7 @@ def _download_20newsgroups(target_dir, cache_path):
     archive_path = _fetch_remote(ARCHIVE, dirname=target_dir)
 
     logger.debug("Decompressing %s", archive_path)
-    # using extractall() can result in files outside destination directory to be overwritten, resulting in an arbitrary file write.
+    # extractall can cause a tar slip
     with closing(tarfile.open(archive_path, "r:gz")) as archive:
         archive.extractall(path=target_dir)
     os.remove(archive_path)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

This is not a response to an existing open issue, however I thought it is worth taking a look at since tar/zip slips can be dangerous and lead to vulnerability!

#### What does this implement/fix? Explain your changes.

Calling extractall() to extract all files from a tar file without sanitization can result in files outside destination directory to be overwritten, resulting in an arbitrary file write. I suggest using:

`with closing(tarfile.open(ARCHIVE_NAME, "r:gz")) as archive:
    archive.extractall(path=PATH_NAME)`

#### Any other comments?

This can lead to an exploit by extracting files from an archive by giving access to parts of the file system outside of the target folder in which they should reside. With that being said, executable files can be overwritten and either be invoked remotely or wait for the system or user to call them, thus achieving remote command execution on the victim’s machine. The vulnerability can also cause damage by overwriting configuration files or other sensitive resources, and can be exploited on both client machines and servers.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
