### PR TITLE
CI reduce verbosity of build_doc.sh

### DIFF
--- a/build_tools/github/build_doc.sh
+++ b/build_tools/github/build_doc.sh
@@ -170,7 +170,7 @@ export CCACHE_COMPRESS=1
 
 # pin conda-lock to latest released version (needs manual update from time to time)
 mamba install conda-lock==1.0.5 -y
-conda-lock install --name $CONDA_ENV_NAME $LOCK_FILE
+conda-lock install --log-level WARNING --name $CONDA_ENV_NAME $LOCK_FILE
 source activate $CONDA_ENV_NAME
 
 mamba list

--- a/build_tools/github/build_doc.sh
+++ b/build_tools/github/build_doc.sh
@@ -180,6 +180,9 @@ mamba list
 export SKLEARN_BUILD_PARALLEL=3
 pip install -e . --no-build-isolation
 
+echo "ccache build summary:"
+ccache -s
+
 export OMP_NUM_THREADS=1
 
 if [[ "$CIRCLE_BRANCH" =~ ^main$ && -z "$CI_PULL_REQUEST" ]]

--- a/build_tools/github/build_doc.sh
+++ b/build_tools/github/build_doc.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -v
 set -e
 
 # Decide what kind of documentation build to run, and run it.
@@ -179,7 +178,7 @@ mamba list
 # Set parallelism to 3 to overlap IO bound tasks with CPU bound tasks on CI
 # workers with 2 cores when building the compiled extensions of scikit-learn.
 export SKLEARN_BUILD_PARALLEL=3
-python setup.py develop
+pip install -e . --no-build-isolation
 
 export OMP_NUM_THREADS=1
 

--- a/build_tools/github/build_doc.sh
+++ b/build_tools/github/build_doc.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -x
+set -v
 set -e
 
 # Decide what kind of documentation build to run, and run it.
@@ -154,17 +154,17 @@ sudo -E apt-get -yq update --allow-releaseinfo-change
 sudo -E apt-get -yq --no-install-suggests --no-install-recommends \
     install dvipng gsfonts ccache zip optipng
 
-# deactivate circleci virtualenv and setup a miniconda env instead
+# deactivate circleci virtualenv and setup a conda env instead
 if [[ `type -t deactivate` ]]; then
   deactivate
 fi
 
-MINICONDA_PATH=$HOME/miniconda
-# Install dependencies with miniconda
-wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh \
-    -O miniconda.sh
-chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
-export PATH="/usr/lib/ccache:$MINICONDA_PATH/bin:$PATH"
+MAMBAFORGE_PATH=$HOME/mambaforge
+# Install dependencies with mamba
+wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh \
+    -O mambaforge.sh
+chmod +x mambaforge.sh && ./mambaforge.sh -b -p $MAMBAFORGE_PATH
+export PATH="/usr/lib/ccache:$MAMBAFORGE_PATH/bin:$PATH"
 
 ccache -M 512M
 export CCACHE_COMPRESS=1

--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -35,8 +35,6 @@ helper functions for loading the data and visualizing results.
 .. [1]  A. Noll, R. Salzmann and M.V. Wuthrich, Case Study: French Motor
     Third-Party Liability Claims (November 8, 2018). `doi:10.2139/ssrn.3164764
     <http://dx.doi.org/10.2139/ssrn.3164764>`_
-
-DEBUG: don't forge to revert me before merging.
 """
 
 # Authors: Christian Lorentzen <lorentzen.ch@gmail.com>

--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -35,6 +35,8 @@ helper functions for loading the data and visualizing results.
 .. [1]  A. Noll, R. Salzmann and M.V. Wuthrich, Case Study: French Motor
     Third-Party Liability Claims (November 8, 2018). `doi:10.2139/ssrn.3164764
     <http://dx.doi.org/10.2139/ssrn.3164764>`_
+
+DEBUG: don't forge to revert me before merging.
 """
 
 # Authors: Christian Lorentzen <lorentzen.ch@gmail.com>


### PR DESCRIPTION
The log of the documentation build is very verbose and can sometimes lead firefox to display black pages with a very long scroll bars for several seconds making it painful to read the error message when working on a failing example (e.g. https://github.com/scikit-learn/scikit-learn/runs/6754051284?check_suite_focus=true).

This PRs changes a few things in the build_doc.sh script to make that log shorter and focused on documentation related issues:

- pass -q to wget to avoid the expanded download progress bar for the mambaforge installer
- <del>try to use `set -v` instead of `set -x`</del> remove all verbose bash options
- the the log level of conda-lock to WARNING instead of INFO to avoid redundant mamba installation output (we already do a mamba list at the end).
- build scikit-learn with `pip` to hide the build log by default when there is not build problem.

I also renamed variables related to miniconda to account for the switch to mambaforge.