### PR TITLE
MNT Use cimport numpy as cnp for sklearn/decomposition

### DIFF
--- a/sklearn/decomposition/_online_lda_fast.pyx
+++ b/sklearn/decomposition/_online_lda_fast.pyx
@@ -1,22 +1,22 @@
 cimport cython
-cimport numpy as np
+cimport numpy as cnp
 import numpy as np
 
-np.import_array()
+cnp.import_array()
 
 from libc.math cimport exp, fabs, log
 from numpy.math cimport EULER
 
 
-def mean_change(np.ndarray[ndim=1, dtype=np.float64_t] arr_1,
-                np.ndarray[ndim=1, dtype=np.float64_t] arr_2):
+def mean_change(cnp.ndarray[ndim=1, dtype=cnp.float64_t] arr_1,
+                cnp.ndarray[ndim=1, dtype=cnp.float64_t] arr_2):
     """Calculate the mean difference between two arrays.
 
     Equivalent to np.abs(arr_1 - arr2).mean().
     """
 
-    cdef np.float64_t total, diff
-    cdef np.npy_intp i, size
+    cdef cnp.float64_t total, diff
+    cdef cnp.npy_intp i, size
 
     size = arr_1.shape[0]
     total = 0.0
@@ -27,9 +27,9 @@ def mean_change(np.ndarray[ndim=1, dtype=np.float64_t] arr_1,
     return total / size
 
 
-def _dirichlet_expectation_1d(np.ndarray[ndim=1, dtype=np.float64_t] doc_topic,
+def _dirichlet_expectation_1d(cnp.ndarray[ndim=1, dtype=cnp.float64_t] doc_topic,
                               double doc_topic_prior,
-                              np.ndarray[ndim=1, dtype=np.float64_t] out):
+                              cnp.ndarray[ndim=1, dtype=cnp.float64_t] out):
     """Dirichlet expectation for a single sample:
         exp(E[log(theta)]) for theta ~ Dir(doc_topic)
     after adding doc_topic_prior to doc_topic, in-place.
@@ -39,8 +39,8 @@ def _dirichlet_expectation_1d(np.ndarray[ndim=1, dtype=np.float64_t] doc_topic,
         out[:] = np.exp(psi(doc_topic) - psi(np.sum(doc_topic)))
     """
 
-    cdef np.float64_t dt, psi_total, total
-    cdef np.npy_intp i, size
+    cdef cnp.float64_t dt, psi_total, total
+    cdef cnp.npy_intp i, size
 
     size = doc_topic.shape[0]
 
@@ -55,7 +55,7 @@ def _dirichlet_expectation_1d(np.ndarray[ndim=1, dtype=np.float64_t] doc_topic,
         out[i] = exp(psi(doc_topic[i]) - psi_total)
 
 
-def _dirichlet_expectation_2d(np.ndarray[ndim=2, dtype=np.float64_t] arr):
+def _dirichlet_expectation_2d(cnp.ndarray[ndim=2, dtype=cnp.float64_t] arr):
     """Dirichlet expectation for multiple samples:
     E[log(theta)] for theta ~ Dir(arr).
 
@@ -64,9 +64,9 @@ def _dirichlet_expectation_2d(np.ndarray[ndim=2, dtype=np.float64_t] arr):
     Note that unlike _dirichlet_expectation_1d, this function doesn't compute
     the exp and doesn't add in the prior.
     """
-    cdef np.float64_t row_total, psi_row_total
-    cdef np.ndarray[ndim=2, dtype=np.float64_t] d_exp
-    cdef np.npy_intp i, j, n_rows, n_cols
+    cdef cnp.float64_t row_total, psi_row_total
+    cdef cnp.ndarray[ndim=2, dtype=cnp.float64_t] d_exp
+    cdef cnp.npy_intp i, j, n_rows, n_cols
 
     n_rows = arr.shape[0]
     n_cols = arr.shape[1]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #23295 (`sklearn/decomposition`)

#### What does this implement/fix? Explain your changes.

Change `np` to `cnp` to reference NumPy's C API according to issue #23295 for `sklearn/decomposition/*`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->