### PR TITLE
DOC improve documentation regarding change of default value

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1208,9 +1208,17 @@ When the change is in a class, we validate and raise warning in ``fit``::
 
 Similar to deprecations, the warning message should always give both the
 version in which the change happened and the version in which the old behavior
-will be removed. The docstring needs to be updated accordingly. We need a test
-which ensures that the warning is raised in relevant cases but not in other
-cases. The warning should be caught in all other tests
+will be removed.
+
+The parameter description in the docstring needs to be updated accordingly by adding
+a `versionchanged` directive with the old and new default value, pointing to the
+version when the change will be effective::
+
+    .. versionchanged:: 0.22
+       The default value for `n_clusters` will change from 5 to 10 in version 0.22.
+
+Finally, we need a test which ensures that the warning is raised in relevant cases but
+not in other cases. The warning should be caught in all other tests
 (using e.g., ``@pytest.mark.filterwarnings``), and there should be no warning
 in the examples.
 


### PR DESCRIPTION
It's not clear in the doc how to update the docstring when we want to change the default value of a parameter.

We've been doing things quite inconsistently so far. I would not add a `deprecated` directive since to me deprecation is for stuff that will be removed. On the other hand `versionchanged` is for stuff that has changed, while we want to inform the user that stuff will change.

I like what @lesteve proposed during an irl discussion, i.e. put a `versionchanged` directive but targeting 2 versions ahead, with a comment saying that the default will change.

This discussion is still open and feel free to propose alternative solutions @scikit-learn/core-devs and @scikit-learn/contributor-experience-team 