### PR TITLE
Add `sample_weight` support to PCA

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -137,6 +137,10 @@ Changelog
   function.
   :pr:`23905` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+  |Feature| :class:`decomposition.PCA` now supports `sample_weight` for weighted
+  PCA.
+  :pr:`24079` by :user:`Nick Smith <nicholastoddsmith>`.
+
 - |API| The `n_iter` parameter of :class:`decomposition.MiniBatchSparsePCA` is
   deprecated and replaced by the parameters `max_iter`, `tol`, and
   `max_no_improvement` to be consistent with

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -744,7 +744,7 @@ class PCA(_BasePCA):
             # Center data
             self.mean_ = np.mean(X, axis=0)
             X -= self.mean_
-            return X, 1 / (X.shape[0] - 1)
+            return X, np.float64(1.0) / (X.shape[0] - 1)
         # Weighted instance; Center with weighted average and weight
         weight_sum = _sample_count(sample_weight, X.shape[0])
         sample_weight /= sample_weight.sum()

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -478,6 +478,17 @@ class PCA(_BasePCA):
 
         return U
 
+    def match_sign(self, pca):
+        """Ensures that the calling object's component signs match those
+        of the provided object to resolve sign indeterminacy.
+        """
+        for c, (i, j) in enumerate(
+            zip(np.sign(self.components_[:, 0]), np.sign(pca.components_[:, 0]))
+        ):
+            if i != j:
+                self.components_[c] *= -1
+        return self
+
     def _fit(self, X, sample_weight=None):
         """Dispatch to the right submethod depending on the chosen solver."""
 

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -414,6 +414,10 @@ class PCA(_BasePCA):
         y : Ignored
             Ignored.
 
+        sample_weight : float or ndarray of shape (n_samples,), default=None
+            Individual weights for each sample. If given a float, every sample
+            will have the same weight.
+
         Returns
         -------
         self : object
@@ -435,6 +439,10 @@ class PCA(_BasePCA):
 
         y : Ignored
             Ignored.
+
+        sample_weight : float or ndarray of shape (n_samples,), default=None
+            Individual weights for each sample. If given a float, every sample
+            will have the same weight.
 
         Returns
         -------
@@ -477,10 +485,7 @@ class PCA(_BasePCA):
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(
-                sample_weight,
-                X,
-                copy=self.copy,
-                only_non_negative=True
+                sample_weight, X, copy=self.copy, only_non_negative=True
             )
             sample_weight /= sample_weight.sum()
 
@@ -510,10 +515,7 @@ class PCA(_BasePCA):
             return self._fit_full(X, n_components, sample_weight=sample_weight)
         elif self._fit_svd_solver in ["arpack", "randomized"]:
             return self._fit_truncated(
-                X,
-                n_components,
-                self._fit_svd_solver,
-                sample_weight=sample_weight
+                X, n_components, self._fit_svd_solver, sample_weight=sample_weight
             )
 
     def _fit_full(self, X, n_components, sample_weight=None):

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -478,7 +478,7 @@ class PCA(_BasePCA):
 
         return U
 
-    def match_sign(self, pca):
+    def _match_sign(self, pca):
         """Ensures that the calling object's component signs match those
         of the provided object to resolve sign indeterminacy.
         """

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -10,7 +10,7 @@
 #
 # License: BSD 3 clause
 
-from math import log, sqrt
+from math import log
 from numbers import Integral, Real
 
 import numpy as np
@@ -100,6 +100,16 @@ def _assess_dimension(spectrum, rank, n_samples):
     ll = pu + pl + pv + pp - pa / 2.0 - rank * log(n_samples) / 2.0
 
     return ll
+
+
+def _sample_count(sample_weight, n_samples):
+    """Determines the number of samples explicitly provided or via sample_weight"""
+    if sample_weight is None:
+        return n_samples
+    # Assume when sample_weight.sum() > n_samples that sample_weight contains count;
+    # otherwise assume that the sums is not meaningful (e.g. it sums to 1) and set
+    # (arbitrarily) the count of unweighted samples to n_samples
+    return max(sample_weight.sum(), n_samples)
 
 
 def _infer_dimension(spectrum, n_samples):
