### PR TITLE
Isomap use validate params

### DIFF
--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -17,6 +17,8 @@ from ..utils.validation import check_is_fitted
 from ..decomposition import KernelPCA
 from ..preprocessing import KernelCenterer
 from ..utils.graph import _fix_connected_components
+from ..utils._param_validation import StrOptions, Interval
+from numbers import Integral, Real
 
 
 class Isomap(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
@@ -158,6 +160,51 @@ class Isomap(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
     >>> X_transformed.shape
     (100, 2)
     """
+
+    _parameter_constraints = {
+        "n_neighbors": [Interval(Integral, 0, None, closed="left"), None],
+        "radius": [Interval(Real, 0.0, None, closed="left"), None],
+        "n_components": [Interval(Integral, 1, None, closed="left"), None],
+        "eigen_solver": [StrOptions({"auto", "dense", "arpack"})],
+        "tol": [Interval(Real, 0.0, None, closed="left")],
+        "max_iter": [Interval(Integral, 0, None, closed="left"), None],
+        "path_method": [StrOptions({"auto", "FW", "D"})],
+        "neighbors_algorithm": [StrOptions({"auto", "brute", "kd_tree", "ball_tree"})],
+        "n_jobs": [Integral, None],
+        "metric": [
+            StrOptions(
+                {
+                    "minkowski",
+                    "cityblock",
+                    "cosine",
+                    "euclidean",
+                    "l1",
+                    "l2",
+                    "manhattan",
+                    "braycurtis",
+                    "canberra",
+                    "chebyshev",
+                    "correlation",
+                    "dice",
+                    "hamming",
+                    "jaccard",
+                    "mahalanobis",
+                    "minkowski",
+                    "rogerstanimoto",
+                    "russellrao",
+                    "seuclidean",
+                    "sokalmichener",
+                    "sokalsneath",
+                    "sqeuclidean",
+                    "yule",
+                    "precomputed",
+                }
+            ),
+            callable,
+        ],
+        "p": [Interval(Integral, 0, 1, closed="neither")],
+        "metric_params": [dict, None],
+    }
 
     def __init__(
         self,
@@ -325,6 +372,7 @@ class Isomap(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         self : object
             Returns a fitted instance of self.
         """
+        self._validate_params()
         self._fit_transform(X)
         return self
 

--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -13,6 +13,7 @@ from scipy.sparse.csgraph import connected_components
 from ..base import BaseEstimator, TransformerMixin, _ClassNamePrefixFeaturesOutMixin
 from ..neighbors import NearestNeighbors, kneighbors_graph
 from ..neighbors import radius_neighbors_graph
+from ..metrics import get_scorer_names
 from ..utils.validation import check_is_fitted
 from ..decomposition import KernelPCA
 from ..preprocessing import KernelCenterer
@@ -172,37 +173,10 @@ class Isomap(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         "neighbors_algorithm": [StrOptions({"auto", "brute", "kd_tree", "ball_tree"})],
         "n_jobs": [Integral, None],
         "metric": [
-            StrOptions(
-                {
-                    "minkowski",
-                    "cityblock",
-                    "cosine",
-                    "euclidean",
-                    "l1",
-                    "l2",
-                    "manhattan",
-                    "braycurtis",
-                    "canberra",
-                    "chebyshev",
-                    "correlation",
-                    "dice",
-                    "hamming",
-                    "jaccard",
-                    "mahalanobis",
-                    "minkowski",
-                    "rogerstanimoto",
-                    "russellrao",
-                    "seuclidean",
-                    "sokalmichener",
-                    "sokalsneath",
-                    "sqeuclidean",
-                    "yule",
-                    "precomputed",
-                }
-            ),
+            StrOptions(set(get_scorer_names())),
             callable,
         ],
-        "p": [Interval(Integral, 0, 1, closed="neither")],
+        "p": [Interval(Integral, 0, None, closed="neither")],
         "metric_params": [dict, None],
     }
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -473,7 +473,6 @@ PARAM_VALIDATION_ESTIMATORS_TO_IGNORE = [
     "FunctionTransformer",
     "GenericUnivariateSelect",
     "HashingVectorizer",
-    # "Isomap",
     "IterativeImputer",
     "LabelPropagation",
     "LabelSpreading",

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -473,7 +473,7 @@ PARAM_VALIDATION_ESTIMATORS_TO_IGNORE = [
     "FunctionTransformer",
     "GenericUnivariateSelect",
     "HashingVectorizer",
-    "Isomap",
+    # "Isomap",
     "IterativeImputer",
     "LabelPropagation",
     "LabelSpreading",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Towards #23462.


#### What does this implement/fix? Explain your changes.
- Defines `_parameter_constraints` in `Isomap`.
- Calls `self._validate_params` in `fit()`


#### Any other comments?
If I could get some feedback, when running `pytest` I receive an error stating the parameter `eigen_solver` requires values in `{"auto, ...}`, but if you see the code I have already done so. The error message is rather non-descript and I do not see where the issue might lie.
