### PR TITLE
MNT Removes parallel sphinx build by default

### DIFF
--- a/build_tools/github/build_doc.sh
+++ b/build_tools/github/build_doc.sh
@@ -145,7 +145,7 @@ else
     make_args=html
 fi
 
-make_args="SPHINXOPTS=-T $make_args"  # show full traceback on exception
+make_args="SPHINXOPTS=-j2 $make_args"
 
 # Installing required system packages to support the rendering of math
 # notation in the HTML documentation and to optimize the image files

--- a/build_tools/github/build_doc.sh
+++ b/build_tools/github/build_doc.sh
@@ -145,7 +145,7 @@ else
     make_args=html
 fi
 
-make_args="SPHINXOPTS=-j2 $make_args"
+make_args="SPHINXOPTS=-T $make_args"  # show full traceback on exception
 
 # Installing required system packages to support the rendering of math
 # notation in the HTML documentation and to optimize the image files

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j auto
+SPHINXOPTS    =
 SPHINXBUILD  ?= sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,6 +6,14 @@ SPHINXOPTS    =
 SPHINXBUILD  ?= sphinx-build
 PAPER         =
 BUILDDIR      = _build
+
+# Disable multiple jobs on OSX
+ifeq ($(shell uname), Darwin)
+	SPHINX_NUMJOBS = 1
+else
+	SPHINX_NUMJOBS = auto
+endif
+
 ifneq ($(EXAMPLES_PATTERN),)
     EXAMPLES_PATTERN_OPTS := -D sphinx_gallery_conf.filename_pattern="$(EXAMPLES_PATTERN)"
 endif
@@ -14,7 +22,7 @@ endif
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -T -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS)\
-    $(EXAMPLES_PATTERN_OPTS) .
+    -j$(SPHINX_NUMJOBS) $(EXAMPLES_PATTERN_OPTS) .
 
 
 .PHONY: help clean html dirhtml ziphtml pickle json latex latexpdf changes linkcheck doctest optipng


### PR DESCRIPTION
Sphinx building in parallel was disabled for versions < 4.4. With sphinx>4.4, it was re-enabled, but it leads to the build freezing.

This PR removes `-j auto` and enables it only on the CI for doc building.