### PR TITLE
ENH Adds text_kw to ConfusionMatrix

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -205,6 +205,11 @@ Changelog
 :mod:`sklearn.metrics`
 ......................
 
+- |Feature| :func:`metrics.ConfusionMatrixDisplay.from_estimator`,
+  :func:`metrics.ConfusionMatrixDisplay.from_predictions`, and
+  :meth:`metrics.ConfusionMatrixDisplay.plot` accepts a `text_kw` parameter which is passed to
+  matplotlib's `text` function. :pr:`xxxxx` by `Thomas Fan`_.
+
 - |Feature| :func:`metrics.class_likelihood_ratios` is added to compute the positive and
   negative likelihood ratios derived from the confusion matrix
   of a binary classification problem. :pr:`22518` by

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -208,7 +208,7 @@ Changelog
 - |Feature| :func:`metrics.ConfusionMatrixDisplay.from_estimator`,
   :func:`metrics.ConfusionMatrixDisplay.from_predictions`, and
   :meth:`metrics.ConfusionMatrixDisplay.plot` accepts a `text_kw` parameter which is passed to
-  matplotlib's `text` function. :pr:`xxxxx` by `Thomas Fan`_.
+  matplotlib's `text` function. :pr:`24051` by `Thomas Fan`_.
 
 - |Feature| :func:`metrics.class_likelihood_ratios` is added to compute the positive and
   negative likelihood ratios derived from the confusion matrix

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -142,6 +142,7 @@ class ConfusionMatrixDisplay:
         default_im_kw = dict(interpolation="nearest", cmap=cmap)
         im_kw = im_kw or {}
         im_kw = {**default_im_kw, **im_kw}
+        text_kw = text_kw or {}
 
         self.im_ = ax.imshow(cm, **im_kw)
         self.text_ = None

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -89,6 +89,7 @@ class ConfusionMatrixDisplay:
         ax=None,
         colorbar=True,
         im_kw=None,
+        text_kw=None,
     ):
         """Plot visualization.
 
@@ -117,6 +118,11 @@ class ConfusionMatrixDisplay:
 
         im_kw : dict, default=None
             Dict with keywords passed to `matplotlib.pyplot.imshow` call.
+
+        text_kw : dict, default=None
+            Dict with keywords passed to `matplotlib.pyplot.text` call.
+
+            .. versionadded:: 1.2
 
         Returns
         -------
@@ -159,9 +165,10 @@ class ConfusionMatrixDisplay:
                 else:
                     text_cm = format(cm[i, j], values_format)
 
-                self.text_[i, j] = ax.text(
-                    j, i, text_cm, ha="center", va="center", color=color
-                )
+                default_text_kwargs = dict(ha="center", va="center", color=color)
+                text_kwargs = {**default_text_kwargs, **text_kw}
+
+                self.text_[i, j] = ax.text(j, i, text_cm, **text_kwargs)
 
         if self.display_labels is None:
             display_labels = np.arange(n_classes)
@@ -203,6 +210,7 @@ class ConfusionMatrixDisplay:
         ax=None,
         colorbar=True,
         im_kw=None,
+        text_kw=None,
     ):
         """Plot Confusion Matrix given an estimator and some data.
 
@@ -271,6 +279,11 @@ class ConfusionMatrixDisplay:
         im_kw : dict, default=None
             Dict with keywords passed to `matplotlib.pyplot.imshow` call.
 
+        text_kw : dict, default=None
+            Dict with keywords passed to `matplotlib.pyplot.text` call.
+
+            .. versionadded:: 1.2
+
         Returns
         -------
         display : :class:`~sklearn.metrics.ConfusionMatrixDisplay`
@@ -318,6 +331,7 @@ class ConfusionMatrixDisplay:
             values_format=values_format,
             colorbar=colorbar,
             im_kw=im_kw,
+            text_kw=text_kw,
         )
 
     @classmethod
@@ -337,6 +351,7 @@ class ConfusionMatrixDisplay:
         ax=None,
         colorbar=True,
         im_kw=None,
+        text_kw=None,
     ):
         """Plot Confusion Matrix given true and predicted labels.
 
@@ -402,6 +417,11 @@ class ConfusionMatrixDisplay:
         im_kw : dict, default=None
             Dict with keywords passed to `matplotlib.pyplot.imshow` call.
 
+        text_kw : dict, default=None
+            Dict with keywords passed to `matplotlib.pyplot.text` call.
+
+            .. versionadded:: 1.2
+
         Returns
         -------
         display : :class:`~sklearn.metrics.ConfusionMatrixDisplay`
@@ -456,6 +476,7 @@ class ConfusionMatrixDisplay:
             values_format=values_format,
             colorbar=colorbar,
             im_kw=im_kw,
+            text_kw=text_kw,
         )
 
 

--- a/sklearn/metrics/_plot/tests/test_confusion_matrix_display.py
+++ b/sklearn/metrics/_plot/tests/test_confusion_matrix_display.py
@@ -377,3 +377,31 @@ def test_im_kw_adjust_vmin_vmax(pyplot):
     clim = disp.im_.get_clim()
     assert clim[0] == pytest.approx(0.0)
     assert clim[1] == pytest.approx(0.8)
+
+
+def test_confusion_matrix_text_kw(pyplot):
+    """Check that text_kw is passed to the text call."""
+    font_size = 15.0
+    X, y = make_classification(random_state=0)
+    classifier = SVC().fit(X, y)
+
+    # from_estimator passes the font size
+    disp = ConfusionMatrixDisplay.from_estimator(
+        classifier, X, y, text_kw={"fontsize": font_size}
+    )
+    for text in disp.text_.reshape(-1):
+        assert text.get_fontsize() == font_size
+
+    # plot adjusts plot to new font size
+    new_font_size = 20.0
+    disp.plot(text_kw={"fontsize": new_font_size})
+    for text in disp.text_.reshape(-1):
+        assert text.get_fontsize() == new_font_size
+
+    # from_predictions passes the font size
+    y_pred = classifier.predict(X)
+    disp = ConfusionMatrixDisplay.from_predictions(
+        y, y_pred, text_kw={"fontsize": font_size}
+    )
+    for text in disp.text_.reshape(-1):
+        assert text.get_fontsize() == font_size


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #19051

#### What does this implement/fix? Explain your changes.
I think `text_kw` is okay to add since `text` is called frequently to place values into the confusion matrix.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
