### PR TITLE
MAINT always use --no-use-pep517 instead of --no-build-isolation

### DIFF
--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -41,14 +41,7 @@ mamba update --yes conda
 mamba create -n testenv --yes $(get_dep python $PYTHON_VERSION)
 source activate testenv
 
-# pin pip to 22.0.4 because pip 22.1 validates build dependencies in
-# pyproject.toml. oldest-supported-numpy is part of the build dependencies in
-# pyproject.toml so using pip 22.1 will cause an error since
-# oldest-supported-numpy is not really meant to be installed in the
-# environment. See https://github.com/scikit-learn/scikit-learn/pull/23336 for
-# more details.
 mamba install --verbose -y  ccache \
-                            pip==22.0.4 \
                             $(get_dep numpy $NUMPY_VERSION) \
                             $(get_dep scipy $SCIPY_VERSION) \
                             $(get_dep cython $CYTHON_VERSION) \
@@ -78,7 +71,7 @@ export SKLEARN_BUILD_PARALLEL=$(($N_CORES + 1))
 
 # Disable the build isolation and build in the tree so that the same folder can be
 # cached between CI runs.
-pip install --verbose --no-build-isolation .
+pip install --verbose --no-build-isolation --no-use-pep517 .
 
 # Report cache usage
 ccache -s --verbose

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -71,7 +71,7 @@ export SKLEARN_BUILD_PARALLEL=$(($N_CORES + 1))
 
 # Disable the build isolation and build in the tree so that the same folder can be
 # cached between CI runs.
-pip install --verbose --no-build-isolation --no-use-pep517 .
+pip install --verbose --no-use-pep517 .
 
 # Report cache usage
 ccache -s --verbose

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -85,7 +85,7 @@ feature, code or documentation improvement).
 
    .. prompt:: bash $
 
-     pip install --verbose --no-build-isolation --no-use-pep517 --editable .
+     pip install --verbose --no-use-pep517 --editable .
 
 #. Check that the installed scikit-learn has a version number ending with
    `.dev0`:
@@ -99,12 +99,10 @@ feature, code or documentation improvement).
 
 .. note::
 
-    You will have to run the
-    ``pip install --no-build-isolation --no-use-pep517 --editable .``
-    command every time the source code of a Cython file is updated
-    (ending in `.pyx` or `.pxd`). Use the ``--no-build-isolation`` flag to
-    avoid compiling the whole project each time, only the files you have
-    modified.
+    You will have to run the ``pip install --no-use-pep517 --editable .``
+    command every time the source code of a Cython file is updated (ending in
+    `.pyx` or `.pxd`). Use the ``--no-build-isolation`` flag to avoid compiling
+    the whole project each time, only the files you have modified.
 
 Dependencies
 ------------
@@ -175,9 +173,9 @@ Editable mode
 
 If you run the development version, it is cumbersome to reinstall the package
 each time you update the sources. Therefore it is recommended that you install
-in with the ``pip install --no-build-isolation --no-use-pep517 --editable .``
-command, which allows you to edit the code in-place. This builds the extension
-in place and creates a link to the development directory (see `the pip docs
+in with the ``pip install --no-use-pep517 --editable .`` command, which allows
+you to edit the code in-place. This builds the extension in place and creates a
+link to the development directory (see `the pip docs
 <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_).
 
 This is fundamentally similar to using the command ``python setup.py develop``
@@ -237,7 +235,7 @@ Finally, build scikit-learn from this command prompt:
 
 .. prompt:: bash $
 
-    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
+    pip install --verbose --no-use-pep517 --editable .
 
 .. _compiler_macos:
 
@@ -279,7 +277,7 @@ scikit-learn from source:
         joblib threadpoolctl pytest compilers llvm-openmp
     conda activate sklearn-dev
     make clean
-    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
+    pip install --verbose --no-use-pep517 --editable .
 
 .. note::
 
