### PR TITLE
TST Fix ridge tests not deterministic

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -121,7 +121,7 @@ def ols_ridge_dataset(global_random_seed, request):
     k = min(n_samples, n_features)
     rng = np.random.RandomState(global_random_seed)
     X = make_low_rank_matrix(
-        n_samples=n_samples, n_features=n_features, effective_rank=k
+        n_samples=n_samples, n_features=n_features, effective_rank=k, random_state=rng
     )
     X[:, -1] = 1  # last columns acts as intercept
     U, s, Vt = linalg.svd(X)


### PR DESCRIPTION
The ``ols_ridge_dataset`` fixture was missing calling ``make_low_rank_matrix`` with a fixed random_state. It's probably the cause of the non determinism we see when trying to run these tests for all random seeds.

Maybe the work done in https://github.com/scikit-learn/scikit-learn/pull/23026 was not necessary after all 😄. But I find it convenient still.