### PR TITLE
MNT Use cimport numpy as cnp for sklearn/svm

### DIFF
--- a/sklearn/svm/_liblinear.pxi
+++ b/sklearn/svm/_liblinear.pxi
@@ -33,7 +33,7 @@ cdef extern from "liblinear_helper.c":
     problem *set_problem (char *, int, int, int, int, double, char *, char *)
     problem *csr_set_problem (char *, int, char *, char *, int, int, int, double, char *, char *)
 
-    model *set_model(parameter *, char *, np.npy_intp *, char *, double)
+    model *set_model(parameter *, char *, cnp.npy_intp *, char *, double)
 
     double get_bias(model *)
     void free_problem (problem *)

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -5,20 +5,20 @@ Author: fabian.pedregosa@inria.fr
 """
 
 import  numpy as np
-cimport numpy as np
+cimport numpy as cnp
 
 from ..utils._cython_blas cimport _dot, _axpy, _scal, _nrm2
 
 include "_liblinear.pxi"
 
-np.import_array()
+cnp.import_array()
 
 
-def train_wrap(X, np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
+def train_wrap(X, cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] Y,
                bint is_sparse, int solver_type, double eps, double bias,
-               double C, np.ndarray[np.float64_t, ndim=1] class_weight,
+               double C, cnp.ndarray[cnp.float64_t, ndim=1] class_weight,
                int max_iter, unsigned random_seed, double epsilon,
-               np.ndarray[np.float64_t, ndim=1, mode='c'] sample_weight):
+               cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] sample_weight):
     cdef parameter *param
     cdef problem *problem
     cdef model *model
@@ -27,19 +27,19 @@ def train_wrap(X, np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
 
     if is_sparse:
         problem = csr_set_problem(
-                (<np.ndarray>X.data).data, X.dtype == np.float64,
-                (<np.ndarray[np.int32_t,   ndim=1, mode='c']>X.indices).data,
-                (<np.ndarray[np.int32_t,   ndim=1, mode='c']>X.indptr).data,
-                (<np.int32_t>X.shape[0]), (<np.int32_t>X.shape[1]),
-                (<np.int32_t>X.nnz), bias, sample_weight.data, Y.data)
+                (<cnp.ndarray>X.data).data, X.dtype == np.float64,
+                (<cnp.ndarray[cnp.int32_t,   ndim=1, mode='c']>X.indices).data,
+                (<cnp.ndarray[cnp.int32_t,   ndim=1, mode='c']>X.indptr).data,
+                (<cnp.int32_t>X.shape[0]), (<cnp.int32_t>X.shape[1]),
+                (<cnp.int32_t>X.nnz), bias, sample_weight.data, Y.data)
     else:
         problem = set_problem(
-                (<np.ndarray>X).data, X.dtype == np.float64,
-                (<np.int32_t>X.shape[0]), (<np.int32_t>X.shape[1]),
-                (<np.int32_t>np.count_nonzero(X)), bias, sample_weight.data,
+                (<cnp.ndarray>X).data, X.dtype == np.float64,
+                (<cnp.int32_t>X.shape[0]), (<cnp.int32_t>X.shape[1]),
+                (<cnp.int32_t>np.count_nonzero(X)), bias, sample_weight.data,
                 Y.data)
 
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.intc)
     param = set_parameter(solver_type, eps, C, class_weight.shape[0],
                           class_weight_label.data, class_weight.data,
@@ -50,7 +50,7 @@ def train_wrap(X, np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
         free_problem(problem)
         free_parameter(param)
         raise ValueError(error_msg)
-    
+
     cdef BlasFunctions blas_functions
     blas_functions.dot = _dot[double]
     blas_functions.axpy = _axpy[double]
@@ -67,13 +67,13 @@ def train_wrap(X, np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
     # destroy_param(param)  don't call this or it will destroy class_weight_label and class_weight
 
     # coef matrix holder created as fortran since that's what's used in liblinear
-    cdef np.ndarray[np.float64_t, ndim=2, mode='fortran'] w
+    cdef cnp.ndarray[cnp.float64_t, ndim=2, mode='fortran'] w
     cdef int nr_class = get_nr_class(model)
 
     cdef int labels_ = nr_class
     if nr_class == 2:
         labels_ = 1
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] n_iter = np.zeros(labels_, dtype=np.intc)
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] n_iter = np.zeros(labels_, dtype=np.intc)
     get_n_iter(model, <int *>n_iter.data)
 
     cdef int nr_feature = get_nr_feature(model)

--- a/sklearn/svm/_libsvm.pxi
+++ b/sklearn/svm/_libsvm.pxi
@@ -44,30 +44,30 @@ cdef extern from "svm.h":
 
 cdef extern from "libsvm_helper.c":
     # this file contains methods for accessing libsvm 'hidden' fields
-    svm_node **dense_to_sparse (char *, np.npy_intp *)
+    svm_node **dense_to_sparse (char *, cnp.npy_intp *)
     void set_parameter (svm_parameter *, int , int , int , double, double ,
                                   double , double , double , double,
                                   double, int, int, int, char *, char *, int,
                                   int)
-    void set_problem (svm_problem *, char *, char *, char *, np.npy_intp *, int)
+    void set_problem (svm_problem *, char *, char *, char *, cnp.npy_intp *, int)
 
-    svm_model *set_model (svm_parameter *, int, char *, np.npy_intp *,
-                         char *, np.npy_intp *, np.npy_intp *, char *,
+    svm_model *set_model (svm_parameter *, int, char *, cnp.npy_intp *,
+                         char *, cnp.npy_intp *, cnp.npy_intp *, char *,
                          char *, char *, char *, char *)
 
     void copy_sv_coef   (char *, svm_model *)
     void copy_n_iter  (char *, svm_model *)
-    void copy_intercept (char *, svm_model *, np.npy_intp *)
-    void copy_SV        (char *, svm_model *, np.npy_intp *)
+    void copy_intercept (char *, svm_model *, cnp.npy_intp *)
+    void copy_SV        (char *, svm_model *, cnp.npy_intp *)
     int copy_support (char *data, svm_model *model)
-    int copy_predict (char *, svm_model *, np.npy_intp *, char *, BlasFunctions *) nogil
-    int copy_predict_proba (char *, svm_model *, np.npy_intp *, char *, BlasFunctions *) nogil
-    int copy_predict_values(char *, svm_model *, np.npy_intp *, char *, int, BlasFunctions *) nogil
+    int copy_predict (char *, svm_model *, cnp.npy_intp *, char *, BlasFunctions *) nogil
+    int copy_predict_proba (char *, svm_model *, cnp.npy_intp *, char *, BlasFunctions *) nogil
+    int copy_predict_values(char *, svm_model *, cnp.npy_intp *, char *, int, BlasFunctions *) nogil
     void copy_nSV     (char *, svm_model *)
-    void copy_probA   (char *, svm_model *, np.npy_intp *)
-    void copy_probB   (char *, svm_model *, np.npy_intp *)
-    np.npy_intp  get_l  (svm_model *)
-    np.npy_intp  get_nr (svm_model *)
+    void copy_probA   (char *, svm_model *, cnp.npy_intp *)
+    void copy_probB   (char *, svm_model *, cnp.npy_intp *)
+    cnp.npy_intp  get_l  (svm_model *)
+    cnp.npy_intp  get_nr (svm_model *)
     int  free_problem   (svm_problem *)
     int  free_model     (svm_model *)
     void set_verbosity(int)

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -29,7 +29,7 @@ Authors
 
 import warnings
 import  numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from libc.stdlib cimport free
 from ..utils._cython_blas cimport _dot
 
@@ -39,7 +39,7 @@ cdef extern from *:
     ctypedef struct svm_parameter:
         pass
 
-np.import_array()
+cnp.import_array()
 
 
 ################################################################################
@@ -51,14 +51,14 @@ LIBSVM_KERNEL_TYPES = ['linear', 'poly', 'rbf', 'sigmoid', 'precomputed']
 # Wrapper functions
 
 def fit(
-    np.ndarray[np.float64_t, ndim=2, mode='c'] X,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] X,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] Y,
     int svm_type=0, kernel='rbf', int degree=3,
     double gamma=0.1, double coef0=0., double tol=1e-3,
     double C=1., double nu=0.5, double epsilon=0.1,
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
         sample_weight=np.empty(0),
     int shrinking=1, int probability=0,
     double cache_size=100.,
@@ -161,8 +161,8 @@ def fit(
     cdef svm_problem problem
     cdef svm_model *model
     cdef const char *error_msg
-    cdef np.npy_intp SV_len
-    cdef np.npy_intp nr
+    cdef cnp.npy_intp SV_len
+    cdef cnp.npy_intp nr
 
 
     if len(sample_weight) == 0:
@@ -178,7 +178,7 @@ def fit(
         &problem, X.data, Y.data, sample_weight.data, X.shape, kernel_index)
     if problem.x == NULL:
         raise MemoryError("Seems we've run out of memory")
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
     set_parameter(
         &param, svm_type, kernel_index, degree, gamma, coef0, nu, cache_size,
@@ -202,25 +202,25 @@ def fit(
     SV_len  = get_l(model)
     n_class = get_nr(model)
 
-    cdef np.ndarray[int, ndim=1, mode='c'] n_iter
+    cdef cnp.ndarray[int, ndim=1, mode='c'] n_iter
     n_iter = np.empty(max(1, n_class * (n_class - 1) // 2), dtype=np.intc)
     copy_n_iter(n_iter.data, model)
 
-    cdef np.ndarray[np.float64_t, ndim=2, mode='c'] sv_coef
+    cdef cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] sv_coef
     sv_coef = np.empty((n_class-1, SV_len), dtype=np.float64)
     copy_sv_coef (sv_coef.data, model)
 
     # the intercept is just model.rho but with sign changed
-    cdef np.ndarray[np.float64_t, ndim=1, mode='c'] intercept
+    cdef cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] intercept
     intercept = np.empty(int((n_class*(n_class-1))/2), dtype=np.float64)
     copy_intercept (intercept.data, model, intercept.shape)
 
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] support
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] support
     support = np.empty (SV_len, dtype=np.int32)
     copy_support (support.data, model)
 
     # copy model.SV
-    cdef np.ndarray[np.float64_t, ndim=2, mode='c'] support_vectors
+    cdef cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] support_vectors
     if kernel_index == 4:
         # precomputed kernel
         support_vectors = np.empty((0, 0), dtype=np.float64)
@@ -228,7 +228,7 @@ def fit(
         support_vectors = np.empty((SV_len, X.shape[1]), dtype=np.float64)
         copy_SV(support_vectors.data, model, support_vectors.shape)
 
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] n_class_SV
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] n_class_SV
     if svm_type == 0 or svm_type == 1:
         n_class_SV = np.empty(n_class, dtype=np.int32)
         copy_nSV(n_class_SV.data, model)
@@ -236,8 +236,8 @@ def fit(
         # OneClass and SVR are considered to have 2 classes
         n_class_SV = np.array([SV_len, SV_len], dtype=np.int32)
 
-    cdef np.ndarray[np.float64_t, ndim=1, mode='c'] probA
-    cdef np.ndarray[np.float64_t, ndim=1, mode='c'] probB
+    cdef cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probA
+    cdef cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probB
     if probability != 0:
         if svm_type < 2: # SVC and NuSVC
             probA = np.empty(int(n_class*(n_class-1)/2), dtype=np.float64)
@@ -280,19 +280,19 @@ cdef void set_predict_params(
                          nr_weight, weight_label, weight, max_iter, random_seed)
 
 
-def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
-            np.ndarray[np.int32_t, ndim=1, mode='c'] support,
-            np.ndarray[np.float64_t, ndim=2, mode='c'] SV,
-            np.ndarray[np.int32_t, ndim=1, mode='c'] nSV,
-            np.ndarray[np.float64_t, ndim=2, mode='c'] sv_coef,
-            np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
-            np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
-            np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
+def predict(cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] X,
+            cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] support,
+            cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] SV,
+            cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] nSV,
+            cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] sv_coef,
+            cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] intercept,
+            cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probA=np.empty(0),
+            cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probB=np.empty(0),
             int svm_type=0, kernel='rbf', int degree=3,
             double gamma=0.1, double coef0=0.,
-            np.ndarray[np.float64_t, ndim=1, mode='c']
+            cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
                 class_weight=np.empty(0),
-            np.ndarray[np.float64_t, ndim=1, mode='c']
+            cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
                 sample_weight=np.empty(0),
             double cache_size=100.):
     """
