### PR TITLE
DOC included link in linkcheck_ignore

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -602,6 +602,8 @@ linkcheck_ignore = [
     "221114584_Random_Fourier_Approximations_"
     "for_Skewed_Multiplicative_Histogram_Kernels",
     "https://doi.org/10.13140/RG.2.2.35280.02565",
+    "https://www.microsoft.com/en-us/research/uploads/prod/2006/01/"
+    "Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf",
     # Broken links from testimonials
     "http://www.bestofmedia.com",
     "http://www.data-publica.com/",


### PR DESCRIPTION

#### Reference Issues/PRs

Towards #23631 

#### What does this implement/fix? Explain your changes.
The link https://www.microsoft.com/en-us/research/uploads/prod/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf works normally in the browser.
I added this link to linkcheck_ignore

#### Any other comments?
None


