### PR TITLE
Fixes Robust Regression Example Link From UCLA issue #23631

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1549,7 +1549,7 @@ in the following ways.
   * Peter J. Huber, Elvezio M. Ronchetti: Robust Statistics, Concomitant scale estimates, pg 172
 
 Note that this estimator is different from the R implementation of Robust Regression
-(http://www.ats.ucla.edu/stat/r/dae/rreg.htm) because the R implementation does a weighted least
+(https://stats.oarc.ucla.edu/stata/dae/robust-regression/) because the R implementation does a weighted least
 squares implementation with weights given to each sample on the basis of how much the residual is
 greater than a certain threshold.
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1549,7 +1549,7 @@ in the following ways.
   * Peter J. Huber, Elvezio M. Ronchetti: Robust Statistics, Concomitant scale estimates, pg 172
 
 Note that this estimator is different from the R implementation of Robust Regression
-(https://stats.oarc.ucla.edu/stata/dae/robust-regression/) because the R implementation does a weighted least
+(https://stats.oarc.ucla.edu/r/dae/robust-regression/) because the R implementation does a weighted least
 squares implementation with weights given to each sample on the basis of how much the residual is
 greater than a certain threshold.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fix broken links in the documentation #23631

#### What does this implement/fix? Explain your changes.

Fixes  http://www.ats.ucla.edu/stat/r/dae/rreg.html broken link in modules/linear_model.rst

by replacing this link with 

https://stats.oarc.ucla.edu/stata/dae/robust-regression/

#### Any other comments?

Super excited to be a contributor to this, especially as a first time contributor. I love scikit-learn
