### PR TITLE
DOC Ensures that extract_patches_2d passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -23,7 +23,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.decomposition._dict_learning.dict_learning_online",
     "sklearn.decomposition._nmf.non_negative_factorization",
     "sklearn.externals._packaging.version.parse",
-    "sklearn.feature_extraction.image.extract_patches_2d",
     "sklearn.feature_extraction.text.strip_accents_unicode",
     "sklearn.inspection._partial_dependence.partial_dependence",
     "sklearn.inspection._plot.partial_dependence.plot_partial_dependence",


### PR DESCRIPTION
**Reference Issues/PRs**

Addresses #21350

**What does this implement/fix? Explain your changes.**

Removed `sklearn.feature_extraction.image.extract_patches_2d` from numpydoc validation check ignore list so that the docstring is validated by numpydoc.

**Any other comments?**