### PR TITLE
DOC Updated `adjusted_rand_score` docstring

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -392,7 +392,7 @@ def adjusted_rand_score(labels_true, labels_pred):
 
     .. [Chacón22] J. E. Chacón and A. I. Rastrojo, Minimum adjusted Rand index
       for two clusterings of a given size, 2022
-      https://link.springer.com/article/10.1007/s11634-022-00491-w
+      https://arxiv.org/pdf/2002.03677.pdf
 
 
     See Also

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -390,9 +390,8 @@ def adjusted_rand_score(labels_true, labels_pred):
 
     .. [wk] https://en.wikipedia.org/wiki/Rand_index#Adjusted_Rand_index
 
-    .. [Chacon22] J. E. Chacón and A. I. Rastrojo, Minimum adjusted Rand index
-      for two clusterings of a given size, 2022
-      https://link.springer.com/content/pdf/10.1007/s11634-022-00491-w.pdf
+    .. [Chacon] :doi:`Minimum adjusted Rand index for two clusterings of a given size,
+      2022, J. E. Chacón and A. I. Rastrojo <10.1007/s11634-022-00491-w>`
 
 
     See Also

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -322,7 +322,8 @@ def adjusted_rand_score(labels_true, labels_pred):
     The adjusted Rand index is thus ensured to have a value close to
     0.0 for random labeling independently of the number of clusters and
     samples and exactly 1.0 when the clusterings are identical (up to
-    a permutation).
+    a permutation). The adjusted Rand index is bounded below by -0.5 for
+    especially discordant clusterings.
 
     ARI is a symmetric measure::
 
@@ -341,7 +342,7 @@ def adjusted_rand_score(labels_true, labels_pred):
     Returns
     -------
     ARI : float
-       Similarity score between -1.0 and 1.0. Random labelings have an ARI
+       Similarity score between -0.5 and 1.0. Random labelings have an ARI
        close to 0.0. 1.0 stands for perfect match.
 
     Examples
@@ -372,6 +373,12 @@ def adjusted_rand_score(labels_true, labels_pred):
       >>> adjusted_rand_score([0, 0, 0, 0], [0, 1, 2, 3])
       0.0
 
+    ARI may take a negative value for especially discordant labelings that
+    underperform compared to the expected value of random labels::
+
+      >>> adjusted_rand_score([0, 0, 1, 1], [0, 1, 0, 1])
+      -0.5
+
     References
     ----------
     .. [Hubert1985] L. Hubert and P. Arabie, Comparing Partitions,
@@ -382,6 +389,11 @@ def adjusted_rand_score(labels_true, labels_pred):
       adjusted Rand index, Psychological Methods 2004
 
     .. [wk] https://en.wikipedia.org/wiki/Rand_index#Adjusted_Rand_index
+
+    .. [Chacón22] J. E. Chacón and A. I. Rastrojo, Minimum adjusted Rand index
+      for two clusterings of a given size, 2022
+      https://link.springer.com/article/10.1007/s11634-022-00491-w
+
 
     See Also
     --------

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -374,7 +374,7 @@ def adjusted_rand_score(labels_true, labels_pred):
       0.0
 
     ARI may take a negative value for especially discordant labelings that
-    underperform compared to the expected value of random labels::
+    are a worse choice than the expected value of random labels::
 
       >>> adjusted_rand_score([0, 0, 1, 1], [0, 1, 0, 1])
       -0.5

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -392,7 +392,7 @@ def adjusted_rand_score(labels_true, labels_pred):
 
     .. [Chacón22] J. E. Chacón and A. I. Rastrojo, Minimum adjusted Rand index
       for two clusterings of a given size, 2022
-      https://arxiv.org/pdf/2002.03677.pdf
+      https://link.springer.com/content/pdf/10.1007/s11634-022-00491-w.pdf
 
 
     See Also

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -390,7 +390,7 @@ def adjusted_rand_score(labels_true, labels_pred):
 
     .. [wk] https://en.wikipedia.org/wiki/Rand_index#Adjusted_Rand_index
 
-    .. [Chacón22] J. E. Chacón and A. I. Rastrojo, Minimum adjusted Rand index
+    .. [Chacon22] J. E. Chacón and A. I. Rastrojo, Minimum adjusted Rand index
       for two clusterings of a given size, 2022
       https://link.springer.com/content/pdf/10.1007/s11634-022-00491-w.pdf
 


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #8166

#### What does this implement/fix? Explain your changes.
Adds correct exact lower bound to docstring, along with an additional example and reference.

#### Any other comments?
This is based off of a [recent paper](https://arxiv.org/pdf/2002.03677.pdf) solving for the exact lower bound.