### PR TITLE
Use docker image for nogil CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
         # Here we make sure, that they are still run on a regular basis.
         SKLEARN_SKIP_NETWORK_TESTS: '0'
 
-- template: build_tools/azure/posix.yml
+- template: build_tools/azure/posix-docker.yml
   # Experimental CPython branch without the Global Interpreter Lock:
   # https://github.com/colesbury/nogil/
   #
@@ -103,6 +103,7 @@ jobs:
     matrix:
       pylatest_pip_nogil:
         DISTRIB: 'pip-nogil'
+        DOCKER_CONTAINER: 'nogil/python'
         COVERAGE: 'false'
 
 # Check compilation with intel C++ compiler (ICC)

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -59,9 +59,8 @@ pre_python_environment_install() {
         apt-get -yq install build-essential
 
     elif [[ "$DISTRIB" == "pip-nogil" ]]; then
-        echo "deb-src http://archive.ubuntu.com/ubuntu/ focal main" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -yq update
-        sudo apt-get install -yq ccache
+        apt-get -yq update
+        apt-get install -yq ccache
 
     elif [[ "$BUILD_WITH_ICC" == "true" ]]; then
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -58,6 +58,11 @@ pre_python_environment_install() {
         apt-get -yq update
         apt-get -yq install build-essential
 
+    elif [[ "$DISTRIB" == "pip-nogil" ]]; then
+        echo "deb-src http://archive.ubuntu.com/ubuntu/ focal main" | sudo tee -a /etc/apt/sources.list
+        sudo apt-get -yq update
+        sudo apt-get install -yq ccache
+
     elif [[ "$BUILD_WITH_ICC" == "true" ]]; then
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -58,12 +58,6 @@ pre_python_environment_install() {
         apt-get -yq update
         apt-get -yq install build-essential
 
-    elif [[ "$DISTRIB" == "pip-nogil" ]]; then
-        echo "deb-src http://archive.ubuntu.com/ubuntu/ focal main" | sudo tee -a /etc/apt/sources.list
-        sudo apt-get -yq update
-        sudo apt-get install -yq ccache
-        sudo apt-get build-dep -yq python3 python3-dev
-
     elif [[ "$BUILD_WITH_ICC" == "true" ]]; then
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
@@ -139,17 +133,6 @@ python_environment_install() {
         pip install https://github.com/python-pillow/Pillow/archive/main.zip
 
     elif [[ "$DISTRIB" == "pip-nogil" ]]; then
-        setup_ccache  # speed-up the build of CPython it-self
-        ORIGINAL_FOLDER=`pwd`
-        cd ..
-        git clone --depth 1 https://github.com/colesbury/nogil
-        cd nogil
-        ./configure && make -j 2
-        ./python -m venv $ORIGINAL_FOLDER/$VIRTUALENV
-        cd $ORIGINAL_FOLDER
-        source $VIRTUALENV/bin/activate
-
-        python -m pip install -U pip
         # The pip version that comes with the nogil branch of CPython
         # automatically uses the custom nogil index as its highest priority
         # index to fetch patched versions of libraries with native code that

--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -27,7 +27,7 @@ jobs:
     PYAMG_VERSION: 'latest'
     PILLOW_VERSION: 'latest'
     MATPLOTLIB_VERSION: 'latest'
-    PYTEST_VERSION: 'latest'
+    PYTEST_VERSION: '6.2.5'
     PYTEST_XDIST_VERSION: 'latest'
     THREADPOOLCTL_VERSION: 'latest'
     COVERAGE: 'false'


### PR DESCRIPTION
Use the `nogil/python` docker image to avoid having to build Python nogil inside the CI. This should make the script a bit simpler.

Also it would make #22448 a bit easier to integrate Python nogil