### PR TITLE
MAINT use validate_params for KNNImputer

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -77,6 +77,11 @@ class _BaseImputer(TransformerMixin, BaseEstimator):
     It adds automatically support for `add_indicator`.
     """
 
+    _parameter_constraints = {
+        "missing_values": [numbers.Real, numbers.Integral, str, None],
+        "add_indicator": ["boolean"],
+    }
+
     def __init__(self, *, missing_values=np.nan, add_indicator=False):
         self.missing_values = missing_values
         self.add_indicator = add_indicator

--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -118,12 +118,11 @@ class KNNImputer(_BaseImputer):
     """
 
     _parameter_constraints = {
-        "missing_values": [Real, Integral, str, None],
+        **_BaseImputer._parameter_constraints,
         "n_neighbors": [Interval(Integral, 1, None, closed="left")],
         "weights": [StrOptions({"uniform", "distance"}), callable],
         "metric": [StrOptions(set(_NAN_METRICS)), callable],
         "copy": ["boolean"],
-        "add_indicator": ["boolean"],
     }
 
     def __init__(

--- a/sklearn/impute/tests/test_knn.py
+++ b/sklearn/impute/tests/test_knn.py
@@ -68,13 +68,6 @@ def test_knn_imputer_default_with_invalid_input(na):
     with pytest.raises(ValueError, match="Input X contains (infinity|NaN)"):
         imputer.transform(X)
 
-    # negative n_neighbors
-    with pytest.raises(
-        ValueError,
-        match="The 'n_neighbors' parameter of KNNImputer must be an int in the range",
-    ):
-        KNNImputer(missing_values=na, n_neighbors=0).fit(X_fit)
-
     # Test with missing_values=0 when NaN present
     imputer = KNNImputer(missing_values=0, n_neighbors=2, weights="uniform")
     X = np.array(
@@ -87,23 +80,6 @@ def test_knn_imputer_default_with_invalid_input(na):
     )
     msg = "Input X contains NaN"
     with pytest.raises(ValueError, match=msg):
-        imputer.fit(X)
-
-    X = np.array(
-        [
-            [0, 0],
-            [np.nan, 2],
-        ]
-    )
-
-    # Test with a metric type without NaN support
-    imputer = KNNImputer(metric="euclidean")
-    bad_metric_msg = (
-        "The 'metric' parameter of KNNImputer must be a str among {'nan_euclidean'} or"
-        " a callable"
-    )
-
-    with pytest.raises(ValueError, match=bad_metric_msg):
         imputer.fit(X)
 
 

--- a/sklearn/impute/tests/test_knn.py
+++ b/sklearn/impute/tests/test_knn.py
@@ -69,7 +69,10 @@ def test_knn_imputer_default_with_invalid_input(na):
         imputer.transform(X)
 
     # negative n_neighbors
-    with pytest.raises(ValueError, match="Expected n_neighbors > 0"):
+    with pytest.raises(
+        ValueError,
+        match="The 'n_neighbors' parameter of KNNImputer must be an int in the range",
+    ):
         KNNImputer(missing_values=na, n_neighbors=0).fit(X_fit)
 
     # Test with missing_values=0 when NaN present
@@ -95,7 +98,11 @@ def test_knn_imputer_default_with_invalid_input(na):
 
     # Test with a metric type without NaN support
     imputer = KNNImputer(metric="euclidean")
-    bad_metric_msg = "The selected metric does not support NaN values"
+    bad_metric_msg = (
+        "The 'metric' parameter of KNNImputer must be a str among {'nan_euclidean'} or"
+        " a callable"
+    )
+
     with pytest.raises(ValueError, match=bad_metric_msg):
         imputer.fit(X)
 
@@ -237,7 +244,6 @@ def test_knn_imputer_verify(na):
 
 @pytest.mark.parametrize("na", [np.nan, -1])
 def test_knn_imputer_one_n_neighbors(na):
-
     X = np.array([[0, 0], [na, 2], [4, 3], [5, na], [7, 7], [na, 8], [14, 13]])
 
     X_imputed = np.array([[0, 0], [4, 2], [4, 3], [5, 3], [7, 7], [7, 8], [14, 13]])
@@ -265,7 +271,6 @@ def test_knn_imputer_all_samples_are_neighbors(na):
 
 @pytest.mark.parametrize("na", [np.nan, -1])
 def test_knn_imputer_weight_uniform(na):
-
     X = np.array([[0, 0], [na, 2], [4, 3], [5, 6], [7, 7], [9, 8], [11, 10]])
 
     # Test with "uniform" weight (or unweighted)
@@ -441,7 +446,6 @@ def test_knn_imputer_weight_distance(na):
 
 
 def test_knn_imputer_callable_metric():
-
     # Define callable metric that returns the l1 norm:
     def custom_callable(x, y, missing_values=np.nan, squared=False):
         x = np.ma.array(x, mask=np.isnan(x))
@@ -467,7 +471,6 @@ def test_knn_imputer_callable_metric():
 # for a small dataset. However, it should raise a UserWarning that we ignore.
 @pytest.mark.filterwarnings("ignore:adhere to working_memory")
 def test_knn_imputer_with_simple_example(na, working_memory):
-
     X = np.array(
         [
             [0, na, 0, na],

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -475,7 +475,6 @@ PARAM_VALIDATION_ESTIMATORS_TO_IGNORE = [
     "Isomap",
     "IsotonicRegression",
     "IterativeImputer",
-    "KNNImputer",
     "KNeighborsTransformer",
     "KernelPCA",
     "LabelPropagation",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


Towards #23462

#### What does this implement/fix? Explain your changes.
This makes `KNNImputer` use `_validate_params`


#### Any other comments?
First contribution, happy to get feedback!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
