### PR TITLE
MNT Use cimport numpy as cnp _loss.pyx.tp and _loss.pxd

### DIFF
--- a/sklearn/_loss/_loss.pxd
+++ b/sklearn/_loss/_loss.pxd
@@ -1,21 +1,21 @@
 # cython: language_level=3
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 
-np.import_array()
+cnp.import_array()
 
 
 # Fused types for y_true, y_pred, raw_prediction
 ctypedef fused Y_DTYPE_C:
-    np.npy_float64
-    np.npy_float32
+    cnp.npy_float64
+    cnp.npy_float32
 
 
 # Fused types for gradient and hessian
 ctypedef fused G_DTYPE_C:
-    np.npy_float64
-    np.npy_float32
+    cnp.npy_float64
+    cnp.npy_float32
 
 
 # Struct to return 2 doubles

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -214,15 +214,11 @@ WARNING: Do not edit `sklearn/_loss/_loss.pyx` file directly, as it is generated
 # TODO: Use const memoryviews with fused types with Cython 3.0 where
 #       appropriate (arguments marked by "# IN").
 
-cimport cython
 from cython.parallel import parallel, prange
 import numpy as np
-cimport numpy as cnp
 
 from libc.math cimport exp, fabs, log, log1p, pow
 from libc.stdlib cimport malloc, free
-
-cnp.import_array()
 
 
 # -------------------------------------

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -217,12 +217,12 @@ WARNING: Do not edit `sklearn/_loss/_loss.pyx` file directly, as it is generated
 cimport cython
 from cython.parallel import parallel, prange
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 
 from libc.math cimport exp, fabs, log, log1p, pow
 from libc.stdlib cimport malloc, free
 
-np.import_array()
+cnp.import_array()
 
 
 # -------------------------------------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #23295 (`sklearn/_loss/_loss.pyx.tp` and `sklearn/_loss/_loss.pxd`)

#### What does this implement/fix? Explain your changes.

Change `np` to `cnp` to reference NumPy's C API according to issue #23295 for `sklearn/_loss/_loss.pyx.tp` and `sklearn/_loss/_loss.pxd`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->