### PR TITLE
DOC Ensures that hinge_loss passes numpydoc validation

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2494,8 +2494,7 @@ def hinge_loss(y_true, pred_decision, *, labels=None, sample_weight=None):
     Returns
     -------
     loss : float
-        Return a cumulated hinge loss value (float), which is an upper bound of the number
-        of mistakes made by the classifier.
+        Hinge loss value.
 
     References
     ----------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2494,6 +2494,8 @@ def hinge_loss(y_true, pred_decision, *, labels=None, sample_weight=None):
     Returns
     -------
     loss : float
+        Return a cumulated hinge loss value (float), which is an upper bound of the number
+        of mistakes made by the classifier.
 
     References
     ----------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2494,7 +2494,7 @@ def hinge_loss(y_true, pred_decision, *, labels=None, sample_weight=None):
     Returns
     -------
     loss : float
-        Hinge loss value.
+        Average hinge loss.
 
     References
     ----------

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -38,7 +38,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics._classification.brier_score_loss",
     "sklearn.metrics._classification.cohen_kappa_score",
     "sklearn.metrics._classification.fbeta_score",
-    "sklearn.metrics._classification.hinge_loss",
     "sklearn.metrics._classification.jaccard_score",
     "sklearn.metrics._classification.log_loss",
     "sklearn.metrics._plot.det_curve.plot_det_curve",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #21350 

#### What does this implement/fix? Explain your changes.

DOC Ensures that sklearn.metrics._classification.hinge_loss passes numpydoc validation 

- Added description for Return value of hinge_loss() in sklearn.metrics._classification.hinge_loss
- Removed sklearn.metrics._classification.hinge_loss from FUNCTION_DOCSTRING_IGNORE_LIST


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
