### PR TITLE
MNT Use list comprehension in place of list keyword

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1778,10 +1778,10 @@ def make_biclusters(
     col_sizes = generator.multinomial(n_cols, np.repeat(1.0 / n_clusters, n_clusters))
 
     row_labels = np.hstack(
-        list(np.repeat(val, rep) for val, rep in zip(range(n_clusters), row_sizes))
+        [np.repeat(val, rep) for val, rep in zip(range(n_clusters), row_sizes)]
     )
     col_labels = np.hstack(
-        list(np.repeat(val, rep) for val, rep in zip(range(n_clusters), col_sizes))
+        [np.repeat(val, rep) for val, rep in zip(range(n_clusters), col_sizes)]
     )
 
     result = np.zeros(shape, dtype=np.float64)
@@ -1881,10 +1881,10 @@ def make_checkerboard(
     )
 
     row_labels = np.hstack(
-        list(np.repeat(val, rep) for val, rep in zip(range(n_row_clusters), row_sizes))
+        [np.repeat(val, rep) for val, rep in zip(range(n_row_clusters), row_sizes)]
     )
     col_labels = np.hstack(
-        list(np.repeat(val, rep) for val, rep in zip(range(n_col_clusters), col_sizes))
+        [np.repeat(val, rep) for val, rep in zip(range(n_col_clusters), col_sizes)]
     )
 
     result = np.zeros(shape, dtype=np.float64)

--- a/sklearn/metrics/cluster/_bicluster.py
+++ b/sklearn/metrics/cluster/_bicluster.py
@@ -37,13 +37,10 @@ def _pairwise_similarity(a, b, similarity):
     n_a = a_rows.shape[0]
     n_b = b_rows.shape[0]
     result = np.array(
-        list(
-            list(
-                similarity(a_rows[i], a_cols[i], b_rows[j], b_cols[j])
-                for j in range(n_b)
-            )
+        [
+            [similarity(a_rows[i], a_cols[i], b_rows[j], b_cols[j]) for j in range(n_b)]
             for i in range(n_a)
-        )
+        ]
     )
     return result
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -483,7 +483,7 @@ def test_multilabel_confusion_matrix_multiclass():
         )
 
     test(y_true, y_pred)
-    test(list(str(y) for y in y_true), list(str(y) for y in y_pred), string_type=True)
+    test([str(y) for y in y_true], [str(y) for y in y_pred], string_type=True)
 
 
 def test_multilabel_confusion_matrix_multilabel():

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1427,10 +1427,10 @@ def test_grid_search_correct_score_results():
         for candidate_i, C in enumerate(Cs):
             clf.set_params(C=C)
             cv_scores = np.array(
-                list(
+                [
                     grid_search.cv_results_["split%d_test_score" % s][candidate_i]
                     for s in range(n_splits)
-                )
+                ]
             )
             for i, (train, test) in enumerate(cv.split(X, y)):
                 clf.fit(X[train], y[train])
@@ -1584,9 +1584,7 @@ def test_grid_search_failing_classifier():
     # that are expected to fail.
     def get_cand_scores(i):
         return np.array(
-            list(
-                gs.cv_results_["split%d_test_score" % s][i] for s in range(gs.n_splits_)
-            )
+            [gs.cv_results_["split%d_test_score" % s][i] for s in range(gs.n_splits_)]
         )
 
     assert all(
@@ -1840,10 +1838,10 @@ def test_grid_search_cv_splits_consistency():
     for score_type in ("train", "test"):
         per_param_scores = {}
         for param_i in range(4):
-            per_param_scores[param_i] = list(
+            per_param_scores[param_i] = [
                 gs.cv_results_["split%d_%s_score" % (s, score_type)][param_i]
                 for s in range(5)
-            )
+            ]
 
         assert_array_almost_equal(per_param_scores[0], per_param_scores[1])
         assert_array_almost_equal(per_param_scores[2], per_param_scores[3])

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1384,7 +1384,7 @@ def test_shufflesplit_reproducible():
     # Check that iterating twice on the ShuffleSplit gives the same
     # sequence of train-test when the random_state is given
     ss = ShuffleSplit(random_state=21)
-    assert_array_equal(list(a for a, b in ss.split(X)), list(a for a, b in ss.split(X)))
+    assert_array_equal([a for a, b in ss.split(X)], [a for a, b in ss.split(X)])
 
 
 def test_stratifiedshufflesplit_list_input():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.
IMHO using list comprehension to create lists makes code more clean. It's also a little bit faster compared to using `list` keyword.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
