### PR TITLE
MNT Adds FeatureTracker to share code between tree splitters

### DIFF
--- a/sklearn/tree/_feature_tracker.pxd
+++ b/sklearn/tree/_feature_tracker.pxd
@@ -1,4 +1,5 @@
 # Feature Tracker used with the splitter to sample features
+cimport cython
 from ._tree cimport SIZE_t
 from ._tree cimport UINT32_t
 
@@ -10,6 +11,7 @@ cdef struct FeatureSample:
     SIZE_t feature
     FeatureStatus status
 
+@cython.final
 cdef class FeatureTracker:
     cdef:
         SIZE_t[::1] features
@@ -25,8 +27,8 @@ cdef class FeatureTracker:
         # n_total_constants = n_known_constants + n_found_constants
         SIZE_t n_total_constants
 
-    cdef void reset(self, SIZE_t n_constant_features) nogil
-    cdef FeatureSample sample(self, UINT32_t* random_state) nogil
-    cdef void update_found_constant(self, SIZE_t f_j) nogil
-    cdef void update_drawn_feature(self, SIZE_t f_j) nogil
-    cdef SIZE_t update_constant_features(self) nogil
+    cdef inline void reset(self, SIZE_t n_constant_features) nogil
+    cdef inline FeatureSample sample(self, UINT32_t* random_state) nogil
+    cdef inline void update_found_constant(self, SIZE_t f_j) nogil
+    cdef inline void update_drawn_feature(self, SIZE_t f_j) nogil
+    cdef inline SIZE_t update_constant_features(self) nogil

--- a/sklearn/tree/_feature_tracker.pxd
+++ b/sklearn/tree/_feature_tracker.pxd
@@ -1,4 +1,4 @@
-# Feature Tracker to be used with the splitter
+# Feature Tracker used with the splitter to sample features
 from ._tree cimport SIZE_t
 from ._tree cimport UINT32_t
 

--- a/sklearn/tree/_feature_tracker.pxd
+++ b/sklearn/tree/_feature_tracker.pxd
@@ -1,0 +1,32 @@
+# Feature Tracker to be used with the splitter
+from ._tree cimport SIZE_t
+from ._tree cimport UINT32_t
+
+cdef enum FeatureStatus:
+    EVALUTE, STOP, CONTINUE
+
+cdef struct FeatureSample:
+    SIZE_t f_j
+    SIZE_t feature
+    FeatureStatus status
+
+cdef class FeatureTracker:
+    cdef:
+        SIZE_t[::1] features
+        SIZE_t[::1] constant_features
+        SIZE_t f_i
+        SIZE_t max_features
+        SIZE_t n_visited_features
+        # Number of features discovered to be constant during the split search
+        SIZE_t n_found_constants
+        # Number of features known to be constant and drawn without replacement
+        SIZE_t n_drawn_constants
+        SIZE_t n_known_constants
+        # n_total_constants = n_known_constants + n_found_constants
+        SIZE_t n_total_constants
+
+    cdef void reset(self, SIZE_t n_constant_features) nogil
+    cdef FeatureSample sample(self, UINT32_t* random_state) nogil
+    cdef void update_found_constant(self, SIZE_t f_j) nogil
+    cdef void update_drawn_feature(self, SIZE_t f_j) nogil
+    cdef SIZE_t update_constant_features(self) nogil

--- a/sklearn/tree/_feature_tracker.pyx
+++ b/sklearn/tree/_feature_tracker.pyx
@@ -1,4 +1,4 @@
-# Feature Tracker to be used with the splitter
+# Feature Tracker used with the splitter to sample features
 cimport cython
 
 from libc.string cimport memcpy

