### PR TITLE
Return-the-terminal-leaves

### DIFF
--- a/sklearn/ensemble/_gradient_boosting.pyx
+++ b/sklearn/ensemble/_gradient_boosting.pyx
@@ -219,7 +219,6 @@ def predict_stages(np.ndarray[object, ndim=2] estimators,
                     tree.nodes, tree.value,
                     scale, k, K, X.shape[0], X.shape[1],
                     <float64 *> (<np.ndarray> out).data)
-                ## out += scale * tree.predict(X).reshape((X.shape[0], 1))
 
 
 def predict_stage(np.ndarray[object, ndim=2] estimators,


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This implementation allows the user to return the leaves of the terminal region of the base learner.


#### Any other comments?

The size of the terminal region is determined by having the number of final nodes.