### PR TITLE
DOC Ensures that strip_tags passes numpydoc validation

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -166,7 +166,7 @@ def strip_accents_ascii(s):
 
 
 def strip_tags(s):
-    """Basic regexp based HTML / XML tag stripper function
+    """Basic regexp based HTML / XML tag stripper function.
 
     For serious HTML/XML preprocessing you should rather use an external
     library such as lxml or BeautifulSoup.
@@ -174,7 +174,12 @@ def strip_tags(s):
     Parameters
     ----------
     s : str
-        The string to strip
+        The string to strip.
+
+    Returns
+    -------
+    s : str
+        The stripped string.
     """
     return re.compile(r"<([^>]+)>", flags=re.UNICODE).sub(" ", s)
 

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -28,7 +28,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.feature_extraction.image.img_to_graph",
     "sklearn.feature_extraction.text.strip_accents_ascii",
     "sklearn.feature_extraction.text.strip_accents_unicode",
-    "sklearn.feature_extraction.text.strip_tags",
     "sklearn.feature_selection._univariate_selection.chi2",
     "sklearn.feature_selection._univariate_selection.f_oneway",
     "sklearn.inspection._partial_dependence.partial_dependence",


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #21350 


#### What does this implement/fix? Explain your changes.

Ensures that sklearn.feature_extraction.text.strip_tags passes numpydoc validation.

Changes:
- Removed sklearn.feature_extraction.text.strip_tags from FUNCTION_DOCSTRING_IGNORE_LIST
- Added "." to the end of multiple lines
- Added a Returns section
