### PR TITLE
DOC Adds changed model entry for _approximate_mode

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -324,6 +324,10 @@ random sampling procedures.
   :class:`tree.DecisionTreeRegressor` can be impacted by a fix in the handling
   of rounding errors. Previously some extra spurious splits could occur.
 
+- |Fix| :func:`model_selection.train_test_split` with a `stratify` parameter
+  and :class:`model_selection.StratifiedShuffleSplit` may result in slightly
+  different.
+
 Details are listed in the changelog below.
 
 (While we are trying to better inform users by providing this information, we

--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -325,8 +325,8 @@ random sampling procedures.
   of rounding errors. Previously some extra spurious splits could occur.
 
 - |Fix| :func:`model_selection.train_test_split` with a `stratify` parameter
-  and :class:`model_selection.StratifiedShuffleSplit` may result in slightly
-  different.
+  and :class:`model_selection.StratifiedShuffleSplit` may lead to slightly
+  different results.
 
 Details are listed in the changelog below.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/22885


#### What does this implement/fix? Explain your changes.
This PR documents the change in behavior that came from https://github.com/scikit-learn/scikit-learn/pull/20904

#### Any other comments?
We likely need to backport this to 1.0.X.

CC @glemaitre 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
