### PR TITLE
CI Update to MacOS-11 in azure build for MacOS-10.15 is deprecated.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,7 +243,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.15
+    vmImage: macOS-11
     dependsOn: [linting, git_commit]
     condition: |
       and(


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #24269

#### What does this implement/fix? Explain your changes.
This pull request update to MacOS-11 the Mac builds on Azure, see https://github.com/actions/runner-images/issues/5583 for reference

#### Any other comments?
Brownout of MacOS-10 are also the reason for the failure of eg #24146 and #24132.
I made a conservative choice not upgrading to MacOS-12 or latest, hoping not to generate too much incompatibilities.
