### PR TITLE
MNT Use cimport numpy as cnp for sklearn/mainfold

### DIFF
--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -6,7 +6,7 @@
 
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from libc.stdio cimport printf
 from libc.math cimport sqrt, log
 from libc.stdlib cimport malloc, free
@@ -14,7 +14,7 @@ from cython.parallel cimport prange, parallel
 
 from ..neighbors._quad_tree cimport _QuadTree
 
-np.import_array()
+cnp.import_array()
 
 
 cdef char* EMPTY_STRING = ""
@@ -45,8 +45,8 @@ cdef extern from "time.h":
 
 cdef float compute_gradient(float[:] val_P,
                             float[:, :] pos_reference,
-                            np.int64_t[:] neighbors,
-                            np.int64_t[:] indptr,
+                            cnp.int64_t[:] neighbors,
+                            cnp.int64_t[:] indptr,
                             float[:, :] tot_force,
                             _QuadTree qt,
                             float theta,
@@ -103,13 +103,13 @@ cdef float compute_gradient(float[:] val_P,
 
 cdef float compute_gradient_positive(float[:] val_P,
                                      float[:, :] pos_reference,
-                                     np.int64_t[:] neighbors,
-                                     np.int64_t[:] indptr,
+                                     cnp.int64_t[:] neighbors,
+                                     cnp.int64_t[:] indptr,
                                      float* pos_f,
                                      int n_dimensions,
                                      int dof,
                                      double sum_Q,
-                                     np.int64_t start,
+                                     cnp.int64_t start,
                                      int verbose,
                                      bint compute_error,
                                      int num_threads) nogil:
@@ -258,8 +258,8 @@ cdef double compute_gradient_negative(float[:, :] pos_reference,
 
 def gradient(float[:] val_P,
              float[:, :] pos_output,
-             np.int64_t[:] neighbors,
-             np.int64_t[:] indptr,
+             cnp.int64_t[:] neighbors,
+             cnp.int64_t[:] indptr,
              float[:, :] forces,
              float theta,
              int n_dimensions,

--- a/sklearn/manifold/_utils.pyx
+++ b/sklearn/manifold/_utils.pyx
@@ -1,10 +1,9 @@
 from libc cimport math
-cimport cython
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from libc.stdio cimport printf
 
-np.import_array()
+cnp.import_array()
 
 
 cdef extern from "numpy/npy_math.h":
@@ -14,8 +13,8 @@ cdef extern from "numpy/npy_math.h":
 cdef float EPSILON_DBL = 1e-8
 cdef float PERPLEXITY_TOLERANCE = 1e-5
 
-cpdef np.ndarray[np.float32_t, ndim=2] _binary_search_perplexity(
-        np.ndarray[np.float32_t, ndim=2] sqdistances,
+cpdef cnp.ndarray[cnp.float32_t, ndim=2] _binary_search_perplexity(
+        cnp.ndarray[cnp.float32_t, ndim=2] sqdistances,
         float desired_perplexity,
         int verbose):
     """Binary search for sigmas of conditional Gaussians.
@@ -65,7 +64,7 @@ cpdef np.ndarray[np.float32_t, ndim=2] _binary_search_perplexity(
 
     # This array is later used as a 32bit array. It has multiple intermediate
     # floating point additions that benefit from the extra precision
-    cdef np.ndarray[np.float64_t, ndim=2] P = np.zeros(
+    cdef cnp.ndarray[cnp.float64_t, ndim=2] P = np.zeros(
         (n_samples, n_neighbors), dtype=np.float64)
 
     for i in range(n_samples):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #23295 (`sklearn/manifold`)

#### What does this implement/fix? Explain your changes.

Change `np` to `cnp` to reference NumPy's C API according to issue #23295 for `sklearn/manifold/*`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->