### PR TITLE
FIX params validation in SelectFromModel with prefit=True

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -94,7 +94,7 @@ random sampling procedures.
 
 - |Fix| :meth:`feature_selection.SelectFromModel.fit` and
   :meth:`feature_selection.SelectFromModel.partial_fit` can now be called with
-  `prefit=True`.
+  `prefit=True`. :pr:`23271` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Changelog
 ---------

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -92,6 +92,10 @@ random sampling procedures.
   the correct variance-scaling coefficient which may result in different model
   behavior.
 
+- |Fix| :meth:`feature_selection.SelectFromModel.fit` and
+  :meth:`feature_selection.SelectFromModel.partial_fit` can now be called with
+  `prefit=True`.
+
 Changelog
 ---------
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -94,6 +94,7 @@ random sampling procedures.
 
 - |Fix| :meth:`feature_selection.SelectFromModel.fit` and
   :meth:`feature_selection.SelectFromModel.partial_fit` can now be called with
+  `prefit=True`. `estimators_` will be a deep copy of `estimator` when
   `prefit=True`. :pr:`23271` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Changelog

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -104,11 +104,12 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
 
     prefit : bool, default=False
         Whether a prefit model is expected to be passed into the constructor
-        directly or not. If True, ``transform`` must be called directly
-        and SelectFromModel cannot be used with ``cross_val_score``,
-        ``GridSearchCV`` and similar utilities that clone the estimator.
-        Otherwise train the model using ``fit`` and then ``transform`` to do
-        feature selection.
+        directly or not.
+        If `True`, `estimator` must be a fitted estimator and will not be
+        be impacted by `fit` and `partial_fit` calls. `estimator_` is then
+        a deep copy of `estimator` to preserve its state.
+        If `False`, `estimator` is cloned and fitted and updated by calling
+        `fit` and `partial_fit`, respectively.
 
     norm_order : non-zero int, inf, -inf, default=1
         Order of the norm used to filter the vectors of coefficients below
@@ -122,10 +123,13 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
           allow.
         - If a callable, then it specifies how to calculate the maximum number of
           features allowed by using the output of `max_feaures(X)`.
+        - If `None, then all features are kept.
 
         To only select based on ``max_features``, set ``threshold=-np.inf``.
 
         .. versionadded:: 0.20
+        .. versionchanged:: 1.1
+           `max_features` accepts a callable.
 
     importance_getter : str or callable, default='auto'
         If 'auto', uses the feature importance either through a ``coef_``
@@ -147,9 +151,12 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
     Attributes
     ----------
     estimator_ : an estimator
-        The base estimator from which the transformer is built.
-        This is stored only when a non-fitted estimator is passed to the
-        ``SelectFromModel``, i.e when prefit is False.
+        The base estimator from which the transformer is built. This attribute
+        exist only when `fit` has been called.
+
+        - If `prefit=True`, it is a deep copy of `estimator`.
+        - If `prefit=False`, it is a clone of `estimator` and fit on the data
+          passed to `fit` or `partial_fit`.
 
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if the
@@ -161,7 +168,7 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
         Maximum number of features calculated during :term:`fit`. Only defined
         if the ``max_features`` is not `None`.
 
-        - If `max_features` is an int, then `max_features_ = max_features`.
+        - If `max_features` is an `int`, then `max_features_ = max_features`.
         - If `max_features` is a callable, then `max_features_ = max_features(X)`.
 
         .. versionadded:: 1.1

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -105,10 +105,8 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
     prefit : bool, default=False
         Whether a prefit model is expected to be passed into the constructor
         directly or not.
-        If `True`, `estimator` must be a fitted estimator and will not be
-        be impacted by `fit` and `partial_fit` calls. `estimator_` is then
-        a deep copy of `estimator` to preserve its state.
-        If `False`, `estimator` is cloned and fitted and updated by calling
+        If `True`, `estimator` must be a fitted estimator.
+        If `False`, `estimator` is fitted and updated by calling
         `fit` and `partial_fit`, respectively.
 
     norm_order : non-zero int, inf, -inf, default=1

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -123,7 +123,7 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
           allow.
         - If a callable, then it specifies how to calculate the maximum number of
           features allowed by using the output of `max_feaures(X)`.
-        - If `None, then all features are kept.
+        - If `None`, then all features are kept.
 
         To only select based on ``max_features``, set ``threshold=-np.inf``.
 
