### PR TITLE
DOC Update model persistence URL

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -332,8 +332,8 @@ class BaseEstimator:
                     "using version {2}. This might lead to breaking code or "
                     "invalid results. Use at your own risk. "
                     "For more info please refer to:\n"
-                    "https://scikit-learn.org/stable/modules/model_persistence"
-                    ".html#security-maintainability-limitations".format(
+                    "https://scikit-learn.org/stable/model_persistence.html"
+                    "#security-maintainability-limitations".format(
                         self.__class__.__name__, pickle_version, __version__
                     ),
                     UserWarning,


### PR DESCRIPTION
This PR fixes a warning-message URL.

**Before**
This URL forwards to the correct page, but the fragment component of the URL is lost in the process:
https://scikit-learn.org/stable/modules/model_persistence.html#security-maintainability-limitations

**After**
https://scikit-learn.org/stable/model_persistence.html#security-maintainability-limitations
