### PR TITLE
DOC Adjusts grammar in `v_measure_score`'s documentation

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -693,11 +693,15 @@ def v_measure_score(labels_true, labels_pred, *, beta=1.0):
 
       >>> print("%.6f" % v_measure_score([0, 0, 1, 2], [0, 0, 1, 1]))
       0.8...
+      >>> print("%.6f" % v_measure_score([0, 1, 2, 3], [0, 0, 1, 1]))
+      0.66...
 
     Labelings that have pure clusters with members coming from the same
     classes are homogeneous but un-necessary splits harm completeness
     and thus penalize V-measure as well::
 
+      >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 0, 1, 2]))
+      0.8...
       >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 1, 2, 3]))
       0.66...
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -689,19 +689,15 @@ def v_measure_score(labels_true, labels_pred, *, beta=1.0):
       1.0
 
     Labelings that assign all classes members to the same clusters
-    are complete be not homogeneous, hence penalized::
+    are complete but not homogeneous, hence penalized::
 
       >>> print("%.6f" % v_measure_score([0, 0, 1, 2], [0, 0, 1, 1]))
       0.8...
-      >>> print("%.6f" % v_measure_score([0, 1, 2, 3], [0, 0, 1, 1]))
-      0.66...
 
     Labelings that have pure clusters with members coming from the same
-    classes are homogeneous but un-necessary splits harms completeness
+    classes are homogeneous but un-necessary splits harm completeness
     and thus penalize V-measure as well::
 
-      >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 0, 1, 2]))
-      0.8...
       >>> print("%.6f" % v_measure_score([0, 0, 1, 1], [0, 1, 2, 3]))
       0.66...
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The documentation for `v_measure_score` has duplicated code which does not correspond to the related text explanation. This commit fixes that.