### PR TITLE
DOC Replace `chi2` with `f_classif` in feature selection examples

### DIFF
--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -70,16 +70,16 @@ as objects that implement the ``transform`` method:
    selection with a configurable strategy. This allows to select the best
    univariate selection strategy with hyper-parameter search estimator.
 
-For instance, we can perform a :math:`\chi^2` test to the samples
+For instance, we can perform a F-test to the samples
 to retrieve only the two best features as follows:
 
   >>> from sklearn.datasets import load_iris
   >>> from sklearn.feature_selection import SelectKBest
-  >>> from sklearn.feature_selection import chi2
+  >>> from sklearn.feature_selection import f_classif
   >>> X, y = load_iris(return_X_y=True)
   >>> X.shape
   (150, 4)
-  >>> X_new = SelectKBest(chi2, k=2).fit_transform(X, y)
+  >>> X_new = SelectKBest(f_classif, k=2).fit_transform(X, y)
   >>> X_new.shape
   (150, 2)
 

--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -34,7 +34,7 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
 from sklearn.svm import LinearSVC
 from sklearn.decomposition import PCA, NMF
-from sklearn.feature_selection import SelectKBest, chi2
+from sklearn.feature_selection import SelectKBest, f_classif
 
 pipe = Pipeline(
     [
@@ -48,17 +48,17 @@ N_FEATURES_OPTIONS = [2, 4, 8]
 C_OPTIONS = [1, 10, 100, 1000]
 param_grid = [
     {
-        "reduce_dim": [PCA(iterated_power=7), NMF()],
+        "reduce_dim": [PCA(iterated_power=7), NMF(init="nndsvda", max_iter=1000)],
         "reduce_dim__n_components": N_FEATURES_OPTIONS,
         "classify__C": C_OPTIONS,
     },
     {
-        "reduce_dim": [SelectKBest(chi2)],
+        "reduce_dim": [SelectKBest(f_classif)],
         "reduce_dim__k": N_FEATURES_OPTIONS,
         "classify__C": C_OPTIONS,
     },
 ]
-reducer_labels = ["PCA", "NMF", "KBest(chi2)"]
+reducer_labels = ["PCA", "NMF", "KBest(f_classif)"]
 
 grid = GridSearchCV(pipe, n_jobs=1, param_grid=param_grid)
 X, y = load_digits(return_X_y=True)

--- a/examples/svm/plot_svm_anova.py
+++ b/examples/svm/plot_svm_anova.py
@@ -26,7 +26,7 @@ X = np.hstack((X, 2 * rng.random((X.shape[0], 36))))
 # Create the pipeline
 # -------------------
 from sklearn.pipeline import Pipeline
-from sklearn.feature_selection import SelectPercentile, chi2
+from sklearn.feature_selection import SelectPercentile, f_classif
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
@@ -35,7 +35,7 @@ from sklearn.svm import SVC
 
 clf = Pipeline(
     [
-        ("anova", SelectPercentile(chi2)),
+        ("anova", SelectPercentile(f_classif)),
         ("scaler", StandardScaler()),
         ("svc", SVC(gamma="auto")),
     ]

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -749,7 +749,7 @@ class SelectFpr(_BaseFilter):
     (569, 30)
     >>> X_new = SelectFpr(f_classif, alpha=0.01).fit_transform(X, y)
     >>> X_new.shape
-    (569, 16)
+    (569, 25)
     """
 
     def __init__(self, score_func=f_classif, *, alpha=5e-2):
@@ -828,7 +828,7 @@ class SelectFdr(_BaseFilter):
     (569, 30)
     >>> X_new = SelectFdr(f_classif, alpha=0.01).fit_transform(X, y)
     >>> X_new.shape
-    (569, 16)
+    (569, 25)
     """
 
     def __init__(self, score_func=f_classif, *, alpha=5e-2):
@@ -905,7 +905,7 @@ class SelectFwe(_BaseFilter):
     (569, 30)
     >>> X_new = SelectFwe(f_classif, alpha=0.01).fit_transform(X, y)
     >>> X_new.shape
-    (569, 15)
+    (569, 25)
     """
 
     def __init__(self, score_func=f_classif, *, alpha=5e-2):

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -550,11 +550,11 @@ class SelectPercentile(_BaseFilter):
     Examples
     --------
     >>> from sklearn.datasets import load_digits
-    >>> from sklearn.feature_selection import SelectPercentile, chi2
+    >>> from sklearn.feature_selection import SelectPercentile, f_classif
     >>> X, y = load_digits(return_X_y=True)
     >>> X.shape
     (1797, 64)
-    >>> X_new = SelectPercentile(chi2, percentile=10).fit_transform(X, y)
+    >>> X_new = SelectPercentile(f_classif, percentile=10).fit_transform(X, y)
     >>> X_new.shape
     (1797, 7)
     """
@@ -650,11 +650,11 @@ class SelectKBest(_BaseFilter):
     Examples
     --------
     >>> from sklearn.datasets import load_digits
-    >>> from sklearn.feature_selection import SelectKBest, chi2
+    >>> from sklearn.feature_selection import SelectKBest, f_classif
     >>> X, y = load_digits(return_X_y=True)
     >>> X.shape
     (1797, 64)
-    >>> X_new = SelectKBest(chi2, k=20).fit_transform(X, y)
+    >>> X_new = SelectKBest(f_classif, k=20).fit_transform(X, y)
     >>> X_new.shape
     (1797, 20)
     """
@@ -743,11 +743,11 @@ class SelectFpr(_BaseFilter):
     Examples
     --------
     >>> from sklearn.datasets import load_breast_cancer
-    >>> from sklearn.feature_selection import SelectFpr, chi2
+    >>> from sklearn.feature_selection import SelectFpr, f_classif
     >>> X, y = load_breast_cancer(return_X_y=True)
     >>> X.shape
     (569, 30)
-    >>> X_new = SelectFpr(chi2, alpha=0.01).fit_transform(X, y)
+    >>> X_new = SelectFpr(f_classif, alpha=0.01).fit_transform(X, y)
     >>> X_new.shape
     (569, 16)
     """
@@ -822,11 +822,11 @@ class SelectFdr(_BaseFilter):
     Examples
     --------
     >>> from sklearn.datasets import load_breast_cancer
-    >>> from sklearn.feature_selection import SelectFdr, chi2
+    >>> from sklearn.feature_selection import SelectFdr, f_classif
     >>> X, y = load_breast_cancer(return_X_y=True)
     >>> X.shape
     (569, 30)
-    >>> X_new = SelectFdr(chi2, alpha=0.01).fit_transform(X, y)
+    >>> X_new = SelectFdr(f_classif, alpha=0.01).fit_transform(X, y)
     >>> X_new.shape
     (569, 16)
     """
@@ -899,11 +899,11 @@ class SelectFwe(_BaseFilter):
     Examples
     --------
     >>> from sklearn.datasets import load_breast_cancer
-    >>> from sklearn.feature_selection import SelectFwe, chi2
+    >>> from sklearn.feature_selection import SelectFwe, f_classif
     >>> X, y = load_breast_cancer(return_X_y=True)
     >>> X.shape
     (569, 30)
-    >>> X_new = SelectFwe(chi2, alpha=0.01).fit_transform(X, y)
+    >>> X_new = SelectFwe(f_classif, alpha=0.01).fit_transform(X, y)
     >>> X_new.shape
     (569, 15)
     """
@@ -978,11 +978,11 @@ class GenericUnivariateSelect(_BaseFilter):
     Examples
     --------
     >>> from sklearn.datasets import load_breast_cancer
-    >>> from sklearn.feature_selection import GenericUnivariateSelect, chi2
+    >>> from sklearn.feature_selection import GenericUnivariateSelect, f_classif
     >>> X, y = load_breast_cancer(return_X_y=True)
     >>> X.shape
     (569, 30)
-    >>> transformer = GenericUnivariateSelect(chi2, mode='k_best', param=20)
+    >>> transformer = GenericUnivariateSelect(f_classif, mode='k_best', param=20)
     >>> X_new = transformer.fit_transform(X, y)
     >>> X_new.shape
     (569, 20)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #17286.

#### What does this implement/fix? Explain your changes.

In this PR, I will fix the usage of the `chi2` function. The `chi2` should be applied to the count of categorical features, but some examples use `chi2` function to estimate the continuous variable features. It may confuse users. I think that the `f_classif` is a preferable choice for the continuous features of classification tasks. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->


In "examples/compose/plot_compare_reduction.py", I added the following changes to remove some `UserWarning.

```diff
- "reduce_dim": [PCA(iterated_power=7), NMF()],
+ "reduce_dim": [PCA(iterated_power=7), NMF(init="nndsvda", max_iter=1000)],
```        

There still exist the following warnings, but I think these are irrelevant to the PR.

```
scikit-learn/sklearn/feature_selection/_univariate_selection.py:110: UserWarning: Features [ 0 32 39] are constant.
  warnings.warn("Features %s are constant." % constant_features_idx, UserWarning)
scikit-learn/sklearn/feature_selection/_univariate_selection.py:111: RuntimeWarning: invalid value encountered in true_divide
  f = msb / msw
```
