### PR TITLE
CI Fix Ubuntu build for all random seeds

### DIFF
--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -483,7 +483,9 @@ def test_fastica_simple_different_solvers(add_noise, global_random_seed):
         assert ica.components_.shape == (2, 2)
         assert sources.shape == (1000, 2)
 
-    assert_allclose(outs["eigh"], outs["svd"])
+    # compared numbers are not all on the same magnitude. Using a small atol to
+    # make the test less brittle
+    assert_allclose(outs["eigh"], outs["svd"], atol=1e-12)
 
 
 def test_fastica_eigh_low_rank_warning(global_random_seed):


### PR DESCRIPTION
Fix #23872

I was able to reproduce on my Ubuntu 22.04 machine, the tricky part for me was to run `sudo update-alternatives --config libblas.so.3-x86_64-linux-gnu` and chose atlas since I had openblas installed on my machine and it was used by default rather than atlas.

For the failing random seed, the numbers we are comparing are quite small ~1e-8, so adding a small atol seems like a reasonable fix:
```
(Pdb) outs['eigh'].ravel()[425]
-9.516159318558055e-09
(Pdb) outs['svd'].ravel()[425]
-9.516162884248294e-09
(Pdb) (1 - outs['eigh']/outs['svd']).ravel()[425]
3.7469831926095765e-07
```
