### PR TITLE
MNT Fix binder setup

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,8 +1,9 @@
---extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple scikit-learn
+--find-links https://pypi.anaconda.org/scipy-wheels-nightly/simple/scikit-learn
 --pre
 matplotlib
 scikit-image
 pandas
+seaborn
+Pillow
 sphinx-gallery
 scikit-learn
-

--- a/.binder/runtime.txt
+++ b/.binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10
+python-3.9


### PR DESCRIPTION
#24088 did not fix binder (my bad I did not test it enough before merging).

- uses python 3.9, for some reason it does not work with python 3.10. No idea why at one point it is trying to install 3.7 wheels ...
- only use development version of scikit-learn rather than for everything that has a nighly wheel (this is the `--find-links` vs `--extra-index` change)
- add seaborn and Pillow that are used in some examples

To check that this is indeed fixing Binder you can look at: https://mybinder.org/v2/gh/lesteve/scikit-learn/enh-binder