### PR TITLE
FET support feature selection based on permutation importance

### DIFF
--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -148,7 +148,7 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
 
     importance_type : {'model', 'permutation'}, default='model'
         Type of feature importance used to select features. Setting it to
-        'model' will use the importance retrieved by ``importance_getter``,
+        'model' will use the feature importance retrieved by ``importance_getter``,
         setting it to `permutation` will use permutation importance.
 
         .. versionadded:: 1.2

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -525,7 +525,7 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
                 n_repeats=self.n_repeats,
                 n_jobs=self.n_jobs,
                 random_state=self.random_state,
-                sample_weight=sample_weight,
+                sample_weight=self.sample_weight,
                 max_samples=self.max_samples,
             )["importances_mean"]
 

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -652,10 +652,9 @@ def test_partial_fit_validate_feature_names(as_frame):
 
 
 def test_permutation_feature_importance():
-    X, y = datasets.make_classification(n_samples=1000, 
-                                        n_features=10,
-                                        n_informative=3,
-                                        random_state=147)
+    X, y = datasets.make_classification(
+        n_samples=1000, n_features=10, n_informative=3, random_state=147
+    )
     rf = RandomForestClassifier().fit(X, y)
     selector = SelectFromModel(estimator=rf, importance_type="permutation")
     X_new = selector.fit_transform(X, y)
@@ -665,9 +664,9 @@ def test_permutation_feature_importance():
 
     # check the selected indices is the same as calling permutation_importance directly
     n_selected = X_new.shape[1]
-    importance = permutation_importance(rf, X, y)['importances_mean']
+    importance = permutation_importance(rf, X, y)["importances_mean"]
     indices = np.argsort(-importance)[:n_selected]
-    assert(selected_indices, sorted(indices))    
+    assert_array_equal(selected_indices, sorted(indices))
 
 
 def test_not_refitted_with_permutation_importance():
@@ -681,3 +680,15 @@ def test_not_refitted_with_permutation_importance():
     selector = SelectFromModel(lr, importance_type="permutation")
     selector.fit(X, y)
     assert_array_equal(selector.estimator.coef_, coef)
+
+
+def test_transform_raise_error_with_permutation_importance():
+    X, y = datasets.make_regression(random_state=17)
+    lr = LinearRegression().fit(X, y)
+    selector = SelectFromModel(lr, importance_type="permutation")
+    err_msg = (
+        "The `fit` method must be called to calculate feature importance"
+        " when using permutation importance."
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        selector.transform(X)

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -423,7 +423,11 @@ def test_prefit():
     # `ValueError`
     clf = SGDClassifier(alpha=0.1, max_iter=10, shuffle=True, random_state=0, tol=None)
     model = SelectFromModel(clf, prefit=True)
-    err_msg = "When `prefit=True`, `estimator` is expected to be a fitted estimator."
+    err_msg = (
+        "When `prefit=True` and `importance_type='model'` or"
+        " `importance_type='permutation'`, `estimator` is expected to"
+        " be a fitted estimator."
+    )
     with pytest.raises(NotFittedError, match=err_msg):
         model.fit(data, y)
     with pytest.raises(NotFittedError, match=err_msg):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Attempt to address #15075

#### What does this implement/fix? Explain your changes.
This PR adds another parameter `importance_type` to `feature_selection.SelectFromModel`, which could be set to "permutation" to use permutation importance for feature selection.

Since permutation importance can be calculated for any other validation sets, user will need to call `fit` method to calculate the importance score before calling `transform`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
