### PR TITLE
DOC Fix variable name in Adaboost example

### DIFF
--- a/examples/ensemble/plot_adaboost_multiclass.py
+++ b/examples/ensemble/plot_adaboost_multiclass.py
@@ -62,11 +62,11 @@ bdt_discrete.fit(X_train, y_train)
 real_test_errors = []
 discrete_test_errors = []
 
-for real_test_predict, discrete_train_predict in zip(
+for real_test_predict, discrete_test_predict in zip(
     bdt_real.staged_predict(X_test), bdt_discrete.staged_predict(X_test)
 ):
     real_test_errors.append(1.0 - accuracy_score(real_test_predict, y_test))
-    discrete_test_errors.append(1.0 - accuracy_score(discrete_train_predict, y_test))
+    discrete_test_errors.append(1.0 - accuracy_score(discrete_test_predict, y_test))
 
 n_trees_discrete = len(bdt_discrete)
 n_trees_real = len(bdt_real)


### PR DESCRIPTION
This PR fixes the variable name used in the "Multi-class AdaBoosted Decision Trees" example. 

The edit does not change the behavior of the example, it only corrects the variable name to emphasize that it is the discrete _test_ predictions rather than the discrete _train_ predictions being used to calculate the discrete _test_ errors. 

Link to example: https://scikit-learn.org/stable/auto_examples/ensemble/plot_adaboost_multiclass.html