### PR TITLE
DOC Specify the meaning of dict_init=None in sklearn.decomposition.dict_learning_online

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -810,7 +810,7 @@ def dict_learning_online(
     dict_init : ndarray of shape (n_components, n_features), default=None
         Initial values for the dictionary for warm restart scenarios.
         If `None`, the initial values for the dictionary are created
-        using :func:`~sklearn.utils.randomized_svd`.
+        with an SVD decomposition of the data via :func:`~sklearn.utils.randomized_svd`.
 
     callback : callable, default=None
         A callable that gets invoked at the end of each iteration.

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -810,10 +810,7 @@ def dict_learning_online(
     dict_init : ndarray of shape (n_components, n_features), default=None
         Initial values for the dictionary for warm restart scenarios.
         If `None`, the initial values for the dictionary are created
-        using :func:`randomized_svd` as::
-
-            _, S, dictionary = randomized_svc(X, n_components, random_state)
-            dictionary = S[:, np.newaxis] * dictionary
+        using :func:`~sklearn.utils.randomized_svd`.
 
     callback : callable, default=None
         A callable that gets invoked at the end of each iteration.

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -808,7 +808,12 @@ def dict_learning_online(
         Whether to also return the code U or just the dictionary `V`.
 
     dict_init : ndarray of shape (n_components, n_features), default=None
-        Initial value for the dictionary for warm restart scenarios.
+        Initial values for the dictionary for warm restart scenarios.
+        If `None`, the initial values for the dictionary are created
+        using :func:`randomized_svd` as::
+
+            _, S, dictionary = randomized_svc(X, n_components, random_state)
+            dictionary = S[:, np.newaxis] * dictionary
 
     callback : callable, default=None
         A callable that gets invoked at the end of each iteration.


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #17295


#### What does this implement/fix? Explain your changes.
I added documentation to the `dict_learning_online` function in `sklearn/decomposition/_dict_learning.py` for the case `dict_init=None`.

#### Any other comments?
In #17295 it is said that `dict_learning_online` also has the attribute `code_init` which also needs further documentation. However, this is a mistake as `dict_learning_online` doesn't have this attribute. 