### PR TITLE
DOC Ensures that non_negative_factorization passes numpydoc

### DIFF
--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -985,7 +985,6 @@ def non_negative_factorization(
 
             &+ 0.5 * alpha\\_H * (1 - l1\\_ratio) * n\\_samples * ||H||_{Fro}^2
 
-
     Where:
 
     :math:`||A||_{Fro}^2 = \\sum_{i,j} A_{ij}^2` (Frobenius norm)
@@ -1142,14 +1141,6 @@ def non_negative_factorization(
     n_iter : int
         Actual number of iterations.
 
-    Examples
-    --------
-    >>> import numpy as np
-    >>> X = np.array([[1,1], [2, 1], [3, 1.2], [4, 1], [5, 0.8], [6, 1]])
-    >>> from sklearn.decomposition import non_negative_factorization
-    >>> W, H, n_iter = non_negative_factorization(
-    ...     X, n_components=2, init='random', random_state=0)
-
     References
     ----------
     .. [1] :doi:`"Fast local algorithms for large scale nonnegative matrix and tensor
@@ -1160,6 +1151,14 @@ def non_negative_factorization(
     .. [2] :doi:`"Algorithms for nonnegative matrix factorization with the
        beta-divergence" <10.1162/NECO_a_00168>`
        Fevotte, C., & Idier, J. (2011). Neural Computation, 23(9).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> X = np.array([[1,1], [2, 1], [3, 1.2], [4, 1], [5, 0.8], [6, 1]])
+    >>> from sklearn.decomposition import non_negative_factorization
+    >>> W, H, n_iter = non_negative_factorization(
+    ...     X, n_components=2, init='random', random_state=0)
     """
     X = check_array(X, accept_sparse=("csr", "csc"), dtype=[np.float64, np.float32])
 

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -14,7 +14,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.decomposition._dict_learning.dict_learning",
     "sklearn.decomposition._dict_learning.dict_learning_online",
-    "sklearn.decomposition._nmf.non_negative_factorization",
     "sklearn.externals._packaging.version.parse",
     "sklearn.feature_extraction.text.strip_accents_unicode",
     "sklearn.inspection._plot.partial_dependence.plot_partial_dependence",


### PR DESCRIPTION
Reference Issues/PRs

Addresses https://github.com/scikit-learn/scikit-learn/issues/21350
What does this implement/fix? Explain your changes.
Just fixed 2 small issues in the docstring concerning the order of the paragraphs and a double linebreak.

Any other comments?

This is my and @majauhar first pull request made during #DataUmbrella sprint.