### PR TITLE
MNT Updated pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.3.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
     -   id: flake8
         types: [file, python]


### PR DESCRIPTION

#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
Hi,
While setting up my dev environment, I realised that some pre-commit hooks  in the `pre-commit-config.yaml` are outdated:

- `flake8` was pointing to [Gitlab](https://gitlab.com/pycqa/flake8). It looks like it is permanently moved to Github, and will not be updated in Gitlab anymore: https://github.com/PyCQA/flake8/issues/1290 and https://github.com/PyCQA/flake8/pull/1305 
I changed the repo link and also updated the version. This is because the [contributing page](https://github.com/scikit-learn/scikit-learn/blob/main/doc/developers/contributing.rst) suggests to install latest flake8 (with `pip install flake8`)

- `pre-commit-hooks`. I just found out by running `pre-commit autoupdate` that this was also outdated.

#### Any other comments?

Please let me know if the versions of these were 'outdated' for a reason. In this case, apologies for the PR! I checked previous issues, PRs and docs but I didn't see mentioned anywhere that the versions should stay fixed.

Thanks :)
