### PR TITLE
DOC: Streamline usage of Gaussian Process reference book

### DIFF
--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -614,6 +614,7 @@ References
    "Gaussian Processes for Machine Learning",
    MIT Press 2006 <https://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
 
-.. [Duv2014] David Duvenaud, "The Kernel Cookbook: Advice on Covariance functions", 2014, `Link <https://www.cs.toronto.edu/~duvenaud/cookbook/>`_ .
+.. [Duv2014] `David Duvenaud, "The Kernel Cookbook: Advice on Covariance functions", 2014
+   <https://www.cs.toronto.edu/~duvenaud/cookbook/>`_
 
 .. currentmodule:: sklearn.gaussian_process

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -610,7 +610,7 @@ shown in the following figure:
 References
 ----------
 
-.. [RW2006] Carl Eduard Rasmussen and Christopher K.I. Williams, "Gaussian Processes for Machine Learning", MIT Press 2006, Link to an official complete PDF version of the book `here <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_ .
+.. [RW2006] Carl Eduard Rasmussen and Christopher K.I. Williams, "Gaussian Processes for Machine Learning", MIT Press 2006, `Book link <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
 
 .. [Duv2014] David Duvenaud, "The Kernel Cookbook: Advice on Covariance functions", 2014, `Link <https://www.cs.toronto.edu/~duvenaud/cookbook/>`_ .
 

--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -610,7 +610,9 @@ shown in the following figure:
 References
 ----------
 
-.. [RW2006] Carl Eduard Rasmussen and Christopher K.I. Williams, "Gaussian Processes for Machine Learning", MIT Press 2006, `Book link <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
+.. [RW2006] `Carl E. Rasmussen and Christopher K.I. Williams,
+   "Gaussian Processes for Machine Learning",
+   MIT Press 2006 <https://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
 
 .. [Duv2014] David Duvenaud, "The Kernel Cookbook: Advice on Covariance functions", 2014, `Link <https://www.cs.toronto.edu/~duvenaud/cookbook/>`_ .
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -37,9 +37,7 @@ COEFS = np.array(
 class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
     """Binary Gaussian process classification based on Laplace approximation.
 
-    The implementation is based on Algorithm 3.1, 3.2, and 5.1 of
-    ``Gaussian Processes for Machine Learning'' (GPML) by Rasmussen and
-    Williams.
+    The implementation is based on Algorithm 3.1, 3.2, and 5.1 from [RW2006]_.
 
     Internally, the Laplace approximation is used for approximating the
     non-Gaussian posterior by a Gaussian.
@@ -145,6 +143,11 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
     log_marginal_likelihood_value_ : float
         The log-marginal-likelihood of ``self.kernel_.theta``
 
+    References
+    ----------
+    .. [RW2006] Carl Eduard Rasmussen and Christopher K.I. Williams,
+       "Gaussian Processes for Machine Learning", MIT Press 2006,
+       `Link <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
     """
 
     def __init__(
@@ -484,9 +487,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
     """Gaussian process classification (GPC) based on Laplace approximation.
 
-    The implementation is based on Algorithm 3.1, 3.2, and 5.1 of
-    Gaussian Processes for Machine Learning (GPML) by Rasmussen and
-    Williams.
+    The implementation is based on Algorithm 3.1, 3.2, and 5.1 from [RW2006]_.
 
     Internally, the Laplace approximation is used for approximating the
     non-Gaussian posterior by a Gaussian.
@@ -620,6 +621,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
     See Also
     --------
     GaussianProcessRegressor : Gaussian process regression (GPR).
+
+    References
+    ----------
+    .. [RW2006] Carl Eduard Rasmussen and Christopher K.I. Williams,
+       "Gaussian Processes for Machine Learning", MIT Press 2006,
+       `Link <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
 
     Examples
     --------

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -145,9 +145,9 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
 
     References
     ----------
-    .. [RW2006] Carl Eduard Rasmussen and Christopher K.I. Williams,
-       "Gaussian Processes for Machine Learning", MIT Press 2006,
-       `Link <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
+    .. [RW2006] `Carl E. Rasmussen and Christopher K.I. Williams,
+       "Gaussian Processes for Machine Learning",
+       MIT Press 2006 <https://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
     """
 
     def __init__(
@@ -624,9 +624,9 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
 
     References
     ----------
-    .. [RW2006] Carl Eduard Rasmussen and Christopher K.I. Williams,
-       "Gaussian Processes for Machine Learning", MIT Press 2006,
-       `Link <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
+    .. [RW2006] `Carl E. Rasmussen and Christopher K.I. Williams,
+       "Gaussian Processes for Machine Learning",
+       MIT Press 2006 <https://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
 
     Examples
     --------

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -155,9 +155,9 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
     References
     ----------
-    .. [RW2006] Carl Eduard Rasmussen and Christopher K.I. Williams,
-       "Gaussian Processes for Machine Learning", MIT Press 2006,
-       `Link <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
+    .. [RW2006] `Carl E. Rasmussen and Christopher K.I. Williams,
+       "Gaussian Processes for Machine Learning",
+       MIT Press 2006 <https://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
 
     Examples
     --------

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -26,7 +26,7 @@ GPR_CHOLESKY_LOWER = True
 class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     """Gaussian process regression (GPR).
 
-    The implementation is based on Algorithm 2.1 of [1]_.
+    The implementation is based on Algorithm 2.1 of [RW2006]_.
 
     In addition to standard scikit-learn estimator API,
     :class:`GaussianProcessRegressor`:
@@ -155,10 +155,9 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
     References
     ----------
-    .. [1] `Rasmussen, Carl Edward.
-       "Gaussian processes in machine learning."
-       Summer school on machine learning. Springer, Berlin, Heidelberg, 2003
-       <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_.
+    .. [RW2006] Carl Eduard Rasmussen and Christopher K.I. Williams,
+       "Gaussian Processes for Machine Learning", MIT Press 2006,
+       `Link <http://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
 
     Examples
     --------


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The main reference book for GPs is RW2006. It was referred to differently in
doc strings and in `modules/gaussian_process.rst` . Use the same
reference entry in all places.

EuroScipy2022 sprint

#### Any other comments?

Docs were built locally and checked for working links. There is no separate issue that this PR would close.
