### PR TITLE
MNT Configure sphinx linkcheck to be more useful

### DIFF
--- a/doc/sphinxext/allow_nan_estimators.py
+++ b/doc/sphinxext/allow_nan_estimators.py
@@ -23,7 +23,7 @@ class AllowNanEstimators(Directive):
             if est._get_tags().get("allow_nan"):
                 module_name = ".".join(est_class.__module__.split(".")[:2])
                 class_title = f"{est_class.__name__}"
-                class_url = f"generated/{module_name}.{class_title}.html"
+                class_url = f"./generated/{module_name}.{class_title}.html"
                 item = nodes.list_item()
                 para = nodes.paragraph()
                 para += nodes.reference(


### PR DESCRIPTION
Right now, we rarely run `make linkcheck` because there is too much noise in the output and it takes a while.

Here are the list of changes that this PR introduces:
- do not run the examples when running linkcheck
- excluding whats_new files from linkcheck, this checks a lot of github links and takes a lot of time (on my machines ~15 minutes when checking whats_new files, ~3 minutes when not checking whats_new files). Alternatively we could only check a few of the latest whats_new files.
- set github token from environment variable if set to be able to avoid github rate limits
- setting timeout to have faster failure on some problematic websites
- ignore local links (e.g. in image directive `target`). There may be a better way but I have not found it ...
- allows redirects, this turns redirects into warnings rather than broken links
- use a browser-like user agent, to decrease the number for falsely broken links, i.e. that linkcheck identifies as broken but that work fine in a browser
- ignore some broken links. There are more broken links, I am planning to open a meta-issue about well-identified broken links in the near future. I would say a fair fraction of them are links to articles that have moved somewhere else since.