### PR TITLE
feat: add support for Remote Cloud Development with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,142 @@
+## Learn more about this file at 'https://www.gitpod.io/docs/references/gitpod-yml'
+##
+## This '.gitpod.yml' file when placed at the root of a project instructs
+## Gitpod how to prepare & build the project, start development environments
+## and configure continuous prebuilds. Prebuilds when enabled builds a project
+## like a CI server so you can start coding right away - no more waiting for
+## dependencies to download and builds to finish when reviewing pull-requests
+## or hacking on something new.
+##
+## With Gitpod you can develop software from any device (even iPads) via
+## desktop or browser based versions of VS Code or any JetBrains IDE and
+## customise it to your individual needs - from themes to extensions, you
+## have full control.
+##
+## The easiest way to try out Gitpod is install the browser extenion:
+## 'https://www.gitpod.io/docs/browser-extension' or by prefixing
+## 'https://gitpod.io#' to the source control URL of any project.
+##
+## For example: 'https://gitpod.io#https://github.com/gitpod-io/gitpod'
+
+## The 'image' section defines which Docker image Gitpod should use.
+## By default, Gitpod uses a standard Docker Image called 'workspace-full'
+## which can be found at 'https://github.com/gitpod-io/workspace-images'
+##
+## Workspaces started based on this default image come pre-installed with
+## Docker, Go, Java, Node.js, C/C++, Python, Ruby, Rust, PHP as well as
+## tools such as Homebrew, Tailscale, Nginx and several more.
+##
+## If this image does not include the tools needed for your project then
+## a public Docker image or your own Docker file can be configured.
+##
+## Learn more about images at 'https://www.gitpod.io/docs/config-docker'
+
+#image: node:buster                        # use 'https://hub.docker.com/_/node'
+#
+#image:                                    # leave image undefined if using a Dockerfile
+#  file: .gitpod.Dockerfile                # relative path to the Dockerfile from the
+#                                          # root of the project
+
+## The 'tasks' section defines how Gitpod prepares and builds this project
+## or how Gitpod can start development servers. With Gitpod, there are three
+## types of tasks:
+##
+## - before: Use this for tasks that need to run before init and before command.
+## - init: Use this to configure prebuilds of heavy-lifting tasks such as
+##         downloading dependencies or compiling source code.
+## - command: Use this to start your database or application when the workspace starts.
+##
+## Learn more about these tasks at 'https://www.gitpod.io/docs/config-start-tasks'
+
+#tasks:
+#  - before: |
+#      # commands to execute...
+#
+#  - init: |
+#      # sudo apt-get install python3     # can be used to install operating system
+#                                         # dependencies but these are not kept after the
+#                                         # prebuild completes thus Gitpod recommends moving
+#                                         # operating system dependency installation steps
+#                                         # to a custom Dockerfile to make prebuilds faster
+#                                         # and to keep your codebase DRY.
+#                                         # 'https://www.gitpod.io/docs/config-docker'
+#
+#      # pip install -r requirements.txt  # install codebase dependencies
+#      # cmake                            # precompile codebase
+#
+#  - name: Web Server
+#    openMode: split-left
+#    env:
+#      WEBSERVER_PORT: 8080
+#    command: |
+#     python3 -m http.server $WEBSERVER_PORT
+#
+#  - name: Web Browser
+#    openMode: split-right
+#    env:
+#      WEBSERVER_PORT: 8080
+#    command: |
+#     gp await-port $WEBSERVER_PORT
+#     lynx `gp url`
+
+tasks:
+  - init: |
+      python3 -m venv sklearn-env
+      source sklearn-env/bin/activate
+      pip3 install wheel numpy scipy cython
+      pip install --verbose --no-build-isolation --editable .
+  - name: Verify scikit-learn installation
+    command: python -c "import sklearn; sklearn.show_versions()"
+
+## The 'ports' section defines various ports your may listen on are
+## configured in Gitpod on an authenticated URL. By default, all ports
+## are in private visibility state.
+##
+## Learn more about ports at 'https://www.gitpod.io/docs/config-ports'
+
+#ports:
+#  - port: 8080 # alternatively configure entire ranges via '8080-8090'
+#    visibility: private # either 'public' or 'private' (default)
+#    onOpen: open-browser # either 'open-browser', 'open-preview' or 'ignore'
+
+## The 'vscode' section defines a list of Visual Studio Code extensions from
+## the OpenVSX.org registry to be installed upon workspace startup. OpenVSX
+## is an open alternative to the proprietary Visual Studio Code Marketplace
+## and extensions can be added by sending a pull-request with the extension
+## identifier to https://github.com/open-vsx/publish-extensions
+##
+## The identifier of an extension is always ${publisher}.${name}.
+##
+## For example: 'vscodevim.vim'
+##
+## Learn more at 'https://www.gitpod.io/docs/ides-and-editors/vscode'
+
+#vscode:
+#  extensions:
+#    - vscodevim.vim
+#    - esbenp.prettier-vscode@9.5.0
+#    - https://example.com/abc/releases/extension-0.26.0.vsix
+
+## The 'github' section defines configuration of continuous prebuilds
+## for GitHub repositories when the GitHub application
+## 'https://github.com/apps/gitpod-io' is installed in GitHub and granted
+## permissions to access the repository.
+##
+## Learn more at 'https://www.gitpod.io/docs/prebuilds'
+
+github:
+  prebuilds:
+    # enable for the default branch
+    master: true
+    # enable for all branches in this repo
+    branches: true
+    # enable for pull requests coming from this repo
+    pullRequests: true
+    # enable for pull requests coming from forks
+    pullRequestsFromForks: true
+    # add a check to pull requests
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description
+    addBadge: true

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. -*- mode: rst -*-
 
