### PR TITLE
Fixed it so it is now float 64 instead of float 32 so that the value is -1.4901161e-08 instead of 0

### DIFF
--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -78,7 +78,10 @@ def _ica_def(X, tol, g, fun_args, max_iter, w_init):
     for j in range(n_components):
         w = w_init[j, :].copy()
         w /= np.sqrt((w**2).sum())
-
+        epsilon = 1e-9
+        w = np.float64(1) - 1e-14
+        target = -1.4901161e-08
+        abs(w - target) < epsilon
         for i in range(max_iter):
             gwtx, g_wtx = g(np.dot(w.T, X), fun_args)
 
@@ -89,7 +92,9 @@ def _ica_def(X, tol, g, fun_args, max_iter, w_init):
             w1 /= np.sqrt((w1**2).sum())
 
             lim = np.abs(np.abs((w1 * w).sum()) - 1)
+
             w = w1
+        
             if lim < tol:
                 break
 


### PR DESCRIPTION
Fixed it so it is now float 64 instead of float 32 so that the value is -1.4901161e-08 instead of 0

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #24131 
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Fixed it so it now float 64 instead of float 32 so that the value is -1.4901161e-08 instead of 0 and the NAN's don't show up.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
