### PR TITLE
Fix DOC Logo 3 link to image without "machine learning" text 

### DIFF
--- a/doc/logos/README.md
+++ b/doc/logos/README.md
@@ -46,7 +46,7 @@ File types:
 - File size: 5 KB
 - File name: [scikit-learn-logo-without-subtitle.svg](https://github.com/scikit-learn/scikit-learn/blob/main/doc/logos/scikit-learn-logo-without-subtitle.svg)
 
-<img src="scikit-learn-logo.svg" width="250px">
+<img src="scikit-learn-logo-without-subtitle.svg" width="250px">
 
 ---
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #23632 


#### What does this implement/fix? Explain your changes.
Previously the image of logo 3 was:
![Annotation 2022-06-15 195749](https://user-images.githubusercontent.com/44309040/173852553-083290b3-a592-4371-a0d5-2cacc14b387c.png)

With the fix the new logo is:
![Annotation 2022-06-15 195052](https://user-images.githubusercontent.com/44309040/173852771-21359a4f-2401-4cbc-9906-2f0321c82dee.png)


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
