### PR TITLE
CI Remove pandas FutureWarning in scipy-dev build

### DIFF
--- a/sklearn/datasets/_arff_parser.py
+++ b/sklearn/datasets/_arff_parser.py
@@ -392,8 +392,12 @@ def _pandas_arff_parser(
     # `"'some string value'"` with pandas.
     single_quote_pattern = re.compile(r"^'(?P<contents>.*)'$")
 
-    def strip_quotes_regex(s):
-        return s.group("contents")
+    def strip_single_quotes(input_string):
+        match = re.search(single_quote_pattern, input_string)
+        if match is None:
+            return input_string
+
+        return match.group("contents")
 
     categorical_columns = [
         name
@@ -401,9 +405,8 @@ def _pandas_arff_parser(
         if pd.api.types.is_categorical_dtype(dtype)
     ]
     for col in categorical_columns:
-        frame[col].cat.categories = frame[col].cat.categories.str.replace(
-            single_quote_pattern, strip_quotes_regex, regex=True
-        )
+        frame[col] = frame[col].cat.rename_categories(strip_single_quotes)
+
     X, y = _post_process_frame(frame, feature_names_to_select, target_names_to_select)
 
     if output_arrays_type == "pandas":


### PR DESCRIPTION
Fix #24203.

Setting the categories in place yield a FutureWarning in the pandas dev version.

```py
import pandas as pd

df = pd.DataFrame({'a': [1, 2, 3]}, dtype='category')

f['a'].cat.categories = [1, 2, 3]
```

```
<ipython-input-4-9b315f2b1a4c>:1: FutureWarning: Setting categories in-place is deprecated and will raise in a future version. Use rename_categories instead.
  df['a'].cat.categories = [1, 2, 3]
```
