### PR TITLE
DOC Ensures that strip_accents_ascii passes numpydoc validation

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -147,7 +147,7 @@ def strip_accents_unicode(s):
 
 
 def strip_accents_ascii(s):
-    """Transform accentuated unicode symbols into ascii or nothing
+    """Transform accentuated unicode symbols into ascii or nothing.
 
     Warning: this solution is only suited for languages that have a direct
     transliteration to ASCII symbols.
@@ -155,7 +155,12 @@ def strip_accents_ascii(s):
     Parameters
     ----------
     s : str
-        The string to strip
+        The string to strip.
+
+    Returns
+    -------
+    s : str
+        The stripped string.
 
     See Also
     --------

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -26,7 +26,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.externals._packaging.version.parse",
     "sklearn.feature_extraction.image.extract_patches_2d",
     "sklearn.feature_extraction.image.img_to_graph",
-    "sklearn.feature_extraction.text.strip_accents_ascii",
     "sklearn.feature_extraction.text.strip_accents_unicode",
     "sklearn.feature_extraction.text.strip_tags",
     "sklearn.feature_selection._univariate_selection.chi2",


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #21350 


#### What does this implement/fix? Explain your changes.

Ensures that sklearn.feature_extraction.text.strip_accents_ascii passes numpydoc validation.

Changes:
- Removed sklearn.feature_extraction.text.strip_accents_ascii from FUNCTION_DOCSTRING_IGNORE_LIST
- Added "." to the end of multiple lines
- Added a Returns section


#### Any other comments?

Initially I accidentally created the branch for this off of another branch for a different numpydoc fix. I closed that pull request once I realized my mistake and created a new, separated branch this time.
