### PR TITLE
MNT Adds dict typing hint to _parameter_constraints for mypy

### DIFF
--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -405,7 +405,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
            [4, 2]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "damping": [Interval(Real, 0.5, 1.0, closed="left")],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
         "convergence_iter": [Interval(Integral, 1, None, closed="left")],

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -890,7 +890,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
     array([1, 1, 1, 0, 0, 0])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_clusters": [Interval(Integral, 1, None, closed="left"), None],
         "affinity": [
             Hidden(StrOptions({"deprecated"})),
@@ -1257,7 +1257,7 @@ class FeatureAgglomeration(
     (1797, 32)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_clusters": [Interval(Integral, 1, None, closed="left"), None],
         "affinity": [
             Hidden(StrOptions({"deprecated"})),

--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -479,7 +479,7 @@ class Birch(
     array([0, 0, 0, 1, 1, 1])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "threshold": [Interval(Real, 0.0, None, closed="neither")],
         "branching_factor": [Interval(Integral, 1, None, closed="neither")],
         "n_clusters": [None, ClusterMixin, Interval(Integral, 1, None, closed="left")],

--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -204,7 +204,7 @@ class BisectingKMeans(_BaseKMeans):
            [ 1., 2.]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseKMeans._parameter_constraints,
         "init": [StrOptions({"k-means++", "random"}), callable],
         "copy_x": ["boolean"],

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -299,7 +299,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
     DBSCAN(eps=3, min_samples=2)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "eps": [Interval(Real, 0.0, None, closed="neither")],
         "min_samples": [Interval(Integral, 1, None, closed="left")],
         "metric": [

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -832,7 +832,7 @@ class _BaseKMeans(
 ):
     """Base class for KMeans and MiniBatchKMeans"""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_clusters": [Interval(Integral, 1, None, closed="left")],
         "init": [StrOptions({"k-means++", "random"}), callable, "array-like"],
         "n_init": [
@@ -1336,7 +1336,7 @@ class KMeans(_BaseKMeans):
            [ 1.,  2.]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseKMeans._parameter_constraints,
         "copy_x": ["boolean"],
         "algorithm": [
@@ -1841,7 +1841,7 @@ class MiniBatchKMeans(_BaseKMeans):
     array([1, 0], dtype=int32)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseKMeans._parameter_constraints,
         "batch_size": [Interval(Integral, 1, None, closed="left")],
         "compute_labels": ["boolean"],

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -381,7 +381,7 @@ class MeanShift(ClusterMixin, BaseEstimator):
     MeanShift(bandwidth=2)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "bandwidth": [Interval(Real, 0, None, closed="neither"), None],
         "seeds": ["array-like", None],
         "bin_seeding": ["boolean"],

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -617,7 +617,7 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
         random_state=0)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_clusters": [Interval(Integral, 1, None, closed="left")],
         "eigen_solver": [StrOptions({"arpack", "lobpcg", "amg"}), None],
         "n_components": [Interval(Integral, 1, None, closed="left"), None],

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -128,7 +128,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
     array([2.])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "regressor": [HasMethods(["fit", "predict"]), None],
         "transformer": [HasMethods("transform"), None],
         "func": [callable, None],

--- a/sklearn/covariance/_elliptic_envelope.py
+++ b/sklearn/covariance/_elliptic_envelope.py
@@ -141,7 +141,7 @@ class EllipticEnvelope(OutlierMixin, MinCovDet):
     """
 
     _parameter_constraints = {
-        **MinCovDet._parameter_constraints,  # type: ignore
+        **MinCovDet._parameter_constraints,
         "contamination": [Interval(Real, 0, 0.5, closed="right")],
     }
 

--- a/sklearn/covariance/_elliptic_envelope.py
+++ b/sklearn/covariance/_elliptic_envelope.py
@@ -140,7 +140,7 @@ class EllipticEnvelope(OutlierMixin, MinCovDet):
     array([0.0813... , 0.0427...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **MinCovDet._parameter_constraints,
         "contamination": [Interval(Real, 0, 0.5, closed="right")],
     }

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -167,7 +167,7 @@ class EmpiricalCovariance(BaseEstimator):
     array([0.0622..., 0.0193...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "store_precision": ["boolean"],
         "assume_centered": ["boolean"],
     }

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -340,7 +340,7 @@ def graphical_lasso(
 
 
 class BaseGraphicalLasso(EmpiricalCovariance):
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **EmpiricalCovariance._parameter_constraints,
         "tol": [Interval(Real, 0, None, closed="right")],
         "enet_tol": [Interval(Real, 0, None, closed="right")],
@@ -463,7 +463,7 @@ class GraphicalLasso(BaseGraphicalLasso):
     array([0.073, 0.04 , 0.038, 0.143])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseGraphicalLasso._parameter_constraints,
         "alpha": [Interval(Real, 0, None, closed="right")],
     }
@@ -840,7 +840,7 @@ class GraphicalLassoCV(BaseGraphicalLasso):
     array([0.073, 0.04 , 0.038, 0.143])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseGraphicalLasso._parameter_constraints,
         "alphas": [Interval(Integral, 1, None, closed="left"), "array-like"],
         "n_refinements": [Interval(Integral, 1, None, closed="left")],

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -700,11 +700,8 @@ class MinCovDet(EmpiricalCovariance):
     """
 
     _parameter_constraints = {
-        **EmpiricalCovariance._parameter_constraints,  # type: ignore
-        "support_fraction": [
-            Interval(Real, 0, 1, closed="right"),
-            None,  # type: ignore
-        ],
+        **EmpiricalCovariance._parameter_constraints,
+        "support_fraction": [Interval(Real, 0, 1, closed="right"), None],
         "random_state": ["random_state"],
     }
     _nonrobust_covariance = staticmethod(empirical_covariance)

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -699,7 +699,7 @@ class MinCovDet(EmpiricalCovariance):
     array([0.0813... , 0.0427...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **EmpiricalCovariance._parameter_constraints,
         "support_fraction": [Interval(Real, 0, 1, closed="right"), None],
         "random_state": ["random_state"],

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -147,7 +147,7 @@ class ShrunkCovariance(EmpiricalCovariance):
     array([0.0622..., 0.0193...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **EmpiricalCovariance._parameter_constraints,
         "shrinkage": [Interval(Real, 0, 1, closed="both")],
     }

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -175,7 +175,7 @@ class _PLS(
     https://stat.uw.edu/sites/default/files/files/reports/2000/tr371.pdf
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "scale": ["boolean"],
         "deflation_mode": [StrOptions({"regression", "canonical"})],
@@ -615,7 +615,7 @@ class PLSRegression(_PLS):
     >>> Y_pred = pls2.predict(X)
     """
 
-    _parameter_constraints = {**_PLS._parameter_constraints}
+    _parameter_constraints: dict = {**_PLS._parameter_constraints}
     for param in ("deflation_mode", "mode", "algorithm"):
         _parameter_constraints.pop(param)
 
@@ -760,7 +760,7 @@ class PLSCanonical(_PLS):
     >>> X_c, Y_c = plsca.transform(X, Y)
     """
 
-    _parameter_constraints = {**_PLS._parameter_constraints}
+    _parameter_constraints: dict = {**_PLS._parameter_constraints}
     for param in ("deflation_mode", "mode"):
         _parameter_constraints.pop(param)
 
@@ -882,7 +882,7 @@ class CCA(_PLS):
     >>> X_c, Y_c = cca.transform(X, Y)
     """
 
-    _parameter_constraints = {**_PLS._parameter_constraints}
+    _parameter_constraints: dict = {**_PLS._parameter_constraints}
     for param in ("deflation_mode", "mode", "algorithm"):
         _parameter_constraints.pop(param)
 
@@ -969,7 +969,7 @@ class PLSSVD(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
     ((4, 2), (4, 2))
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "scale": ["boolean"],
         "copy": ["boolean"],

--- a/sklearn/decomposition/_factor_analysis.py
+++ b/sklearn/decomposition/_factor_analysis.py
@@ -161,7 +161,7 @@ class FactorAnalysis(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEst
     (1797, 7)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 0, None, closed="left"), None],
         "tol": [Interval(Real, 0.0, None, closed="left")],
         "copy": ["boolean"],

--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -475,7 +475,7 @@ class FastICA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
     (1797, 7)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left"), None],
         "algorithm": [StrOptions({"parallel", "deflation"})],
         "whiten": [

--- a/sklearn/decomposition/_incremental_pca.py
+++ b/sklearn/decomposition/_incremental_pca.py
@@ -179,7 +179,7 @@ class IncrementalPCA(_BasePCA):
     (1797, 7)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left"), None],
         "whiten": ["boolean"],
         "copy": ["boolean"],

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -239,7 +239,7 @@ class KernelPCA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
     (1797, 7)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [
             Interval(Integral, 1, None, closed="left"),
             None,

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -1188,7 +1188,7 @@ def non_negative_factorization(
 class _BaseNMF(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator, ABC):
     """Base class for NMF and MiniBatchNMF."""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left"), None],
         "init": [
             StrOptions({"random", "nndsvd", "nndsvda", "nndsvdar", "custom"}),
@@ -1575,7 +1575,7 @@ class NMF(_BaseNMF):
     >>> H = model.components_
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseNMF._parameter_constraints,
         "solver": [StrOptions({"mu", "cd"})],
         "alpha": [
@@ -2043,7 +2043,7 @@ class MiniBatchNMF(_BaseNMF):
     >>> H = model.components_
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseNMF._parameter_constraints,
         "max_no_improvement": [Interval(Integral, 1, None, closed="left"), None],
         "batch_size": [Interval(Integral, 1, None, closed="left")],

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -359,7 +359,7 @@ class PCA(_BasePCA):
     [6.30061...]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [
             Interval(Integral, 0, None, closed="left"),
             Interval(Real, 0, 1, closed="neither"),

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -18,7 +18,7 @@ from ._dict_learning import dict_learning, MiniBatchDictionaryLearning
 class _BaseSparsePCA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
     """Base class for SparsePCA and MiniBatchSparsePCA"""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [None, Interval(Integral, 1, None, closed="left")],
         "alpha": [Interval(Real, 0.0, None, closed="left")],
         "ridge_alpha": [Interval(Real, 0.0, None, closed="left")],
@@ -264,7 +264,7 @@ class SparsePCA(_BaseSparsePCA):
     0.9666...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseSparsePCA._parameter_constraints,
         "U_init": [None, np.ndarray],
         "V_init": [None, np.ndarray],
@@ -472,7 +472,7 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
     0.9...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseSparsePCA._parameter_constraints,
         "max_iter": [Interval(Integral, 0, None, closed="left"), None],
         "n_iter": [

--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -155,7 +155,7 @@ class TruncatedSVD(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
     [35.2410...  4.5981...   4.5420...  4.4486...  4.3288...]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "algorithm": [StrOptions({"arpack", "randomized"})],
         "n_iter": [Interval(Integral, 0, None, closed="left")],

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -309,7 +309,7 @@ class LinearDiscriminantAnalysis(
     [1]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "solver": [StrOptions({"svd", "lsqr", "eigen"})],
         "shrinkage": [StrOptions({"auto"}), Interval(Real, 0, 1, closed="both"), None],
         "n_components": [Interval(Integral, 1, None, closed="left"), None],
@@ -819,7 +819,7 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
     [1]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "priors": ["array-like", None],
         "reg_param": [Interval(Real, 0, 1, closed="both")],
         "store_covariance": ["boolean"],

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -137,7 +137,7 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
     0.75
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "strategy": [
             StrOptions({"most_frequent", "prior", "stratified", "uniform", "constant"})
         ],
@@ -526,7 +526,7 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     0.0
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "strategy": [StrOptions({"mean", "median", "quantile", "constant"})],
         "quantile": [Interval(Real, 0.0, 1.0, closed="both"), None],
         "constant": [

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -239,7 +239,7 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
     instead.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "base_estimator": "no_validation",
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "max_samples": [

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -197,7 +197,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
     instead.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "bootstrap": ["boolean"],
         "oob_score": ["boolean"],
@@ -1385,7 +1385,7 @@ class RandomForestClassifier(ForestClassifier):
     [1]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **ForestClassifier._parameter_constraints,
         **DecisionTreeClassifier._parameter_constraints,
         "class_weight": [
@@ -1733,7 +1733,7 @@ class RandomForestRegressor(ForestRegressor):
     [-8.32987858]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **ForestRegressor._parameter_constraints,
         **DecisionTreeRegressor._parameter_constraints,
     }
@@ -2074,7 +2074,7 @@ class ExtraTreesClassifier(ForestClassifier):
     array([1])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **ForestClassifier._parameter_constraints,
         **DecisionTreeClassifier._parameter_constraints,
         "class_weight": [
@@ -2409,7 +2409,7 @@ class ExtraTreesRegressor(ForestRegressor):
     0.2727...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **ForestRegressor._parameter_constraints,
         **DecisionTreeRegressor._parameter_constraints,
     }
@@ -2649,7 +2649,7 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
            [0., 1., 1., 0., 1., 0., 0., 1., 1., 0.]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "n_jobs": [Integral, None],
         "verbose": ["verbose"],

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -135,7 +135,7 @@ class VerboseReporter:
 class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
     """Abstract base class for Gradient Boosting."""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **DecisionTreeRegressor._parameter_constraints,
         "learning_rate": [Interval(Real, 0.0, None, closed="left")],
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
@@ -1214,7 +1214,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
     """
 
     # TODO(1.3): remove "deviance"
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseGradientBoosting._parameter_constraints,
         "loss": [
             StrOptions({"log_loss", "deviance", "exponential"}, deprecated={"deviance"})
@@ -1785,7 +1785,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     """
 
     # TODO(1.2): remove "ls" and "lad"
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseGradientBoosting._parameter_constraints,
         "loss": [
             StrOptions(

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1296,7 +1296,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
     # TODO(1.2): remove "least_absolute_deviation"
     _parameter_constraints = {
-        **BaseHistGradientBoosting._parameter_constraints,  # type: ignore
+        **BaseHistGradientBoosting._parameter_constraints,
         "loss": [
             StrOptions(
                 {
@@ -1637,7 +1637,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
 
     # TODO(1.3): Remove "binary_crossentropy", "categorical_crossentropy", "auto"
     _parameter_constraints = {
-        **BaseHistGradientBoosting._parameter_constraints,  # type: ignore
+        **BaseHistGradientBoosting._parameter_constraints,
         "loss": [
             StrOptions(
                 {

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -87,7 +87,7 @@ def _update_leaves_values(loss, grower, y_true, raw_prediction, sample_weight):
 class BaseHistGradientBoosting(BaseEstimator, ABC):
     """Base class for histogram-based gradient boosting estimators."""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "loss": [BaseLoss],
         "learning_rate": [Interval(Real, 0, None, closed="neither")],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
@@ -1295,7 +1295,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     """
 
     # TODO(1.2): remove "least_absolute_deviation"
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseHistGradientBoosting._parameter_constraints,
         "loss": [
             StrOptions(
@@ -1636,7 +1636,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
     """
 
     # TODO(1.3): Remove "binary_crossentropy", "categorical_crossentropy", "auto"
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseHistGradientBoosting._parameter_constraints,
         "loss": [
             StrOptions(

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -197,7 +197,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
     array([ 1,  1, -1])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "max_samples": [
             StrOptions({"auto"}),

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -54,7 +54,7 @@ def _estimator_has(attr):
 class _BaseStacking(TransformerMixin, _BaseHeterogeneousEnsemble, metaclass=ABCMeta):
     """Base class for stacking method."""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "estimators": [list],
         "final_estimator": [None, HasMethods("fit")],
         "cv": ["cv_object", StrOptions({"prefit"})],
@@ -533,7 +533,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
     """
 
     _parameter_constraints = {
-        **_BaseStacking._parameter_constraints,  # type: ignore
+        **_BaseStacking._parameter_constraints,
         "stack_method": [
             StrOptions({"auto", "predict_proba", "decision_function", "predict"})
         ],

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -532,7 +532,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
     0.9...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseStacking._parameter_constraints,
         "stack_method": [
             StrOptions({"auto", "predict_proba", "decision_function", "predict"})

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -46,7 +46,7 @@ class _BaseVoting(TransformerMixin, _BaseHeterogeneousEnsemble):
     instead.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "estimators": [list],
         "weights": ["array-like", None],
         "n_jobs": [None, Integral],
@@ -287,7 +287,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
     """
 
     _parameter_constraints = {
-        **_BaseVoting._parameter_constraints,  # type: ignore
+        **_BaseVoting._parameter_constraints,
         "voting": [StrOptions({"hard", "soft"})],
         "flatten_transform": ["boolean"],
     }

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -286,7 +286,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
     (6, 6)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseVoting._parameter_constraints,
         "voting": [StrOptions({"hard", "soft"})],
         "flatten_transform": ["boolean"],

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -59,7 +59,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
     instead.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "base_estimator": "no_validation",  # TODO create an estimator-like constraint ?
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "learning_rate": [Interval(Real, 0, None, closed="neither")],
@@ -455,7 +455,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
     """
 
     _parameter_constraints = {
-        **BaseWeightBoosting._parameter_constraints,  # type: ignore
+        **BaseWeightBoosting._parameter_constraints,
         "algorithm": [StrOptions({"SAMME", "SAMME.R"})],
     }
 
@@ -1012,7 +1012,7 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
     """
 
     _parameter_constraints = {
-        **BaseWeightBoosting._parameter_constraints,  # type: ignore
+        **BaseWeightBoosting._parameter_constraints,
         "loss": [StrOptions({"linear", "square", "exponential"})],
     }
 

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -454,7 +454,7 @@ class AdaBoostClassifier(ClassifierMixin, BaseWeightBoosting):
     0.983...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseWeightBoosting._parameter_constraints,
         "algorithm": [StrOptions({"SAMME", "SAMME.R"})],
     }
@@ -1011,7 +1011,7 @@ class AdaBoostRegressor(RegressorMixin, BaseWeightBoosting):
     0.9771...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseWeightBoosting._parameter_constraints,
         "loss": [StrOptions({"linear", "square", "exponential"})],
     }

--- a/sklearn/feature_extraction/_dict_vectorizer.py
+++ b/sklearn/feature_extraction/_dict_vectorizer.py
@@ -97,7 +97,7 @@ class DictVectorizer(TransformerMixin, BaseEstimator):
     array([[0., 0., 4.]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "dtype": "no_validation",  # validation delegated to numpy,
         "separator": [str],
         "sparse": ["boolean"],

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1102,7 +1102,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
      [0 0 1 0 1 0 1 0 0 0 0 0 1]]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "input": [StrOptions({"filename", "file", "content"})],
         "encoding": [str],
         "decode_error": [StrOptions({"strict", "ignore", "replace"})],
@@ -1612,7 +1612,7 @@ class TfidfTransformer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     (4, 8)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "norm": [StrOptions({"l1", "l2"}), None],
         "use_idf": ["boolean"],
         "smooth_idf": ["boolean"],
@@ -1950,7 +1950,7 @@ class TfidfVectorizer(CountVectorizer):
     (4, 9)
     """
 
-    _parameter_constraints = {**CountVectorizer._parameter_constraints}
+    _parameter_constraints: dict = {**CountVectorizer._parameter_constraints}
     _parameter_constraints.update(
         {
             "norm": [StrOptions({"l1", "l2"}), None],

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -184,7 +184,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
     array([1, 1, 1, 1, 1, 6, 4, 3, 2, 5])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "estimator": [HasMethods(["fit"])],
         "n_features_to_select": [
             None,
@@ -628,8 +628,8 @@ class RFECV(RFE):
     array([1, 1, 1, 1, 1, 6, 4, 3, 2, 5])
     """
 
-    _parameter_constraints = {
-        **RFE._parameter_constraints,  # type: ignore
+    _parameter_constraints: dict = {
+        **RFE._parameter_constraints,
         "min_features_to_select": [Interval(Integral, 0, None, closed="neither")],
         "cv": ["cv_object"],
         "scoring": [None, str, callable],

--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -146,7 +146,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
     (150, 3)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "estimator": [HasMethods(["fit"])],
         "n_features_to_select": [
             StrOptions({"auto", "warn"}, deprecated={"warn"}),

--- a/sklearn/feature_selection/_variance_threshold.py
+++ b/sklearn/feature_selection/_variance_threshold.py
@@ -69,7 +69,9 @@ class VarianceThreshold(SelectorMixin, BaseEstimator):
                [1, 1]])
     """
 
-    _parameter_constraints = {"threshold": [Interval(Real, 0, None, closed="left")]}
+    _parameter_constraints: dict = {
+        "threshold": [Interval(Real, 0, None, closed="left")]
+    }
 
     def __init__(self, threshold=0.0):
         self.threshold = threshold

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -637,7 +637,7 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
            [0.79064206, 0.06525643, 0.14410151]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "kernel": [Kernel, None],
         "optimizer": [StrOptions({"fmin_l_bfgs_b"}), callable, None],
         "n_restarts_optimizer": [Interval(Integral, 0, None, closed="left")],

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -175,7 +175,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     (array([653.0..., 592.1...]), array([316.6..., 316.6...]))
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "kernel": [None, Kernel],
         "alpha": [Interval(Real, 0, None, closed="left"), np.ndarray],
         "optimizer": [StrOptions({"fmin_l_bfgs_b"}), callable, None],

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -77,7 +77,7 @@ class _BaseImputer(TransformerMixin, BaseEstimator):
     It adds automatically support for `add_indicator`.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "missing_values": [numbers.Real, numbers.Integral, str, None],
         "add_indicator": ["boolean"],
     }

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -768,7 +768,7 @@ class MissingIndicator(TransformerMixin, BaseEstimator):
            [False, False]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "missing_values": [numbers.Real, numbers.Integral, str, None],
         "features": [StrOptions({"missing-only", "all"})],
         "sparse": ["boolean", StrOptions({"auto"})],

--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -117,7 +117,7 @@ class KNNImputer(_BaseImputer):
     """
 
     _parameter_constraints = {
-        **_BaseImputer._parameter_constraints,  # type: ignore
+        **_BaseImputer._parameter_constraints,
         "n_neighbors": [Interval(Integral, 1, None, closed="left")],
         "weights": [StrOptions({"uniform", "distance"}), callable, Hidden(None)],
         "metric": [StrOptions(set(_NAN_METRICS)), callable],

--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -116,7 +116,7 @@ class KNNImputer(_BaseImputer):
            [8. , 8. , 7. ]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseImputer._parameter_constraints,
         "n_neighbors": [Interval(Integral, 1, None, closed="left")],
         "weights": [StrOptions({"uniform", "distance"}), callable, Hidden(None)],

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -228,7 +228,7 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
     array([1.8628..., 3.7256...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "y_min": [Interval(Real, None, None, closed="both"), None],
         "y_max": [Interval(Real, None, None, closed="both"), None],
         "increasing": ["boolean", StrOptions({"auto"})],

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -446,7 +446,7 @@ class SkewedChi2Sampler(
     1.0
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "skewedness": [Interval(Real, None, None, closed="neither")],
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "random_state": ["random_state"],

--- a/sklearn/kernel_ridge.py
+++ b/sklearn/kernel_ridge.py
@@ -131,7 +131,7 @@ class KernelRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
     KernelRidge(alpha=1.0)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "alpha": [Interval(Real, 0, None, closed="left"), "array-like"],
         "kernel": [
             StrOptions(set(PAIRWISE_KERNEL_FUNCTIONS.keys()) | {"precomputed"}),

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -638,7 +638,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
     array([16.])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "fit_intercept": ["boolean"],
         "normalize": [Hidden(StrOptions({"deprecated"})), "boolean"],
         "copy_X": ["boolean"],

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -658,7 +658,7 @@ class ARDRegression(RegressorMixin, LinearModel):
     array([1.])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_iter": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0, None, closed="left")],
         "alpha_1": [Interval(Real, 0, None, closed="left")],

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -843,7 +843,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     [1.451...]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "alpha": [Interval(Real, 0, None, closed="left")],
         "l1_ratio": [Interval(Real, 0, 1, closed="both")],
         "fit_intercept": ["boolean"],
@@ -1268,7 +1268,7 @@ class Lasso(ElasticNet):
     0.15...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **ElasticNet._parameter_constraints,
     }
     _parameter_constraints.pop("l1_ratio")
@@ -1461,7 +1461,7 @@ def _path_residuals(
 class LinearModelCV(MultiOutputMixin, LinearModel, ABC):
     """Base class for iterative model fitting along a regularization path."""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "eps": [Interval(Real, 0, None, closed="neither")],
         "n_alphas": [Interval(Integral, 1, None, closed="left")],
         "alphas": ["array-like", None],
@@ -2216,7 +2216,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
     [0.398...]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **LinearModelCV._parameter_constraints,
         "l1_ratio": [Interval(Real, 0, 1, closed="both"), "array-like"],
     }
@@ -2871,7 +2871,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
     [0.00166409 0.00166409]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **LinearModelCV._parameter_constraints,
         "l1_ratio": [Interval(Real, 0, 1, closed="both"), "array-like"],
     }
@@ -3114,7 +3114,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
     array([[153.7971...,  94.9015...]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **LinearModelCV._parameter_constraints,
     }
     _parameter_constraints.pop("precompute")

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -123,7 +123,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         we have `y_pred = exp(X @ coeff + intercept)`.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "alpha": [Interval(Real, 0.0, None, closed="left")],
         "fit_intercept": ["boolean"],
         "solver": [StrOptions({"lbfgs"})],
@@ -525,7 +525,9 @@ class PoissonRegressor(_GeneralizedLinearRegressor):
     array([10.676..., 21.875...])
     """
 
-    _parameter_constraints = {**_GeneralizedLinearRegressor._parameter_constraints}
+    _parameter_constraints: dict = {
+        **_GeneralizedLinearRegressor._parameter_constraints
+    }
     _parameter_constraints.pop("solver")
 
     def __init__(
@@ -638,7 +640,9 @@ class GammaRegressor(_GeneralizedLinearRegressor):
     array([19.483..., 35.795...])
     """
 
-    _parameter_constraints = {**_GeneralizedLinearRegressor._parameter_constraints}
+    _parameter_constraints: dict = {
+        **_GeneralizedLinearRegressor._parameter_constraints
+    }
     _parameter_constraints.pop("solver")
 
     def __init__(
@@ -781,7 +785,7 @@ class TweedieRegressor(_GeneralizedLinearRegressor):
     array([2.500..., 4.599...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_GeneralizedLinearRegressor._parameter_constraints,
         "power": [Interval(Real, None, None, closed="neither")],
         "link": [StrOptions({"auto", "identity", "log"})],

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -247,7 +247,7 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     Linear Regression coefficients: [-1.9221...  7.0226...]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "epsilon": [Interval(Real, 1.0, None, closed="left")],
         "max_iter": [Interval(Integral, 0, None, closed="left")],
         "alpha": [Interval(Real, 0, None, closed="left")],

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1014,7 +1014,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     0.97...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         # TODO(1.4): Remove "none" option
         "penalty": [
             StrOptions({"l1", "l2", "elasticnet", "none"}, deprecated={"none"}),
@@ -1612,7 +1612,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
     0.98...
     """
 
-    _parameter_constraints = {**LogisticRegression._parameter_constraints}
+    _parameter_constraints: dict = {**LogisticRegression._parameter_constraints}
 
     for param in ["C", "warm_start", "l1_ratio"]:
         _parameter_constraints.pop(param)

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -691,7 +691,7 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
     array([-78.3854...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_nonzero_coefs": [Interval(Integral, 1, None, closed="left"), None],
         "tol": [Interval(Real, 0, None, closed="left"), None],
         "fit_intercept": ["boolean"],
@@ -998,7 +998,7 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
     array([-78.3854...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "copy": ["boolean"],
         "fit_intercept": ["boolean"],
         "normalize": ["boolean", Hidden(StrOptions({"deprecated"}))],

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -174,7 +174,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     [1]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseSGDClassifier._parameter_constraints,
         "loss": [StrOptions({"hinge", "squared_hinge"})],
         "C": [Interval(Real, 0, None, closed="right")],
@@ -459,7 +459,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     [-0.02306214]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseSGDRegressor._parameter_constraints,
         "loss": [StrOptions({"epsilon_insensitive", "squared_epsilon_insensitive"})],
         "C": [Interval(Real, 0, None, closed="right")],

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -166,7 +166,7 @@ class Perceptron(BaseSGDClassifier):
     0.939...
     """
 
-    _parameter_constraints = {**BaseSGDClassifier._parameter_constraints}
+    _parameter_constraints: dict = {**BaseSGDClassifier._parameter_constraints}
     _parameter_constraints.pop("loss")
     _parameter_constraints.pop("average")
     _parameter_constraints.update(

--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -107,7 +107,7 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
     0.8
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "quantile": [Interval(Real, 0, 1, closed="neither")],
         "alpha": [Interval(Real, 0, None, closed="left")],
         "fit_intercept": ["boolean"],

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -777,7 +777,7 @@ def _ridge_regression(
 
 class _BaseRidge(LinearModel, metaclass=ABCMeta):
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "alpha": [Interval(Real, 0, None, closed="left"), np.ndarray],
         "fit_intercept": ["boolean"],
         "normalize": [Hidden(StrOptions({"deprecated"})), "boolean"],
@@ -1383,7 +1383,7 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
     0.9595...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseRidge._parameter_constraints,
         "class_weight": [dict, StrOptions({"balanced"}), None],
     }

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -80,7 +80,7 @@ class _ValidationScoreCallback:
 class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
     """Base class for SGD classification and regression."""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "fit_intercept": ["boolean"],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0, None, closed="left"), None],
@@ -501,7 +501,7 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
         "squared_epsilon_insensitive": (SquaredEpsilonInsensitive, DEFAULT_EPSILON),
     }
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseSGD._parameter_constraints,
         "loss": [
             StrOptions(
@@ -1177,7 +1177,7 @@ class SGDClassifier(BaseSGDClassifier):
     [1]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseSGDClassifier._parameter_constraints,
         "penalty": [StrOptions({"l2", "l1", "elasticnet"}), None],
         "alpha": [Interval(Real, 0, None, closed="left")],
@@ -1377,7 +1377,7 @@ class BaseSGDRegressor(RegressorMixin, BaseSGD):
         "squared_epsilon_insensitive": (SquaredEpsilonInsensitive, DEFAULT_EPSILON),
     }
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseSGD._parameter_constraints,
         "loss": [
             StrOptions(
@@ -1953,7 +1953,7 @@ class SGDRegressor(BaseSGDRegressor):
                     ('sgdregressor', SGDRegressor())])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseSGDRegressor._parameter_constraints,
         "penalty": [StrOptions({"l2", "l1", "elasticnet"}), None],
         "alpha": [Interval(Real, 0, None, closed="left")],
@@ -2164,7 +2164,7 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
 
     loss_functions = {"hinge": (Hinge, 1.0)}
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseSGD._parameter_constraints,
         "nu": [Interval(Real, 0.0, 1.0, closed="right")],
         "learning_rate": [

--- a/sklearn/linear_model/_theil_sen.py
+++ b/sklearn/linear_model/_theil_sen.py
@@ -322,7 +322,7 @@ class TheilSenRegressor(RegressorMixin, LinearModel):
     array([-31.5871...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "fit_intercept": ["boolean"],
         "copy_X": ["boolean"],
         # target_type should be Integral but can accept Real for backward compatibility

--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -688,7 +688,7 @@ class LocallyLinearEmbedding(
     (100, 2)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_neighbors": [Interval(Integral, 1, None, closed="left")],
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "reg": [Interval(Real, 0, None, closed="left")],

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -484,7 +484,7 @@ class MDS(BaseEstimator):
     (100, 2)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "metric": ["boolean"],
         "n_init": [Interval(Integral, 1, None, closed="left")],

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -746,7 +746,7 @@ class TSNE(BaseEstimator):
     (4, 2)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "perplexity": [Interval(Real, 0, None, closed="neither")],
         "early_exaggeration": [Interval(Real, 1, None, closed="left")],

--- a/sklearn/mixture/_base.py
+++ b/sklearn/mixture/_base.py
@@ -48,7 +48,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
     provides basic common methods for mixture models.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0.0, None, closed="left")],
         "reg_covar": [Interval(Real, 0.0, None, closed="left")],

--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -342,7 +342,7 @@ class BayesianGaussianMixture(BaseMixture):
     array([0, 1])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseMixture._parameter_constraints,
         "covariance_type": [StrOptions({"spherical", "tied", "diag", "full"})],
         "weight_concentration_prior_type": [

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -637,7 +637,7 @@ class GaussianMixture(BaseMixture):
     array([1, 0])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseMixture._parameter_constraints,
         "covariance_type": [StrOptions({"full", "tied", "diag", "spherical"})],
         "weights_init": ["array-like", None],

--- a/sklearn/model_selection/tests/test_successive_halving.py
+++ b/sklearn/model_selection/tests/test_successive_halving.py
@@ -30,7 +30,7 @@ class FastClassifier(DummyClassifier):
     grid searching."""
 
     # update the constraints such that we accept all parameters from a to z
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **DummyClassifier._parameter_constraints,
         **{
             chr(key): "no_validation"  # type: ignore

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -927,7 +927,7 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
     array([1])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "estimator": [
             HasMethods(["fit", "decision_function"]),
             HasMethods(["fit", "predict_proba"]),

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -86,7 +86,7 @@ def _available_if_estimator_has(attr):
 
 class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "estimator": [HasMethods(["fit", "predict"])],
         "n_jobs": [Integral, None],
     }

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -238,7 +238,7 @@ class GaussianNB(_BaseNB):
     [1]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "priors": ["array-like", None],
         "var_smoothing": [Interval(Real, 0, None, closed="left")],
     }
@@ -545,7 +545,7 @@ class _BaseDiscreteNB(_BaseNB):
     _count(X, Y)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "alpha": [Interval(Real, 0, None, closed="left"), "array-like"],
         "fit_prior": ["boolean"],
         "class_prior": ["array-like", None],
@@ -1052,7 +1052,7 @@ class ComplementNB(_BaseDiscreteNB):
     [3]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseDiscreteNB._parameter_constraints,
         "norm": ["boolean"],
     }
@@ -1213,7 +1213,7 @@ class BernoulliNB(_BaseDiscreteNB):
     [3]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseDiscreteNB._parameter_constraints,
         "binarize": [None, Interval(Real, 0, None, closed="left")],
     }
@@ -1392,7 +1392,7 @@ class CategoricalNB(_BaseDiscreteNB):
     [3]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **_BaseDiscreteNB._parameter_constraints,
         "min_categories": [
             None,

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -377,7 +377,7 @@ def _radius_neighbors_from_graph(graph, radius, return_distance):
 class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
     """Base class for nearest neighbors estimators."""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_neighbors": [Interval(Integral, 1, None, closed="left"), None],
         "radius": [Interval(Real, 0, None, closed="both"), None],
         "algorithm": [StrOptions({"auto", "ball_tree", "kd_tree", "brute"})],

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -163,7 +163,7 @@ class KNeighborsClassifier(KNeighborsMixin, ClassifierMixin, NeighborsBase):
     [[0.666... 0.333...]]
     """
 
-    _parameter_constraints = {**NeighborsBase._parameter_constraints}
+    _parameter_constraints: dict = {**NeighborsBase._parameter_constraints}
     _parameter_constraints.pop("radius")
     _parameter_constraints.update(
         {"weights": [StrOptions({"uniform", "distance"}), callable, None]}
@@ -482,7 +482,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin, ClassifierMixin, Neighbors
     [[0.66666667 0.33333333]]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **NeighborsBase._parameter_constraints,
         "weights": [StrOptions({"uniform", "distance"}), callable, None],
         "outlier_label": [Integral, str, "array-like", None],

--- a/sklearn/neighbors/_graph.py
+++ b/sklearn/neighbors/_graph.py
@@ -342,7 +342,7 @@ class KNeighborsTransformer(
     (178, 178)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **NeighborsBase._parameter_constraints,
         "mode": [StrOptions({"distance", "connectivity"})],
     }
@@ -570,7 +570,7 @@ class RadiusNeighborsTransformer(
     [ 29  15 111  11  12]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **NeighborsBase._parameter_constraints,
         "mode": [StrOptions({"distance", "connectivity"})],
     }

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -127,7 +127,7 @@ class KernelDensity(BaseEstimator):
     array([-1.52955942, -1.51462041, -1.60244657])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "bandwidth": [
             Interval(Real, 0, None, closed="neither"),
             StrOptions({"scott", "silverman"}),

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -184,7 +184,7 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
     array([ -0.9821...,  -1.0370..., -73.3697...,  -0.9821...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **NeighborsBase._parameter_constraints,
         "contamination": [
             StrOptions({"auto"}),

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -101,7 +101,7 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
     [1]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "metric": [
             StrOptions(
                 set(_VALID_METRICS) - {"mahalanobis", "seuclidean", "wminkowski"}

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -161,7 +161,7 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
     [0.5]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **NeighborsBase._parameter_constraints,
         "weights": [StrOptions({"uniform", "distance"}), callable, None],
     }
@@ -393,7 +393,7 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin, RegressorMixin, NeighborsBa
     [0.5]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **NeighborsBase._parameter_constraints,
         "weights": [StrOptions({"uniform", "distance"}), callable, None],
     }

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -56,7 +56,7 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
     .. versionadded:: 0.18
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "hidden_layer_sizes": [
             "array-like",
             Interval(Integral, 1, None, closed="left"),

--- a/sklearn/neural_network/_rbm.py
+++ b/sklearn/neural_network/_rbm.py
@@ -128,7 +128,7 @@ class BernoulliRBM(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
     BernoulliRBM(n_components=2)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "learning_rate": [Interval(Real, 0, None, closed="neither")],
         "batch_size": [Interval(Integral, 1, None, closed="left")],

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -380,7 +380,7 @@ class MinMaxScaler(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     [[1.5 0. ]]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "feature_range": [tuple],
         "copy": ["boolean"],
         "clip": ["boolean"],
@@ -773,7 +773,7 @@ class StandardScaler(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     [[3. 3.]]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "copy": ["boolean"],
         "with_mean": ["boolean"],
         "with_std": ["boolean"],
@@ -1131,7 +1131,7 @@ class MaxAbsScaler(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
            [ 0. ,  1. , -0.5]])
     """
 
-    _parameter_constraints = {"copy": ["boolean"]}
+    _parameter_constraints: dict = {"copy": ["boolean"]}
 
     def __init__(self, *, copy=True):
         self.copy = copy
@@ -1470,7 +1470,7 @@ class RobustScaler(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
            [ 1. ,  0. , -1.6]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "with_centering": ["boolean"],
         "with_scaling": ["boolean"],
         "quantile_range": [tuple],
@@ -1933,7 +1933,7 @@ class Normalizer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
            [0.5, 0.7, 0.5, 0.1]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "norm": [StrOptions({"l1", "l2", "max"})],
         "copy": ["boolean"],
     }
@@ -2107,7 +2107,7 @@ class Binarizer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
            [0., 1., 0.]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "threshold": [Real],
         "copy": ["boolean"],
     }
@@ -2486,7 +2486,7 @@ class QuantileTransformer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator
     array([...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_quantiles": [Interval(Integral, 1, None, closed="left")],
         "output_distribution": [StrOptions({"uniform", "normal"})],
         "ignore_implicit_zeros": ["boolean"],
@@ -3045,7 +3045,7 @@ class PowerTransformer(_OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
      [ 1.106...  1.414...]]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "method": [StrOptions({"yeo-johnson", "box-cox"})],
         "standardize": ["boolean"],
         "copy": ["boolean"],

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -152,7 +152,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
            [ 0.5,  3.5, -1.5,  1.5]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_bins": [Interval(Integral, 2, None, closed="left"), "array-like"],
         "encode": [StrOptions({"onehot", "onehot-dense", "ordinal"})],
         "strategy": [StrOptions({"uniform", "quantile", "kmeans"})],

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -433,7 +433,7 @@ class OneHotEncoder(_BaseEncoder):
            [1., 0., 0.]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "categories": [StrOptions({"auto"}), list],
         "drop": [StrOptions({"first", "if_binary"}), "array-like", None],
         "dtype": "no_validation",  # validation delegated to numpy
@@ -1188,7 +1188,7 @@ class OrdinalEncoder(_OneToOneFeatureMixin, _BaseEncoder):
            [ 0., -1.]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "categories": [StrOptions({"auto"}), list],
         "dtype": "no_validation",  # validation delegated to numpy
         "encoded_missing_value": [Integral, type(np.nan)],

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -256,7 +256,7 @@ class LabelBinarizer(TransformerMixin, BaseEstimator):
            [0, 1, 0]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "neg_label": [Integral],
         "pos_label": [Integral],
         "sparse_output": ["boolean"],
@@ -743,7 +743,7 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
     array(['comedy', 'sci-fi', 'thriller'], dtype=object)
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "classes": ["array-like", None],
         "sparse_output": ["boolean"],
     }

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -130,7 +130,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
            [ 1.,  4.,  5., 20.]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "degree": [Interval(Integral, 0, None, closed="left"), "array-like"],
         "interaction_only": ["boolean"],
         "include_bias": ["boolean"],
@@ -632,7 +632,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
            [0.  , 0.  , 0.5 , 0.5 ]])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_knots": [Interval(Integral, 2, None, closed="left")],
         "degree": [Interval(Integral, 0, None, closed="left")],
         "knots": [StrOptions({"uniform", "quantile"}), "array-like"],

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -300,7 +300,7 @@ class BaseRandomProjection(
     Use derived classes instead.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "n_components": [
             Interval(Integral, 1, None, closed="left"),
             StrOptions({"auto"}),
@@ -734,7 +734,7 @@ class SparseRandomProjection(BaseRandomProjection):
     0.0182...
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseRandomProjection._parameter_constraints,
         "density": [Interval(Real, 0.0, 1.0, closed="right"), StrOptions({"auto"})],
         "dense_output": ["boolean"],

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -144,7 +144,7 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
 
     _estimator_type = "classifier"
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         # We don't require `predic_proba` here to allow passing a meta-estimator
         # that only exposes `predict_proba` after fitting.
         "base_estimator": [HasMethods(["fit"])],

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -693,7 +693,7 @@ class BaseSVC(ClassifierMixin, BaseLibSVM, metaclass=ABCMeta):
     """ABC for LibSVM-based classifiers."""
 
     _parameter_constraints = {
-        **BaseLibSVM._parameter_constraints,  # type: ignore
+        **BaseLibSVM._parameter_constraints,
         "decision_function_shape": [StrOptions({"ovr", "ovo"})],
         "break_ties": ["boolean"],
     }

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -70,7 +70,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
     Parameter documentation is in the derived `SVC` class.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "kernel": [
             StrOptions({"linear", "poly", "rbf", "sigmoid", "precomputed"}),
             callable,
@@ -692,7 +692,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
 class BaseSVC(ClassifierMixin, BaseLibSVM, metaclass=ABCMeta):
     """ABC for LibSVM-based classifiers."""
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseLibSVM._parameter_constraints,
         "decision_function_shape": [StrOptions({"ovr", "ovo"})],
         "break_ties": ["boolean"],

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -1040,7 +1040,7 @@ class NuSVC(BaseSVC):
     _impl = "nu_svc"
 
     _parameter_constraints = {
-        **BaseSVC._parameter_constraints,  # type: ignore
+        **BaseSVC._parameter_constraints,
         "nu": [Interval(Real, 0.0, 1.0, closed="right")],
     }
     _parameter_constraints.pop("C")
@@ -1256,7 +1256,7 @@ class SVR(RegressorMixin, BaseLibSVM):
 
     _impl = "epsilon_svr"
 
-    _parameter_constraints = {**BaseLibSVM._parameter_constraints}  # type: ignore
+    _parameter_constraints = {**BaseLibSVM._parameter_constraints}
     for unused_param in ["class_weight", "nu", "probability", "random_state"]:
         _parameter_constraints.pop(unused_param)
 
@@ -1465,7 +1465,7 @@ class NuSVR(RegressorMixin, BaseLibSVM):
 
     _impl = "nu_svr"
 
-    _parameter_constraints = {**BaseLibSVM._parameter_constraints}  # type: ignore
+    _parameter_constraints = {**BaseLibSVM._parameter_constraints}
     for unused_param in ["class_weight", "epsilon", "probability", "random_state"]:
         _parameter_constraints.pop(unused_param)
 
@@ -1664,7 +1664,7 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
 
     _impl = "one_class"
 
-    _parameter_constraints = {**BaseLibSVM._parameter_constraints}  # type: ignore
+    _parameter_constraints = {**BaseLibSVM._parameter_constraints}
     for unused_param in ["C", "class_weight", "epsilon", "probability", "random_state"]:
         _parameter_constraints.pop(unused_param)
 

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -191,7 +191,7 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     [1]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "penalty": [StrOptions({"l1", "l2"})],
         "loss": [StrOptions({"hinge", "squared_hinge"})],
         "dual": ["boolean"],
@@ -443,7 +443,7 @@ class LinearSVR(RegressorMixin, LinearModel):
     [-2.384...]
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "epsilon": [Real],
         "tol": [Interval(Real, 0.0, None, closed="neither")],
         "C": [Interval(Real, 0.0, None, closed="neither")],
@@ -1039,7 +1039,7 @@ class NuSVC(BaseSVC):
 
     _impl = "nu_svc"
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseSVC._parameter_constraints,
         "nu": [Interval(Real, 0.0, 1.0, closed="right")],
     }
@@ -1256,7 +1256,7 @@ class SVR(RegressorMixin, BaseLibSVM):
 
     _impl = "epsilon_svr"
 
-    _parameter_constraints = {**BaseLibSVM._parameter_constraints}
+    _parameter_constraints: dict = {**BaseLibSVM._parameter_constraints}
     for unused_param in ["class_weight", "nu", "probability", "random_state"]:
         _parameter_constraints.pop(unused_param)
 
@@ -1465,7 +1465,7 @@ class NuSVR(RegressorMixin, BaseLibSVM):
 
     _impl = "nu_svr"
 
-    _parameter_constraints = {**BaseLibSVM._parameter_constraints}
+    _parameter_constraints: dict = {**BaseLibSVM._parameter_constraints}
     for unused_param in ["class_weight", "epsilon", "probability", "random_state"]:
         _parameter_constraints.pop(unused_param)
 
@@ -1664,7 +1664,7 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
 
     _impl = "one_class"
 
-    _parameter_constraints = {**BaseLibSVM._parameter_constraints}
+    _parameter_constraints: dict = {**BaseLibSVM._parameter_constraints}
     for unused_param in ["C", "class_weight", "epsilon", "probability", "random_state"]:
         _parameter_constraints.pop(unused_param)
 

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -98,7 +98,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
     Use derived classes instead.
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         "splitter": [StrOptions({"best", "random"})],
         "max_depth": [Interval(Integral, 1, None, closed="left"), None],
         "min_samples_split": [
@@ -845,7 +845,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
             0.93...,  0.93...,  1.     ,  0.93...,  1.      ])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseDecisionTree._parameter_constraints,
         "criterion": [StrOptions({"gini", "entropy", "log_loss"}), Hidden(Criterion)],
         "class_weight": [dict, list, StrOptions({"balanced"}), None],
@@ -1227,7 +1227,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
            0.16...,  0.11..., -0.73..., -0.30..., -0.00...])
     """
 
-    _parameter_constraints = {
+    _parameter_constraints: dict = {
         **BaseDecisionTree._parameter_constraints,
         "criterion": [
             StrOptions(

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -51,7 +51,7 @@ class _Class:
 class _Estimator(BaseEstimator):
     """An estimator to test the validation of estimator parameters."""
 
-    _parameter_constraints = {"a": [Real]}
+    _parameter_constraints: dict = {"a": [Real]}
 
     def __init__(self, a):
         self.a = a


### PR DESCRIPTION
This PR adds the `dict` typing hint to `_parameter_constraints`, which means we do not need to write `# type: ignore` anymore.

If we only want to avoid the `# type: ignores` we have right now, then not every `_parameter_constraints` requires `dict`. I added them all in this PR because it is more consistent and makes it easier for contributors.