### PR TITLE
CI Allow documentation building when the fork uses the main branch

### DIFF
--- a/build_tools/github/trigger_hosting.sh
+++ b/build_tools/github/trigger_hosting.sh
@@ -14,10 +14,11 @@ then
           | jq '.[0].number')
 
      if [[ "$PULL_REQUEST_NUMBER" == "null" ]]; then
-          # The pull request was on the main (default) branch of the fork. The above API
+          # The pull request is on the main (default) branch of the fork. The above API
           # call is unable to get the PR number associated with the commit:
           # https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
-          # The search API is not used all the time because it has a lower rate limit.
+          # We fallback to the search API here. The search API is not used everytime
+          # because it has a lower rate limit.
           PULL_REQUEST_NUMBER=$(curl \
                -H "Accept: application/vnd.github+json" \
                -H "Authorization: token $GITHUB_TOKEN" \

--- a/build_tools/github/trigger_hosting.sh
+++ b/build_tools/github/trigger_hosting.sh
@@ -12,6 +12,19 @@ then
           -H "Authorization: token $GITHUB_TOKEN" \
           https://api.github.com/repos/$REPO_NAME/commits/$COMMIT_SHA/pulls 2>/dev/null \
           | jq '.[0].number')
+
+     if [[ "$PULL_REQUEST_NUMBER" == "null" ]]; then
+          # The pull request was on the main (default) branch of the fork. The above API
+          # call is unable to get the PR number associated with the commit:
+          # https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
+          # The search API is not used all the time because it has a lower rate limit.
+          PULL_REQUEST_NUMBER=$(curl \
+               -H "Accept: application/vnd.github+json" \
+               -H "Authorization: token $GITHUB_TOKEN" \
+               "https://api.github.com/search/issues?q=$COMMIT_SHA+repo:$GITHUB_REPOSITORY" 2>/dev/null \
+               | jq '.items[0].number')
+     fi
+
      BRANCH=pull/$PULL_REQUEST_NUMBER/head
 else
      BRANCH=$HEAD_BRANCH


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This fixes the doc building issue in https://github.com/scikit-learn/scikit-learn/pull/23869


#### What does this implement/fix? Explain your changes.
This PR uses the search API instead when the first API call does not work. According to the [docs](https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit), the commits/SHA/pulls API does not return PRs if the commit is on the default branch (`main`).

The search API is not used all the time because it has a much lower rate limit.

CC @adrinjalali 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
