### PR TITLE
FIX Param validation: fix generating invalid param when 2 interval constraints

### DIFF
--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -434,8 +434,8 @@ def generate_invalid_param_val(constraint, constraints=None):
         The constraint to generate a value for.
 
     constraints : list of _Constraint instances or None, default=None
-        The list of all constraints for this parameter. If None, the list containt only
-        the constraint is used.
+        The list of all constraints for this parameter. If None, the list only
+        containing `constraint` is used.
 
     Returns
     -------

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -415,7 +415,7 @@ class _RandomStates(_Constraint):
         )
 
 
-def generate_invalid_param_val(constraint):
+def generate_invalid_param_val(constraint, constraints=None):
     """Return a value that does not satisfy the constraint.
 
     This is only useful for testing purpose.
@@ -425,6 +425,10 @@ def generate_invalid_param_val(constraint):
     constraint : Constraint
         The constraint to generate a value for.
 
+    constraints : list of Constraint or None, default=None
+        The list of all constraints for this parameter. If None, the list containt only
+        the constraint is used.
+
     Returns
     -------
     val : object
@@ -432,14 +436,106 @@ def generate_invalid_param_val(constraint):
     """
     if isinstance(constraint, StrOptions):
         return f"not {' or '.join(constraint.options)}"
-    elif isinstance(constraint, Interval):
-        interval = constraint
-        if interval.left is None and interval.right is None:
-            raise NotImplementedError
 
-        if interval.left is not None:
-            return interval.left - 1
-        else:
-            return interval.right + 1
-    else:
+    if not isinstance(constraint, Interval):
         raise NotImplementedError
+
+    # constraint is an interval
+    constraints = [constraint] if constraints is None else constraints
+    return _generate_invalid_param_val_interval(constraint, constraints)
+
+
+def _generate_invalid_param_val_interval(interval, constraints):
+    """Return a value that does not satisfy an interval constraint.
+
+    Generating a invalid value for an integer interval depends on the other constraints
+    since an int is a real, meaning that it can be valid for a real interval.
+    Assumes that there can be at most 2 interval constraints: one integer interval
+    and/or one real interval.
+
+    This is only useful for testing purpose.
+
+    Parameters
+    ----------
+    interval : Interval
+        The interval to generate a value for.
+
+    constraints : list of Constraint
+        The list of all constraints for this parameter.
+
+    Returns
+    -------
+    val : object
+        A value that does not satisfy the interval constraint.
+    """
+    if interval.left is None and interval.right is None:
+        raise NotImplementedError
+
+    if interval.type is Real:
+        # generate a non-integer value such that it can't be valid even if there's also
+        # an integer interval constraint.
+        if interval.left is not None:
+            return np.floor(interval.left) - 0.5
+        else:  # right is not None
+            return np.ceil(interval.right) + 0.5
+
+    else:  # interval.type is Integral
+        # We need to check if there's also a real interval constraint to generate a
+        # value that is not valid for any of the 2 interval constraints.
+        real_intervals = [
+            i for i in constraints if isinstance(i, Interval) and i.type is Real
+        ]
+        real_interval = real_intervals[0] if real_intervals else None
+
+        if real_interval is None:
+            # Only the integer interval constraint -> easy
+            if interval.left is not None:
+                return interval.left - 1
+            else:
+                return interval.right + 1
+
+        # There's also a real interval constraint. Try to find a value left to both or
+        # right to both or in between them.
+
+        # redefine left and right bounds to be smallest and largest valid integers in
+        # both intervals.
+        int_left = interval.left
+        if int_left is not None and interval.closed in ("right", "neither"):
+            int_left = int_left + 1
+
+        int_right = interval.right
+        if int_right is not None and interval.closed in ("left", "neither"):
+            int_right = int_right - 1
+
+        real_left = real_interval.left
+        if real_interval.left is not None:
+            real_left = int(np.ceil(real_interval.left))
+            if real_interval.closed in ("right", "neither"):
+                real_left = real_left + 1
+
+        real_right = real_interval.right
+        if real_interval.right is not None:
+            real_right = int(np.floor(real_interval.right))
+            if real_interval.closed in ("left", "neither"):
+                real_right = real_right - 1
+
+        if int_left is not None and real_left is not None:
+            # there exists an int left to both intervals
+            return min(int_left, real_left) - 1
+
+        if int_right is not None and real_right is not None:
+            # there exists an int right to both intervals
+            return max(int_right, real_right) + 1
+
+        if int_left is not None:
+            if real_right is not None and int_left - real_right >= 2:
+                # there exists an int between the 2 intervals
+                return int_left - 1
+            else:
+                raise NotImplementedError
+        else:  # int_right is not None
+            if real_left is not None and real_left - int_right >= 2:
+                # there exists an int between the 2 intervals
+                return int_right + 1
+            else:
+                raise NotImplementedError

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -430,10 +430,10 @@ def generate_invalid_param_val(constraint, constraints=None):
 
     Parameters
     ----------
