### PR TITLE
FIX Ensure correct sklearn.metrics.coverage_error error message for 1D array

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -119,6 +119,9 @@ Changelog
   of a binary classification problem. :pr:`22518` by
   :user:`Arturo Amor <ArturoAmorQ>`.
 
+- |Fix| Fixed error message of :class:`metrics.coverage_error` for 1D array input.
+  :pr:`23548` by :user:`Hao Chun Chang <haochunchang>`.
+
 :mod:`sklearn.neighbors`
 ........................
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1155,8 +1155,8 @@ def coverage_error(y_true, y_score, *, sample_weight=None):
            handbook (pp. 667-685). Springer US.
 
     """
-    y_true = check_array(y_true, ensure_2d=False)
-    y_score = check_array(y_score, ensure_2d=False)
+    y_true = check_array(y_true, ensure_2d=True)
+    y_score = check_array(y_score, ensure_2d=True)
     check_consistent_length(y_true, y_score, sample_weight)
 
     y_type = type_of_target(y_true, input_name="y_true")

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -910,6 +910,9 @@ invalids_nan_inf = [
 )
 @pytest.mark.parametrize("y_true, y_score", invalids_nan_inf)
 def test_regression_thresholded_inf_nan_input(metric, y_true, y_score):
+    if metric == coverage_error:
+        y_true = [y_true]
+        y_score = [y_score]
     with pytest.raises(ValueError, match=r"contains (NaN|infinity)"):
         metric(y_true, y_score)
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -910,6 +910,7 @@ invalids_nan_inf = [
 )
 @pytest.mark.parametrize("y_true, y_score", invalids_nan_inf)
 def test_regression_thresholded_inf_nan_input(metric, y_true, y_score):
+    # Reshape since coverage_error only accepts 2D arrays.
     if metric == coverage_error:
         y_true = [y_true]
         y_score = [y_score]

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1570,15 +1570,10 @@ def test_coverage_tie_handling():
 
 
 def test_coverage_1d_error_message():
-    y_true = [1, 0, 1]
-    msg = (
-        "Expected 2D array, got 1D array instead:\narray=[1 0 1].\n"
-        "Reshape your data either using array.reshape(-1, 1) if "
-        "your data has a single feature or array.reshape(1, -1) "
-        "if it contains a single sample."
-    )
-    with pytest.raises(ValueError, match=re.escape(msg)):
-        coverage_error(y_true, [0.25, 0.5, 0.5])
+    with pytest.raises(ValueError, match=r"Expected 2D array, got 1D array instead"):
+        coverage_error([1, 0, 1], [0.25, 0.5, 0.5])
+        coverage_error([1, 0, 1], [[0.25, 0.5, 0.5]])
+        coverage_error([[1, 0, 1]], [0.25, 0.5, 0.5])
 
 
 def test_label_ranking_loss():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1578,6 +1578,8 @@ def test_coverage_tie_handling():
     ],
 )
 def test_coverage_1d_error_message(y_true, y_score):
+    # Non-regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/23368
     with pytest.raises(ValueError, match=r"Expected 2D array, got 1D array instead"):
         coverage_error(y_true, y_score)
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1569,11 +1569,17 @@ def test_coverage_tie_handling():
     assert_almost_equal(coverage_error([[1, 1, 1]], [[0.25, 0.5, 0.5]]), 3)
 
 
-def test_coverage_1d_error_message():
+@pytest.mark.parametrize(
+    "y_true, y_score",
+    [
+        ([1, 0, 1], [0.25, 0.5, 0.5]),
+        ([1, 0, 1], [[0.25, 0.5, 0.5]]),
+        ([[1, 0, 1]], [0.25, 0.5, 0.5]),
+    ],
+)
+def test_coverage_1d_error_message(y_true, y_score):
     with pytest.raises(ValueError, match=r"Expected 2D array, got 1D array instead"):
-        coverage_error([1, 0, 1], [0.25, 0.5, 0.5])
-        coverage_error([1, 0, 1], [[0.25, 0.5, 0.5]])
-        coverage_error([[1, 0, 1]], [0.25, 0.5, 0.5])
+        coverage_error(y_true, y_score)
 
 
 def test_label_ranking_loss():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1569,6 +1569,18 @@ def test_coverage_tie_handling():
     assert_almost_equal(coverage_error([[1, 1, 1]], [[0.25, 0.5, 0.5]]), 3)
 
 
+def test_coverage_1d_error_message():
+    y_true = [1, 0, 1]
+    msg = (
+        "Expected 2D array, got 1D array instead:\narray=[1 0 1].\n"
+        "Reshape your data either using array.reshape(-1, 1) if "
+        "your data has a single feature or array.reshape(1, -1) "
+        "if it contains a single sample."
+    )
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        coverage_error(y_true, [0.25, 0.5, 0.5])
+
+
 def test_label_ranking_loss():
     assert_almost_equal(label_ranking_loss([[0, 1]], [[0.25, 0.75]]), 0)
     assert_almost_equal(label_ranking_loss([[0, 1]], [[0.75, 0.25]]), 1)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #23368 

#### What does this implement/fix? Explain your changes.
* Change the 2 calls `check_array(., ensure_2d=False)` at the beginning of coverage_error to `ensure_2d=True`.
* Add "if metric == coverage_error then reshape y_true to 2d" in `test_regression_thresholded_inf_nan_input` in metrics common test to fix failed tests.
* Add coverage_error specific test to check correct error message is raised when passing a 1d array as input.

#### Any other comments?
Not sure if adding the "if else" in the common test is elegant. It might adds more cognitive complexity. Hoping for any comment on it.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
