### PR TITLE
DOC Update MDS init docs in fit

### DIFF
--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -539,7 +539,7 @@ class MDS(BaseEstimator):
         y : Ignored
             Not used, present for API consistency by convention.
 
-        init : ndarray of shape (n_samples,), default=None
+        init : ndarray of shape (n_samples, n_components), default=None
             Starting configuration of the embedding to initialize the SMACOF
             algorithm. By default, the algorithm is initialized with a randomly
             chosen array.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #24067
Issue #22265

#### What does this implement/fix? Explain your changes.
Adds `n_components` to `init` docstring. This update is consistent with the `smacof` docstring that MDS uses:

https://github.com/scikit-learn/scikit-learn/blob/ec6efc57fac36820919184ffb5fae70a7e871b62/sklearn/manifold/_mds.py#L222-L224

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
