### PR TITLE
MNT Adds black commit to git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -22,3 +22,6 @@
 
 # PR 22474: Update to Black 22.1.0
 1fc86b6aacd89da44a3b4e8abf7c3e2ba4336ffe
+
+# PR 22983: Update to Black 22.3.0
+d4aad64b1eb2e42e76f49db2ccfbe4b4660d092b


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #22983

#### What does this implement/fix? Explain your changes.
This PR adds https://github.com/scikit-learn/scikit-learn/commit/d4aad64b1eb2e42e76f49db2ccfbe4b4660d092b to `.git-blame-ignore-revs`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
