### PR TITLE
Update to mypy 0.961 to ensure compatibility with python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: flake8
         types: [file, python]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.782
+    rev: v0.961
     hooks:
      -  id: mypy
         files: sklearn/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
         versionSpec: '3.9'
     - bash: |
         # Include pytest compatibility with mypy
-        pip install pytest flake8 mypy==0.782 black==22.3.0
+        pip install pytest flake8 mypy==0.961 black==22.3.0
       displayName: Install linters
     - bash: |
         black --check --diff .

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -39,7 +39,7 @@ dependent_packages = {
     "pytest-cov": ("2.9.0", "tests"),
     "flake8": ("3.8.2", "tests"),
     "black": ("22.3.0", "tests"),
-    "mypy": ("0.770", "tests"),
+    "mypy": ("0.961", "tests"),
     "pyamg": ("4.0.0", "tests"),
     "sphinx": ("4.0.1", "docs"),
     "sphinx-gallery": ("0.7.0", "docs"),

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -79,7 +79,7 @@ from sklearn.model_selection import GridSearchCV
 
 
 try:
-    WindowsError
+    WindowsError  # type: ignore
 except NameError:
     WindowsError = None
 

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -73,7 +73,7 @@ SPARSE_OR_DENSE = SPARSE_TYPES + (np.asarray,)
 ALGORITHMS = ("ball_tree", "brute", "kd_tree", "auto")
 COMMON_VALID_METRICS = sorted(
     set.intersection(*map(set, neighbors.VALID_METRICS.values()))
-)
+)  # type: ignore
 P = (1, 2, 3, 4, np.inf)
 JOBLIB_BACKENDS = list(joblib.parallel.BACKENDS.keys())
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -34,7 +34,7 @@ from unittest import TestCase
 
 # WindowsError only exist on Windows
 try:
-    WindowsError
+    WindowsError  # type: ignore
 except NameError:
     WindowsError = None
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

When running the pre-commit hooks with Python 3.10, the following error occurs.
```
ERROR: Failed building wheel for typed-ast
```

Therefore the `mypy` version is updated to `v0.961` so that this bug is fixed.
The `mypy` version was also updated in the `azure-pipelines.yml` file, and the `sklearn/_min_dependencies.py`. 


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
