### PR TITLE
TST Set eigen_tol in SpectralEmbedding to stabilize test

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -757,6 +757,11 @@ def _set_checking_parameters(estimator):
     if name in CROSS_DECOMPOSITION:
         estimator.set_params(n_components=1)
 
+    # Default "auto" parameter can lead to different ordering of eigenvalues on
+    # windows: #24105
+    if name == "SpectralEmbedding":
+        estimator.set_params(eigen_tol=1e-5)
+
 
 class _NotAnArray:
     """An object that is convertible to an array.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #24105


#### What does this implement/fix? Explain your changes.
The most recent change to `SpectralEmbedding` came from: https://github.com/scikit-learn/scikit-learn/pull/23210. I suspect it has to do with setting `tol=None` giving different results in `lobpcg`:

https://github.com/scikit-learn/scikit-learn/blob/5d9dc4a7fd6bb2e7e75b87b2aadf7365ed905407/sklearn/manifold/_spectral_embedding.py#L356-L357

Before #23210, `tol` was always 1e-5. This PR sets the tolerance back manually.

#### Any other comments?
The auto behavior has adopted to pass in `None` because of https://github.com/scikit-learn/scikit-learn/pull/23210#discussion_r862938950.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
