### PR TITLE
FIX Set n_jobs=None as default for neighbors transformers

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -254,6 +254,11 @@ Changelog
   instead of failing with a low-level error message at predict-time.
   :pr:`23874` by :user:`Juan Gomez <2357juan>`.
 
+- |Fix| Set `n_jobs=None` by default (instead of `1`) for
+  :class:`neighbors.KNeighborsTransformer` and
+  :class:`neighbors.RadiusNeighborsTransformer`.
+  :pr:`24075` by :user:`Valentin Laurent <Valentin-Laurent>`.
+
 :mod:`sklearn.svm`
 ..................
 

--- a/sklearn/neighbors/_graph.py
+++ b/sklearn/neighbors/_graph.py
@@ -291,7 +291,7 @@ class KNeighborsTransformer(
     metric_params : dict, default=None
         Additional keyword arguments for the metric function.
 
-    n_jobs : int, default=1
+    n_jobs : int, default=None
         The number of parallel jobs to run for neighbors search.
         If ``-1``, then the number of jobs is set to the number of CPU cores.
 
@@ -358,7 +358,7 @@ class KNeighborsTransformer(
         metric="minkowski",
         p=2,
         metric_params=None,
-        n_jobs=1,
+        n_jobs=None,
     ):
         super(KNeighborsTransformer, self).__init__(
             n_neighbors=n_neighbors,
@@ -515,7 +515,7 @@ class RadiusNeighborsTransformer(
     metric_params : dict, default=None
         Additional keyword arguments for the metric function.
 
-    n_jobs : int, default=1
+    n_jobs : int, default=None
         The number of parallel jobs to run for neighbors search.
         If ``-1``, then the number of jobs is set to the number of CPU cores.
 
@@ -586,7 +586,7 @@ class RadiusNeighborsTransformer(
         metric="minkowski",
         p=2,
         metric_params=None,
-        n_jobs=1,
+        n_jobs=None,
     ):
         super(RadiusNeighborsTransformer, self).__init__(
             n_neighbors=None,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #23904.

#### What does this implement/fix? Explain your changes.
Sets `n_jobs=None` by default (instead of `1`) for classes `KNeighborsTransformer` and `RadiusNeighborsTransformer`.
This change is backward incompatible but is considered a bug fix (unless the opposite decision is taken, in which case I can change the PR to a deprecation one).