### PR TITLE
DOC Ensures that `label_binarize` passes numpydoc validation

### DIFF
--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -456,6 +456,11 @@ def label_binarize(y, *, classes, neg_label=0, pos_label=1, sparse_output=False)
         Shape will be (n_samples, 1) for binary problems. Sparse matrix will
         be of CSR format.
 
+    See Also
+    --------
+    LabelBinarizer : Class used to wrap the functionality of label_binarize and
+        allow for fitting to classes independently of the transform operation.
+
     Examples
     --------
     >>> from sklearn.preprocessing import label_binarize
@@ -476,11 +481,6 @@ def label_binarize(y, *, classes, neg_label=0, pos_label=1, sparse_output=False)
            [0],
            [0],
            [1]])
-
-    See Also
-    --------
-    LabelBinarizer : Class used to wrap the functionality of label_binarize and
-        allow for fitting to classes independently of the transform operation.
     """
     if not isinstance(y, list):
         # XXX Workaround that will be removed when list of list format is

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -47,7 +47,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.pairwise_distances_chunked",
     "sklearn.preprocessing._data.maxabs_scale",
     "sklearn.preprocessing._data.scale",
-    "sklearn.preprocessing._label.label_binarize",
     "sklearn.random_projection.johnson_lindenstrauss_min_dim",
     "sklearn.svm._bounds.l1_min_c",
     "sklearn.tree._export.plot_tree",


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #21350


#### What does this implement/fix? Explain your changes.

Fixed the following numpydoc validation errors on `sklearn.preprocessing._label.label_binarize`:

- GL07: Sections are in the wrong order. Correct order is: Parameters, Returns, See Also, Examples