### PR TITLE
EHN: RadiusNeighborRegressor speedup

### DIFF
--- a/asv_benchmarks/benchmarks/neighbors.py
+++ b/asv_benchmarks/benchmarks/neighbors.py
@@ -1,8 +1,8 @@
-from sklearn.neighbors import KNeighborsClassifier
+from sklearn.neighbors import KNeighborsClassifier, RadiusNeighborsRegressor
 
 from .common import Benchmark, Estimator, Predictor
-from .datasets import _20newsgroups_lowdim_dataset
-from .utils import make_gen_classif_scorers
+from .datasets import _20newsgroups_lowdim_dataset, _synth_regression_dataset
+from .utils import make_gen_classif_scorers, make_gen_reg_scorers
 
 
 class KNeighborsClassifierBenchmark(Predictor, Estimator, Benchmark):
@@ -37,3 +37,34 @@ class KNeighborsClassifierBenchmark(Predictor, Estimator, Benchmark):
 
     def make_scorers(self):
         make_gen_classif_scorers(self)
+
+
+class RadiusNeighborsRegressorBenchmark(Predictor, Estimator, Benchmark):
+    """
+    Benchmarks for RadiusNeighborsRegressor
+    """
+    param_names = ["algorithm", "dimension", "n_jobs"]
+    params = (["brute", "kd_tree", "ball_tree"], ["very-low", "low", "high"], Benchmark.n_jobs_vals)
+    dim_to_number = {"very-low": 3, "low": 20, "high": 200}
+
+    def setup_cache(self):
+        super().setup_cache()
+
+    def make_data(self, params):
+        algorithm, dimension, n_jobs = params
+
+        n_features = self.dim_to_number[dimension]
+
+        data = _synth_regression_dataset(n_samples=10000, n_features=n_features)
+
+        return data
+
+    def make_estimator(self, params):
+        algorithm, dimension, n_jobs = params
+
+        estimator = RadiusNeighborsRegressor(algorithm=algorithm, n_jobs=n_jobs, radius=0.05)
+
+        return estimator
+
+    def make_scorers(self):
+        make_gen_reg_scorers(self)

--- a/asv_benchmarks/benchmarks/neighbors.py
+++ b/asv_benchmarks/benchmarks/neighbors.py
@@ -43,8 +43,13 @@ class RadiusNeighborsRegressorBenchmark(Predictor, Estimator, Benchmark):
     """
     Benchmarks for RadiusNeighborsRegressor
     """
+
     param_names = ["algorithm", "dimension", "n_jobs"]
-    params = (["brute", "kd_tree", "ball_tree"], ["very-low", "low", "high"], Benchmark.n_jobs_vals)
+    params = (
+        ["brute", "kd_tree", "ball_tree"],
+        ["very-low", "low", "high"],
+        Benchmark.n_jobs_vals,
+    )
     dim_to_number = {"very-low": 3, "low": 20, "high": 200}
 
     def setup_cache(self):
@@ -62,7 +67,9 @@ class RadiusNeighborsRegressorBenchmark(Predictor, Estimator, Benchmark):
     def make_estimator(self, params):
         algorithm, dimension, n_jobs = params
 
-        estimator = RadiusNeighborsRegressor(algorithm=algorithm, n_jobs=n_jobs, radius=0.05)
+        estimator = RadiusNeighborsRegressor(
+            algorithm=algorithm, n_jobs=n_jobs, radius=0.05
+        )
 
         return estimator
 

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -472,17 +472,18 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin, RegressorMixin, NeighborsBa
         n_neigh = np.asarray([len(ind) for ind in neigh_ind])
 
         neigh_dst = np.concatenate(neigh_ind, axis=0)
-        neigh_src = np.repeat(np.arange(n_samples), repeats=n_neigh) 
-    
+        neigh_src = np.repeat(np.arange(n_samples), repeats=n_neigh)
+
         if weights is None:
             weights = np.ones(len(neigh_src), dtype=bool)
         else:
             weights = np.concatenate(weights, axis=0)
-        
+
         weights = csr_matrix(
-            (weights, (neigh_src, neigh_dst)), shape=(n_samples, len(_y)),
+            (weights, (neigh_src, neigh_dst)),
+            shape=(n_samples, len(_y)),
         )
-        
+
         # normalization factor so weights sum = 1
         norm_factor = weights.sum(axis=1)
         y_pred = weights @ _y

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -13,6 +13,7 @@
 import warnings
 
 import numpy as np
+from scipy.sparse import csr_matrix
 
 from ._base import _get_weights
 from ._base import NeighborsBase, KNeighborsMixin, RadiusNeighborsMixin
