### PR TITLE
DOC Detail superseded workflow for PRs

### DIFF
--- a/doc/developers/bug_triaging.rst
+++ b/doc/developers/bug_triaging.rst
@@ -66,7 +66,7 @@ can do the following important tasks:
 
 - If a stalled PR is taken over by a newer PR, then label the stalled PR as
   "Superseded", leave a comment on the stalled PR linking to the new PR, and
-  close the stalled PR.
+  likely close the stalled PR.
 
 - Triage issues:
 

--- a/doc/developers/bug_triaging.rst
+++ b/doc/developers/bug_triaging.rst
@@ -64,6 +64,10 @@ can do the following important tasks:
   or needs help (this is typically very important in the context
   of sprints, where the risk is to create many unfinished PRs)
 
+- If a stalled PR is taken over by a newer PR, then label the stalled PR as
+  "Superseded", leave a comment on the stalled PR linking to the new PR, and
+  close the stalled PR.
+
 - Triage issues:
 
   - **close usage questions** and politely point the reporter to use


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/issues/14570#issuecomment-518702144


#### What does this implement/fix? Explain your changes.
This adds a policy to close stalled PRs when they become superseded. To me, closing superseded PRs is similar to closing duplicate issues. If a superseded PRs is closed, we signal to contributors that all new discussions continue on the new PR.

An extreme example are these 5 PRs on the same issue: https://github.com/scikit-learn/scikit-learn/pull/13042, https://github.com/scikit-learn/scikit-learn/pull/12285, https://github.com/scikit-learn/scikit-learn/pull/10168, https://github.com/scikit-learn/scikit-learn/pull/18094, https://github.com/scikit-learn/scikit-learn/pull/22562 where 4 of them are superseded.

CC @scikit-learn/core-devs @scikit-learn/contributor-experience-team 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
