### PR TITLE
MNT Removed object dtype validation in `check_array` for scipy nightly

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -358,7 +358,9 @@ def test_check_array():
 
     Xs = [X_csc, X_coo, X_dok, X_int, X_float]
     accept_sparses = [["csr", "coo"], ["coo", "dok"]]
-    for X, dtype, accept_sparse, copy in product(Xs, dtypes, accept_sparses, copys):
+    for X, dtype, accept_sparse, copy in product(
+        Xs, dtypes[:-1], accept_sparses, copys
+    ):
         with warnings.catch_warnings(record=True) as w:
             X_checked = check_array(
                 X, dtype=dtype, accept_sparse=accept_sparse, copy=copy

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -363,9 +363,7 @@ def test_check_array():
     for X, dtype, accept_sparse, copy in product(
         Xs, dtypes[:-1], accept_sparses, copys
     ):
-        X_checked = check_array(
-            X, dtype=dtype, accept_sparse=accept_sparse, copy=copy
-        )
+        X_checked = check_array(X, dtype=dtype, accept_sparse=accept_sparse, copy=copy)
         if dtype is not None:
             assert X_checked.dtype == dtype
         else:

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -360,8 +360,9 @@ def test_check_array():
     accept_sparses = [["csr", "coo"], ["coo", "dok"]]
     # scipy sparse matrices do not support the object dtype so
     # this dtype is skipped in this loop
+    non_object_dtypes = [dt for dt in dtypes if dt is not object]
     for X, dtype, accept_sparse, copy in product(
-        Xs, dtypes[:-1], accept_sparses, copys
+        Xs, non_object_dtypes, accept_sparses, copys
     ):
         X_checked = check_array(X, dtype=dtype, accept_sparse=accept_sparse, copy=copy)
         if dtype is not None:

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -358,23 +358,14 @@ def test_check_array():
 
     Xs = [X_csc, X_coo, X_dok, X_int, X_float]
     accept_sparses = [["csr", "coo"], ["coo", "dok"]]
+    # scipy sparse matrices do not support the object dtype so
+    # this dtype is skipped in this loop
     for X, dtype, accept_sparse, copy in product(
         Xs, dtypes[:-1], accept_sparses, copys
     ):
-        with warnings.catch_warnings(record=True) as w:
-            X_checked = check_array(
-                X, dtype=dtype, accept_sparse=accept_sparse, copy=copy
-            )
-        if (dtype is object or sp.isspmatrix_dok(X)) and len(w):
-            # XXX unreached code as of v0.22
-            message = str(w[0].message)
-            messages = [
-                "object dtype is not supported by sparse matrices",
-                "Can't check dok sparse matrix for nan or inf.",
-            ]
-            assert message in messages
-        else:
-            assert len(w) == 0
+        X_checked = check_array(
+            X, dtype=dtype, accept_sparse=accept_sparse, copy=copy
+        )
         if dtype is not None:
             assert X_checked.dtype == dtype
         else:


### PR DESCRIPTION
#### Reference Issues/PRs
Relates to #23626

#### What does this implement/fix? Explain your changes.
`scipy` throws an error now when trying to create a sparse array with `dtype=Object`, so I removed support for `check_array` for sparse object dtype arrays.

#### Any other comments?
