### PR TITLE
CI Fixes junit in CI based on docker

### DIFF
--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -69,7 +69,6 @@ jobs:
         -e CCACHE_DIR=/ccache
         -e DISTRIB
         -e LOCK_FILE
-        -e TEST_DIR
         -e JUNITXML
         -e VIRTUALENV
         -e PYTEST_XDIST_VERSION


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/pull/24251
Fixes https://github.com/scikit-learn/scikit-learn/issues/24280
Fixes https://github.com/scikit-learn/scikit-learn/issues/24279


#### What does this implement/fix? Explain your changes.
The second `TEST_DIR` is overwriting the first one:

https://github.com/scikit-learn/scikit-learn/blob/7ae0cb688a25701c2019dfc0e55f0e07bf234346/build_tools/azure/posix-docker.yml#L68

which is causing the junit file to end up not in the mounted volume.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
