### PR TITLE
DOC Correct typo in SelectFromModel

### DIFF
--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -123,7 +123,7 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
         - If an integer, then it specifies the maximum number of features to
           allow.
         - If a callable, then it specifies how to calculate the maximum number of
-          features allowed by using the output of `max_feaures(X)`.
+          features allowed by using the output of `max_features(X)`.
         - If `None`, then all features are kept.
 
         To only select based on ``max_features``, set ``threshold=-np.inf``.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixing docstring from max_feaures to max_fea**t**ures(X).
