### PR TITLE
DOC Rework `plot_kmeans_stability_low_dim_dense.py` to make it more colorblind friendly

### DIFF
--- a/examples/cluster/plot_kmeans_stability_low_dim_dense.py
+++ b/examples/cluster/plot_kmeans_stability_low_dim_dense.py
@@ -74,13 +74,13 @@ plots = []
 legends = []
 
 cases = [
-    (KMeans, "k-means++", {}),
-    (KMeans, "random", {}),
-    (MiniBatchKMeans, "k-means++", {"max_no_improvement": 3}),
-    (MiniBatchKMeans, "random", {"max_no_improvement": 3, "init_size": 500}),
+    (KMeans, "k-means++", {}, "^-"),
+    (KMeans, "random", {}, "o-"),
+    (MiniBatchKMeans, "k-means++", {"max_no_improvement": 3}, "x-"),
+    (MiniBatchKMeans, "random", {"max_no_improvement": 3, "init_size": 500}, "d-"),
 ]
 
-for factory, init, params in cases:
+for factory, init, params, format in cases:
     print("Evaluation of %s with %s init" % (factory.__name__, init))
     inertia = np.empty((len(n_init_range), n_runs))
 
@@ -95,7 +95,9 @@ for factory, init, params in cases:
                 **params,
             ).fit(X)
             inertia[i, run_id] = km.inertia_
-    p = plt.errorbar(n_init_range, inertia.mean(axis=1), inertia.std(axis=1))
+    p = plt.errorbar(
+        n_init_range, inertia.mean(axis=1), inertia.std(axis=1), fmt=format
+    )
     plots.append(p[0])
     legends.append("%s with %s init" % (factory.__name__, init))
 

--- a/examples/cluster/plot_kmeans_stability_low_dim_dense.py
+++ b/examples/cluster/plot_kmeans_stability_low_dim_dense.py
@@ -117,7 +117,7 @@ plt.figure()
 for k in range(n_clusters):
     my_members = km.labels_ == k
     color = cm.nipy_spectral(float(k) / n_clusters, 1)
-    plt.plot(X[my_members, 0], X[my_members, 1], "o", marker=".", c=color)
+    plt.plot(X[my_members, 0], X[my_members, 1], ".", c=color)
     cluster_center = km.cluster_centers_[k]
     plt.plot(
         cluster_center[0],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Contributes to #5435 



#### What does this implement/fix? Explain your changes.
This adds markers to the line plot to help make the plot more colorblind friendly.

<details>
<img width="642" alt="Screenshot 2022-09-02 at 12 34 25" src="https://user-images.githubusercontent.com/1448859/188121556-4f7dff54-490e-4d4b-b0bc-28e91e7237b1.png">
</details>

The cluster "grid" plot is unchanged as finding a colorblind safe, qualitative colormap with ten different colors is hard. Simulating a few colorblindnesses makes me think the situation is similarly bad/good compared to when not simulating it. Some screenshots in the details:

<details>
<img width="646" alt="Screenshot 2022-09-02 at 12 19 57" src="https://user-images.githubusercontent.com/1448859/188119158-eb9757ee-4c33-44c9-aca4-9033170523f8.png">
<img width="645" alt="Screenshot 2022-09-02 at 12 15 58" src="https://user-images.githubusercontent.com/1448859/188119174-5de68fe1-a9d6-4ea8-aaba-b90f9836cebc.png">
<img width="650" alt="Screenshot 2022-09-02 at 12 15 43" src="https://user-images.githubusercontent.com/1448859/188119178-7a5bc330-f4a6-4088-bda6-9e8c455bcb03.png">

</details>