@@ -344,12 +344,12 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
     dec_values : array
         Predicted values.
     """
-    cdef np.ndarray[np.float64_t, ndim=1, mode='c'] dec_values
+    cdef cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] dec_values
     cdef svm_parameter param
     cdef svm_model *model
     cdef int rv
 
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
 
     set_predict_params(&param, svm_type, kernel, degree, gamma, coef0,
@@ -374,19 +374,19 @@ def predict(np.ndarray[np.float64_t, ndim=2, mode='c'] X,
 
 
 def predict_proba(
-    np.ndarray[np.float64_t, ndim=2, mode='c'] X,
-    np.ndarray[np.int32_t, ndim=1, mode='c'] support,
-    np.ndarray[np.float64_t, ndim=2, mode='c'] SV,
-    np.ndarray[np.int32_t, ndim=1, mode='c'] nSV,
-    np.ndarray[np.float64_t, ndim=2, mode='c'] sv_coef,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
-    np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] X,
+    cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] support,
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] SV,
+    cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] nSV,
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] sv_coef,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] intercept,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probA=np.empty(0),
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probB=np.empty(0),
     int svm_type=0, kernel='rbf', int degree=3,
     double gamma=0.1, double coef0=0.,
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
         sample_weight=np.empty(0),
     double cache_size=100.):
     """
