### PR TITLE
DOC Give local recommendations about IterativeImputer in docstrings

### DIFF
--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -24,7 +24,7 @@ _ImputerTriplet = namedtuple(
 
 
 class IterativeImputer(_BaseImputer):
-    r"""Multivariate imputer that estimates each feature from all the others.
+    """Multivariate imputer that estimates each feature from all the others.
 
     A strategy for imputing missing values by modeling each feature with
     missing values as a function of other features in a round-robin fashion.
@@ -197,7 +197,7 @@ class IterativeImputer(_BaseImputer):
     Features which contain all missing values at :meth:`fit` are discarded upon
     :meth:`transform`.
 
-    Using defaults, the imputer scales in :math:`\mathcal{O}(knp^3\min(n,p))`
+    Using defaults, the imputer scales in :math:`\\mathcal{O}(knp^3\\min(n,p))`
     where :math:`k` = `max_iter`, :math:`n` the number of samples and
     :math:`p` the number of features. It thus becomes prohibitively costly when
     the number of features increases. Setting

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -184,6 +184,8 @@ class IterativeImputer(_BaseImputer):
     See Also
     --------
     SimpleImputer : Univariate imputation of missing values.
+    KNNImputer : Multivariate imputer that estimates missing features using
+        nearest samples.
 
     Notes
     -----

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -32,8 +32,8 @@ class IterativeImputer(_BaseImputer):
     Using defaults, the imputer scales in :math:`\mathcal{O}(knp^3\min(n,p))`
     where :math:`k` = `max_iter`, :math:`n` the number of samples and
     :math:`p` the number of features. It thus becomes prohibitively costly when
-    the number of features increases. Setting `n_nearest_features` <<
-    `n_features`, `skip_complete` = `True` or increasing `tol` can help to
+    the number of features increases. Setting `n_nearest_features <<
+    n_features`, `skip_complete=True` or increasing `tol` can help to
     reduce its computational cost.
 
     Depending on the nature of missing values, simple imputers can be

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -200,9 +200,9 @@ class IterativeImputer(_BaseImputer):
     Using defaults, the imputer scales in :math:`\mathcal{O}(knp^3\min(n,p))`
     where :math:`k` = `max_iter`, :math:`n` the number of samples and
     :math:`p` the number of features. It thus becomes prohibitively costly when
-    the number of features increases. Setting `n_nearest_features <<
-    n_features`, `skip_complete=True` or increasing `tol` can help to
-    reduce its computational cost.
+    the number of features increases. Setting
+    `n_nearest_features << n_features`, `skip_complete=True` or increasing `tol`
+    can help to reduce its computational cost.
 
     Depending on the nature of missing values, simple imputers can be
     preferable in a prediction context.

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -29,6 +29,16 @@ class IterativeImputer(_BaseImputer):
     A strategy for imputing missing values by modeling each feature with
     missing values as a function of other features in a round-robin fashion.
 
+    Using defaults, the imputer scales in :math:`\mathcal{O}(knp^3\min(n,p))`
+    where :math:`k` = `max_iter`, :math:`n` the number of samples and
+    :math:`p` the number of features. It thus becomes prohibitively costly when
+    the number of features increases. Setting `n_nearest_features` <<
+    `n_features`, `skip_complete` = `True` or increasing `tol` can help to
+    reduce its computational cost.
+
+    Depending on the nature of missing values, simple imputers can be
+    preferable in a prediction context.
+
     Read more in the :ref:`User Guide <iterative_imputer>`.
 
     .. versionadded:: 0.21

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -29,16 +29,6 @@ class IterativeImputer(_BaseImputer):
     A strategy for imputing missing values by modeling each feature with
     missing values as a function of other features in a round-robin fashion.
 
-    Using defaults, the imputer scales in :math:`\mathcal{O}(knp^3\min(n,p))`
-    where :math:`k` = `max_iter`, :math:`n` the number of samples and
-    :math:`p` the number of features. It thus becomes prohibitively costly when
-    the number of features increases. Setting `n_nearest_features <<
-    n_features`, `skip_complete=True` or increasing `tol` can help to
-    reduce its computational cost.
-
-    Depending on the nature of missing values, simple imputers can be
-    preferable in a prediction context.
-
     Read more in the :ref:`User Guide <iterative_imputer>`.
 
     .. versionadded:: 0.21
@@ -206,6 +196,16 @@ class IterativeImputer(_BaseImputer):
 
     Features which contain all missing values at :meth:`fit` are discarded upon
     :meth:`transform`.
+
+    Using defaults, the imputer scales in :math:`\mathcal{O}(knp^3\min(n,p))`
+    where :math:`k` = `max_iter`, :math:`n` the number of samples and
+    :math:`p` the number of features. It thus becomes prohibitively costly when
+    the number of features increases. Setting `n_nearest_features <<
+    n_features`, `skip_complete=True` or increasing `tol` can help to
+    reduce its computational cost.
+
+    Depending on the nature of missing values, simple imputers can be
+    preferable in a prediction context.
 
     References
     ----------

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -24,7 +24,7 @@ _ImputerTriplet = namedtuple(
 
 
 class IterativeImputer(_BaseImputer):
-    """Multivariate imputer that estimates each feature from all the others.
+    r"""Multivariate imputer that estimates each feature from all the others.
 
     A strategy for imputing missing values by modeling each feature with
     missing values as a function of other features in a round-robin fashion.

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -183,7 +183,8 @@ class IterativeImputer(_BaseImputer):
 
     See Also
     --------
-    SimpleImputer : Univariate imputation of missing values.
+    SimpleImputer : Univariate imputer for completing missing values
+        with simple strategies.
     KNNImputer : Multivariate imputer that estimates missing features using
         nearest samples.
 

--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -90,7 +90,7 @@ class KNNImputer(_BaseImputer):
 
     See Also
     --------
-    SimpleImputer : Imputation transformer for completing missing values
+    SimpleImputer : Univariate imputer for completing missing values
         with simple strategies.
     IterativeImputer : Multivariate imputer that estimates each feature
         from all the others.

--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -92,8 +92,8 @@ class KNNImputer(_BaseImputer):
     --------
     SimpleImputer : Univariate imputer for completing missing values
         with simple strategies.
-    IterativeImputer : Multivariate imputer that estimates each feature
-        from all the others.
+    IterativeImputer : Multivariate imputer that estimates values to impute for
+        each feature with missing values from all the others.
 
     References
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses first task of #21967.


#### What does this implement/fix? Explain your changes.
Adapt the docstrings to give local recommendations for IterativeImputer.

#### Any other comments?
I refer to KNNImputer as a "multivariate imputer" in the "see also" part because it uses observed features to impute the missing ones (and does not use only the missing ones as does the univariate SimpleImputer). However, in the [user guide](https://scikit-learn.org/stable/modules/impute.html#iterative-imputer) it is outside of the "multivariate imputation" part. Is it ok to refer to KNNImputer as a multivariate imputer as I did?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
