### PR TITLE
MNT Param validation: Helper constraint for the verbose parameter

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -842,7 +842,7 @@ class _BaseKMeans(
         ],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0, None, closed="left")],
-        "verbose": [Interval(Integral, 0, None, closed="left"), bool],
+        "verbose": ["verbose"],
         "random_state": ["random_state"],
     }
 

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -31,6 +31,7 @@ def validate_parameter_constraints(parameter_constraints, params, caller_name):
         - any type, meaning that any instance of this type is valid
         - a StrOptions object, representing a set of strings
         - the string "boolean"
+        - the string "verbose"
 
     params : dict
         A dictionary `param_name: param_value`. The parameters to validate against the
@@ -105,6 +106,8 @@ def make_constraint(constraint):
         return constraint
     if isinstance(constraint, str) and constraint == "boolean":
         return _Booleans()
+    if isinstance(constraint, str) and constraint == "verbose":
+        return _VerboseHelper()
     if isinstance(constraint, Hidden):
         constraint = make_constraint(constraint.constraint)
         constraint.hidden = True
@@ -464,6 +467,31 @@ class _Booleans(_Constraint):
         )
 
 
+class _VerboseHelper(_Constraint):
+    """Helper constraint for the verbose parameter.
+
+    Convenience class for
+    [Interval(Integral, 0, None, closed="left"), bool, numpy.bool_]
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._constraints = [
+            Interval(Integral, 0, None, closed="left"),
+            _InstancesOf(bool),
+            _InstancesOf(np.bool_),
+        ]
+
+    def is_satisfied_by(self, val):
+        return any(c.is_satisfied_by(val) for c in self._constraints)
+
+    def __str__(self):
+        return (
+            f"{', '.join([str(c) for c in self._constraints[:-1]])} or"
+            f" {self._constraints[-1]}"
+        )
+
+
 class Hidden:
     """Class encapsulating a constraint not meant to be exposed to the user.
 
@@ -500,6 +528,9 @@ def generate_invalid_param_val(constraint, constraints=None):
     """
     if isinstance(constraint, StrOptions):
         return f"not {' or '.join(constraint.options)}"
+
+    if isinstance(constraint, _VerboseHelper):
+        return -1
 
     if not isinstance(constraint, Interval):
         raise NotImplementedError
@@ -630,20 +661,33 @@ def generate_valid_param(constraint):
     """
     if isinstance(constraint, _ArrayLikes):
         return np.array([1, 2, 3])
-    elif isinstance(constraint, _SparseMatrices):
+
+    if isinstance(constraint, _SparseMatrices):
         return csr_matrix([[0, 1], [1, 0]])
-    elif isinstance(constraint, _RandomStates):
+
+    if isinstance(constraint, _RandomStates):
         return np.random.RandomState(42)
-    elif isinstance(constraint, _Callables):
+
+    if isinstance(constraint, _Callables):
         return lambda x: x
-    elif isinstance(constraint, _NoneConstraint):
+
+    if isinstance(constraint, _NoneConstraint):
         return None
-    elif isinstance(constraint, _InstancesOf):
+
+    if isinstance(constraint, _InstancesOf):
         return constraint.type()
+
+    if isinstance(constraint, _Booleans):
+        return True
+
+    if isinstance(constraint, _VerboseHelper):
+        return 1
+
     if isinstance(constraint, StrOptions):
         for option in constraint.options:
             return option
-    elif isinstance(constraint, Interval):
+
+    if isinstance(constraint, Interval):
         interval = constraint
         if interval.left is None and interval.right is None:
             return 0
@@ -656,3 +700,5 @@ def generate_valid_param(constraint):
                 return (interval.left + interval.right) / 2
             else:
                 return interval.left + 1
+
+    raise ValueError(f"Unknown constraint type: {constraint}")

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -16,6 +16,7 @@ from sklearn.utils._param_validation import _InstancesOf
 from sklearn.utils._param_validation import _NoneConstraint
 from sklearn.utils._param_validation import _RandomStates
 from sklearn.utils._param_validation import _SparseMatrices
+from sklearn.utils._param_validation import _VerboseHelper
 from sklearn.utils._param_validation import make_constraint
 from sklearn.utils._param_validation import generate_invalid_param_val
 from sklearn.utils._param_validation import generate_valid_param
@@ -162,6 +163,7 @@ def test_instances_of_type_human_readable(type, expected_type_name):
         Interval(Real, 0, None, closed="left"),
         Interval(Real, None, None, closed="neither"),
         StrOptions({"a", "b", "c"}),
+        _VerboseHelper(),
     ],
 )
 def test_generate_invalid_param_val(constraint):
@@ -269,6 +271,11 @@ def test_generate_invalid_param_val_2_intervals(integer_interval, real_interval)
     [
         [_ArrayLikes()],
         [_InstancesOf(list)],
+        [_Callables()],
+        [_NoneConstraint()],
+        [_RandomStates()],
+        [_SparseMatrices()],
+        [_Booleans()],
         [Interval(Real, None, None, closed="both")],
         [
             Interval(Integral, 0, None, closed="left"),
@@ -294,23 +301,7 @@ def test_generate_invalid_param_val_all_valid(constraints):
         _RandomStates(),
         _SparseMatrices(),
         _Booleans(),
-    ],
-)
-def test_generate_invalid_param_val_not_error(constraint):
-    """Check that the value generated does not satisfy the constraint"""
-    with pytest.raises(NotImplementedError):
-        generate_invalid_param_val(constraint)
-
-
-@pytest.mark.parametrize(
-    "constraint",
-    [
-        _ArrayLikes(),
-        _Callables(),
-        _InstancesOf(list),
-        _NoneConstraint(),
-        _RandomStates(),
-        _SparseMatrices(),
+        _VerboseHelper(),
         StrOptions({"a", "b", "c"}),
         Interval(Integral, None, None, closed="neither"),
         Interval(Integral, 0, 10, closed="neither"),
@@ -345,6 +336,7 @@ def test_generate_valid_param(constraint):
         (int, 1),
         (Real, 0.5),
         ("boolean", False),
+        ("verbose", 1),
     ],
 )
 def test_is_satisfied_by(constraint_declaration, value):
@@ -365,6 +357,7 @@ def test_is_satisfied_by(constraint_declaration, value):
         (callable, _Callables),
         (int, _InstancesOf),
         ("boolean", _Booleans),
+        ("verbose", _VerboseHelper),
     ],
 )
 def test_make_constraint(constraint_declaration, expected_constraint_class):


### PR DESCRIPTION
Came up in reviews for param validation PRs (for #23462). The `verbose` parameter is used in many estimator and always has the same meaning, so we could introduce a helper for that to avoid repeating the same union of constraints all the time (and probably avoid some mistakes).

I'm not entirely convinced by the need of this helper, and I'd also be fine just paying attention to the verbose parameter while reviewing param validation PRs. The constraint is not that complicated: `[Interval(Integral, 0, None, closed="left"), bool, numpy.bool_]`. Do you find it useful or unnecessary ?

cc/ @glemaitre 