### PR TITLE
FIX Update randomized SVD benchmark

### DIFF
--- a/benchmarks/bench_plot_randomized_svd.py
+++ b/benchmarks/bench_plot_randomized_svd.py
@@ -153,7 +153,7 @@ def get_data(dataset_name):
     elif dataset_name == "rcv1":
         X = fetch_rcv1().data
     elif dataset_name == "CIFAR":
-        if handle_missing_dataset(CIFAR_FOLDER) == "skip":
+        if handle_missing_dataset(CIFAR_FOLDER) == 0:
             return
         X1 = [unpickle("%sdata_batch_%d" % (CIFAR_FOLDER, i + 1)) for i in range(5)]
         X = np.vstack(X1)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -240,6 +240,11 @@ def randomized_range_finder(
     # Sample the range of A using by linear projection of Q
     # Extract an orthonormal basis
     Q, _ = linalg.qr(safe_sparse_dot(A, Q), mode="economic")
+
+    if hasattr(A, "dtype") and A.dtype.kind == "f":
+        # Ensure f32 is preserved as f32
+        Q = Q.astype(A.dtype, copy=False)
+
     return Q
 
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -216,9 +216,6 @@ def randomized_range_finder(
 
     # Generating normal random vectors with shape: (A.shape[1], size)
     Q = random_state.normal(size=(A.shape[1], size))
-    if A.dtype.kind == "f":
-        # Ensure f32 is preserved as f32
-        Q = Q.astype(A.dtype, copy=False)
 
     # Deal with "auto" mode
     if power_iteration_normalizer == "auto":


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #23262 

#### What does this implement/fix? Explain your changes.
Try to fix #23262. After some debugging, I found the Randomized SVD benchmark is broken because the `float32` matrix `Q` will cause numeric overflow. Simply removing the following lines of code could solve the error. I am not familiar with the history and background behind these lines of code. Appreciate any extra information.
```python
 if A.dtype.kind == "f":
      # Ensure f32 is preserved as f32
      Q = Q.astype(A.dtype, copy=False)
```
Also, replace `skip` with `0` to match the return value of `handle_missing_dataset` which returns `0` when the dataset is missing.
#### Any other comments?
Especially, the lfw_people dataset seems to fail by using float32 matrix Q. 
Appreciate any extra information and comments.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
