### PR TITLE
ENH make sure warn_on errors on invalid child

### DIFF
--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -849,6 +849,19 @@ def test_metadata_routing_get_param_names():
     ) == router._get_param_names(method="fit", return_alias=False, ignore_self=True)
 
 
+def test_warn_on_invalid_child():
+    """Test that we error if the child is not known."""
+    with pytest.raises(ValueError, match="Unknown child"):
+        MetadataRouter(owner="test").add(
+            estimator=LinearRegression(), method_mapping="one-to-one"
+        ).warn_on(
+            child="invalid",
+            method="fit",
+            params=None,
+            raise_on="1.4",
+        )
+
+
 def test_router_deprecation_warning():
     """This test checks the warning mechanism related to `warn_on`.
 

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -948,6 +948,9 @@ class MetadataRouter:
         self : MetadataRouter
             Returns `self`.
         """
+        if child not in self._route_mappings:
+            raise ValueError(f"Unknown child object: {child}")
+
         if child not in self._warn_on:
             self._warn_on[child] = dict()
         self._warn_on[child][method] = {"params": params, "raise_on": raise_on}


### PR DESCRIPTION
I encountered a bug where I had passed the wrong child name to `warn_on`, this PR makes sure the method errors in that case to prevent those bugs.

Towards https://github.com/scikit-learn/scikit-learn/issues/22893

cc @thomasjpfan @glemaitre 