### PR TITLE
DOC fix link to reference for nonnegative matrix and tensor factorizations #23713

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -961,7 +961,7 @@ is not readily available from the start, or when the data does not fit into memo
 
     .. [5] `"Fast local algorithms for large scale nonnegative matrix and tensor
       factorizations."
-      <https://www.researchgate.net/profile/Anh-Huy-Phan/publication/220241471_Fast_Local_Algorithms_for_Large_Scale_Nonnegative_Matrix_and_Tensor_Factorizations/links/00b7d519df30965c23000000/Fast-Local-Algorithms-for-Large-Scale-Nonnegative-Matrix-and-Tensor-Factorizations.pdf>`_
+      <https://www.researchgate.net/profile/Anh-Huy-Phan/publication/220241471_Fast_Local_Algorithms_for_Large_Scale_Nonnegative_Matrix_and_Tensor_Factorizations>`_
       A. Cichocki, A. Phan, 2009
 
     .. [6] :arxiv:`"Algorithms for nonnegative matrix factorization with

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -961,7 +961,7 @@ is not readily available from the start, or when the data does not fit into memo
 
     .. [5] `"Fast local algorithms for large scale nonnegative matrix and tensor
       factorizations."
-      <https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.214.6398&rep=rep1&type=pdf>`_
+      <https://www.researchgate.net/profile/Anh-Huy-Phan/publication/220241471_Fast_Local_Algorithms_for_Large_Scale_Nonnegative_Matrix_and_Tensor_Factorizations/links/00b7d519df30965c23000000/Fast-Local-Algorithms-for-Large-Scale-Nonnegative-Matrix-and-Tensor-Factorizations.pdf>`_
       A. Cichocki, A. Phan, 2009
 
     .. [6] :arxiv:`"Algorithms for nonnegative matrix factorization with


### PR DESCRIPTION
Updated link to reference "Fast local algorithms for large scale nonnegative matrix and tensor factorizations." in 
#### Reference Issues/PRs

https://github.com/scikit-learn/scikit-learn/issues/23631



#### What does this implement/fix? Explain your changes.
Link to "Fast local algorithms for large scale nonnegative matrix and tensor
      factorizations." changed from `https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.214.6398&rep=rep1&type=pdf` to `https://www.researchgate.net/profile/Anh-Huy-Phan/publication/220241471_Fast_Local_Algorithms_for_Large_Scale_Nonnegative_Matrix_and_Tensor_Factorizations/links/00b7d519df30965c23000000/Fast-Local-Algorithms-for-Large-Scale-Nonnegative-Matrix-and-Tensor-Factorizations.pdf.

#### Any other comments?
Doi of the article leads to this site https://www.jstage.jst.go.jp/article/transfun/E92.A/3/E92.A_3_708/_article but it is under a paywall. The article in ResearchGate has a downloadable full-text pdf.

