### PR TITLE
DOC Fix broken link pandas

### DIFF
--- a/doc/developers/bug_triaging.rst
+++ b/doc/developers/bug_triaging.rst
@@ -156,4 +156,4 @@ The following workflow [1]_ is a good way to approach issue triaging:
 #. Remove the "Needs Triage" label from the issue if the label exists.
 
 .. [1] Adapted from the pandas project `maintainers guide
-       <https://dev.pandas.io/docs/development/maintaining.html>`_
+       <https://pandas.pydata.org/docs/development/maintaining.html>`_


### PR DESCRIPTION
#### Reference Issues/PRs

scikit-learn#23631

#### What does this implement/fix? Explain your changes.

Changed the broken URL <https://dev.pandas.io/docs/development/maintaining.html> by <https://pandas.pydata.org/docs/development/maintaining.html>

I checked on waybackmachine and the two pages are similar (the new one have some added features)

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
