### PR TITLE
MNT Param validation: convenience constraint for booleans

### DIFF
--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -207,7 +207,7 @@ class BisectingKMeans(_BaseKMeans):
     _parameter_constraints = {
         **_BaseKMeans._parameter_constraints,
         "init": [StrOptions({"k-means++", "random"}), callable],
-        "copy_x": [bool],
+        "copy_x": ["boolean"],
         "algorithm": [StrOptions({"lloyd", "elkan"})],
         "bisecting_strategy": [StrOptions({"biggest_inertia", "largest_cluster"})],
     }

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1335,7 +1335,7 @@ class KMeans(_BaseKMeans):
 
     _parameter_constraints = {
         **_BaseKMeans._parameter_constraints,
-        "copy_x": [bool],
+        "copy_x": ["boolean"],
         "algorithm": [
             StrOptions({"lloyd", "elkan", "auto", "full"}, deprecated={"auto", "full"})
         ],
@@ -1831,7 +1831,7 @@ class MiniBatchKMeans(_BaseKMeans):
     _parameter_constraints = {
         **_BaseKMeans._parameter_constraints,
         "batch_size": [Interval(Integral, 1, None, closed="left")],
-        "compute_labels": [bool],
+        "compute_labels": ["boolean"],
         "max_no_improvement": [Interval(Integral, 0, None, closed="left"), None],
         "init_size": [Interval(Integral, 1, None, closed="left"), None],
         "reassignment_ratio": [Interval(Real, 0, None, closed="left")],

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -639,11 +639,11 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
     """
 
     _parameter_constraints = {
-        "fit_intercept": [bool],
-        "normalize": [Hidden(StrOptions({"deprecated"})), bool],
-        "copy_X": [bool],
+        "fit_intercept": ["boolean"],
+        "normalize": [Hidden(StrOptions({"deprecated"})), "boolean"],
+        "copy_X": ["boolean"],
         "n_jobs": [None, Integral],
-        "positive": [bool],
+        "positive": ["boolean"],
     }
 
     def __init__(


### PR DESCRIPTION
Already merged and currently under reviews PRs for https://github.com/scikit-learn/scikit-learn/issues/23462 define the constraints for boolean params as ``[bool]``. The issue is that it's not backward compatible since we usually also accept ``np.bool_`` and even an ``int``.
(Issue raised in this comment https://github.com/scikit-learn/scikit-learn/pull/23593#discussion_r895785664)

Accpeting an int doesn't seem necessary and I propose to deprecate it. Accepting a np.bool_ is probably convenient for many users. To avoid having to repeat all accepted options all the time I propose to make a helper for that and just specify ``["boolean"]`` instead.

Question: Should the docstrings mention ``bool or np.bool_`` or ``boolean`` instead of just ``bool`` ?