### PR TITLE
ENH add NaN and NA support in parameter validation

### DIFF
--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -255,7 +255,7 @@ class _NanConstraint(_Constraint):
     """Constraint representing the indicator `np.nan`."""
 
     def is_satisfied_by(self, val):
-        return np.isnan(val)
+        return isinstance(val, Real) and np.isnan(val)
 
     def __str__(self):
         return "numpy.nan"
@@ -268,7 +268,7 @@ class _NAConstraint(_Constraint):
         # This should only be called if pandas is available
         import pandas as pd
 
-        return pd.isna(val)
+        return isinstance(val, type(pd.NA)) and pd.isna(val)
 
     def __str__(self):
         return "pandas.NA"

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -265,10 +265,12 @@ class _NAConstraint(_Constraint):
     """Constraint representing the indicator `pd.NA`."""
 
     def is_satisfied_by(self, val):
-        # This should only be called if pandas is available
-        import pandas as pd
+        try:
+            import pandas as pd
 
-        return isinstance(val, type(pd.NA)) and pd.isna(val)
+            return isinstance(val, type(pd.NA)) and pd.isna(val)
+        except ImportError:
+            return False
 
     def __str__(self):
         return "pandas.NA"
@@ -535,9 +537,7 @@ class _MissingValues(_Constraint):
     """Helper constraint for the `missing_values` parameters.
 
     Convenience for
-    [Integral, Real, str, np.nan, None, pd.NA]
-
-    Note that `pd.NA` is only included if `pandas` is available at runtime.
+    [Integral, Real, str, _NoneConstraint, _NanConstraint, _NAConstraint]
     """
 
     def __init__(self):
@@ -548,14 +548,8 @@ class _MissingValues(_Constraint):
             _InstancesOf(str),
             _NoneConstraint(),
             _NanConstraint(),
+            _NAConstraint(),
         ]
-        try:
-            import pandas as pd  # noqa
-
-            self._constraints.append(_NAConstraint())
-        except ImportError:
-            # pandas is not available at runtime and `pd.NA` is not supported.
-            pass
 
     def is_satisfied_by(self, val):
         return any(c.is_satisfied_by(val) for c in self._constraints)

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -541,14 +541,21 @@ class _MissingValues(_Constraint):
     """Helper constraint for the `missing_values` parameters.
 
     Convenience for
-    [Integral, Real, str, None, _NanConstraint, _PandasNAConstraint]
+    [
+        Integral,
+        Interval(Real, None, None, closed="both"),
+        str,
+        None,
+        _NanConstraint(),
+        _PandasNAConstraint(),
+    ]
     """
 
     def __init__(self):
         super().__init__()
         self._constraints = [
             _InstancesOf(Integral),
-            # we use an interval of Real to ignore np.nan that has is own constraint
+            # we use an interval of Real to ignore np.nan that has its own constraint
             Interval(Real, None, None, closed="both"),
             _InstancesOf(str),
             _NoneConstraint(),

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -538,14 +538,15 @@ class _MissingValues(_Constraint):
     """Helper constraint for the `missing_values` parameters.
 
     Convenience for
-    [Integral, Real, str, _NoneConstraint, _NanConstraint, _PandasNAConstraint]
+    [Integral, Real, str, None, _NanConstraint, _PandasNAConstraint]
     """
 
     def __init__(self):
         super().__init__()
         self._constraints = [
             _InstancesOf(Integral),
-            _InstancesOf(Real),
+            # we use an interval of Real to ignore np.nan that has is own constraint
+            Interval(Real, None, None, closed="both"),
             _InstancesOf(str),
             _NoneConstraint(),
             _NanConstraint(),

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from abc import abstractmethod
 import functools
+import math
 from inspect import signature
 from numbers import Integral
 from numbers import Real
@@ -255,13 +256,13 @@ class _NanConstraint(_Constraint):
     """Constraint representing the indicator `np.nan`."""
 
     def is_satisfied_by(self, val):
-        return isinstance(val, Real) and np.isnan(val)
+        return isinstance(val, Real) and math.isnan(val)
 
     def __str__(self):
         return "numpy.nan"
 
 
-class _NAConstraint(_Constraint):
+class _PandasNAConstraint(_Constraint):
     """Constraint representing the indicator `pd.NA`."""
 
     def is_satisfied_by(self, val):
@@ -537,7 +538,7 @@ class _MissingValues(_Constraint):
     """Helper constraint for the `missing_values` parameters.
 
     Convenience for
-    [Integral, Real, str, _NoneConstraint, _NanConstraint, _NAConstraint]
+    [Integral, Real, str, _NoneConstraint, _NanConstraint, _PandasNAConstraint]
     """
 
     def __init__(self):
@@ -548,7 +549,7 @@ class _MissingValues(_Constraint):
             _InstancesOf(str),
             _NoneConstraint(),
             _NanConstraint(),
-            _NAConstraint(),
+            _PandasNAConstraint(),
         ]
 
     def is_satisfied_by(self, val):

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -123,7 +123,7 @@ def make_constraint(constraint):
     if isinstance(constraint, str) and constraint == "verbose":
         return _VerboseHelper()
     if isinstance(constraint, str) and constraint == "missing_values":
-        return _MissingValuesHelper()
+        return _MissingValues()
     if isinstance(constraint, Hidden):
         constraint = make_constraint(constraint.constraint)
         constraint.hidden = True
@@ -531,7 +531,7 @@ class _VerboseHelper(_Constraint):
         )
 
 
