### PR TITLE
MNT Param validation: Uniformize constraints for kernel params

### DIFF
--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -623,7 +623,7 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
         "n_components": [Interval(Integral, 1, None, closed="left"), None],
         "random_state": ["random_state"],
         "n_init": [Interval(Integral, 1, None, closed="left")],
-        "gamma": [Interval(Real, 0, None, closed="neither")],
+        "gamma": [Interval(Real, 0, None, closed="left")],
         "affinity": [
             callable,
             StrOptions(
@@ -637,7 +637,7 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
             StrOptions({"auto"}),
         ],
         "assign_labels": [StrOptions({"kmeans", "discretize", "cluster_qr"})],
-        "degree": [Interval(Integral, 1, None, closed="left")],
+        "degree": [Interval(Integral, 0, None, closed="left")],
         "coef0": [Interval(Real, None, None, closed="neither")],
         "kernel_params": [dict, None],
         "n_jobs": [Integral, None],

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -139,7 +139,7 @@ class KernelRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
         ],
         "gamma": [Interval(Real, 0, None, closed="left"), None],
         "degree": [Interval(Integral, 0, None, closed="left")],
-        "coef0": [Interval(Real, 0, None, closed="left")],
+        "coef0": [Interval(Real, None, None, closed="neither")],
         "kernel_params": [dict, None],
     }
 

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -78,7 +78,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         "degree": [Interval(Integral, 0, None, closed="left")],
         "gamma": [
             StrOptions({"scale", "auto"}),
-            Interval(Real, 0.0, None, closed="neither"),
+            Interval(Real, 0.0, None, closed="left"),
         ],
         "coef0": [Interval(Real, None, None, closed="neither")],
         "tol": [Interval(Real, 0.0, None, closed="neither")],


### PR DESCRIPTION
We(I)'ve not been very consistent for the parameter constraints of the ``gamma``, ``coef0`` and ``degree`` parameters. They are parameters of kernel based estimators, usually directly passed to the kernel. This PR uniformizes the constraint.
Note that degree=0 and gamma=0 lead to constant kernel which is probably not very useful but we keep them for now, at least for backward compat.

cc/ @glemaitre 