### PR TITLE
DOC Fix various sphinx warnings.

### DIFF
--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -918,7 +918,7 @@ Changelog
 
 - |Fix| :class:`model_selection.GridSearchCV` and
   `model_selection.RandomizedSearchCV` now supports the
-  :term:`_pairwise` property, which prevents an error during cross-validation
+  `_pairwise` property, which prevents an error during cross-validation
   for estimators with pairwise inputs (such as
   :class:`neighbors.KNeighborsClassifier` when :term:`metric` is set to
   'precomputed').

--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -35,13 +35,14 @@ helper functions for loading the data and visualizing results.
 .. [1]  A. Noll, R. Salzmann and M.V. Wuthrich, Case Study: French Motor
     Third-Party Liability Claims (November 8, 2018). `doi:10.2139/ssrn.3164764
     <http://dx.doi.org/10.2139/ssrn.3164764>`_
-
 """
-# %%
+
 # Authors: Christian Lorentzen <lorentzen.ch@gmail.com>
 #          Roman Yurchak <rth.yurchak@gmail.com>
 #          Olivier Grisel <olivier.grisel@ensta.org>
 # License: BSD 3 clause
+
+# %%
 
 from functools import partial
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This pull request fixes two sphinx warnings in the documentation build.
```
scikit-learn/doc/auto_examples/linear_model/plot_tweedie_regression_insurance_claims.rst:63: WARNING: Definition list ends without a blank line; unexpected unindent.
```
and
```
scikit-learn/doc/whats_new/v0.22.rst:919: WARNING: term not in glossary: _pairwise
```