### PR TITLE
MNT Centralize conda-lock version into min_dependencies.py

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -74,8 +74,7 @@ pre_python_environment_install() {
 python_environment_install_and_activate() {
     if [[ "$DISTRIB" == "conda"* ]]; then
         conda update -n base conda -y
-        # pin conda-lock to latest released version (needs manual update from time to time)
-        conda install -c conda-forge conda-lock==1.0.5 -y
+        conda install -c conda-forge "$(get_dep conda-lock min)" -y
         conda-lock install --name $VIRTUALENV $LOCK_FILE
         source activate $VIRTUALENV
 

--- a/build_tools/azure/install_win.sh
+++ b/build_tools/azure/install_win.sh
@@ -8,9 +8,8 @@ source build_tools/shared.sh
 
 if [[ "$DISTRIB" == "conda" ]]; then
     conda update -n base conda -y
-    # TODO: update conda-lock version from time to time
     conda install pip -y
-    pip install conda-lock==1.0.5
+    pip install "$(get_dep conda-lock min)"
     conda-lock install --name $VIRTUALENV $LOCK_FILE
     source activate $VIRTUALENV
 else

--- a/build_tools/circle/build_test_arm.sh
+++ b/build_tools/circle/build_test_arm.sh
@@ -6,6 +6,9 @@ set -x
 UNAMESTR=`uname`
 N_CORES=`nproc --all`
 
+# defines the get_dep and show_installed_libraries functions
+source build_tools/shared.sh
+
 setup_ccache() {
     echo "Setting up ccache"
     mkdir /tmp/ccache/
@@ -28,8 +31,7 @@ chmod +x mambaforge.sh && ./mambaforge.sh -b -p $MINICONDA_PATH
 export PATH=$MINICONDA_PATH/bin:$PATH
 mamba init --all --verbose
 mamba update --yes conda
-# TODO Update conda-lock version from time to time
-mamba install conda-lock=1.0.5 -y
+mamba install "$(get_dep conda-lock min)" -y
 conda-lock install --name $CONDA_ENV_NAME $LOCK_FILE
 source activate $CONDA_ENV_NAME
 

--- a/build_tools/update_environments_and_lock_files.py
+++ b/build_tools/update_environments_and_lock_files.py
@@ -24,7 +24,7 @@ with pip.
 
 To run this script you need:
 - conda-lock. The version should match the one used in the CI in
-  build_tools/azure/install.sh
+  sklearn/_min_dependencies.py
 - pip-tools
 
 """

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -46,6 +46,9 @@ dependent_packages = {
     "Pillow": ("7.1.2", "docs"),
     "sphinx-prompt": ("1.3.0", "docs"),
     "sphinxext-opengraph": ("0.4.2", "docs"),
+    # XXX: Pin conda-lock to the latest released version (needs manual update
+    # from time to time)
+    "conda-lock": ("1.0.5", "maintenance"),
 }
 
 

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -55,7 +55,15 @@ dependent_packages = {
 # create inverse mapping for setuptools
 tag_to_packages: dict = {
     extra: []
-    for extra in ["build", "install", "docs", "examples", "tests", "benchmark"]
+    for extra in [
+        "build",
+        "install",
+        "docs",
+        "examples",
+        "tests",
+        "benchmark",
+        "maintenance",
+    ]
 }
 for package, (min_version, extras) in dependent_packages.items():
     for extra in extras.split(", "):

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -1,4 +1,5 @@
 """All minimum dependencies for scikit-learn."""
+from collections import defaultdict
 import platform
 import argparse
 
@@ -53,18 +54,7 @@ dependent_packages = {
 
 
 # create inverse mapping for setuptools
-tag_to_packages: dict = {
-    extra: []
-    for extra in [
-        "build",
-        "install",
-        "docs",
-        "examples",
-        "tests",
-        "benchmark",
-        "maintenance",
-    ]
-}
+tag_to_packages: dict = defaultdict(list)
 for package, (min_version, extras) in dependent_packages.items():
     for extra in extras.split(", "):
         tag_to_packages[extra].append("{}>={}".format(package, min_version))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #22425


#### What does this implement/fix? Explain your changes.
This PR moves the pinned version of `conda-lock` into `min_dependencies.py` and grabs the version from there.

WDYT @lesteve ?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
