### PR TITLE
CI Do not post again if bot comment already exists

### DIFF
--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -101,11 +101,19 @@ def close_issue_if_opened():
     print("Test has no failures!")
     issue = get_issue()
     if issue is not None:
-        comment = (
-            f"## CI is no longer failing! ✅\n\n[Successful run]({args.link_to_ci_run})"
+        # Comment only if the "## CI is no longer failing" comment does not exist
+        comment_exists = any(
+            c.body.startswith("## CI is no longer failing")
+            for c in issue.get_comments()
         )
-        print(f"Commented on issue #{issue.number}")
-        issue.create_comment(body=comment)
+        if not comment_exists:
+            comment = (
+                "## CI is no longer failing! ✅\n\n[Successful"
+                f" run]({args.link_to_ci_run})"
+            )
+            print(f"Commented on issue #{issue.number}")
+            issue.create_comment(body=comment)
+
         if args.auto_close.lower() == "true":
             print(f"Closing issue #{issue.number}")
             issue.edit(state="closed")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/issues/23754


#### What does this implement/fix? Explain your changes.
This stops the bot from spamming the issue if the CI is still succeeding. As seen in #23754, the bot does not auto-close the issue because of `global_random_seed`. In #23754, the CI failed for a specific seed so the issue should remain open.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
