### PR TITLE
CI Fix arm build

### DIFF
--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -73,7 +73,6 @@ export SKLEARN_BUILD_PARALLEL=$(($N_CORES + 1))
 
 # Disable the build isolation and build in the tree so that the same folder can be
 # cached between CI runs.
-# TODO: remove the '--use-feature' flag when made obsolete in pip 21.3.
 pip install --verbose --no-build-isolation .
 
 # Report cache usage

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -41,7 +41,12 @@ mamba update --yes conda
 mamba create -n testenv --yes $(get_dep python $PYTHON_VERSION)
 source activate testenv
 
-# Use the latest by default
+# pin pip to 22.0.4 because pip 22.1 validates build dependencies in
+# pyproject.toml when using --no-build-isolation. oldest-supported-numpy is
+# part of the build dependencies in pyproject.toml so using pip 22.1 will cause
+# an error since oldest-supported-numpy is not really meant to be installed in
+# the environment. See https://github.com/scikit-learn/scikit-learn/pull/23336
+# for more details
 mamba install --verbose -y  ccache \
                             pip==22.0.4 \
                             $(get_dep numpy $NUMPY_VERSION) \

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -43,8 +43,7 @@ source activate testenv
 
 # Use the latest by default
 mamba install --verbose -y  ccache \
-                            pip \
-                      			'setuptools<60' \
+                            pip==22.0.4 \
                             $(get_dep numpy $NUMPY_VERSION) \
                             $(get_dep scipy $SCIPY_VERSION) \
                             $(get_dep cython $CYTHON_VERSION) \

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -44,6 +44,7 @@ source activate testenv
 # Use the latest by default
 mamba install --verbose -y  ccache \
                             pip \
+                      			setuptools<60 \
                             $(get_dep numpy $NUMPY_VERSION) \
                             $(get_dep scipy $SCIPY_VERSION) \
                             $(get_dep cython $CYTHON_VERSION) \

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -44,7 +44,7 @@ source activate testenv
 # Use the latest by default
 mamba install --verbose -y  ccache \
                             pip \
-                      			setuptools<60 \
+                      			'setuptools<60' \
                             $(get_dep numpy $NUMPY_VERSION) \
                             $(get_dep scipy $SCIPY_VERSION) \
                             $(get_dep cython $CYTHON_VERSION) \

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -42,11 +42,11 @@ mamba create -n testenv --yes $(get_dep python $PYTHON_VERSION)
 source activate testenv
 
 # pin pip to 22.0.4 because pip 22.1 validates build dependencies in
-# pyproject.toml when using --no-build-isolation. oldest-supported-numpy is
-# part of the build dependencies in pyproject.toml so using pip 22.1 will cause
-# an error since oldest-supported-numpy is not really meant to be installed in
-# the environment. See https://github.com/scikit-learn/scikit-learn/pull/23336
-# for more details
+# pyproject.toml. oldest-supported-numpy is part of the build dependencies in
+# pyproject.toml so using pip 22.1 will cause an error since
+# oldest-supported-numpy is not really meant to be installed in the
+# environment. See https://github.com/scikit-learn/scikit-learn/pull/23336 for
+# more details.
 mamba install --verbose -y  ccache \
                             pip==22.0.4 \
                             $(get_dep numpy $NUMPY_VERSION) \

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -74,7 +74,7 @@ export SKLEARN_BUILD_PARALLEL=$(($N_CORES + 1))
 # Disable the build isolation and build in the tree so that the same folder can be
 # cached between CI runs.
 # TODO: remove the '--use-feature' flag when made obsolete in pip 21.3.
-pip install --verbose --no-build-isolation --use-feature=in-tree-build .
+pip install --verbose --no-build-isolation .
 
 # Report cache usage
 ccache -s --verbose


### PR DESCRIPTION
`--feature=in-tree-build` option is ignored since pip 21.3 (see [here](https://pip.pypa.io/en/stable/news/#v21-3)) and gives an error in pip 22.

See this [build log](https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn/26896/workflows/574e43f0-726d-44cb-b36b-a6d0e90edcf0/jobs/192211)

After doing the easy fixes, it seems that you need to pin pip to 22.0.4. The error is that `pip` 22.1 validates build dependencies in the `pyproject.toml` and so errors because `oldest-supported-numpy` is not installed:

```
❯ pip install --no-build-isolation -v .
Using pip 22.1 from /home/local/lesteve/miniconda3/envs/scratch/lib/python3.10/site-packages/pip (python 3.10)
Obtaining file:///home/local/lesteve/dev/scikit-learn
ERROR: Some build dependencies for file:///home/local/lesteve/dev/scikit-learn are missing: 'oldest-supported-numpy'.
```