@@ -448,10 +448,10 @@ def predict_proba(
     dec_values : array
         Predicted values.
     """
-    cdef np.ndarray[np.float64_t, ndim=2, mode='c'] dec_values
+    cdef cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] dec_values
     cdef svm_parameter param
     cdef svm_model *model
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
     cdef int rv
 
@@ -463,7 +463,7 @@ def predict_proba(
                       sv_coef.data, intercept.data, nSV.data,
                       probA.data, probB.data)
 
-    cdef np.npy_intp n_class = get_nr(model)
+    cdef cnp.npy_intp n_class = get_nr(model)
     cdef BlasFunctions blas_functions
     blas_functions.dot = _dot[double]
     try:
@@ -479,19 +479,19 @@ def predict_proba(
 
 
 def decision_function(
-    np.ndarray[np.float64_t, ndim=2, mode='c'] X,
-    np.ndarray[np.int32_t, ndim=1, mode='c'] support,
-    np.ndarray[np.float64_t, ndim=2, mode='c'] SV,
-    np.ndarray[np.int32_t, ndim=1, mode='c'] nSV,
-    np.ndarray[np.float64_t, ndim=2, mode='c'] sv_coef,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] intercept,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] probA=np.empty(0),
-    np.ndarray[np.float64_t, ndim=1, mode='c'] probB=np.empty(0),
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] X,
+    cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] support,
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] SV,
+    cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] nSV,
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] sv_coef,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] intercept,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probA=np.empty(0),
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probB=np.empty(0),
     int svm_type=0, kernel='rbf', int degree=3,
     double gamma=0.1, double coef0=0.,
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
          sample_weight=np.empty(0),
     double cache_size=100.):
     """
@@ -546,12 +546,12 @@ def decision_function(
     dec_values : array
         Predicted values.
     """
-    cdef np.ndarray[np.float64_t, ndim=2, mode='c'] dec_values
+    cdef cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] dec_values
     cdef svm_parameter param
     cdef svm_model *model
-    cdef np.npy_intp n_class
+    cdef cnp.npy_intp n_class
 
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
 
     cdef int rv
@@ -585,14 +585,14 @@ def decision_function(
 
 
 def cross_validation(
-    np.ndarray[np.float64_t, ndim=2, mode='c'] X,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
+    cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] X,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] Y,
     int n_fold, svm_type=0, kernel='rbf', int degree=3,
     double gamma=0.1, double coef0=0., double tol=1e-3,
     double C=1., double nu=0.5, double epsilon=0.1,
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
         class_weight=np.empty(0),
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
         sample_weight=np.empty(0),
     int shrinking=0, int probability=0, double cache_size=100.,
     int max_iter=-1,
@@ -679,8 +679,8 @@ def cross_validation(
     cdef svm_problem problem
     cdef svm_model *model
     cdef const char *error_msg
-    cdef np.npy_intp SV_len
-    cdef np.npy_intp nr
+    cdef cnp.npy_intp SV_len
+    cdef cnp.npy_intp nr
 
     if len(sample_weight) == 0:
         sample_weight = np.ones(X.shape[0], dtype=np.float64)
@@ -699,7 +699,7 @@ def cross_validation(
         &problem, X.data, Y.data, sample_weight.data, X.shape, kernel_index)
     if problem.x == NULL:
         raise MemoryError("Seems we've run out of memory")
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
 
     # set parameters
@@ -713,7 +713,7 @@ def cross_validation(
     if error_msg:
         raise ValueError(error_msg)
 
-    cdef np.ndarray[np.float64_t, ndim=1, mode='c'] target
+    cdef cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] target
     cdef BlasFunctions blas_functions
     blas_functions.dot = _dot[double]
     try:

--- a/sklearn/svm/_libsvm_sparse.pyx
+++ b/sklearn/svm/_libsvm_sparse.pyx
@@ -1,10 +1,10 @@
 import warnings
 import  numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from scipy import sparse
 from ..exceptions import ConvergenceWarning
 from ..utils._cython_blas cimport _dot
-np.import_array()
+cnp.import_array()
 
 cdef extern from *:
     ctypedef char* const_char_p "const char*"
@@ -28,11 +28,11 @@ cdef extern from "svm.h":
 
 cdef extern from "libsvm_sparse_helper.c":
     # this file contains methods for accessing libsvm 'hidden' fields
-    svm_csr_problem * csr_set_problem (char *, np.npy_intp *,
-         char *, np.npy_intp *, char *, char *, char *, int )
+    svm_csr_problem * csr_set_problem (char *, cnp.npy_intp *,
+         char *, cnp.npy_intp *, char *, char *, char *, int )
     svm_csr_model *csr_set_model(svm_parameter *param, int nr_class,
-                            char *SV_data, np.npy_intp *SV_indices_dims,
-                            char *SV_indices, np.npy_intp *SV_intptr_dims,
+                            char *SV_data, cnp.npy_intp *SV_indices_dims,
+                            char *SV_indices, cnp.npy_intp *SV_intptr_dims,
                             char *SV_intptr,
                             char *sv_coef, char *rho, char *nSV,
                             char *probA, char *probB)
@@ -43,28 +43,28 @@ cdef extern from "libsvm_sparse_helper.c":
     void copy_sv_coef   (char *, svm_csr_model *)
     void copy_n_iter  (char *, svm_csr_model *)
     void copy_support   (char *, svm_csr_model *)
-    void copy_intercept (char *, svm_csr_model *, np.npy_intp *)
-    int copy_predict (char *, svm_csr_model *, np.npy_intp *, char *, BlasFunctions *)
-    int csr_copy_predict_values (np.npy_intp *data_size, char *data, np.npy_intp *index_size,
-        	char *index, np.npy_intp *intptr_size, char *size,
+    void copy_intercept (char *, svm_csr_model *, cnp.npy_intp *)
+    int copy_predict (char *, svm_csr_model *, cnp.npy_intp *, char *, BlasFunctions *)
+    int csr_copy_predict_values (cnp.npy_intp *data_size, char *data, cnp.npy_intp *index_size,
+        	char *index, cnp.npy_intp *intptr_size, char *size,
                 svm_csr_model *model, char *dec_values, int nr_class, BlasFunctions *)
-    int csr_copy_predict (np.npy_intp *data_size, char *data, np.npy_intp *index_size,
-        	char *index, np.npy_intp *intptr_size, char *size,
+    int csr_copy_predict (cnp.npy_intp *data_size, char *data, cnp.npy_intp *index_size,
+        	char *index, cnp.npy_intp *intptr_size, char *size,
                 svm_csr_model *model, char *dec_values, BlasFunctions *) nogil
-    int csr_copy_predict_proba (np.npy_intp *data_size, char *data, np.npy_intp *index_size,
-        	char *index, np.npy_intp *intptr_size, char *size,
+    int csr_copy_predict_proba (cnp.npy_intp *data_size, char *data, cnp.npy_intp *index_size,
+        	char *index, cnp.npy_intp *intptr_size, char *size,
                 svm_csr_model *model, char *dec_values, BlasFunctions *) nogil
 
-    int  copy_predict_values(char *, svm_csr_model *, np.npy_intp *, char *, int, BlasFunctions *)
-    int  csr_copy_SV (char *values, np.npy_intp *n_indices,
-        	char *indices, np.npy_intp *n_indptr, char *indptr,
+    int  copy_predict_values(char *, svm_csr_model *, cnp.npy_intp *, char *, int, BlasFunctions *)
+    int  csr_copy_SV (char *values, cnp.npy_intp *n_indices,
+        	char *indices, cnp.npy_intp *n_indptr, char *indptr,
                 svm_csr_model *model, int n_features)
-    np.npy_intp get_nonzero_SV ( svm_csr_model *)
+    cnp.npy_intp get_nonzero_SV ( svm_csr_model *)
     void copy_nSV     (char *, svm_csr_model *)
-    void copy_probA   (char *, svm_csr_model *, np.npy_intp *)
-    void copy_probB   (char *, svm_csr_model *, np.npy_intp *)
-    np.npy_intp  get_l  (svm_csr_model *)
-    np.npy_intp  get_nr (svm_csr_model *)
+    void copy_probA   (char *, svm_csr_model *, cnp.npy_intp *)
+    void copy_probB   (char *, svm_csr_model *, cnp.npy_intp *)
+    cnp.npy_intp  get_l  (svm_csr_model *)
+    cnp.npy_intp  get_nr (svm_csr_model *)
     int  free_problem   (svm_csr_problem *)
     int  free_model     (svm_csr_model *)
     int  free_param     (svm_parameter *)
@@ -72,21 +72,21 @@ cdef extern from "libsvm_sparse_helper.c":
     void set_verbosity(int)
 
 
-np.import_array()
+cnp.import_array()
 
 
-def libsvm_sparse_train ( int n_features,
-                     np.ndarray[np.float64_t, ndim=1, mode='c'] values,
-                     np.ndarray[np.int32_t,   ndim=1, mode='c'] indices,
-                     np.ndarray[np.int32_t,   ndim=1, mode='c'] indptr,
-                     np.ndarray[np.float64_t, ndim=1, mode='c'] Y,
-                     int svm_type, int kernel_type, int degree, double gamma,
-                     double coef0, double eps, double C,
-                     np.ndarray[np.float64_t, ndim=1, mode='c'] class_weight,
-                     np.ndarray[np.float64_t, ndim=1, mode='c'] sample_weight,
-                     double nu, double cache_size, double p, int
-                     shrinking, int probability, int max_iter,
-                     int random_seed):
+def libsvm_sparse_train (int n_features,
+                         cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] values,
+                         cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] indices,
+                         cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] indptr,
+                         cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] Y,
+                         int svm_type, int kernel_type, int degree, double gamma,
+                         double coef0, double eps, double C,
+                         cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] class_weight,
+                         cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] sample_weight,
+                         double nu, double cache_size, double p, int
+                         shrinking, int probability, int max_iter,
+                         int random_seed):
     """
     Wrap svm_train from libsvm using a scipy.sparse.csr matrix
 
@@ -132,7 +132,7 @@ def libsvm_sparse_train ( int n_features,
                               indptr.shape, indptr.data, Y.data,
                               sample_weight.data, kernel_type)
 
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
 
     # set parameters
@@ -157,40 +157,40 @@ def libsvm_sparse_train ( int n_features,
     with nogil:
         model = svm_csr_train(problem, param, &fit_status, &blas_functions)
 
-    cdef np.npy_intp SV_len = get_l(model)
-    cdef np.npy_intp n_class = get_nr(model)
+    cdef cnp.npy_intp SV_len = get_l(model)
+    cdef cnp.npy_intp n_class = get_nr(model)
 
-    cdef np.ndarray[int, ndim=1, mode='c'] n_iter
+    cdef cnp.ndarray[int, ndim=1, mode='c'] n_iter
     n_iter = np.empty(max(1, n_class * (n_class - 1) // 2), dtype=np.intc)
     copy_n_iter(n_iter.data, model)
 
     # copy model.sv_coef
     # we create a new array instead of resizing, otherwise
     # it would not erase previous information
-    cdef np.ndarray sv_coef_data
+    cdef cnp.ndarray sv_coef_data
     sv_coef_data = np.empty((n_class-1)*SV_len, dtype=np.float64)
     copy_sv_coef (sv_coef_data.data, model)
 
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] support
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] support
     support = np.empty(SV_len, dtype=np.int32)
     copy_support(support.data, model)
 
     # copy model.rho into the intercept
     # the intercept is just model.rho but with sign changed
-    cdef np.ndarray intercept
+    cdef cnp.ndarray intercept
     intercept = np.empty(n_class*(n_class-1)//2, dtype=np.float64)
     copy_intercept (intercept.data, model, intercept.shape)
 
     # copy model.SV
     # we erase any previous information in SV
     # TODO: custom kernel
-    cdef np.npy_intp nonzero_SV
+    cdef cnp.npy_intp nonzero_SV
     nonzero_SV = get_nonzero_SV (model)
 
-    cdef np.ndarray SV_data, SV_indices, SV_indptr
+    cdef cnp.ndarray SV_data, SV_indices, SV_indptr
     SV_data = np.empty(nonzero_SV, dtype=np.float64)
     SV_indices = np.empty(nonzero_SV, dtype=np.int32)
-    SV_indptr = np.empty(<np.npy_intp>SV_len + 1, dtype=np.int32)
+    SV_indptr = np.empty(<cnp.npy_intp>SV_len + 1, dtype=np.int32)
     csr_copy_SV(SV_data.data, SV_indices.shape, SV_indices.data,
                 SV_indptr.shape, SV_indptr.data, model, n_features)
     support_vectors_ = sparse.csr_matrix(
@@ -198,12 +198,12 @@ def libsvm_sparse_train ( int n_features,
 
     # copy model.nSV
     # TODO: do only in classification
-    cdef np.ndarray n_class_SV
+    cdef cnp.ndarray n_class_SV
     n_class_SV = np.empty(n_class, dtype=np.int32)
     copy_nSV(n_class_SV.data, model)
 
     # # copy probabilities
-    cdef np.ndarray probA, probB
+    cdef cnp.ndarray probA, probB
     if probability != 0:
         if svm_type < 2: # SVC and NuSVC
             probA = np.empty(n_class*(n_class-1)//2, dtype=np.float64)
@@ -225,23 +225,23 @@ def libsvm_sparse_train ( int n_features,
             probA, probB, fit_status, n_iter)
 
 
-def libsvm_sparse_predict (np.ndarray[np.float64_t, ndim=1, mode='c'] T_data,
-                            np.ndarray[np.int32_t,   ndim=1, mode='c'] T_indices,
-                            np.ndarray[np.int32_t,   ndim=1, mode='c'] T_indptr,
-                            np.ndarray[np.float64_t, ndim=1, mode='c'] SV_data,
-                            np.ndarray[np.int32_t,   ndim=1, mode='c'] SV_indices,
-                            np.ndarray[np.int32_t,   ndim=1, mode='c'] SV_indptr,
-                            np.ndarray[np.float64_t, ndim=1, mode='c'] sv_coef,
-                            np.ndarray[np.float64_t, ndim=1, mode='c']
-                            intercept, int svm_type, int kernel_type, int
-                            degree, double gamma, double coef0, double
-                            eps, double C,
-                            np.ndarray[np.float64_t, ndim=1] class_weight,
-                            double nu, double p, int
-                            shrinking, int probability,
-                            np.ndarray[np.int32_t, ndim=1, mode='c'] nSV,
-                            np.ndarray[np.float64_t, ndim=1, mode='c'] probA,
-                            np.ndarray[np.float64_t, ndim=1, mode='c'] probB):
+def libsvm_sparse_predict (cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] T_data,
+                           cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] T_indices,
+                           cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] T_indptr,
+                           cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] SV_data,
+                           cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] SV_indices,
+                           cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] SV_indptr,
+                           cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] sv_coef,
+                           cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
+                           intercept, int svm_type, int kernel_type, int
+                           degree, double gamma, double coef0, double
+                           eps, double C,
+                           cnp.ndarray[cnp.float64_t, ndim=1] class_weight,
+                           double nu, double p, int
+                           shrinking, int probability,
+                           cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] nSV,
+                           cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probA,
+                           cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probB):
     """
     Predict values T given a model.
 
@@ -264,10 +264,10 @@ def libsvm_sparse_predict (np.ndarray[np.float64_t, ndim=1, mode='c'] T_data,
     dec_values : array
         predicted values.
     """