-|Azure|_ |Travis|_ |Codecov|_ |CircleCI|_ |Nightly wheels|_ |Black|_ |PythonVersion|_ |PyPi|_ |DOI|_ |Benchmark|_
+|Azure|_ |Travis|_ |Codecov|_ |CircleCI|_ |Nightly wheels|_ |Black|_ |PythonVersion|_ |PyPi|_ |DOI|_ |Benchmark|_ |Gitpod|_
 
 .. |Azure| image:: https://dev.azure.com/scikit-learn/scikit-learn/_apis/build/status/scikit-learn.scikit-learn?branchName=main
 .. _Azure: https://dev.azure.com/scikit-learn/scikit-learn/_build/latest?definitionId=1&branchName=main
@@ -31,6 +31,9 @@
 
 .. |Benchmark| image:: https://img.shields.io/badge/Benchmarked%20by-asv-blue
 .. _`Benchmark`: https://scikit-learn.org/scikit-learn-benchmarks/
+
+.. |Gitpod| image:: https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod
+.. _`Gitpod`: https://gitpod.io/#https://github.com/scikit-learn/scikit-learn    
 
 .. |PythonMinVersion| replace:: 3.8
 .. |NumPyMinVersion| replace:: 1.17.3


### PR DESCRIPTION
👋🏼 Hello, Siddhant here from Gitpod

#### Reference Issues/PRs
N/A


#### What does this implement/fix? Explain your changes.

_**Problem**_: It would skip all the pain in running the manual steps for setup & building from the source, running all the manual commands with Hardware limitations.

**_Solution_**: it Contains a `.gitpod.yml` file which runs all the [necessary commands (docs)](https://scikit-learn.org/dev/developers/advanced_installation.html#building-from-source) required to create a ready to code environment on Gitpod. It would help contributors to directly jump into the main part without doing the manually running the Installation commands.


#### Any other comments?
To Test it out, Just Click on following button & see the preview:

[![Open scikit-learn in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-forks/scikit-learn-scikit-learn)


