### PR TITLE
[WIP] ENH Tree Splitter: 50% performance improvement with radix sort and feature ranks

### DIFF
--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -238,10 +238,11 @@ cdef class BestSplitter(BaseDenseSplitter):
     """Splitter for finding the best split."""
 
     cdef const SIZE_t[:, :] _X_ranks
-    cdef const SIZE_t[:, :] _X_order
     cdef SIZE_t[::1] feature_ranks
-    cdef SIZE_t[::1] _value_copies
-    cdef SIZE_t[::1] _index_copies
+
+    # Auxiliary arrays for sorting.
+    cdef SIZE_t[::1] _rank_copies
+    cdef SIZE_t[::1] _sample_copies
 
     cdef int init(self,
                   object X,
@@ -253,21 +254,22 @@ cdef class BestSplitter(BaseDenseSplitter):
         or 0 otherwise.
         """
 
-        #cdef SIZE_t i, j
-
-        # for i in range(self.n_samples):
-        #     for j in range(self.n_samples):
-        #         self._X_ranks[]
-
         # Call parent init
         Splitter.init(self, X, y, sample_weight)
 
         self.X = X
-        self._X_order = np.argsort(X, axis=0)
-        self._X_ranks = np.argsort(self._X_order, axis=0)
+
+        # TODO: accept X_ranks as parameter to avoid redundantly obtaining them
+        #       in ensembles and cross-validation.
+        # Since multiple sorting steps will be required in recursive X parti-
+        # tioning, its effective to calculate rank values for each feature
+        # and utilize integer sorting algorithms in subsequent runs.
+        self._X_ranks = np.argsort(np.argsort(X, axis=0), axis=0)
         self.feature_ranks = np.empty(self.n_samples, dtype=np.intp)
-        self._value_copies = np.empty(self.n_samples, dtype=np.intp)
-        self._index_copies = np.empty(self.n_samples, dtype=np.intp)
+
+        # Radix sort requires auxiliary arrays, that we allocate here only once.
+        self._rank_copies = np.empty(self.n_samples, dtype=np.intp)
+        self._sample_copies = np.empty(self.n_samples, dtype=np.intp)
 
         return 0
         
@@ -298,9 +300,8 @@ cdef class BestSplitter(BaseDenseSplitter):
         cdef DTYPE_t[::1] Xf = self.feature_values
         cdef SIZE_t[::1] Xf_ranks = self.feature_ranks
 
-        # TODO: remove
-        cdef SIZE_t[::1] value_copies = self._value_copies
-        cdef SIZE_t[::1] index_copies = self._index_copies
+        cdef SIZE_t[::1] rank_copies = self._rank_copies
+        cdef SIZE_t[::1] sample_copies = self._sample_copies
 
         cdef SIZE_t max_features = self.max_features
         cdef SIZE_t min_samples_leaf = self.min_samples_leaf
@@ -377,15 +378,16 @@ cdef class BestSplitter(BaseDenseSplitter):
             # f_j in the interval [n_total_constants, f_i[
             current.feature = features[f_j]
 
-            # Sort samples along that feature; by
-            # copying the values into an array and
-            # sorting the array in a manner which utilizes the cache more
-            # effectively.
             for i in range(start, end):
                 Xf_ranks[i] = self._X_ranks[samples[i], current.feature]
 
+            # Sort samples along that feature; by
+            # copying the ranks into an array and
+            # sorting the array in a manner which utilizes the cache more
+            # effectively. Sorting on ranks allows for using faster integer
+            # sorting algorithms such as radix sort.
             integer_sort(&Xf_ranks[start], &samples[start], end - start,
-                         &value_copies[0], &index_copies[0])
+                         &rank_copies[0], &sample_copies[0])
 
             for i in range(start, end):
                 Xf[i] = self.X[samples[i], current.feature]
@@ -498,11 +500,11 @@ cdef inline void sort(DTYPE_t* Xf, SIZE_t* samples, SIZE_t n) nogil:
 cdef inline void integer_sort(
     SIZE_t* Xf_ranks, SIZE_t* samples,
     SIZE_t n,
-    SIZE_t* value_copies, SIZE_t* index_copies,
+    SIZE_t* rank_copies, SIZE_t* sample_copies,
 ) nogil:
     if n == 0:
       return
-    simultaneous_radix_sort(Xf_ranks, samples, n, value_copies, index_copies)
+    simultaneous_radix_sort(Xf_ranks, samples, n, rank_copies, sample_copies)
 
 
 cdef inline void swap(DTYPE_t* Xf, SIZE_t* samples,

--- a/sklearn/utils/_sorting.pxd
+++ b/sklearn/utils/_sorting.pxd
@@ -7,3 +7,11 @@ cdef int simultaneous_sort(
     ITYPE_t *idx,
     ITYPE_t size,
 ) nogil
+
+cdef int simultaneous_radix_sort(
+    ITYPE_t *values,
+    ITYPE_t *indices,
+    ITYPE_t size,
+    ITYPE_t* value_copies,
+    ITYPE_t* index_copies,
+) nogil

--- a/sklearn/utils/_sorting.pyx
+++ b/sklearn/utils/_sorting.pyx
@@ -1,5 +1,4 @@
 from cython cimport floating
-from libc.stdlib cimport malloc, free
 
 
 cdef inline void dual_swap(

--- a/sklearn/utils/_sorting.pyx
+++ b/sklearn/utils/_sorting.pyx
@@ -91,3 +91,23 @@ cdef int simultaneous_sort(
                               indices + pivot_idx + 1,
                               size - pivot_idx - 1)
     return 0
+
+def radix_sort(xs, long r=8):
+    ''' 
+    Modifyied from https://searchcode.com/codesearch/view/29200571/
+
+    Efficient Radix Sort -- See http://www.koders.com/python/fidF772268CB8176B16FFA7B81B012D0253E894DBEB.aspx?s=merge+sort '''
+    cdef long k = 2**r
+    cdef long i, x, j
+    cdef long mask = int('1'*r, 2)
+    cdef long J = len(xs)
+    for i in range(0, 32/r):
+        counter = [0]*k
+        for j in range(0,J):
+            counter[(xs[j]>>(i*r))&mask] += 1
+        for j in range(1, k):
+            counter[j] = counter[j-1] + counter[j]
+        for x in reversed(xs[:]):
+            xs[counter[(x>>(i*r))&mask]-1] = x
+            counter[(x>>(i*r))&mask] -= 1
+    return xs


### PR DESCRIPTION
Since sorting on subsets of `X`'s columns is performed multiple times when searching for the best split, we can achieve around 50% reduction in split search duration by computing the ranks of each feature and using them for future sorts instead of the actual feature values in `Xf`, given that integer sorting algorithms such as radix sort can run in linear time. 

#### Benchmarks (script from https://github.com/scikit-learn/scikit-learn/pull/22868)
Test durations in seconds comparing this PR to `sklearn 1.1`:

![image](https://user-images.githubusercontent.com/24875675/186261845-8da2c71f-3a30-4017-bb3e-f922fe713625.png)

#### Pending discussion topics
- [ ] The extra memory needed to store the feature ranks may break old code using large datasets. Should this be an optional feature then? A `FasterBestSplitter` class could be created, allowing users to opt for the faster version using the `splitter` parameter of decision tree-based estimators. I haven't found a good way to implement this though, avoiding copy-pasting the whole `BestSplit.node_split()`. A `BestSplitter._sort()` method maybe could be created, but wrapping the two sorting procedures (radix and the current introsort)  in the same method seems a little complicated;
- [ ] We should be able to pass a precomputed `X_ranks` array to the Splitter to avoid redundant calculation in ensembles or cross-validation;
- [x] ~~In this implementation, I used `numpy.argsort` twice to compute the ranks. Is there any better option? Numpy [already uses](https://numpy.org/doc/stable/reference/generated/numpy.sort.html) radix sort for integer types;~~ Found a [way of sorting once](https://github.com/scikit-learn/scikit-learn/pull/24239#issuecomment-1226603092), based on Scipy's `rankdata`. I don't see much room for improvement, but ideas are always appreciated;
- [x] ~~In the first tree node, when the ranks are sorted, the results would be the sorted indices (output from `np.argsort`). Since these sorted indices would naturally be obtained when determining the ranks, is it possible to reuse them in the root node?~~ I imagine this would require to store not only the ranks but also the sorted indices, which adds a lot of memory load for very small gains. An alternative could be calculating the ranks in the root node, but I don't see any intuitive way of doing so;
- [ ] Two [auxiliary arrays ](https://github.com/scikit-learn/scikit-learn/compare/main...pedroilidio:scikit-learn:use_radix_sort?expand=1#diff-e2cca285e1e883ab1d427120dfa974c1ba83eb6e2f5d5f416bbd99717ca5f5fcR243-R245)were created, but some algorithms such as [American Flag Sorting
](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.22.6990) claim to be able to perform in-place sorting with similar time complexity. I did not explore those;
- [x] ~~Also implement a sparse splitter version.~~ Delegated to future PR. 

The branch passes all `tree/tests/test_tree.py` tests.
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
