### PR TITLE
FIX Enable SelfTrainingClassifier to work with vectorizers

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -71,6 +71,12 @@ Changelog
   matrices in a variety of estimators and avoid an `EfficiencyWarning`.
   :pr:`23139` by `Tom Dupre la Tour`_.
 
+:mod:`sklearn.semi_supervised`
+..............................
+
+- |Fix| :class:`semi_supervised.SelfTrainingClassifier` now delegates validation
+  to it's base estimator. :pr:`xxxxx` by `Thomas Fan`_.
+
 Code and Documentation Contributors
 -----------------------------------
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/23323


#### What does this implement/fix? Explain your changes.
This PR tries to delegate most responsibilities to the base estimator in `SelfTrainingClassifier`. Note this PR will fail this test:

https://github.com/scikit-learn/scikit-learn/blob/a47d569e670fd4102af37c3165c9b1ddf6fd3005/sklearn/utils/estimator_checks.py#L3076

because it does not cast the "NotAnArray" to a ndarray, which means it can not index it anymore with `_safe_indexing`. The only work around I see is for `_safe_indexing` to call `np.asarray` so the "NotAnArray" can be indexed

#### Any other comments?
I have an PR with a similar issue at https://github.com/scikit-learn/scikit-learn/pull/21811. In that case `Bagging` is trying to index the array in both axis.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
