### PR TITLE
FIX Fixes performance regression in trees

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -33,6 +33,16 @@ Changelog
   precision=class balance.
   :pr:`23214` by :user:`Stéphane Collot <stephanecollot>` and :user:`Max Baak <mbaak>`.
 
+:mod:`sklearn.tree`
+...................
+
+- |Fix| Fixes performance regression :class:`tree.DecisionTreeClassifier`,
+  :class:`tree.DecisionTreeRegressor`,
+  :class:`ensemble.RandomForestClassifier`,
+  :class:`ensemble.RandomForestRegressor`,
+  :class:`ensemble.GradientBoostingClassifier`, and
+  :class:`ensemble.GradientBoostingRegressor`. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.utils`
 ....................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -41,7 +41,7 @@ Changelog
   :class:`ensemble.RandomForestClassifier`,
   :class:`ensemble.RandomForestRegressor`,
   :class:`ensemble.GradientBoostingClassifier`, and
-  :class:`ensemble.GradientBoostingRegressor`. :pr:`xxxxx` by `Thomas Fan`_.
+  :class:`ensemble.GradientBoostingRegressor`. :pr:`23404` by `Thomas Fan`_.
 
 :mod:`sklearn.utils`
 ....................

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -342,7 +342,7 @@ cdef class BestSplitter(BaseDenseSplitter):
             for i in range(start, end):
                 Xf[i] = self.X[samples[i], current.feature]
 
-            simultaneous_sort(&Xf[start], &samples[start], end - start)
+            simultaneous_sort(&Xf[start], &samples[start], end - start, use_introsort=1)
 
             if Xf[end - 1] <= Xf[start] + FEATURE_THRESHOLD:
                 features[f_j], features[n_total_constants] = features[n_total_constants], features[f_j]
@@ -1049,9 +1049,11 @@ cdef class BestSparseSplitter(BaseSparseSplitter):
                              &is_samples_sorted)
 
             # Sort the positive and negative parts of `Xf`
-            simultaneous_sort(&Xf[start], &samples[start], end_negative - start)
+            simultaneous_sort(&Xf[start], &samples[start], end_negative - start,
+                              use_introsort=1)
             if start_positive < end:
-                simultaneous_sort(&Xf[start_positive], &samples[start_positive], end - start_positive)
+                simultaneous_sort(&Xf[start_positive], &samples[start_positive],
+                                  end - start_positive, use_introsort=1)
 
             # Update index_to_samples to take into account the sort
             for p in range(start, end_negative):

--- a/sklearn/utils/_sorting.pxd
+++ b/sklearn/utils/_sorting.pxd
@@ -6,4 +6,5 @@ cdef int simultaneous_sort(
     floating *dist,
     ITYPE_t *idx,
     ITYPE_t size,
+    bint use_introsort=*,
 ) nogil

--- a/sklearn/utils/_sorting.pyx
+++ b/sklearn/utils/_sorting.pyx
@@ -129,7 +129,6 @@ cdef inline int _simultaneous_sort(
             if values[0] > values[1]:
                 dual_swap(values, indices, 0, 1)
     elif use_introsort and max_depth <= 0:
-        # heapsort
         heapsort(values, indices, size)
     else:
         if use_introsort:

--- a/sklearn/utils/_sorting.pyx
+++ b/sklearn/utils/_sorting.pyx
@@ -131,8 +131,6 @@ cdef inline int _simultaneous_sort(
     elif use_introsort and max_depth <= 0:
         heapsort(values, indices, size)
     else:
-        if use_introsort:
-            max_depth -= 1
         # Determine the pivot using the median-of-three rule.
         # The smallest of the three is moved to the beginning of the array,
         # the middle (the pivot value) is moved to the end, and the largest
@@ -159,9 +157,9 @@ cdef inline int _simultaneous_sort(
 
         # Recursively sort each side of the pivot
         if pivot_idx > 1:
-            _simultaneous_sort(values, indices, pivot_idx, max_depth, use_introsort)
+            _simultaneous_sort(values, indices, pivot_idx, max_depth - 1, use_introsort)
         if pivot_idx + 2 < size:
             _simultaneous_sort(values + pivot_idx + 1,
                                indices + pivot_idx + 1,
-                               size - pivot_idx - 1, max_depth, use_introsort)
+                               size - pivot_idx - 1, max_depth - 1, use_introsort)
     return 0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #23397


#### What does this implement/fix? Explain your changes.
This PR adds the heapsort part of introsort back into `simultaneous_sort` as a flag.

Using the [benchmark for low cardinality](https://github.com/scikit-learn/scikit-learn/issues/23397#issuecomment-1129010537), I get `3.24 s` on `main`, `0.11 s` with this PR, and `0.07 s` on `1.0.X`.

This PR makes the performance about the same compared to `main`, but still much faster compared to `1.0.1`.

<details><summary>Original with high cardinality benchmark</summary>

```python
from time import perf_counter
import json
from statistics import mean, stdev

from sklearn.tree import DecisionTreeClassifier
from sklearn.datasets import make_classification
from collections import defaultdict


N_SAMPLES = [1_000, 5_000, 10_000, 20_000]
N_REPEATS = 5

results = defaultdict(list)

for n_samples in N_SAMPLES:
    for n_repeat in range(N_REPEATS):
        X, y = make_classification(
            random_state=n_repeat, n_samples=n_samples, n_features=100
        )
        tree = DecisionTreeClassifier(random_state=n_repeat)
        start = perf_counter()
        tree.fit(X, y)
        duration = perf_counter() - start
        results[n_samples].append(duration)
    results_mean, results_stdev = mean(results[n_samples]), stdev(results[n_samples])
    print(f"n_samples={n_samples} with {results_mean:.3f} +/- {results_stdev:.3f}")
```

</details>

### This PR

```bash
n_samples=1000 with 0.043 +/- 0.006
n_samples=5000 with 0.410 +/- 0.116
n_samples=10000 with 1.085 +/- 0.078
n_samples=20000 with 3.276 +/- 0.484
```

### main

```bash
n_samples=1000 with 0.044 +/- 0.006
n_samples=5000 with 0.398 +/- 0.108
n_samples=10000 with 1.048 +/- 0.077
n_samples=20000 with 3.179 +/- 0.466
```

### 1.0.1

```bash
n_samples=1000 with 0.049 +/- 0.007
n_samples=5000 with 0.472 +/- 0.128
n_samples=10000 with 1.240 +/- 0.086
n_samples=20000 with 3.810 +/- 0.560
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
