### PR TITLE
[MRG] Add sep param for _encoder to allow for different separators between features and categories

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -1079,7 +1079,7 @@ class OneHotEncoder(_BaseEncoder):
 
         return np.array(feature_names, dtype=object)
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features=None, sep="_"):
         """Get output feature names for transformation.
 
         Parameters
@@ -1093,6 +1093,9 @@ class OneHotEncoder(_BaseEncoder):
               `["x0", "x1", ..., "x(n_features_in_ - 1)"]`.
             - If `input_features` is an array-like, then `input_features` must
               match `feature_names_in_` if `feature_names_in_` is defined.
+
+        sep : str, default="_"
+            Determines the separator between the input_features and the categories
 
         Returns
         -------
@@ -1108,7 +1111,7 @@ class OneHotEncoder(_BaseEncoder):
 
         feature_names = []
         for i in range(len(cats)):
-            names = [input_features[i] + "_" + str(t) for t in cats[i]]
+            names = [input_features[i] + sep + str(t) for t in cats[i]]
             feature_names.extend(names)
 
         return np.array(feature_names, dtype=object)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
When you use the `get_feature_name_out` method from OneHotEncoder, it automatically sets your separator to be an underscore.  In some cases it's beneficial, especially if your categories contain underscores, to be able to specify the separator such that you can quickly parse your category from your feature if needed.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
