### PR TITLE
MNT Param validation: do not expose internal values in error msg

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -266,6 +266,27 @@ def _tolerance(X, tol):
     return np.mean(variances) * tol
 
 
+@validate_params(
+    {
+        "X": ["array-like", "sparse matrix"],
+        "n_clusters": [Interval(Integral, 1, None, closed="left")],
+        "sample_weight": ["array-like", None],
+        "init": [StrOptions({"k-means++", "random"}), callable, "array-like"],
+        "n_init": [
+            StrOptions({"auto", "warn"}, internal={"warn"}),
+            Interval(Integral, 1, None, closed="left"),
+        ],
+        "max_iter": [Interval(Integral, 1, None, closed="left")],
+        "verbose": [Interval(Integral, 0, None, closed="left"), bool],
+        "tol": [Interval(Real, 0, None, closed="left")],
+        "random_state": ["random_state"],
+        "copy_x": [bool],
+        "algorithm": [
+            StrOptions({"lloyd", "elkan", "auto", "full"}, deprecated={"auto", "full"})
+        ],
+        "return_n_iter": [bool],
+    }
+)
 def k_means(
     X,
     n_clusters,
@@ -813,7 +834,7 @@ class _BaseKMeans(
         "n_clusters": [Interval(Integral, 1, None, closed="left")],
         "init": [StrOptions({"k-means++", "random"}), callable, "array-like"],
         "n_init": [
-            StrOptions({"auto", "warn"}),
+            StrOptions({"auto", "warn"}, internal={"warn"}),
             Interval(Integral, 1, None, closed="left"),
         ],
         "max_iter": [Interval(Integral, 1, None, closed="left")],

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -226,8 +226,13 @@ class StrOptions(_Constraint):
     )
     def __init__(self, options, deprecated=None, internal=None):
         self.options = options
-        self.deprecated = deprecated or {}
-        self.internal = internal or {}
+        self.deprecated = deprecated or set()
+        self.internal = internal or set()
+
+        if self.deprecated & self.internal:
+            raise ValueError(
+                "The deprecated and internal parameters should not overlap."
+            )
 
     def is_satisfied_by(self, val):
         return isinstance(val, str) and val in self.options

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -229,6 +229,16 @@ class StrOptions(_Constraint):
         self.deprecated = deprecated or set()
         self.internal = internal or set()
 
+        if self.deprecated - self.options:
+            raise ValueError(
+                "The deprecated options must be a subset of the options."
+            )
+        
+        if self.internal - self.options:
+            raise ValueError(
+                "The internal options must be a subset of the options."
+            )
+
         if self.deprecated & self.internal:
             raise ValueError(
                 "The deprecated and internal parameters should not overlap."

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -230,14 +230,10 @@ class StrOptions(_Constraint):
         self.internal = internal or set()
 
         if self.deprecated - self.options:
-            raise ValueError(
-                "The deprecated options must be a subset of the options."
-            )
-        
+            raise ValueError("The deprecated options must be a subset of the options.")
+
         if self.internal - self.options:
-            raise ValueError(
-                "The internal options must be a subset of the options."
-            )
+            raise ValueError("The internal options must be a subset of the options.")
 
         if self.deprecated & self.internal:
             raise ValueError(

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -52,6 +52,11 @@ def validate_parameter_constraints(parameter_constraints, params, caller_name):
                 break
         else:
             # No constraint is satisfied, raise with an informative message.
+
+            # Ignore constraints that only contains internal options that we don't want
+            # to expose in the error message
+            constraints = [constraint for constraint in constraints if str(constraint)]
+
             if len(constraints) == 1:
                 constraints_str = f"{constraints[0]}"
             else:
@@ -216,10 +221,13 @@ class StrOptions(_Constraint):
         A subset of the `options` to mark as deprecated in the repr of the constraint.
     """
 
-    @validate_params({"options": [set], "deprecated": [set, None]})
-    def __init__(self, options, deprecated=None):
+    @validate_params(
+        {"options": [set], "deprecated": [set, None], "internal": [set, None]}
+    )
+    def __init__(self, options, deprecated=None, internal=None):
         self.options = options
         self.deprecated = deprecated or {}
+        self.internal = internal or {}
 
     def is_satisfied_by(self, val):
         return isinstance(val, str) and val in self.options
@@ -232,8 +240,13 @@ class StrOptions(_Constraint):
         return option_str
 
     def __str__(self):
+        visible_options = [o for o in self.options if o not in self.internal]
+
+        if not visible_options:
+            return ""
+
         options_str = (
-            f"{', '.join([self._mark_if_deprecated(o) for o in self.options])}"
+            f"{', '.join([self._mark_if_deprecated(o) for o in visible_options])}"
         )
         return f"a str among {{{options_str}}}"
 

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -116,12 +116,13 @@ def test_interval_errors(params, error, match):
 
 def test_stroptions():
     """Sanity check for the StrOptions constraint"""
-    options = StrOptions({"a", "b", "c"}, deprecated={"c"})
+    options = StrOptions({"a", "b", "c"}, deprecated={"c"}, internal={"b"})
     assert options.is_satisfied_by("a")
     assert options.is_satisfied_by("c")
     assert not options.is_satisfied_by("d")
 
     assert "'c' (deprecated)" in str(options)
+    assert "'b'" not in str(options)
 
 
 @pytest.mark.parametrize(
@@ -215,6 +216,7 @@ def test_make_constraint(constraint_declaration, expected_constraint_class):
 
 
 def test_make_constraint_unknown():
+    """Check that an informative error is raised when an unknown constraint is passed"""
     with pytest.raises(ValueError, match="Unknown constraint"):
         make_constraint("not a valid constraint")
 
@@ -242,8 +244,10 @@ def test_validate_params():
 
 
 def test_validate_params_match_error():
-    # Check that an informative error is raised when the constraints do not match the
-    # function parameters.
+    """Check that an informative error is raised when the constraints do not match the
+    function parameters.
+    """
+
     @validate_params({"a": [int], "c": [int]})
     def func(a, b):
         pass
@@ -254,8 +258,7 @@ def test_validate_params_match_error():
 
 
 def test_decorate_validated_function():
-    # Check that validate_params functions can be decorated
-
+    """Check that validate_params functions can be decorated"""
     decorated_function = deprecated()(_func)
 
     with pytest.warns(FutureWarning, match="Function _func is deprecated"):
@@ -287,3 +290,38 @@ def test_validate_params_estimator():
 
     with pytest.raises(ValueError, match="The 'a' parameter of _Estimator must be"):
         est.fit()
+
+
+def test_internal_values_not_exposed():
+    """Check that valid values that are for internal purpose, e.g. "warn" or
+    "deprecated" are not exposed in the error message
+    """
+
+    @validate_params({"param": [StrOptions({"auto", "warn"}, internal={"warn"})]})
+    def f(param):
+        pass
+
+    with pytest.raises(ValueError, match="The 'param' parameter") as exc_info:
+        f(param="bad")
+
+    err_msg = str(exc_info.value)
+    assert "a str among" in err_msg
+    assert "auto" in err_msg
+    assert "warn" not in err_msg
+
+    # no error
+    f(param="warn")
+
+    @validate_params({"param": [int, StrOptions({"warn"}, internal={"warn"})]})
+    def g(param):
+        pass
+
+    with pytest.raises(ValueError, match="The 'param' parameter") as exc_info:
+        g(param="bad")
+
+    err_msg = str(exc_info.value)
+    assert "a str among" not in err_msg
+    assert "warn" not in err_msg
+
+    # no error
+    g(param="warn")

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -331,3 +331,12 @@ def test_stroptions_deprecated_internal_overlap():
     """Check that the internal and deprecated parameters are not allowed to overlap."""
     with pytest.raises(ValueError, match="should not overlap"):
         StrOptions({"a", "b", "c"}, deprecated={"b", "c"}, internal={"a", "b"})
+
+
+def test_stroptions_deprecated_internal_subset():
+    """Check that the deprecated and internal parameters must be subsets of options."""
+    with pytest.raises(ValueError, match="deprecated options must be a subset"):
+        StrOptions({"a", "b", "c"}, deprecated={"a", "d"})
+
+    with pytest.raises(ValueError, match="internal options must be a subset"):
+        StrOptions({"a", "b", "c"}, internal={"a", "d"})

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -325,3 +325,9 @@ def test_internal_values_not_exposed():
 
     # no error
     g(param="warn")
+
+
+def test_stroptions_deprecated_internal_overlap():
+    """Check that the internal and deprecated parameters are not allowed to overlap."""
+    with pytest.raises(ValueError, match="should not overlap"):
+        StrOptions({"a", "b", "c"}, deprecated={"b", "c"}, internal={"a", "b"})


### PR DESCRIPTION
We have valid values for parameters that are for internal purpose (e.g. "warn" or "deprecated") and I don't think we should expose them in the error message raised by the param validation.

for instance we currently have (since we merged https://github.com/scikit-learn/scikit-learn/pull/23038)
```py
>>> KMeans(n_init="bad").fit(None)
ValueError: The 'n_init' parameter of KMeans must be a str among {'auto', 'warn'} or an int in the range [1, inf). Got 'bad' instead.
```
With this PR, the message becomes
```py
ValueError: The 'n_init' parameter of KMeans must be a str among {'auto'} or an int in the range [1, inf). Got 'bad' instead.
```
Also, suppose you have a param that only accepts integers. If we deprecate it, it will accept the string "deprecated". I don't think we want the error message to mention that a str is a valid type at all.

I propose to add a param `internal` to `StrOptions` such that values that are listed in `internal` won't be exposed and if all options are internal options, even the fact that a str is valid is not exposed.