### PR TITLE
DOC Move 23299 what's new for 1.1.1

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -24,6 +24,13 @@ Changelog
 - |Fix| Avoid timeouts in :func:`datasets.fetch_openml` by not passing a
   `timeout` argument, :pr:`23358` by `Loïc Estève <lesteve>`.
 
+:mod:`sklearn.feature_selection`
+................................
+
+- |Fix| The `partial_fit` method of :class:`feature_selection.SelectFromModel`
+  now conducts validation for `max_features` and `feature_names_in` parameters.
+  :pr:`23299` by :user:`Long Bao <lorentzbao>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -64,13 +64,6 @@ Changelog
 - |Efficiency| Improve runtime performance of :class:`ensemble.IsolationForest`
   by avoiding data copies. :pr:`23252` by :user:`Zhehao Liu <MaxwellLZH>`.
 
-:mod:`sklearn.feature_selection`
-................................
-
-- |Fix| The `partial_fit` method of :class:`feature_selection.SelectFromModel`
-  now conducts validation for `max_features` and `feature_names_in` parameters.
-  :pr:`23299` by :user:`Long Bao <lorentzbao>`.
-
 :mod:`sklearn.metrics`
 ......................
 


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/23393

The fix for https://github.com/scikit-learn/scikit-learn/issues/23393 is already in main but was not released in 1.1.1. We should not wait 1.2 to release it. All we have to do is move the what's new to be sure to include it when we release 1.1.1.