-class _MissingValuesHelper(_Constraint):
+class _MissingValues(_Constraint):
     """Helper constraint for the `missing_values` parameters.
 
     Convenience for
@@ -637,8 +637,8 @@ def generate_invalid_param_val(constraint, constraints=None):
     if isinstance(constraint, StrOptions):
         return f"not {' or '.join(constraint.options)}"
 
-    if isinstance(constraint, _MissingValuesHelper):
-        return complex()
+    if isinstance(constraint, _MissingValues):
+        return np.array([1, 2, 3])
 
     if isinstance(constraint, _VerboseHelper):
         return -1
@@ -797,7 +797,7 @@ def generate_valid_param(constraint):
     if isinstance(constraint, _VerboseHelper):
         return 1
 
-    if isinstance(constraint, _MissingValuesHelper):
+    if isinstance(constraint, _MissingValues):
         return np.nan
 
     if isinstance(constraint, HasMethods):

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -13,6 +13,7 @@ from sklearn.utils._param_validation import _ArrayLikes
 from sklearn.utils._param_validation import _Booleans
 from sklearn.utils._param_validation import _Callables
 from sklearn.utils._param_validation import _InstancesOf
+from sklearn.utils._param_validation import _MissingValuesHelper
 from sklearn.utils._param_validation import _NoneConstraint
 from sklearn.utils._param_validation import _RandomStates
 from sklearn.utils._param_validation import _SparseMatrices
@@ -184,6 +185,7 @@ def test_hasmethods():
         Interval(Real, 0, None, closed="left"),
         Interval(Real, None, None, closed="neither"),
         StrOptions({"a", "b", "c"}),
+        _MissingValuesHelper(),
         _VerboseHelper(),
         HasMethods("fit"),
     ],
@@ -324,6 +326,7 @@ def test_generate_invalid_param_val_all_valid(constraints):
         _SparseMatrices(),
         _Booleans(),
         _VerboseHelper(),
+        _MissingValuesHelper(),
         StrOptions({"a", "b", "c"}),
         Interval(Integral, None, None, closed="neither"),
         Interval(Integral, 0, 10, closed="neither"),
@@ -360,6 +363,10 @@ def test_generate_valid_param(constraint):
         (Real, 0.5),
         ("boolean", False),
         ("verbose", 1),
+        ("missing_values", -1),
+        ("missing_values", -1.0),
+        ("missing_values", None),
+        ("missing_values", "np.nan"),
         (HasMethods("fit"), _Estimator(a=0)),
     ],
 )
@@ -382,6 +389,7 @@ def test_is_satisfied_by(constraint_declaration, value):
         (int, _InstancesOf),
         ("boolean", _Booleans),
         ("verbose", _VerboseHelper),
+        ("missing_values", _MissingValuesHelper),
         (HasMethods("fit"), HasMethods),
     ],
 )

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -369,6 +369,7 @@ def test_generate_valid_param(constraint):
         ("missing_values", None),
         ("missing_values", float("nan")),
         ("missing_values", np.nan),
+        ("missing_values", "prefit"),
         (HasMethods("fit"), _Estimator(a=0)),
     ],
 )

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -579,3 +579,11 @@ def test_no_validation():
 
     f(param2=SomeType)
     f(param2=SomeType())
+
+
+def test_missing_values_pd_na():
+    """Add a specific test for checking support for `pandas.NA`."""
+    pd = pytest.importorskip("pandas")
+
+    missing_values_constraint = _MissingValuesHelper()
+    print(missing_values_constraint.is_satisfied_by(pd.NA))

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -13,7 +13,8 @@ from sklearn.utils._param_validation import _ArrayLikes
 from sklearn.utils._param_validation import _Booleans
 from sklearn.utils._param_validation import _Callables
 from sklearn.utils._param_validation import _InstancesOf
-from sklearn.utils._param_validation import _MissingValuesHelper
+from sklearn.utils._param_validation import _MissingValues
+from sklearn.utils._param_validation import _NAConstraint
 from sklearn.utils._param_validation import _NoneConstraint
 from sklearn.utils._param_validation import _RandomStates
 from sklearn.utils._param_validation import _SparseMatrices
@@ -185,7 +186,7 @@ def test_hasmethods():
         Interval(Real, 0, None, closed="left"),
         Interval(Real, None, None, closed="neither"),
         StrOptions({"a", "b", "c"}),
-        _MissingValuesHelper(),
+        _MissingValues(),
         _VerboseHelper(),
         HasMethods("fit"),
     ],
@@ -326,7 +327,7 @@ def test_generate_invalid_param_val_all_valid(constraints):
         _SparseMatrices(),
         _Booleans(),
         _VerboseHelper(),
-        _MissingValuesHelper(),
+        _MissingValues(),
         StrOptions({"a", "b", "c"}),
         Interval(Integral, None, None, closed="neither"),
         Interval(Integral, 0, 10, closed="neither"),
@@ -389,7 +390,7 @@ def test_is_satisfied_by(constraint_declaration, value):
         (int, _InstancesOf),
         ("boolean", _Booleans),
         ("verbose", _VerboseHelper),
-        ("missing_values", _MissingValuesHelper),
+        ("missing_values", _MissingValues),
         (HasMethods("fit"), HasMethods),
     ],
 )
@@ -585,5 +586,6 @@ def test_missing_values_pd_na():
     """Add a specific test for checking support for `pandas.NA`."""
     pd = pytest.importorskip("pandas")
 
-    missing_values_constraint = _MissingValuesHelper()
-    assert missing_values_constraint.is_satisfied_by(pd.NA)
+    na_constraint = _NAConstraint()
+    assert na_constraint.is_satisfied_by(pd.NA)
+    assert not na_constraint.is_satisfied_by(np.array([1, 2, 3]))

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -369,7 +369,7 @@ def test_generate_valid_param(constraint):
         ("missing_values", None),
         ("missing_values", float("nan")),
         ("missing_values", np.nan),
-        ("missing_values", "prefit"),
+        ("missing_values", "missing"),
         (HasMethods("fit"), _Estimator(a=0)),
     ],
 )

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -582,10 +582,21 @@ def test_no_validation():
     f(param2=SomeType())
 
 
-def test_missing_values_pd_na():
+def test_na_constraint_with_pd_na():
     """Add a specific test for checking support for `pandas.NA`."""
     pd = pytest.importorskip("pandas")
 
     na_constraint = _NAConstraint()
     assert na_constraint.is_satisfied_by(pd.NA)
     assert not na_constraint.is_satisfied_by(np.array([1, 2, 3]))
+
+
+def test_missing_values_str():
+    """Check the `MissingValues` `str()` string."""
+    missing_values = _MissingValues()
+
+    assert (
+        str(missing_values)
+        == "an instance of 'int', an instance of 'float', an instance of 'str', None,"
+        " numpy.nan or pandas.NA"
+    )

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -14,7 +14,7 @@ from sklearn.utils._param_validation import _Booleans
 from sklearn.utils._param_validation import _Callables
 from sklearn.utils._param_validation import _InstancesOf
 from sklearn.utils._param_validation import _MissingValues
-from sklearn.utils._param_validation import _NAConstraint
+from sklearn.utils._param_validation import _PandasNAConstraint
 from sklearn.utils._param_validation import _NoneConstraint
 from sklearn.utils._param_validation import _RandomStates
 from sklearn.utils._param_validation import _SparseMatrices
@@ -367,7 +367,8 @@ def test_generate_valid_param(constraint):
         ("missing_values", -1),
         ("missing_values", -1.0),
         ("missing_values", None),
-        ("missing_values", "np.nan"),
+        ("missing_values", float("nan")),
+        ("missing_values", np.nan),
         (HasMethods("fit"), _Estimator(a=0)),
     ],
 )
@@ -582,21 +583,10 @@ def test_no_validation():
     f(param2=SomeType())
 
 
-def test_na_constraint_with_pd_na():
+def test_pandas_na_constraint_with_pd_na():
     """Add a specific test for checking support for `pandas.NA`."""
     pd = pytest.importorskip("pandas")
 
-    na_constraint = _NAConstraint()
+    na_constraint = _PandasNAConstraint()
     assert na_constraint.is_satisfied_by(pd.NA)
     assert not na_constraint.is_satisfied_by(np.array([1, 2, 3]))
-
-
-def test_missing_values_str():
-    """Check the `MissingValues` `str()` string."""
-    missing_values = _MissingValues()
-
-    assert (
-        str(missing_values)
-        == "an instance of 'int', an instance of 'float', an instance of 'str', None,"
-        " numpy.nan or pandas.NA"
-    )

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -586,4 +586,4 @@ def test_missing_values_pd_na():
     pd = pytest.importorskip("pandas")
 
     missing_values_constraint = _MissingValuesHelper()
-    print(missing_values_constraint.is_satisfied_by(pd.NA))
+    assert missing_values_constraint.is_satisfied_by(pd.NA)


### PR DESCRIPTION
closes #23919

Create a new constraint for the validation of the `missing_values` parameter in the different scikit-learn imputers.