### PR TITLE
MAINT make sure that x0 is 1D when passed to minimize

### DIFF
--- a/sklearn/neighbors/_nca.py
+++ b/sklearn/neighbors/_nca.py
@@ -229,7 +229,7 @@ class NeighborhoodComponentsAnalysis(
         # (n_samples, n_samples)
 
         # Initialize the transformation
-        transformation = self._initialize(X, y, init)
+        transformation = np.ravel(self._initialize(X, y, init))
 
         # Create a dictionary of parameters to be passed to the optimizer
         disp = self.verbose - 2 if self.verbose > 1 else -1


### PR DESCRIPTION
Related to https://github.com/scikit-learn/scikit-learn/issues/23626

`minimize` validates the input and `x0` should be a 1D array in the future.