### PR TITLE
FIX Wrong method in FutureWarning: if_available

### DIFF
--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -200,7 +200,7 @@ class _IffHasAttrDescriptor(_AvailableIfDescriptor):
     def _check(self, obj):
         warnings.warn(
             "if_delegate_has_method was deprecated in version 1.1 and will be "
-            "removed in version 1.3. Use if_available instead.",
+            "removed in version 1.3. Use available_if instead.",
             FutureWarning,
         )
 


### PR DESCRIPTION
The FutureWarning that triggers when using the deprecated if_delegate_has_method proposes the non-existing method if_available as replacement. Now changed to correct name: available_if
