### PR TITLE
MNT Use cimport numpy as cnp in _isotonic.pyx

### DIFF
--- a/sklearn/_isotonic.pyx
+++ b/sklearn/_isotonic.pyx
@@ -5,11 +5,11 @@
 # pool at each step.
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 cimport cython
 from cython cimport floating
 
-np.import_array()
+cnp.import_array()
 
 
 def _inplace_contiguous_isotonic_regression(floating[::1] y, floating[::1] w):
@@ -63,9 +63,9 @@ def _inplace_contiguous_isotonic_regression(floating[::1] y, floating[::1] w):
             i = k
 
 
-def _make_unique(np.ndarray[dtype=floating] X,
-                 np.ndarray[dtype=floating] y,
-                 np.ndarray[dtype=floating] sample_weights):
+def _make_unique(cnp.ndarray[dtype=floating] X,
+                 cnp.ndarray[dtype=floating] y,
+                 cnp.ndarray[dtype=floating] sample_weights):
     """Average targets for duplicate X, drop duplicates.
 
     Aggregates duplicate X values into a single X value where
@@ -76,10 +76,10 @@ def _make_unique(np.ndarray[dtype=floating] X,
     """
     unique_values = len(np.unique(X))
 
-    cdef np.ndarray[dtype=floating] y_out = np.empty(unique_values,
+    cdef cnp.ndarray[dtype=floating] y_out = np.empty(unique_values,
                                                      dtype=X.dtype)
-    cdef np.ndarray[dtype=floating] x_out = np.empty_like(y_out)
-    cdef np.ndarray[dtype=floating] weights_out = np.empty_like(y_out)
+    cdef cnp.ndarray[dtype=floating] x_out = np.empty_like(y_out)
+    cdef cnp.ndarray[dtype=floating] weights_out = np.empty_like(y_out)
 
     cdef floating current_x = X[0]
     cdef floating current_y = 0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #23295 (`sklearn/_isotonic.pyx`)

#### What does this implement/fix? Explain your changes.

Change `np` to `cnp` to reference NumPy's C API according to issue #23295 for `sklearn/_isotonic.pyx`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
