### PR TITLE
DOC Rework `plot_affinity_propagation.py` to make it colorblind friendly

### DIFF
--- a/examples/cluster/plot_affinity_propagation.py
+++ b/examples/cluster/plot_affinity_propagation.py
@@ -8,6 +8,7 @@ Brendan J. Frey and Delbert Dueck, "Clustering by Passing Messages
 Between Data Points", Science Feb. 2007
 
 """
+import numpy as np
 
 from sklearn.cluster import AffinityPropagation
 from sklearn import metrics
@@ -48,27 +49,26 @@ print(
 # Plot result
 # -----------
 import matplotlib.pyplot as plt
-from itertools import cycle
 
 plt.close("all")
 plt.figure(1)
 plt.clf()
 
-colors = cycle("bgrcmykbgrcmykbgrcmykbgrcmyk")
+colors = plt.cycler("color", plt.cm.viridis(np.linspace(0, 1, 4)))
+
 for k, col in zip(range(n_clusters_), colors):
     class_members = labels == k
     cluster_center = X[cluster_centers_indices[k]]
-    plt.plot(X[class_members, 0], X[class_members, 1], col + ".")
-    plt.plot(
-        cluster_center[0],
-        cluster_center[1],
-        "o",
-        markerfacecolor=col,
-        markeredgecolor="k",
-        markersize=14,
+    plt.scatter(
+        X[class_members, 0], X[class_members, 1], color=col["color"], marker="."
+    )
+    plt.scatter(
+        cluster_center[0], cluster_center[1], s=14, color=col["color"], marker="o"
     )
     for x in X[class_members]:
-        plt.plot([cluster_center[0], x[0]], [cluster_center[1], x[1]], col)
+        plt.plot(
+            [cluster_center[0], x[0]], [cluster_center[1], x[1]], color=col["color"]
+        )
 
 plt.title("Estimated number of clusters: %d" % n_clusters_)
 plt.show()

--- a/examples/cluster/plot_affinity_propagation.py
+++ b/examples/cluster/plot_affinity_propagation.py
@@ -54,7 +54,7 @@ plt.close("all")
 plt.figure(1)
 plt.clf()
 
-colors = plt.cycler("color", plt.get_cmap()(np.linspace(0, 1, 4)))
+colors = plt.cycler("color", plt.cm.viridis(np.linspace(0, 1, 4)))
 
 for k, col in zip(range(n_clusters_), colors):
     class_members = labels == k

--- a/examples/cluster/plot_affinity_propagation.py
+++ b/examples/cluster/plot_affinity_propagation.py
@@ -54,7 +54,7 @@ plt.close("all")
 plt.figure(1)
 plt.clf()
 
-colors = plt.cycler("color", plt.cm.viridis(np.linspace(0, 1, 4)))
+colors = plt.cycler("color", plt.get_cmap()(np.linspace(0, 1, 4)))
 
 for k, col in zip(range(n_clusters_), colors):
     class_members = labels == k


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Contributes to https://github.com/scikit-learn/scikit-learn/issues/5435 


#### What does this implement/fix? Explain your changes.

This changes the cycled colors from RGB to the Viridis colormap, which is colorblind friendly. 
See below the before/after images.

This PR also changes the scatter plots to actually use `plt.scatter`.

<details>
  <summary>Before</summary>

![old](https://user-images.githubusercontent.com/103438616/188149475-bdbde926-cc4c-4cc9-87ba-d494c131d422.png)

<img width="690" alt="old_cb" src="https://user-images.githubusercontent.com/103438616/188149469-2d2282ba-f7c0-46c8-a983-372283e95c9d.png">


</details>

<details>
  <summary>After</summary>

![new](https://user-images.githubusercontent.com/103438616/188149524-14740afa-6410-4af5-ac7a-0004b1e9972e.png)

<img width="690" alt="new_cb" src="https://user-images.githubusercontent.com/103438616/188149517-9c7557b8-b0cd-4dfe-a3dc-caeb2c31f6b8.png">



</details>


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
