### PR TITLE
Release 1.1.0 final

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -92,26 +92,26 @@ Changelog
   for dense float64 datasets have been refactored. The following functions
   and estimators now benefit from improved performances in terms of hardware
   scalability and speed-ups:
-  - :func:`sklearn.metrics.pairwise_distances_argmin`
-  - :func:`sklearn.metrics.pairwise_distances_argmin_min`
-  - :class:`sklearn.cluster.AffinityPropagation`
-  - :class:`sklearn.cluster.Birch`
-  - :class:`sklearn.cluster.MeanShift`
-  - :class:`sklearn.cluster.OPTICS`
-  - :class:`sklearn.cluster.SpectralClustering`
-  - :func:`sklearn.feature_selection.mutual_info_regression`
-  - :class:`sklearn.neighbors.KNeighborsClassifier`
-  - :class:`sklearn.neighbors.KNeighborsRegressor`
-  - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
-  - :class:`sklearn.neighbors.RadiusNeighborsRegressor`
-  - :class:`sklearn.neighbors.LocalOutlierFactor`
-  - :class:`sklearn.neighbors.NearestNeighbors`
-  - :class:`sklearn.manifold.Isomap`
-  - :class:`sklearn.manifold.LocallyLinearEmbedding`
-  - :class:`sklearn.manifold.TSNE`
-  - :func:`sklearn.manifold.trustworthiness`
-  - :class:`sklearn.semi_supervised.LabelPropagation`
-  - :class:`sklearn.semi_supervised.LabelSpreading`
+    - :func:`sklearn.metrics.pairwise_distances_argmin`
+    - :func:`sklearn.metrics.pairwise_distances_argmin_min`
+    - :class:`sklearn.cluster.AffinityPropagation`
+    - :class:`sklearn.cluster.Birch`
+    - :class:`sklearn.cluster.MeanShift`
+    - :class:`sklearn.cluster.OPTICS`
+    - :class:`sklearn.cluster.SpectralClustering`
+    - :func:`sklearn.feature_selection.mutual_info_regression`
+    - :class:`sklearn.neighbors.KNeighborsClassifier`
+    - :class:`sklearn.neighbors.KNeighborsRegressor`
+    - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
+    - :class:`sklearn.neighbors.RadiusNeighborsRegressor`
+    - :class:`sklearn.neighbors.LocalOutlierFactor`
+    - :class:`sklearn.neighbors.NearestNeighbors`
+    - :class:`sklearn.manifold.Isomap`
+    - :class:`sklearn.manifold.LocallyLinearEmbedding`
+    - :class:`sklearn.manifold.TSNE`
+    - :func:`sklearn.manifold.trustworthiness`
+    - :class:`sklearn.semi_supervised.LabelPropagation`
+    - :class:`sklearn.semi_supervised.LabelSpreading`
 
   For instance :class:`sklearn.neighbors.NearestNeighbors.kneighbors` and
   :class:`sklearn.neighbors.NearestNeighbors.radius_neighbors`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -763,6 +763,10 @@ Changelog
   of sample weights when the input is sparse.
   :pr:`22899` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |Fix| :class:`linear_model.SGDRegressor` and :class:`linear_model.SGDClassifier` now
+  computes the validation error correctly when early stopping is enabled.
+  :pr:`23256` by :user:`Zhehao Liu <MaxwellLZH>`.
+
 - |API| :class:`linear_model.LassoLarsIC` now exposes `noise_variance` as
   a parameter in order to provide an estimate of the noise variance.
   This is particularly relevant when `n_features > n_samples` and the

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -1128,58 +1128,58 @@ Code and Documentation Contributors
 Thanks to everyone who has contributed to the maintenance and improvement of
 the project since version 1.0, including:
 
