### PR TITLE
FIX Add ElasticNet* and LassoCV checks in feature_selection._from_model threshold

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -134,7 +134,6 @@ Changelog
   :class:`linear_model.LassoCV`. :pr:`23636` by :user:`Hao Chun Chang
   <haochunchang>`
 
-
 :mod:`sklearn.impute`
 .....................
 

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -128,10 +128,11 @@ Changelog
 
 :mod:`sklearn.feature_selection`
 ................................
-- |Fix| :class:`feature_selection.SelectFromModel` defaults to selection threshold
-  1e-5 when the estimator is either :class:`linear_model.ElasticNet` or
-  :class:`linear_model.ElasticNetCV` with `l1_ratio` equals 1 or :class:`linear_model.LassoCV`.
-  :pr:`23636` by :user:`Hao Chun Chang <haochunchang>`
+- |Fix| :class:`feature_selection.SelectFromModel` defaults to selection
+  threshold 1e-5 when the estimator is either :class:`linear_model.ElasticNet`
+  or :class:`linear_model.ElasticNetCV` with `l1_ratio` equals 1 or
+  :class:`linear_model.LassoCV`. :pr:`23636` by :user:`Hao Chun Chang
+  <haochunchang>`
 
 
 :mod:`sklearn.impute`

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -129,8 +129,8 @@ Changelog
 :mod:`sklearn.feature_selection`
 ................................
 - |Fix| :class:`feature_selection.SelectFromModel` defaults to selection threshold
-  1e-5 when the estimator is `ElasticNet` and `l1_ration` equals 1.
-  :pr:`23636` by :user:`Hao Chun Chang <haochunchang>`
+  1e-5 when the estimator is :class:`linear_model.ElasticNet` and
+  `l1_ratio` equals 1. :pr:`23636` by :user:`Hao Chun Chang <haochunchang>`
 
 
 :mod:`sklearn.impute`

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -126,6 +126,13 @@ Changelog
   :pr:`11860` by :user:`Pierre Ablin <pierreablin>`,
   :pr:`22527` by :user:`Meekail Zain <micky774>` and `Thomas Fan`_.
 
+:mod:`sklearn.feature_selection`
+................................
+- |Fix| :class:`feature_selection.SelectFromModel` defaults to selection threshold
+  1e-5 when the estimator is `ElasticNet` and `l1_ration` equals 1.
+  :pr:`23636` by :user:`Hao Chun Chang <haochunchang>`
+
+
 :mod:`sklearn.impute`
 .....................
 

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -129,8 +129,9 @@ Changelog
 :mod:`sklearn.feature_selection`
 ................................
 - |Fix| :class:`feature_selection.SelectFromModel` defaults to selection threshold
-  1e-5 when the estimator is :class:`linear_model.ElasticNet` and
-  `l1_ratio` equals 1. :pr:`23636` by :user:`Hao Chun Chang <haochunchang>`
+  1e-5 when the estimator is either :class:`linear_model.ElasticNet` or
+  :class:`linear_model.ElasticNetCV` with `l1_ratio` equals 1 or :class:`linear_model.LassoCV`.
+  :pr:`23636` by :user:`Hao Chun Chang <haochunchang>`
 
 
 :mod:`sklearn.impute`

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -22,17 +22,13 @@ def _calculate_threshold(estimator, importances, threshold):
     if threshold is None:
         # determine default from estimator
         est_name = estimator.__class__.__name__
