### PR TITLE
Update documentation of fetch_lfw functions

### DIFF
--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -308,6 +308,9 @@ def fetch_lfw_people(
         target : numpy array of shape (13233,)
             Labels associated to each face image.
             Those labels range from 0-5748 and correspond to the person IDs.
+        target_names : numpy array of shape (5749,)
+            Names of all persons in the dataset. 
+            Position in array corresponds to the person ID in the target array.    
         DESCR : str
             Description of the Labeled Faces in the Wild (LFW) dataset.
 
@@ -489,6 +492,9 @@ def fetch_lfw_pairs(
         target : numpy array of shape (2200,). Shape depends on ``subset``.
             Labels associated to each pair of images.
             The two label values being different persons or the same person.
+        target_names : numpy array of shape (2,)
+            Explains the target values of the target array.
+            0 corresponds to "Different person", 1 corresponds to "same person".            
         DESCR : str
             Description of the Labeled Faces in the Wild (LFW) dataset.
 


### PR DESCRIPTION
Updated documentation of fetch_lfw_people and fetch_lfw_pairs to include the target_names array, which was mentioned in the [user guide](https://scikit-learn.org/stable/datasets/real_world.html#labeled-faces-in-the-wild-dataset), but missing in the [documentation](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_lfw_people.html#sklearn.datasets.fetch_lfw_people).

Personally, since target_names for fetch_lfw_pairs is has only 2 values I think it's more intuitive to omit the target_names entirely for fetch_lfw_pairs and explain in the documentation of the target array that 0 corresponds to different persons and 1 corresponds to same person, but there might be consistency reasons to keep it that way, so I did not want to make any changes to that. See also #13962