### PR TITLE
DOC weighted&micro avg recall same as accuracy; macro same as (unadj.) balanced accuracy

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1836,16 +1836,21 @@ def recall_score(
             This is applicable only if targets (``y_{true,pred}``) are binary.
         ``'micro'``:
             Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
+            false negatives and false positives. This gives the
+            same result as 'weighted' and is identical to the 
+            :func:`accuracy_score`.
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
-            mean.  This does not take label imbalance into account.
+            mean.  This does not take label imbalance into account.  The result
+            is identical to the result of :func:`balanced_accuracy_score` (with
+            its default adjusted=False).
         ``'weighted'``:
             Calculate metrics for each label, and find their average weighted
             by support (the number of true instances for each label). This
-            alters 'macro' to account for label imbalance; it can result in an
-            F-score that is not between precision and recall. Weighted recall
-            is equal to accuracy.
+            alters 'macro' to account for label imbalance and gives the same
+            result as 'micro', and in fact the same result as 
+            :func:`accuracy_score`. It can result in an
+            F-score that is not between precision and recall.
         ``'samples'``:
             Calculate metrics for each instance, and find their average (only
             meaningful for multilabel classification where this differs from

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1836,7 +1836,8 @@ def recall_score(
             This is applicable only if targets (``y_{true,pred}``) are binary.
         ``'micro'``:
             Calculate metrics globally by counting the total true positives,
-            false negatives and false positives (or summing their weights).  
+            false negatives and false positives (or summing their weights).
+            Gives same result as 'weighted'.
             Except in multilabel classification, this and 'weighted' are both  
             identical to the result of :func:`accuracy_score`.   It can result 
             in an F-score that is not between precision and recall.
@@ -1849,8 +1850,9 @@ def recall_score(
         ``'weighted'``:
             Calculate metrics for each label, and find their average weighted
             by support (the number or total weight of true instances for each 
-            label). This alters 'macro' to account for label imbalance.  Except 
-            in multilabel classification, this and 'micro' are both  
+            label). This alters 'macro' to account for label imbalance.  
+            Gives same result as 'micro'.
+            Except in multilabel classification, this and 'micro' are both  
             identical to the result of :func:`accuracy_score`.   It can result 
             in an F-score that is not between precision and recall.
         ``'samples'``:

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2085,8 +2085,18 @@ def classification_report(
         See also :func:`precision_recall_fscore_support` for more details
         on averages.
 
-        Note that in binary classification, recall of the positive class
-        is also known as "sensitivity"; recall of the negative class is
+        Note that whenever accuracy is shown in the report, i.e. for binary 
+        or multiclass (not multilabel) classification, it is identical to the 
+        weighted average recall which is also being shown.  (See 
+        :func:`recall_score` with average='weighted' and average='micro'.)
+
+        Also note that the macro average recall is identical to 
+        :func:`balanced_accuracy_score` (with its default adjusted=False), 
+        except in multilabel classification (which is not supported by 
+        :func:`balanced_accuracy_score` anyway).
+
+        Finally, note that in binary classification, recall of the positive
+        class is also known as "sensitivity"; recall of the negative class is
         "specificity".
 
     See Also

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1836,23 +1836,23 @@ def recall_score(
             This is applicable only if targets (``y_{true,pred}``) are binary.
         ``'micro'``:
             Calculate metrics globally by counting the total true positives,
-            false negatives and false positives. This is identical to the 
-            :func:`accuracy_score`, and except in multi-label classification,
-            gives the same result as 'weighted' as well.
+            false negatives and false positives (or summing their weights).  
+            Except in multilabel classification, this and 'weighted' are both  
+            identical to the result of :func:`accuracy_score`.   It can result 
+            in an F-score that is not between precision and recall.
         ``'macro'``:
-            Calculate metrics for each label, and find their unweighted
-            mean.  This does not take label imbalance into account.  At least
-            for binary and multi-class classification, this is identical
-            to the result of :func:`balanced_accuracy_score` (with its
-            default adjusted=False).
+            Calculate metrics for each label, and find their simple (unweighted)
+            mean.  This does not take label imbalance into account.  This is 
+            identical to the result of :func:`balanced_accuracy_score` (with 
+            its default adjusted=False), except in multilabel classification
+            which is not supported by :func:`balanced_accuracy_score`.
         ``'weighted'``:
             Calculate metrics for each label, and find their average weighted
-            by support (the number of true instances for each label). This
-            alters 'macro' to account for label imbalance and, except in
-            the multi-label case, gives the same result
-            as 'micro' and therefeore the same result as 
-            :func:`accuracy_score`. It can result in an
-            F-score that is not between precision and recall.
+            by support (the number or total weight of true instances for each 
+            label). This alters 'macro' to account for label imbalance.  Except 
+            in multilabel classification, this and 'micro' are both  
+            identical to the result of :func:`accuracy_score`.   It can result 
+            in an F-score that is not between precision and recall.
         ``'samples'``:
             Calculate metrics for each instance, and find their average (only
             meaningful for multilabel classification where this differs from

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1836,19 +1836,21 @@ def recall_score(
             This is applicable only if targets (``y_{true,pred}``) are binary.
         ``'micro'``:
             Calculate metrics globally by counting the total true positives,
-            false negatives and false positives. This gives the
-            same result as 'weighted' and is identical to the 
-            :func:`accuracy_score`.
+            false negatives and false positives. This is identical to the 
+            :func:`accuracy_score`, and except in multi-label classification,
+            gives the same result as 'weighted' as well.
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
-            mean.  This does not take label imbalance into account.  The result
-            is identical to the result of :func:`balanced_accuracy_score` (with
-            its default adjusted=False).
+            mean.  This does not take label imbalance into account.  At least
+            for binary and multi-class classification, this is identical
+            to the result of :func:`balanced_accuracy_score` (with its
+            default adjusted=False).
         ``'weighted'``:
             Calculate metrics for each label, and find their average weighted
             by support (the number of true instances for each label). This
-            alters 'macro' to account for label imbalance and gives the same
-            result as 'micro', and in fact the same result as 
+            alters 'macro' to account for label imbalance and, except in
+            the multi-label case, gives the same result
+            as 'micro' and therefeore the same result as 
             :func:`accuracy_score`. It can result in an
             F-score that is not between precision and recall.
         ``'samples'``:

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1838,22 +1838,22 @@ def recall_score(
             Calculate metrics globally by counting the total true positives,
             false negatives and false positives (or summing their weights).
             Gives same result as 'weighted'.
-            Except in multilabel classification, this and 'weighted' are both  
-            identical to the result of :func:`accuracy_score`.   It can result 
+            Except in multilabel classification, this and 'weighted' are both
+            identical to the result of :func:`accuracy_score`.   It can result
             in an F-score that is not between precision and recall.
         ``'macro'``:
             Calculate metrics for each label, and find their simple (unweighted)
-            mean.  This does not take label imbalance into account.  This is 
-            identical to the result of :func:`balanced_accuracy_score` (with 
+            mean.  This does not take label imbalance into account.  This is
+            identical to the result of :func:`balanced_accuracy_score` (with
             its default adjusted=False), except in multilabel classification
             which is not supported by :func:`balanced_accuracy_score`.
         ``'weighted'``:
             Calculate metrics for each label, and find their average weighted
-            by support (the number or total weight of true instances for each 
-            label). This alters 'macro' to account for label imbalance.  
+            by support (the number or total weight of true instances for each
+            label). This alters 'macro' to account for label imbalance.
             Gives same result as 'micro'.
-            Except in multilabel classification, this and 'micro' are both  
-            identical to the result of :func:`accuracy_score`.   It can result 
+            Except in multilabel classification, this and 'micro' are both
+            identical to the result of :func:`accuracy_score`.   It can result
             in an F-score that is not between precision and recall.
         ``'samples'``:
             Calculate metrics for each instance, and find their average (only
@@ -2087,14 +2087,14 @@ def classification_report(
         See also :func:`precision_recall_fscore_support` for more details
         on averages.
 
-        Note that whenever accuracy is shown in the report, i.e. for binary 
-        or multiclass (not multilabel) classification, it is identical to the 
-        weighted average recall which is also being shown.  (See 
+        Note that whenever accuracy is shown in the report, i.e. for binary
+        or multiclass (not multilabel) classification, it is identical to the
+        weighted average recall which is also being shown.  (See
         :func:`recall_score` with average='weighted' and average='micro'.)
 
-        Also note that the macro average recall is identical to 
-        :func:`balanced_accuracy_score` (with its default adjusted=False), 
-        except in multilabel classification (which is not supported by 
+        Also note that the macro average recall is identical to
+        :func:`balanced_accuracy_score` (with its default adjusted=False),
+        except in multilabel classification (which is not supported by
         :func:`balanced_accuracy_score` anyway).
 
         Finally, note that in binary classification, recall of the positive


### PR DESCRIPTION
Clarify that the recall_score with average='micro' always gives same result as with average='weighted'.  And except in multilabel classification, both also give same result as accuracy_score. It is important to know that there is no need to look at more than one of these three metrics/variants since all three are in fact identical, not distinct.

And also clarify that the recall score with average='macro' gives the same result as the balanced_accuracy_score, except in multilabel classification which isn't supported by balanced_accuracy_score.   Again important to know which seemingly-distinct metrics are in fact identical and so need not be compared separately which would be a redundant waste of the user's time.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Here's a (non-toy) multi-class example showing that accuracy matches weighted avg recall, and balanced accuracy matches macro avg recall, in all 15 decimal places in the classification_report :

```
classification_report(y_tst, y_pred_tst, digits=15) =
                 precision         recall            f1-score               support

              0  0.817246835443038 0.683879510095995 0.744638673634889      3021
              1  0.829678021465236 0.696708463949843 0.757401490947817      2552
              2  0.770103092783505 0.630912162162162 0.693593314763231      1184
              3  0.331294597349643 0.844155844155844 0.475841874084919       385
              4  0.394505494505494 0.920512820512820 0.552307692307692       390

       accuracy                                      0.700345193839618      7532
      macro avg  0.628565608309383 0.755233760175333 0.644756609147710      7532
   weighted avg  0.767319254559894 0.700345193839618 0.717240526308044      7532

balanced_accuracy_score(
              y_tst, y_pred_tst) = 0.755233760175333
```

(I've inserted some spaces above to fix the misalignment of the classification_report output for this many digits. Would you like to see the confusion matrix that gives rise to the classification report above?)

These matches are of course not a coincidence. If you compare the definition of accuracy to that of micro average recall, you will see that they are one and the same, and the weighted average recall is known to be equal to the micro average recall and therefore equal to the accuracy.

Similarly the definition of macro average recall is the same as the definition of balanced accuracy used (by default) by metrics.balanced_accuracy_score: basically the simple average over classes of the proportion (of sample weight) classified correctly among the actual instances of each given class.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
