### PR TITLE
Fix Taylor expansion documentation

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -681,7 +681,7 @@ approximated as follows:
 .. note::
 
   Briefly, a first-order Taylor approximation says that
-  :math:`l(z) \approx l(a) + (z - a) \frac{\partial l(a)}{\partial z}`.
+  :math:`l(z) \approx l(a) + (z - a) \frac{\partial l}{\partial z}(a)`.
   Here, :math:`z` corresponds to :math:`F_{m - 1}(x_i) + h_m(x_i)`, and
   :math:`a` corresponds to :math:`F_{m-1}(x_i)`
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -681,7 +681,7 @@ approximated as follows:
 .. note::
 
   Briefly, a first-order Taylor approximation says that
-  :math:`l(z) \approx l(a) + (z - a) \frac{\partial l(a)}{\partial a}`.
+  :math:`l(z) \approx l(a) + (z - a) \frac{\partial l(a)}{\partial z}`.
   Here, :math:`z` corresponds to :math:`F_{m - 1}(x_i) + h_m(x_i)`, and
   :math:`a` corresponds to :math:`F_{m-1}(x_i)`
 


### PR DESCRIPTION
There is an error in the documentation for Gradient Boosting Trees, specifically in the section "1.11.4.5. Mathematical formulation". 

In particular, the derivative should be taken with respect to $z$, not $a$ in the example "Note" in the documentation. This PR should correct this error. 

Link: https://scikit-learn.org/stable/modules/ensemble.html