### PR TITLE
CI remove lingering scipy-dev failures due to interior-point solver deprecation

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -55,6 +55,8 @@ from ..model_selection import ShuffleSplit
 from ..model_selection._validation import _safe_split
 from ..metrics.pairwise import rbf_kernel, linear_kernel, pairwise_distances
 from ..utils.fixes import threadpool_info
+from ..utils.fixes import sp_version
+from ..utils.fixes import parse_version
 from ..utils.validation import check_is_fitted
 from ..utils._param_validation import make_constraint
 from ..utils._param_validation import generate_invalid_param_val
@@ -747,6 +749,11 @@ def _set_checking_parameters(estimator):
 
     if name == "OneHotEncoder":
         estimator.set_params(handle_unknown="ignore")
+
+    if name == "QuantileRegressor":
+        # Avoid warning due to Scipy deprecating interior-point solver
+        solver = "highs" if sp_version >= parse_version("1.6.0") else "interior-point"
+        estimator.set_params(solver=solver)
 
     if name in CROSS_DECOMPOSITION:
         estimator.set_params(n_components=1)


### PR DESCRIPTION
follow-up of https://github.com/scikit-learn/scikit-learn/pull/23637.

There are still some failures related to the scipy deprecation of `solver='interior-point'` in the scipy-dev build, see the [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=44084&view=logs&jobId=67fbb25f-e417-50be-be55-3b1e9637fce5&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081) and search for 'interior-point'

With the changes in this PR, the common tests for QuantileRegressor all pass:
```
pytest sklearn/tests/test_common.py -k QuantileRegressor -Werror::DeprecationWarning
```

I triggered a scipy-dev build, so a good way to make sure this PR works is to check there is no failure about interior-point anymore. There should still be some failures in the scipy-dev build since there is some work still to be done on https://github.com/scikit-learn/scikit-learn/issues/23626