### PR TITLE
FIX remove sign_flip parameter in FastICA

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -36,6 +36,10 @@ random sampling procedures.
   to a tiny value. Moreover, `verbose` is now properly propagated to L-BFGS-B.
   :pr:`23619` by :user:`Christian Lorentzen <lorentzenchr>`.
 
+- |Fix| The `components_` signs in :class:`decomposition.FastICA` might differ.
+  It is now consistent and deterministic with all SVD solvers.
+  :pr:`22527` by :user:`Meekail Zain <micky774>` and `Thomas Fan`_.
+
 Changes impacting all modules
 -----------------------------
 
@@ -153,10 +157,7 @@ Changelog
   how whitening is performed through the new `whiten_solver` parameter, which
   supports `svd` and `eigh`. `whiten_solver` defaults to `svd` although `eigh`
   may be faster and more memory efficient in cases where
-  `num_features > num_samples`. An additional `sign_flip` parameter is added.
-  When `sign_flip=True`, then the output of both solvers will be reconciled
-  during `fit` so that their outputs match. This may change the output of the
-  default solver, and hence may not be backwards compatible.
+  `num_features > num_samples`.
   :pr:`11860` by :user:`Pierre Ablin <pierreablin>`,
   :pr:`22527` by :user:`Meekail Zain <micky774>` and `Thomas Fan`_.
 

--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -170,7 +170,6 @@ def fastica(
     return_X_mean=False,
     compute_sources=True,
     return_n_iter=False,
-    sign_flip=False,
 ):
     """Perform Fast Independent Component Analysis.
 
@@ -261,21 +260,6 @@ def fastica(
     return_n_iter : bool, default=False
         Whether or not to return the number of iterations.
 
-    sign_flip : bool, default=False
-        Used to determine whether to enable sign flipping during whitening for
-        consistency in output between solvers.
-
-        - If `sign_flip=False` then the output of different choices for
-          `whiten_solver` may not be equal. Both outputs will still be correct,
-          but may differ numerically.
-
-        - If `sign_flip=True` then the output of both solvers will be
-          reconciled during fit so that their outputs match. This may produce
-          a different output for each solver when compared to
-          `sign_flip=False`.
-
-        .. versionadded:: 1.2
-
     Returns
     -------
     K : ndarray of shape (n_components, n_features) or None
@@ -334,7 +318,6 @@ def fastica(
         w_init=w_init,
         whiten_solver=whiten_solver,
         random_state=random_state,
-        sign_flip=sign_flip,
     )
     S = est._fit_transform(X, compute_sources=compute_sources)
 
@@ -430,21 +413,6 @@ class FastICA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
         across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    sign_flip : bool, default=False
-        Used to determine whether to enable sign flipping during whitening for
-        consistency in output between solvers.
-
-        - If `sign_flip=False` then the output of different choices for
-          `whiten_solver` may not be equal. Both outputs will still be correct,
-          but may differ numerically.
-
-        - If `sign_flip=True` then the output of both solvers will be
-          reconciled during fit so that their outputs match. This may produce
-          a different output for each solver when compared to
-          `sign_flip=False`.
-
-        .. versionadded:: 1.2
-
     Attributes
     ----------
     components_ : ndarray of shape (n_components, n_features)
@@ -522,7 +490,6 @@ class FastICA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
         "w_init": ["array-like", None],
         "whiten_solver": [StrOptions({"eigh", "svd"})],
         "random_state": ["random_state"],
-        "sign_flip": ["boolean"],
     }
 
     def __init__(
@@ -538,7 +505,6 @@ class FastICA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
         w_init=None,
         whiten_solver="svd",
         random_state=None,
-        sign_flip=False,
     ):
         super().__init__()
         self.n_components = n_components
@@ -551,7 +517,6 @@ class FastICA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
         self.w_init = w_init
         self.whiten_solver = whiten_solver
         self.random_state = random_state
-        self.sign_flip = sign_flip
 
     def _fit_transform(self, X, compute_sources=False):
         """Fit the model.
@@ -650,8 +615,7 @@ class FastICA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
                 u, d = linalg.svd(XT, full_matrices=False, check_finite=False)[:2]
 
             # Give consistent eigenvectors for both svd solvers
-            if self.sign_flip:
-                u *= np.sign(u[0])
+            u *= np.sign(u[0])
 
             K = (u / d).T[:n_components]  # see (6.33) p.140
             del u, d

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -453,7 +453,7 @@ def test_fastica_output_shape(whiten, return_X_mean, return_n_iter):
 
 @pytest.mark.parametrize("add_noise", [True, False])
 def test_fastica_simple_different_solvers(add_noise, global_random_seed):
-    """Test FastICA is consistent between whiten_solvers when `sign_flip=True`."""
+    """Test FastICA is consistent between whiten_solvers."""
     rng = np.random.RandomState(global_random_seed)
     n_samples = 1000
     # Generate two sources:
@@ -475,9 +475,7 @@ def test_fastica_simple_different_solvers(add_noise, global_random_seed):
 
     outs = {}
     for solver in ("svd", "eigh"):
-        ica = FastICA(
-            random_state=0, whiten="unit-variance", whiten_solver=solver, sign_flip=True
-        )
+        ica = FastICA(random_state=0, whiten="unit-variance", whiten_solver=solver)
         sources = ica.fit_transform(m.T)
         outs[solver] = sources
         assert ica.components_.shape == (2, 2)


### PR DESCRIPTION
closes #23997

As discussed in https://github.com/scikit-learn/scikit-learn/pull/23935/, I am removing the `sign_flip` and consider the change as a bug fix.