### PR TITLE
API prepare change of default solver QuantileRegressor

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -142,10 +142,9 @@ Changelog
   `solver="newton-cg"`, `fit_intercept=True`, and a single feature. :pr:`23608`
   by `Tom Dupre la Tour`_.
 
-- |Enhancement| The `solver` parameter in `linear_model.QuantileRegressor`
-  now accepts an `"auto"` option that will automatically use `"highs"` method
-  if available, otherwise `"interior-point"`. `"auto"` will be come the default
-  in 1.4 because `"interior-point"` will be removed from SciPy v. 1.11.
+- |API| The default value for the `solver` parameter in
+  :class:`linear_model.QuantileRegressor` will change from `"interior-point"`
+  to `"highs"` in version 1.4.
   :pr:`23637` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.metrics`

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -138,6 +138,12 @@ Changelog
 - |Fix| Use dtype-aware tolerances for the validation of gram matrices (passed by users
   or precomputed). :pr:`22059` by :user:`Malte S. Kurz <MalteKurz>`.
 
+- |Enhancement| The `solver` parameter in `linear_model.QuantileRegressor`
+  now accepts an `"auto"` option that will automatically use `"highs"` method
+  if available, otherwise `"interior-point"`. `"auto"` will be come the default
+  in 1.4 because `"interior-point"` will be removed from SciPy v. 1.11.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/examples/linear_model/plot_quantile_regression.py
+++ b/examples/linear_model/plot_quantile_regression.py
@@ -111,13 +111,20 @@ _ = axs[1, 1].set_xlabel("Residuals")
 #
 # We will use the quantiles at 5% and 95% to find the outliers in the training
 # sample beyond the central 90% interval.
+from sklearn.utils.fixes import sp_version, parse_version
+
+# This is line is to avoid incompatibility if older SciPy version.
+# You should use `solver="highs"` with recent version of SciPy.
+solver = "highs" if sp_version >= parse_version("1.6.0") else "interior-point"
+
+# %%
 from sklearn.linear_model import QuantileRegressor
 
 quantiles = [0.05, 0.5, 0.95]
 predictions = {}
 out_bounds_predictions = np.zeros_like(y_true_mean, dtype=np.bool_)
 for quantile in quantiles:
-    qr = QuantileRegressor(quantile=quantile, alpha=0)
+    qr = QuantileRegressor(quantile=quantile, alpha=0, solver=solver)
     y_pred = qr.fit(X, y_normal).predict(X)
     predictions[quantile] = y_pred
 
@@ -179,7 +186,7 @@ quantiles = [0.05, 0.5, 0.95]
 predictions = {}
 out_bounds_predictions = np.zeros_like(y_true_mean, dtype=np.bool_)
 for quantile in quantiles:
-    qr = QuantileRegressor(quantile=quantile, alpha=0)
+    qr = QuantileRegressor(quantile=quantile, alpha=0, solver=solver)
     y_pred = qr.fit(X, y_pareto).predict(X)
     predictions[quantile] = y_pred
 
@@ -250,7 +257,7 @@ from sklearn.metrics import mean_absolute_error
 from sklearn.metrics import mean_squared_error
 
 linear_regression = LinearRegression()
-quantile_regression = QuantileRegressor(quantile=0.5, alpha=0)
+quantile_regression = QuantileRegressor(quantile=0.5, alpha=0, solver=solver)
 
 y_pred_lr = linear_regression.fit(X, y_pareto).predict(X)
 y_pred_qr = quantile_regression.fit(X, y_pareto).predict(X)

--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -97,7 +97,10 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
     >>> rng = np.random.RandomState(0)
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
-    >>> reg = QuantileRegressor(quantile=0.8).fit(X, y)
+    >>> # the two following lines are optional in practice
+    >>> from sklearn.utils.fixes import sp_version, parser_version
+    >>> solver = "highs" if sp_version >= parse_version("1.6.0") else "interior-point"
+    >>> reg = QuantileRegressor(quantile=0.8, solver=solver).fit(X, y)
     >>> np.mean(y <= reg.predict(X))
     0.8
     """

--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -42,7 +42,7 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
         Whether or not to fit the intercept.
 
     solver : {'highs-ds', 'highs-ipm', 'highs', 'interior-point', \
-            'revised simplex', 'auto'}, default='interior-point'
+            'revised simplex'}, default='interior-point'
         Method used by :func:`scipy.optimize.linprog` to solve the linear
         programming formulation.
 
@@ -52,14 +52,8 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
 
         From `scipy>=1.11.0`, "interior-point" is not available anymore.
 
-        Use `solver="auto"` will use "highs" if available (most recent SciPy
-        version), otherwise it will use "interior-point" (old SciPy version).
-
-        .. versionadded:: 1.2
-           `"auto"` option was added in 1.2.
-
         .. versionchanged:: 1.4
-           The default of `solver` will change to `"auto"` in 1.4.
+           The default of `solver` will change to `"highs"` in version 1.4.
 
     solver_options : dict, default=None
         Additional parameters passed to :func:`scipy.optimize.linprog` as
@@ -180,16 +174,12 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
 
         if self.solver == "warn":
             warnings.warn(
-                "The default solver will change from 'interior-point' to 'auto' in "
-                "1.4. Set `solver='auto'` or to the desired solver to silence this "
-                "warning.",
+                "The default solver will change from 'interior-point' to 'highs' in "
+                "version 1.4. Set `solver='highs'` or to the desired solver to silence "
+                "this warning.",
                 FutureWarning,
             )
             solver = "interior-point"
-        elif self.solver == "auto":
-            solver = (
-                "interior-point" if sp_version < parse_version("1.6.0") else "highs"
-            )
         elif self.solver in (
             "highs-ds",
             "highs-ipm",

--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -203,6 +203,10 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
             "revised simplex",
         ):
             raise ValueError(f"Invalid value for argument solver, got {solver}")
+        elif solver == "interior-point" and sp_version >= parse_version("1.11.0"):
+            raise ValueError(
+                f"Solver {solver} is not anymore available in SciPy >= 1.11.0."
+            )
 
         if sparse.issparse(X) and solver not in ["highs", "highs-ds", "highs-ipm"]:
             raise ValueError(

--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -98,7 +98,7 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
     >>> y = rng.randn(n_samples)
     >>> X = rng.randn(n_samples, n_features)
     >>> # the two following lines are optional in practice
-    >>> from sklearn.utils.fixes import sp_version, parser_version
+    >>> from sklearn.utils.fixes import sp_version, parse_version
     >>> solver = "highs" if sp_version >= parse_version("1.6.0") else "interior-point"
     >>> reg = QuantileRegressor(quantile=0.8, solver=solver).fit(X, y)
     >>> np.mean(y <= reg.predict(X))

--- a/sklearn/linear_model/tests/test_quantile.py
+++ b/sklearn/linear_model/tests/test_quantile.py
@@ -46,7 +46,7 @@ def default_solver():
     ],
 )
 @pytest.mark.filterwarnings(
-    # FIXME (1.4): remove once we changed the default solver to "auto"
+    # FIXME (1.4): remove once we changed the default solver to "highs"
     "ignore:The default solver will change from 'interior-point'"
 )
 def test_init_parameters_validation(X_y_data, params, err_msg):

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -20,6 +20,7 @@ from sklearn.utils import all_estimators
 from sklearn.utils.estimator_checks import _enforce_estimator_tags_y
 from sklearn.utils.estimator_checks import _enforce_estimator_tags_x
 from sklearn.utils.estimator_checks import _construct_instance
+from sklearn.utils.fixes import sp_version, parse_version
 from sklearn.utils.deprecation import _is_deprecated
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
@@ -265,6 +266,11 @@ def test_fit_docstring_attributes(name, Estimator):
     # TODO(1.4): TO BE REMOVED for 1.4 (avoid FutureWarning)
     if Estimator.__name__ in ("KMeans", "MiniBatchKMeans"):
         est.set_params(n_init="auto")
+
+    # TODO(1.4): TO BE REMOVED for 1.4 (avoid FutureWarning)
+    if Estimator.__name__ == "QuantileRegressor":
+        solver = "highs" if sp_version >= parse_version("1.6.0") else "interior-point"
+        est.set_params(solver=solver)
 
     # In case we want to deprecate some attributes in the future
     skipped_attributes = {}


### PR DESCRIPTION
Related to https://github.com/scikit-learn/scikit-learn/issues/23626

`"interior-point"` solver will be removed from SciPy 1.11.
We need to introduce an `"auto"` mode to switch from one solver to another and announce a change of default.