-        if (
-            (hasattr(estimator, "penalty") and estimator.penalty == "l1")
-            or "Lasso" in est_name
-            or (
-                "ElasticNet" in est_name
-                and (
-                    (hasattr(estimator, "l1_ratio_") and estimator.l1_ratio_ == 1)
-                    or (hasattr(estimator, "l1_ratio") and estimator.l1_ratio == 1)
-                )
-            )
-        ):
+        is_l1_penalized = hasattr(estimator, "penalty") and estimator.penalty == "l1"
+        is_lasso = "Lasso" in est_name
+        is_elasticnet_l1_penalized = "ElasticNet" in est_name and (
+            (hasattr(estimator, "l1_ratio_") and np.isclose(estimator.l1_ratio_, 1.0))
+            or (hasattr(estimator, "l1_ratio") and np.isclose(estimator.l1_ratio, 1.0))
+        )
+        if is_l1_penalized or is_lasso or is_elasticnet_l1_penalized:
             # the natural default threshold is 0 when l1 penalty was used
             threshold = 1e-5
         else:

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -23,8 +23,10 @@ def _calculate_threshold(estimator, importances, threshold):
         # determine default from estimator
         est_name = estimator.__class__.__name__
         if (
-            hasattr(estimator, "penalty") and estimator.penalty == "l1"
-        ) or "Lasso" in est_name:
+            (hasattr(estimator, "penalty") and estimator.penalty == "l1")
+            or "Lasso" in est_name
+            or "ElasticNet" in est_name
+        ):
             # the natural default threshold is 0 when l1 penalty was used
             threshold = 1e-5
         else:

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -25,8 +25,13 @@ def _calculate_threshold(estimator, importances, threshold):
         if (
             (hasattr(estimator, "penalty") and estimator.penalty == "l1")
             or "Lasso" in est_name
-            or (hasattr(estimator, "l1_ratio") and estimator.l1_ratio == 1)
-            or (hasattr(estimator, "l1_ratio_") and estimator.l1_ratio_ == 1)
+            or (
+                "ElasticNet" in est_name
+                and (
+                    (hasattr(estimator, "l1_ratio_") and estimator.l1_ratio_ == 1)
+                    or (hasattr(estimator, "l1_ratio") and estimator.l1_ratio == 1)
+                )
+            )
         ):
             # the natural default threshold is 0 when l1 penalty was used
             threshold = 1e-5

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -25,7 +25,8 @@ def _calculate_threshold(estimator, importances, threshold):
         if (
             (hasattr(estimator, "penalty") and estimator.penalty == "l1")
             or "Lasso" in est_name
-            or ("ElasticNet" in est_name and estimator.l1_ratio == 1)
+            or (hasattr(estimator, "l1_ratio") and estimator.l1_ratio == 1)
+            or (hasattr(estimator, "l1_ratio_") and estimator.l1_ratio_ == 1)
         ):
             # the natural default threshold is 0 when l1 penalty was used
             threshold = 1e-5

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -25,7 +25,7 @@ def _calculate_threshold(estimator, importances, threshold):
         if (
             (hasattr(estimator, "penalty") and estimator.penalty == "l1")
             or "Lasso" in est_name
-            or "ElasticNet" in est_name
+            or ("ElasticNet" in est_name and estimator.l1_ratio == 1)
         ):
             # the natural default threshold is 0 when l1 penalty was used
             threshold = 1e-5

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -14,7 +14,14 @@ from sklearn import datasets
 from sklearn.cross_decomposition import CCA, PLSCanonical, PLSRegression
 from sklearn.datasets import make_friedman1
 from sklearn.exceptions import NotFittedError
-from sklearn.linear_model import LogisticRegression, SGDClassifier, Lasso, ElasticNet
+from sklearn.linear_model import (
+    LogisticRegression,
+    SGDClassifier,
+    Lasso,
+    LassoCV,
+    ElasticNet,
+    ElasticNetCV,
+)
 from sklearn.svm import LinearSVC
 from sklearn.feature_selection import SelectFromModel
 from sklearn.ensemble import RandomForestClassifier, HistGradientBoostingClassifier
@@ -322,7 +329,9 @@ def test_sample_weight():
     "estimator",
     [
         Lasso(alpha=0.1, random_state=42),
+        LassoCV(random_state=42),
         ElasticNet(l1_ratio=1, random_state=42),
+        ElasticNetCV(l1_ratio=[1], random_state=42),
     ],
 )
 def test_coef_default_threshold(estimator):

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -322,7 +322,7 @@ def test_sample_weight():
     "estimator",
     [
         Lasso(alpha=0.1, random_state=42),
-        ElasticNet(random_state=42),
+        ElasticNet(l1_ratio=1, random_state=42),
     ],
 )
 def test_coef_default_threshold(estimator):

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -14,7 +14,7 @@ from sklearn import datasets
 from sklearn.cross_decomposition import CCA, PLSCanonical, PLSRegression
 from sklearn.datasets import make_friedman1
 from sklearn.exceptions import NotFittedError
-from sklearn.linear_model import LogisticRegression, SGDClassifier, Lasso
+from sklearn.linear_model import LogisticRegression, SGDClassifier, Lasso, ElasticNet
 from sklearn.svm import LinearSVC
 from sklearn.feature_selection import SelectFromModel
 from sklearn.ensemble import RandomForestClassifier, HistGradientBoostingClassifier
@@ -318,7 +318,14 @@ def test_sample_weight():
     assert np.all(weighted_mask == reweighted_mask)
 
 
-def test_coef_default_threshold():
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        Lasso(alpha=0.1, random_state=42),
+        ElasticNet(random_state=42),
+    ],
+)
+def test_coef_default_threshold(estimator):
     X, y = datasets.make_classification(
         n_samples=100,
         n_features=10,
@@ -330,7 +337,7 @@ def test_coef_default_threshold():
     )
 
     # For the Lasso and related models, the threshold defaults to 1e-5
-    transformer = SelectFromModel(estimator=Lasso(alpha=0.1, random_state=42))
+    transformer = SelectFromModel(estimator=estimator)
     transformer.fit(X, y)
     X_new = transformer.transform(X)
     mask = np.abs(transformer.estimator_.coef_) > 1e-5


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #23537 

#### What does this implement/fix? Explain your changes.
* Add 'ElasticNet' checks in `feature_selection._from_model._calculate_threshold`
* Add test to test SelectFromModel by ElasticNet have default threshold (1e-5).

#### Any other comments?
Not sure if adding the special case is the conclusion for the fix.
Also, if setting the threshold to 1e-5 only makes sense when `l1_ratio == 1`, then the special case checks should add 
`and estimator.l1_ratio == 1`.
Hopefully this PR can at least facilitate the discussion. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
