### PR TITLE
TST: speed-up MLP tests by using default batch size

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -675,7 +675,7 @@ def _set_checking_parameters(estimator):
     if "n_init" in params:
         # K-Means
         estimator.set_params(n_init=2)
-    if "batch_size" in params:
+    if "batch_size" in params and not name.startswith("MLP"):
         estimator.set_params(batch_size=10)
 
     if name == "MeanShift":


### PR DESCRIPTION
Looks like the `batch_size` was set to 10 which is smaller than the default value for `MLP*` objects and was making the tests slower. I bumped into this while looking at the results of #23211 in more details.

On my machine, the common MLP tests go from 30s on main to 10s in this PR.

This PR (~10s)
```
❯ pytest sklearn/tests/test_common.py -k MLP --durations 20              
==================================================================== test session starts ====================================================================
platform linux -- Python 3.9.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/local/lesteve/dev/scikit-learn, configfile: setup.cfg
collected 8934 items / 8838 deselected / 96 selected                                                                                                        

sklearn/tests/test_common.py .........................s..................................................................xx..                         [100%]

=================================================================== slowest 20 durations ====================================================================
0.67s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_estimator_sparse_data]
0.59s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_estimator_sparse_data]
0.40s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_train]
0.37s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_train(readonly_memmap=True,X_dtype=float32)]
0.37s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_train(readonly_memmap=True)]
0.28s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressor_data_not_an_array]
0.19s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_classes]
0.16s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_estimators_dtypes]
0.16s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_multilabel_representation_invariance]
0.15s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressors_train(readonly_memmap=True,X_dtype=float32)]
0.14s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressors_train(readonly_memmap=True)]
0.14s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressors_train]
0.14s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifier_data_not_an_array]
0.13s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_estimators_dtypes]
0.08s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressors_int]
0.08s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_supervised_y_2d]
0.08s call     sklearn/tests/test_common.py::test_pandas_column_name_consistency[MLPClassifier()]
0.08s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_pipeline_consistency]
0.08s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_dtype_object]
0.07s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_estimators_nan_inf]
========================================== 93 passed, 1 skipped, 8838 deselected, 2 xfailed, 59 warnings in 10.42s ==========================================
```

In main (~30s):
```
❯ pytest sklearn/tests/test_common.py -k MLP --durations 20
==================================================================== test session starts ====================================================================
platform linux -- Python 3.9.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/local/lesteve/dev/scikit-learn, configfile: setup.cfg
collected 8934 items / 8838 deselected / 96 selected                                                                                                        

sklearn/tests/test_common.py .........................s..................................................................xx..                         [100%]

=================================================================== slowest 20 durations ====================================================================
2.79s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_train(readonly_memmap=True,X_dtype=float32)]
2.70s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_train(readonly_memmap=True)]
2.68s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_train]
2.15s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_estimator_sparse_data]
1.94s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_estimator_sparse_data]
1.93s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressor_data_not_an_array]
1.02s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressors_train(readonly_memmap=True,X_dtype=float32)]
0.99s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressors_train(readonly_memmap=True)]
0.99s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressors_train]
0.70s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_multilabel_representation_invariance]
0.44s call     sklearn/tests/test_common.py::test_pandas_column_name_consistency[MLPClassifier()]
0.41s call     sklearn/tests/test_common.py::test_check_n_features_in_after_fitting[MLPClassifier()]
0.40s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_non_transformer_estimators_n_iter]
0.37s call     sklearn/tests/test_common.py::test_pandas_column_name_consistency[MLPRegressor()]
0.36s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_classes]
0.35s call     sklearn/tests/test_common.py::test_check_n_features_in_after_fitting[MLPRegressor()]
0.27s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_estimators_dtypes]
0.25s call     sklearn/tests/test_common.py::test_estimators[MLPRegressor()-check_regressors_int]
0.24s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifiers_multilabel_output_format_decision_function]
0.23s call     sklearn/tests/test_common.py::test_estimators[MLPClassifier()-check_classifier_data_not_an_array]
========================================== 93 passed, 1 skipped, 8838 deselected, 2 xfailed, 59 warnings in 29.49s ==========================================
```
