### PR TITLE
FIX Restore tie-break for `BallTree.query`

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -68,6 +68,13 @@ Changelog
   precision=class balance.
   :pr:`23214` by :user:`Stéphane Collot <stephanecollot>` and :user:`Max Baak <mbaak>`.
 
+:mod:`sklearn.neighbors`
+........................
+
+- |Fix| The tie break of :func:`neighbors.BallTree.query` has been reverted to have the
+  same behavior than the one used in previous version is preserved.
+  :pr:`23667` by :user:`Julien Jerphanion <jjerphan>`
+
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -71,8 +71,8 @@ Changelog
 :mod:`sklearn.neighbors`
 ........................
 
-- |Fix| The tie break of :func:`neighbors.BallTree.query` has been reverted to have the
-  same behavior than the one used in previous version is preserved.
+- |Fix| The tie break of :func:`neighbors.BallTree.query` has been restored to the
+  one of scikit-lean<1.0.
   :pr:`23667` by :user:`Julien Jerphanion <jjerphan>`
 
 :mod:`sklearn.preprocessing`

--- a/sklearn/neighbors/_partition_nodes.pyx
+++ b/sklearn/neighbors/_partition_nodes.pyx
@@ -35,7 +35,7 @@ cdef extern from *:
         bool operator()(const I &a, const I &b) const {
             D a_value = data[a * n_features + split_dim];
             D b_value = data[b * n_features + split_dim];
-            return a_value == b_value ? a < b : a_value < b_value;
+            return a_value == b_value ? a <= b : a_value < b_value;
         }
     };
 

--- a/sklearn/neighbors/_partition_nodes.pyx
+++ b/sklearn/neighbors/_partition_nodes.pyx
@@ -35,6 +35,8 @@ cdef extern from *:
         bool operator()(const I &a, const I &b) const {
             D a_value = data[a * n_features + split_dim];
             D b_value = data[b * n_features + split_dim];
+            // The condition on indices (a <= b) is less natural but it preserves
+            // the tie break of queries to be the one of scikit-learn<1.0.
             return a_value == b_value ? a <= b : a_value < b_value;
         }
     };


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/23667.

#### What does this implement/fix? Explain your changes.

The introduction of `IndexComparator` used in `partition_node_indices` breaks tie differently than the previous algorithm.

This causes in turn `BallTree.query` to break ties differently.

This change should revert the previous tie-break.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
