### PR TITLE
DOC spectral biclustering: corrected contradiction of warning and documentation for parameter method

### DIFF
--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -385,7 +385,7 @@ class SpectralBiclustering(BaseSpectral):
         default is 'bistochastic'.
 
         .. warning::
-           if `method='log'`, the data must be sparse.
+           if `method='log'`, the data must not be sparse.
 
     n_components : int, default=6
         Number of singular vectors to check.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
none

#### What does this implement/fix? Explain your changes.

Corrected the contradiction in the documentation of the parameter `method` in `sklearn.cluster.SpectralBiclustering` 

The parameter explaination of `method` says correctly: If the data is sparse, however, log normalization will not work.
The warning says: if method='log', the data must be sparse. 

Fixed the warning, indeed the data must **not** be sparse, otherwise an error will be raised.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