-2357juan, Abhishek Gupta, adamgonzo, Adam Li, adijohar, Aditya Kumawat, Aditya 
-Raghuwanshi, Aditya Singh, Adrian Trujillo Duron, Adrin Jalali, ahmadjubair33, 
-AJ Druck, aj-white, Alan Peixinho, Alberto Mario Ceballos-Arroyo, Alek 
-Lefebvre, Alex, Alexandre Gramfort, alexanmv, almeidayoel, Amanda Dsouza, Aman 
-Sharma, Amar pratap singh, Amit, amrcode, András Simon, Andreas Mueller, 
-Andrew Knyazev, Andriy, Angus L'Herrou, Ankit Sharma, Anne Ducout, Arisa, Arth, 
-arthurmello, Arturo Amor, ArturoAmor, Atharva Patil, aufarkari, Aurélien 
-Geron, avm19, Ayan Bag, baam, Behrouz B, Ben3940, Benjamin Bossan, Bharat 
-Raghunathan, Bijil Subhash, bmreiniger, Brandon Truth, Brenden Kadota, Brian 
-Sun, cdrig, Chalmer Lowe, Chiara Marmo, Chitteti Srinath Reddy, Chloe-Agathe 
-Azencott, Christian Lorentzen, Christian Ritter, christopherlim98, Christoph T. 
-Weidemann, Christos Aridas, Claudio Salvatore Arcidiacono, combscCode, Daniela 
-Fernandes, Dave Eargle, David Poznik, Dea María Léon, Dennis Osei, DessyVV, 
-Dev514, Dimitri Papadopoulos Orfanos, Diwakar Gupta, Dr. Felix M. Riese, drskd, 
-Emiko Sano, Emmanouil Gionanidis, EricEllwanger, Erich Schubert, Eric Larson, 
-Eric Ndirangu, Estefania Barreto-Ojeda, eyast, Fatima GASMI, Federico Luna, 
-Felix Glushchenkov, fkaren27, Fortune Uwha, FPGAwesome, francoisgoupil, Frans 
-Larsson, Gabor Berei, Gabor Kertesz, Gabriel Stefanini Vicente, Gabriel S 
-Vicente, Gael Varoquaux, GAURAV CHOUDHARY, Gauthier I, genvalen, 
-Geoffrey-Paris, Giancarlo Pablo, glennfrutiz, gpapadok, Guillaume Lemaitre, 
-Guillermo Tomás Fernández Martín, Gustavo Oliveira, Haidar Almubarak, Hannah 
-Bohle, Haoyin Xu, Haya, Helder Geovane Gomes de Lima, henrymooresc, Hideaki 
-Imamura, Himanshu Kumar, Hind-M, hmasdev, hvassard, i-aki-y, iasoon, Inclusive 
-Coding Bot, Ingela, iofall, Ishan Kumar, Jack Liu, Jake Cowton, jalexand3r, J 
-Alexander, Jauhar, Jaya Surya Kommireddy, Jay Stanley, Jeff Hale, je-kr, 
-JElfner, Jenny Vo, Jérémie du Boisberranger, Jihane, Jirka Borovec, Joel 
-Nothman, Jon Haitz Legarreta Gorroño, Jordan Silke, Jorge Ciprián, Jorge 
-Loayza, Joseph Chazalon, Joseph Schwartz-Messing, JSchuerz, Juan Carlos Alfaro 
-Jiménez, Juan Martin Loyola, Julien Jerphanion, katotten, Kaushik Roy 
-Chowdhury, Ken4git, Kevin Doucet, KimAYoung, Koushik Joshi, Kranthi Sedamaki, 
-krumetoft, lesnee, Logan Thomas, Loic Esteve, Louis Wagner, LucieClair, Lucy 
-Liu, Luiz Eduardo Amaral, Magali, MaggieChege, Mai, mandjevant, Mandy Gu, 
-Manimaran, MarcoM, Maren Westermann, Maria Boerner, MarieS-WiMLDS, Martel 
-Corentin, mathurinm, Matías, matjansen, Matteo Francia, Maxwell, Meekail Zain, 
-Megabyte, Mehrdad Moradizadeh, melemo2, Michael I Chen, michalkrawczyk, 
-Micky774, milana2, millawell, Ming-Yang Ho, Mitzi, miwojc, Mizuki, mlant, 
-Mohamed Haseeb, Mohit Sharma, Moonkyung94, mpoemsl, MrinalTyagi, Mr. Leu, 
-msabatier, murata-yu, N, Nadirhan Şahin, NartayXD, nastegiano, nathansquan, 
-nat-salt, Nicki Skafte Detlefsen, Nicolas Hug, Niket Jain, Nikhil Suresh, 
-Nikita Titov, Nikolay Kondratyev, Ohad Michel, Oleksandr Husak, Olivier Grisel, 
-partev, Patrick Ferreira, Paul, pelennor, PierreAttard, Pieter Gijsbers, Pinky, 
-poloso, Pramod Anantharam, puhuk, Purna Chandra Mansingh, QuadV, Rahil Parikh, 
-Randall Boyes, randomgeek78, Raz Hoshia, Reshama Shaikh, Ricardo Ferreira, 
-Richard Taylor, Rileran, Rishabh, Robin Thibaut, Roman Feldbauer, Roman 
-Yurchak, Ross Barnowski, rsnegrin, Sachin Yadav, sakinaOuisrani, Sam Adam Day, 
-Sanjay Marreddi, Sebastian Pujalte, SEELE, Seyedsaman (Sam) Emami, ShanDeng123, 
-Shao Yang Hong, sharmadharmpal, shaymerNaturalint, Shubhraneel Pal, siavrez, 
-slishak, Smile, spikebh, sply88, Sultan Orazbayev, Sumit Saha, Sven Eschlbeck, 
-Swapnil Jha, Sylvain Marié, Takeshi Oura, Tamires Santana, Tenavi, teunpe, 
-Theis Ferré Hjortkjær, Thiruvenkadam, Thomas J. Fan, t-jakubek, Tom Dupré la 
-Tour, TONY GEORGE, Tyler Martin, Tyler Reddy, Udit Gupta, Ugo Marchand, Varun 
-Agrawal, Venkatachalam N, Vera Komeyer, victoirelouis, Vikas Vishwakarma, 
-Vikrant khedkar, Vladimir Chernyy, Vladimir Kim, WeijiaDu, Xiao Yuan, Yar Khine 
+2357juan, Abhishek Gupta, adamgonzo, Adam Li, adijohar, Aditya Kumawat, Aditya
+Raghuwanshi, Aditya Singh, Adrian Trujillo Duron, Adrin Jalali, ahmadjubair33,
+AJ Druck, aj-white, Alan Peixinho, Alberto Mario Ceballos-Arroyo, Alek
+Lefebvre, Alex, Alexandre Gramfort, alexanmv, almeidayoel, Amanda Dsouza, Aman
+Sharma, Amar pratap singh, Amit, amrcode, András Simon, Andreas Mueller,
+Andrew Knyazev, Andriy, Angus L'Herrou, Ankit Sharma, Anne Ducout, Arisa, Arth,
+arthurmello, Arturo Amor, ArturoAmor, Atharva Patil, aufarkari, Aurélien
+Geron, avm19, Ayan Bag, baam, Behrouz B, Ben3940, Benjamin Bossan, Bharat
+Raghunathan, Bijil Subhash, bmreiniger, Brandon Truth, Brenden Kadota, Brian
+Sun, cdrig, Chalmer Lowe, Chiara Marmo, Chitteti Srinath Reddy, Chloe-Agathe
+Azencott, Christian Lorentzen, Christian Ritter, christopherlim98, Christoph T.
+Weidemann, Christos Aridas, Claudio Salvatore Arcidiacono, combscCode, Daniela
+Fernandes, Dave Eargle, David Poznik, Dea María Léon, Dennis Osei, DessyVV,
+Dev514, Dimitri Papadopoulos Orfanos, Diwakar Gupta, Dr. Felix M. Riese, drskd,
+Emiko Sano, Emmanouil Gionanidis, EricEllwanger, Erich Schubert, Eric Larson,
+Eric Ndirangu, Estefania Barreto-Ojeda, eyast, Fatima GASMI, Federico Luna,
+Felix Glushchenkov, fkaren27, Fortune Uwha, FPGAwesome, francoisgoupil, Frans
+Larsson, Gabor Berei, Gabor Kertesz, Gabriel Stefanini Vicente, Gabriel S
+Vicente, Gael Varoquaux, GAURAV CHOUDHARY, Gauthier I, genvalen,
+Geoffrey-Paris, Giancarlo Pablo, glennfrutiz, gpapadok, Guillaume Lemaitre,
+Guillermo Tomás Fernández Martín, Gustavo Oliveira, Haidar Almubarak, Hannah
+Bohle, Haoyin Xu, Haya, Helder Geovane Gomes de Lima, henrymooresc, Hideaki
+Imamura, Himanshu Kumar, Hind-M, hmasdev, hvassard, i-aki-y, iasoon, Inclusive
+Coding Bot, Ingela, iofall, Ishan Kumar, Jack Liu, Jake Cowton, jalexand3r, J
+Alexander, Jauhar, Jaya Surya Kommireddy, Jay Stanley, Jeff Hale, je-kr,
+JElfner, Jenny Vo, Jérémie du Boisberranger, Jihane, Jirka Borovec, Joel
+Nothman, Jon Haitz Legarreta Gorroño, Jordan Silke, Jorge Ciprián, Jorge
+Loayza, Joseph Chazalon, Joseph Schwartz-Messing, JSchuerz, Juan Carlos Alfaro
+Jiménez, Juan Martin Loyola, Julien Jerphanion, katotten, Kaushik Roy
+Chowdhury, Ken4git, Kevin Doucet, KimAYoung, Koushik Joshi, Kranthi Sedamaki,
+krumetoft, lesnee, Logan Thomas, Loic Esteve, Louis Wagner, LucieClair, Lucy
+Liu, Luiz Eduardo Amaral, Magali, MaggieChege, Mai, mandjevant, Mandy Gu,
+Manimaran, MarcoM, Maren Westermann, Maria Boerner, MarieS-WiMLDS, Martel
+Corentin, mathurinm, Matías, matjansen, Matteo Francia, Maxwell, Meekail Zain,
+Megabyte, Mehrdad Moradizadeh, melemo2, Michael I Chen, michalkrawczyk,
+Micky774, milana2, millawell, Ming-Yang Ho, Mitzi, miwojc, Mizuki, mlant,
+Mohamed Haseeb, Mohit Sharma, Moonkyung94, mpoemsl, MrinalTyagi, Mr. Leu,
+msabatier, murata-yu, N, Nadirhan Şahin, NartayXD, nastegiano, nathansquan,
+nat-salt, Nicki Skafte Detlefsen, Nicolas Hug, Niket Jain, Nikhil Suresh,
+Nikita Titov, Nikolay Kondratyev, Ohad Michel, Oleksandr Husak, Olivier Grisel,
+partev, Patrick Ferreira, Paul, pelennor, PierreAttard, Pieter Gijsbers, Pinky,
+poloso, Pramod Anantharam, puhuk, Purna Chandra Mansingh, QuadV, Rahil Parikh,
+Randall Boyes, randomgeek78, Raz Hoshia, Reshama Shaikh, Ricardo Ferreira,
+Richard Taylor, Rileran, Rishabh, Robin Thibaut, Roman Feldbauer, Roman
+Yurchak, Ross Barnowski, rsnegrin, Sachin Yadav, sakinaOuisrani, Sam Adam Day,
+Sanjay Marreddi, Sebastian Pujalte, SEELE, Seyedsaman (Sam) Emami, ShanDeng123,
+Shao Yang Hong, sharmadharmpal, shaymerNaturalint, Shubhraneel Pal, siavrez,
+slishak, Smile, spikebh, sply88, Sultan Orazbayev, Sumit Saha, Sven Eschlbeck,
+Swapnil Jha, Sylvain Marié, Takeshi Oura, Tamires Santana, Tenavi, teunpe,
+Theis Ferré Hjortkjær, Thiruvenkadam, Thomas J. Fan, t-jakubek, Tom Dupré la
+Tour, TONY GEORGE, Tyler Martin, Tyler Reddy, Udit Gupta, Ugo Marchand, Varun
+Agrawal, Venkatachalam N, Vera Komeyer, victoirelouis, Vikas Vishwakarma,
+Vikrant khedkar, Vladimir Chernyy, Vladimir Kim, WeijiaDu, Xiao Yuan, Yar Khine
 Phyo, Ying Xiong, yiyangq, Yosshi999, Yuki Koyama, Zach Deane-Mayer, Zeel B Patel,
 zempleni, zhenfisher, 赵丰 (Zhao Feng)

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -525,6 +525,9 @@ Changelog
   :class:`ensemble.ExtraTreesClassifier`.
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
 
