### PR TITLE
DOC fix link to reference in Skewed Chi Squared Kernel

### DIFF
--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -237,9 +237,9 @@ or store training examples.
       <https://papers.nips.cc/paper/2007/hash/013a006f03dbc5392effeb8f18fda755-Abstract.html>`_
       Rahimi, A. and Recht, B. - Advances in neural information processing 2007,
     .. [LS2010] `"Random Fourier approximations for skewed multiplicative histogram kernels"
-      <https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.227.1802&rep=rep1&type=pdf>`_
-      Random Fourier approximations for skewed multiplicative histogram kernels
-      - Lecture Notes for Computer Sciencd (DAGM)
+      <https://www.researchgate.net/publication/221114584_Random_Fourier_Approximations_for_Skewed_Multiplicative_Histogram_Kernels>`_
+      Li, F., Ionescu, C., and Sminchisescu, C.
+      - Pattern Recognition,  DAGM 2010, Lecture Notes in Computer Science. 
     .. [VZ2010] `"Efficient additive kernels via explicit feature maps"
       <https://www.robots.ox.ac.uk/~vgg/publications/2011/Vedaldi11/vedaldi11.pdf>`_
       Vedaldi, A. and Zisserman, A. - Computer Vision and Pattern Recognition 2010


### PR DESCRIPTION
Updated link to reference "Random Fourier approximations for skewed multiplicative histogram kernels"

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#23631

#### What does this implement/fix? Explain your changes.

Link to  “Random Fourier approximations for skewed multiplicative histogram kernels” changed from `https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.227.1802&rep=rep1&type=pdf ` to `https://www.researchgate.net/publication/221114584_Random_Fourier_Approximations_for_Skewed_Multiplicative_Histogram_Kernels`

#### Any other comments?
Doi of the article leads to this site https://link.springer.com/chapter/10.1007/978-3-642-15986-2_27 but it is under a paywall. The article in ResearchGate has a downloadable full-text pdf.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