@@ -353,7 +351,7 @@ Finally, build scikit-learn in verbose mode (to check for the presence of the
 .. prompt:: bash $
 
     make clean
-    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
+    pip install --verbose --no-use-pep517 --editable .
 
 .. _compiler_linux:
 
@@ -413,7 +411,7 @@ in the user folder using conda:
     conda create -n sklearn-dev -c conda-forge python numpy scipy cython \
         joblib threadpoolctl pytest compilers
     conda activate sklearn-dev
-    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
+    pip install --verbose --no-use-pep517 --editable .
 
 .. _compiler_freebsd:
 
@@ -442,7 +440,7 @@ Finally, build the package using the standard command:
 
 .. prompt:: bash $
 
-    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
+    pip install --verbose --no-use-pep517 --editable .
 
 For the upcoming FreeBSD 12.1 and 11.3 versions, OpenMP will be included in
 the base system and these steps will not be necessary.
@@ -533,7 +531,7 @@ and environment variable as follows before calling the ``pip install`` or
 ``python setup.py build_ext`` commands::
 
     export SKLEARN_BUILD_PARALLEL=3
-    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
+    pip install --verbose --no-use-pep517 --editable .
 
 On a machine with 2 CPU cores, it can be beneficial to use a parallelism level
 of 3 to overlap IO bound tasks (reading and writing files on disk) with CPU

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -85,7 +85,7 @@ feature, code or documentation improvement).
 
    .. prompt:: bash $
 
-     pip install --verbose --no-build-isolation --editable .
+     pip install --verbose --no-build-isolation --no-use-pep517 --editable .
 
 #. Check that the installed scikit-learn has a version number ending with
    `.dev0`:
@@ -99,7 +99,8 @@ feature, code or documentation improvement).
 
 .. note::
 
-    You will have to run the ``pip install --no-build-isolation --editable .``
+    You will have to run the
+    ``pip install --no-build-isolation --no-use-pep517 --editable .``
     command every time the source code of a Cython file is updated
     (ending in `.pyx` or `.pxd`). Use the ``--no-build-isolation`` flag to
     avoid compiling the whole project each time, only the files you have
@@ -174,9 +175,9 @@ Editable mode
 
 If you run the development version, it is cumbersome to reinstall the package
 each time you update the sources. Therefore it is recommended that you install
-in with the ``pip install --no-build-isolation --editable .`` command, which
-allows you to edit the code in-place. This builds the extension in place and
-creates a link to the development directory (see `the pip docs
+in with the ``pip install --no-build-isolation --no-use-pep517 --editable .``
+command, which allows you to edit the code in-place. This builds the extension
+in place and creates a link to the development directory (see `the pip docs
 <https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_).
 
 This is fundamentally similar to using the command ``python setup.py develop``
@@ -236,7 +237,7 @@ Finally, build scikit-learn from this command prompt:
 
 .. prompt:: bash $
 
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
 
 .. _compiler_macos:
 
@@ -278,7 +279,7 @@ scikit-learn from source:
         joblib threadpoolctl pytest compilers llvm-openmp
     conda activate sklearn-dev
     make clean
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
 
 .. note::
 
@@ -352,7 +353,7 @@ Finally, build scikit-learn in verbose mode (to check for the presence of the
 .. prompt:: bash $
 
     make clean
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
 
 .. _compiler_linux:
 
@@ -412,7 +413,7 @@ in the user folder using conda:
     conda create -n sklearn-dev -c conda-forge python numpy scipy cython \
         joblib threadpoolctl pytest compilers
     conda activate sklearn-dev
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
 
 .. _compiler_freebsd:
 
@@ -441,7 +442,7 @@ Finally, build the package using the standard command:
 
 .. prompt:: bash $
 
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
 
 For the upcoming FreeBSD 12.1 and 11.3 versions, OpenMP will be included in
 the base system and these steps will not be necessary.
@@ -532,7 +533,7 @@ and environment variable as follows before calling the ``pip install`` or
 ``python setup.py build_ext`` commands::
 
     export SKLEARN_BUILD_PARALLEL=3
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-build-isolation --no-use-pep517 --editable .
 
 On a machine with 2 CPU cores, it can be beneficial to use a parallelism level
 of 3 to overlap IO bound tasks (reading and writing files on disk) with CPU


### PR DESCRIPTION
As observed in #23336, the latest version of pip (22.1) always checks that all the dependencies in `pyproject.toml` are installed before proceeding.

However to make sure that packaged versions of scikit-learn are binary compatible with old versions of numpy, we use the `oldest-supported-numpy` meta-package as a dependency in our `pyproject.toml` file.

But then when we develop, we typically want to build scikit-learn and run in the same env with a recent version of numpy and the pinning imposed by `oldest-supported-numpy` is preventing this.

So we need to pass `--no-use-pep517` whenever we use `--no-build-isolation` as a result...