### PR TITLE
Changed variable 'input' to 'input_type' to avoid keyword override

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -221,11 +221,11 @@ class _VectorizerMixin:
         doc: str
             A string of unicode symbols.
         """
-        if self.input == "filename":
+        if self.input_type == "filename":
             with open(doc, "rb") as fh:
                 doc = fh.read()
 
-        elif self.input == "file":
+        elif self.input_type == "file":
             doc = doc.read()
 
         if isinstance(doc, bytes):
@@ -604,7 +604,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
 
     Parameters
     ----------
-    input : {'filename', 'file', 'content'}, default='content'
+    input_type : {'filename', 'file', 'content'}, default='content'
         - If `'filename'`, the sequence passed as an argument to fit is
           expected to be a list of filenames that need reading to fetch
           the raw content to analyze.
@@ -737,7 +737,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
     def __init__(
         self,
         *,
-        input="content",
+        input_type="content",
         encoding="utf-8",
         decode_error="strict",
         strip_accents=None,
@@ -754,7 +754,7 @@ class HashingVectorizer(TransformerMixin, _VectorizerMixin, BaseEstimator):
         alternate_sign=True,
         dtype=np.float64,
     ):
-        self.input = input
+        self.input_type = input_type
         self.encoding = encoding
         self.decode_error = decode_error
         self.strip_accents = strip_accents
@@ -904,7 +904,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
 
     Parameters
     ----------
-    input : {'filename', 'file', 'content'}, default='content'
+    input_type : {'filename', 'file', 'content'}, default='content'
         - If `'filename'`, the sequence passed as an argument to fit is
           expected to be a list of filenames that need reading to fetch
           the raw content to analyze.
@@ -1099,7 +1099,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
     def __init__(
         self,
         *,
-        input="content",
+        input_type="content",
         encoding="utf-8",
         decode_error="strict",
         strip_accents=None,
@@ -1117,7 +1117,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         binary=False,
         dtype=np.int64,
     ):
-        self.input = input
+        self.input_type = input_type
         self.encoding = encoding
         self.decode_error = decode_error
         self.strip_accents = strip_accents
@@ -1734,7 +1734,7 @@ class TfidfVectorizer(CountVectorizer):
 
     Parameters
     ----------
-    input : {'filename', 'file', 'content'}, default='content'
+    input_type : {'filename', 'file', 'content'}, default='content'
         - If `'filename'`, the sequence passed as an argument to fit is
           expected to be a list of filenames that need reading to fetch
           the raw content to analyze.
@@ -1936,7 +1936,7 @@ class TfidfVectorizer(CountVectorizer):
     def __init__(
         self,
         *,
-        input="content",
+        input_type="content",
         encoding="utf-8",
         decode_error="strict",
         strip_accents=None,
@@ -1960,7 +1960,7 @@ class TfidfVectorizer(CountVectorizer):
     ):
 
         super().__init__(
-            input=input,
+            input_type=input_type,
             encoding=encoding,
             decode_error=decode_error,
             strip_accents=strip_accents,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #23880 

#### What does this implement/fix? Explain your changes.
In the file feature_extraction/text.py, edits the classes _VectorizerMixin, HashingVectorizer, and CountVectorizer to change the argument `input` to `input_type`. Described in the linked issue, `input` is a Python keyword and using this name can result in potential overrides. 

#### Any other comments?
PEP8 convention would be to add a trailing underscore to a variable name to avoid an override (i.e. `input_`). However, for user intuition and since the variable is a string descriptor, the name `input_type` can be more clear while fixing this problem.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
