### PR TITLE
MAINT Fix conversion of `FiniteStatus` from C to Python

### DIFF
--- a/sklearn/utils/_isfinite.pyx
+++ b/sklearn/utils/_isfinite.pyx
@@ -14,7 +14,21 @@ def cy_isfinite(floating[::1] a, bint allow_nan=False):
     cdef FiniteStatus result
     with nogil:
         result = _isfinite(a, allow_nan)
-    return result
+    return _convert_FiniteStatus_c_to_py(result)
+
+
+cdef inline _convert_FiniteStatus_c_to_py(FiniteStatus fs):
+    # Manually map C enum values to Python ones.
+    # This is a workaround for an upstream Cython issue.
+    # xref: https://github.com/cython/cython/issues/2732
+    if fs == FiniteStatus.all_finite:
+        return (<object>FiniteStatus).all_finite
+    elif fs == FiniteStatus.has_nan:
+        return (<object>FiniteStatus).has_nan
+    elif fs == FiniteStatus.has_infinite:
+        return (<object>FiniteStatus).has_infinite
+    else:
+        raise ValueError(f"Unknown `FiniteStatus` value: {fs}")
 
 
 cdef inline FiniteStatus _isfinite(floating[::1] a, bint allow_nan) nogil:


### PR DESCRIPTION
#### Reference Issues/PRs

Follow up to PR ( https://github.com/scikit-learn/scikit-learn/pull/23849 ) and PR ( https://github.com/scikit-learn/scikit-learn/pull/23197 ).

#### What does this implement/fix? Explain your changes.

Currently when Cython converts a `cpdef enum` from C to Python, it constructs a Python `int` instead of using the `IntEnum`-based `FiniteStatus` Python object created by `cpdef`. As `IntEnum` values can be compared with `int`, this doesn't cause
issues atm. That said, to avoid issues it would be good to return `FiniteStatus` objects to Python code. This adds some code to manually perform this conversion between C and Python code to workaround this Cython issue ( https://github.com/cython/cython/issues/2732 ).

#### Any other comments?

NA