-    cdef np.ndarray[np.float64_t, ndim=1, mode='c'] dec_values
+    cdef cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] dec_values
     cdef svm_parameter *param
     cdef svm_csr_model *model
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
     cdef int rv
     param = set_parameter(svm_type, kernel_type, degree, gamma,
@@ -303,29 +303,29 @@ def libsvm_sparse_predict (np.ndarray[np.float64_t, ndim=1, mode='c'] T_data,
 
 
 def libsvm_sparse_predict_proba(
-    np.ndarray[np.float64_t, ndim=1, mode='c'] T_data,
-    np.ndarray[np.int32_t,   ndim=1, mode='c'] T_indices,
-    np.ndarray[np.int32_t,   ndim=1, mode='c'] T_indptr,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] SV_data,
-    np.ndarray[np.int32_t,   ndim=1, mode='c'] SV_indices,
-    np.ndarray[np.int32_t,   ndim=1, mode='c'] SV_indptr,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] sv_coef,
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] T_data,
+    cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] T_indices,
+    cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] T_indptr,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] SV_data,
+    cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] SV_indices,
+    cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] SV_indptr,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] sv_coef,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
     intercept, int svm_type, int kernel_type, int
     degree, double gamma, double coef0, double
     eps, double C,
-    np.ndarray[np.float64_t, ndim=1] class_weight,
+    cnp.ndarray[cnp.float64_t, ndim=1] class_weight,
     double nu, double p, int shrinking, int probability,
