### PR TITLE
MNT Handle NaNs in scipy dev rankdata

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -191,6 +191,13 @@ Changelog
   :pr:`22710` by :user:`Conroy Trinh <trinhcon>` and
   :pr:`23461` by :user:`Meekail Zain <micky774>`.
 
+:mod:`sklearn.model_selection`
+..............................
+
+- |Fix| For all `SearchCV` classes and scipy >= 1.10, rank corresponding to a
+  nan score is correctly set to the maximum possible rank, rather than
+  `np.iinfo(np.int32).min`. :pr:`24141` by :user:`Loïc Estève <lesteve>`.
+
 :mod:`sklearn.multioutput`
 ..........................
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -965,9 +965,13 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             results["std_%s" % key_name] = array_stds
 
             if rank:
-                results["rank_%s" % key_name] = np.asarray(
-                    rankdata(-array_means, method="min"), dtype=np.int32
-                )
+                rank_result = rankdata(-array_means, method="min")
+                # when input is nan, scipy >= 1.10 rankdata returns nan. To
+                # keep previous behaviour nans are set to the
+                # maximum possible rank
+                rank_result[np.isnan(rank_result)] = len(rank_result)
+                rank_result = np.asarray(rank_result, dtype=np.int32)
+                results["rank_%s" % key_name] = rank_result
 
         _store("fit_time", out["fit_time"])
         _store("score_time", out["score_time"])


### PR DESCRIPTION
One of the failure in the scipy-dev build https://github.com/scikit-learn/scikit-learn/issues/23626 (turns out it fixes all the scipy-dev failures for some reason ...)

This is a change in scipy 1.10.dev: https://github.com/scipy/scipy/pull/16140

```py
import numpy as np

from scipy.stats import rankdata

print(rankdata([1, 2, np.nan]))
```

scipy 1.10.dev: `array([ 1.,  2., nan])`
scipy 1.9: `array([ 1.,  2., 3.])`

Note: the change in scipy breaks backward-compatibility for the rank in the `cv_results_` attribute. For nan scores, the associated rank will be `np.iinfo(np.int32).min` i.e. `-2147483648`. I am not sure how much the ranks are used in general (I would guess not used very much) and how acceptable such a breaking change is.