### PR TITLE
MAINT parameter validation for Normalizer

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1902,7 +1902,10 @@ class Normalizer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
            [0.5, 0.7, 0.5, 0.1]])
     """
 
-    _parameter_constraints = {"norm": [StrOptions({"l1", "l2", "max"})], "copy": [bool]}
+    _parameter_constraints = {
+        "norm": [StrOptions({"l1", "l2", "max"})],
+        "copy": ["boolean"],
+    }
 
     def __init__(self, norm="l2", *, copy=True):
         self.norm = norm

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -23,6 +23,7 @@ from ..base import (
     _ClassNamePrefixFeaturesOutMixin,
 )
 from ..utils import check_array
+from ..utils._param_validation import StrOptions
 from ..utils.extmath import _incremental_mean_and_var, row_norms
 from ..utils.sparsefuncs_fast import (
     inplace_csr_row_normalize_l1,
@@ -1901,6 +1902,8 @@ class Normalizer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
            [0.5, 0.7, 0.5, 0.1]])
     """
 
+    _parameter_constraints = {"norm": [StrOptions({"l1", "l2", "max"})], "copy": [bool]}
+
     def __init__(self, norm="l2", *, copy=True):
         self.norm = norm
         self.copy = copy
@@ -1924,6 +1927,7 @@ class Normalizer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         self : object
             Fitted transformer.
         """
+        self._validate_params()
         self._validate_data(X, accept_sparse="csr")
         return self
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -556,7 +556,6 @@ PARAM_VALIDATION_ESTIMATORS_TO_IGNORE = [
     "NearestCentroid",
     "NearestNeighbors",
     "NeighborhoodComponentsAnalysis",
-    "Normalizer",
     "NuSVC",
     "NuSVR",
     "Nystroem",


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #23462 


#### What does this implement/fix? Explain your changes.

Included a class attribute `_parameter_constraints` that defines the valid types and values for the parameters of `Normalizer`.
`fit` calls `self._validate_params()` as the first step.

#### Any other comments?

Nope
