### PR TITLE
MNT: TrucatedSVD uses _validate_parameters

### DIFF
--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -234,7 +234,10 @@ class TruncatedSVD(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
 
         elif self.algorithm == "randomized":
             if self.n_components > X.shape[1]:
-                raise ValueError(f"n_components({self.n_components}) must be <= n_features({X.shape[1]}).")
+                raise ValueError(
+                    f"n_components({self.n_components}) must be <="
+                    f" n_features({X.shape[1]})."
+                )
             U, Sigma, VT = randomized_svd(
                 X,
                 self.n_components,

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -523,7 +523,6 @@ PARAM_VALIDATION_ESTIMATORS_TO_IGNORE = [
     "StackingClassifier",
     "StackingRegressor",
     "TransformedTargetRegressor",
-    "TruncatedSVD",
     "VotingClassifier",
     "VotingRegressor",
 ]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

towards #23462 


#### What does this implement/fix? Explain your changes.


- Defines _parameter_constraints in TrucatedSVD.
- Following the steps in the reference PR to let TruncatedSVD models call self._validate_params.
- Remove unnecessarily conventional validation check.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

I don't have for now.
