### PR TITLE
DOC fix link "Comparison of model selection for regression"

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -392,7 +392,7 @@ formula is valid only when `n_samples > n_features`.
   .. [13] `Cherkassky, Vladimir, and Yunqian Ma.
            "Comparison of model selection for regression."
            Neural computation 15.7 (2003): 1691-1714.
-           <https://documents.pub/document/comparison-of-model-selection-for-regression-comparison-of-model-selection.html?page=1>`_
+           <http://www.ece.umn.edu/users/cherkass/comparison_paper_Mar05.pdf>`_
 
 Comparison with the regularization parameter of SVM
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -392,7 +392,7 @@ formula is valid only when `n_samples > n_features`.
   .. [13] `Cherkassky, Vladimir, and Yunqian Ma.
            "Comparison of model selection for regression."
            Neural computation 15.7 (2003): 1691-1714.
-           <https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.392.8794&rep=rep1&type=pdf>`_
+           <https://documents.pub/document/comparison-of-model-selection-for-regression-comparison-of-model-selection.html?page=1>`_
 
 Comparison with the regularization parameter of SVM
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -392,7 +392,7 @@ formula is valid only when `n_samples > n_features`.
   .. [13] :doi:`Cherkassky, Vladimir, and Yunqian Ma.
            "Comparison of model selection for regression."
            Neural computation 15.7 (2003): 1691-1714.
-           <10.1162/089976603321891864>`_
+           <10.1162/089976603321891864>`
 
 Comparison with the regularization parameter of SVM
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -389,10 +389,10 @@ formula is valid only when `n_samples > n_features`.
            The Annals of Statistics 35.5 (2007): 2173-2192.
            <0712.0881.pdf>`
 
-  .. [13] `Cherkassky, Vladimir, and Yunqian Ma.
+  .. [13] :doi:`Cherkassky, Vladimir, and Yunqian Ma.
            "Comparison of model selection for regression."
            Neural computation 15.7 (2003): 1691-1714.
-           <http://www.ece.umn.edu/users/cherkass/comparison_paper_Mar05.pdf>`_
+           <10.1162/089976603321891864>`_
 
 Comparison with the regularization parameter of SVM
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Towards #23631 

#### What does this implement/fix? Explain your changes.
Fix broken link to `Cherkassky, Vladimir, and Yunqian Ma.
"Comparison of model selection for regression."
Neural computation 15.7 (2003): 1691-1714.

#### Any other comments?