### PR TITLE
DOC Update maintainers doc for the release

### DIFF
--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -272,8 +272,8 @@ Making a release
 
        twine upload dist/*
 
-9. For major/minor (not bug-fix release), update the symlink for ``stable``
-   and the ``latestStable`` variable in
+9. For major/minor (not bug-fix release or release candidates), update the symlink for
+   ``stable`` and the ``latestStable`` variable in
    https://github.com/scikit-learn/scikit-learn.github.io:
 
    .. prompt:: bash $

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -224,53 +224,53 @@ Making a release
      git tag -a 0.99.0  # in the 0.99.X branch
      git push git@github.com:scikit-learn/scikit-learn.git 0.99.0
 
-6. Trigger the GitHub Actions workflow again but this time to upload the artifacts
-   to the real https://pypi.org (replace "testpypi" by "pypi" in the "Run
-   workflow" form).
-
-7. Confirm that the bot has detected the tag on the conda-forge feedstock repo:
+6. Confirm that the bot has detected the tag on the conda-forge feedstock repo:
    https://github.com/conda-forge/scikit-learn-feedstock. If not, submit a PR for the
    release. If you want to publish an RC release on conda-forge, the PR should target
    the `rc` branch as opposed to the `main` branch. The two branches need to be kept
    sync together otherwise.
 
-8. Alternatively, it's possible to collect locally the generated binary wheel
-   packages and source tarball and upload them all to PyPI by running the
-   following commands in the scikit-learn source folder (checked out at the
-   release tag):
+7. Trigger the GitHub Actions workflow again but this time to upload the artifacts
+   to the real https://pypi.org (replace "testpypi" by "pypi" in the "Run
+   workflow" form).
 
-   .. prompt:: bash $
+   7.1. Alternatively, it's possible to collect locally the generated binary wheel
+        packages and source tarball and upload them all to PyPI by running the
+        following commands in the scikit-learn source folder (checked out at the
+        release tag):
 
-       rm -r dist
-       pip install -U wheelhouse_uploader twine
-       python -m wheelhouse_uploader fetch \
-         --version 0.99.0 \
-         --local-folder dist \
-         scikit-learn \
-         https://pypi.anaconda.org/scikit-learn-wheels-staging/simple/scikit-learn/
+        .. prompt:: bash $
 
-   This command will download all the binary packages accumulated in the
-   `staging area on the anaconda.org hosting service
-   <https://anaconda.org/scikit-learn-wheels-staging/scikit-learn/files>`_ and
-   put them in your local `./dist` folder.
+            rm -r dist
+            pip install -U wheelhouse_uploader twine
+            python -m wheelhouse_uploader fetch \
+              --version 0.99.0 \
+              --local-folder dist \
+              scikit-learn \
+              https://pypi.anaconda.org/scikit-learn-wheels-staging/simple/scikit-learn/
 
-   Check the content of the `./dist` folder: it should contain all the wheels
-   along with the source tarball ("scikit-learn-RRR.tar.gz").
+        This command will download all the binary packages accumulated in the
+        `staging area on the anaconda.org hosting service
+        <https://anaconda.org/scikit-learn-wheels-staging/scikit-learn/files>`_ and
+        put them in your local `./dist` folder.
 
-   Make sure that you do not have developer versions or older versions of
-   the scikit-learn package in that folder.
+        Check the content of the `./dist` folder: it should contain all the wheels
+        along with the source tarball ("scikit-learn-RRR.tar.gz").
 
-   Before uploading to pypi, you can test upload to test.pypi.org:
+        Make sure that you do not have developer versions or older versions of
+        the scikit-learn package in that folder.
 
-   .. prompt:: bash $
+        Before uploading to pypi, you can test upload to test.pypi.org:
 
-       twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
+        .. prompt:: bash $
 
-   Upload everything at once to https://pypi.org:
+            twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
 
-   .. prompt:: bash $
+        Upload everything at once to https://pypi.org:
 
-       twine upload dist/*
+        .. prompt:: bash $
+
+            twine upload dist/*
 
 9. For major/minor (not bug-fix release or release candidates), update the symlink for
    ``stable`` and the ``latestStable`` variable in

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -211,12 +211,6 @@ Making a release
 
    https://github.com/scikit-learn/scikit-learn/actions?query=workflow%3A%22Publish+to+Pypi%22
 
-4.1 You can test the conda-forge builds by submitting a PR to the feedstock
-    repo: https://github.com/conda-forge/scikit-learn-feedstock. If you want to
-    publish an RC release on conda-forge, the PR should target the `rc` branch
-    as opposed to the `master` branch. The two branches need to be kept sync
-    together otherwise.
-
 5. If this went fine, you can proceed with tagging. Proceed with caution.
    Ideally, tags should be created when you're almost certain that the release
    is ready, since adding a tag to the main repo can trigger certain automated
@@ -234,7 +228,13 @@ Making a release
    to the real https://pypi.org (replace "testpypi" by "pypi" in the "Run
    workflow" form).
 
-7. Alternatively, it's possible to collect locally the generated binary wheel
+7. Confirm that the bot has detected the tag on the conda-forge feedstock repo:
+   https://github.com/conda-forge/scikit-learn-feedstock. If not, submit a PR for the
+   release. If you want to publish an RC release on conda-forge, the PR should target
+   the `rc` branch as opposed to the `main` branch. The two branches need to be kept
+   sync together otherwise.
+
+8. Alternatively, it's possible to collect locally the generated binary wheel
    packages and source tarball and upload them all to PyPI by running the
    following commands in the scikit-learn source folder (checked out at the
    release tag):
@@ -272,7 +272,7 @@ Making a release
 
        twine upload dist/*
 
-8. For major/minor (not bug-fix release), update the symlink for ``stable``
+9. For major/minor (not bug-fix release), update the symlink for ``stable``
    and the ``latestStable`` variable in
    https://github.com/scikit-learn/scikit-learn.github.io:
 

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -272,7 +272,7 @@ Making a release
 
             twine upload dist/*
 
-9. For major/minor (not bug-fix release or release candidates), update the symlink for
+8. For major/minor (not bug-fix release or release candidates), update the symlink for
    ``stable`` and the ``latestStable`` variable in
    https://github.com/scikit-learn/scikit-learn.github.io:
 

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -306,7 +306,7 @@ The following GitHub checklist might be helpful in a release PR::
     * [ ] confirm bot detected at
       https://github.com/conda-forge/scikit-learn-feedstock and wait for merge
     * [ ] upload the wheels and source tarball to PyPI
-    * [ ] https://github.com/scikit-learn/scikit-learn/releases publish
+    * [ ] https://github.com/scikit-learn/scikit-learn/releases publish (except for RC)
     * [ ] announce on mailing list and on Twitter, and LinkedIn
 
 Merging Pull Requests

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -234,45 +234,45 @@ Making a release
    to the real https://pypi.org (replace "testpypi" by "pypi" in the "Run
    workflow" form).
 
-   7.1. Alternatively, it's possible to collect locally the generated binary wheel
-        packages and source tarball and upload them all to PyPI by running the
-        following commands in the scikit-learn source folder (checked out at the
-        release tag):
+8. **Alternative to step 7**: it's possible to collect locally the generated binary
+   wheel packages and source tarball and upload them all to PyPI by running the
+   following commands in the scikit-learn source folder (checked out at the
+   release tag):
 
-        .. prompt:: bash $
+   .. prompt:: bash $
 
-            rm -r dist
-            pip install -U wheelhouse_uploader twine
-            python -m wheelhouse_uploader fetch \
-              --version 0.99.0 \
-              --local-folder dist \
-              scikit-learn \
-              https://pypi.anaconda.org/scikit-learn-wheels-staging/simple/scikit-learn/
+       rm -r dist
+       pip install -U wheelhouse_uploader twine
+       python -m wheelhouse_uploader fetch \
+         --version 0.99.0 \
+         --local-folder dist \
+         scikit-learn \
+         https://pypi.anaconda.org/scikit-learn-wheels-staging/simple/scikit-learn/
 
-        This command will download all the binary packages accumulated in the
-        `staging area on the anaconda.org hosting service
-        <https://anaconda.org/scikit-learn-wheels-staging/scikit-learn/files>`_ and
-        put them in your local `./dist` folder.
+   This command will download all the binary packages accumulated in the
+   `staging area on the anaconda.org hosting service
+   <https://anaconda.org/scikit-learn-wheels-staging/scikit-learn/files>`_ and
+   put them in your local `./dist` folder.
 
-        Check the content of the `./dist` folder: it should contain all the wheels
-        along with the source tarball ("scikit-learn-RRR.tar.gz").
+   Check the content of the `./dist` folder: it should contain all the wheels
+   along with the source tarball ("scikit-learn-RRR.tar.gz").
 
-        Make sure that you do not have developer versions or older versions of
-        the scikit-learn package in that folder.
+   Make sure that you do not have developer versions or older versions of
+   the scikit-learn package in that folder.
 
-        Before uploading to pypi, you can test upload to test.pypi.org:
+   Before uploading to pypi, you can test upload to test.pypi.org:
 
-        .. prompt:: bash $
+   .. prompt:: bash $
 
-            twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
+       twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
 
-        Upload everything at once to https://pypi.org:
+   Upload everything at once to https://pypi.org:
 
-        .. prompt:: bash $
+   .. prompt:: bash $
 
-            twine upload dist/*
+       twine upload dist/*
 
-8. For major/minor (not bug-fix release or release candidates), update the symlink for
+9. For major/minor (not bug-fix release or release candidates), update the symlink for
    ``stable`` and the ``latestStable`` variable in
    https://github.com/scikit-learn/scikit-learn.github.io:
 


### PR DESCRIPTION
It's not possible to make a test PR on conda-forge feedstock before the tag since it requires a tarball (``https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz``).

I moved that item to a later position, and modified the content a bit.

(also, the `4.1` used to break the rendering)