-    np.ndarray[np.int32_t, ndim=1, mode='c'] nSV,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] probA,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] probB):
+    cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] nSV,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probA,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probB):
     """
     Predict values T given a model.
     """
-    cdef np.ndarray[np.float64_t, ndim=2, mode='c'] dec_values
+    cdef cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] dec_values
     cdef svm_parameter *param
     cdef svm_csr_model *model
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
     param = set_parameter(svm_type, kernel_type, degree, gamma,
                           coef0, nu,
@@ -341,7 +341,7 @@ def libsvm_sparse_predict_proba(
                           sv_coef.data, intercept.data,
                           nSV.data, probA.data, probB.data)
     #TODO: use check_model
-    cdef np.npy_intp n_class = get_nr(model)
+    cdef cnp.npy_intp n_class = get_nr(model)
     cdef int rv
     dec_values = np.empty((T_indptr.shape[0]-1, n_class), dtype=np.float64)
     cdef BlasFunctions blas_functions
@@ -364,34 +364,34 @@ def libsvm_sparse_predict_proba(
 
 
 def libsvm_sparse_decision_function(
-    np.ndarray[np.float64_t, ndim=1, mode='c'] T_data,
-    np.ndarray[np.int32_t,   ndim=1, mode='c'] T_indices,
-    np.ndarray[np.int32_t,   ndim=1, mode='c'] T_indptr,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] SV_data,
-    np.ndarray[np.int32_t,   ndim=1, mode='c'] SV_indices,
-    np.ndarray[np.int32_t,   ndim=1, mode='c'] SV_indptr,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] sv_coef,
-    np.ndarray[np.float64_t, ndim=1, mode='c']
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] T_data,
+    cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] T_indices,
+    cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] T_indptr,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] SV_data,
+    cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] SV_indices,
+    cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] SV_indptr,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] sv_coef,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
     intercept, int svm_type, int kernel_type, int
     degree, double gamma, double coef0, double
     eps, double C,
