### PR TITLE
DOC Ensures that `mutual_info_score` passes numpydoc validation

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -768,14 +768,14 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
        Mutual information, a non-negative value, measured in nats using the
        natural logarithm.
 
-    Notes
-    -----
-    The logarithm used is the natural logarithm (base-e).
-
     See Also
     --------
     adjusted_mutual_info_score : Adjusted against chance Mutual Information.
     normalized_mutual_info_score : Normalized Mutual Information.
+
+    Notes
+    -----
+    The logarithm used is the natural logarithm (base-e).
     """
     if contingency is None:
         labels_true, labels_pred = check_clusterings(labels_true, labels_pred)

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -39,7 +39,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.cluster._supervised.adjusted_rand_score",
     "sklearn.metrics.cluster._supervised.entropy",
     "sklearn.metrics.cluster._supervised.fowlkes_mallows_score",
-    "sklearn.metrics.cluster._supervised.mutual_info_score",
     "sklearn.metrics.cluster._supervised.normalized_mutual_info_score",
     "sklearn.metrics.cluster._supervised.pair_confusion_matrix",
     "sklearn.metrics.cluster._supervised.rand_score",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #21350 

#### What does this implement/fix? Explain your changes.
Fixed the following numpydoc validation error on `sklearn.metrics.cluster._supervised.mutual_info_score`:
- GL07: Sections are in the wrong order. Correct order is: Parameters, Returns, See Also, Notes

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
