### PR TITLE
DOC Expand multilabel in decision function in glossary

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1178,17 +1178,18 @@ Methods
             :term:`classes_`.
         multilabel classification
             Scikit-learn is inconsistent in its representation of multilabel
-            decision functions.  Some estimators represent it like multiclass
-            multioutput, i.e. a list of 2d arrays, each with two columns. Others
-            represent it with a single 2d array, whose columns correspond to
-            the individual binary classification decisions. The latter
-            representation is ambiguously identical to the multiclass
-            classification format, though its semantics differ: it should be
-            interpreted, like in the binary case, by thresholding at 0.
+            decision functions. It may be represented one of two ways:
 
-            TODO: `This gist
-            <https://gist.github.com/jnothman/4807b1b0266613c20ba4d1f88d0f8cf5>`_
-            highlights the use of the different formats for multilabel.
+            - List of 2d arrays, each array of shape: (`n_samples`, 2), like in
+              multiclass multioutput. List is of length `n_labels`.
+
+            - Single 2d array of shape (`n_samples`, `n_labels`), with each
+              'columns' in the array corresponding to the individual binary
+              classification decisions. This is ambiguously identical to the
+              multiclass classification format, though its semantics differ: it
+              should be interpreted, like in the binary case, by thresholding at
+              0.
+
         multioutput classification
             A list of 2d arrays, corresponding to each multiclass decision
             function.

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1185,7 +1185,7 @@ Methods
 
             - Single 2d array of shape (`n_samples`, `n_labels`), with each
               'column' in the array corresponding to the individual binary
-              classification decisions. This is ambiguously identical to the
+              classification decisions. This is identical to the
               multiclass classification format, though its semantics differ: it
               should be interpreted, like in the binary case, by thresholding at
               0.

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1177,7 +1177,7 @@ Methods
             predicted class.  Columns are ordered according to
             :term:`classes_`.
         multilabel classification
-            Scikit-learn is inconsistent in its representation of multilabel
+            Scikit-learn is inconsistent in its representation of :term:`multilabel`
             decision functions. It may be represented one of two ways:
 
             - List of 2d arrays, each array of shape: (`n_samples`, 2), like in

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1184,7 +1184,7 @@ Methods
               multiclass multioutput. List is of length `n_labels`.
 
             - Single 2d array of shape (`n_samples`, `n_labels`), with each
-              'columns' in the array corresponding to the individual binary
+              'column' in the array corresponding to the individual binary
               classification decisions. This is ambiguously identical to the
               multiclass classification format, though its semantics differ: it
               should be interpreted, like in the binary case, by thresholding at


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
(Continues from stalled PR) Closes https://github.com/scikit-learn/scikit-learn/pull/13660
closes https://github.com/scikit-learn/scikit-learn/issues/13533.


<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Expand multilabel in decision function in glossary, using the suggestion: https://github.com/scikit-learn/scikit-learn/pull/13660#discussion_r379449939

I didn't include the code from the gist as no other section of the glossary included code. I could give an example based off of the code in the gist (e.g., dataset of 5 labels and 3 samples, the shape would be: ... ) but was not sure. Happy to take suggestions

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