-    np.ndarray[np.float64_t, ndim=1] class_weight,
+    cnp.ndarray[cnp.float64_t, ndim=1] class_weight,
     double nu, double p, int shrinking, int probability,
-    np.ndarray[np.int32_t, ndim=1, mode='c'] nSV,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] probA,
-    np.ndarray[np.float64_t, ndim=1, mode='c'] probB):
+    cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] nSV,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probA,
+    cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probB):
     """
     Predict margin (libsvm name for this is predict_values)
 
     We have to reconstruct model and parameters to make sure we stay
     in sync with the python object.
     """
-    cdef np.ndarray[np.float64_t, ndim=2, mode='c'] dec_values
+    cdef cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] dec_values
     cdef svm_parameter *param
-    cdef np.npy_intp n_class
+    cdef cnp.npy_intp n_class
 
     cdef svm_csr_model *model
-    cdef np.ndarray[np.int32_t, ndim=1, mode='c'] \
+    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
         class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
     param = set_parameter(svm_type, kernel_type, degree, gamma,
                           coef0, nu,

--- a/sklearn/svm/_libsvm_sparse.pyx
+++ b/sklearn/svm/_libsvm_sparse.pyx
@@ -72,9 +72,6 @@ cdef extern from "libsvm_sparse_helper.c":
     void set_verbosity(int)
 
 
-cnp.import_array()
-
-
 def libsvm_sparse_train (int n_features,
                          cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] values,
                          cnp.ndarray[cnp.int32_t,   ndim=1, mode='c'] indices,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #23295 (`sklearn/svm`)

#### What does this implement/fix? Explain your changes.

Change `np` to `cnp` to reference NumPy's C API according to issue #23295 for `sklearn/svm/*`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->