### PR TITLE
MNT use warnings rather than np.warnings

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -3293,8 +3293,8 @@ class PowerTransformer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
             reset=in_fit,
         )
 
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")
             if check_positive and self.method == "box-cox" and np.nanmin(X) <= 0:
                 raise ValueError(
                     "The Box-Cox transformation can only be "


### PR DESCRIPTION
Part of https://github.com/scikit-learn/scikit-learn/issues/23626

`numpy` has no attribute `warnings` in the development version 1.24.dev. Before that `np.warnings` was the same as the stdlib `warnings`.

This will break scikit-learn when numpy 1.24 is released. This may be worth considering backporting this to 1.1.2?