### PR TITLE
DOC fix link to reference document in Cross decomposition 

### DIFF
--- a/doc/modules/cross_decomposition.rst
+++ b/doc/modules/cross_decomposition.rst
@@ -185,7 +185,7 @@ targets is greater than the number of samples.
 
    .. [1] `A survey of Partial Least Squares (PLS) methods, with emphasis on
       the two-block case
-      <https://www.stat.washington.edu/research/reports/2000/tr371.pdf>`_
+      <https://stat.uw.edu/sites/default/files/files/reports/2000/tr371.pdf>`_
       JA Wegelin
 
 .. topic:: Examples:


### PR DESCRIPTION
Update reference link to "A survey of Partial Least Squares (PLS) methods, with emphasis on the two-block case" by JA Wegelin

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#23631

#### What does this implement/fix? Explain your changes.

The link to the reference document "A survey of Partial Least Squares (PLS) methods, with emphasis on the two-block case" by JA Wegelin `https://www.stat.washington.edu/research/reports/2000/tr371.pdf` was changed to `https://stat.uw.edu/sites/default/files/files/reports/2000/tr371.pdf`

#### Any other comments?
 
The old link, when clicked redirects to the document in the new link location. So the old link is replaced with the new one. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