@@ -150,7 +150,7 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
 
     Attributes
     ----------
-    estimator_ : an estimator
+    estimator_ : estimator
         The base estimator from which the transformer is built. This attribute
         exist only when `fit` has been called.
 

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -454,10 +454,9 @@ def test_prefit_max_features():
 
 def test_prefit_get_feature_names_out():
     """Check the interaction between prefit and the feature names."""
-    prefit, max_features = True, 1
     clf = RandomForestClassifier(n_estimators=2, random_state=0)
     clf.fit(data, y)
-    model = SelectFromModel(clf, prefit=prefit, max_features=max_features)
+    model = SelectFromModel(clf, prefit=True, max_features=1)
 
     # FIXME: the error message should be improved. Raising a `NotFittedError`
     # would be better since it would force to validate all class attribute and

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -13,6 +13,7 @@ from sklearn.utils._testing import MinimalClassifier
 from sklearn import datasets
 from sklearn.cross_decomposition import CCA, PLSCanonical, PLSRegression
 from sklearn.datasets import make_friedman1
+from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression, SGDClassifier, Lasso
 from sklearn.svm import LinearSVC
 from sklearn.feature_selection import SelectFromModel
@@ -412,10 +413,62 @@ def test_prefit():
     model.fit(data, y)
     assert_array_almost_equal(model.transform(data), X_transform)
 
-    # Check that prefit=True and calling fit raises a ValueError
+    # Check that passing an unfitted estimator with `prefit=True` raises a
+    # `ValueError`
+    clf = SGDClassifier(alpha=0.1, max_iter=10, shuffle=True, random_state=0, tol=None)
     model = SelectFromModel(clf, prefit=True)
-    with pytest.raises(ValueError):
+    err_msg = "When `prefit=True`, `estimator` is expected to be a fitted estimator."
+    with pytest.raises(NotFittedError, match=err_msg):
         model.fit(data, y)
+    with pytest.raises(NotFittedError, match=err_msg):
+        model.partial_fit(data, y)
+    with pytest.raises(NotFittedError, match=err_msg):
+        model.transform(data)
+
+
+def test_prefit_max_features():
+    """Check the interaction between `prefit` and `max_features`."""
+    # case 1: an error should be raised at `transform` if `fit` was not called to
+    # validate the attributes
+    prefit, max_features = True, lambda X: X.shape[1]
+    estimator = RandomForestClassifier(n_estimators=5, random_state=0)
+    estimator.fit(data, y)
+    model = SelectFromModel(estimator, prefit=prefit, max_features=max_features)
+
+    err_msg = (
+        "When `prefit=True` and `max_features` is a callable, call `fit` "
+        "before calling `transform`."
+    )
+    with pytest.raises(NotFittedError, match=err_msg):
+        model.transform(data)
+
+    # case 2: `max_features` is not validated and different from an integer
+    # FIXME: we cannot validate the upper bound of the attribute at transform
+    # and we should force calling `fit` if we intend to force the attribute
+    # to have such an upper bound.
+    max_features = 2.5
+    model.set_params(max_features=max_features)
+    with pytest.raises(ValueError, match="`max_features` must be an integer"):
+        model.transform(data)
+
+
+def test_prefit_get_feature_names_out():
+    """Check the interaction between prefit and the feature names."""
+    prefit, max_features = True, 1
+    clf = RandomForestClassifier(n_estimators=2, random_state=0)
+    clf.fit(data, y)
+    model = SelectFromModel(clf, prefit=prefit, max_features=max_features)
+
+    # FIXME: the error message should be improved. Raising a `NotFittedError`
+    # would be better since it would force to validate all class attribute and
+    # create all the necessary fitted attribute
+    err_msg = "Unable to generate feature names without n_features_in_"
+    with pytest.raises(ValueError, match=err_msg):
+        model.get_feature_names_out()
+
+    model.fit(data, y)
+    feature_names = model.get_feature_names_out()
+    assert feature_names == ["x3"]
 
 
 def test_threshold_string():

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -430,10 +430,9 @@ def test_prefit_max_features():
     """Check the interaction between `prefit` and `max_features`."""
     # case 1: an error should be raised at `transform` if `fit` was not called to
     # validate the attributes
