### PR TITLE
MAINT `@abstractmethod` in `_gb_losses.py`

### DIFF
--- a/sklearn/ensemble/_gb_losses.py
+++ b/sklearn/ensemble/_gb_losses.py
@@ -35,9 +35,9 @@ class LossFunction(metaclass=ABCMeta):
     def __init__(self, n_classes):
         self.K = n_classes
 
+    @abstractmethod
     def init_estimator(self):
         """Default ``init`` estimator for loss function."""
-        raise NotImplementedError()
 
     @abstractmethod
     def __call__(self, y, raw_predictions, sample_weight=None):
@@ -584,6 +584,7 @@ class QuantileLossFunction(RegressionLossFunction):
 class ClassificationLossFunction(LossFunction, metaclass=ABCMeta):
     """Base class for classification loss functions."""
 
+    @abstractmethod
     def _raw_prediction_to_proba(self, raw_predictions):
         """Template method to convert raw predictions into probabilities.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Some methods in `sklearn/ensemble/_gb_losses.py` seem to have 
`@abstractmethod` decorator.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
