### PR TITLE
DOC Fix typos in GP kernels

### DIFF
--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -484,7 +484,7 @@ Note that magic methods ``__add__``, ``__mul___`` and ``__pow__`` are
 overridden on the Kernel objects, so one can use e.g. ``RBF() + RBF()`` as
 a shortcut for ``Sum(RBF(), RBF())``.
 
-Radial-basis function (RBF) kernel
+Radial basis function (RBF) kernel
 ----------------------------------
 The :class:`RBF` kernel is a stationary kernel. It is also known as the "squared
 exponential" kernel. It is parameterized by a length-scale parameter :math:`l>0`, which

--- a/examples/gaussian_process/plot_gpr_noisy.py
+++ b/examples/gaussian_process/plot_gpr_noisy.py
@@ -97,7 +97,7 @@ y_mean, y_std = gpr.predict(X, return_std=True)
 
 # %%
 plt.plot(X, y, label="Expected signal")
-plt.scatter(x=X_train[:, 0], y=y_train, color="black", alpha=0.4, label="Observsations")
+plt.scatter(x=X_train[:, 0], y=y_train, color="black", alpha=0.4, label="Observations")
 plt.errorbar(X, y_mean, y_std)
 plt.legend()
 plt.xlabel("X")

--- a/examples/gaussian_process/plot_gpr_prior_posterior.py
+++ b/examples/gaussian_process/plot_gpr_prior_posterior.py
@@ -158,7 +158,7 @@ print(
 )
 
 # %%
-# Periodic kernel
+# Exp-Sine-Squared kernel
 # ...............
 from sklearn.gaussian_process.kernels import ExpSineSquared
 
@@ -183,7 +183,7 @@ axs[1].scatter(X_train[:, 0], y_train, color="red", zorder=10, label="Observatio
 axs[1].legend(bbox_to_anchor=(1.05, 1.5), loc="upper left")
 axs[1].set_title("Samples from posterior distribution")
 
-fig.suptitle("Periodic kernel", fontsize=18)
+fig.suptitle("Exp-Sine-Squared kernel", fontsize=18)
 plt.tight_layout()
 
 # %%
@@ -194,7 +194,7 @@ print(
 )
 
 # %%
-# Dot product kernel
+# Dot-product kernel
 # ..................
 from sklearn.gaussian_process.kernels import ConstantKernel, DotProduct
 
@@ -216,7 +216,7 @@ axs[1].scatter(X_train[:, 0], y_train, color="red", zorder=10, label="Observatio
 axs[1].legend(bbox_to_anchor=(1.05, 1.5), loc="upper left")
 axs[1].set_title("Samples from posterior distribution")
 
-fig.suptitle("Dot product kernel", fontsize=18)
+fig.suptitle("Dot-product kernel", fontsize=18)
 plt.tight_layout()
 
 # %%
@@ -227,7 +227,7 @@ print(
 )
 
 # %%
-# Mattern kernel
+# Matérn kernel
 # ..............
 from sklearn.gaussian_process.kernels import Matern
 
@@ -247,7 +247,7 @@ axs[1].scatter(X_train[:, 0], y_train, color="red", zorder=10, label="Observatio
 axs[1].legend(bbox_to_anchor=(1.05, 1.5), loc="upper left")
 axs[1].set_title("Samples from posterior distribution")
 
-fig.suptitle("Mattern kernel", fontsize=18)
+fig.suptitle("Matérn kernel", fontsize=18)
 plt.tight_layout()
 
 # %%

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1421,7 +1421,7 @@ class WhiteKernel(StationaryKernelMixin, GenericKernelMixin, Kernel):
 
 
 class RBF(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
-    """Radial-basis function kernel (aka squared-exponential kernel).
+    """Radial basis function kernel (aka squared-exponential kernel).
 
     The RBF kernel is a stationary kernel. It is also known as the
     "squared exponential" kernel. It is parameterized by a length scale


### PR DESCRIPTION
Fixes the following things in the Gaussian processes docs:

- [x] radial-basis function -> radial basis function
- [x] periodic -> exp-sine-squared (synonyms, but less confusing to be consistent)
- [x] Mattern -> Matérn
- [x] Observsations typo fix