### PR TITLE
MNT compute t-sne gradient norm only when checking convergence

### DIFF
--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -396,7 +396,6 @@ def _gradient_descent(
         kwargs["compute_error"] = check_convergence or i == n_iter - 1
 
         error, grad = objective(p, *args, **kwargs)
-        grad_norm = linalg.norm(grad)
 
         inc = update * grad < 0.0
         dec = np.invert(inc)
@@ -411,6 +410,7 @@ def _gradient_descent(
             toc = time()
             duration = toc - tic
             tic = toc
+            grad_norm = linalg.norm(grad)
 
             if verbose >= 2:
                 print(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #23510

#### What does this implement/fix? Explain your changes.

Inside `_gradient_descent()`, move the line `grad_norm = linalg.norm(grad)` into the `if check_convergence` block, so the grad
norm is not computed for every iteration, but only when convergence check is performed.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
