### PR TITLE
DOC Ensures that strip_accents_unicode passes numpydoc

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -122,7 +122,7 @@ def _analyze(
 
 
 def strip_accents_unicode(s):
-    """Transform accentuated unicode symbols into their simple counterpart
+    """Transform accentuated unicode symbols into their simple counterpart.
 
     Warning: the python-level loop and join operations make this
     implementation 20 times slower than the strip_accents_ascii basic
@@ -130,13 +130,21 @@ def strip_accents_unicode(s):
 
     Parameters
     ----------
-    s : string
-        The string to strip
+    s : str
+        The string to strip.
+
+    Returns
+    -------
+    s : str
+        The stripped string.
 
     See Also
     --------
     strip_accents_ascii : Remove accentuated char for any unicode symbol that
         has a direct ASCII equivalent.
+    """
+    """_summary_
+
     """
     try:
         # If `s` is ASCII-compatible, then it does not contain any accented

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -143,9 +143,6 @@ def strip_accents_unicode(s):
     strip_accents_ascii : Remove accentuated char for any unicode symbol that
         has a direct ASCII equivalent.
     """
-    """_summary_
-
-    """
     try:
         # If `s` is ASCII-compatible, then it does not contain any accented
         # characters and we can avoid an expensive list comprehension

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -16,7 +16,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.decomposition._dict_learning.dict_learning_online",
     "sklearn.decomposition._nmf.non_negative_factorization",
     "sklearn.externals._packaging.version.parse",
-    "sklearn.feature_extraction.text.strip_accents_unicode",
     "sklearn.inspection._plot.partial_dependence.plot_partial_dependence",
     "sklearn.linear_model._least_angle.lars_path_gram",
     "sklearn.linear_model._omp.orthogonal_mp_gram",


### PR DESCRIPTION
Reference Issues/PRs

Addresses https://github.com/scikit-learn/scikit-learn/issues/21350
What does this implement/fix? Explain your changes.

No errors were thrown for strip_accents_unicode. Therefore just removed it from the list of functions whose docstring should be ignored: `FUNCTION_DOCSTRING_IGNORE_LIST`.

Any other comments?

None, a simple enough first PR!

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
