### PR TITLE
DOC fix docstring of assert_allclose (atol is not being set based on the provided arrays' dtypes)

### DIFF
--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -414,7 +414,6 @@ def assert_allclose(
         If None, it is set based on the provided arrays' dtypes.
     atol : float, optional, default=0.
         Absolute tolerance.
-        If None, it is set based on the provided arrays' dtypes.
     equal_nan : bool, optional, default=True
         If True, NaNs will compare equal.
     err_msg : str, optional, default=''


### PR DESCRIPTION
#### Reference Issues/PRs

Docstring fix moved to a separate PR (see https://github.com/scikit-learn/scikit-learn/pull/22059#discussion_r889566900 @thomasjpfan)


#### What does this implement/fix? Explain your changes.

Fixes the docstring of `sklearn.utils._testing.assert_allclose`. There, for `rtol` as well as `atol` it was stated that "If None, it is set based on the provided arrays' dtypes.". However, looking into the code it becomes clear that only `rtol` is dtype-aware (if set to `None`) but not `atol`. Therefore, in this PR the statement is removed from the `atol` docstring.
