### PR TITLE
TST Work-around for Ubuntu atlas float32 failure

### DIFF
--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -4,6 +4,7 @@ Test the fastica algorithm.
 import itertools
 import pytest
 import warnings
+import os
 
 import numpy as np
 from scipy import stats
@@ -75,6 +76,18 @@ def test_fastica_return_dtypes(global_dtype):
 )
 @pytest.mark.parametrize("add_noise", [True, False])
 def test_fastica_simple(add_noise, global_random_seed, global_dtype):
+    if (
+        global_random_seed == 20
+        and global_dtype == np.float32
+        and os.getenv("DISTRIB") == "ubuntu"
+    ):
+        pytest.xfail(
+            "fastica instability with Ubuntu Atlas build with float32 "
+            "global_dtype. For more details, see "
+            "https://github.com/scikit-learn/scikit-learn/issues/24131"
+            "#issuecomment-1208091119"
+        )
+
     # Test the FastICA algorithm on very simple data.
     rng = np.random.RandomState(global_random_seed)
     n_samples = 1000

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -83,7 +83,7 @@ def test_fastica_simple(add_noise, global_random_seed, global_dtype):
         and os.getenv("DISTRIB") == "ubuntu"
     ):
         pytest.xfail(
-            "fastica instability with Ubuntu Atlas build with float32 "
+            "FastICA instability with Ubuntu Atlas build with float32 "
             "global_dtype. For more details, see "
             "https://github.com/scikit-learn/scikit-learn/issues/24131#issuecomment-1208091119"  # noqa
         )

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -84,8 +84,7 @@ def test_fastica_simple(add_noise, global_random_seed, global_dtype):
         pytest.xfail(
             "fastica instability with Ubuntu Atlas build with float32 "
             "global_dtype. For more details, see "
-            "https://github.com/scikit-learn/scikit-learn/issues/24131"
-            "#issuecomment-1208091119"
+            "https://github.com/scikit-learn/scikit-learn/issues/24131#issuecomment-1208091119"  # noqa
         )
 
     # Test the FastICA algorithm on very simple data.

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -79,6 +79,7 @@ def test_fastica_simple(add_noise, global_random_seed, global_dtype):
     if (
         global_random_seed == 20
         and global_dtype == np.float32
+        and not add_noise
         and os.getenv("DISTRIB") == "ubuntu"
     ):
         pytest.xfail(


### PR DESCRIPTION
This fixes the Ubuntu atlas issue seen in https://github.com/scikit-learn/scikit-learn/issues/24131#issuecomment-1208091119. I have tried using the magic `[all random seeds]` syntax for the CI, let's see if that works :crossed_fingers:.

This is definitely a kludgy work-around but maybe good enough since the failure seems to happen quite rarely (see below for more details)?

The snippet below reproduces the problem (both for Ubuntu 20.04 with atlas and when installing from conda-forge). Trying different `random_state` for the `fastica` call, the exception happens 1-3 times out of 10000 so maybe this is rare enough to use this work-around. 

```py
import numpy as np
from scipy import stats
from sklearn.decomposition import fastica
import sys

global_random_seed = 20
global_dtype = np.float32


def center_and_norm(x, axis=-1):
    x = np.rollaxis(x, axis)
    x -= x.mean(axis=0)
    x /= x.std(axis=0)


rng = np.random.RandomState(global_random_seed)
n_samples = 1000
# Generate two sources:
s1 = (2 * np.sin(np.linspace(0, 100, n_samples)) > 0) - 1
s2 = stats.t.rvs(1, size=n_samples, random_state=global_random_seed)
s = np.c_[s1, s2].T
center_and_norm(s)
s = s.astype(global_dtype)
s1, s2 = s

# Mixing angle
phi = 0.6
mixing = np.array([[np.cos(phi), np.sin(phi)], [np.sin(phi), -np.cos(phi)]])
mixing = mixing.astype(global_dtype)
m = np.dot(mixing, s)
center_and_norm(m)

algo = 'deflation'
nl = 'logcosh'
whiten = 'arbitrary-variance'

problematic_random_state = 13441

k_, mixing_, s_ = fastica(
    m.T, fun=nl, whiten=whiten, algorithm=algo, random_state=problematic_random_state
)
```

More than happy to create an issue about the division by zero in fastica for a more proper fix