### PR TITLE
TST skip test_dataframe_support if matplotlib not installed

### DIFF
--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -328,7 +328,7 @@ def test_string_target(pyplot):
     )
 
 
-def test_dataframe_support():
+def test_dataframe_support(pyplot):
     """Check that passing a dataframe at fit and to the Display does not
     raise warnings.
 


### PR DESCRIPTION
follow up of #23318

The test should be skipped if matplotlib is not installed. It's not catched by the CI because it's always installed when pandas is but it was catched in https://github.com/scikit-learn/scikit-learn/pull/23321