### PR TITLE
DOC Ensures that mean_pinball_loss passes numpydoc validation

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -226,8 +226,8 @@ def mean_pinball_loss(
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
 
-    alpha: float, slope of the pinball loss, default=0.5,
-        this loss is equivalent to :ref:`mean_absolute_error` when `alpha=0.5`,
+    alpha : float, slope of the pinball loss, default=0.5,
+        This loss is equivalent to :ref:`mean_absolute_error` when `alpha=0.5`,
         `alpha=0.95` is minimized by estimators of the 95th percentile.
 
     multioutput : {'raw_values', 'uniform_average'}  or array-like of shape \

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -24,7 +24,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics._ranking.coverage_error",
     "sklearn.metrics._ranking.dcg_score",
     "sklearn.metrics._ranking.roc_curve",
-    "sklearn.metrics._regression.mean_pinball_loss",
     "sklearn.metrics.cluster._bicluster.consensus_score",
     "sklearn.metrics.cluster._supervised.adjusted_mutual_info_score",
     "sklearn.metrics.cluster._supervised.adjusted_rand_score",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350

Fixes docstring for `mean_pinball_loss`.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->



#### What does this implement/fix? Explain your changes.
Add whitespace and capitalize the docstring of one of the parameters - `alpha`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
#euroscipy2022