### PR TITLE
FIX "CategoricalNB fails with sparse matrix" #16561

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -1340,14 +1340,14 @@ class CategoricalNB(_BaseDiscreteNB):
     def _check_X(self, X):
         """Validate X, used only in predict* methods."""
         X = self._validate_data(
-            X, dtype="int", accept_sparse="csr", force_all_finite=True, reset=False
+            X, dtype="int", accept_sparse="csc", force_all_finite=True, reset=False
         )
         check_non_negative(X, "CategoricalNB (input X)")
         return X
 
     def _check_X_y(self, X, y, reset=True):
         X, y = self._validate_data(
-            X, y, dtype="int", accept_sparse="csr", force_all_finite=True, reset=reset
+            X, y, dtype="int", accept_sparse="csc", force_all_finite=True, reset=reset
         )
         check_non_negative(X, "CategoricalNB (input X)")
         return X, y

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -688,6 +688,7 @@ def test_categoricalnb():
     clf.fit(X3, y3)
     assert_array_equal(clf.n_categories_, np.array([3, 6]))
 
+    # Check error is raised for X with negative entries
     X = np.array([[0, -1]])
     y = np.array([1])
     error_msg = re.escape("Negative values in data passed to CategoricalNB (input X)")

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -688,7 +688,6 @@ def test_categoricalnb():
     clf.fit(X3, y3)
     assert_array_equal(clf.n_categories_, np.array([3, 6]))
 
-    # Check error is raised for X with negative entries
     X = np.array([[0, -1]])
     y = np.array([1])
     error_msg = re.escape("Negative values in data passed to CategoricalNB (input X)")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #16561.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I fixed a bug where even though the documentation says `CategoricalNB` accepts `sparse_matrix` as a feature matrix, it cannot.

Now `CategoricalNB` accepts a sparce matrix (in particular, csr_matrix) without any error.
Also, I added the test for it.


#### Any other comments?

In #16561, one of the maintainers asked in what situation you want CategoricalNB for sparse data.

When I did an assignment in my university class, I was required to train a very simple model like naive Bayes algorithms with sparse data, which is originally text data.
If `toarray()` was used, the memory error occurred. 

I created such an example. If I run the following code on my local computer with 16GB memory, the process was killed becaues of the memory shortage if I didn't use a sparse matrix. If I did, I was able to successfully finish it.

```
from sklearn.naive_bayes import CategoricalNB, MultinomialNB
from scipy.sparse import csr_matrix
import numpy as np

sample_size = 1000
n_features = 50000
n_ones = 100
is_sparse = True

rng = np.random.RandomState(1)
rows = rng.choice(sample_size, size=n_ones)
cols = rng.choice(n_features, size=n_ones)

if is_sparse:
    X = csr_matrix((np.ones(n_ones), [rows, cols]), shape=(sample_size, n_features))
else:
    X = np.zeros((sample_size, n_features))
    X[rows, cols] = 1
y = rng.choice(2, size=sample_size)
clf = CategoricalNB(min_categories=3, class_prior=np.array([0.3, 0.7]))
clf.fit(X, y)
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
