### PR TITLE
MAINT Param validation: add helper constraint for cv object

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -10,7 +10,6 @@ import operator
 import sys
 import time
 
-from collections.abc import Iterable
 from numbers import Integral, Real
 import numpy as np
 from scipy import linalg
@@ -25,7 +24,7 @@ from ..utils.validation import (
     check_scalar,
 )
 from ..utils.fixes import delayed
-from ..utils._param_validation import HasMethods, Interval, StrOptions
+from ..utils._param_validation import Interval, StrOptions
 
 # mypy error: Module 'sklearn.linear_model' has no attribute '_cd_fast'
 from ..linear_model import _cd_fast as cd_fast  # type: ignore
@@ -845,12 +844,7 @@ class GraphicalLassoCV(BaseGraphicalLasso):
         **BaseGraphicalLasso._parameter_constraints,
         "alphas": [Interval(Integral, 1, None, closed="left"), "array-like"],
         "n_refinements": [Interval(Integral, 1, None, closed="left")],
-        "cv": [
-            Interval(Integral, 2, None, closed="left"),
-            HasMethods(["split", "get_n_splits"]),
-            Iterable,
-            None,
-        ],
+        "cv": ["cv_object"],
         "n_jobs": [Integral, None],
     }
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -11,7 +11,6 @@ import numbers
 from abc import ABC, abstractmethod
 from functools import partial
 from numbers import Integral, Real
-from collections.abc import Iterable
 
 import numpy as np
 from scipy import sparse
@@ -22,7 +21,7 @@ from ..base import RegressorMixin, MultiOutputMixin
 from ._base import _preprocess_data, _deprecate_normalize
 from ..utils import check_array, check_scalar
 from ..utils.validation import check_random_state
-from ..utils._param_validation import Hidden, HasMethods, Interval, StrOptions
+from ..utils._param_validation import Hidden, Interval, StrOptions
 from ..model_selection import check_cv
 from ..utils.extmath import safe_sparse_dot
 from ..utils.validation import (
@@ -1472,12 +1471,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, ABC):
         "max_iter": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0, None, closed="left")],
         "copy_X": ["boolean"],
-        "cv": [
-            Interval(Integral, 2, None, closed="left"),
-            Iterable,
-            HasMethods(["split", "get_n_splits"]),
-            None,
-        ],
+        "cv": ["cv_object"],
         "verbose": ["verbose"],
         "n_jobs": [Integral, None],
         "positive": ["boolean"],

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -17,9 +17,7 @@ import warnings
 import numpy as np
 from scipy import optimize
 from joblib import Parallel, effective_n_jobs
-from collections.abc import Iterable
 
-from sklearn.model_selection import BaseCrossValidator
 from sklearn.metrics import get_scorer_names
 
 from ._base import LinearClassifierMixin, SparseCoefMixin, BaseEstimator
@@ -1605,12 +1603,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
     _parameter_constraints.update(
         {
             "Cs": [Interval(Integral, 1, None, closed="left"), "array-like"],
-            "cv": [
-                Interval(Integral, 2, None, closed="left"),
-                Iterable,
-                BaseCrossValidator,
-                None,
-            ],
+            "cv": ["cv_object"],
             "scoring": [StrOptions(set(get_scorer_names())), callable, None],
             "l1_ratios": ["array-like", None],
             "refit": ["boolean"],

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -8,7 +8,6 @@
 import warnings
 from math import sqrt
 
-from collections.abc import Iterable
 from numbers import Integral, Real
 import numpy as np
 from scipy import linalg
@@ -19,7 +18,7 @@ from ._base import LinearModel, _pre_fit, _deprecate_normalize
 from ..base import RegressorMixin, MultiOutputMixin
 from ..utils import as_float_array, check_array
 from ..utils.fixes import delayed
-from ..utils._param_validation import HasMethods, Hidden, Interval, StrOptions
+from ..utils._param_validation import Hidden, Interval, StrOptions
 from ..model_selection import check_cv
 
 premature = (
@@ -1004,12 +1003,7 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
         "fit_intercept": ["boolean"],
         "normalize": ["boolean", Hidden(StrOptions({"deprecated"}))],
         "max_iter": [Interval(Integral, 0, None, closed="left"), None],
-        "cv": [
-            Interval(Integral, 2, None, closed="left"),
-            HasMethods(["split", "get_n_splits"]),
-            Iterable,
-            None,
-        ],
+        "cv": ["cv_object"],
         "n_jobs": [Integral, None],
         "verbose": ["verbose"],
     }

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -554,7 +554,7 @@ class _IterablesNotString(_Constraint):
 
 class _CVObjects(_Constraint):
     """Constraint representing cv objects.
-    
+
     Convenient class for
     [
         Interval(Integral, 2, None, closed="left"),

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -626,6 +626,12 @@ def generate_invalid_param_val(constraint, constraints=None):
     if isinstance(constraint, HasMethods):
         return type("HasNotMethods", (), {})()
 
+    if isinstance(constraint, _IterablesNotString):
+        return "a string"
+
+    if isinstance(constraint, _CVObjects):
+        return "not a cv object"
+
     if not isinstance(constraint, Interval):
         raise NotImplementedError
 
@@ -781,6 +787,12 @@ def generate_valid_param(constraint):
         return type(
             "ValidHasMethods", (), {m: lambda self: None for m in constraint.methods}
         )()
+
+    if isinstance(constraint, _IterablesNotString):
+        return [1, 2, 3]
+
+    if isinstance(constraint, _CVObjects):
+        return 5
 
     if isinstance(constraint, StrOptions):
         for option in constraint.options:


### PR DESCRIPTION
Until now we've set 
```
"cv": [
    Interval(Integral, 2, None, closed="left"),
    Iterable,
    HasMethods(["split", "get_n_splits"]),
    None,
]
```
for the constraints of the cv parameter of several estimators. The issue is that ``Iterable`` includes strings which should not be allowed. This PR add a new constraint `IterableNotString` to fix that. I also made a constraint helper to avoid repeating these constraints for all occurences of the cv parameter but I can also revert it if we're sick of helpers 😄.

TODO still missing some tests