### PR TITLE
DOC Remove deprecated multichannel parameter in example

### DIFF
--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -156,7 +156,7 @@ also referred to as connected components) when clustering an image.
     >>> from skimage.transform import rescale
     >>> rescaled_coins = rescale(
     ...     gaussian_filter(coins(), sigma=2),
-    ...     0.2, mode='reflect', anti_aliasing=False, multichannel=False
+    ...     0.2, mode='reflect', anti_aliasing=False
     ... )
     >>> X = np.reshape(rescaled_coins, (-1, 1))
 

--- a/examples/cluster/plot_coin_segmentation.py
+++ b/examples/cluster/plot_coin_segmentation.py
@@ -44,9 +44,7 @@ orig_coins = coins()
 # Applying a Gaussian filter for smoothing prior to down-scaling
 # reduces aliasing artifacts.
 smoothened_coins = gaussian_filter(orig_coins, sigma=2)
-rescaled_coins = rescale(
-    smoothened_coins, 0.2, mode="reflect", anti_aliasing=False, multichannel=False
-)
+rescaled_coins = rescale(smoothened_coins, 0.2, mode="reflect", anti_aliasing=False)
 
 # Convert the image into a graph with the value of the gradient on the
 # edges.


### PR DESCRIPTION
According to the skimage [docs](https://scikit-image.org/docs/0.19.x/api/skimage.transform.html?highlight=rescale#skimage.transform.rescale) the `multichannel` parameter is deprecated and will be removed in 1.0.

Since the default `multichannel=False`, we do not need to pass this into the `rescale` call.

Note that for our minimum skimage version 0.16, the [default](https://scikit-image.org/docs/0.16.x/api/skimage.transform.html?highlight=rescale#skimage.transform.rescale) value for `multichannel` was still False.