### PR TITLE
DOC add plt.show to be used when executing plot_cyclical_feature_engineering example as script

### DIFF
--- a/examples/applications/plot_cyclical_feature_engineering.py
+++ b/examples/applications/plot_cyclical_feature_engineering.py
@@ -791,7 +791,7 @@ for ax, pred, label in zip(axes, predictions, labels):
     )
     ax.legend()
 
-
+plt.show()
 # %%
 # This visualization confirms the conclusions we draw on the previous plot.
 #


### PR DESCRIPTION
Otherwise plotting results are not shown

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

When running `python examples/applications/plot_cyclical_feature_engineering.py` no plots are displayed at the end. Only text based results are printed out to the terminal. In this PR I just add `plt.show()` at the end of the script.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
