### PR TITLE
DOC Fix link for SVD based initialization: A head start for nonnegative matrix factorization

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -956,7 +956,7 @@ is not readily available from the start, or when the data does not fit into memo
 
     .. [4] `"SVD based initialization: A head start for nonnegative
       matrix factorization"
-      <http://scgroup.hpclab.ceid.upatras.gr/faculty/stratis/Papers/HPCLAB020107.pdf>`_
+      <https://www.docdroid.net/LYFTe8e/hpclab020107-pdf>`_
       C. Boutsidis, E. Gallopoulos, 2008
 
     .. [5] `"Fast local algorithms for large scale nonnegative matrix and tensor


### PR DESCRIPTION
#### Reference Issues/PRs
For Issue #23631

#### What does this implement/fix? Explain your changes.
Fixed the link to a research paper for `SVD based initialization: A head start for non-negative matrix factorization`
This change is for the file: `scikit-learn/doc/modules/decomposition.rst` on line 957.

#### Any other comments?
Let me know if you accept using `https://www.docdroid.net/` as the provider for the new link URL.

Thanks.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
