### PR TITLE
DOC Ensures that `johnson_lindenstrauss_min_dim` passes numpydoc validation

### DIFF
--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -96,6 +96,15 @@ def johnson_lindenstrauss_min_dim(n_samples, *, eps=0.1):
         The minimal number of components to guarantee with good probability
         an eps-embedding with n_samples.
 
+    References
+    ----------
+
+    .. [1] https://en.wikipedia.org/wiki/Johnson%E2%80%93Lindenstrauss_lemma
+
+    .. [2] Sanjoy Dasgupta and Anupam Gupta, 1999,
+           "An elementary proof of the Johnson-Lindenstrauss Lemma."
+           http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.45.3654
+
     Examples
     --------
     >>> from sklearn.random_projection import johnson_lindenstrauss_min_dim
@@ -107,16 +116,6 @@ def johnson_lindenstrauss_min_dim(n_samples, *, eps=0.1):
 
     >>> johnson_lindenstrauss_min_dim([1e4, 1e5, 1e6], eps=0.1)
     array([ 7894,  9868, 11841])
-
-    References
-    ----------
-
-    .. [1] https://en.wikipedia.org/wiki/Johnson%E2%80%93Lindenstrauss_lemma
-
-    .. [2] Sanjoy Dasgupta and Anupam Gupta, 1999,
-           "An elementary proof of the Johnson-Lindenstrauss Lemma."
-           http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.45.3654
-
     """
     eps = np.asarray(eps)
     n_samples = np.asarray(n_samples)

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -48,7 +48,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.preprocessing._data.maxabs_scale",
     "sklearn.preprocessing._data.scale",
     "sklearn.preprocessing._label.label_binarize",
-    "sklearn.random_projection.johnson_lindenstrauss_min_dim",
     "sklearn.svm._bounds.l1_min_c",
     "sklearn.tree._export.plot_tree",
     "sklearn.utils.axis0_safe_slice",


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #21350


#### What does this implement/fix? Explain your changes.

Fixed the following numpydoc validation errors on `sklearn.random_projection.johnson_lindenstrauss_min_dim`:

 - GL03: Double line break found; please use only one blank line to separate sections or paragraphs, and do not leave blank lines at the end of docstrings
- GL07: Sections are in the wrong order. Correct order is: Parameters, Returns, References, Examples