### PR TITLE
DOC Ensure homogeneity_completeness_v_measure passes numpydoc validation

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -429,10 +429,10 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred, *, beta=1.0):
     Parameters
     ----------
     labels_true : int array, shape = [n_samples]
-        ground truth class labels to be used as a reference
+        Ground truth class labels to be used as a reference.
 
     labels_pred : array-like of shape (n_samples,)
-        cluster labels to evaluate
+        Gluster labels to evaluate.
 
     beta : float, default=1.0
         Ratio of weight attributed to ``homogeneity`` vs ``completeness``.
@@ -443,13 +443,13 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred, *, beta=1.0):
     Returns
     -------
     homogeneity : float
-       score between 0.0 and 1.0. 1.0 stands for perfectly homogeneous labeling
+        Score between 0.0 and 1.0. 1.0 stands for perfectly homogeneous labeling.
 
     completeness : float
-       score between 0.0 and 1.0. 1.0 stands for perfectly complete labeling
+        Score between 0.0 and 1.0. 1.0 stands for perfectly complete labeling.
 
     v_measure : float
-        harmonic mean of the first two
+        Harmonic mean of the first two.
 
     See Also
     --------

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -453,9 +453,9 @@ def homogeneity_completeness_v_measure(labels_true, labels_pred, *, beta=1.0):
 
     See Also
     --------
-    homogeneity_score
-    completeness_score
-    v_measure_score
+    homogeneity_score : Homogeneity metric of cluster labeling.
+    completeness_score : Completeness metric of cluster labeling.
+    v_measure_score : V-Measure (NMI with arithmetic mean option).
     """
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
 

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -42,7 +42,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.cluster._supervised.adjusted_rand_score",
     "sklearn.metrics.cluster._supervised.entropy",
     "sklearn.metrics.cluster._supervised.fowlkes_mallows_score",
-    "sklearn.metrics.cluster._supervised.homogeneity_completeness_v_measure",
     "sklearn.metrics.cluster._supervised.mutual_info_score",
     "sklearn.metrics.cluster._supervised.normalized_mutual_info_score",
     "sklearn.metrics.cluster._supervised.pair_confusion_matrix",


### PR DESCRIPTION
**Reference Issues/PRs**
Address #21350

**What does this implement/fix? Explain your changes.**

1. Remove sklearn.metrics.cluster._supervised.homogeneity_completeness_v_measure from test_doctrings.py FUNCTION_DOCSTRING_IGNORE_LIST
2. Fix the following
	- PR08: Parameter "labels_true" description should start with a capital letter
	- PR09: Parameter "labels_true" description should finish with "."
	- PR08: Parameter "labels_pred" description should start with a capital letter
	- PR09: Parameter "labels_pred" description should finish with "."
	- RT04: Return value description should start with a capital letter
	- RT05: Return value description should finish with "."
	- RT04: Return value description should start with a capital letter
	- RT05: Return value description should finish with "."
	- RT04: Return value description should start with a capital letter
	- RT05: Return value description should finish with "."
	- SA04: Missing description for See Also "homogeneity_score" reference
	- SA04: Missing description for See Also "completeness_score" reference
	- SA04: Missing description for See Also "v_measure_score" reference