### PR TITLE
Param validation for Dictvectorizer

### DIFF
--- a/sklearn/feature_extraction/_dict_vectorizer.py
+++ b/sklearn/feature_extraction/_dict_vectorizer.py
@@ -13,6 +13,7 @@ import scipy.sparse as sp
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array, tosequence
 from ..utils.deprecation import deprecated
+from ..utils._param_validation import StrOptions
 
 
 def _tosequence(X):
@@ -97,6 +98,13 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
     array([[0., 0., 4.]])
     """
 
+    _parameter_constraints = {
+        "dtype": [type],  # TODO: TypeOptions constraint,
+        "separator": [str, StrOptions({"="})],
+        "sparse": ["boolean"],
+        "sort": ["boolean"],
+    }
+
     def __init__(self, *, dtype=np.float64, separator="=", sparse=True, sort=True):
         self.dtype = dtype
         self.separator = separator
@@ -154,6 +162,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
         self : object
             DictVectorizer class instance.
         """
+        self._validate_params()
         feature_names = []
         vocab = {}
 

--- a/sklearn/feature_extraction/_dict_vectorizer.py
+++ b/sklearn/feature_extraction/_dict_vectorizer.py
@@ -13,7 +13,6 @@ import scipy.sparse as sp
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array, tosequence
 from ..utils.deprecation import deprecated
-from ..utils._param_validation import StrOptions
 
 
 def _tosequence(X):
@@ -100,7 +99,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
 
     _parameter_constraints = {
         "dtype": [type],  # TODO: TypeOptions constraint,
-        "separator": [str, StrOptions({"="})],
+        "separator": [str],
         "sparse": ["boolean"],
         "sort": ["boolean"],
     }

--- a/sklearn/feature_extraction/_dict_vectorizer.py
+++ b/sklearn/feature_extraction/_dict_vectorizer.py
@@ -98,7 +98,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
     """
 
     _parameter_constraints = {
-        "dtype": [type],  # TODO: TypeOptions constraint,
+        "dtype": "no validation",  # validation delegated to numpy,
         "separator": [str],
         "sparse": ["boolean"],
         "sort": ["boolean"],
@@ -318,6 +318,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
         Xa : {array, sparse matrix}
             Feature vectors; always 2-d.
         """
+        self._validate_params()
         return self._transform(X, fitting=True)
 
     def inverse_transform(self, X, dict_type=dict):

--- a/sklearn/feature_extraction/_dict_vectorizer.py
+++ b/sklearn/feature_extraction/_dict_vectorizer.py
@@ -98,7 +98,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
     """
 
     _parameter_constraints = {
-        "dtype": "no validation",  # validation delegated to numpy,
+        "dtype": "no_validation",  # validation delegated to numpy,
         "separator": [str],
         "sparse": ["boolean"],
         "sort": ["boolean"],

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -457,7 +457,6 @@ PARAM_VALIDATION_ESTIMATORS_TO_IGNORE = [
     "CalibratedClassifierCV",
     "ClassifierChain",
     "CountVectorizer",
-    "DictVectorizer",
     "DictionaryLearning",
     "ElasticNetCV",
     "EllipticEnvelope",


### PR DESCRIPTION
#### Reference Issues/PRs
Issue: #23462 (make estimators use _validate_params)

#### What does this implement/fix? Explain your changes.
Adds parameter validation to DictVectorizer.

#### Any other comments?
Added **#Todo** for parameter **dtype** 