### PR TITLE
MNT Improves comment when CI fails a second time

### DIFF
--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -71,18 +71,19 @@ def get_issue():
 
 def create_or_update_issue(body=""):
     # Interact with GitHub API to create issue
-    header = f"**CI Failed on [{args.ci_name}]({args.link_to_ci_run})**"
-    body_text = f"{header}\n{body}"
+    link = f"[{args.ci_name}]({args.link_to_ci_run})"
     issue = get_issue()
 
     if issue is None:
         # Create new issue
-        issue = issue_repo.create_issue(title=title, body=body_text)
+        header = f"**CI failed on {link}**"
+        issue = issue_repo.create_issue(title=title, body=f"{header}\n{body}")
         print(f"Created issue in {args.issue_repo}#{issue.number}")
         sys.exit()
     else:
         # Add comment to existing issue
-        issue.create_comment(body=body_text)
+        header = f"**CI is still failing on {link}**"
+        issue.create_comment(body=f"{header}\n{body}")
         print(f"Commented on issue: {args.issue_repo}#{issue.number}")
         sys.exit()
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #23454


#### What does this implement/fix? Explain your changes.
From #23454, if the CI is still failing, the new comment matches the opening comment exactly. I think it's a little better to change the new comment, so we can tell something changed.

CC @lesteve 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
