### PR TITLE
[MRG] Add fit_params to RFECV.fit

### DIFF
--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -666,6 +666,10 @@ class RFECV(RFE):
 
             .. versionadded:: 0.20
 
+        **fit_params : dict
+            Additional parameters passed to the `fit` method of the underlying
+            estimator.
+
         Returns
         -------
         self : object

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -136,6 +136,21 @@ def test_RFE_fit_score_params():
     RFE(estimator=TestEstimator()).fit(X, y, prop="foo").score(X, y, prop="foo")
 
 
+def test_RFECV_fit_params():
+    """Test that RFECV passes fit_params to underlying estimator."""
+
+    class MockClassifierWithFitParam(MockClassifier):
+        def fit(self, X, y, prop=None):
+            if prop is None:
+                raise ValueError("fit: prop cannot be None")
+            return super().fit(X, y)
+
+    X, y = load_iris(return_X_y=True)
+    with pytest.raises(ValueError, match="fit: prop cannot be None"):
+        RFECV(estimator=MockClassifierWithFitParam()).fit(X, y)
+    RFECV(estimator=MockClassifierWithFitParam()).fit(X, y, prop="foo")
+
+
 @pytest.mark.parametrize("n_features_to_select", [-1, 2.1])
 def test_rfe_invalid_n_features_errors(n_features_to_select):
     clf = SVC(kernel="linear")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #17954

#### What does this implement/fix? Explain your changes.
Add support for `**fit_params` to `RFECV.fit` and added a test to check that these parameters are passed to the underlying estimator.

#### Any other comments?



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
