### PR TITLE
CI Fix don't run all random seeds all the time

### DIFF
--- a/build_tools/azure/get_selected_tests.py
+++ b/build_tools/azure/get_selected_tests.py
@@ -26,6 +26,9 @@ def get_selected_tests():
 if __name__ == "__main__":
     # set the environment variable to be propagated to other steps
     selected_tests = get_selected_tests()
-    print(f"##vso[task.setvariable variable=SELECTED_TESTS]'{selected_tests}'")
 
-    print(f"selected tests: {selected_tests}")  # helps debugging
+    if selected_tests:
+        print(f"##vso[task.setvariable variable=SELECTED_TESTS]'{selected_tests}'")
+        print(f"selected tests: {selected_tests}")  # helps debugging
+
+    print("no selected tests")

--- a/build_tools/azure/get_selected_tests.py
+++ b/build_tools/azure/get_selected_tests.py
@@ -30,5 +30,5 @@ if __name__ == "__main__":
     if selected_tests:
         print(f"##vso[task.setvariable variable=SELECTED_TESTS]'{selected_tests}'")
         print(f"selected tests: {selected_tests}")  # helps debugging
-
-    print("no selected tests")
+    else:
+        print("no selected tests")

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -xe
+set -e
 
 # defines the show_installed_libraries function
 source build_tools/shared.sh
@@ -70,12 +70,13 @@ if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
     TEST_CMD="$TEST_CMD -ra"
 fi
 
-if [[ -z "$SELECTED_TESTS" ]]; then
+if [[ -n "$SELECTED_TESTS" ]]; then
     TEST_CMD="$TEST_CMD -k $SELECTED_TESTS"
 
     # Override to make selected tests run on all random seeds
     export SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all"
 fi
 
+set -x
 eval "$TEST_CMD --pyargs sklearn"
 set +x

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -70,7 +70,7 @@ if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
     TEST_CMD="$TEST_CMD -ra"
 fi
 
-if [[ "$SELECTED_TESTS" != "" ]]; then
+if [[ -z "$SELECTED_TESTS" ]]; then
     TEST_CMD="$TEST_CMD -k $SELECTED_TESTS"
 
     # Override to make selected tests run on all random seeds

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -xe
 
 # defines the show_installed_libraries function
 source build_tools/shared.sh
@@ -77,6 +77,5 @@ if [[ -z "$SELECTED_TESTS" ]]; then
     export SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all"
 fi
 
-set -x
 eval "$TEST_CMD --pyargs sklearn"
 set +x


### PR DESCRIPTION
Fixes #23185 

Since https://github.com/scikit-learn/scikit-learn/pull/23026, it turns out that the CI runs for all random seeds all the time, making it take a lot more time.