### PR TITLE
DOC Fixes confusing notation for y and y_pred

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -930,8 +930,8 @@ produce an F-score that is not between precision and recall.
 
 To make this more explicit, consider the following notation:
 
-* :math:`y` the set of *predicted* :math:`(sample, label)` pairs
-* :math:`\hat{y}` the set of *true* :math:`(sample, label)` pairs
+* :math:`y` the set of *true* :math:`(sample, label)` pairs
+* :math:`\hat{y}` the set of *predicted* :math:`(sample, label)` pairs
 * :math:`L` the set of labels
 * :math:`S` the set of samples
 * :math:`y_s` the subset of :math:`y` with sample :math:`s`,
@@ -939,9 +939,9 @@ To make this more explicit, consider the following notation:
 * :math:`y_l` the subset of :math:`y` with label :math:`l`
 * similarly, :math:`\hat{y}_s` and :math:`\hat{y}_l` are subsets of
   :math:`\hat{y}`
-* :math:`P(A, B) := \frac{\left| A \cap B \right|}{\left|A\right|}` for some
+* :math:`P(A, B) := \frac{\left| A \cap B \right|}{\left|\right|}` for some
   sets :math:`A` and :math:`B`
-* :math:`R(A, B) := \frac{\left| A \cap B \right|}{\left|B\right|}`
+* :math:`R(A, B) := \frac{\left| A \cap B \right|}{\left|A\right|}`
   (Conventions vary on handling :math:`B = \emptyset`; this implementation uses
   :math:`R(A, B):=0`, and similar for :math:`P`.)
 * :math:`F_\beta(A, B) := \left(1 + \beta^2\right) \frac{P(A, B) \times R(A, B)}{\beta^2 P(A, B) + R(A, B)}`


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #18864
Closes #18873 (Superseeds)


#### What does this implement/fix? Explain your changes.
The current user guide is correct, but it users `y_hat` to mean the true values and `y` to mean the predicted. This is not consistent with most literature. This PR fixes flipping the notation.


#### Any other comments?
CC @glemaitre 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