+- |Efficiency| Improve runtime performance of :class:`ensemble.IsolationForest`
+  by skipping repetitive input checks. :pr:`23149` by :user:`Zhehao Liu <MaxwellLZH>`.
+
 :mod:`sklearn.feature_extraction`
 .................................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -73,6 +73,11 @@ random sampling procedures.
   the correct variance-scaling coefficient which may result in different model
   behavior.
 
+- |Fix| :meth:`feature_selection.SelectFromModel.fit` and
+  :meth:`feature_selection.SelectFromModel.partial_fit` can now be called with
+  `prefit=True`. `estimators_` will be a deep copy of `estimator` when
+  `prefit=True`. :pr:`23271` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Changelog
 ---------
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -273,6 +273,13 @@ Changelog
   specific shape for `coef_` (e.g. :class:`feature_selection.RFE`).
   :pr:`22016` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |API| add the fitted attribute `intercept_` to
+  :class:`cross_decomposition.PLSCanonical`,
+  :class:`cross_decomposition.PLSRegression`, and
+  :class:`cross_decomposition.CCA`. The method `predict` is indeed equivalent to
+  `Y = X @ coef_ + intercept_`.
+  :pr:`22015` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.datasets`
 .......................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -92,26 +92,27 @@ Changelog
   for dense float64 datasets have been refactored. The following functions
   and estimators now benefit from improved performances in terms of hardware
   scalability and speed-ups:
-    - :func:`sklearn.metrics.pairwise_distances_argmin`
-    - :func:`sklearn.metrics.pairwise_distances_argmin_min`
-    - :class:`sklearn.cluster.AffinityPropagation`
-    - :class:`sklearn.cluster.Birch`
-    - :class:`sklearn.cluster.MeanShift`
-    - :class:`sklearn.cluster.OPTICS`
-    - :class:`sklearn.cluster.SpectralClustering`
-    - :func:`sklearn.feature_selection.mutual_info_regression`
-    - :class:`sklearn.neighbors.KNeighborsClassifier`
-    - :class:`sklearn.neighbors.KNeighborsRegressor`
-    - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
-    - :class:`sklearn.neighbors.RadiusNeighborsRegressor`
-    - :class:`sklearn.neighbors.LocalOutlierFactor`
-    - :class:`sklearn.neighbors.NearestNeighbors`
-    - :class:`sklearn.manifold.Isomap`
-    - :class:`sklearn.manifold.LocallyLinearEmbedding`
-    - :class:`sklearn.manifold.TSNE`
-    - :func:`sklearn.manifold.trustworthiness`
-    - :class:`sklearn.semi_supervised.LabelPropagation`
-    - :class:`sklearn.semi_supervised.LabelSpreading`
+
+  - :func:`sklearn.metrics.pairwise_distances_argmin`
+  - :func:`sklearn.metrics.pairwise_distances_argmin_min`
+  - :class:`sklearn.cluster.AffinityPropagation`
+  - :class:`sklearn.cluster.Birch`
+  - :class:`sklearn.cluster.MeanShift`
+  - :class:`sklearn.cluster.OPTICS`
+  - :class:`sklearn.cluster.SpectralClustering`
+  - :func:`sklearn.feature_selection.mutual_info_regression`
+  - :class:`sklearn.neighbors.KNeighborsClassifier`
+  - :class:`sklearn.neighbors.KNeighborsRegressor`
+  - :class:`sklearn.neighbors.RadiusNeighborsClassifier`
+  - :class:`sklearn.neighbors.RadiusNeighborsRegressor`
+  - :class:`sklearn.neighbors.LocalOutlierFactor`
+  - :class:`sklearn.neighbors.NearestNeighbors`
+  - :class:`sklearn.manifold.Isomap`
+  - :class:`sklearn.manifold.LocallyLinearEmbedding`
+  - :class:`sklearn.manifold.TSNE`
+  - :func:`sklearn.manifold.trustworthiness`
+  - :class:`sklearn.semi_supervised.LabelPropagation`
+  - :class:`sklearn.semi_supervised.LabelSpreading`
 
   For instance :class:`sklearn.neighbors.NearestNeighbors.kneighbors` and
   :class:`sklearn.neighbors.NearestNeighbors.radius_neighbors`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -497,6 +497,9 @@ Changelog
   `warm_start` enabled.
   :pr:`22106` by :user:`Pieter Gijsbers <PGijsbers>`.
 
+- |Efficiency| Improve runtime performance of :class:`ensemble.IsolationForest`
+  by skipping repetitive input checks. :pr:`23149` by :user:`Zhehao Liu <MaxwellLZH>`.
+
 - |Fix| Change the parameter `validation_fraction` in
   :class:`ensemble.GradientBoostingClassifier` and
   :class:`ensemble.GradientBoostingRegressor` so that an error is raised if anything
@@ -530,9 +533,6 @@ Changelog
   changes are also applied for :class:`ensemble.ExtraTreesRegressor` and
   :class:`ensemble.ExtraTreesClassifier`.
   :pr:`20803` by :user:`Brian Sun <bsun94>`.
-
-- |Efficiency| Improve runtime performance of :class:`ensemble.IsolationForest`
-  by skipping repetitive input checks. :pr:`23149` by :user:`Zhehao Liu <MaxwellLZH>`.
 
 :mod:`sklearn.feature_extraction`
 .................................

--- a/examples/release_highlights/plot_release_highlights_1_1_0.py
+++ b/examples/release_highlights/plot_release_highlights_1_1_0.py
@@ -26,7 +26,6 @@ or with conda::
 # ----------------------------------------------------------------
 # :class:`ensemble.HistGradientBoostingRegressor` can model quantiles with
 # `loss="quantile"` and the new parameter `quantile`.
-from sklearn.datasets import make_regression
 from sklearn.ensemble import HistGradientBoostingRegressor
 import numpy as np
 import matplotlib.pyplot as plt

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "1.1.0rc1"
+__version__ = "1.1.0"
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -358,6 +358,7 @@ class _PLS(
         # TODO(1.3): change `self._coef_` to `self.coef_`
         self._coef_ = np.dot(self.x_rotations_, self.y_loadings_.T)
         self._coef_ = (self._coef_ * self._y_std).T
+        self.intercept_ = self._y_mean
         self._n_features_out = self.x_rotations_.shape[1]
         return self
 
@@ -473,7 +474,7 @@ class _PLS(
         X /= self._x_std
         # TODO(1.3): change `self._coef_` to `self.coef_`
         Ypred = X @ self._coef_.T
-        return Ypred + self._y_mean
+        return Ypred + self.intercept_
 
     def fit_transform(self, X, y=None):
         """Learn and apply the dimension reduction on the train data.
@@ -501,6 +502,7 @@ class _PLS(
         # TODO(1.3): remove and change `self._coef_` to `self.coef_`
         #            remove catch warnings from `_get_feature_importances`
         #            delete self._coef_no_warning
+        #            update the docstring of `coef_` and `intercept_` attribute
         if hasattr(self, "_coef_") and getattr(self, "_coef_warning", True):
             warnings.warn(
                 "The attribute `coef_` will be transposed in version 1.3 to be "
@@ -581,7 +583,13 @@ class PLSRegression(_PLS):
 
     coef_ : ndarray of shape (n_features, n_targets)
         The coefficients of the linear model such that `Y` is approximated as
-        `Y = X @ coef_`.
+        `Y = X @ coef_ + intercept_`.
+
+    intercept_ : ndarray of shape (n_targets,)
+        The intercepts of the linear model such that `Y` is approximated as
+        `Y = X @ coef_ + intercept_`.
+
+        .. versionadded:: 1.1
 
     n_iter_ : list of shape (n_components,)
         Number of iterations of the power method, for each
@@ -715,7 +723,13 @@ class PLSCanonical(_PLS):
 
     coef_ : ndarray of shape (n_features, n_targets)
         The coefficients of the linear model such that `Y` is approximated as
-        `Y = X @ coef_`.
+        `Y = X @ coef_ + intercept_`.
+
+    intercept_ : ndarray of shape (n_targets,)
+        The intercepts of the linear model such that `Y` is approximated as
+        `Y = X @ coef_ + intercept_`.
+
+        .. versionadded:: 1.1
 
     n_iter_ : list of shape (n_components,)
         Number of iterations of the power method, for each
@@ -827,7 +841,13 @@ class CCA(_PLS):
 
     coef_ : ndarray of shape (n_features, n_targets)
         The coefficients of the linear model such that `Y` is approximated as
-        `Y = X @ coef_`.
+        `Y = X @ coef_ + intercept_`.
+
+    intercept_ : ndarray of shape (n_targets,)
+        The intercepts of the linear model such that `Y` is approximated as
+        `Y = X @ coef_ + intercept_`.
+
+        .. versionadded:: 1.1
 
     n_iter_ : list of shape (n_components,)
         Number of iterations of the power method, for each

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -616,6 +616,29 @@ def test_pls_coef_shape(PLSEstimator):
     assert pls._coef_.shape == (Y.shape[1], X.shape[1])
 
 
+# TODO (1.3): remove the filterwarnings and adapt the dot product between `X_trans` and
+# `pls.coef_`
+@pytest.mark.filterwarnings("ignore:The attribute `coef_` will be transposed")
+@pytest.mark.parametrize("scale", [True, False])
+@pytest.mark.parametrize("PLSEstimator", [PLSRegression, PLSCanonical, CCA])
+def test_pls_prediction(PLSEstimator, scale):
+    """Check the behaviour of the prediction function."""
+    d = load_linnerud()
+    X = d.data
+    Y = d.target
+
+    pls = PLSEstimator(copy=True, scale=scale).fit(X, Y)
+    Y_pred = pls.predict(X, copy=True)
+
+    y_mean = Y.mean(axis=0)
+    X_trans = X - X.mean(axis=0)
+    if scale:
+        X_trans /= X.std(axis=0, ddof=1)
+
+    assert_allclose(pls.intercept_, y_mean)
+    assert_allclose(Y_pred, X_trans @ pls.coef_ + pls.intercept_)
+
+
 @pytest.mark.parametrize("Klass", [CCA, PLSSVD, PLSRegression, PLSCanonical])
 def test_pls_feature_names_out(Klass):
     """Check `get_feature_names_out` cross_decomposition module."""

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -9,6 +9,7 @@ import numbers
 import numpy as np
 from abc import ABCMeta, abstractmethod
 from warnings import warn
+from functools import partial
 
 from joblib import Parallel
 
@@ -68,7 +69,15 @@ def _generate_bagging_indices(
 
 
 def _parallel_build_estimators(
-    n_estimators, ensemble, X, y, sample_weight, seeds, total_n_estimators, verbose
+    n_estimators,
+    ensemble,
+    X,
+    y,
+    sample_weight,
+    seeds,
+    total_n_estimators,
+    verbose,
+    check_input,
 ):
     """Private function used to build a batch of estimators within a job."""
     # Retrieve settings
@@ -78,6 +87,7 @@ def _parallel_build_estimators(
     bootstrap = ensemble.bootstrap
     bootstrap_features = ensemble.bootstrap_features
     support_sample_weight = has_fit_parameter(ensemble.base_estimator_, "sample_weight")
+    has_check_input = has_fit_parameter(ensemble.base_estimator_, "check_input")
     if not support_sample_weight and sample_weight is not None:
         raise ValueError("The base estimator doesn't support sample weight")
 
@@ -94,6 +104,11 @@ def _parallel_build_estimators(
 
         random_state = seeds[i]
         estimator = ensemble._make_estimator(append=False, random_state=random_state)
+
+        if has_check_input:
+            estimator_fit = partial(estimator.fit, check_input=check_input)
+        else:
+            estimator_fit = estimator.fit
 
         # Draw random feature, sample indices
         features, indices = _generate_bagging_indices(
@@ -120,10 +135,10 @@ def _parallel_build_estimators(
                 not_indices_mask = ~indices_to_mask(indices, n_samples)
                 curr_sample_weight[not_indices_mask] = 0
 
-            estimator.fit(X[:, features], y, sample_weight=curr_sample_weight)
+            estimator_fit(X[:, features], y, sample_weight=curr_sample_weight)
 
         else:
-            estimator.fit((X[indices])[:, features], y[indices])
+            estimator_fit(X[indices][:, features], y[indices])
 
         estimators.append(estimator)
         estimators_features.append(features)
@@ -284,7 +299,15 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
     def _parallel_args(self):
         return {}
 
-    def _fit(self, X, y, max_samples=None, max_depth=None, sample_weight=None):
+    def _fit(
+        self,
+        X,
+        y,
+        max_samples=None,
+        max_depth=None,
+        sample_weight=None,
+        check_input=True,
+    ):
         """Build a Bagging ensemble of estimators from the training
            set (X, y).
 
@@ -309,6 +332,10 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
             Sample weights. If None, then samples are equally weighted.
             Note that this is supported only if the base estimator supports
             sample weighting.
+
+        check_input : bool, default=True
+            Override value used when fitting base estimator. Only supported
+            if the base estimator has a check_input parameter for fit function.
 
         Returns
         -------
@@ -416,6 +443,7 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
                 seeds[starts[i] : starts[i + 1]],
                 total_n_estimators,
                 verbose=self.verbose,
+                check_input=check_input,
             )
             for i in range(n_jobs)
         )

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -304,7 +304,12 @@ class IsolationForest(OutlierMixin, BaseBagging):
         self.max_samples_ = max_samples
         max_depth = int(np.ceil(np.log2(max(max_samples, 2))))
         super()._fit(
-            X, y, max_samples, max_depth=max_depth, sample_weight=sample_weight
+            X,
+            y,
+            max_samples,
+            max_depth=max_depth,
+            sample_weight=sample_weight,
+            check_input=False,
         )
 
         if self.contamination == "auto":

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -294,9 +294,16 @@ class DecisionBoundaryDisplay:
             np.linspace(x0_min, x0_max, grid_resolution),
             np.linspace(x1_min, x1_max, grid_resolution),
         )
+        if hasattr(X, "iloc"):
+            # we need to preserve the feature names and therefore get an empty dataframe
+            X_grid = X.iloc[[], :].copy()
+            X_grid.iloc[:, 0] = xx0.ravel()
+            X_grid.iloc[:, 1] = xx1.ravel()
+        else:
+            X_grid = np.c_[xx0.ravel(), xx1.ravel()]
 
         pred_func = _check_boundary_response_method(estimator, response_method)
-        response = pred_func(np.c_[xx0.ravel(), xx1.ravel()])
+        response = pred_func(X_grid)
 
         # convert classes predictions into integers
         if pred_func.__name__ == "predict" and hasattr(estimator, "classes_"):

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -328,7 +328,7 @@ def test_string_target(pyplot):
     )
 
 
-def test_dataframe_support():
+def test_dataframe_support(pyplot):
     """Check that passing a dataframe at fit and to the Display does not
     raise warnings.
 

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -280,10 +280,10 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
         Returns
         -------
         validation_mask : ndarray of shape (n_samples, )
-            Equal to 1 on the validation set, 0 on the training set.
+            Equal to True on the validation set, False on the training set.
         """
         n_samples = y.shape[0]
-        validation_mask = np.zeros(n_samples, dtype=np.uint8)
+        validation_mask = np.zeros(n_samples, dtype=np.bool_)
         if not self.early_stopping:
             # use the full set for training, with an empty validation set
             return validation_mask
@@ -310,7 +310,7 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
                 )
             )
 
-        validation_mask[idx_val] = 1
+        validation_mask[idx_val] = True
         return validation_mask
 
     def _make_validation_score_cb(


### PR DESCRIPTION
* [x] update news and what's new date in release branch
* [x] update news and what's new date and sklearn dev0 version in main branch
* [x] check that the for the release wheels can be built successfully
       **missing wheels for arm64**
* [x] merge the PR with `[cd build]` commit message to upload wheels to the staging repo
* [x] upload the wheels and source tarball to https://test.pypi.org
* [x] create tag on the main github repo
* [x] confirm bot detected at
  https://github.com/conda-forge/scikit-learn-feedstock and wait for merge
* [x] upload the wheels and source tarball to PyPI
* [x] https://github.com/scikit-learn/scikit-learn/releases publish (except for RC)
* [x] announce on mailing list and on Twitter, and LinkedInbackported

backported
```
pick f9d25239be API add intercept_ attribute to PLS estimators (#22015)
pick ac24e405b4 ENH Optimize runtime for IsolationForest (#23149)
pick f862b7da26 MAINT remove trailing spaces in what's new 1.1 (#23240)
pick 6f30cd42fe DOC Correctly format list for 1.1 `whats_new` (#23241)
pick dc9f5da133 DOC Fixes sphinx warning in whats_new 1.1 (#23246)
pick 32deddf499 FIX SGDRegreesor and SGDClassifier use correct number of validation data (#23256)
pick 5f0abbab71 FIX params validation in SelectFromModel with prefit=True (#23271)
pick 8ce6aed46d DOC Remove unneeded import in 1.1 highlights (#23292)
pick 3fae010eb7 FIX DecisionBoundaryPlot should not raise spurious warning (#23318)
```