### PR TITLE
DOC Ensures that top_k_accuracy_score passes numpydoc validation

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1704,9 +1704,11 @@ def top_k_accuracy_score(
         `normalize == True` and the number of samples with
         `normalize == False`.
 
-    See also
+    See Also
     --------
-    accuracy_score
+    accuracy_score : Compute the accuracy score. By default, the function will
+        return the fraction of correct predictions divided by the total number
+        of predictions.
 
     Notes
     -----
@@ -1729,7 +1731,6 @@ def top_k_accuracy_score(
     >>> # Not normalizing gives the number of "correctly" classified samples
     >>> top_k_accuracy_score(y_true, y_score, k=2, normalize=False)
     3
-
     """
     y_true = check_array(y_true, ensure_2d=False, dtype=None)
     y_true = column_or_1d(y_true)

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -25,7 +25,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics._ranking.coverage_error",
     "sklearn.metrics._ranking.dcg_score",
     "sklearn.metrics._ranking.roc_curve",
-    "sklearn.metrics._ranking.top_k_accuracy_score",
     "sklearn.metrics._regression.mean_pinball_loss",
     "sklearn.metrics.cluster._bicluster.consensus_score",
     "sklearn.metrics.cluster._supervised.adjusted_mutual_info_score",


### PR DESCRIPTION
#### Reference Issues/PRs
This pull request addresses #21350.

#### What does this implement/fix? Explain your changes.
1. Deleted an extra blank line at the end of the docstring.
2. Updated the section "See Also" instead of "See also".
3. Added a description to the "accuracy_score" inside the "See Also" section.
4. Removed the `sklearn.metrics._ranking.top_k_accuracy_score` string from `FUNCTION_DOCSTRING_IGNORE_LIST` at docstring's test file.

#### Any other comments?
When I was looking for what exactly to add for the `accuracy_score` description I did a `grep -r "accuracy_score : " sklearn/metrics` and found this 3 instances where `accuracy_score` appears on "See Also" section (respectively for `jaccard_score`, `zero_one_loss` and `hamming_loss`):

https://github.com/scikit-learn/scikit-learn/blob/feaf3829969b640594a145029e3adcffd2db0999/sklearn/metrics/_classification.py#L745-L747

https://github.com/scikit-learn/scikit-learn/blob/feaf3829969b640594a145029e3adcffd2db0999/sklearn/metrics/_classification.py#L956-L960

https://github.com/scikit-learn/scikit-learn/blob/feaf3829969b640594a145029e3adcffd2db0999/sklearn/metrics/_classification.py#L2431-L2435

As the `zero_one_loss` and `hamming_loss` description of the `accuracy_score` looked more complete I decided to go with theirs for now. To be honest, I don't know what would be the best pattern you prefer. A loat of this "See Also" description are very straightforward, such as:

https://github.com/scikit-learn/scikit-learn/blob/feaf3829969b640594a145029e3adcffd2db0999/sklearn/metrics/_classification.py#L2436

Also, **_should I update the `jaccard_score`'s `accuracy_score` description to match?_** I'm just raising this because I think it would make sense if all the "See Also" descriptions were equal. But I don't know if you are concerned about this.

Thanks in advance for the reviews! :D