### PR TITLE
DOC fix links with broken anchors

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -152,7 +152,7 @@ Note that:
 
 You will find additional details about joblib mitigation of oversubscription
 in `joblib documentation
-<https://joblib.readthedocs.io/en/latest/parallel.html#avoiding-over-subscription-of-cpu-ressources>`_.
+<https://joblib.readthedocs.io/en/latest/parallel.html#avoiding-over-subscription-of-cpu-resources>`_.
 
 
 Configuration switches

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -177,11 +177,11 @@ each time you update the sources. Therefore it is recommended that you install
 in with the ``pip install --no-build-isolation --editable .`` command, which
 allows you to edit the code in-place. This builds the extension in place and
 creates a link to the development directory (see `the pip docs
-<https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_).
+<https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs>`_).
 
-This is fundamentally similar to using the command ``python setup.py develop``
-(see `the setuptool docs
-<https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode>`_).
+As the doc aboves explains, this is fundamentally similar to using the command
+``python setup.py develop``. (see `the setuptool docs
+<https://setuptools.pypa.io/en/latest/userguide/development_mode.html>`_).
 It is however preferred to use pip.
 
 On Unix-like systems, you can equivalently type ``make in`` from the top-level

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -924,7 +924,7 @@ Monitoring performance
 ======================
 
 *This section is heavily inspired from the* `pandas documentation
-<https://pandas.pydata.org/docs/development/contributing.html#running-the-performance-test-suite>`_.
+<https://pandas.pydata.org/docs/development/contributing_codebase.html#running-the-performance-test-suite>`_.
 
 When proposing changes to the existing code base, it's important to make sure
 that they don't introduce performance regressions. Scikit-learn uses

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -677,7 +677,8 @@ In addition, we add the following guidelines:
   find bugs in scikit-learn.
 
 * Use the `numpy docstring standard
-  <https://numpydoc.readthedocs.io/en/latest/format.html#numpydoc-docstring-guide>`_ in all your docstrings.
+  <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
+  in all your docstrings.
 
 
 A good example of code that we like can be found `here

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -2555,14 +2555,16 @@ Pinball loss
 ------------
 
 The :func:`mean_pinball_loss` function is used to evaluate the predictive
-performance of quantile regression models. The `pinball loss
-<https://en.wikipedia.org/wiki/Quantile_regression#Computation>`_ is equivalent
-to :func:`mean_absolute_error` when the quantile parameter ``alpha`` is set to
-0.5.
+performance of `quantile regression
+<https://en.wikipedia.org/wiki/Quantile_regression>`_ models.
 
 .. math::
 
   \text{pinball}(y, \hat{y}) = \frac{1}{n_{\text{samples}}} \sum_{i=0}^{n_{\text{samples}}-1}  \alpha \max(y_i - \hat{y}_i, 0) + (1 - \alpha) \max(\hat{y}_i - y_i, 0)
+
+The pinball loss is equivalent to :func:`mean_absolute_error` when the quantile
+parameter ``alpha`` is set to 0.5.
+
 
 Here is a small example of usage of the :func:`mean_pinball_loss` function::
 

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -423,16 +423,15 @@ C5.0 is Quinlan's latest version release under a proprietary license.
 It uses less memory and builds smaller rulesets than C4.5 while being
 more accurate.
 
-CART_ (Classification and Regression Trees) is very similar to C4.5, but
+CART (Classification and Regression Trees) is very similar to C4.5, but
 it differs in that it supports numerical target variables (regression) and
 does not compute rule sets. CART constructs binary trees using the feature
 and threshold that yield the largest information gain at each node.
 
-scikit-learn uses an optimized version of the CART algorithm; however, the 
+scikit-learn uses an optimized version of the CART algorithm; however, the
 scikit-learn implementation does not support categorical variables for now.
 
 .. _ID3: https://en.wikipedia.org/wiki/ID3_algorithm
-.. _CART: https://en.wikipedia.org/wiki/Predictive_analytics#Classification_and_regression_trees_.28CART.29
 
 
 .. _tree_mathematical_formulation:
@@ -515,7 +514,7 @@ Log Loss or Entropy:
   computed on a dataset :math:`D` is defined as follows:
 
   .. math::
-  
+
       \mathrm{LL}(D, T) = -\frac{1}{n} \sum_{(x_i, y_i) \in D} \sum_k I(y_i = k) \log(T_k(x_i))
 
   where :math:`D` is a training dataset of :math:`n` pairs :math:`(x_i, y_i)`.
@@ -529,7 +528,7 @@ Log Loss or Entropy:
   the number of training data points that reached each leaf:
 
   .. math::
-  
+
       \mathrm{LL}(D, T) = \sum_{m \in T} \frac{n_m}{n} H(Q_m)
 
 Regression criteria

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -257,8 +257,8 @@ Subpackage-specific goals
 * Cross-validation should be able to be replaced by OOB estimates whenever a
   cross-validation iterator is used.
 * Redundant computations in pipelines should be avoided (related to point
-  above) cf `daskml
-  <https://dask-ml.readthedocs.io/en/latest/hyper-parameter-search.html#avoid-repeated-work>`_
+  above) cf `dask-ml
+  <https://ml.dask.org/hyper-parameter-search.html#avoid-repeated-work>`_
 
 :mod:`sklearn.neighbors`
 


### PR DESCRIPTION
Most changes are straightforward, the ones which are not straightforward:
- I removed the CART link, even with older versions where the anchor existed, the info was generic and did not add anything to what we are already saying in the doc: e.g. see this [older version of the Wikipedia page](https://en.wikipedia.org/w/index.php?title=Predictive_analytics&oldid=979766569#Classification_and_regression_trees_.28CART.29)
- for the pinball loss, I find the older link not that useful (see this [older version of the Wikipedia page](https://en.wikipedia.org/w/index.php?title=Quantile_regression&oldid=891680559#Computation), since we are already showing the loss formula). I kept a link to the "Quantile regression" Wikipedia page.

With the changes in this PR, there are no page with broken anchor anymore.