### PR TITLE
DOC Link works fine, added it to `linkcheck_ignore`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -595,6 +595,7 @@ linkcheck_ignore = [
     r"http://www.utstat.toronto.edu/~rsalakhu/sta4273/notes/Lecture2.pdf#page=.*",
     "https://www.fordfoundation.org/media/2976/"
     "roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure.pdf#page=.*",
+    "http://users.jyu.fi/~samiayr/pdf/ayramo_eurogen05.pdf",
     # Broken links from testimonials
     "http://www.bestofmedia.com",
     "http://www.data-publica.com/",


### PR DESCRIPTION

#### Reference Issues/PRs

scikit-learn#23631


#### What does this implement/fix? Explain your changes.

The link [http://users.jyu.fi/~samiayr/pdf/ayramo_eurogen05.pdf](http://users.jyu.fi/~samiayr/pdf/ayramo_eurogen05.pdf) is working properly, added it to the `linkcheck_ignore` list in `scikit-learn/doc/conf.py`