-    prefit, max_features = True, lambda X: X.shape[1]
     estimator = RandomForestClassifier(n_estimators=5, random_state=0)
     estimator.fit(data, y)
-    model = SelectFromModel(estimator, prefit=prefit, max_features=max_features)
+    model = SelectFromModel(estimator, prefit=True, max_features=lambda X: X.shape[1])
 
     err_msg = (
         "When `prefit=True` and `max_features` is a callable, call `fit` "

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -100,7 +100,7 @@ def test_max_features_error(max_features, err_type, err_msg):
         transformer.fit(data, y)
 
 
-@pytest.mark.parametrize("max_features", [0, 2, data.shape[1]])
+@pytest.mark.parametrize("max_features", [0, 2, data.shape[1], None])
 def test_inferred_max_features_integer(max_features):
     """Check max_features_ and output shape for integer max_features."""
     clf = RandomForestClassifier(n_estimators=5, random_state=0)
@@ -108,8 +108,12 @@ def test_inferred_max_features_integer(max_features):
         estimator=clf, max_features=max_features, threshold=-np.inf
     )
     X_trans = transformer.fit_transform(data, y)
-    assert transformer.max_features_ == max_features
-    assert X_trans.shape[1] == transformer.max_features_
+    if max_features is not None:
+        assert transformer.max_features_ == max_features
+        assert X_trans.shape[1] == transformer.max_features_
+    else:
+        assert not hasattr(transformer, "max_features_")
+        assert X_trans.shape[1] == data.shape[1]
 
 
 @pytest.mark.parametrize(

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -406,6 +406,8 @@ def test_prefit():
     clf.fit(data, y)
     model = SelectFromModel(clf, prefit=True)
     assert_array_almost_equal(model.transform(data), X_transform)
+    model.fit(data, y)
+    assert model.estimator_ is not clf
 
     # Check that the model is rewritten if prefit=False and a fitted model is
     # passed
@@ -424,6 +426,15 @@ def test_prefit():
         model.partial_fit(data, y)
     with pytest.raises(NotFittedError, match=err_msg):
         model.transform(data)
+
+    # Check that the internal parameters of prefitted model are not changed
+    # when calling `fit` or `partial_fit` with `prefit=True`
+    clf = SGDClassifier(alpha=0.1, max_iter=10, shuffle=True, tol=None).fit(data, y)
+    model = SelectFromModel(clf, prefit=True)
+    model.fit(data, y)
+    assert_allclose(model.estimator_.coef_, clf.coef_)
+    model.partial_fit(data, y)
+    assert_allclose(model.estimator_.coef_, clf.coef_)
 
 
 def test_prefit_max_features():


### PR DESCRIPTION
closes #23267 

This PR introduces:

- The possibility to call `fit` to always validate attributes
- Force calling `fit` when `max_features` is callable to ensure it is validated. There are no clean nor straightforward solutions to validate `max_features` at `transform`.

In a future PR, I think that we should deprecate the possibility to call `transform` without calling `fit`. This PR still keep the backward compatibility.