### PR TITLE
Raise Error when (max_samples * X.shape[0]) is less than 1.0

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -338,8 +338,8 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         """
         self._validate_params()
         # Ensure that there are insufficient samples for max_samples value
-        if 0.0 < self.max_samples < 1.0 and not int(X.shape[0] * self.max_samples) :
-            raise ValueError("insufficient samples for max_samples value")
+        if not int(X.shape[0] * self.max_samples) :
+            raise ValueError("max_samples value is too low to generate any samples")
         # Validate or convert input data
         if issparse(y):
             raise ValueError("sparse multilabel-indicator for y is not supported.")

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -337,7 +337,9 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             Fitted estimator.
         """
         self._validate_params()
-
+        # Ensure that there are insufficient samples for max_samples value
+        if 0.0 < self.max_samples < 1.0 and not int(X.shape[0] * self.max_samples) :
+            raise ValueError("insufficient samples for max_samples value")
         # Validate or convert input data
         if issparse(y):
             raise ValueError("sparse multilabel-indicator for y is not supported.")

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -338,7 +338,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         """
         self._validate_params()
         # Ensure that the max_samples value is enough to make any samples
-        if not int(X.shape[0] * self.max_samples) :
+        if not int(X.shape[0] * self.max_samples):
             raise ValueError("max_samples value is too low to generate any samples")
         # Validate or convert input data
         if issparse(y):

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -337,7 +337,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             Fitted estimator.
         """
         self._validate_params()
-        # Ensure that there are insufficient samples for max_samples value
+        # Ensure that the max_samples value is enough to make any samples
         if not int(X.shape[0] * self.max_samples) :
             raise ValueError("max_samples value is too low to generate any samples")
         # Validate or convert input data


### PR DESCRIPTION
Reference Issues/PRs
I have solved the wrong error output for a small enough max_samples value.
Fixes [#24037](https://github.com/scikit-learn/scikit-learn/issues/24037)

What does this implement/fix? Explain your changes.
When RandomForestClassifier is initialized with a float max_samples value between [0.0 and 1.0], then it will draw (max_samples * X.shape[0]) number of samples. Please see [RandomForestClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html).
However, when the max_samples value is small enough so the number of drawn samples is less than 1.0, there was an error of "IndexError: arrays used as indices must be of integer (or boolean) type".

I have added an if statement in the fit function, that when (max_samples * X.shape[0]) is less than 1, now it raises a ValueError of "max_samples value is too low to generate any samples".

Any other comments?
This is my first contribution to scikit-learn repo, so I am very excited about this pull request.


