### PR TITLE
[t-SNE] Removed redundant logic for squaring distances, and replaced format() with f-strings

### DIFF
--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -119,7 +119,7 @@ def _joint_probabilities_nn(distances, desired_perplexity, verbose):
     assert np.all(np.abs(P.data) <= 1.0)
     if verbose >= 2:
         duration = time() - t0
-        print("[t-SNE] Computed conditional probabilities in {:.3f}s".format(duration))
+        print(f"[t-SNE] Computed conditional probabilities in {duration:.3f}s")
     return P
 
 
@@ -881,9 +881,8 @@ class TSNE(BaseEstimator):
 
         if self.early_exaggeration < 1.0:
             raise ValueError(
-                "early_exaggeration must be at least 1, but is {}".format(
-                    self.early_exaggeration
-                )
+                "early_exaggeration must be at least 1, but is"
+                f" {self.early_exaggeration}"
             )
 
         if self.n_iter < 250:
@@ -896,7 +895,7 @@ class TSNE(BaseEstimator):
             # Retrieve the distance matrix, either using the precomputed one or
             # computing it.
             if self.metric == "precomputed":
-                distances = X
+                distances = X**2
             else:
                 if self.verbose:
                     print("[t-SNE] Computing pairwise distances...")
@@ -919,9 +918,6 @@ class TSNE(BaseEstimator):
                     "All distances should be positive, the metric given is not correct"
                 )
 
-            if self.metric != "euclidean":
-                distances **= 2
-
             # compute the joint probability distribution for the input space
             P = _joint_probabilities(distances, self.perplexity, self.verbose)
             assert np.all(np.isfinite(P)), "All probabilities should be finite"
@@ -938,7 +934,7 @@ class TSNE(BaseEstimator):
             n_neighbors = min(n_samples - 1, int(3.0 * self.perplexity + 1))
 
             if self.verbose:
-                print("[t-SNE] Computing {} nearest neighbors...".format(n_neighbors))
+                print(f"[t-SNE] Computing {n_neighbors} nearest neighbors...")
 
             # Find the nearest neighbors for every point
             knn = NearestNeighbors(
@@ -952,25 +948,19 @@ class TSNE(BaseEstimator):
             knn.fit(X)
             duration = time() - t0
             if self.verbose:
-                print(
-                    "[t-SNE] Indexed {} samples in {:.3f}s...".format(
-                        n_samples, duration
-                    )
-                )
+                print(f"[t-SNE] Indexed {n_samples} samples in {duration:.3f}s...")
 
             t0 = time()
             distances_nn = knn.kneighbors_graph(mode="distance")
             duration = time() - t0
             if self.verbose:
                 print(
-                    "[t-SNE] Computed neighbors for {} samples in {:.3f}s...".format(
-                        n_samples, duration
-                    )
+                    f"[t-SNE] Computed neighbors for {n_samples} samples in"
+                    f" {duration:.3f}s..."
                 )
 
             # Free the memory used by the ball_tree
             del knn
-
             # knn return the euclidean distance but we need it squared
             # to be consistent with the 'exact' method. Note that the
             # the method was derived using the euclidean method as in the
@@ -1070,8 +1060,8 @@ class TSNE(BaseEstimator):
         params, kl_divergence, it = _gradient_descent(obj_func, params, **opt_args)
         if self.verbose:
             print(
-                "[t-SNE] KL divergence after %d iterations with early exaggeration: %f"
-                % (it + 1, kl_divergence)
+                f"[t-SNE] KL divergence after {it + 1} iterations with early"
+                f" exaggeration: {float(kl_divergence)}"
             )
 
         # Learning schedule (part 2): disable early exaggeration and finish
@@ -1090,8 +1080,8 @@ class TSNE(BaseEstimator):
 
         if self.verbose:
             print(
-                "[t-SNE] KL divergence after %d iterations: %f"
-                % (it + 1, kl_divergence)
+                f"[t-SNE] KL divergence after {it + 1} iterations:"
+                f" {float(kl_divergence)}"
             )
 
         X_embedded = params.reshape(n_samples, self.n_components)

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -906,13 +906,12 @@ class TSNE(BaseEstimator):
                 # Also, Euclidean is slower for n_jobs>1, so don't set here
                 distances = pairwise_distances(X, metric=self.metric, squared=True)
             else:
-                metric_params_ = self.metric_params or {}
-                distances = (
-                    pairwise_distances(
+                if self.metric != "precomputed":
+                    metric_params_ = self.metric_params or {}
+                    distances = pairwise_distances(
                         X, metric=self.metric, n_jobs=self.n_jobs, **metric_params_
                     )
-                    ** 2
-                )
+                distances **= 2
 
             if np.any(distances < 0):
                 raise ValueError(

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -34,28 +34,6 @@ MACHINE_EPSILON = np.finfo(np.double).eps
 
 
 def _joint_probabilities(distances, desired_perplexity, verbose):
-    """Compute joint probabilities p_ij from distances.
-
-    Parameters
-    ----------
-    distances : ndarray of shape (n_samples * (n_samples-1) / 2,)
-        Distances of samples are stored as condensed matrices, i.e.
-        we omit the diagonal and duplicate entries and store everything
-        in a one-dimensional array.
-
-    desired_perplexity : float
-        Desired perplexity of the joint probability distributions.
-
-    verbose : int
-        Verbosity level.
-
-    Returns
-    -------
-    P : ndarray of shape (n_samples * (n_samples-1) / 2,)
-        Condensed joint probability matrix.
-    """
-    # Compute conditional probabilities such that they approximately match
-    # the desired perplexity
     distances = distances.astype(np.float32, copy=False)
     conditional_P = _utils._binary_search_perplexity(
         distances, desired_perplexity, verbose
@@ -67,35 +45,7 @@ def _joint_probabilities(distances, desired_perplexity, verbose):
 
 
 def _joint_probabilities_nn(distances, desired_perplexity, verbose):
-    """Compute joint probabilities p_ij from distances using just nearest
-    neighbors.
-
-    This method is approximately equal to _joint_probabilities. The latter
-    is O(N), but limiting the joint probability to nearest neighbors improves
-    this substantially to O(uN).
-
-    Parameters
-    ----------
-    distances : sparse matrix of shape (n_samples, n_samples)
-        Distances of samples to its n_neighbors nearest neighbors. All other
-        distances are left to zero (and are not materialized in memory).
-        Matrix should be of CSR format.
-
-    desired_perplexity : float
-        Desired perplexity of the joint probability distributions.
-
-    verbose : int
-        Verbosity level.
-
-    Returns
-    -------
-    P : sparse matrix of shape (n_samples, n_samples)
-        Condensed joint probability matrix with only nearest neighbors. Matrix
-        will be of CSR format.
-    """
     t0 = time()
-    # Compute conditional probabilities such that they approximately match
-    # the desired perplexity
     distances.sort_indices()
     n_samples = distances.shape[0]
     distances_data = distances.data.reshape(n_samples, -1)
@@ -104,15 +54,12 @@ def _joint_probabilities_nn(distances, desired_perplexity, verbose):
         distances_data, desired_perplexity, verbose
     )
     assert np.all(np.isfinite(conditional_P)), "All probabilities should be finite"
-
-    # Symmetrize the joint probability distribution using sparse operations
     P = csr_matrix(
         (conditional_P.ravel(), distances.indices, distances.indptr),
         shape=(n_samples, n_samples),
     )
     P = P + P.T
 
-    # Normalize the joint probability distribution
     sum_P = np.maximum(P.sum(), MACHINE_EPSILON)
     P /= sum_P
 
@@ -132,43 +79,7 @@ def _kl_divergence(
     skip_num_points=0,
     compute_error=True,
 ):
-    """t-SNE objective function: gradient of the KL divergence
-    of p_ijs and q_ijs and the absolute error.
 
-    Parameters
-    ----------
-    params : ndarray of shape (n_params,)
-        Unraveled embedding.
-
-    P : ndarray of shape (n_samples * (n_samples-1) / 2,)
-        Condensed joint probability matrix.
-
-    degrees_of_freedom : int
-        Degrees of freedom of the Student's-t distribution.
-
-    n_samples : int
-        Number of samples.
-
-    n_components : int
-        Dimension of the embedded space.
-
-    skip_num_points : int, default=0
-        This does not compute the gradient for points with indices below
-        `skip_num_points`. This is useful when computing transforms of new
-        data where you'd like to keep the old data fixed.
-
-    compute_error: bool, default=True
-        If False, the kl_divergence is not computed and returns NaN.
-
-    Returns
-    -------
-    kl_divergence : float
-        Kullback-Leibler divergence of p_ij and q_ij.
-
-    grad : ndarray of shape (n_params,)
-        Unraveled gradient of the Kullback-Leibler divergence with respect to
-        the embedding.
-    """
     X_embedded = params.reshape(n_samples, n_components)
 
     # Q is a heavy-tailed distribution: Student's t-distribution
@@ -212,62 +123,6 @@ def _kl_divergence_bh(
     compute_error=True,
     num_threads=1,
 ):
-    """t-SNE objective function: KL divergence of p_ijs and q_ijs.
-
-    Uses Barnes-Hut tree methods to calculate the gradient that
-    runs in O(NlogN) instead of O(N^2).
-
-    Parameters
-    ----------
-    params : ndarray of shape (n_params,)
-        Unraveled embedding.
-
-    P : sparse matrix of shape (n_samples, n_sample)
-        Sparse approximate joint probability matrix, computed only for the
-        k nearest-neighbors and symmetrized. Matrix should be of CSR format.
-
-    degrees_of_freedom : int
-        Degrees of freedom of the Student's-t distribution.
-
-    n_samples : int
-        Number of samples.
-
-    n_components : int
-        Dimension of the embedded space.
-
-    angle : float, default=0.5
-        This is the trade-off between speed and accuracy for Barnes-Hut T-SNE.
-        'angle' is the angular size (referred to as theta in [3]) of a distant
-        node as measured from a point. If this size is below 'angle' then it is
-        used as a summary node of all points contained within it.
-        This method is not very sensitive to changes in this parameter
-        in the range of 0.2 - 0.8. Angle less than 0.2 has quickly increasing
-        computation time and angle greater 0.8 has quickly increasing error.
-
-    skip_num_points : int, default=0
-        This does not compute the gradient for points with indices below
-        `skip_num_points`. This is useful when computing transforms of new
-        data where you'd like to keep the old data fixed.
-
-    verbose : int, default=False
-        Verbosity level.
-
-    compute_error: bool, default=True
-        If False, the kl_divergence is not computed and returns NaN.
-
-    num_threads : int, default=1
-        Number of threads used to compute the gradient. This is set here to
-        avoid calling _openmp_effective_n_threads for each gradient step.
-
-    Returns
-    -------
-    kl_divergence : float
-        Kullback-Leibler divergence of p_ij and q_ij.
-
-    grad : ndarray of shape (n_params,)
-        Unraveled gradient of the Kullback-Leibler divergence with respect to
-        the embedding.
-    """
     params = params.astype(np.float32, copy=False)
     X_embedded = params.reshape(n_samples, n_components)
 
@@ -311,72 +166,6 @@ def _gradient_descent(
     args=None,
     kwargs=None,
 ):
-    """Batch gradient descent with momentum and individual gains.
-
-    Parameters
-    ----------
-    objective : callable
-        Should return a tuple of cost and gradient for a given parameter
-        vector. When expensive to compute, the cost can optionally
-        be None and can be computed every n_iter_check steps using
-        the objective_error function.
-
-    p0 : array-like of shape (n_params,)
-        Initial parameter vector.
-
-    it : int
-        Current number of iterations (this function will be called more than
-        once during the optimization).
-
-    n_iter : int
-        Maximum number of gradient descent iterations.
-
-    n_iter_check : int, default=1
-        Number of iterations before evaluating the global error. If the error
-        is sufficiently low, we abort the optimization.
-
-    n_iter_without_progress : int, default=300
-        Maximum number of iterations without progress before we abort the
-        optimization.
-
-    momentum : float within (0.0, 1.0), default=0.8
-        The momentum generates a weight for previous gradients that decays
-        exponentially.
-
-    learning_rate : float, default=200.0
-        The learning rate for t-SNE is usually in the range [10.0, 1000.0]. If
-        the learning rate is too high, the data may look like a 'ball' with any
-        point approximately equidistant from its nearest neighbours. If the
-        learning rate is too low, most points may look compressed in a dense
-        cloud with few outliers.
-
-    min_gain : float, default=0.01
-        Minimum individual gain for each parameter.
-
-    min_grad_norm : float, default=1e-7
-        If the gradient norm is below this threshold, the optimization will
-        be aborted.
-
-    verbose : int, default=0
-        Verbosity level.
-
-    args : sequence, default=None
-        Arguments to pass to objective function.
-
-    kwargs : dict, default=None
-        Keyword arguments to pass to objective function.
-
-    Returns
-    -------
-    p : ndarray of shape (n_params,)
-        Optimum parameters.
-
-    error : float
-        Optimum.
-
-    i : int
-        Last iteration.
-    """
     if args is None:
         args = []
     if kwargs is None:
@@ -895,23 +684,24 @@ class TSNE(BaseEstimator):
             # Retrieve the distance matrix, either using the precomputed one or
             # computing it.
             if self.metric == "precomputed":
-                distances = X**2
+                distances = X
+            elif self.verbose:
+                print("[t-SNE] Computing pairwise distances...")
+            if self.metric == "euclidean":
+                # Euclidean is squared here, rather than using **= 2,
+                # because euclidean_distances already calculates
+                # squared distances, and returns np.sqrt(dist) for
+                # squared=False.
+                # Also, Euclidean is slower for n_jobs>1, so don't set here
+                distances = pairwise_distances(X, metric=self.metric, squared=True)
             else:
-                if self.verbose:
-                    print("[t-SNE] Computing pairwise distances...")
-
-                if self.metric == "euclidean":
-                    # Euclidean is squared here, rather than using **= 2,
-                    # because euclidean_distances already calculates
-                    # squared distances, and returns np.sqrt(dist) for
-                    # squared=False.
-                    # Also, Euclidean is slower for n_jobs>1, so don't set here
-                    distances = pairwise_distances(X, metric=self.metric, squared=True)
-                else:
-                    metric_params_ = self.metric_params or {}
-                    distances = pairwise_distances(
+                metric_params_ = self.metric_params or {}
+                distances = (
+                    pairwise_distances(
                         X, metric=self.metric, n_jobs=self.n_jobs, **metric_params_
                     )
+                    ** 2
+                )
 
             if np.any(distances < 0):
                 raise ValueError(


### PR DESCRIPTION
#### Reference Issues/PRs
I was just looking at the original implementation of t-SNE here and wanted to make the logic more clear.

#### What does this implement/fix? Explain your changes.
There is a check for `self.metric != "euclidean"` before squaring the distance manually. However, above, we have an if/else statement that covers this case already:
```
if self.metric == "precomputed":
    #do something
else:
   #do something else
```
We can take the code from the not-equals check and put it under `self.metric == "precomputed"`, since that is the only possibility not covered by the else statement.

#### Any other comments?
I also replaced calls to format() with f-strings (I don't know if that should be a separate pull request). This is my first time contributing, sorry in advance for any mistakes.
