### PR TITLE
MNT Use cimport numpy as cnp in sklearn/linear_model

### DIFF
--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -7,11 +7,10 @@
 # License: BSD 3 clause
 
 from libc.math cimport fabs
-cimport numpy as np
+cimport numpy as cnp
 import numpy as np
 import numpy.linalg as linalg
 
-cimport cython
 from cpython cimport bool
 from cython cimport floating
 import warnings
@@ -24,10 +23,10 @@ from ..utils._cython_blas cimport RowMajor, ColMajor, Trans, NoTrans
 
 from ..utils._random cimport our_rand_r
 
-ctypedef np.float64_t DOUBLE
-ctypedef np.uint32_t UINT32_t
+ctypedef cnp.float64_t DOUBLE
+ctypedef cnp.uint32_t UINT32_t
 
-np.import_array()
+cnp.import_array()
 
 # The following two functions are shamelessly copied from the tree code.
 
@@ -280,9 +279,9 @@ def sparse_enet_coordinate_descent(
     floating [::1] w,
     floating alpha,
     floating beta,
-    np.ndarray[floating, ndim=1, mode='c'] X_data,
-    np.ndarray[int, ndim=1, mode='c'] X_indices,
-    np.ndarray[int, ndim=1, mode='c'] X_indptr,
+    cnp.ndarray[floating, ndim=1, mode='c'] X_data,
+    cnp.ndarray[int, ndim=1, mode='c'] X_indices,
+    cnp.ndarray[int, ndim=1, mode='c'] X_indptr,
     floating[::1] y,
     floating[::1] sample_weight,
     floating[::1] X_mean,
@@ -570,9 +569,9 @@ def enet_coordinate_descent_gram(
     floating[::1] w,
     floating alpha,
     floating beta,
-    np.ndarray[floating, ndim=2, mode='c'] Q,
-    np.ndarray[floating, ndim=1, mode='c'] q,
-    np.ndarray[floating, ndim=1] y,
+    cnp.ndarray[floating, ndim=2, mode='c'] Q,
+    cnp.ndarray[floating, ndim=1, mode='c'] q,
+    cnp.ndarray[floating, ndim=1] y,
     int max_iter,
     floating tol,
     object rng,
@@ -742,8 +741,8 @@ def enet_coordinate_descent_multi_task(
     floating l1_reg,
     floating l2_reg,
     # TODO: use const qualified fused-typed memoryview when Cython 3.0 is used.
-    np.ndarray[floating, ndim=2, mode='fortran'] X,
-    np.ndarray[floating, ndim=2, mode='fortran'] Y,
+    cnp.ndarray[floating, ndim=2, mode='fortran'] X,
+    cnp.ndarray[floating, ndim=2, mode='fortran'] Y,
     int max_iter,
     floating tol,
     object rng,

--- a/sklearn/linear_model/_sag_fast.pyx.tp
+++ b/sklearn/linear_model/_sag_fast.pyx.tp
@@ -38,7 +38,7 @@ SAG and SAGA implementation
 WARNING: Do not edit .pyx file directly, it is generated from .pyx.tp
 """
 
-cimport numpy as np
+cimport numpy as cnp
 import numpy as np
 from libc.math cimport fabs, exp, log
 from libc.time cimport time, time_t
@@ -50,7 +50,7 @@ from ..utils._seq_dataset cimport SequentialDataset32, SequentialDataset64
 
 from libc.stdio cimport printf
 
-np.import_array()
+cnp.import_array()
 
 
 {{for name_suffix, c_type, np_type in dtypes}}
@@ -212,8 +212,8 @@ cdef inline {{c_type}} _soft_thresholding{{name_suffix}}({{c_type}} x, {{c_type}
 {{for name_suffix, c_type, np_type in dtypes}}
 
 def sag{{name_suffix}}(SequentialDataset{{name_suffix}} dataset,
-        np.ndarray[{{c_type}}, ndim=2, mode='c'] weights_array,
-        np.ndarray[{{c_type}}, ndim=1, mode='c'] intercept_array,
+        cnp.ndarray[{{c_type}}, ndim=2, mode='c'] weights_array,
+        cnp.ndarray[{{c_type}}, ndim=1, mode='c'] intercept_array,
         int n_samples,
         int n_features,
         int n_classes,
@@ -223,12 +223,12 @@ def sag{{name_suffix}}(SequentialDataset{{name_suffix}} dataset,
         double step_size,
         double alpha,
         double beta,
-        np.ndarray[{{c_type}}, ndim=2, mode='c'] sum_gradient_init,
-        np.ndarray[{{c_type}}, ndim=2, mode='c'] gradient_memory_init,
-        np.ndarray[bint, ndim=1, mode='c'] seen_init,
+        cnp.ndarray[{{c_type}}, ndim=2, mode='c'] sum_gradient_init,
+        cnp.ndarray[{{c_type}}, ndim=2, mode='c'] gradient_memory_init,
+        cnp.ndarray[bint, ndim=1, mode='c'] seen_init,
         int num_seen,
         bint fit_intercept,
-        np.ndarray[{{c_type}}, ndim=1, mode='c'] intercept_sum_gradient_init,
+        cnp.ndarray[{{c_type}}, ndim=1, mode='c'] intercept_sum_gradient_init,
         double intercept_decay,
         bint saga,
         bint verbose):
@@ -302,25 +302,25 @@ def sag{{name_suffix}}(SequentialDataset{{name_suffix}} dataset,
     cdef {{c_type}}* gradient_memory = <{{c_type}}*> gradient_memory_init.data
 
     # the cumulative sums needed for JIT params
-    cdef np.ndarray[{{c_type}}, ndim=1] cumulative_sums_array = \
+    cdef cnp.ndarray[{{c_type}}, ndim=1] cumulative_sums_array = \
         np.empty(n_samples, dtype={{np_type}}, order="c")
     cdef {{c_type}}* cumulative_sums = <{{c_type}}*> cumulative_sums_array.data
 
     # the index for the last time this feature was updated
-    cdef np.ndarray[int, ndim=1] feature_hist_array = \
+    cdef cnp.ndarray[int, ndim=1] feature_hist_array = \
         np.zeros(n_features, dtype=np.int32, order="c")
     cdef int* feature_hist = <int*> feature_hist_array.data
 
     # the previous weights to use to compute stopping criteria
-    cdef np.ndarray[{{c_type}}, ndim=2] previous_weights_array = \
+    cdef cnp.ndarray[{{c_type}}, ndim=2] previous_weights_array = \
         np.zeros((n_features, n_classes), dtype={{np_type}}, order="c")
     cdef {{c_type}}* previous_weights = <{{c_type}}*> previous_weights_array.data
 
-    cdef np.ndarray[{{c_type}}, ndim=1] prediction_array = \
+    cdef cnp.ndarray[{{c_type}}, ndim=1] prediction_array = \
         np.zeros(n_classes, dtype={{np_type}}, order="c")
     cdef {{c_type}}* prediction = <{{c_type}}*> prediction_array.data
 
-    cdef np.ndarray[{{c_type}}, ndim=1] gradient_array = \
+    cdef cnp.ndarray[{{c_type}}, ndim=1] gradient_array = \
         np.zeros(n_classes, dtype={{np_type}}, order="c")
     cdef {{c_type}}* gradient = <{{c_type}}*> gradient_array.data
 
@@ -340,7 +340,7 @@ def sag{{name_suffix}}(SequentialDataset{{name_suffix}} dataset,
     cumulative_sums[0] = 0.0
 
     # the multipliative scale needed for JIT params
-    cdef np.ndarray[{{c_type}}, ndim=1] cumulative_sums_prox_array
+    cdef cnp.ndarray[{{c_type}}, ndim=1] cumulative_sums_prox_array
     cdef {{c_type}}* cumulative_sums_prox
 
     cdef bint prox = beta > 0 and saga
@@ -727,8 +727,8 @@ cdef void predict_sample{{name_suffix}}({{c_type}}* x_data_ptr, int* x_ind_ptr, 
 
 def _multinomial_grad_loss_all_samples(
         SequentialDataset64 dataset,
-        np.ndarray[double, ndim=2, mode='c'] weights_array,
-        np.ndarray[double, ndim=1, mode='c'] intercept_array,
+        cndarray[double, ndim=2, mode='c'] weights_array,
+        cnp.ndarray[double, ndim=1, mode='c'] intercept_array,
         int n_samples, int n_features, int n_classes):
     """Compute multinomial gradient and loss across all samples.
 
@@ -750,15 +750,15 @@ def _multinomial_grad_loss_all_samples(
 
     cdef MultinomialLogLoss64 multiloss = MultinomialLogLoss64()
 
-    cdef np.ndarray[double, ndim=2] sum_gradient_array = \
+    cdef cnp.ndarray[double, ndim=2] sum_gradient_array = \
         np.zeros((n_features, n_classes), dtype=np.double, order="c")
     cdef double* sum_gradient = <double*> sum_gradient_array.data
 
-    cdef np.ndarray[double, ndim=1] prediction_array = \
+    cdef cnp.ndarray[double, ndim=1] prediction_array = \
         np.zeros(n_classes, dtype=np.double, order="c")
     cdef double* prediction = <double*> prediction_array.data
 
-    cdef np.ndarray[double, ndim=1] gradient_array = \
+    cdef cnp.ndarray[double, ndim=1] gradient_array = \
         np.zeros(n_classes, dtype=np.double, order="c")
     cdef double* gradient = <double*> gradient_array.data
 

--- a/sklearn/linear_model/_sag_fast.pyx.tp
+++ b/sklearn/linear_model/_sag_fast.pyx.tp
@@ -727,7 +727,7 @@ cdef void predict_sample{{name_suffix}}({{c_type}}* x_data_ptr, int* x_ind_ptr, 
 
 def _multinomial_grad_loss_all_samples(
         SequentialDataset64 dataset,
-        cndarray[double, ndim=2, mode='c'] weights_array,
+        cnp.ndarray[double, ndim=2, mode='c'] weights_array,
         cnp.ndarray[double, ndim=1, mode='c'] intercept_array,
         int n_samples, int n_features, int n_classes):
     """Compute multinomial gradient and loss across all samples.

--- a/sklearn/linear_model/_sgd_fast.pyx
+++ b/sklearn/linear_model/_sgd_fast.pyx
@@ -10,9 +10,8 @@ import numpy as np
 import sys
 from time import time
 
-cimport cython
 from libc.math cimport exp, log, sqrt, pow, fabs
-cimport numpy as np
+cimport numpy as cnp
 from numpy.math cimport INFINITY
 cdef extern from "_sgd_fast_helpers.h":
     bint skl_isfinite(double) nogil
@@ -20,7 +19,7 @@ cdef extern from "_sgd_fast_helpers.h":
 from ..utils._weight_vector cimport WeightVector64 as WeightVector
 from ..utils._seq_dataset cimport SequentialDataset64 as SequentialDataset
 
-np.import_array()
+cnp.import_array()
 
 # Penalty constants
 DEF NO_PENALTY = 0
@@ -362,20 +361,20 @@ cdef class SquaredEpsilonInsensitive(Regression):
         return SquaredEpsilonInsensitive, (self.epsilon,)
 
 
-def _plain_sgd(np.ndarray[double, ndim=1, mode='c'] weights,
+def _plain_sgd(cnp.ndarray[double, ndim=1, mode='c'] weights,
                double intercept,
-               np.ndarray[double, ndim=1, mode='c'] average_weights,
+               cnp.ndarray[double, ndim=1, mode='c'] average_weights,
                double average_intercept,
                LossFunction loss,
                int penalty_type,
                double alpha, double C,
                double l1_ratio,
                SequentialDataset dataset,
-               np.ndarray[unsigned char, ndim=1, mode='c'] validation_mask,
+               cnp.ndarray[unsigned char, ndim=1, mode='c'] validation_mask,
                bint early_stopping, validation_score_cb,
                int n_iter_no_change,
                int max_iter, double tol, int fit_intercept,
-               int verbose, bint shuffle, np.uint32_t seed,
+               int verbose, bint shuffle, cnp.uint32_t seed,
                double weight_pos, double weight_neg,
                int learning_rate, double eta0,
                double power_t,
@@ -435,7 +434,7 @@ def _plain_sgd(np.ndarray[double, ndim=1, mode='c'] weights,
         The weight of the positive class.
     weight_neg : float
         The weight of the negative class.
-    seed : np.uint32_t
+    seed : cnp.uint32_t
         Seed of the pseudorandom number generator used to shuffle the data.
     learning_rate : int
         The learning rate:
@@ -515,7 +514,7 @@ def _plain_sgd(np.ndarray[double, ndim=1, mode='c'] weights,
     cdef unsigned char [:] validation_mask_view = validation_mask
 
     # q vector is only used for L1 regularization
-    cdef np.ndarray[double, ndim = 1, mode = "c"] q = None
+    cdef cnp.ndarray[double, ndim = 1, mode = "c"] q = None
     cdef double * q_data_ptr = NULL
     if penalty_type == L1 or penalty_type == ELASTICNET:
         q = np.zeros((n_features,), dtype=np.float64, order="c")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #23295 (`sklearn/linear_model`)

#### What does this implement/fix? Explain your changes.

Change `np` to `cnp` to reference NumPy's C API according to issue #23295 for `sklearn/linear_model/*`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->