### PR TITLE
MAINT Parameters validation for OAS

### DIFF
--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -683,6 +683,8 @@ class OAS(EmpiricalCovariance):
         self : object
             Returns the instance itself.
         """
+        self._validate_params()
+
         X = self._validate_data(X)
         # Not calling the parent object to fit, to avoid computing the
         # covariance matrix (and potentially the precision)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -469,7 +469,6 @@ PARAM_VALIDATION_ESTIMATORS_TO_IGNORE = [
     "MultiTaskElasticNet",
     "MultiTaskLasso",
     "Nystroem",
-    "OAS",
     "OPTICS",
     "OneVsOneClassifier",
     "OneVsRestClassifier",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #23462

#### What does this implement/fix? Explain your changes.

Implement parameters validation for OAS - this class doesn't introduce custom parameters, so it just calls `self._validate_params` in `fit` to validate the parameters of the base class. This is as discussed with maintainers at EuroSciPy 2022 sprint.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