--- a/sklearn/tree/_feature_tracker.pyx
+++ b/sklearn/tree/_feature_tracker.pyx
@@ -1,0 +1,119 @@
+# Feature Tracker to be used with the splitter
+cimport cython
+
+from libc.string cimport memcpy
+from ._utils cimport rand_int
+
+import numpy as np
+
+@cython.final
+cdef class FeatureTracker:
+    """Feature Sampler using Fisher-Yates-based algorithm.
+
+    Sample up to max_features without replacement using a Fisher-Yates-based algorithm
+    (using the local variables `f_i` and `f_j` to compute a permutation of the
+    `features` array).
+
+    Skip the CPU intensive evaluation of the impurity criterion for features that were
+    already detected as constant (hence not suitable for good splitting) by ancestor
+    nodes and save the information on newly discovered constant features to spare
+    computation on descendant nodes.
+    """
+
+    def __init__(self, SIZE_t n_features, SIZE_t max_features):
+        self.features = np.arange(n_features, dtype=np.intp)
+        self.constant_features = np.empty(n_features, dtype=np.intp)
+        self.max_features = max_features
+
+    cdef inline void reset(self, SIZE_t n_constant_features) nogil:
+        """Reset for feature sampler."""
+        self.f_i = self.features.shape[0]
+        self.n_visited_features = 0
+        self.n_found_constants = 0
+        self.n_drawn_constants = 0
+        self.n_known_constants = n_constant_features
+        self.n_total_constants = n_constant_features
+
+    cdef inline FeatureSample sample(self, UINT32_t* random_state) nogil:
+        """Sample for new feature to check.
+
+        This function can return a struct with a feature index, it's value, and status.
+        """
+        cdef:
+            SIZE_t f_j
+            bint should_continue
+            SIZE_t[::1] features = self.features
+            FeatureSample output
+
+        should_continue = (
+            self.f_i > self.n_total_constants and  # Stop early if remaining features are constant
+            (self.n_visited_features < self.max_features or
+            # At least one drawn features must be non constant
+            self.n_visited_features <= self.n_found_constants + self.n_drawn_constants))
+
+        if not should_continue:
+            output.status = FeatureStatus.STOP
+            return output
+
+        self.n_visited_features += 1
+
+        # Loop invariant: elements of features in
+        # - [:n_drawn_constant[ holds drawn and known constant features;
+        # - [n_drawn_constant:n_known_constant[ holds known constant
+        #   features that haven't been drawn yet;
+        # - [n_known_constant:n_total_constant[ holds newly found constant
+        #   features;
+        # - [n_total_constant:f_i[ holds features that haven't been drawn
+        #   yet and aren't constant apriori.
+        # - [f_i:n_features[ holds features that have been drawn
+        #   and aren't constant.
+
+        # Draw a feature at random
+        f_j = rand_int(self.n_drawn_constants, self.f_i - self.n_found_constants,
+                       random_state)
+
+        if f_j < self.n_known_constants:
+            # f_j in the interval [n_drawn_constants, n_known_constants[
+            features[f_j], features[self.n_drawn_constants] = (
+                features[self.n_drawn_constants], features[f_j]
+            )
+
+            self.n_drawn_constants += 1
+            output.status = FeatureStatus.CONTINUE
+            return output
+
+        # f_j in the interval [n_known_constants, f_i - n_found_constants[
+        f_j += self.n_found_constants
+        # f_j in the interval [n_total_constants, f_i[
+        output.f_j = f_j
+        output.feature = features[f_j]
+        output.status = FeatureStatus.EVALUTE
+        return output
+
+    cdef inline void update_found_constant(self, SIZE_t f_j) nogil:
+        """Mark f_j as constant."""
+        cdef SIZE_t[::1] features = self.features
+        features[f_j], features[self.n_total_constants] = (
+            features[self.n_total_constants], features[f_j]
+        )
+        self.n_found_constants += 1
+        self.n_total_constants += 1
+
+    cdef inline void update_drawn_feature(self, SIZE_t f_j) nogil:
+        """Move f_j into features that have been drawn and are not constant."""
+        cdef SIZE_t[::1] features = self.features
+        self.f_i -= 1
+        features[self.f_i], features[f_j] = features[f_j], features[self.f_i]
+
+    cdef inline SIZE_t update_constant_features(self) nogil:
+        """Move constant features.
+
+        Respect invariant for constant features: the original order of element in
+        features[:n_known_constants] must be preserved for sibling and child nodes.
+        """
+        cdef SIZE_t[::1] features = self.features
+        cdef SIZE_t[::1] constant_features = self.constant_features
+        memcpy(&features[0], &constant_features[0], sizeof(SIZE_t) * self.n_known_constants)
+        # Copy newly found constant features
+        memcpy(&constant_features[self.n_known_constants], &features[self.n_known_constants],
+               sizeof(SIZE_t) * self.n_found_constants)

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -10,6 +10,7 @@
 # See _splitter.pyx for details.
 
 from ._criterion cimport Criterion
