### PR TITLE
MNT Use cimport numpy as cnp in Cython files for NumPy C API for sklearn/utils/_fast_dict.pxd 

### DIFF
--- a/sklearn/utils/_fast_dict.pxd
+++ b/sklearn/utils/_fast_dict.pxd
@@ -8,11 +8,11 @@ integers, and values float.
 from libcpp.map cimport map as cpp_map
 
 # Import the C-level symbols of numpy
-cimport numpy as np
+cimport numpy as cnp
 
-ctypedef np.float64_t DTYPE_t
+ctypedef cnp.float64_t DTYPE_t
 
-ctypedef np.intp_t ITYPE_t
+ctypedef cnp.intp_t ITYPE_t
 
 ###############################################################################
 # An object to be used in Python


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #23295: sklearn/utils/_fast_dict.pxd  

#### What does this implement/fix? Explain your changes.
Change np to cnp to reference NumPy's C API according to issue #23295 for file sklearn/utils/_fast_dict.pxd.  



