### PR TITLE
[MRG] added Manifold Learning Method NEML (Nonlinear embedding preserving mulitple local-linearities)

### DIFF
--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -216,7 +216,7 @@ The overall complexity of standard LLE is
      Roweis, S. & Saul, L.  Science 290:2323 (2000)
 
 
-Modified Locally Linear Embedding
+Multiple Local Weights
 =================================
 
 One well-known issue with LLE is the regularization problem.  When the number
@@ -228,6 +228,9 @@ formally that as :math:`r \to 0`, the solution converges to the desired
 embedding, there is no guarantee that the optimal solution will be found
 for :math:`r > 0`.  This problem manifests itself in embeddings which distort
 the underlying geometry of the manifold.
+
+Modified Locally Linear Embedding
+---------------------------------
 
 One method to address the regularization problem is to use multiple weight
 vectors in each neighborhood.  This is the essence of *modified locally
@@ -241,10 +244,17 @@ It requires ``n_neighbors > n_components``.
    :align: center
    :scale: 50
 
+Nonlinear embedding preserving multiple local-linearities
+---------------------------------------------------------
+
+An alternative implementation of MLLE is given in :class:`LocallyLinearEmbedding`, with the keyword ``method = 'neml'``.
+It follows the same idea as MLLE but is based on a subsequent publication introducing a Nonlinear embedding preserving multiple local-linearities (NEML).
+
+
 Complexity
 ----------
 
-The MLLE algorithm comprises three stages:
+The MLLE and NEML algorithm comprise three stages:
 
 1. **Nearest Neighbors Search**.  Same as standard LLE
 
@@ -257,7 +267,7 @@ The MLLE algorithm comprises three stages:
 
 3. **Partial Eigenvalue Decomposition**. Same as standard LLE
 
-The overall complexity of MLLE is
+The overall complexity of MLLE and NEML is
 :math:`O[D \log(k) N \log(N)] + O[D N k^3] + O[N (k-D) k^2] + O[d N^2]`.
 
 * :math:`N` : number of training data points
@@ -270,6 +280,11 @@ The overall complexity of MLLE is
    * `"MLLE: Modified Locally Linear Embedding Using Multiple Weights"
      <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.70.382>`_
      Zhang, Z. & Wang, J.
+   
+   * `"Nonlinear embedding preserving multiple local-linearities"
+     <https://dl.acm.org/doi/10.1016/j.patcog.2009.09.014>`_
+     Wang, J. & Zhang, Z.
+
 
 
 Hessian Eigenmapping

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -21,6 +21,7 @@ representation of the data in the low-dimensional space.
 """
 
 # Author: Jake Vanderplas -- <vanderplas@astro.washington.edu>
+# edited: Markus Wnuk -- <markuswnuk@gmx.de>
 
 # %%
 # Dataset preparation
@@ -81,6 +82,14 @@ def add_2d_scatter(ax, points, points_color, title=None):
     ax.xaxis.set_major_formatter(ticker.NullFormatter())
     ax.yaxis.set_major_formatter(ticker.NullFormatter())
 
+def add_3d_scatter(ax, points, points_color, title=None):
+    x, y, z = points.T
+    ax.scatter(x, y, z, c=points_color, s=50, alpha=0.8)
+    ax.set_title(title)
+    ax.view_init(azim=-60, elev=9)
+    ax.xaxis.set_major_locator(ticker.MultipleLocator(1))
+    ax.yaxis.set_major_locator(ticker.MultipleLocator(1))
+    ax.zaxis.set_major_locator(ticker.MultipleLocator(1))
 
 plot_3d(S_points, S_color, "Original S-curve samples")
 
@@ -125,19 +134,36 @@ S_hessian = lle_hessian.fit_transform(S_points)
 lle_mod = manifold.LocallyLinearEmbedding(method="modified", modified_tol=0.8, **params)
 S_mod = lle_mod.fit_transform(S_points)
 
+lle_neml = manifold.LocallyLinearEmbedding(method="neml", **params)
+S_neml = lle_neml.fit_transform(S_points)
 # %%
-fig, axs = plt.subplots(
-    nrows=2, ncols=2, figsize=(7, 7), facecolor="white", constrained_layout=True
-)
-fig.suptitle("Locally Linear Embeddings", size=16)
+# fig, axs = plt.subplots(
+#     nrows=2, ncols=2, figsize=(7, 7), facecolor="white", constrained_layout=True
+# )
+# fig.suptitle("Locally Linear Embeddings", size=16)
 
 lle_methods = [
     ("Standard locally linear embedding", S_standard),
     ("Local tangent space alignment", S_ltsa),
     ("Hessian eigenmap", S_hessian),
-    ("Modified locally linear embedding", S_mod),
+    ("Modified locally linear embedding \n (MLLE)", S_mod),
+    ("Nonlinear embedding preserving multiple local-linearities \n (NEML)", S_neml),
 ]
-for ax, method in zip(axs.flat, lle_methods):
+# for ax, method in zip(axs.flat, lle_methods):
+#     name, points = method
+#     add_2d_scatter(ax, points, S_color, name)
+nrows=2
+ncols=3
+fig = plt.figure(figsize=(20, 9))
+fig.suptitle("Locally Linear Embeddings", size=16)
+
+# fig, axs = plt.subplots(
+#     nrows=2, ncols=3, figsize=(9, 7), facecolor="white", constrained_layout=True
+# )
+ax = fig.add_subplot(nrows, ncols, 1,projection='3d')
+add_3d_scatter(ax,S_points, S_color,"Original S-curve samples")
+for i, method in enumerate(lle_methods):
+    ax = fig.add_subplot(nrows, ncols, i+2)
     name, points = method
     add_2d_scatter(ax, points, S_color, name)
 

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -81,7 +81,7 @@ def test_lle_simple_grid(global_dtype):
     assert linalg.norm(X_reembedded - clf.embedding_) < tol
 
 
-@pytest.mark.parametrize("method", ["standard", "hessian", "modified", "ltsa"])
+@pytest.mark.parametrize("method", ["standard", "hessian", "modified", "neml", "ltsa"])
 @pytest.mark.parametrize("solver", eigen_solvers)
 def test_lle_manifold(global_dtype, method, solver):
     rng = np.random.RandomState(0)
@@ -153,7 +153,7 @@ def test_integer_input():
     rand = np.random.RandomState(0)
     X = rand.randint(0, 100, size=(20, 3))
 
-    for method in ["standard", "hessian", "modified", "ltsa"]:
+    for method in ["standard", "hessian", "modified", "neml", "ltsa"]:
         clf = manifold.LocallyLinearEmbedding(method=method, n_neighbors=10)
         clf.fit(X)  # this previously raised a TypeError
 


### PR DESCRIPTION
### Implementation of the NEML manifold learning algorithm
The NEML algorithm is an alternative implementation of the MLLE algorithm already implemented in the LLE class.

### Changes
- This change implements an additional manifold learning method called NEML
- The implementation uses the same interface as the previous methods.
- Compared to the current MLLE Implementation the NEML achieves more statisfactory results.

### Further Comments:
- The Documentation for the LLE class implementing the method was updated.
- The example on comparing different manifold learning methods was updated to also include NEML.

![ManifoldLearning_NEML](https://user-images.githubusercontent.com/61986870/187937695-a931e7eb-c59d-4596-b460-1f797b667502.jpg)
