### PR TITLE
DOC Ensure `rbf_kernel` passes numpydoc validation

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1258,8 +1258,7 @@ def sigmoid_kernel(X, Y=None, gamma=None, coef0=1):
 
 
 def rbf_kernel(X, Y=None, gamma=None):
-    """
-    Compute the rbf (gaussian) kernel between X and Y::
+    """Compute the rbf (gaussian) kernel between X and Y.
 
         K(x, y) = exp(-gamma ||x-y||^2)
 
@@ -1270,16 +1269,18 @@ def rbf_kernel(X, Y=None, gamma=None):
     Parameters
     ----------
     X : ndarray of shape (n_samples_X, n_features)
+        A feature array.
 
     Y : ndarray of shape (n_samples_Y, n_features), default=None
-        If `None`, uses `Y=X`.
+        An optional second feature array. If `None`, uses `Y=X`.
 
     gamma : float, default=None
-        If None, defaults to 1.0 / n_features.
+        Slope. If None, defaults to 1.0 / n_features.
 
     Returns
     -------
     kernel_matrix : ndarray of shape (n_samples_X, n_samples_Y)
+        The RBF kernel.
     """
     X, Y = check_pairwise_arrays(X, Y)
     if gamma is None:

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1275,7 +1275,7 @@ def rbf_kernel(X, Y=None, gamma=None):
         An optional second feature array. If `None`, uses `Y=X`.
 
     gamma : float, default=None
-        Slope. If None, defaults to 1.0 / n_features.
+        If None, defaults to 1.0 / n_features.
 
     Returns
     -------

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -59,7 +59,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.pairwise_distances_argmin_min",
     "sklearn.metrics.pairwise.pairwise_distances_chunked",
     "sklearn.metrics.pairwise.polynomial_kernel",
-    "sklearn.metrics.pairwise.rbf_kernel",
     "sklearn.metrics.pairwise.sigmoid_kernel",
     "sklearn.preprocessing._data.maxabs_scale",
     "sklearn.preprocessing._data.scale",


### PR DESCRIPTION
**Reference Issues/PRs**
Address #21350

**What does this implement/fix? Explain your changes.**

1. Remove `sklearn.metrics.pairwise.rbf_kernel`from test_doctrings.py `FUNCTION_DOCSTRING_IGNORE_LIST`.
2. Fix the following:
	- SS03: Summary does not end with a period
	- PR07: Parameter "X" has no description
	- RT03: Return value has no description