### PR TITLE
MAINT Parameters validation for AdditiveChi2Sampler

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -599,6 +599,19 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
     def __init__(self, *, sample_steps=2, sample_interval=None):
         self.sample_steps = sample_steps
         self.sample_interval = sample_interval
+        self._map_sample_steps_to_sample_interval()
+
+    def _map_sample_steps_to_sample_interval(self):
+        if self.sample_interval is None:
+            # See reference, figure 2 c)
+            if self.sample_steps == 1:
+                self.sample_interval_ = 0.8
+            elif self.sample_steps == 2:
+                self.sample_interval_ = 0.5
+            elif self.sample_steps == 3:
+                self.sample_interval_ = 0.4
+        else:
+            self.sample_interval_ = self.sample_interval
 
     def fit(self, X, y=None):
         """Set the parameters.
@@ -621,22 +634,6 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
         self._validate_params()
         X = self._validate_data(X, accept_sparse="csr")
         check_non_negative(X, "X in AdditiveChi2Sampler.fit")
-
-        if self.sample_interval is None:
-            # See reference, figure 2 c)
-            if self.sample_steps == 1:
-                self.sample_interval_ = 0.8
-            elif self.sample_steps == 2:
-                self.sample_interval_ = 0.5
-            elif self.sample_steps == 3:
-                self.sample_interval_ = 0.4
-            else:
-                raise ValueError(
-                    "If sample_steps is not in [1, 2, 3],"
-                    " you need to provide sample_interval"
-                )
-        else:
-            self.sample_interval_ = self.sample_interval
         return self
 
     def transform(self, X):

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -592,31 +592,13 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
     """
 
     _parameter_constraints = {
-        "sample_steps": [Interval(int, left=1, right=None, closed="left")],
+        "sample_steps": [Interval(int, 1, None, closed="left")],
         "sample_interval": [None, Interval(float, 0, None, closed="left")],
     }
 
     def __init__(self, *, sample_steps=2, sample_interval=None):
         self.sample_steps = sample_steps
         self.sample_interval = sample_interval
-        self._map_sample_steps_to_sample_interval()
-
-    def _map_sample_steps_to_sample_interval(self):
-        if self.sample_interval is None:
-            # See reference, figure 2 c)
-            if self.sample_steps == 1:
-                self.sample_interval_ = 0.8
-            elif self.sample_steps == 2:
-                self.sample_interval_ = 0.5
-            elif self.sample_steps == 3:
-                self.sample_interval_ = 0.4
-            else:
-                raise ValueError(
-                    "If sample_steps is not in [1, 2, 3],"
-                    " you need to provide sample_interval"
-                )
-        else:
-            self.sample_interval_ = self.sample_interval
 
     def fit(self, X, y=None):
         """Set the parameters.
@@ -637,6 +619,21 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
             Returns the transformer.
         """
         self._validate_params()
+        if self.sample_interval is None:
+            # See reference, figure 2 c)
+            if self.sample_steps == 1:
+                self.sample_interval_ = 0.8
+            elif self.sample_steps == 2:
+                self.sample_interval_ = 0.5
+            elif self.sample_steps == 3:
+                self.sample_interval_ = 0.4
+            else:
+                raise ValueError(
+                    "If sample_steps is not in [1, 2, 3],"
+                    " you need to provide sample_interval"
+                )
+        else:
+            self.sample_interval_ = self.sample_interval
         X = self._validate_data(X, accept_sparse="csr")
         check_non_negative(X, "X in AdditiveChi2Sampler.fit")
         return self

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -28,6 +28,7 @@ from .utils.validation import check_is_fitted
 from .utils.validation import _check_feature_names_in
 from .metrics.pairwise import pairwise_kernels, KERNEL_PARAMS
 from .utils.validation import check_non_negative
+from .utils._param_validation import Interval
 
 
 class PolynomialCountSketch(
@@ -590,6 +591,11 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
     0.9499...
     """
 
+    _parameter_constraints = {
+        "sample_steps": [Interval(int, left=1, right=3, closed="both")],
+        "sample_interval": [None, Interval(float, 0, None, closed="left")],
+    }
+
     def __init__(self, *, sample_steps=2, sample_interval=None):
         self.sample_steps = sample_steps
         self.sample_interval = sample_interval
@@ -612,6 +618,7 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
         self : object
             Returns the transformer.
         """
+        self._validate_params()
         X = self._validate_data(X, accept_sparse="csr")
         check_non_negative(X, "X in AdditiveChi2Sampler.fit")
 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -592,7 +592,7 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
     """
 
     _parameter_constraints = {
-        "sample_steps": [Interval(int, left=1, right=3, closed="both")],
+        "sample_steps": [Interval(int, left=1, right=None, closed="left")],
         "sample_interval": [None, Interval(float, 0, None, closed="left")],
     }
 
@@ -610,6 +610,11 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
                 self.sample_interval_ = 0.5
             elif self.sample_steps == 3:
                 self.sample_interval_ = 0.4
+            else:
+                raise ValueError(
+                    "If sample_steps is not in [1, 2, 3],"
+                    " you need to provide sample_interval"
+                )
         else:
             self.sample_interval_ = self.sample_interval
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -464,7 +464,6 @@ def test_estimators_do_not_raise_errors_in_init_or_set_params(Estimator):
 
 
 PARAM_VALIDATION_ESTIMATORS_TO_IGNORE = [
-    "AdditiveChi2Sampler",
     "BayesianRidge",
     "CalibratedClassifierCV",
     "ClassifierChain",

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -135,7 +135,7 @@ def test_additive_chi2_sampler():
 
     # test that the sample_interval is set correctly
     sample_interval = 0.3
-    transform = AdditiveChi2Sampler(sample_steps=3, sample_interval=sample_interval)
+    transform = AdditiveChi2Sampler(sample_steps=4, sample_interval=sample_interval)
     assert transform.sample_interval == sample_interval
     transform.fit(X)
     assert transform.sample_interval_ == sample_interval

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -1,5 +1,3 @@
-import re
-
 import numpy as np
 from scipy.sparse import csr_matrix
 import pytest
@@ -123,14 +121,6 @@ def test_additive_chi2_sampler():
     with pytest.raises(ValueError, match=msg):
         transform.transform(Y_neg)
 
-    # test error on invalid sample_steps
-    transform = AdditiveChi2Sampler(sample_steps=4)
-    msg = re.escape(
-        "If sample_steps is not in [1, 2, 3], you need to provide sample_interval"
-    )
-    with pytest.raises(ValueError, match=msg):
-        transform.fit(X)
-
     # test that the sample interval is set correctly
     sample_steps_available = [1, 2, 3]
     for sample_steps in sample_steps_available:
@@ -145,7 +135,7 @@ def test_additive_chi2_sampler():
 
     # test that the sample_interval is set correctly
     sample_interval = 0.3
-    transform = AdditiveChi2Sampler(sample_steps=4, sample_interval=sample_interval)
+    transform = AdditiveChi2Sampler(sample_steps=3, sample_interval=sample_interval)
     assert transform.sample_interval == sample_interval
     transform.fit(X)
     assert transform.sample_interval_ == sample_interval


### PR DESCRIPTION
Reference Issues/PRs

towards https://github.com/scikit-learn/scikit-learn/issues/23462
What does this implement/fix? Explain your changes.

    Defines _parameter_constraints in AdditiveChi2Sampler.
    Following the steps in the reference PR to let AdditiveChi2Sampler models calls self._validate_params.

Any other comments?
Nope.