-    constraint : Constraint
+    constraint : _Constraint instance
         The constraint to generate a value for.
 
-    constraints : list of Constraint or None, default=None
+    constraints : list of _Constraint instances or None, default=None
         The list of all constraints for this parameter. If None, the list containt only
         the constraint is used.
 
@@ -465,10 +465,10 @@ def _generate_invalid_param_val_interval(interval, constraints):
 
     Parameters
     ----------
-    interval : Interval
+    interval : Interval instance
         The interval to generate a value for.
 
-    constraints : list of Constraint
+    constraints : list of _Constraint instances
         The list of all constraints for this parameter.
 
     Returns

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -4081,7 +4081,7 @@ def check_param_validation(name, estimator_orig):
 
         for constraint in constraints:
             try:
-                bad_value = generate_invalid_param_val(constraint)
+                bad_value = generate_invalid_param_val(constraint, constraints)
             except NotImplementedError:
                 continue
 

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -78,8 +78,8 @@ def test_interval_inf_in_bounds():
     assert -np.inf in interval
 
     interval = Interval(Real, None, None, closed="neither")
-    assert not np.inf in interval
-    assert not -np.inf in interval
+    assert np.inf not in interval
+    assert -np.inf not in interval
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -155,6 +155,100 @@ def test_generate_invalid_param_val(constraint):
 
 
 @pytest.mark.parametrize(
+    "integer_interval, real_interval",
+    [
+        (
+            Interval(Integral, None, 3, closed="right"),
+            Interval(Real, -5, 5, closed="both"),
+        ),
+        (
+            Interval(Integral, None, 3, closed="right"),
+            Interval(Real, -5, 5, closed="neither"),
+        ),
+        (
+            Interval(Integral, None, 3, closed="right"),
+            Interval(Real, 4, 5, closed="both"),
+        ),
+        (
+            Interval(Integral, None, 3, closed="right"),
+            Interval(Real, 5, None, closed="left"),
+        ),
+        (
+            Interval(Integral, None, 3, closed="right"),
+            Interval(Real, 4, None, closed="neither"),
+        ),
+        (
+            Interval(Integral, 3, None, closed="left"),
+            Interval(Real, -5, 5, closed="both"),
+        ),
+        (
+            Interval(Integral, 3, None, closed="left"),
+            Interval(Real, -5, 5, closed="neither"),
+        ),
+        (
+            Interval(Integral, 3, None, closed="left"),
+            Interval(Real, 1, 2, closed="both"),
+        ),
+        (
+            Interval(Integral, 3, None, closed="left"),
+            Interval(Real, None, -5, closed="left"),
+        ),
+        (
+            Interval(Integral, 3, None, closed="left"),
+            Interval(Real, None, -4, closed="neither"),
+        ),
+        (
+            Interval(Integral, -5, 5, closed="both"),
+            Interval(Real, None, 1, closed="right"),
+        ),
+        (
+            Interval(Integral, -5, 5, closed="both"),
+            Interval(Real, 1, None, closed="left"),
+        ),
+        (
+            Interval(Integral, -5, 5, closed="both"),
+            Interval(Real, -10, -4, closed="neither"),
+        ),
+        (
+            Interval(Integral, -5, 5, closed="both"),
+            Interval(Real, -10, -4, closed="right"),
+        ),
+        (
+            Interval(Integral, -5, 5, closed="neither"),
+            Interval(Real, 6, 10, closed="neither"),
+        ),
+        (
+            Interval(Integral, -5, 5, closed="neither"),
+            Interval(Real, 6, 10, closed="left"),
+        ),
+        (
+            Interval(Integral, 2, None, closed="left"),
+            Interval(Real, 0, 1, closed="both"),
+        ),
+        (
+            Interval(Integral, 1, None, closed="left"),
+            Interval(Real, 0, 1, closed="both"),
+        ),
+    ],
+)
+def test_generate_invalid_param_val_2_intervals(integer_interval, real_interval):
+    """Check that the value generated for an interval constraint does not satisfy any of
+    the interval constraints.
+    """
+    bad_value = generate_invalid_param_val(
+        real_interval, constraints=[real_interval, integer_interval]
+    )
+    assert not real_interval.is_satisfied_by(bad_value)
+    assert not integer_interval.is_satisfied_by(bad_value)
+
+    bad_value = generate_invalid_param_val(
+        integer_interval, constraints=[real_interval, integer_interval]
+    )
+    assert not real_interval.is_satisfied_by(bad_value)
+    assert not integer_interval.is_satisfied_by(bad_value)
+
+
+@pytest.mark.parametrize(
     "constraint",
     [
         _ArrayLikes,

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -67,7 +67,7 @@ def test_interval_range(interval_type):
 
 
 def test_interval_inf_in_bounds():
-    """Check that inf is included if a bound is closed and set to None.
+    """Check that inf is included iff a bound is closed and set to None.
 
     Only valid for real intervals.
     """
@@ -76,6 +76,19 @@ def test_interval_inf_in_bounds():
 
     interval = Interval(Real, None, 0, closed="left")
     assert -np.inf in interval
+
+    interval = Interval(Real, None, None, closed="neither")
+    assert not np.inf in interval
+    assert not -np.inf in interval
+
+
+@pytest.mark.parametrize(
+    "interval",
+    [Interval(Real, 0, 1, closed="left"), Interval(Real, None, None, closed="both")],
+)
+def test_nan_not_in_interval(interval):
+    """Check that np.nan is not in any interval."""
+    assert np.nan not in interval
 
 
 @pytest.mark.parametrize(
@@ -145,6 +158,7 @@ def test_instances_of_type_human_readable(type, expected_type_name):
     [
         Interval(Real, None, 0, closed="left"),
         Interval(Real, 0, None, closed="left"),
+        Interval(Real, None, None, closed="neither"),
         StrOptions({"a", "b", "c"}),
     ],
 )
@@ -246,6 +260,26 @@ def test_generate_invalid_param_val_2_intervals(integer_interval, real_interval)
     )
     assert not real_interval.is_satisfied_by(bad_value)
     assert not integer_interval.is_satisfied_by(bad_value)
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
+        [_ArrayLikes()],
+        [_InstancesOf(list)],
+        [Interval(Real, None, None, closed="both")],
+        [
+            Interval(Integral, 0, None, closed="left"),
+            Interval(Real, None, 0, closed="neither"),
+        ],
+    ],
+)
+def test_generate_invalid_param_val_all_valid(constraints):
+    """Check that the function raises NotImplementedError when there's no invalid value
+    for the constraint.
+    """
+    with pytest.raises(NotImplementedError):
+        generate_invalid_param_val(constraints[0], constraints=constraints)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use case seen in https://github.com/scikit-learn/scikit-learn/pull/23499

It's possible that a parameter accepts float and int with different ranges (usually and `int >= 1` meaning an absolute value or a `float in [0, 1]` meaning a fraction). In that case, generating an invalid param (for automatic testing) must take both constraints into account since we must find a value that is in neither of the intervals.

This PR fixes it but assumes that there will at most be 1 integer interval constraint and 1 real interval constraint. I don't think we ever need to have constraints be unions of more intervals in scikit-learn.