### PR TITLE
MNT fix body too long in update_tracking_issue.py

### DIFF
--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -74,6 +74,15 @@ def create_or_update_issue(body=""):
     link = f"[{args.ci_name}]({args.link_to_ci_run})"
     issue = get_issue()
 
+    max_body_length = 60_000
+    original_body_length = len(body)
+    # Avoid "body is too long (maximum is 65536 characters)" error from github REST API
+    if original_body_length > max_body_length:
+        body = (
+            f"{body[:max_body_length]}\n...\n"
+            f"Body was too long ({original_body_length} characters) and was shortened"
+        )
+
     if issue is None:
         # Create new issue
         header = f"**CI failed on {link}**"


### PR DESCRIPTION
Plenty of tests failed in scipy_dev https://github.com/scikit-learn/scikit-learn/issues/23614.

The script creating the issue automatically fails because the body is too long:
https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=43215&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=a806c63c-6a55-5993-5e78-a1ba6c47dc00

This is a simple fix so that at least we get an issue about this