### PR TITLE
CI simplify passing of environment variables in Azure docker template

### DIFF
--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -59,12 +59,14 @@ jobs:
     # the JUNITXML file
     - script: >
         docker container run --rm
-        --volume $TEST_DIR:$TEST_DIR
+        --volume $TEST_DIR:/temp_dir
         --volume $PWD:/io
-        --volume $CCACHE_DIR:$CCACHE_DIR
+        --volume $CCACHE_DIR:/ccache
         -w /io
         --detach
         --name skcontainer
+        -e TEST_DIR=/temp_dir
+        -e CCACHE_DIR=/ccache
         -e DISTRIB
         -e LOCK_FILE
         -e TEST_DIR

--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -13,6 +13,7 @@ jobs:
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:
+    VIRTUALENV: 'testvenv'
     TEST_DIR: '$(Agent.WorkFolder)/tmp_folder'
     JUNITXML: 'test-data.xml'
     OMP_NUM_THREADS: '2'
@@ -58,27 +59,26 @@ jobs:
     # the JUNITXML file
     - script: >
         docker container run --rm
-        --volume $TEST_DIR:/temp_dir
+        --volume $TEST_DIR:$TEST_DIR
         --volume $PWD:/io
-        --volume $CCACHE_DIR:/ccache
+        --volume $CCACHE_DIR:$CCACHE_DIR
         -w /io
         --detach
         --name skcontainer
-        -e DISTRIB=$DISTRIB
-        -e LOCK_FILE=$LOCK_FILE
-        -e TEST_DIR=/temp_dir
-        -e JUNITXML=$JUNITXML
-        -e VIRTUALENV=testvenv
-        -e PYTEST_XDIST_VERSION=$PYTEST_XDIST_VERSION
-        -e OMP_NUM_THREADS=$OMP_NUM_THREADS
-        -e OPENBLAS_NUM_THREADS=$OPENBLAS_NUM_THREADS
-        -e SKLEARN_SKIP_NETWORK_TESTS=$SKLEARN_SKIP_NETWORK_TESTS
-        -e SELECTED_TESTS="$SELECTED_TESTS"
-        -e CPU_COUNT=$CPU_COUNT
-        -e CCACHE_DIR=/ccache
-        -e CCACHE_COMPRESS=$CCACHE_COMPRESS
-        -e BUILD_SOURCEVERSIONMESSAGE="$BUILD_SOURCEVERSIONMESSAGE"
-        -e BUILD_REASON="$BUILD_REASON"
+        -e DISTRIB
+        -e LOCK_FILE
+        -e TEST_DIR
+        -e JUNITXML
+        -e VIRTUALENV
+        -e PYTEST_XDIST_VERSION
+        -e OMP_NUM_THREADS
+        -e OPENBLAS_NUM_THREADS
+        -e SKLEARN_SKIP_NETWORK_TESTS
+        -e SELECTED_TESTS
+        -e CPU_COUNT
+        -e CCACHE_COMPRESS
+        -e BUILD_SOURCEVERSIONMESSAGE
+        -e BUILD_REASON
         $DOCKER_CONTAINER
         sleep 1000000
       displayName: 'Start container'


### PR DESCRIPTION
This simplifies passing env variable into the docker container by using `-e VAR` instead of `-e VAR=$VAR`. The main motivation is that it is easy to forget doing `-e VAR="$VAR"` where quoting is needed and then you get an error which is not super easy to diagnose. I bumped into this at one point in #24202. 

Other tweaks to achieve this which can be reverted if too controversial:
- use bind volumes with same name in the host and the container. I think this should not cause any issues.
- use `VIRTUALENV` as yml environment variable, which is also consistent with other Azure templates

In this PR, the only build to watch to check nothing is too badly broken is debian 32bit build.