### PR TITLE
MNT Use cimport numpy as cnp for sklearn/metrics

### DIFF
--- a/sklearn/metrics/_dist_metrics.pxd
+++ b/sklearn/metrics/_dist_metrics.pxd
@@ -1,4 +1,4 @@
-cimport numpy as np
+cimport numpy as cnp
 from libc.math cimport sqrt, exp
 
 from ..utils._typedefs cimport DTYPE_t, ITYPE_t
@@ -11,7 +11,7 @@ from ..utils._typedefs cimport DTYPE_t, ITYPE_t
 cdef inline DTYPE_t euclidean_dist(const DTYPE_t* x1, const DTYPE_t* x2,
                                    ITYPE_t size) nogil except -1:
     cdef DTYPE_t tmp, d=0
-    cdef np.intp_t j
+    cdef cnp.intp_t j
     for j in range(size):
         tmp = x1[j] - x2[j]
         d += tmp * tmp
@@ -21,7 +21,7 @@ cdef inline DTYPE_t euclidean_dist(const DTYPE_t* x1, const DTYPE_t* x2,
 cdef inline DTYPE_t euclidean_rdist(const DTYPE_t* x1, const DTYPE_t* x2,
                                     ITYPE_t size) nogil except -1:
     cdef DTYPE_t tmp, d=0
-    cdef np.intp_t j
+    cdef cnp.intp_t j
     for j in range(size):
         tmp = x1[j] - x2[j]
         d += tmp * tmp

--- a/sklearn/metrics/_dist_metrics.pyx
+++ b/sklearn/metrics/_dist_metrics.pyx
@@ -3,19 +3,19 @@
 # License: BSD
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from cython cimport final
 
-np.import_array()  # required in order to use C-API
+cnp.import_array()  # required in order to use C-API
 
 
 # First, define a function to get an ndarray from a memory buffer
 cdef extern from "arrayobject.h":
-    object PyArray_SimpleNewFromData(int nd, np.npy_intp* dims,
+    object PyArray_SimpleNewFromData(int nd, cnp.npy_intp* dims,
                                      int typenum, void* data)
 
 
-cdef inline np.ndarray _buffer_to_ndarray(const DTYPE_t* x, np.npy_intp n):
+cdef inline cnp.ndarray _buffer_to_ndarray(const DTYPE_t* x, cnp.npy_intp n):
     # Wrap a memory buffer with an ndarray. Warning: this is not robust.
     # In particular, if x is deallocated before the returned array goes
     # out of scope, this could cause memory errors.  Since there is not
@@ -407,9 +407,9 @@ cdef class DistanceMetric:
             The shape (Nx, Ny) array of pairwise distances between points in
             X and Y.
         """
-        cdef np.ndarray[DTYPE_t, ndim=2, mode='c'] Xarr
-        cdef np.ndarray[DTYPE_t, ndim=2, mode='c'] Yarr
-        cdef np.ndarray[DTYPE_t, ndim=2, mode='c'] Darr
+        cdef cnp.ndarray[DTYPE_t, ndim=2, mode='c'] Xarr
+        cdef cnp.ndarray[DTYPE_t, ndim=2, mode='c'] Yarr
+        cdef cnp.ndarray[DTYPE_t, ndim=2, mode='c'] Darr
 
         Xarr = np.asarray(X, dtype=DTYPE, order='C')
         self._validate_data(Xarr)
@@ -480,7 +480,7 @@ cdef class SEuclideanDistance(DistanceMetric):
     cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         cdef DTYPE_t tmp, d=0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             tmp = x1[j] - x2[j]
             d += tmp * tmp / self.vec[j]
@@ -518,7 +518,7 @@ cdef class ManhattanDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef DTYPE_t d = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             d += fabs(x1[j] - x2[j])
         return d
@@ -551,7 +551,7 @@ cdef class ChebyshevDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef DTYPE_t d = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             d = fmax(d, fabs(x1[j] - x2[j]))
         return d
@@ -613,7 +613,7 @@ cdef class MinkowskiDistance(DistanceMetric):
     cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         cdef DTYPE_t d=0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         cdef bint has_w = self.size > 0
         if has_w:
             for j in range(size):
@@ -687,7 +687,7 @@ cdef class WMinkowskiDistance(DistanceMetric):
     cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         cdef DTYPE_t d=0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             d += pow(self.vec[j] * fabs(x1[j] - x2[j]), self.p)
         return d
@@ -750,7 +750,7 @@ cdef class MahalanobisDistance(DistanceMetric):
     cdef inline DTYPE_t rdist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) nogil except -1:
         cdef DTYPE_t tmp, d = 0
-        cdef np.intp_t i, j
+        cdef cnp.intp_t i, j
 
         # compute (x1 - x2).T * VI * (x1 - x2)
         for i in range(size):
@@ -795,7 +795,7 @@ cdef class HammingDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int n_unequal = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             if x1[j] != x2[j]:
                 n_unequal += 1
@@ -817,7 +817,7 @@ cdef class CanberraDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef DTYPE_t denom, d = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             denom = fabs(x1[j]) + fabs(x2[j])
             if denom > 0:
@@ -840,7 +840,7 @@ cdef class BrayCurtisDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef DTYPE_t num = 0, denom = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             num += fabs(x1[j] - x2[j])
             denom += fabs(x1[j]) + fabs(x2[j])
@@ -866,7 +866,7 @@ cdef class JaccardDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_eq = 0, nnz = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             tf1 = x1[j] != 0
             tf2 = x2[j] != 0
@@ -896,7 +896,7 @@ cdef class MatchingDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_neq = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             tf1 = x1[j] != 0
             tf2 = x2[j] != 0
@@ -920,7 +920,7 @@ cdef class DiceDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_neq = 0, ntt = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             tf1 = x1[j] != 0
             tf2 = x2[j] != 0
@@ -945,7 +945,7 @@ cdef class KulsinskiDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, ntt = 0, n_neq = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             tf1 = x1[j] != 0
             tf2 = x2[j] != 0
@@ -970,7 +970,7 @@ cdef class RogersTanimotoDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_neq = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             tf1 = x1[j] != 0
             tf2 = x2[j] != 0
@@ -994,7 +994,7 @@ cdef class RussellRaoDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, ntt = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             tf1 = x1[j] != 0
             tf2 = x2[j] != 0
@@ -1018,7 +1018,7 @@ cdef class SokalMichenerDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, n_neq = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             tf1 = x1[j] != 0
             tf2 = x2[j] != 0
@@ -1042,7 +1042,7 @@ cdef class SokalSneathDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                              ITYPE_t size) nogil except -1:
         cdef int tf1, tf2, ntt = 0, n_neq = 0
-        cdef np.intp_t j
+        cdef cnp.intp_t j
         for j in range(size):
             tf1 = x1[j] != 0
             tf2 = x2[j] != 0
@@ -1107,7 +1107,7 @@ cdef class HaversineDistance(DistanceMetric):
 #    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
 #                             ITYPE_t size):
 #        cdef int tf1, tf2, ntf = 0, nft = 0, ntt = 0, nff = 0
-#        cdef np.intp_t j
+#        cdef cintp_t j
 #        for j in range(size):
 #            tf1 = x1[j] != 0
 #            tf2 = x2[j] != 0
@@ -1127,7 +1127,7 @@ cdef class HaversineDistance(DistanceMetric):
 #    cdef inline DTYPE_t dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
 #                             ITYPE_t size):
 #        cdef DTYPE_t d = 0, norm1 = 0, norm2 = 0
-#        cdef np.intp_t j
+#        cdef cnp.intp_t j
 #        for j in range(size):
 #            d += x1[j] * x2[j]
 #            norm1 += x1[j] * x1[j]
@@ -1146,7 +1146,7 @@ cdef class HaversineDistance(DistanceMetric):
 #        cdef DTYPE_t mu1 = 0, mu2 = 0, x1nrm = 0, x2nrm = 0, x1Tx2 = 0
 #        cdef DTYPE_t tmp1, tmp2
 #
-#        cdef np.intp_t i
+#        cdef cnp.intp_t i
 #        for i in range(size):
 #            mu1 += x1[i]
 #            mu2 += x2[i]
@@ -1191,8 +1191,8 @@ cdef class PyFuncDistance(DistanceMetric):
 
     cdef inline DTYPE_t _dist(self, const DTYPE_t* x1, const DTYPE_t* x2,
                               ITYPE_t size) except -1 with gil:
-        cdef np.ndarray x1arr
-        cdef np.ndarray x2arr
+        cdef cnp.ndarray x1arr
+        cdef cnp.ndarray x2arr
         x1arr = _buffer_to_ndarray(x1, size)
         x2arr = _buffer_to_ndarray(x2, size)
         d = self.func(x1arr, x2arr, **self.kwargs)

--- a/sklearn/metrics/_pairwise_distances_reduction.pyx
+++ b/sklearn/metrics/_pairwise_distances_reduction.pyx
@@ -13,7 +13,7 @@
 # Furthermore, the chunking strategy is also used to leverage OpenMP-based parallelism
 # (using Cython prange loops) which gives another multiplicative speed-up in
 # favorable cases on many-core machines.
-cimport numpy as np
+cimport numpy as cnp
 import numpy as np
 import warnings
 
@@ -54,7 +54,7 @@ from ..utils._openmp_helpers import _openmp_effective_n_threads
 from ..utils._typedefs import ITYPE, DTYPE
 
 
-np.import_array()
+cnp.import_array()
 
 # TODO: change for `libcpp.algorithm.move` once Cython 3 is used
 # Introduction in Cython:
@@ -76,14 +76,14 @@ ctypedef fused vector_vector_DITYPE_t:
     vector[vector[DTYPE_t]]
 
 
-cdef np.ndarray[object, ndim=1] coerce_vectors_to_nd_arrays(
+cdef cnp.ndarray[object, ndim=1] coerce_vectors_to_nd_arrays(
     shared_ptr[vector_vector_DITYPE_t] vecs
 ):
     """Coerce a std::vector of std::vector to a ndarray of ndarray."""
     cdef:
         ITYPE_t n = deref(vecs).size()
-        np.ndarray[object, ndim=1] nd_arrays_of_nd_arrays = np.empty(n,
-                                                                     dtype=np.ndarray)
+        cnp.ndarray[object, ndim=1] nd_arrays_of_nd_arrays = np.empty(n,
+                                                                      dtype=np.ndarray)
 
     for i in range(n):
         nd_arrays_of_nd_arrays[i] = vector_to_nd_array(&(deref(vecs)[i]))

--- a/sklearn/metrics/_pairwise_fast.pyx
+++ b/sklearn/metrics/_pairwise_fast.pyx
@@ -4,24 +4,23 @@
 #
 # License: BSD 3 clause
 
-import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from cython cimport floating
 from cython.parallel cimport prange
 from libc.math cimport fabs
 
 from ..utils._openmp_helpers import _openmp_effective_n_threads
 
-np.import_array()
+cnp.import_array()
 
 
 def _chi2_kernel_fast(floating[:, :] X,
                       floating[:, :] Y,
                       floating[:, :] result):
-    cdef np.npy_intp i, j, k
-    cdef np.npy_intp n_samples_X = X.shape[0]
-    cdef np.npy_intp n_samples_Y = Y.shape[0]
-    cdef np.npy_intp n_features = X.shape[1]
+    cdef cnp.npy_intp i, j, k
+    cdef cnp.npy_intp n_samples_X = X.shape[0]
+    cdef cnp.npy_intp n_samples_Y = Y.shape[0]
+    cdef cnp.npy_intp n_features = X.shape[1]
     cdef double res, nom, denom
 
     with nogil:
@@ -47,7 +46,7 @@ def _sparse_manhattan(floating[::1] X_data, int[:] X_indices, int[:] X_indptr,
     ...                   Y.data, Y.indices, Y.indptr,
     ...                   D)
     """
-    cdef np.npy_intp px, py, i, j, ix, iy
+    cdef cnp.npy_intp px, py, i, j, ix, iy
     cdef double d = 0.0
 
     cdef int m = D.shape[0]

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -5,21 +5,21 @@
 from libc.math cimport exp, lgamma
 from scipy.special import gammaln
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 cimport cython
 
-np.import_array()
-ctypedef np.float64_t DOUBLE
+cnp.import_array()
+ctypedef cnp.float64_t DOUBLE
 
 
 def expected_mutual_information(contingency, int n_samples):
     """Calculate the expected mutual information for two labelings."""
     cdef int R, C
     cdef DOUBLE N, gln_N, emi, term2, term3, gln
-    cdef np.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_Nnij
-    cdef np.ndarray[DOUBLE] nijs, term1
-    cdef np.ndarray[DOUBLE] log_a, log_b
-    cdef np.ndarray[np.int32_t] a, b
+    cdef cnp.ndarray[DOUBLE] gln_a, gln_b, gln_Na, gln_Nb, gln_nij, log_Nnij
+    cdef cnp.ndarray[DOUBLE] nijs, term1
+    cdef cnp.ndarray[DOUBLE] log_a, log_b
+    cdef cnp.ndarray[cnp.int32_t] a, b
     #cdef np.ndarray[int, ndim=2] start, end
     R, C = contingency.shape
     N = <DOUBLE>n_samples


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #23295 (`sklearn/linear_metrics`)

#### What does this implement/fix? Explain your changes.

Change `np` to `cnp` to reference NumPy's C API according to issue #23295 for `sklearn/metrics/*`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->