### PR TITLE
DOC Fix return type of weighted_n_node_samples

### DIFF
--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -574,7 +574,7 @@ cdef class Tree:
     n_node_samples : array of int, shape [node_count]
         n_node_samples[i] holds the number of training samples reaching node i.
 
-    weighted_n_node_samples : array of int, shape [node_count]
+    weighted_n_node_samples : array of double, shape [node_count]
         weighted_n_node_samples[i] holds the weighted number of training samples
         reaching node i.
     """


### PR DESCRIPTION
#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.

It just corrects the documentation for weighted_n_node_samples, which I can see at runtime is float64.

#### Any other comments?

-