### PR TITLE
TST Speed-up test_minibatch_dictionary_learning_dtype_match

### DIFF
--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -911,9 +911,12 @@ def test_minibatch_dictionary_learning_dtype_match(
         batch_size=10,
         fit_algorithm=fit_algorithm,
         transform_algorithm=transform_algorithm,
+        max_iter=100,
+        tol=1e-1,
         random_state=0,
     )
     dict_learner.fit(X.astype(data_type))
+
     assert dict_learner.components_.dtype == expected_type
     assert dict_learner.transform(X.astype(data_type)).dtype == expected_type
     assert dict_learner._inner_stats[0].dtype == expected_type


### PR DESCRIPTION
This test takes almost 1min to run locally. I can't imagine on azure. This PR makes it run in less than 2 secs.