### PR TITLE
DOC Updated URL for Jake's tutorial link

### DIFF
--- a/doc/presentations.rst
+++ b/doc/presentations.rst
@@ -63,7 +63,7 @@ Videos
 
     3-hours long introduction to prediction tasks using scikit-learn.
 
-- `scikit-learn - Machine Learning in Python <https://newcircle.com/s/post/1152/scikit-learn_machine_learning_in_python>`_
+- `scikit-learn - Machine Learning in Python <https://www.youtube.com/watch?v=cHZONQ2-x7I>`_
   by `Jake Vanderplas`_ at the 2012 PyData workshop at Google
 
     Interactive demonstration of some scikit-learn features. 75 minutes.


### PR DESCRIPTION
**Reference Issues/PRs**
Addresses [#23631](https://github.com/scikit-learn/scikit-learn/issues/23631)

**What does this implement/fix? Explain your changes.**
Fixed broken link [https://newcircle.com/s/post/1152/scikit-learn_machine_learning_in_python](https://newcircle.com/s/post/1152/scikit-learn_machine_learning_in_python) for Jake Vanderplas 75 minutes interactive session in docs/presentations.rst

**by replace with**

Original Youtube link: [https://www.youtube.com/watch?v=cHZONQ2-x7I](https://www.youtube.com/watch?v=cHZONQ2-x7I)

**Any other comments?**
The **scikit-learn tutorial by Jake Vanderplas at PyData NYC 2012**: 45 minutes video link redirects to this youtube video as well. But on further investigation on this webpage [http://vanderplas.com/speaking.html](http://vanderplas.com/speaking.html) in November 2012 section, it seems like the video is not available. Let me know if I should remove that list point, because it seems like the video link is stale.
