### PR TITLE
DOC Removes redundant time_ variable in plot_birch example

### DIFF
--- a/examples/cluster/plot_birch_vs_minibatchkmeans.py
+++ b/examples/cluster/plot_birch_vs_minibatchkmeans.py
@@ -62,7 +62,6 @@ final_step = ["without global clustering", "with global clustering"]
 for ind, (birch_model, info) in enumerate(zip(birch_models, final_step)):
     t = time()
     birch_model.fit(X)
-    time_ = time() - t
     print("BIRCH %s as the final step took %0.2f seconds" % (info, (time() - t)))
 
     # Plot result


### PR DESCRIPTION
#### Reference Issues/PRs

Example: Fixes #23160.

#### What does this implement/fix? Explain your changes.

Removes  variable definition `time_`which was unused.