### PR TITLE
DOC Fix scipy broken link

### DIFF
--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -153,7 +153,7 @@ A continuous log-uniform random variable is available through
 log-spaced parameters. For example to specify ``C`` above, ``loguniform(1,
 100)`` can be used instead of ``[1, 10, 100]`` or ``np.logspace(0, 2,
 num=1000)``. This is an alias to SciPy's `stats.reciprocal
-<https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.reciprocal.html>`_.
+<https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.stats.reciprocal.html>`_.
 
 Mirroring the example above in grid search, we can specify a continuous random
 variable that is log-uniformly distributed between ``1e0`` and ``1e3``::

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -152,9 +152,8 @@ A continuous log-uniform random variable is available through
 :class:`~sklearn.utils.fixes.loguniform`. This is a continuous version of
 log-spaced parameters. For example to specify ``C`` above, ``loguniform(1,
 100)`` can be used instead of ``[1, 10, 100]`` or ``np.logspace(0, 2,
-num=1000)``. This is an alias to SciPy's `stats.loguniform
-<https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.loguniform.html>`_
-(note that the ``loguniform`` is an alias to ``reciprocal`` for SciPy < 1.4).
+num=1000)``. This is an alias to `scipy.stats.loguniform
+<https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.loguniform.html>`_.
 
 Mirroring the example above in grid search, we can specify a continuous random
 variable that is log-uniformly distributed between ``1e0`` and ``1e3``::

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -152,8 +152,8 @@ A continuous log-uniform random variable is available through
 :class:`~sklearn.utils.fixes.loguniform`. This is a continuous version of
 log-spaced parameters. For example to specify ``C`` above, ``loguniform(1,
 100)`` can be used instead of ``[1, 10, 100]`` or ``np.logspace(0, 2,
-num=1000)``. This is an alias to SciPy's `stats.reciprocal
-<https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.stats.reciprocal.html>`_.
+num=1000)``. This is an alias to SciPy's `stats.loguniform
+<https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.loguniform.html>`_.
 
 Mirroring the example above in grid search, we can specify a continuous random
 variable that is log-uniformly distributed between ``1e0`` and ``1e3``::

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -153,7 +153,8 @@ A continuous log-uniform random variable is available through
 log-spaced parameters. For example to specify ``C`` above, ``loguniform(1,
 100)`` can be used instead of ``[1, 10, 100]`` or ``np.logspace(0, 2,
 num=1000)``. This is an alias to SciPy's `stats.loguniform
-<https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.loguniform.html>`_.
+<https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.loguniform.html>`_
+(note that the ``loguniform`` is an alias to ``reciprocal`` for SciPy < 1.4).
 
 Mirroring the example above in grid search, we can specify a continuous random
 variable that is log-uniformly distributed between ``1e0`` and ``1e3``::


### PR DESCRIPTION
Reference Issues/PRs

scikit-learn#23631


What does this implement/fix? Explain your changes.
The link <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.reciprocal.html> vas broken, replaced it with <https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.stats.reciprocal.html>.

As the scipy.stats.reciprocal disappeared in new version of scipy, I changed the link to an old version of the doc.

Any other comments?