### PR TITLE
DOC Ensures that partial_dependence passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -71,6 +71,7 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.sparsefuncs.count_nonzero",
     "sklearn.utils.sparsefuncs.csc_median_axis_0",
     "sklearn.utils.sparsefuncs.incr_mean_variance_axis",
+    "sklearn.utils.sparsefuncs.inplace_swap_row",
     "sklearn.utils.sparsefuncs.inplace_swap_row_csc",
     "sklearn.utils.sparsefuncs.inplace_swap_row_csr",
     "sklearn.utils.sparsefuncs.mean_variance_axis",

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -18,7 +18,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.decomposition._nmf.non_negative_factorization",
     "sklearn.externals._packaging.version.parse",
     "sklearn.feature_extraction.text.strip_accents_unicode",
-    "sklearn.inspection._partial_dependence.partial_dependence",
     "sklearn.inspection._plot.partial_dependence.plot_partial_dependence",
     "sklearn.linear_model._least_angle.lars_path_gram",
     "sklearn.linear_model._omp.orthogonal_mp_gram",

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -71,7 +71,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.sparsefuncs.count_nonzero",
     "sklearn.utils.sparsefuncs.csc_median_axis_0",
     "sklearn.utils.sparsefuncs.incr_mean_variance_axis",
-    "sklearn.utils.sparsefuncs.inplace_swap_row",
     "sklearn.utils.sparsefuncs.inplace_swap_row_csc",
     "sklearn.utils.sparsefuncs.inplace_swap_row_csr",
     "sklearn.utils.sparsefuncs.mean_variance_axis",

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -361,7 +361,7 @@ def inplace_swap_row_csr(X, m, n):
 
 def inplace_swap_row(X, m, n):
     """
-    Swaps two rows of a CSC/CSR matrix in-place.
+    To swap two rows of a CSC/CSR matrix in-place.
 
     Parameters
     ----------

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -361,7 +361,7 @@ def inplace_swap_row_csr(X, m, n):
 
 def inplace_swap_row(X, m, n):
     """
-    To swap two rows of a CSC/CSR matrix in-place.
+    Swaps two rows of a CSC/CSR matrix in-place.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #21350 

#### What does this implement/fix? Explain your changes.
Ensures that sklearn.inspection._partial_dependence.partial_dependence passes numpydoc validation. 
Verified that all tests passed.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
