### PR TITLE
DOC Fix grammar in contributing doc

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -443,7 +443,7 @@ complies with the following rules before marking a PR as ``[MRG]``. The
 
         git diff upstream/main -u -- "*.py" | flake8 --diff
 
-   or `make flake8-diff` which should work on unix-like system.
+   or `make flake8-diff` which should work on Unix-like systems.
 
 7. Follow the :ref:`coding-guidelines`.
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #23552 


#### What does this implement/fix? Explain your changes.
There is a small typo in the `scikit-learn/doc/developers/contributing.rst` file:
```
or `make flake8-diff` which should work on unix-like system.
```

I believe the following sentence would be a better replacement:
```
or `make flake8-diff` which should work on Unix-like systems.
```

#### Any other comments?
I ran the `make` command in the `doc` directory in order to generate the full web site. The build succeeded after running this command.
