### PR TITLE
MNT Param validation: Make it possible to mark a constraint as hidden

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -35,6 +35,7 @@ from ..utils import check_array
 from ..utils import check_random_state
 from ..utils.validation import check_is_fitted, _check_sample_weight
 from ..utils.validation import _is_arraylike_not_scalar
+from ..utils._param_validation import Hidden
 from ..utils._param_validation import Interval
 from ..utils._param_validation import StrOptions
 from ..utils._param_validation import validate_params
@@ -273,7 +274,8 @@ def _tolerance(X, tol):
         "sample_weight": ["array-like", None],
         "init": [StrOptions({"k-means++", "random"}), callable, "array-like"],
         "n_init": [
-            StrOptions({"auto", "warn"}, internal={"warn"}),
+            StrOptions({"auto"}),
+            Hidden(StrOptions({"warn"})),
             Interval(Integral, 1, None, closed="left"),
         ],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
@@ -834,7 +836,8 @@ class _BaseKMeans(
         "n_clusters": [Interval(Integral, 1, None, closed="left")],
         "init": [StrOptions({"k-means++", "random"}), callable, "array-like"],
         "n_init": [
-            StrOptions({"auto", "warn"}, internal={"warn"}),
+            StrOptions({"auto"}),
+            Hidden(StrOptions({"warn"})),
             Interval(Integral, 1, None, closed="left"),
         ],
         "max_iter": [Interval(Integral, 1, None, closed="left")],

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -28,7 +28,7 @@ from scipy.special import expit
 from joblib import Parallel
 from numbers import Integral
 
-from ..utils._param_validation import StrOptions, Internal
+from ..utils._param_validation import StrOptions, Hidden
 from ..base import BaseEstimator, ClassifierMixin, RegressorMixin, MultiOutputMixin
 from ..preprocessing._data import _is_constant_feature
 from ..utils import check_array
@@ -640,7 +640,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
 
     _parameter_constraints = {
         "fit_intercept": [bool],
-        "normalize": [Internal(StrOptions({"deprecated"})), bool],
+        "normalize": [Hidden(StrOptions({"deprecated"})), bool],
         "copy_X": [bool],
         "n_jobs": [None, Integral],
         "positive": [bool],

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -28,7 +28,7 @@ from scipy.special import expit
 from joblib import Parallel
 from numbers import Integral
 
-from ..utils._param_validation import StrOptions
+from ..utils._param_validation import StrOptions, Internal
 from ..base import BaseEstimator, ClassifierMixin, RegressorMixin, MultiOutputMixin
 from ..preprocessing._data import _is_constant_feature
 from ..utils import check_array
@@ -640,7 +640,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
 
     _parameter_constraints = {
         "fit_intercept": [bool],
-        "normalize": [StrOptions({"deprecated"}, internal={"deprecated"}), bool],
+        "normalize": [Internal(StrOptions({"deprecated"})), bool],
         "copy_X": [bool],
         "n_jobs": [None, Integral],
         "positive": [bool],

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -56,9 +56,7 @@ def validate_parameter_constraints(parameter_constraints, params, caller_name):
             # Ignore constraints that we don't want to expose in the error message,
             # i.e. options that are for internal purpose or not officially supported.
             constraints = [
-                constraint
-                for constraint in constraints
-                if not getattr(constraint, "hidden_constraint", False)
+                constraint for constraint in constraints if not constraint.hidden
             ]
 
             if len(constraints) == 1:
@@ -104,7 +102,7 @@ def make_constraint(constraint):
         return constraint
     if isinstance(constraint, Hidden):
         constraint = make_constraint(constraint.constraint)
-        constraint.hidden_constraint = True
+        constraint.hidden = True
         return constraint
     raise ValueError(f"Unknown constraint type: {constraint}")
 
@@ -157,7 +155,7 @@ class _Constraint(ABC):
     """Base class for the constraint objects."""
 
     def __init__(self):
-        self.hidden_constraint = False
+        self.hidden = False
 
     @abstractmethod
     def is_satisfied_by(self, val):

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -233,9 +233,7 @@ class StrOptions(_Constraint):
         A subset of the `options` to mark as deprecated in the repr of the constraint.
     """
 
-    @validate_params(
-        {"options": [set], "deprecated": [set, None]}
-    )
+    @validate_params({"options": [set], "deprecated": [set, None]})
     def __init__(self, options, deprecated=None):
         super().__init__()
         self.options = options

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -58,7 +58,7 @@ def validate_parameter_constraints(parameter_constraints, params, caller_name):
             constraints = [
                 constraint
                 for constraint in constraints
-                if not getattr(constraint, "internal_constraint", False)
+                if not getattr(constraint, "hidden_constraint", False)
             ]
 
             if len(constraints) == 1:
@@ -102,9 +102,9 @@ def make_constraint(constraint):
         return _InstancesOf(constraint)
     if isinstance(constraint, (Interval, StrOptions)):
         return constraint
-    if isinstance(constraint, Internal):
+    if isinstance(constraint, Hidden):
         constraint = make_constraint(constraint.constraint)
-        setattr(constraint, "internal_constraint", True)
+        setattr(constraint, "hidden_constraint", True)
         return constraint
     raise ValueError(f"Unknown constraint type: {constraint}")
 
@@ -254,7 +254,7 @@ class StrOptions(_Constraint):
         if self.options == self.internal:
             raise ValueError(
                 "All options can't be internal, use "
-                f"Internal(StrOptions({self.options})) instead."
+                f"Hidden(StrOptions({self.options})) instead."
             )
 
     def is_satisfied_by(self, val):
@@ -432,7 +432,7 @@ class _RandomStates(_Constraint):
         )
 
 
-class Internal:
+class Hidden:
     """Class encapsulating a constraint not meant to be exposed to the user.
 
     Parameters

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -55,7 +55,11 @@ def validate_parameter_constraints(parameter_constraints, params, caller_name):
 
             # Ignore constraints that only contains internal options that we don't want
             # to expose in the error message
-            constraints = [constraint for constraint in constraints if not getattr(constraint, "internal_constraint", False)]
+            constraints = [
+                constraint
+                for constraint in constraints
+                if not getattr(constraint, "internal_constraint", False)
+            ]
 
             if len(constraints) == 1:
                 constraints_str = f"{constraints[0]}"
@@ -249,7 +253,7 @@ class StrOptions(_Constraint):
 
         if self.options == self.internal:
             raise ValueError(
-                f"All options can't be internal, use "
+                "All options can't be internal, use "
                 f"Internal(StrOptions({self.options})) instead."
             )
 
@@ -436,6 +440,7 @@ class Internal:
     constraint : str or _Constraint instance
         The constraint to be used internally.
     """
+
     def __init__(self, constraint):
         self.constraint = constraint
 

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -448,6 +448,7 @@ def test_hidden_constraint():
 
 def test_hidden_stroptions():
     """Check that we can have 2 StrOptions constraints, one being hidden."""
+
     @validate_params({"param": [StrOptions({"auto"}), Hidden(StrOptions({"warn"}))]})
     def f(param):
         pass

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -338,13 +338,14 @@ def test_stroptions_not_all_internal():
 
 def test_internal_constraint():
     """Check that internal constraints are not exposed in the error message."""
+
     @validate_params({"param": [Internal(list), dict]})
     def f(param):
         pass
 
     # list and dict are valid params
     f({"a": 1, "b": 2, "c": 3})
-    f([1,2,3])
+    f([1, 2, 3])
 
     with pytest.raises(ValueError, match="The 'param' parameter") as exc_info:
         f(param="bad")

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -6,7 +6,7 @@ import pytest
 
 from sklearn.base import BaseEstimator
 from sklearn.utils import deprecated
-from sklearn.utils._param_validation import Internal
+from sklearn.utils._param_validation import Hidden
 from sklearn.utils._param_validation import Interval
 from sklearn.utils._param_validation import StrOptions
 from sklearn.utils._param_validation import _ArrayLikes
@@ -336,10 +336,10 @@ def test_stroptions_not_all_internal():
         StrOptions({"a", "b"}, internal={"a", "b"})
 
 
-def test_internal_constraint():
+def test_hidden_constraint():
     """Check that internal constraints are not exposed in the error message."""
 
-    @validate_params({"param": [Internal(list), dict]})
+    @validate_params({"param": [Hidden(list), dict]})
     def f(param):
         pass
 

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -130,13 +130,12 @@ def test_interval_errors(params, error, match):
 
 def test_stroptions():
     """Sanity check for the StrOptions constraint"""
-    options = StrOptions({"a", "b", "c"}, deprecated={"c"}, internal={"b"})
+    options = StrOptions({"a", "b", "c"}, deprecated={"c"})
     assert options.is_satisfied_by("a")
     assert options.is_satisfied_by("c")
     assert not options.is_satisfied_by("d")
 
     assert "'c' (deprecated)" in str(options)
-    assert "'b'" not in str(options)
 
 
 @pytest.mark.parametrize(
@@ -421,47 +420,10 @@ def test_validate_params_estimator():
         est.fit()
 
 
-def test_internal_values_not_exposed():
-    """Check that valid values that are for internal purpose, e.g. "warn" or
-    "deprecated" are not exposed in the error message
-    """
-
-    @validate_params({"param": [StrOptions({"auto", "warn"}, internal={"warn"})]})
-    def f(param):
-        pass
-
-    with pytest.raises(ValueError, match="The 'param' parameter") as exc_info:
-        f(param="bad")
-
-    err_msg = str(exc_info.value)
-    assert "a str among" in err_msg
-    assert "auto" in err_msg
-    assert "warn" not in err_msg
-
-    # no error
-    f(param="warn")
-
-
-def test_stroptions_deprecated_internal_overlap():
-    """Check that the internal and deprecated parameters are not allowed to overlap."""
-    with pytest.raises(ValueError, match="should not overlap"):
-        StrOptions({"a", "b", "c"}, deprecated={"b", "c"}, internal={"a", "b"})
-
-
-def test_stroptions_deprecated_internal_subset():
-    """Check that the deprecated and internal parameters must be subsets of options."""
+def test_stroptions_deprecated_subset():
+    """Check that the deprecated parameter must be a subset of options."""
     with pytest.raises(ValueError, match="deprecated options must be a subset"):
         StrOptions({"a", "b", "c"}, deprecated={"a", "d"})
-
-    with pytest.raises(ValueError, match="internal options must be a subset"):
-        StrOptions({"a", "b", "c"}, internal={"a", "d"})
-
-
-def test_stroptions_not_all_internal():
-    """Check that all options can't be internal."""
-
-    with pytest.raises(ValueError, match="All options can't be internal"):
-        StrOptions({"a", "b"}, internal={"a", "b"})
 
 
 def test_hidden_constraint():
@@ -482,3 +444,22 @@ def test_hidden_constraint():
     err_msg = str(exc_info.value)
     assert "an instance of 'dict'" in err_msg
     assert "an instance of 'list'" not in err_msg
+
+
+def test_hidden_stroptions():
+    """Check that we can have 2 StrOptions constraints, one being hidden."""
+    @validate_params({"param": [StrOptions({"auto"}), Hidden(StrOptions({"warn"}))]})
+    def f(param):
+        pass
+
+    # "auto" and "warn" are valid params
+    f("auto")
+    f("warn")
+
+    with pytest.raises(ValueError, match="The 'param' parameter") as exc_info:
+        f(param="bad")
+
+    # the "warn" option is not exposed in the error message
+    err_msg = str(exc_info.value)
+    assert "auto" in err_msg
+    assert "warn" not in err_msg


### PR DESCRIPTION
Some parameters accepts types as an unofficial way. For instance `criterion` in trees can be an instance of `Criterion` but that's not documented and not meant to be documented.

For these, we don't want the error message of the validation of this parameter to say that this unofficial type is valid. Hence this PR proposes to make it possible to mark a constraint as `internal` such that it's not shown in the message.