### PR TITLE
MNT Make error catching more explicit in tests

### DIFF
--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -150,10 +150,8 @@ def test_unseen_or_no_features():
             X = X.toarray()
         assert_array_equal(X, np.zeros((1, 2)))
 
-        try:
+        with pytest.raises(ValueError, match="empty"):
             v.transform([])
-        except ValueError as e:
-            assert "empty" in str(e)
 
 
 def test_deterministic_vocabulary():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1299,10 +1299,8 @@ def test_big_input():
     # Test if the warning for too large inputs is appropriate.
     X = np.repeat(10**40.0, 4).astype(np.float64).reshape(-1, 1)
     clf = DecisionTreeClassifier()
-    try:
+    with pytest.raises(ValueError, match="float32"):
         clf.fit(X, [0, 1, 0, 1])
-    except ValueError as e:
-        assert "float32" in str(e)
 
 
 def test_realloc():

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -801,15 +801,15 @@ def test_check_is_fitted():
         assert False, "check_is_fitted failed with ValueError"
 
     # NotFittedError is a subclass of both ValueError and AttributeError
-    try:
-        check_is_fitted(ard, msg="Random message %(name)s, %(name)s")
-    except ValueError as e:
-        assert str(e) == "Random message ARDRegression, ARDRegression"
+    msg = "Random message %(name)s, %(name)s"
+    match = "Random message ARDRegression, ARDRegression"
+    with pytest.raises(ValueError, match=match):
+        check_is_fitted(ard, msg=msg)
 
-    try:
-        check_is_fitted(svr, msg="Another message %(name)s, %(name)s")
-    except AttributeError as e:
-        assert str(e) == "Another message SVR, SVR"
+    msg = "Another message %(name)s, %(name)s"
+    match = "Another message SVR, SVR"
+    with pytest.raises(AttributeError, match=match):
+        check_is_fitted(svr, msg=msg)
 
     ard.fit(*make_blobs())
     svr.fit(*make_blobs())


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
Minor changes to make error catching more explicit in tests (i.e. replace `try/except` with `pytest.raises` where applicable).

#### Any other comments?
There were a few instances where `try/except` blocks were used to filter areas where errors may occur, e.g. in `sklearn/model_selection/tests/test_split.py::test_2d_y` where the test iterates over a large list of splitters, line 181 may produce a `ValueError` but will not always do so since only some splitters such as `StratifiedKFold` actually generate the `ValueError`.

I'm not a huge fan of the way that test is written, since it's not explicit with _which_ splitters it expects to raise errors, or _why_ (e.g. `isinstance(splitter, StratifiedKFold)...` would accomplish both) but I didn't include it in this PR since it does work as intended and potentially saves on some indentation and extra if/else clauses (at the cost of explicitness and clarity imo).