### PR TITLE
HOTFIX Type and cast val in get_dense_row_string

### DIFF
--- a/sklearn/datasets/_svmlight_format_fast.pyx
+++ b/sklearn/datasets/_svmlight_format_fast.pyx
@@ -141,13 +141,14 @@ def get_dense_row_string(
         Py_ssize_t row_length = X.shape[1]
         Py_ssize_t x_nz_used = 0
         Py_ssize_t k
+        int_or_float val
 
     for k in range(row_length):
         val = X[row,k]
         if val == 0:
             continue
         x_inds[x_nz_used] = k
-        x_vals[x_nz_used] = val
+        x_vals[x_nz_used] = <double_or_longlong> val
         x_nz_used += 1
     return " ".join(value_pattern % (j+one_based, val) for i, (j, val) in enumerate(zip(x_inds, x_vals)) if i < x_nz_used)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Hot-fix attempt for #23668.

#### What does this implement/fix? Explain your changes.

This type and cast `val`, solving the compilation when using Cython>=3.0.0a6.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
