### PR TITLE
DOC Ensures that sklearn.feature_extraction.text.strip_accents_ascii passes numpydoc validation

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -147,7 +147,7 @@ def strip_accents_unicode(s):
 
 
 def strip_accents_ascii(s):
-    """Transform accentuated unicode symbols into ascii or nothing
+    """Transform accentuated unicode symbols into ascii or nothing.
 
     Warning: this solution is only suited for languages that have a direct
     transliteration to ASCII symbols.
@@ -155,7 +155,12 @@ def strip_accents_ascii(s):
     Parameters
     ----------
     s : str
-        The string to strip
+        The string to strip.
+
+    Returns
+    -------
+    s : str
+        The stripped string.
 
     See Also
     --------

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -166,7 +166,7 @@ def strip_accents_ascii(s):
 
 
 def strip_tags(s):
-    """Basic regexp based HTML / XML tag stripper function
+    """Basic regexp based HTML / XML tag stripper function.
 
     For serious HTML/XML preprocessing you should rather use an external
     library such as lxml or BeautifulSoup.
@@ -174,7 +174,12 @@ def strip_tags(s):
     Parameters
     ----------
     s : str
-        The string to strip
+        The string to strip.
+
+    Returns
+    -------
+    s : str
+        The stripped string.
     """
     return re.compile(r"<([^>]+)>", flags=re.UNICODE).sub(" ", s)
 

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -28,7 +28,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.feature_extraction.image.img_to_graph",
     "sklearn.feature_extraction.text.strip_accents_ascii",
     "sklearn.feature_extraction.text.strip_accents_unicode",
-    "sklearn.feature_extraction.text.strip_tags",
     "sklearn.feature_selection._univariate_selection.chi2",
     "sklearn.feature_selection._univariate_selection.f_oneway",
     "sklearn.inspection._partial_dependence.partial_dependence",

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -26,7 +26,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.externals._packaging.version.parse",
     "sklearn.feature_extraction.image.extract_patches_2d",
     "sklearn.feature_extraction.image.img_to_graph",
-    "sklearn.feature_extraction.text.strip_accents_ascii",
     "sklearn.feature_extraction.text.strip_accents_unicode",
     "sklearn.feature_selection._univariate_selection.chi2",
     "sklearn.feature_selection._univariate_selection.f_oneway",


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #21350 


#### What does this implement/fix? Explain your changes.

Ensures that sklearn.feature_extraction.text.strip_accents_ascii passes numpydoc validation.

Changes:
- Removed sklearn.feature_extraction.text.strip_accents_ascii from FUNCTION_DOCSTRING_IGNORE_LIST
- Added "." to the end of multiple lines
- Added a Returns section