### PR TITLE
DOC Adds example on how to use column transformer with vectorizer

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -191,7 +191,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     array([[0. , 1. , 0.5, 0.5],
            [0.5, 0.5, 0. , 1. ]])
 
-    :class:`ColumnTransformer` can be configured with a transformer that require
+    :class:`ColumnTransformer` can be configured with a transformer that requires
     a 1d array by setting the column to a scalar string:
 
     >>> from sklearn.feature_extraction import FeatureHasher

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -192,7 +192,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
            [0.5, 0.5, 0. , 1. ]])
 
     :class:`ColumnTransformer` can be configured with a transformer that requires
-    a 1d array by setting the column to a scalar string:
+    a 1d array by setting the column to a string:
 
     >>> from sklearn.feature_extraction import FeatureHasher
     >>> from sklearn.preprocessing import MinMaxScaler
@@ -201,7 +201,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     ...     "documents": ["First item", "second one here", "Is this the last?"],
     ...     "width": [3, 4, 5],
     ... })  # doctest: +SKIP
-    >>> # "documents" is scalar string which configures ColumnTransformer to
+    >>> # "documents" is a string which configures ColumnTransformer to
     >>> # pass the documents column as a 1d array to the FeatureHasher
     >>> ct = ColumnTransformer(
     ...     [("text_preprocess", FeatureHasher(input_type="string"), "documents"),

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -190,6 +190,23 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     >>> ct.fit_transform(X)
     array([[0. , 1. , 0.5, 0.5],
            [0.5, 0.5, 0. , 1. ]])
+
+    :class:`ColumnTransformer` can be configured with a transformer that require
+    a 1d array by setting the column to a scalar string:
+
+    >>> from sklearn.feature_extraction import FeatureHasher
+    >>> from sklearn.preprocessing import MinMaxScaler
+    >>> import pandas as pd   # doctest: +SKIP
+    >>> X = pd.DataFrame({
+    ...     "documents": ["First item", "second one here", "Is this the last?"],
+    ...     "width": [3, 4, 5],
+    ... })  # doctest: +SKIP
+    >>> # "documents" is scalar string which configures ColumnTransformer to
+    >>> # pass the documents column as a 1d array to the FeatureHasher
+    >>> ct = ColumnTransformer(
+    ...     [("text_preprocess", FeatureHasher(input_type="string"), "documents"),
+    ...      ("num_preprocess", MinMaxScaler(), ["width"])])
+    >>> X_trans = ct.fit_transform(X)  # doctest: +SKIP
     """
 
     _required_parameters = ["transformers"]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/13568


#### What does this implement/fix? Explain your changes.
This PR adds an example to `ColumnTransformer` the describes how to use a transformer that a 1d array.

#### Any other comments?
We already have examples in the user guide with vectorizers:

https://github.com/scikit-learn/scikit-learn/blob/728e62a64e6cd2d702108fb0d287c5226386d0b7/doc/modules/compose.rst?plain=1#L450-L453

but I think it's good to have an example in the docstring as well.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
