### PR TITLE
MAINT Use the newest NumPy C API where possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,9 +201,7 @@ try:
 
             for ext in self.extensions:
                 if ext.name in USE_NEWEST_NUMPY_C_API:
-                    print(
-                        f"Use newest NumPy C API for extension {ext.name}"
-                    )
+                    print(f"Use newest NumPy C API for extension {ext.name}")
                     ext.define_macros.append(DEFINE_MACRO_NUMPY_C_API)
                 else:
                     print(f"Use old NumPy C API (version 1.7) for extension {ext.name}")

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,9 @@ DEFINE_MACRO_NUMPY_C_API = (
 # XXX: add new extensions to this list when they
 # are not using the old NumPy C API (i.e. version 1.4)
 # TODO: when Cython>=3.0 is used, make sure all Cython extensions
-# use the newest NumPy C API (i.e. version 1.7) and remove this list.
+# use the newest NumPy C API by `#defining` `NPY_NO_DEPRECATED_API` to be
+# `NPY_1_7_API_VERSION`, and remove this list.
+# See: https://github.com/cython/cython/blob/1777f13461f971d064bd1644b02d92b350e6e7d1/docs/src/userguide/migrating_to_cy30.rst#numpy-c-api # noqa
 USE_NEWEST_NUMPY_C_API = (
     "sklearn.__check_build._check_build",
     "sklearn._loss._loss",

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,9 @@ try:
                     print(f"Using newest NumPy C API for extension {ext.name}")
                     ext.define_macros.append(DEFINE_MACRO_NUMPY_C_API)
                 else:
-                    print(f"Using old NumPy C API (version 1.7) for extension {ext.name}")
+                    print(
+                        f"Using old NumPy C API (version 1.7) for extension {ext.name}"
+                    )
 
             if sklearn._OPENMP_SUPPORTED:
                 openmp_flag = get_openmp_flag(self.compiler)

--- a/setup.py
+++ b/setup.py
@@ -62,30 +62,51 @@ DEFINE_MACRO_NUMPY_C_API = (
     "NPY_1_7_API_VERSION",
 )
 
-# TODO: remove call to NumPy C API (version 1.4) in those extensions
-USE_OLD_NUMPY_C_API = (
-    "sklearn.decomposition._online_lda_fast",
-    "sklearn.manifold._utils",
-    "sklearn.ensemble._gradient_boosting",
-    "sklearn.preprocessing._csr_polynomial_expansion",
-    "sklearn.cluster._dbscan_inner",
-    "sklearn.cluster._hierarchical_fast",
-    "sklearn.neighbors._quad_tree",
-    "sklearn.tree._criterion",
-    "sklearn.utils.murmurhash",
-    "sklearn.neighbors._kd_tree",
-    "sklearn.neighbors._ball_tree",
-    "sklearn.utils.arrayfuncs",
-    "sklearn.utils._seq_dataset",
-    "sklearn.svm._liblinear",
-    "sklearn.tree._tree",
-    "sklearn.svm._libsvm_sparse",
-    "sklearn.svm._libsvm",
-    "sklearn.metrics._dist_metrics",
-    "sklearn.utils.sparsefuncs_fast",
-    "sklearn.linear_model._cd_fast",
-    "sklearn.linear_model._sgd_fast",
-    "sklearn.linear_model._sag_fast",
+# XXX: add new extension to this list when their
+# are not using the old NumPy C API (version 1.4)
+USE_NEWEST_NUMPY_C_API = (
+    "sklearn.__check_build._check_build",
+    "sklearn._loss._loss",
+    "sklearn.cluster._k_means_common",
+    "sklearn.cluster._k_means_lloyd",
+    "sklearn.cluster._k_means_elkan",
+    "sklearn.cluster._k_means_minibatch",
+    "sklearn.datasets._svmlight_format_fast",
+    "sklearn.decomposition._cdnmf_fast",
+    "sklearn.ensemble._hist_gradient_boosting._gradient_boosting",
+    "sklearn.ensemble._hist_gradient_boosting.histogram",
+    "sklearn.ensemble._hist_gradient_boosting.splitting",
+    "sklearn.ensemble._hist_gradient_boosting._binning",
+    "sklearn.ensemble._hist_gradient_boosting._predictor",
+    "sklearn.ensemble._hist_gradient_boosting._bitset",
+    "sklearn.ensemble._hist_gradient_boosting.common",
+    "sklearn.ensemble._hist_gradient_boosting.utils",
+    "sklearn.feature_extraction._hashing_fast",
+    "sklearn.manifold._barnes_hut_tsne",
+    "sklearn.metrics.cluster._expected_mutual_info_fast",
+    "sklearn.metrics._pairwise_distances_reduction._datasets_pair",
+    "sklearn.metrics._pairwise_distances_reduction._gemm_term_computer",
+    "sklearn.metrics._pairwise_distances_reduction._base",
+    "sklearn.metrics._pairwise_distances_reduction._argkmin",
+    "sklearn.metrics._pairwise_distances_reduction._radius_neighborhood",
+    "sklearn.metrics._pairwise_fast",
+    "sklearn.neighbors._partition_nodes",
+    "sklearn.tree._splitter",
+    "sklearn.tree._utils",
+    "sklearn.utils._cython_blas",
+    "sklearn.utils._fast_dict",
+    "sklearn.utils._openmp_helpers",
+    "sklearn.utils._weight_vector",
+    "sklearn.utils._random",
+    "sklearn.utils._logistic_sigmoid",
+    "sklearn.utils._readonly_array_wrapper",
+    "sklearn.utils._typedefs",
+    "sklearn.utils._heap",
+    "sklearn.utils._sorting",
+    "sklearn.utils._vector_sentinel",
+    "sklearn.utils._isfinite",
+    "sklearn.svm._newrand",
+    "sklearn._isotonic",
 )
 
 # For some commands, use setuptools
@@ -175,7 +196,7 @@ try:
             from sklearn._build_utils.openmp_helpers import get_openmp_flag
 
             for ext in self.extensions:
-                if ext.name not in USE_OLD_NUMPY_C_API:
+                if ext.name in USE_NEWEST_NUMPY_C_API:
                     print(
                         f"Use newest NumPy C API (version 1.7) for extension {ext.name}"
                     )

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ DEFINE_MACRO_NUMPY_C_API = (
 )
 
 # XXX: add new extensions to this list when they
-# are not using the old NumPy C API (i.e. version 1.4)
+# are not using the old NumPy C API (i.e. version 1.7)
 # TODO: when Cython>=3.0 is used, make sure all Cython extensions
 # use the newest NumPy C API by `#defining` `NPY_NO_DEPRECATED_API` to be
 # `NPY_1_7_API_VERSION`, and remove this list.
@@ -202,11 +202,11 @@ try:
             for ext in self.extensions:
                 if ext.name in USE_NEWEST_NUMPY_C_API:
                     print(
-                        f"Use newest NumPy C API (version 1.7) for extension {ext.name}"
+                        f"Use newest NumPy C API for extension {ext.name}"
                     )
                     ext.define_macros.append(DEFINE_MACRO_NUMPY_C_API)
                 else:
-                    print(f"Use old NumPy C API (version 1.4) for extension {ext.name}")
+                    print(f"Use old NumPy C API (version 1.7) for extension {ext.name}")
 
             if sklearn._OPENMP_SUPPORTED:
                 openmp_flag = get_openmp_flag(self.compiler)

--- a/setup.py
+++ b/setup.py
@@ -201,10 +201,10 @@ try:
 
             for ext in self.extensions:
                 if ext.name in USE_NEWEST_NUMPY_C_API:
-                    print(f"Use newest NumPy C API for extension {ext.name}")
+                    print(f"Using newest NumPy C API for extension {ext.name}")
                     ext.define_macros.append(DEFINE_MACRO_NUMPY_C_API)
                 else:
-                    print(f"Use old NumPy C API (version 1.7) for extension {ext.name}")
+                    print(f"Using old NumPy C API (version 1.7) for extension {ext.name}")
 
             if sklearn._OPENMP_SUPPORTED:
                 openmp_flag = get_openmp_flag(self.compiler)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ DEFINE_MACRO_NUMPY_C_API = (
     "NPY_1_7_API_VERSION",
 )
 
-# XXX: add new extension to this list when their
+# XXX: add new extension to this list when they
 # are not using the old NumPy C API (version 1.4)
 USE_NEWEST_NUMPY_C_API = (
     "sklearn.__check_build._check_build",

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,10 @@ DEFINE_MACRO_NUMPY_C_API = (
     "NPY_1_7_API_VERSION",
 )
 
-# XXX: add new extension to this list when they
-# are not using the old NumPy C API (version 1.4)
+# XXX: add new extensions to this list when they
+# are not using the old NumPy C API (i.e. version 1.4)
+# TODO: when Cython>=3.0 is used, make sure all Cython extensions
+# use the newest NumPy C API (i.e. version 1.7) and remove this list.
 USE_NEWEST_NUMPY_C_API = (
     "sklearn.__check_build._check_build",
     "sklearn._loss._loss",

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,37 @@ from sklearn.externals._packaging.version import parse as parse_version  # noqa
 
 VERSION = sklearn.__version__
 
+# See: https://numpy.org/doc/stable/reference/c-api/deprecations.html
+DEFINE_MACRO_NUMPY_C_API = (
+    "NPY_NO_DEPRECATED_API",
+    "NPY_1_7_API_VERSION",
+)
+
+# TODO: remove call to NumPy C API (version 1.4) in those extensions
+USE_OLD_NUMPY_C_API = (
+    "sklearn.decomposition._online_lda_fast",
+    "sklearn.manifold._utils",
+    "sklearn.ensemble._gradient_boosting",
+    "sklearn.preprocessing._csr_polynomial_expansion",
+    "sklearn.cluster._dbscan_inner",
+    "sklearn.cluster._hierarchical_fast",
+    "sklearn.neighbors._quad_tree",
+    "sklearn.tree._criterion",
+    "sklearn.utils.murmurhash",
+    "sklearn.neighbors._kd_tree",
+    "sklearn.neighbors._ball_tree",
+    "sklearn.utils.arrayfuncs",
+    "sklearn.utils._seq_dataset",
+    "sklearn.svm._liblinear",
+    "sklearn.tree._tree",
+    "sklearn.svm._libsvm_sparse",
+    "sklearn.svm._libsvm",
+    "sklearn.metrics._dist_metrics",
+    "sklearn.utils.sparsefuncs_fast",
+    "sklearn.linear_model._cd_fast",
+    "sklearn.linear_model._sgd_fast",
+    "sklearn.linear_model._sag_fast",
+)
 
 # For some commands, use setuptools
 SETUPTOOLS_COMMANDS = {
@@ -142,6 +173,15 @@ try:
 
         def build_extensions(self):
             from sklearn._build_utils.openmp_helpers import get_openmp_flag
+
+            for ext in self.extensions:
+                if ext.name not in USE_OLD_NUMPY_C_API:
+                    print(
+                        f"Use newest NumPy C API (version 1.7) for extension {ext.name}"
+                    )
+                    ext.define_macros.append(DEFINE_MACRO_NUMPY_C_API)
+                else:
+                    print(f"Use old NumPy C API (version 1.4) for extension {ext.name}")
 
             if sklearn._OPENMP_SUPPORTED:
                 openmp_flag = get_openmp_flag(self.compiler)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

NumPy has several C API versions. Currently, scikit-learn is using an old one.
This currently might not offer the best performance and features for our implementations.
This also creates a lot of warning and noise when compiling generated C and C++ sources,
which we ideally would like to get ride of for quality, clarity and to eventually prevent problems in the future.

This PR specifies using the newest NumPy C API for some Cython extension where currently possible.

See the mecanism: https://numpy.org/doc/stable/reference/c-api/deprecations.html

#### Any other comments?

Some extensions are still relying on the previous NumPy C API yet, and we first need to change the code of those extensions not to use this previous API. As of now, they are not listed in `USE_NEWEST_NUMPY_C_API`.
