### PR TITLE
DOC Add note about deactivating and reactivating the conda env after installing compilers.

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -296,6 +296,12 @@ forge using the following command:
 
 which should include ``compilers`` and ``llvm-openmp``.
 
+.. note::
+
+   If you installed these packages after creating and activating a new conda
+   environment, you will need to first deactivate and then reactivate the
+   environment for these changes to take effect.
+
 The compilers meta-package will automatically set custom environment
 variables:
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I was setting up the development environment on a new macOS machine using the docs, but I had some issues that I only figured out by looking at the sprints setup information from EuroPython ([separate repo](https://github.com/scikit-learn-inria-fondation/EuroPython22/blob/main/1.environment.md)). There is a small gotcha in the current way the setup is written in the docs. In [step 2](https://scikit-learn.org/stable/developers/advanced_installation.html#building-from-source) you create a conda environment. Then in [step 4](https://scikit-learn.org/stable/developers/advanced_installation.html#compiler-macos), you are instructed to install a compiler by creating a new conda environment. Rather than create a second environment, I chose to `conda install` the extra dependencies listed, but then noticed I was unable to successfully run the `pip install --verbose --no-build-isolation --editable .` command due to missing dependencies, which should have been handled by installing compilers. I'm adding a note just under the compilers install here that you need to deactivate and then reactivate the environment for the change to take effect. After this, running the `pip install --verbose --no-build-isolation --editable .` command works.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
