### PR TITLE
TST use global_random_seed in sklearn/cluster/tests/test_bicluster.py

### DIFF
--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -145,8 +145,8 @@ def _do_bistochastic_test(scaled):
     assert_almost_equal(scaled.sum(axis=0).mean(), scaled.sum(axis=1).mean(), decimal=1)
 
 
-def test_scale_normalize():
-    generator = np.random.RandomState(0)
+def test_scale_normalize(global_random_seed):
+    generator = np.random.RandomState(global_random_seed)
     X = generator.rand(100, 100)
     for mat in (X, csr_matrix(X)):
         scaled, _, _ = _scale_normalize(mat)
@@ -155,8 +155,8 @@ def test_scale_normalize():
             assert issparse(scaled)
 
 
-def test_bistochastic_normalize():
-    generator = np.random.RandomState(0)
+def test_bistochastic_normalize(global_random_seed):
+    generator = np.random.RandomState(global_random_seed)
     X = generator.rand(100, 100)
     for mat in (X, csr_matrix(X)):
         scaled = _bistochastic_normalize(mat)
@@ -165,10 +165,10 @@ def test_bistochastic_normalize():
             assert issparse(scaled)
 
 
-def test_log_normalize():
+def test_log_normalize(global_random_seed):
     # adding any constant to a log-scaled matrix should make it
     # bistochastic
-    generator = np.random.RandomState(0)
+    generator = np.random.RandomState(global_random_seed)
     mat = generator.rand(100, 100)
     scaled = _log_normalize(mat) + 1
     _do_bistochastic_test(scaled)

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -60,7 +60,7 @@ def _test_shape_indices(model):
         assert len(j_ind) == n
 
 
-def test_spectral_coclustering():
+def test_spectral_coclustering(global_random_seed):
     # Test Dhillon's Spectral CoClustering on a simple problem.
     param_grid = {
         "svd_method": ["randomized", "arpack"],
@@ -69,8 +69,8 @@ def test_spectral_coclustering():
         "init": ["k-means++"],
         "n_init": [10],
     }
-    random_state = 0
-    S, rows, cols = make_biclusters((30, 30), 3, noise=0.5, random_state=random_state)
+    random_state = global_random_seed
+    S, rows, cols = make_biclusters((30, 30), 3, noise=0.1, random_state=random_state)
     S -= S.min()  # needs to be nonnegative before making it sparse
     S = np.where(S < 1, 0, S)  # threshold some values
     for mat in (S, csr_matrix(S)):
@@ -88,9 +88,11 @@ def test_spectral_coclustering():
             _test_shape_indices(model)
 
 
-def test_spectral_biclustering():
+def test_spectral_biclustering(global_random_seed):
     # Test Kluger methods on a checkerboard dataset.
-    S, rows, cols = make_checkerboard((30, 30), 3, noise=0.5, random_state=0)
+    S, rows, cols = make_checkerboard(
+        (30, 30), 3, noise=0.5, random_state=global_random_seed
+    )
 
     non_default_params = {
         "method": ["scale", "log"],
@@ -107,7 +109,7 @@ def test_spectral_biclustering():
                     n_clusters=3,
                     n_init=3,
                     init="k-means++",
-                    random_state=0,
+                    random_state=global_random_seed,
                 )
                 model.set_params(**dict([(param_name, param_value)]))
 
@@ -174,15 +176,15 @@ def test_log_normalize(global_random_seed):
     _do_bistochastic_test(scaled)
 
 
-def test_fit_best_piecewise():
-    model = SpectralBiclustering(random_state=0)
+def test_fit_best_piecewise(global_random_seed):
+    model = SpectralBiclustering(random_state=global_random_seed)
     vectors = np.array([[0, 0, 0, 1, 1, 1], [2, 2, 2, 3, 3, 3], [0, 1, 2, 3, 4, 5]])
     best = model._fit_best_piecewise(vectors, n_best=2, n_clusters=2)
     assert_array_equal(best, vectors[:2])
 
 
-def test_project_and_cluster():
-    model = SpectralBiclustering(random_state=0)
+def test_project_and_cluster(global_random_seed):
+    model = SpectralBiclustering(random_state=global_random_seed)
     data = np.array([[1, 1, 1], [1, 1, 1], [3, 6, 3], [3, 6, 3]])
     vectors = np.array([[1, 0], [0, 1], [0, 0]])
     for mat in (data, csr_matrix(data)):
@@ -190,19 +192,20 @@ def test_project_and_cluster():
         assert_almost_equal(v_measure_score(labels, [0, 0, 1, 1]), 1.0)
 
 
-def test_perfect_checkerboard():
+def test_perfect_checkerboard(global_random_seed):
     # XXX Previously failed on build bot (not reproducible)
