### PR TITLE
FIX Show a HTML repr for meta-estimatosr with invalid parameters

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -12,7 +12,7 @@ Version 1.1.2
 Changelog
 ---------
 
-- |Fix| A default HTML representation is shown for meta-estimators having invalid
+- |Fix| A default HTML representation is shown for meta-estimators with invalid
   parameters. :pr:`24015` by `Thomas Fan`_.
 
 :mod:`sklearn.cluster`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -12,7 +12,7 @@ Version 1.1.2
 Changelog
 ---------
 
-- |Fix| An default HTML representation is shown for meta-estimators having invalid
+- |Fix| A default HTML representation is shown for meta-estimators having invalid
   parameters. :pr:`24015` by `Thomas Fan`_.
 
 :mod:`sklearn.cluster`

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -13,7 +13,7 @@ Changelog
 ---------
 
 - |Fix| An default HTML representation is shown for meta-estimators having invalid
-  parameters. :pr:`xxxxx` by `Thomas Fan`_.
+  parameters. :pr:`24015` by `Thomas Fan`_.
 
 :mod:`sklearn.cluster`
 ......................

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -12,6 +12,9 @@ Version 1.1.2
 Changelog
 ---------
 
+- |Fix| An default HTML representation is shown for meta-estimators having invalid
+  parameters. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.cluster`
 ......................
 

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -1,5 +1,4 @@
 from contextlib import closing
-from contextlib import suppress
 from io import StringIO
 from string import Template
 import html
@@ -103,8 +102,16 @@ def _write_label_html(
 
 def _get_visual_block(estimator):
     """Generate information about how to display an estimator."""
-    with suppress(AttributeError):
-        return estimator._sk_visual_block_()
+    if hasattr(estimator, "_sk_visual_block_"):
+        try:
+            return estimator._sk_visual_block_()
+        except Exception:
+            return _VisualBlock(
+                "single",
+                estimator,
+                names=estimator.__class__.__name__,
+                name_details=str(estimator),
+            )
 
     if isinstance(estimator, str):
         return _VisualBlock(

--- a/sklearn/utils/tests/test_estimator_html_repr.py
+++ b/sklearn/utils/tests/test_estimator_html_repr.py
@@ -309,3 +309,14 @@ def test_show_arrow_pipeline():
         'class="sk-toggleable__label sk-toggleable__label-arrow">Pipeline'
         in html_output
     )
+
+
+def test_invalid_parameters_in_stacking():
+    """Invalidate stacking configuration uses default repr.
+
+    Non-regression test for #24009.
+    """
+    stacker = StackingClassifier(estimators=[])
+
+    html_output = estimator_html_repr(stacker)
+    assert html.escape(str(stacker)) in html_output


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #24009

#### What does this implement/fix? Explain your changes.
For the case of `_sk_visual_block_`, this PR enhances `_get_visual_block` to have a better default if `_sk_visual_block_` fails for any reason. The default here is to treat the meta-estimator as a single estimator:

![Screen Shot 2022-07-26 at 1 05 41 PM](https://user-images.githubusercontent.com/5402633/181067854-044e1fdd-0c85-4d3e-b3c6-b9ed3fd2a86b.jpg)


#### Any other comments?
The alternative is to adjust all the meta-estimators and validate some parameters in `_sk_visual_block_`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
