### PR TITLE
DOC fix link to scikit-learn's NumFOCUS donation page

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -586,9 +586,8 @@ Donating to the project
 .......................
 
 If you are interested in donating to the project or to one of our code-sprints,
-you can use the *Paypal* button below or the `NumFOCUS Donations Page
-<https://www.numfocus.org/support-numfocus.html>`_ (if you use the latter,
-please indicate that you are donating for the scikit-learn project).
+please donate via the `NumFOCUS Donations Page
+<https://numfocus.org/donate-to-scikit-learn>`_  (please make sure that you are donating for the scikit-learn project).
 
 All donations will be handled by `NumFOCUS
 <https://numfocus.org/>`_, a non-profit-organization which is

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -587,7 +587,7 @@ Donating to the project
 
 If you are interested in donating to the project or to one of our code-sprints,
 please donate via the `NumFOCUS Donations Page
-<https://numfocus.org/donate-to-scikit-learn>`_  (please make sure that you are donating for the scikit-learn project).
+<https://numfocus.org/donate-to-scikit-learn>`_.
 
 All donations will be handled by `NumFOCUS
 <https://numfocus.org/>`_, a non-profit-organization which is

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -589,6 +589,14 @@ If you are interested in donating to the project or to one of our code-sprints,
 please donate via the `NumFOCUS Donations Page
 <https://numfocus.org/donate-to-scikit-learn>`_.
 
+.. raw :: html
+
+   </br></br>
+   <div style="text-align: center;">
+   <a class="btn btn-warning btn-big sk-donate-btn mb-1" href="https://numfocus.org/donate-to-scikit-learn">Help us, <strong>donate!</strong></a>
+   </div>
+   </br>
+
 All donations will be handled by `NumFOCUS
 <https://numfocus.org/>`_, a non-profit-organization which is
 managed by a board of `Scipy community members
@@ -601,13 +609,6 @@ The received donations for the scikit-learn project mostly will go towards
 covering travel-expenses for code sprints, as well as towards the organization
 budget of the project [#f1]_.
 
-.. raw :: html
-
-   </br></br>
-   <div style="text-align: center;">
-   <a class="btn btn-warning btn-big sk-donate-btn mb-1" href="https://numfocus.org/donate-to-scikit-learn">Help us, <strong>donate!</strong></a>
-   </div>
-   </br>
 
 .. rubric:: Notes
 

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -591,7 +591,6 @@ please donate via the `NumFOCUS Donations Page
 
 .. raw :: html
 
-   </br></br>
    <div style="text-align: center;">
    <a class="btn btn-warning btn-big sk-donate-btn mb-1" href="https://numfocus.org/donate-to-scikit-learn">Help us, <strong>donate!</strong></a>
    </div>


### PR DESCRIPTION
Updated link to scikit-learn's donation page on numfocus.
Remove reference to paypal button.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#23631

#### What does this implement/fix? Explain your changes.

Updated link to scikit-learn's numfocus page. New link `https://numfocus.org/donate-to-scikit-learn`.

Removed reference to PayPal button in the donation section since it is no longer available.

#### Any other comments?

Made changes requested by @lesteve in PR #23663
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