@@ -456,15 +466,15 @@ class PCA(_BasePCA):
         """
         self._validate_params()
 
-        U, S, Vt = self._fit(X, sample_weight=sample_weight)
+        U, S, Vt, u_scale = self._fit(X, sample_weight=sample_weight)
         U = U[:, : self.n_components_]
 
         if self.whiten:
-            # X_new = X * V / S * sqrt(n_samples) = U * sqrt(n_samples)
-            U *= sqrt(X.shape[0] - 1)
+            # Readjust for sample weights only
+            U *= u_scale
         else:
-            # X_new = X * V = U * S * Vt * V = U * S
-            U *= S[: self.n_components_]
+            # Readjust for sample weights and scale by singular values
+            U *= u_scale * S[: self.n_components_]
 
         return U
 
@@ -483,11 +493,33 @@ class PCA(_BasePCA):
             X, dtype=[np.float64, np.float32], ensure_2d=True, copy=self.copy
         )
 
-        if sample_weight is not None:
-            sample_weight = _check_sample_weight(
-                sample_weight, X, copy=self.copy, only_non_negative=True
-            )
-            sample_weight /= sample_weight.sum()
+        # Validate sample weights and compute scale parameter for fit_transform
+        if sample_weight is None:
+            # No weights; whiten with sqrt(n - 1); non-whiten x1 for a No-op
+            u_scale = np.sqrt(X.shape[0] - 1) if self.whiten else 1.0
+        else:
+            sample_weight = _check_sample_weight(sample_weight, X, copy=self.copy)
+
+            # U * S * Vt = (1/n * W)^1/2 * X = sqrt(1/n) * W^(1/2) * X
+            # Non-whitened:
+            # sqrt(n) * W^(-1/2) * U * S * Vt = X
+            # sqrt(n) * W^(-1/2) * U * S = X * V
+            # = sqrt(n) * W^(-1/2) * U * S
+            #
+            # Whitened: N.B. transform uses explained variance w/ Bessel's correction
+            # While SVD is done using "weighted average" so we need to scale up then
+            # apply Bessel's correction on singular values. That is we want:
+            # X * [(n / (n-1) * S^2)^(-1/2)] * V
+            # Multiplying both sides by P^(-1/2) with P = (n / (n-1) * S^2)
+            # X * P^(-1/2) * V = sqrt(n)*W^(-1/2) * U * S*[(n/(n-1)*S^2)^(-1/2)]
+            # = sqrt(n) * sqrt(n-1) / sqrt(n) * W^(-1/2) * U * S * S^-1
+            # = sqrt(n - 1) * W^(-1/2) * U
+            weight_sum = _sample_count(sample_weight, X.shape[0])
+            u_scale = np.sqrt(
+                ((weight_sum - 1) / sample_weight)
+                if self.whiten
+                else (weight_sum / sample_weight)
+            )[:, None]
 
         # Handle n_components==None
         if self.n_components is None:
@@ -512,11 +544,13 @@ class PCA(_BasePCA):
 
         # Call different fits for either full or truncated SVD
         if self._fit_svd_solver == "full":
-            return self._fit_full(X, n_components, sample_weight=sample_weight)
+            U, S, Vt = self._fit_full(X, n_components, sample_weight=sample_weight)
         elif self._fit_svd_solver in ["arpack", "randomized"]:
-            return self._fit_truncated(
+            U, S, Vt = self._fit_truncated(
                 X, n_components, self._fit_svd_solver, sample_weight=sample_weight
             )
+
+        return U, S, Vt, u_scale
 
     def _fit_full(self, X, n_components, sample_weight=None):
         """Fit the model by computing full SVD on X."""
@@ -534,16 +568,7 @@ class PCA(_BasePCA):
                 "svd_solver='full'" % (n_components, min(n_samples, n_features))
             )
 
-        if sample_weight is None:
-            # Center data
-            self.mean_ = np.mean(X, axis=0)
-            X -= self.mean_
-        else:
-            # Center with weighted average and weight
-            W = sample_weight.reshape(-1, 1)
-            self.mean_ = W.T @ X
-            X -= self.mean_
-            X *= np.sqrt(W)
+        X, sv_scale = self._weight_and_center(X, sample_weight=sample_weight)
 
         U, S, Vt = linalg.svd(X, full_matrices=False)
         # flip eigenvectors' sign to enforce deterministic output
@@ -552,7 +577,7 @@ class PCA(_BasePCA):
         components_ = Vt
 
         # Get variance explained by singular values
-        explained_variance_ = (S**2) / (n_samples - 1)
+        explained_variance_ = (S**2) * sv_scale
         total_var = explained_variance_.sum()
         explained_variance_ratio_ = explained_variance_ / total_var
         singular_values_ = S.copy()  # Store the singular values.
@@ -612,16 +637,7 @@ class PCA(_BasePCA):
 
         random_state = check_random_state(self.random_state)
 
-        if sample_weight is None:
-            # Center data
-            self.mean_ = np.mean(X, axis=0)
-            X -= self.mean_
-        else:
-            # Center with weighted average and weight
-            W = sample_weight.reshape(-1, 1)
-            self.mean_ = W.T @ X
-            X -= self.mean_
-            X *= np.sqrt(W)
+        X, sv_scale = self._weight_and_center(X, sample_weight=sample_weight)
 
         if svd_solver == "arpack":
             v0 = _init_arpack_v0(min(X.shape), random_state)
@@ -649,7 +665,7 @@ class PCA(_BasePCA):
         self.n_components_ = n_components
 
         # Get variance explained by singular values
-        self.explained_variance_ = (S**2) / (n_samples - 1)
+        self.explained_variance_ = (S**2) * sv_scale
 
         # Workaround in-place variance calculation since at the time numpy
         # did not have a way to calculate variance in-place.
@@ -720,3 +736,22 @@ class PCA(_BasePCA):
 
     def _more_tags(self):
         return {"preserves_dtype": [np.float64, np.float32]}
+
+    def _weight_and_center(self, X, sample_weight=None):
+        """Center X and apply sample weights if applicable"""
+        if sample_weight is None:
+            # Center data
+            self.mean_ = np.mean(X, axis=0)
+            X -= self.mean_
+            return X, 1 / (X.shape[0] - 1)
+        # Weighted instance; Center with weighted average and weight
+        weight_sum = _sample_count(sample_weight, X.shape[0])
+        sample_weight /= sample_weight.sum()
+        sample_weight = sample_weight.reshape(-1, 1)
+        # Center with weighted average
+        self.mean_ = sample_weight.T @ X
+        X -= self.mean_
+        # Perform SVD on weighted data matrix
+        X *= np.sqrt(sample_weight)
+        # Apply Bessel's correction adjusting for weighted average
+        return X, weight_sum / (weight_sum - 1)

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -66,11 +66,7 @@ def test_weighted_pca(svd_solver, n_components, whiten):
     pca_red.fit(X, sample_weight=W)
 
     # Ensure signs match for comparison
-    for c, (i, j) in enumerate(
-        zip(np.sign(pca_full.components_[:, 0]), np.sign(pca_red.components_[:, 0]))
-    ):
-        if i != j:
-            pca_red.components_[c] *= -1
+    pca_red.match_sign(pca_full)
 
     # Transform and expand repeats
     X_red = np.repeat(pca_red.transform(X), W, axis=0)
@@ -116,11 +112,7 @@ def test_fit_transform_weighted(svd_solver, n_components, whiten):
     pca_full.fit(R)
 
     # Ensure signs match for comparison
-    for c, (i, j) in enumerate(
-        zip(np.sign(pca_full.components_[:, 0]), np.sign(pca_red.components_[:, 0]))
-    ):
-        if i != j:
-            pca_full.components_[c] *= -1
+    pca_full.match_sign(pca_red)
 
     X_full = pca_full.transform(R)
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -41,7 +41,8 @@ def test_pca(svd_solver, n_components):
 
 @pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
 @pytest.mark.parametrize("n_components", range(1, iris.data.shape[1]))
-def test_weighted_pca(svd_solver, n_components):
+@pytest.mark.parametrize("whiten", [False, True])
+def test_weighted_pca(svd_solver, n_components, whiten):
     rng = np.random.RandomState(0)
     X = iris.data
 
@@ -54,13 +55,13 @@ def test_weighted_pca(svd_solver, n_components):
     R = np.repeat(X, W, axis=0)
 
     # Perform PCA on full (repeated) data
-    pca_full = PCA(n_components=n_components, svd_solver=svd_solver)
+    pca_full = PCA(n_components=n_components, svd_solver=svd_solver, whiten=whiten)
 
     X_full = pca_full.fit_transform(R)
     assert X_full.shape[1] == n_components
 
     # Perform PCA on reduced data with weights
-    pca_red = PCA(n_components=n_components, svd_solver=svd_solver)
+    pca_red = PCA(n_components=n_components, svd_solver=svd_solver, whiten=whiten)
 
     pca_red.fit(X, sample_weight=W)
 
@@ -70,11 +71,11 @@ def test_weighted_pca(svd_solver, n_components):
     ):
         if i != j:
             pca_red.components_[c] *= -1
+            print("flip sign")
 
     # Transform and expand repeats
     X_red = np.repeat(pca_red.transform(X), W, axis=0)
 
-    # Assert that two approach yield same transformation
     assert_allclose(X_full, X_red)
 
     # Check that inverse transform also works
@@ -87,6 +88,51 @@ def test_weighted_pca(svd_solver, n_components):
     cov = pca_red.get_covariance()
     precision = pca_red.get_precision()
     assert_allclose(np.dot(cov, precision), np.eye(X.shape[1]), atol=1e-12)
+
+
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
+@pytest.mark.parametrize("n_components", range(1, iris.data.shape[1]))
+@pytest.mark.parametrize("whiten", [False, True])
+def test_fit_transform_weighted(svd_solver, n_components, whiten):
+    rng = np.random.RandomState(0)
+    X = iris.data
+
+    n_samples, n_features = X.shape
+
+    # Repeats (or weightings) of the rows of X
+    W = rng.randint(1, 10, size=n_samples)
+
+    # Perform PCA on reduced data with weights
+    pca_red = PCA(n_components=n_components, svd_solver=svd_solver, whiten=whiten)
+
+    # Transform and expand repeats
+    X_red = np.repeat(pca_red.fit_transform(X, sample_weight=W), W, axis=0)
+    assert X_red.shape[1] == n_components
+
+    # Row i of X is repeated W[i] times
+    R = np.repeat(X, W, axis=0)
+
+    # Perform PCA on full (repeated) data
+    pca_full = PCA(n_components=n_components, svd_solver=svd_solver, whiten=whiten)
+    pca_full.fit(R)
+
+    # Ensure signs match for comparison
+    for c, (i, j) in enumerate(
+        zip(np.sign(pca_full.components_[:, 0]), np.sign(pca_red.components_[:, 0]))
+    ):
+        if i != j:
+            pca_full.components_[c] *= -1
+
+    X_full = pca_full.transform(R)
+
+    # Assert that two approach yield same transformation
+    assert_allclose(X_full, X_red)
+
+    # Check that inverse transform also works
+    assert_allclose(
+        pca_full.inverse_transform(X_full),
+        pca_red.inverse_transform(X_red),
+    )
 
 
 def test_no_empty_slice_warning():

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -66,7 +66,7 @@ def test_weighted_pca(svd_solver, n_components, whiten):
     pca_red.fit(X, sample_weight=W)
 
     # Ensure signs match for comparison
-    pca_red.match_sign(pca_full)
+    pca_red._match_sign(pca_full)
 
     # Transform and expand repeats
     X_red = np.repeat(pca_red.transform(X), W, axis=0)
@@ -112,7 +112,7 @@ def test_fit_transform_weighted(svd_solver, n_components, whiten):
     pca_full.fit(R)
 
     # Ensure signs match for comparison
-    pca_full.match_sign(pca_red)
+    pca_full._match_sign(pca_red)
 
     X_full = pca_full.transform(R)
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -71,7 +71,6 @@ def test_weighted_pca(svd_solver, n_components, whiten):
     ):
         if i != j:
             pca_red.components_[c] *= -1
-            print("flip sign")
 
     # Transform and expand repeats
     X_red = np.repeat(pca_red.transform(X), W, axis=0)

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -38,6 +38,7 @@ def test_pca(svd_solver, n_components):
     precision = pca.get_precision()
     assert_allclose(np.dot(cov, precision), np.eye(X.shape[1]), atol=1e-12)
 
+
 @pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
 @pytest.mark.parametrize("n_components", range(1, iris.data.shape[1]))
 def test_weighted_pca(svd_solver, n_components):
@@ -64,12 +65,11 @@ def test_weighted_pca(svd_solver, n_components):
     pca_red.fit(X, sample_weight=W)
 
     # Ensure signs match for comparison
-    for c, (i, j) in enumerate(zip(
-        np.sign(pca_full.components_[:, 0]),
-        np.sign(pca_red.components_[:, 0]))
+    for c, (i, j) in enumerate(
+        zip(np.sign(pca_full.components_[:, 0]), np.sign(pca_red.components_[:, 0]))
     ):
-      if i != j:
-         pca_red.components_[c] *= -1
+        if i != j:
+            pca_red.components_[c] *= -1
 
     # Transform and expand repeats
     X_red = np.repeat(pca_red.transform(X), W, axis=0)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1086,7 +1086,7 @@ def check_sample_weights_invariance(name, estimator_orig, kind="ones"):
 
     # Handle sign-indeterminacy for PCA
     if isinstance(estimator1, PCA) and isinstance(estimator2, PCA):
-        estimator2.match_sign(estimator1)
+        estimator2._match_sign(estimator1)
 
     for method in ["predict", "predict_proba", "decision_function", "transform"]:
         if hasattr(estimator_orig, method):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -27,6 +27,8 @@ from ._testing import create_memmap_backed_data
 from ._testing import raises
 from . import is_scalar_nan
 
+from ..decomposition import PCA
+
 from ..linear_model import LinearRegression
 from ..linear_model import LogisticRegression
 from ..linear_model import RANSACRegressor
@@ -1081,6 +1083,10 @@ def check_sample_weights_invariance(name, estimator_orig, kind="ones"):
 
     estimator1.fit(X1, y=y1, sample_weight=None)
     estimator2.fit(X2, y=y2, sample_weight=sw2)
+
+    # Handle sign-indeterminacy for PCA
+    if isinstance(estimator1, PCA) and isinstance(estimator2, PCA):
+        estimator2.match_sign(estimator1)
 
     for method in ["predict", "predict_proba", "decision_function", "transform"]:
         if hasattr(estimator_orig, method):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR adds support for the `sample_weight` parameter in the `PCA` class, AKA weighted PCA. This allows for e.g. performing PCA on distinct data with aggregated counts. 


#### Any other comments?

I added 2 new unit tests to help validate the functionality, in addition to these tests I ran a battery of my own randomized instances to help ensure things are working properly.

A few things that probably need some eyes:

1) The `fit_transform` logic is a bit tricky with sample weights. I added comments to help clarify. Let me know if they are too verbose.
2) If an already normalized `sample_weight` vector is provided, it's ambiguous how many samples there truly are. I have somewhat of a heuristic defined in `_sample_count` to determine the true sample count, and in this situation it would default to `n_samples`.

Feedback, questions, or comments are welcome.