### PR TITLE
DOC Ensure `cosine_distances` passes numpydoc validation

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -972,10 +972,11 @@ def cosine_distances(X, Y=None):
     Returns
     -------
     distance matrix : ndarray of shape (n_samples_X, n_samples_Y)
+        Returns the cosine distance between samples in X and Y.
 
     See Also
     --------
-    cosine_similarity
+    cosine_similarity : Compute cosine similarity between samples in X and Y.
     scipy.spatial.distance.cosine : Dense matrices only.
     """
     # 1.0 - cosine_similarity(X, Y) without copy

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -51,7 +51,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.additive_chi2_kernel",
     "sklearn.metrics.pairwise.check_paired_arrays",
     "sklearn.metrics.pairwise.chi2_kernel",
-    "sklearn.metrics.pairwise.cosine_distances",
     "sklearn.metrics.pairwise.cosine_similarity",
     "sklearn.metrics.pairwise.distance_metrics",
     "sklearn.metrics.pairwise.kernel_metrics",


### PR DESCRIPTION
**Reference Issues/PRs**
Address #21350

**What does this implement/fix? Explain your changes.**

1. Remove `sklearn.metrics.pairwise.cosine_distances`from test_doctrings.py `FUNCTION_DOCSTRING_IGNORE_LIST`.
2. Fix the following:
	- RT03: Return value has no description
	- SA04: Missing description for See Also "cosine_similarity" reference