### PR TITLE
DOC Ensure `pairwise_distances_argmin` passes numpydoc validation

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -766,7 +766,7 @@ def pairwise_distances_argmin(X, Y, *, axis=1, metric="euclidean", metric_kwargs
 
     See Also
     --------
-    pairwise_distances : Distances between pairs of elements of X and Y.
+    pairwise_distances : Distances between every pair of samples of X and Y.
     pairwise_distances_argmin_min : Minimum distances between one point and a
                                     set of points.
     """

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -766,8 +766,9 @@ def pairwise_distances_argmin(X, Y, *, axis=1, metric="euclidean", metric_kwargs
 
     See Also
     --------
-    sklearn.metrics.pairwise_distances
-    sklearn.metrics.pairwise_distances_argmin_min
+    pairwise_distances : Distances between pairs of elements of X and Y.
+    pairwise_distances_argmin_min : Minimum distances between one point and a
+                                    set of points.
     """
     if metric_kwargs is None:
         metric_kwargs = {}

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -767,8 +767,8 @@ def pairwise_distances_argmin(X, Y, *, axis=1, metric="euclidean", metric_kwargs
     See Also
     --------
     pairwise_distances : Distances between every pair of samples of X and Y.
-    pairwise_distances_argmin_min : Minimum distances between one point and a
-                                    set of points.
+    pairwise_distances_argmin_min : Same as `pairwise_distances_argmin` but also
+        returns the distances.
     """
     if metric_kwargs is None:
         metric_kwargs = {}

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -55,7 +55,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.cosine_similarity",
     "sklearn.metrics.pairwise.distance_metrics",
     "sklearn.metrics.pairwise.kernel_metrics",
-    "sklearn.metrics.pairwise.pairwise_distances_argmin",
     "sklearn.metrics.pairwise.pairwise_distances_argmin_min",
     "sklearn.metrics.pairwise.pairwise_distances_chunked",
     "sklearn.metrics.pairwise.polynomial_kernel",


### PR DESCRIPTION
**Reference Issues/PRs**
Address #21350

**What does this implement/fix? Explain your changes.**

1. Remove `sklearn.metrics.pairwise.pairwise_distances_argmin`from test_doctrings.py `FUNCTION_DOCSTRING_IGNORE_LIST`.
2. Fix the following:
	- SA04: Missing description for See Also "pairwise_distances" reference
	- SA04: Missing description for See Also "pairwise_distances_argmin_min" reference