### PR TITLE
fix rgb color to hex

### DIFF
--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -243,7 +243,7 @@ class _BaseTreeExporter:
         # compute the color as alpha against white
         color = [int(round(alpha * c + (1 - alpha) * 255, 0)) for c in color]
         # Return html color code in #RRGGBB format
-        return "#%2x%2x%2x" % tuple(color)
+        return "#%02x%02x%02x" % tuple(color)
 
     def get_fill_color(self, tree, node_id):
         # Fetch appropriate color for node


### PR DESCRIPTION
Hi guys, 
I custom colors to plot tree, but an error occurred, it said:
```
ValueError: Invalid RGBA argument: '# 62adc'
```
then I found that  it was the problem of converting the color to hex:

```
color = [1,2,3]
"#%2x%2x%2x" % tuple(color)
# the formatted str is "# 1 2 3"
```

Change it to the following way to make it safer :
```
color = [1,2,3]
"#%02x%02x%02x" % tuple(color)
# the formatted str is "#010203"
```

References:
https://github.com/scikit-learn/scikit-learn/blob/5fd66bc55f03740f395971abf1189b11594252b1/sklearn/tree/_export.py#L267

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