-    model = SpectralBiclustering(3, svd_method="arpack", random_state=0)
+    random_state = global_random_seed
+    model = SpectralBiclustering(3, svd_method="arpack", random_state=random_state)
 
-    S, rows, cols = make_checkerboard((30, 30), 3, noise=0, random_state=0)
+    S, rows, cols = make_checkerboard((30, 30), 3, noise=0, random_state=random_state)
     model.fit(S)
     assert consensus_score(model.biclusters_, (rows, cols)) == 1
 
-    S, rows, cols = make_checkerboard((40, 30), 3, noise=0, random_state=0)
+    S, rows, cols = make_checkerboard((40, 30), 3, noise=0, random_state=random_state)
     model.fit(S)
     assert consensus_score(model.biclusters_, (rows, cols)) == 1
 
-    S, rows, cols = make_checkerboard((30, 40), 3, noise=0, random_state=0)
+    S, rows, cols = make_checkerboard((30, 40), 3, noise=0, random_state=random_state)
     model.fit(S)
     assert consensus_score(model.biclusters_, (rows, cols)) == 1
 

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -69,14 +69,15 @@ def test_spectral_coclustering(global_random_seed):
         "init": ["k-means++"],
         "n_init": [10],
     }
-    random_state = global_random_seed
-    S, rows, cols = make_biclusters((30, 30), 3, noise=0.1, random_state=random_state)
+    S, rows, cols = make_biclusters(
+        (30, 30), 3, noise=0.1, random_state=global_random_seed
+    )
     S -= S.min()  # needs to be nonnegative before making it sparse
     S = np.where(S < 1, 0, S)  # threshold some values
     for mat in (S, csr_matrix(S)):
         for kwargs in ParameterGrid(param_grid):
             model = SpectralCoclustering(
-                n_clusters=3, random_state=random_state, **kwargs
+                n_clusters=3, random_state=global_random_seed, **kwargs
             )
             model.fit(mat)
 
@@ -194,18 +195,25 @@ def test_project_and_cluster(global_random_seed):
 
 def test_perfect_checkerboard(global_random_seed):
     # XXX Previously failed on build bot (not reproducible)
-    random_state = global_random_seed
-    model = SpectralBiclustering(3, svd_method="arpack", random_state=random_state)
+    model = SpectralBiclustering(
+        3, svd_method="arpack", random_state=global_random_seed
+    )
 
-    S, rows, cols = make_checkerboard((30, 30), 3, noise=0, random_state=random_state)
+    S, rows, cols = make_checkerboard(
+        (30, 30), 3, noise=0, random_state=global_random_seed
+    )
     model.fit(S)
     assert consensus_score(model.biclusters_, (rows, cols)) == 1
 
-    S, rows, cols = make_checkerboard((40, 30), 3, noise=0, random_state=random_state)
+    S, rows, cols = make_checkerboard(
+        (40, 30), 3, noise=0, random_state=global_random_seed
+    )
     model.fit(S)
     assert consensus_score(model.biclusters_, (rows, cols)) == 1
 
-    S, rows, cols = make_checkerboard((30, 40), 3, noise=0, random_state=random_state)
+    S, rows, cols = make_checkerboard(
+        (30, 40), 3, noise=0, random_state=global_random_seed
+    )
     model.fit(S)
     assert consensus_score(model.biclusters_, (rows, cols)) == 1
 


### PR DESCRIPTION
#### Reference Issues/PRs
towards #22827


#### What does this implement/fix? Explain your changes.
I used the global_random_seed fixture in some of the tests in the `tests/test_bicluster.py` module where I thought it's appropriate.

#### Any other comments?
`test_spectral_coclustering`: 
I tried using global_random_seed in this test which resulted in 6 test failures which I was able to fix by reducing `noise` from 0.5 to 0.1 (line 73). However, after the change the test finished in 17 seconds on my machine (compared to 6 seconds before). As this is quite long I didn't apply global_random_seed to this test. 

`test_spectral_biclustering`: 
When I used global_random_seed in this test, the test run time increased from 0.6 sec to 51 sec, so I left the test unchanged. 

`test_fit_best_piecewise`: 
Using global_random_seed in this test increased the test  run time from 0.08 sec to 2 sec. If I understand correctly, global_random_seed is not really needed in this test, so I left this test unchanged. 

`test_project_and_cluster`: 
Using global_random_seed here increased the test run time from from 0.08 sec to 1.51 sec. I think global_random_seed is also not really needed here, so I also left this test unchanged. 

`test_perfect_checkerboard`: 
Introducing global_random_seed to this test increased the test run time from 0.3 sec to 23.4 sec. From my understanding global_random_seed is also not of great importance here, I so didn't change this test. 