### PR TITLE
[MRG] Fix sklearn.utils._param_validation._InstancesOf is insufficient for numpy data types

### DIFF
--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -173,12 +173,12 @@ class _InstancesOf(_Constraint):
 
     Parameters
     ----------
-    type : type
-        The valid type.
+    param_type : param_type
+        The valid paramater type.
     """
 
-    def __init__(self, type):
-        self.type = type
+    def __init__(self, param_type):
+        self.param_type = param_type
 
     def _type_name(self, t):
         """Convert type into human readable string."""
@@ -193,10 +193,10 @@ class _InstancesOf(_Constraint):
         return f"{module}.{qualname}"
 
     def is_satisfied_by(self, val):
-        return isinstance(val, self.type)
+        return isinstance(val, self.param_type)
 
     def __str__(self):
-        return f"an instance of {self._type_name(self.type)!r}"
+        return f"an instance of {self._type_name(self.param_type)!r}"
 
 
 class _NoneConstraint(_Constraint):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes  #23599


#### What does this implement/fix? Explain your changes.
sklearn.utils._param_validation._InstancesOf currently doesn't support numpy data types. The fix changes `self.type` into `self.param_type` to allow testing for different types than the built-in 'type'.

#### Any other comments?
This fix is necessary to implement validate_params (https://github.com/scikit-learn/scikit-learn/issues/23462) in objects that have numpy data types as parameters (e.g. https://github.com/scikit-learn/scikit-learn/pull/23579).
