### PR TITLE
ENH  Optimize runtime for IsolationForest

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -33,6 +33,12 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.ensemble`
+.......................
+
+- |Efficiency| Improve runtime performance of :class:`ensemble.IsolationForest`
+  by avoiding data copies. :pr:`23252` by :user:`Zhehao Liu <MaxwellLZH>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -135,8 +135,13 @@ def _parallel_build_estimators(
                 not_indices_mask = ~indices_to_mask(indices, n_samples)
                 curr_sample_weight[not_indices_mask] = 0
 
-            estimator_fit(X[:, features], y, sample_weight=curr_sample_weight)
+            # Indicator of if indexing is necessary
+            require_indexing = bootstrap_features or max_features != n_features
 
+            if require_indexing:
+                estimator_fit(X[:, features], y, sample_weight=curr_sample_weight)
+            else:
+                estimator_fit(X, y, sample_weight=curr_sample_weight)
         else:
             estimator_fit(X[indices][:, features], y[indices])
 

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -88,6 +88,8 @@ def _parallel_build_estimators(
     bootstrap_features = ensemble.bootstrap_features
     support_sample_weight = has_fit_parameter(ensemble.base_estimator_, "sample_weight")
     has_check_input = has_fit_parameter(ensemble.base_estimator_, "check_input")
+    requires_feature_indexing = bootstrap_features or max_features != n_features
+
     if not support_sample_weight and sample_weight is not None:
         raise ValueError("The base estimator doesn't support sample weight")
 
@@ -135,15 +137,11 @@ def _parallel_build_estimators(
                 not_indices_mask = ~indices_to_mask(indices, n_samples)
                 curr_sample_weight[not_indices_mask] = 0
 
-            # Indicator of if indexing is necessary
-            require_indexing = bootstrap_features or max_features != n_features
-
-            if require_indexing:
-                estimator_fit(X[:, features], y, sample_weight=curr_sample_weight)
-            else:
-                estimator_fit(X, y, sample_weight=curr_sample_weight)
+            X_ = X[:, features] if requires_feature_indexing else X
+            estimator_fit(X_, y, sample_weight=curr_sample_weight)
         else:
-            estimator_fit(X[indices][:, features], y[indices])
+            X_ = X[indices][:, features] if requires_feature_indexing else X[indices]
+            estimator_fit(X_, y[indices])
 
         estimators.append(estimator)
         estimators_features.append(features)

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -81,6 +81,9 @@ class IsolationForest(OutlierMixin, BaseBagging):
             - If int, then draw `max_features` features.
             - If float, then draw `max_features * X.shape[1]` features.
 
+        Note: using a float number less than 1.0 or integer less than number of
+        features will enable feature subsampling and leads to a longerr runtime.
+
     bootstrap : bool, default=False
         If True, individual trees are fit on random subsets of the training
         data sampled with replacement. If False, sampling without replacement

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -8,6 +8,7 @@ from scipy.sparse import issparse
 from warnings import warn
 
 from ..tree import ExtraTreeRegressor
+from ..tree._tree import DTYPE as tree_dtype
 from ..utils import (
     check_random_state,
     check_array,
@@ -254,7 +255,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
         self : object
             Fitted estimator.
         """
-        X = self._validate_data(X, accept_sparse=["csc"])
+        X = self._validate_data(X, accept_sparse=["csc"], dtype=tree_dtype)
         if issparse(X):
             # Pre-sort indices to avoid that each individual tree of the
             # ensemble sorts the indices.

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -354,6 +354,6 @@ def test_iforest_with_n_jobs_does_not_segfault():
     
     Non-regression test for #23252
     """
-    X, _ = make_classification(n_samples=50000, n_features=100)
+    X, _ = make_classification(n_samples=85_000, n_features=100, random_state=0)
     X = csc_matrix(X)
     IsolationForest(n_estimators=10, max_samples=256, n_jobs=2).fit(X)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -349,8 +349,11 @@ def test_n_features_deprecation():
         est.n_features_
 
 
-def test_iforest_with_n_jobs():
-    """This is a non-regression test for PR #23252"""
+def test_iforest_with_n_jobs_does_not_segfault():
+    """Check that Isolation Forest does not segfault with n_jobs=2
+    
+    Non-regression test for #23252
+    """
     X, _ = make_classification(n_samples=50000, n_features=100)
     X = csc_matrix(X)
     X.sort_indices()

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -351,7 +351,7 @@ def test_n_features_deprecation():
 
 def test_iforest_with_n_jobs_does_not_segfault():
     """Check that Isolation Forest does not segfault with n_jobs=2
-    
+
     Non-regression test for #23252
     """
     X, _ = make_classification(n_samples=85_000, n_features=100, random_state=0)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -357,5 +357,4 @@ def test_iforest_with_n_jobs_does_not_segfault():
     X, _ = make_classification(n_samples=50000, n_features=100)
     X = csc_matrix(X)
     X.sort_indices()
-    for n_jobs in [2, 3, 4]:
-        IsolationForest(n_estimators=10, max_samples=256, n_jobs=n_jobs).fit(X)
+    IsolationForest(n_estimators=10, max_samples=256, n_jobs=2).fit(X)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -356,5 +356,4 @@ def test_iforest_with_n_jobs_does_not_segfault():
     """
     X, _ = make_classification(n_samples=50000, n_features=100)
     X = csc_matrix(X)
-    X.sort_indices()
     IsolationForest(n_estimators=10, max_samples=256, n_jobs=2).fit(X)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -20,7 +20,7 @@ from sklearn.model_selection import ParameterGrid
 from sklearn.ensemble import IsolationForest
 from sklearn.ensemble._iforest import _average_path_length
 from sklearn.model_selection import train_test_split
-from sklearn.datasets import load_diabetes, load_iris
+from sklearn.datasets import load_diabetes, load_iris, make_classification
 from sklearn.utils import check_random_state
 from sklearn.metrics import roc_auc_score
 
@@ -347,3 +347,12 @@ def test_n_features_deprecation():
 
     with pytest.warns(FutureWarning, match="`n_features_` was deprecated"):
         est.n_features_
+
+
+def test_iforest_with_n_jobs():
+    """This is a non-regression test for PR #23252"""
+    X, _ = make_classification(n_samples=50000, n_features=100)
+    X = csc_matrix(X)
+    X.sort_indices()
+    for n_jobs in [2, 3, 4]:
+        IsolationForest(n_estimators=10, max_samples=256, n_jobs=n_jobs).fit(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #19275
This is a follow-up PR of #23149.

#### What does this implement/fix? Explain your changes.
As discussed in the [comment](https://github.com/scikit-learn/scikit-learn/pull/23149#issuecomment-1107512467), the indexing operation in `_bagging.py: _parallel_build_estimators` is quite expensive, so when `bootstrap_features` is set to **False** and `max_features_` is equal to number of features, we can skip indexing to get better performance.

#### Benchmark result
Code used for profiling:
```python
from sklearn.datasets import make_classification
from scipy.sparse import csc_matrix, csr_matrix
from sklearn.ensemble import IsolationForest

X, y = make_classification(n_samples=50000, n_features=1000)
X = csc_matrix(X)
X.sort_indices()
IsolationForest(n_estimators=10, max_samples=256, n_jobs=1).fit(X)
```
**Sparse Input:**
Before (4.97s)
![image](https://user-images.githubusercontent.com/16646940/164909922-70a89054-a81e-4931-acca-46e4779d8eba.png)


After (0.241s)
![image](https://user-images.githubusercontent.com/16646940/164909946-4c070410-0176-43ed-a94b-cd9e08afb1af.png)


**Dense Input:**
Before (7.99s)
![image](https://user-images.githubusercontent.com/16646940/164909872-3cec6573-efd9-4baf-83a2-d47caaec7e14.png)

After (5.19s)
![image](https://user-images.githubusercontent.com/16646940/164909792-52b711b6-0280-44cc-8566-036ba0043162.png)


#### Any other comments?
`boostrap_features` is set to **False** already for IsolationForest, but users can still set `max_features` freely, which will cause a worse runtime when it's not 1.0. 

Since in IsolationForest, we're randomly picking a single feature to split, shall we deprecate the `max_features` argument and always set it to 1.0 for better runtime ?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