+from ._feature_tracker cimport FeatureTracker
 
 from ._tree cimport DTYPE_t          # Type of X
 from ._tree cimport DOUBLE_t         # Type of y, sample_weight
@@ -27,35 +28,6 @@ cdef struct SplitRecord:
     double improvement     # Impurity improvement given parent node.
     double impurity_left   # Impurity of the left split.
     double impurity_right  # Impurity of the right split.
-
-cdef enum FeatureStatus:
-    EVALUTE, STOP, CONTINUE
-
-cdef struct FeatureSample:
-    SIZE_t f_j
-    SIZE_t feature
-    FeatureStatus status
-
-cdef class FeatureTracker:
-    cdef:
-        SIZE_t[::1] features
-        SIZE_t[::1] constant_features
-        SIZE_t f_i
-        SIZE_t max_features
-        SIZE_t n_visited_features
-        # Number of features discovered to be constant during the split search
-        SIZE_t n_found_constants
-        # Number of features known to be constant and drawn without replacement
-        SIZE_t n_drawn_constants
-        SIZE_t n_known_constants
-        # n_total_constants = n_known_constants + n_found_constants
-        SIZE_t n_total_constants
-
-    cdef void reset(self, SIZE_t n_constant_features) nogil
-    cdef FeatureSample sample(self, UINT32_t* random_state) nogil
-    cdef void update_found_constant(self, SIZE_t f_j) nogil
-    cdef void update_drawn_feature(self, SIZE_t f_j) nogil
-    cdef SIZE_t update_constant_features(self) nogil
 
 cdef class Splitter:
     # The splitter searches in the input space for a feature and a threshold

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -53,7 +53,7 @@ cdef class FeatureTracker:
 
     cdef void reset(self, SIZE_t n_constant_features) nogil
     cdef FeatureSample sample(self, UINT32_t* random_state) nogil
-    cdef void is_constant(self, SIZE_t f_j) nogil
+    cdef void found_constant(self, SIZE_t f_j) nogil
     cdef void update_drawn_feature(self, SIZE_t f_j) nogil
     cdef SIZE_t update_constant_features(self) nogil
 

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -53,7 +53,7 @@ cdef class FeatureTracker:
 
     cdef void reset(self, SIZE_t n_constant_features) nogil
     cdef FeatureSample sample(self, UINT32_t* random_state) nogil
-    cdef void found_constant(self, SIZE_t f_j) nogil
+    cdef void update_found_constant(self, SIZE_t f_j) nogil
     cdef void update_drawn_feature(self, SIZE_t f_j) nogil
     cdef SIZE_t update_constant_features(self) nogil
 

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -149,7 +149,7 @@ cdef class Splitter:
         self.weighted_n_samples = weighted_n_samples
 
         cdef SIZE_t n_features = X.shape[1]
-        self.feature_tracker = FeatureTracker(X.shape[1], self.max_features)
+        self.feature_tracker = FeatureTracker(n_features, self.max_features)
         self.feature_values = np.empty(n_samples, dtype=np.float32)
 
         self.y = y

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -121,7 +121,7 @@ cdef class FeatureTracker:
         output.status = FeatureStatus.EVALUTE
         return output
 
