### PR TITLE
CI Update to macOS-11 in Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,7 +243,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.15
+    vmImage: macOS-11
     dependsOn: [linting, git_commit]
     condition: |
       and(


### PR DESCRIPTION
`macOS-10.15` is deprecated and going through a brownout. This PR updates the image to use macOS-11.