### PR TITLE
DOC Fixes typo in empirical_covariance.py

### DIFF
--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -207,7 +207,7 @@ class EmpiricalCovariance(BaseEstimator):
         return precision
 
     def fit(self, X, y=None):
-        """Fit the maximum liklihood covariance estimator to X.
+        """Fit the maximum likelihood covariance estimator to X.
 
         Parameters
         ----------


### PR DESCRIPTION
Typo in fit() method's docstring
