### PR TITLE
FIX np.divide undefined behaviour with where in gaussian processes

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -198,6 +198,13 @@ Changelog
 :mod:`sklearn.feature_selection`
 ................................
 
+:mod:`sklearn.gaussian_process`
+...............................
+
+- |Fix| Fix :class:`gaussian_process.kernels.Matern` gradient computation with
+  `nu=0.5` for PyPy (and possibly other non CPython interpreters). :pr:`24245`
+  by :user:`Loïc Estève <lesteve>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1733,12 +1733,14 @@ class Matern(RBF):
 
             if self.nu == 0.5:
                 denominator = np.sqrt(D.sum(axis=2))[:, :, np.newaxis]
-                K_gradient = K[..., np.newaxis] * np.divide(
+                divide_result = np.zeros_like(D)
+                np.divide(
                     D,
                     denominator,
-                    out=np.zeros_like(D),
+                    out=divide_result,
                     where=denominator != 0,
                 )
+                K_gradient = K[..., np.newaxis] * divide_result
             elif self.nu == 1.5:
                 K_gradient = 3 * D * np.exp(-np.sqrt(3 * D.sum(-1)))[..., np.newaxis]
             elif self.nu == 2.5:

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -1734,7 +1734,10 @@ class Matern(RBF):
             if self.nu == 0.5:
                 denominator = np.sqrt(D.sum(axis=2))[:, :, np.newaxis]
                 K_gradient = K[..., np.newaxis] * np.divide(
-                    D, denominator, where=denominator != 0
+                    D,
+                    denominator,
+                    out=np.zeros_like(D),
+                    where=denominator != 0,
                 )
             elif self.nu == 1.5:
                 K_gradient = 3 * D * np.exp(-np.sqrt(3 * D.sum(-1)))[..., np.newaxis]

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -34,7 +34,6 @@ from sklearn.utils._testing import (
     assert_array_equal,
     assert_array_almost_equal,
     assert_allclose,
-    fails_if_pypy,
 )
 
 
@@ -70,8 +69,6 @@ for metric in PAIRWISE_KERNEL_FUNCTIONS:
     kernels.append(PairwiseKernel(gamma=1.0, metric=metric))
 
 
-# Numerical precisions errors in PyPy
-@fails_if_pypy
 @pytest.mark.parametrize("kernel", kernels)
 def test_kernel_gradient(kernel):
     # Compare analytic and numeric gradient of kernels.


### PR DESCRIPTION
Triggered by investigating #24221.

We are using code like:
```py
result = np.divide(numerator, denominator, where=denominator!=0)
```

`result[denominator == 0]` values are undefined when using this. For CPython it seems like the `np.empty` allocated for the return value reuses a temporary array created in a previous line that computes `(X[:, np.newaxis, :] - X[np.newaxis, :, :]) ** 2` so that `result[denominator == 0]` only contains 0. For PyPy this is not the case and at one point we get a 4. rather than a 0. (don't ask me where the 4. comes from ...).

A snippet to reproduce a similar behaviour:
```py
import numpy as np

numerator = np.array([1., 1., 1.])
denominator = np.array([0., 1., 1.])
where = denominator != 0

tmp = np.array([-999., -999., -999.])
print(f"tmp address: {tmp.__array_interface__['data'][0]}")
del tmp
divide_result = np.divide(numerator, denominator, where=where)
print(f"div address: {divide_result.__array_interface__['data'][0]}")
print(f"{divide_result}")
```

Output with CPython (address is the same so the -999. of the `tmp` array is reused):

```
tmp address: 94515367946736
div address: 94515367946736
[-999.    1.    1.]
```

Output with pypy (address is not the same first value is random):
```
tmp address: 94369592900336
div address: 94369602251488
[4.66247785e-310 1.00000000e+000 1.00000000e+000]
```
