### PR TITLE
DOC add missing docstring in functions in hgbt module

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -182,6 +182,28 @@ class TreeGrower:
         to determine the effective number of threads use, which takes cgroups CPU
         quotes into account. See the docstring of `_openmp_effective_n_threads`
         for details.
+
+    Attributes
+    ----------
+    histogram_builder : HistogramBuilder
+    splitter : Splitter
+    root : TreeNode
+    finalized_leaves : list of TreeNode
+    splittable_nodes : list of TreeNode
+    missing_values_bin_idx : int
+        equals n_bins - 1
+    n_categorical_splits : int
+    n_features : int
+    n_nodes : int
+    total_find_split_time : float
+        time spent finding the best splits
+    total_compute_hist_time : float
+        time spent computing histograms
+    total_apply_split_time : float
+        time spent splitting nodes
+    with_monotonic_cst : bool
+        Whether there are monotonic constraints that apply. False iff monotonic_cst is
+        None.
     """
 
     def __init__(

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -191,16 +191,16 @@ class TreeGrower:
     finalized_leaves : list of TreeNode
     splittable_nodes : list of TreeNode
     missing_values_bin_idx : int
-        equals n_bins - 1
+        Equals n_bins - 1
     n_categorical_splits : int
     n_features : int
     n_nodes : int
     total_find_split_time : float
-        time spent finding the best splits
+        Time spent finding the best splits
     total_compute_hist_time : float
-        time spent computing histograms
+        Time spent computing histograms
     total_apply_split_time : float
-        time spent splitting nodes
+        Time spent splitting nodes
     with_monotonic_cst : bool
         Whether there are monotonic constraints that apply. False iff monotonic_cst is
         None.

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -136,6 +136,10 @@ cdef class Splitter:
         feature.
     is_categorical : ndarray of bool of shape (n_features,)
         Indicates categorical features.
+    monotonic_cst : ndarray of shape (n_features,), dtype=int
+        Indicates the monotonic constraint to enforce on each feature. -1, 1
+        and 0 respectively correspond to a positive constraint, negative
+        constraint and no constraint.
     l2_regularization : float
         The L2 regularization parameter.
     min_hessian_to_split : float, default=1e-3
@@ -149,6 +153,8 @@ cdef class Splitter:
         be ignored.
     hessians_are_constant: bool, default is False
         Whether hessians are constant.
+    n_threads : int, default=1
+        Number of OpenMP threads to use.
     """
     cdef public:
         const X_BINNED_DTYPE_C [::1, :] X_binned

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -138,7 +138,7 @@ cdef class Splitter:
         Indicates categorical features.
     monotonic_cst : ndarray of shape (n_features,), dtype=int
         Indicates the monotonic constraint to enforce on each feature. -1, 1
-        and 0 respectively correspond to a positive constraint, negative
+        and 0 respectively correspond to a negative constraint, positive
         constraint and no constraint.
     l2_regularization : float
         The L2 regularization parameter.


### PR DESCRIPTION
#### Reference Issues/PRs
This popped up in a review of https://github.com/scikit-learn/scikit-learn/pull/21020#discussion_r946805959.

#### What does this implement/fix? Explain your changes.
Add missing docstring entries in the histogram gradient boosting submodule (attributes, parameters).
