### PR TITLE
[ENH] add dtype preservation to BernoulliRBM

### DIFF
--- a/sklearn/neural_network/_rbm.py
+++ b/sklearn/neural_network/_rbm.py
@@ -447,5 +447,6 @@ class BernoulliRBM(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstim
                 "check_methods_sample_order_invariance": (
                     "fails for the score_samples method"
                 ),
-            }
+            },
+            "preserves_dtype": [np.float64, np.float32],
         }


### PR DESCRIPTION
#### Reference Issues/PRs

In scope of  #11000 
See also [#16352](https://github.com/scikit-learn/scikit-learn/pull/16352)

#### What does this implement/fix? Explain your changes.

we added the remaining check for `_more_tags`

`sklearn/tests/test_common.py::test_estimators[BernoulliRBM()-check_transformer_preserve_dtypes] PASSED` 

#### Any other comments?

