### PR TITLE
DOC Ensure sklearn.inspection._plot.partial_dependence.plot_partial_dependence passes numpydoc validation

### DIFF
--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -21,7 +21,7 @@ from ...utils.fixes import delayed
 
 @deprecated(
     "Function `plot_partial_dependence` is deprecated in 1.0 and will be "
-    "removed in 1.2. Use PartialDependenceDisplay.from_estimator instead"
+    "removed in 1.2. Use PartialDependenceDisplay.from_estimator instead."
 )
 def plot_partial_dependence(
     estimator,
@@ -47,11 +47,15 @@ def plot_partial_dependence(
     random_state=None,
     centered=False,
 ):
-    """Partial dependence (PD) and individual conditional expectation (ICE)
-    plots.
+    """Partial dependence and individual conditional expectation plots.
 
-    Partial dependence plots, individual conditional expectation plots or an
-    overlay of both of them can be plotted by setting the ``kind``
+    .. deprecated:: 1.0
+       `plot_partial_dependence` is deprecated in 1.0 and will be removed in
+       1.2. Please use the class method:
+       :func:`~sklearn.metrics.PartialDependenceDisplay.from_estimator`.
+
+    Partial dependence plots (PD), individual conditional expectation (ICE)
+    plots or an overlay of both of them can be plotted by setting the ``kind``
     parameter.
 
     The ICE and PD plots can be centered with the parameter `centered`.
@@ -98,11 +102,6 @@ def plot_partial_dependence(
         :class:`~sklearn.ensemble.GradientBoostingRegressor`, not to
         :class:`~sklearn.ensemble.HistGradientBoostingClassifier` and
         :class:`~sklearn.ensemble.HistGradientBoostingRegressor`.
-
-    .. deprecated:: 1.0
-       `plot_partial_dependence` is deprecated in 1.0 and will be removed in
-       1.2. Please use the class method:
-       :func:`~sklearn.metrics.PartialDependenceDisplay.from_estimator`.
 
     Parameters
     ----------
@@ -297,6 +296,7 @@ def plot_partial_dependence(
     Returns
     -------
     display : :class:`~sklearn.inspection.PartialDependenceDisplay`
+        Partial Dependence Plot.
 
     See Also
     --------

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -14,6 +14,8 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.decomposition._dict_learning.dict_learning",
     "sklearn.externals._packaging.version.parse",
+    # sklearn.deprecation._update_doc is updating the doc against the numpydoc.
+    # This will be fixed in future PRs.
     "sklearn.inspection._plot.partial_dependence.plot_partial_dependence",
     "sklearn.linear_model._least_angle.lars_path_gram",
     "sklearn.linear_model._omp.orthogonal_mp_gram",


### PR DESCRIPTION
towards #21350
There is an additional issue within the @sklearn.utils.deprecated decorator which updates the docstring against the numpydoc and will be fixed in other PR, issue: #24328

@glemaitre @ogrisel 

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
