### PR TITLE
DOC fix glossary link

### DIFF
--- a/build_tools/github/build_doc.sh
+++ b/build_tools/github/build_doc.sh
@@ -19,7 +19,9 @@ set -e
 
 if [ -n "$GITHUB_ACTION" ]
 then
-    CIRCLE_SHA1=$GITHUB_SHA
+    # Map the variables for the new documentation builder to the old one
+    CIRCLE_SHA1=$(git log -1 --pretty=format:%H)
+
     CIRCLE_JOB=$GITHUB_JOB
 
     if [ "$GITHUB_EVENT_NAME" == "pull_request" ]

--- a/build_tools/github/build_doc.sh
+++ b/build_tools/github/build_doc.sh
@@ -19,8 +19,7 @@ set -e
 
 if [ -n "$GITHUB_ACTION" ]
 then
-    # Map the variables for the new documentation builder to the old one
-    CIRCLE_SHA1=$(git log --no-merges -1 --pretty=format:%H)
+    CIRCLE_SHA1=$GITHUB_SHA
     CIRCLE_JOB=$GITHUB_JOB
 
     if [ "$GITHUB_EVENT_NAME" == "pull_request" ]

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -268,7 +268,7 @@ Then, setup the magics in a manner similar to ``line_profiler``.
 - **Under IPython 0.11+**, first create a configuration profile:
 
 .. prompt:: bash $
-  
+
     ipython profile create
 
 
@@ -425,4 +425,4 @@ See `joblib documentation <https://joblib.readthedocs.io>`_
 A simple algorithmic trick: warm restarts
 =========================================
 
-See the glossary entry for `warm_start <http://scikit-learn.org/dev/glossary.html#term-warm-start>`_
+See the glossary entry for `warm_start <http://scikit-learn.org/dev/glossary.html#term-warm_start>`_

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -425,4 +425,4 @@ See `joblib documentation <https://joblib.readthedocs.io>`_
 A simple algorithmic trick: warm restarts
 =========================================
 
-See the glossary entry for `warm_start <http://scikit-learn.org/dev/glossary.html#term-warm_start>`_
+See the glossary entry for :term:`warm_start`


### PR DESCRIPTION
In https://scikit-learn.org/dev/developers/performance.html
The link is http://scikit-learn.org/dev/glossary.html#term-warm-start rather than http://scikit-learn.org/dev/glossary.html#term-warm_start so it does not go to the right place in the glossary.

This allows to double-check https://github.com/scikit-learn/scikit-learn/pull/23508 as well.
