### PR TITLE
DOC changed <= symbol to \leq in tree module documentation

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -452,7 +452,7 @@ feature :math:`j` and threshold :math:`t_m`, partition the data into
 
 .. math::
 
-    Q_m^{left}(\theta) = \{(x, y) | x_j <= t_m\}
+    Q_m^{left}(\theta) = \{(x, y) | x_j \leq t_m\}
 
     Q_m^{right}(\theta) = Q_m \setminus Q_m^{left}(\theta)
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #23424 

#### What does this implement/fix? Explain your changes.

Changed "<=" to "\leq" symbol in tree module documentation page for consistency.
