### PR TITLE
FIX Allow `BaseEstimator.get_params` to handle `type` type params

### DIFF
--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -12,6 +12,13 @@ Version 1.1.2
 Changelog
 ---------
 
+:mod:`sklearn.base`
+......................
+
+- |Fix| The `get_params` method of the :class:`BaseEstimator` class now supports
+  estimators with `type`-type params that have the `get_params` method.
+  :pr`24017` by :user:`Henry Sorsky <hsorsky>`.
+
 :mod:`sklearn.cluster`
 ......................
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -20,7 +20,7 @@ Changelog
 
 - |Fix| The `get_params` method of the :class:`BaseEstimator` class now supports
   estimators with `type`-type params that have the `get_params` method.
-  :pr`24017` by :user:`Henry Sorsky <hsorsky>`.
+  :pr:`24017` by :user:`Henry Sorsky <hsorsky>`.
 
 :mod:`sklearn.cluster`
 ......................

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -160,7 +160,7 @@ class BaseEstimator:
         out = dict()
         for key in self._get_param_names():
             value = getattr(self, key)
-            if deep and hasattr(value, "get_params"):
+            if deep and hasattr(value, "get_params") and not isinstance(value, type):
                 deep_items = value.get_params().items()
                 out.update((key + "__" + k, val) for k, val in deep_items)
             out[key] = value

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -229,7 +229,7 @@ def test_str():
 
 
 def test_get_params():
-    test = T(K(), K())
+    test = T(K(), K)
 
     assert "a__d" in test.get_params(deep=True)
     assert "a__d" not in test.get_params(deep=False)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #24016 


#### What does this implement/fix? Explain your changes.
Adds `type` type estimator param handling to `get_params`

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