-    cdef inline void found_constant(self, SIZE_t f_j) nogil:
+    cdef inline void update_found_constant(self, SIZE_t f_j) nogil:
         """Mark f_j as constant."""
         cdef SIZE_t[::1] features = self.features
         features[f_j], features[self.n_total_constants] = (
@@ -408,7 +408,7 @@ cdef class BestSplitter(BaseDenseSplitter):
             sort(&Xf[start], &samples[start], end - start)
 
             if Xf[end - 1] <= Xf[start] + FEATURE_THRESHOLD:
-                self.feature_tracker.found_constant(f_j)
+                self.feature_tracker.update_found_constant(f_j)
                 continue
             self.feature_tracker.update_drawn_feature(f_j)
 
@@ -669,7 +669,7 @@ cdef class RandomSplitter(BaseDenseSplitter):
                     max_feature_value = current_feature_value
 
             if max_feature_value <= min_feature_value + FEATURE_THRESHOLD:
-                self.feature_tracker.found_constant(f_j)
+                self.feature_tracker.update_found_constant(f_j)
                 continue
 
             self.feature_tracker.update_drawn_feature(f_j)
@@ -1131,7 +1131,7 @@ cdef class BestSparseSplitter(BaseSparseSplitter):
                     end_negative += 1
 
             if Xf[end - 1] <= Xf[start] + FEATURE_THRESHOLD:
-                self.feature_tracker.found_constant(f_j)
+                self.feature_tracker.update_found_constant(f_j)
                 continue
 
             self.feature_tracker.update_drawn_feature(f_j)
@@ -1310,7 +1310,7 @@ cdef class RandomSparseSplitter(BaseSparseSplitter):
                     max_feature_value = current_feature_value
 
             if max_feature_value <= min_feature_value + FEATURE_THRESHOLD:
-                self.feature_tracker.found_constant(f_j)
+                self.feature_tracker.update_found_constant(f_j)
                 continue
 
             self.feature_tracker.update_drawn_feature(f_j)

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -13,6 +13,8 @@
 
 cimport cython
 from ._criterion cimport Criterion
+from ._feature_tracker cimport FeatureStatus
+from ._feature_tracker cimport FeatureSample
 
 from libc.stdlib cimport free
 from libc.stdlib cimport qsort
@@ -24,7 +26,6 @@ import numpy as np
 from scipy.sparse import csc_matrix
 
 from ._utils cimport log
-from ._utils cimport rand_int
 from ._utils cimport rand_uniform
 from ._utils cimport RAND_R_MAX
 
@@ -36,119 +37,6 @@ cdef DTYPE_t FEATURE_THRESHOLD = 1e-7
 # Constant to switch between algorithm non zero value extract algorithm
 # in SparseSplitter
 cdef DTYPE_t EXTRACT_NNZ_SWITCH = 0.1
-
-@cython.final
-cdef class FeatureTracker:
-    """Feature Sampler using Fisher-Yates-based algorithm.
-
-    Sample up to max_features without replacement using a Fisher-Yates-based algorithm
-    (using the local variables `f_i` and `f_j` to compute a permutation of the
-    `features` array).
-
-    Skip the CPU intensive evaluation of the impurity criterion for features that were
-    already detected as constant (hence not suitable for good splitting) by ancestor
-    nodes and save the information on newly discovered constant features to spare
-    computation on descendant nodes.
-    """
-
-    def __init__(self, SIZE_t n_features, SIZE_t max_features):
-        self.features = np.arange(n_features, dtype=np.intp)
-        self.constant_features = np.empty(n_features, dtype=np.intp)
-        self.max_features = max_features
-
-    cdef inline void reset(self, SIZE_t n_constant_features) nogil:
-        """Reset for feature sampler."""
-        self.f_i = self.features.shape[0]
-        self.n_visited_features = 0
-        self.n_found_constants = 0
-        self.n_drawn_constants = 0
-        self.n_known_constants = n_constant_features
-        self.n_total_constants = n_constant_features
-
-    cdef inline FeatureSample sample(self, UINT32_t* random_state) nogil:
-        """Sample for new feature to check.
-
-        This function can return a struct with a feature index, it's value, and status.
-        """
-        cdef:
-            SIZE_t f_j
-            bint should_continue
-            SIZE_t[::1] features = self.features
-            FeatureSample output
-
-        should_continue = (
-            self.f_i > self.n_total_constants and  # Stop early if remaining features are constant
-            (self.n_visited_features < self.max_features or
-            # At least one drawn features must be non constant
-            self.n_visited_features <= self.n_found_constants + self.n_drawn_constants))
-
-        if not should_continue:
-            output.status = FeatureStatus.STOP
-            return output
-
-        self.n_visited_features += 1
-
-        # Loop invariant: elements of features in
-        # - [:n_drawn_constant[ holds drawn and known constant features;
-        # - [n_drawn_constant:n_known_constant[ holds known constant
-        #   features that haven't been drawn yet;
-        # - [n_known_constant:n_total_constant[ holds newly found constant
-        #   features;
-        # - [n_total_constant:f_i[ holds features that haven't been drawn
-        #   yet and aren't constant apriori.
-        # - [f_i:n_features[ holds features that have been drawn
-        #   and aren't constant.
-
-        # Draw a feature at random
-        f_j = rand_int(self.n_drawn_constants, self.f_i - self.n_found_constants,
-                       random_state)
-
-        if f_j < self.n_known_constants:
-            # f_j in the interval [n_drawn_constants, n_known_constants[
-            features[f_j], features[self.n_drawn_constants] = (
-                features[self.n_drawn_constants], features[f_j]
-            )
-
-            self.n_drawn_constants += 1
-            output.status = FeatureStatus.CONTINUE
-            return output
-
-        # f_j in the interval [n_known_constants, f_i - n_found_constants[
-        f_j += self.n_found_constants
-        # f_j in the interval [n_total_constants, f_i[
-        output.f_j = f_j
-        output.feature = features[f_j]
-        output.status = FeatureStatus.EVALUTE
-        return output
-
-    cdef inline void update_found_constant(self, SIZE_t f_j) nogil:
-        """Mark f_j as constant."""
-        cdef SIZE_t[::1] features = self.features
-        features[f_j], features[self.n_total_constants] = (
-            features[self.n_total_constants], features[f_j]
-        )
-        self.n_found_constants += 1
-        self.n_total_constants += 1
-
-    cdef inline void update_drawn_feature(self, SIZE_t f_j) nogil:
-        """Move f_j into features that have been drawn and are not constant."""
-        cdef SIZE_t[::1] features = self.features
-        self.f_i -= 1
-        features[self.f_i], features[f_j] = features[f_j], features[self.f_i]
-
-    cdef inline SIZE_t update_constant_features(self) nogil:
-        """Move constant features.
-
-        Respect invariant for constant features: the original order of element in
-        features[:n_known_constants] must be preserved for sibling and child nodes.
-        """
-        cdef SIZE_t[::1] features = self.features
-        cdef SIZE_t[::1] constant_features = self.constant_features
-        memcpy(&features[0], &constant_features[0], sizeof(SIZE_t) * self.n_known_constants)
-        # Copy newly found constant features
-        memcpy(&constant_features[self.n_known_constants], &features[self.n_known_constants],
-               sizeof(SIZE_t) * self.n_found_constants)
-
 
 cdef inline void _init_split(SplitRecord* self, SIZE_t start_pos) nogil:
     self.impurity_left = INFINITY

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -68,8 +68,7 @@ cdef class FeatureTracker:
     cdef inline FeatureSample sample(self, UINT32_t* random_state) nogil:
         """Sample for new feature to check.
 
-        This function can return a struct with a feature index, it's value,
-        and status.
+        This function can return a struct with a feature index, it's value, and status.
         """
         cdef:
             SIZE_t f_j
@@ -140,9 +139,8 @@ cdef class FeatureTracker:
     cdef inline SIZE_t update_constant_features(self) nogil:
         """Move constant features.
 
-        Respect invariant for constant features: the original order of
-        element in features[:n_known_constants] must be preserved for sibling
-        and child nodes.
+        Respect invariant for constant features: the original order of element in
+        features[:n_known_constants] must be preserved for sibling and child nodes.
         """
         cdef SIZE_t[::1] features = self.features
         cdef SIZE_t[::1] constant_features = self.constant_features

--- a/sklearn/tree/setup.py
+++ b/sklearn/tree/setup.py
@@ -38,6 +38,12 @@ def configuration(parent_package="", top_path=None):
         libraries=libraries,
         extra_compile_args=["-O3"],
     )
+    config.add_extension(
+        "_feature_tracker",
+        sources=["_feature_tracker.pyx"],
+        libraries=libraries,
+        extra_compile_args=["-O3"],
+    )
 
     config.add_subpackage("tests")
 


### PR DESCRIPTION
This PR adds a `FeatureTracker` so the dense and sparse splitters can share code with each other. The `FeatureTracker` takes ownership of sampling for new features to evaluate and to maintain the invariance of `self.features`. 