### PR TITLE
MAINT add link to Bishop book as falsely broken hyperlink

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -614,6 +614,7 @@ linkcheck_ignore = [
     r"https://github.com/conda-forge/miniforge#miniforge",
     r"https://stackoverflow.com/questions/5836335/"
     "consistently-create-same-random-numpy-array/5837352#comment6712034_5837352",
+    "https://www.microsoft.com/en-us/research/uploads/prod/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf",
 ]
 
 # Use a browser-like user agent to avoid some "403 Client Error: Forbidden for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -602,6 +602,8 @@ linkcheck_ignore = [
     "221114584_Random_Fourier_Approximations_"
     "for_Skewed_Multiplicative_Histogram_Kernels",
     "https://doi.org/10.13140/RG.2.2.35280.02565",
+    "https://www.microsoft.com/en-us/research/uploads/prod/2006/01/"
+    "Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf",
     # Broken links from testimonials
     "http://www.bestofmedia.com",
     "http://www.data-publica.com/",
@@ -614,8 +616,6 @@ linkcheck_ignore = [
     r"https://github.com/conda-forge/miniforge#miniforge",
     r"https://stackoverflow.com/questions/5836335/"
     "consistently-create-same-random-numpy-array/5837352#comment6712034_5837352",
-    "https://www.microsoft.com/en-us/research/uploads/prod/2006/01/"
-    "Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf",
 ]
 
 # Use a browser-like user agent to avoid some "403 Client Error: Forbidden for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -614,7 +614,8 @@ linkcheck_ignore = [
     r"https://github.com/conda-forge/miniforge#miniforge",
     r"https://stackoverflow.com/questions/5836335/"
     "consistently-create-same-random-numpy-array/5837352#comment6712034_5837352",
-    "https://www.microsoft.com/en-us/research/uploads/prod/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf",
+    "https://www.microsoft.com/en-us/research/uploads/prod/2006/01/"
+    "Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf",
 ]
 
 # Use a browser-like user agent to avoid some "403 Client Error: Forbidden for


### PR DESCRIPTION
**Reference Issues/PRs**
Towards #23631 

This link is working in a browser, it should be addded to linkcheck_ignore similarly to what was done in https://github.com/scikit-learn/scikit-learn/pull/23737 https://www.microsoft.com/en-us/research/uploads/prod/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf modules/svm.rst

`HTTPSConnectionPool(host='www.microsoft.com', port=443): Read timed out. (read timeout=10)`

**What does this implement/fix? Explain your changes.**
The link https://www.microsoft.com/en-us/research/uploads/prod/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf opens the document in the browser. Added the link to linkcheck_ignore

**Any other comments?**
None