### PR TITLE
[MRG] DOC Add link of kernal approx to svm user guide

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -483,7 +483,7 @@ Different kernels are specified by the `kernel` parameter::
     >>> rbf_svc.kernel
     'rbf'
 
-See also :ref:`kernel_approximation` for usage with other algorithms.
+See also :ref:`kernel_approximation` for a solution to use RBF kernels that is much faster and more scalable.
 
 Parameters of the RBF Kernel
 ----------------------------

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -483,6 +483,8 @@ Different kernels are specified by the `kernel` parameter::
     >>> rbf_svc.kernel
     'rbf'
 
+See also :ref:`kernel_approximation` for usage with other algorithms.
+
 Parameters of the RBF Kernel
 ----------------------------
 


### PR DESCRIPTION
#### Reference Issues/PRs
Partial fix for #23524 

#### What does this implement/fix? Explain your changes.
Add a "See also ..." in the SVM user guide in Kernel Function section.
In order to let reader aware of the Kernel approximation module.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