@@ -466,25 +467,28 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin, RegressorMixin, NeighborsBa
         if _y.ndim == 1:
             _y = _y.reshape((-1, 1))
 
-        empty_obs = np.full_like(_y[0], np.nan)
+        # converting weights to sparse matrix
+        n_samples = len(neigh_ind)
+        n_neigh = np.asarray([len(ind) for ind in neigh_ind])
 
+        neigh_dst = np.concatenate(neigh_ind, axis=0)
+        neigh_src = np.repeat(np.arange(n_samples), repeats=n_neigh) 
+    
         if weights is None:
-            y_pred = np.array(
-                [
-                    np.mean(_y[ind, :], axis=0) if len(ind) else empty_obs
-                    for (i, ind) in enumerate(neigh_ind)
-                ]
-            )
-
+            weights = np.ones(len(neigh_src), dtype=bool)
         else:
-            y_pred = np.array(
-                [
-                    np.average(_y[ind, :], axis=0, weights=weights[i])
-                    if len(ind)
-                    else empty_obs
-                    for (i, ind) in enumerate(neigh_ind)
-                ]
-            )
+            weights = np.concatenate(weights, axis=0)
+        
+        weights = csr_matrix(
+            (weights, (neigh_src, neigh_dst)), shape=(n_samples, len(_y)),
+        )
+        
+        # normalization factor so weights sum = 1
+        norm_factor = weights.sum(axis=1)
+        y_pred = weights @ _y
+        with np.errstate(divide="ignore"):
+            # normalizing and assigning NaN to lonely samples
+            y_pred = np.where(norm_factor > 0, y_pred / norm_factor, np.nan)
 
         if np.any(np.isnan(y_pred)):
             empty_warning_msg = (


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

When working with low-dimensional data the neighborhood queries are very fast and most of the time is spent iterating through the neighborhood to compute the predictions since the neighborhoods might not have the same length it employs a different mechanism than the `KNNRegressor`.

This PR converts the loop operations to sparse matrix multiplications, providing 10x speed on low-dimensional datasets without performance decrease on higher dimensions (where most of the time is spent on neighbor's query).

Relevant results from ASV:

```
THIS BRANCH:

[16.67%] ··· neighbors.RadiusNeighborsRegressorBenchmark.peakmem_predict                                                                             ok
[16.67%] ··· =========== ============== ========= ==========
             --                   dimension / n_jobs        
             ----------- -----------------------------------
              algorithm   very-low / 4   low / 4   high / 4 
             =========== ============== ========= ==========
                brute         788M         777M      686M   
               kd_tree       87.9M        91.7M      128M   
              ball_tree      87.4M        91.4M      127M   
             =========== ============== ========= ==========

[33.33%] ··· neighbors.RadiusNeighborsRegressorBenchmark.time_predict                                                                                ok
[33.33%] ··· =========== ============== ========== ============
             --                    dimension / n_jobs          
             ----------- --------------------------------------
              algorithm   very-low / 4   low / 4     high / 4  
             =========== ============== ========== ============
                brute       825±30ms     847±30ms    920±30ms  
               kd_tree      15.1±3ms     36.3±6ms    211±50ms  
              ball_tree     63.7±8ms     785±60ms   4.31±0.03s 
             =========== ============== ========== ============

MAIN BRANCH:

[66.67%] ··· neighbors.RadiusNeighborsRegressorBenchmark.peakmem_predict                                                                             ok
[66.67%] ··· =========== ============== ========= ==========
             --                   dimension / n_jobs        
             ----------- -----------------------------------
              algorithm   very-low / 4   low / 4   high / 4 
             =========== ============== ========= ==========
                brute         817M         729M      641M   
               kd_tree       88.1M         92M       128M   
              ball_tree      87.9M        91.7M      127M   
             =========== ============== ========= ==========
             
[83.33%] ··· neighbors.RadiusNeighborsRegressorBenchmark.time_predict                                                                                ok
[83.33%] ··· =========== ============== ========== ============
             --                    dimension / n_jobs          
             ----------- --------------------------------------
              algorithm   very-low / 4   low / 4     high / 4  
             =========== ============== ========== ============
                brute       906±40ms     939±30ms   1.02±0.04s 
               kd_tree      116±20ms     130±20ms    320±60ms  
              ball_tree     166±20ms     890±40ms   4.31±0.04s 
             =========== ============== ========== ============
```

#### Any other comments?

After these changes, profiling indicates that more than half of the time (for low-dimension datasets) is spent on the `_get_weights` function. I was able to get a speedup on it, but the behavior changed a little bit when there's a point identical to the training set. Hence, I'm not pushing this change, but additional suggestions are welcome.
