### PR TITLE
DOC fix link to Statistical Learning with Sparsity: The Lasso and Generalizations

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1223,7 +1223,7 @@ def d2_tweedie_score(y_true, y_pred, *, sample_weight=None, power=0):
     ----------
     .. [1] Eq. (3.11) of Hastie, Trevor J., Robert Tibshirani and Martin J.
            Wainwright. "Statistical Learning with Sparsity: The Lasso and
-           Generalizations." (2015). https://trevorhastie.github.io
+           Generalizations." (2015). https://hastie.su.domains/StatLearnSparsity/
 
     Examples
     --------
@@ -1326,7 +1326,7 @@ def d2_pinball_score(
            <http://dx.doi.org/10.1080/01621459.1999.10473882>`_
     .. [2] Eq. (3.11) of Hastie, Trevor J., Robert Tibshirani and Martin J.
            Wainwright. "Statistical Learning with Sparsity: The Lasso and
-           Generalizations." (2015). https://trevorhastie.github.io
+           Generalizations." (2015). https://hastie.su.domains/StatLearnSparsity/
 
     Examples
     --------
@@ -1464,7 +1464,7 @@ def d2_absolute_error_score(
     ----------
     .. [1] Eq. (3.11) of Hastie, Trevor J., Robert Tibshirani and Martin J.
            Wainwright. "Statistical Learning with Sparsity: The Lasso and
-           Generalizations." (2015). https://trevorhastie.github.io
+           Generalizations." (2015). https://hastie.su.domains/StatLearnSparsity/
 
     Examples
     --------


### PR DESCRIPTION
Updated website link to the homepage of the book "Statistical Learning with Sparsity: The Lasso and Generalizations"

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#23631

#### What does this implement/fix? Explain your changes.
Fix link to the book "Statistical Learning with Sparsity: The Lasso and Generalizations" from `https://trevorhastie.github.io/` to `https://hastie.su.domains/StatLearnSparsity/`

Issue shows problem only in d2_absolute_error_score, but found totally 3 instances where this link is referenced in the file. Fixed all 3 occurrences. 


#### Any other comments?

Verified website link using an older copy of the website using WayBackMachine. Link `https://web.archive.org/web/20210614125225/http://trevorhastie.github.io/`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
