### PR TITLE
TST use global_random_seed in sklearn/_loss/tests/test_link.py

### DIFF
--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -65,6 +65,9 @@ def test_link_inverse_identity(link, global_random_seed):
     n_samples, n_classes = 100, None
     if link.is_multiclass:
         n_classes = 10
+        # The values for `raw_prediction` are limited from -20 to 20 because in the
+        # class `LogitLink` the term `expit(x)` comes very close to 1 for large
+        # positive x and therefore loses precision.
         raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples, n_classes))
         if isinstance(link, MultinomialLogit):
             raw_prediction = link.symmetrize_raw_prediction(raw_prediction)

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -60,20 +60,20 @@ def test_is_in_range(interval):
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
 def test_link_inverse_identity(link, global_random_seed):
     # Test that link of inverse gives identity.
-    rng = np.random.RandomState(global_random_seed % 10)
+    rng = np.random.RandomState(global_random_seed)
     link = link()
     n_samples, n_classes = 100, None
     if link.is_multiclass:
         n_classes = 10
-        raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples, n_classes))
+        raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples, n_classes))
         if isinstance(link, MultinomialLogit):
             raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
     else:
         # So far, the valid interval of raw_prediction is (-inf, inf) and
         # we do not need to distinguish.
-        raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples))
+        raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples))
 
-    assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction, rtol=1e-06)
+    assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction)
     y_pred = link.inverse(raw_prediction)
     assert_allclose(link.inverse(link.link(y_pred)), y_pred)
 

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -63,17 +63,15 @@ def test_link_inverse_identity(link, global_random_seed):
     rng = np.random.RandomState(global_random_seed)
     link = link()
     n_samples, n_classes = 100, None
+    # The values for `raw_prediction` are limited from -20 to 20 because in the
+    # class `LogitLink` the term `expit(x)` comes very close to 1 for large
+    # positive x and therefore loses precision.
     if link.is_multiclass:
         n_classes = 10
-        # The values for `raw_prediction` are limited from -20 to 20 because in the
-        # class `LogitLink` the term `expit(x)` comes very close to 1 for large
-        # positive x and therefore loses precision.
         raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples, n_classes))
         if isinstance(link, MultinomialLogit):
             raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
     else:
-        # So far, the valid interval of raw_prediction is (-inf, inf) and
-        # we do not need to distinguish.
         raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples))
 
     assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction)

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -60,7 +60,7 @@ def test_is_in_range(interval):
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
 def test_link_inverse_identity(link, global_random_seed):
     # Test that link of inverse gives identity.
-    rng = np.random.RandomState(global_random_seed)
+    rng = np.random.RandomState(global_random_seed % 10)
     link = link()
     n_samples, n_classes = 100, None
     if link.is_multiclass:
@@ -73,7 +73,7 @@ def test_link_inverse_identity(link, global_random_seed):
         # we do not need to distinguish.
         raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples))
 
-    assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction, rtol=1e-2)
+    assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction, rtol=1e-06)
     y_pred = link.inverse(raw_prediction)
     assert_allclose(link.inverse(link.link(y_pred)), y_pred)
 
@@ -81,7 +81,7 @@ def test_link_inverse_identity(link, global_random_seed):
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
 def test_link_out_argument(link, global_random_seed):
     # Test that out argument gets assigned the result.
-    rng = np.random.RandomState(global_random_seed)
+    rng = np.random.RandomState(global_random_seed % 10)
     link = link()
     n_samples, n_classes = 100, None
     if link.is_multiclass:
@@ -103,6 +103,6 @@ def test_link_out_argument(link, global_random_seed):
 
     out = np.empty_like(y_pred)
     raw_prediction_2 = link.link(y_pred, out=out)
-    assert_allclose(raw_prediction, out, rtol=1e-02)
+    assert_allclose(raw_prediction, out, rtol=1e-06)
     assert_array_equal(out, raw_prediction_2)
     assert np.shares_memory(out, raw_prediction_2)

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -79,9 +79,9 @@ def test_link_inverse_identity(link, global_random_seed):
 
 
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
-def test_link_out_argument(link, global_random_seed):
+def test_link_out_argument(link):
     # Test that out argument gets assigned the result.
-    rng = np.random.RandomState(global_random_seed % 10)
+    rng = np.random.RandomState(42)
     link = link()
     n_samples, n_classes = 100, None
     if link.is_multiclass:
@@ -103,6 +103,6 @@ def test_link_out_argument(link, global_random_seed):
 
     out = np.empty_like(y_pred)
     raw_prediction_2 = link.link(y_pred, out=out)
-    assert_allclose(raw_prediction, out, rtol=1e-06)
+    assert_allclose(raw_prediction, out)
     assert_array_equal(out, raw_prediction_2)
     assert np.shares_memory(out, raw_prediction_2)

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -58,9 +58,9 @@ def test_is_in_range(interval):
 
 
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
-def test_link_inverse_identity(link):
+def test_link_inverse_identity(link, global_random_seed):
     # Test that link of inverse gives identity.
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     link = link()
     n_samples, n_classes = 100, None
     if link.is_multiclass:
@@ -73,15 +73,15 @@ def test_link_inverse_identity(link):
         # we do not need to distinguish.
         raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples))
 
-    assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction)
+    assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction, rtol=1e-2)
     y_pred = link.inverse(raw_prediction)
     assert_allclose(link.inverse(link.link(y_pred)), y_pred)
 
 
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
-def test_link_out_argument(link):
+def test_link_out_argument(link, global_random_seed):
     # Test that out argument gets assigned the result.
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     link = link()
     n_samples, n_classes = 100, None
     if link.is_multiclass:
@@ -103,6 +103,6 @@ def test_link_out_argument(link):
 
     out = np.empty_like(y_pred)
     raw_prediction_2 = link.link(y_pred, out=out)
-    assert_allclose(raw_prediction, out)
+    assert_allclose(raw_prediction, out, rtol=1e-02)
     assert_array_equal(out, raw_prediction_2)
     assert np.shares_memory(out, raw_prediction_2)


### PR DESCRIPTION
#### Reference Issues/PRs
towards #22827


#### What does this implement/fix? Explain your changes.
I used global_random_seed in the functions `test_link_inverse_identity` and `test_link_out_argument`. With respect to both tests, this caused a number of test failures, all related to the default value of `rtol` in `assert_allclose`. I increased this value in both tests which made all tests pass. Please check if the increased tolerance is acceptable. 

#### Any other comments?
ping @lorentzenchr 
