### PR TITLE
MNT Use cimport numpy as cnp for sklearn/preprocessing

### DIFF
--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -2,16 +2,16 @@
 
 from scipy.sparse import csr_matrix
 from numpy cimport ndarray
-cimport numpy as np
+cimport numpy as cnp
 
-np.import_array()
-ctypedef np.int32_t INDEX_T
+cnp.import_array()
+ctypedef cnp.int32_t INDEX_T
 
 ctypedef fused DATA_T:
-    np.float32_t
-    np.float64_t
-    np.int32_t
-    np.int64_t
+    cnp.float32_t
+    cnp.float64_t
+    cnp.int32_t
+    cnp.int64_t
 
 
 cdef inline INDEX_T _deg2_column(INDEX_T d, INDEX_T i, INDEX_T j,

--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -111,7 +111,7 @@ def _csr_polynomial_expansion(cnp.ndarray[DATA_T, ndim=1] data,
     cdef cnp.ndarray[INDEX_T, ndim=1] expanded_indices = cnp.ndarray(
         shape=total_nnz, dtype=indices.dtype)
     cdef INDEX_T num_rows = indptr.shape[0] - 1
-    cdef cnp.ndarray[INDEX_T, ndim=1] expanded_indptr = np.ndarray(
+    cdef cnp.ndarray[INDEX_T, ndim=1] expanded_indptr = cnp.ndarray(
         shape=num_rows + 1, dtype=indptr.dtype)
 
     cdef INDEX_T expanded_index = 0, row_starts, row_ends, i, j, k, \

--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -108,7 +108,7 @@ def _csr_polynomial_expansion(cnp.ndarray[DATA_T, ndim=1] data,
     # Make the arrays that will form the CSR matrix of the expansion.
     cdef cnp.ndarray[DATA_T, ndim=1] expanded_data = cnp.ndarray(
         shape=total_nnz, dtype=data.dtype)
-    cdef cnp.ndarray[INDEX_T, ndim=1] expanded_indices = np.ndarray(
+    cdef cnp.ndarray[INDEX_T, ndim=1] expanded_indices = cnp.ndarray(
         shape=total_nnz, dtype=indices.dtype)
     cdef INDEX_T num_rows = indptr.shape[0] - 1
     cdef cnp.ndarray[INDEX_T, ndim=1] expanded_indptr = np.ndarray(

--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -106,7 +106,7 @@ def _csr_polynomial_expansion(cnp.ndarray[DATA_T, ndim=1] data,
                           - interaction_only * nnz ** 2)
 
     # Make the arrays that will form the CSR matrix of the expansion.
-    cdef cnp.ndarray[DATA_T, ndim=1] expanded_data = np.ndarray(
+    cdef cnp.ndarray[DATA_T, ndim=1] expanded_data = cnp.ndarray(
         shape=total_nnz, dtype=data.dtype)
     cdef cnp.ndarray[INDEX_T, ndim=1] expanded_indices = np.ndarray(
         shape=total_nnz, dtype=indices.dtype)

--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -1,7 +1,6 @@
 # Author: Andrew nystrom <awnystrom@gmail.com>
 
 from scipy.sparse import csr_matrix
-import numpy as np
 cimport numpy as cnp
 
 cnp.import_array()

--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -1,7 +1,7 @@
 # Author: Andrew nystrom <awnystrom@gmail.com>
 
 from scipy.sparse import csr_matrix
-from numpy cimport ndarray
+import numpy as np
 cimport numpy as cnp
 
 cnp.import_array()
@@ -44,9 +44,9 @@ cdef inline INDEX_T _deg3_column(INDEX_T d, INDEX_T i, INDEX_T j, INDEX_T k,
                 + d * j + k)
 
 
-def _csr_polynomial_expansion(ndarray[DATA_T, ndim=1] data,
-                              ndarray[INDEX_T, ndim=1] indices,
-                              ndarray[INDEX_T, ndim=1] indptr,
+def _csr_polynomial_expansion(cnp.ndarray[DATA_T, ndim=1] data,
+                              cnp.ndarray[INDEX_T, ndim=1] indices,
+                              cnp.ndarray[INDEX_T, ndim=1] indptr,
                               INDEX_T d, INDEX_T interaction_only,
                               INDEX_T degree):
     """
@@ -106,12 +106,12 @@ def _csr_polynomial_expansion(ndarray[DATA_T, ndim=1] data,
                           - interaction_only * nnz ** 2)
 
     # Make the arrays that will form the CSR matrix of the expansion.
-    cdef ndarray[DATA_T, ndim=1] expanded_data = ndarray(
+    cdef cnp.ndarray[DATA_T, ndim=1] expanded_data = np.ndarray(
         shape=total_nnz, dtype=data.dtype)
-    cdef ndarray[INDEX_T, ndim=1] expanded_indices = ndarray(
+    cdef cnp.ndarray[INDEX_T, ndim=1] expanded_indices = np.ndarray(
         shape=total_nnz, dtype=indices.dtype)
     cdef INDEX_T num_rows = indptr.shape[0] - 1
-    cdef ndarray[INDEX_T, ndim=1] expanded_indptr = ndarray(
+    cdef cnp.ndarray[INDEX_T, ndim=1] expanded_indptr = np.ndarray(
         shape=num_rows + 1, dtype=indptr.dtype)
 
     cdef INDEX_T expanded_index = 0, row_starts, row_ends, i, j, k, \


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #23295 (`sklearn/preprocessing`)

#### What does this implement/fix? Explain your changes.

Change `np` to `cnp` to reference NumPy's C API according to issue #23295 for `sklearn/preprocessing/*`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->