### PR TITLE
MNT make linkcheck run without errors

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -423,7 +423,7 @@ time of Joris van den Bossche (2017-2018).
 .. image:: images/cds-logo.png
    :width: 100pt
    :align: center
-   :target: https://www.datascience-paris-saclay.fr/
+   :target: http://www.datascience-paris-saclay.fr/
 
 .. raw:: html
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -598,15 +598,19 @@ linkcheck_ignore = [
     # links falsely flagged as broken
     "https://www.researchgate.net/publication/"
     "233096619_A_Dendrite_Method_for_Cluster_Analysis",
-    "https://www.researchgate.net/publication/"
-    "221114584_Random_Fourier_Approximations_"
+    "https://www.researchgate.net/publication/221114584_Random_Fourier_Approximations_"
     "for_Skewed_Multiplicative_Histogram_Kernels",
+    "https://www.researchgate.net/publication/4974606_"
+    "Hedonic_housing_prices_and_the_demand_for_clean_air",
+    "https://www.researchgate.net/profile/Anh-Huy-Phan/publication/220241471_Fast_"
+    "Local_Algorithms_for_Large_Scale_Nonnegative_Matrix_and_Tensor_Factorizations",
     "https://doi.org/10.13140/RG.2.2.35280.02565",
     "https://www.microsoft.com/en-us/research/uploads/prod/2006/01/"
     "Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf",
-    "https://www.researchgate.net/publication/4974606_"
-    "Hedonic_housing_prices_and_the_demand_for_clean_air",
+    "https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tr-99-87.pdf",
+    "https://microsoft.com/",
     "https://www.jstor.org/stable/2984099",
+    "https://stat.uw.edu/sites/default/files/files/reports/2000/tr371.pdf",
     # Broken links from testimonials
     "http://www.bestofmedia.com",
     "http://www.data-publica.com/",

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -956,7 +956,7 @@ is not readily available from the start, or when the data does not fit into memo
 
     .. [4] `"SVD based initialization: A head start for nonnegative
       matrix factorization"
-      <http://www.boutsidis.org/Boutsidis_PRE_08.pdf>`_
+      <https://www.boutsidis.org/Boutsidis_PRE_08.pdf>`_
       C. Boutsidis, E. Gallopoulos, 2008
 
     .. [5] `"Fast local algorithms for large scale nonnegative matrix and tensor

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -956,7 +956,7 @@ is not readily available from the start, or when the data does not fit into memo
 
     .. [4] `"SVD based initialization: A head start for nonnegative
       matrix factorization"
-      <https://www.cb.uu.se/~milan/histo/before2011august/Boutsidis.pdf>`_
+      <http://www.boutsidis.org/Boutsidis_PRE_08.pdf>`_
       C. Boutsidis, E. Gallopoulos, 2008
 
     .. [5] `"Fast local algorithms for large scale nonnegative matrix and tensor

--- a/doc/modules/semi_supervised.rst
+++ b/doc/modules/semi_supervised.rst
@@ -148,4 +148,4 @@ which can drastically reduce running times.
 
     [3] Olivier Delalleau, Yoshua Bengio, Nicolas Le Roux. Efficient
     Non-Parametric Function Induction in Semi-Supervised Learning. AISTAT 2005
-    http://www.gatsby.ucl.ac.uk/aistats/fullpapers/204.pdf
+    https://www.gatsby.ucl.ac.uk/aistats/fullpapers/204.pdf

--- a/doc/modules/semi_supervised.rst
+++ b/doc/modules/semi_supervised.rst
@@ -148,4 +148,4 @@ which can drastically reduce running times.
 
     [3] Olivier Delalleau, Yoshua Bengio, Nicolas Le Roux. Efficient
     Non-Parametric Function Induction in Semi-Supervised Learning. AISTAT 2005
-    https://research.microsoft.com/en-us/people/nicolasl/efficient_ssl.pdf
+    http://www.gatsby.ucl.ac.uk/aistats/fullpapers/204.pdf

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -589,11 +589,11 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
            Stella X. Yu, Jianbo Shi
            <https://www1.icsi.berkeley.edu/~stellayu/publication/doc/2003kwayICCV.pdf>`_
 
-    .. [4] `Toward the Optimal Preconditioned Eigensolver:
-           Locally Optimal Block Preconditioned Conjugate Gradient Method, 2001.
+    .. [4] :doi:`Toward the Optimal Preconditioned Eigensolver:
+           Locally Optimal Block Preconditioned Conjugate Gradient Method, 2001
            A. V. Knyazev
            SIAM Journal on Scientific Computing 23, no. 2, pp. 517-541.
-           <https://epubs.siam.org/doi/pdf/10.1137/S1064827500366124>`_
+           <10.1137/S1064827500366124>`
 
     .. [5] :doi:`Simple, direct, and efficient multi-way spectral clustering, 2019
            Anil Damle, Victor Minden, Lexing Ying

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -170,7 +170,7 @@ class _PLS(
 
     Main ref: Wegelin, a survey of Partial Least Squares (PLS) methods,
     with emphasis on the two-block case
-    https://www.stat.washington.edu/research/reports/2000/tr371.pdf
+    https://stat.uw.edu/sites/default/files/files/reports/2000/tr371.pdf
     """
 
     @abstractmethod

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -216,7 +216,7 @@ class KernelPCA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
     .. [2] `Bakır, Gökhan H., Jason Weston, and Bernhard Schölkopf.
        "Learning to find pre-images."
        Advances in neural information processing systems 16 (2004): 449-456.
-       <https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.68.5164&rep=rep1&type=pdf>`_
+       <https://papers.nips.cc/paper/2003/file/ac1ad983e08ad3304a97e147f522747e-Paper.pdf>`_
 
     .. [3] :arxiv:`Halko, Nathan, Per-Gunnar Martinsson, and Joel A. Tropp.
        "Finding structure with randomness: Probabilistic algorithms for
@@ -532,7 +532,7 @@ class KernelPCA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
         `Bakır, Gökhan H., Jason Weston, and Bernhard Schölkopf.
         "Learning to find pre-images."
         Advances in neural information processing systems 16 (2004): 449-456.
-        <https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.68.5164&rep=rep1&type=pdf>`_
+        <https://papers.nips.cc/paper/2003/file/ac1ad983e08ad3304a97e147f522747e-Paper.pdf>`_
         """
         if not self.fit_inverse_transform:
             raise NotFittedError(


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/issues/23631.

With these changes `make linkcheck` runs without any error.

The remaining issues were:
- some links were fixed in a single place rather than everywhere in the project
- some links were fixed but they needed to be added to `lincheck_ignore` since `make linkcheck` flags them as broken but they work fine in a browser