### PR TITLE
DOC Ensure `check_paired_arrays` passes numpydoc validation

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -210,7 +210,6 @@ def check_paired_arrays(X, Y):
     safe_Y : {array-like, sparse matrix} of shape (n_samples_Y, n_features)
         An array equal to Y if Y was not None, guaranteed to be a numpy array.
         If Y was None, safe_Y will be a pointer to X.
-
     """
     X, Y = check_pairwise_arrays(X, Y)
     if X.shape != Y.shape:

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -49,7 +49,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.cluster._supervised.rand_score",
     "sklearn.metrics.cluster._supervised.v_measure_score",
     "sklearn.metrics.pairwise.additive_chi2_kernel",
-    "sklearn.metrics.pairwise.check_paired_arrays",
     "sklearn.metrics.pairwise.chi2_kernel",
     "sklearn.metrics.pairwise.cosine_distances",
     "sklearn.metrics.pairwise.cosine_similarity",


### PR DESCRIPTION
**Reference Issues/PRs**
Address #21350

**What does this implement/fix? Explain your changes.**

1. Remove `sklearn.metrics.pairwise.check_paired_arrays`from test_doctrings.py `FUNCTION_DOCSTRING_IGNORE_LIST`.
2. Fix the following:
	- GL03: Double line break found; please use only one blank line to separate sections or paragraphs, and do not leave blank lines at the end of docstrings