### PR TITLE
MNT Fixes flake8 issues

### DIFF
--- a/doc/sphinxext/allow_nan_estimators.py
+++ b/doc/sphinxext/allow_nan_estimators.py
@@ -1,11 +1,7 @@
 from sklearn.utils import all_estimators
-from sklearn.compose import ColumnTransformer
-from sklearn.pipeline import FeatureUnion
-from sklearn.decomposition import SparseCoder
 from sklearn.utils.estimator_checks import _construct_instance
 from sklearn.utils._testing import SkipTest
 from docutils import nodes
-import warnings
 from contextlib import suppress
 
 from docutils.parsers.rst import Directive

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -873,7 +873,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
            Refer to the User Guide for more information regarding
            :class:`LogisticRegression` and more specifically the
            :ref:`Table <Logistic_regression>`
-           summarazing solver/penalty supports.
+           summarizing solver/penalty supports.
 
         .. versionadded:: 0.17
            Stochastic Average Gradient descent solver.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -872,7 +872,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         .. seealso::
            Refer to the User Guide for more information regarding
            :class:`LogisticRegression` and more specifically the
-           `Table <https://scikit-learn.org/dev/modules/linear_model.html#logistic-regression>`_
+           :ref:`Table <Logistic_regression>`
            summarazing solver/penalty supports.
 
         .. versionadded:: 0.17

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -653,9 +653,9 @@ def test_feature_names_in():
         "Feature names only support names that are all strings. "
         "Got feature names with dtypes: ['int', 'str']"
     )
-    with pytest.warns(FutureWarning, match=msg) as record:
+    with pytest.warns(FutureWarning, match=msg):
         trans.fit(df_mixed)
 
     # transform on feature names that are mixed also warns:
-    with pytest.warns(FutureWarning, match=msg) as record:
+    with pytest.warns(FutureWarning, match=msg):
         trans.transform(df_mixed)


### PR DESCRIPTION
This fixes minor flake8 issues when running:

```bash
flake8 --exclude=sklearn/externals/ sklearn examples doc/sphinxext
```

```
sklearn/tests/test_base.py:660:52: F841 local variable 'record' is assigned to but never used
sklearn/linear_model/_logistic.py:875:89: E501 line too long (96 > 88 characters)
doc/sphinxext/allow_nan_estimators.py:2:1: F401 'sklearn.compose.ColumnTransformer' imported but unused
doc/sphinxext/allow_nan_estimators.py:3:1: F401 'sklearn.pipeline.FeatureUnion' imported but unused
doc/sphinxext/allow_nan_estimators.py:4:1: F401 'sklearn.decomposition.SparseCoder' imported but unused
doc/sphinxext/allow_nan_estimators.py:8:1: F401 'warnings' imported but unused
```