### PR TITLE
FEA Add support for micro averaging in ovr-roc-auc

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -262,8 +262,9 @@ Changelog
   :pr:`22710` by :user:`Conroy Trinh <trinhcon>` and
   :pr:`23461` by :user:`Meekail Zain <micky774>`.
 
-- |Feature| :func:`metrics.roc_auc_score` now supports micro-averaging for the
-  ovr multiclass problem. :pr:`24338` by :user:`Arturo Amor <ArturoAmorQ>`.
+- |Feature| :func:`metrics.roc_auc_score` now supports micro-averaging
+  (`average="micro"`) for the One-vs-Rest multiclass case (`multi_class="ovr"`).
+  :pr:`24338` by :user:`Arturo Amor <ArturoAmorQ>`.
 
 :mod:`sklearn.model_selection`
 ..............................

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -262,6 +262,9 @@ Changelog
   :pr:`22710` by :user:`Conroy Trinh <trinhcon>` and
   :pr:`23461` by :user:`Meekail Zain <micky774>`.
 
+- |Feature| :func:`metrics.roc_auc_score` now supports micro-averaging for the
+  ovr multiclass problem. :pr:`22518` by :user:`Arturo Amor <ArturoAmorQ>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -263,7 +263,7 @@ Changelog
   :pr:`23461` by :user:`Meekail Zain <micky774>`.
 
 - |Feature| :func:`metrics.roc_auc_score` now supports micro-averaging for the
-  ovr multiclass problem. :pr:`22518` by :user:`Arturo Amor <ArturoAmorQ>`.
+  ovr multiclass problem. :pr:`24338` by :user:`Arturo Amor <ArturoAmorQ>`.
 
 :mod:`sklearn.model_selection`
 ..............................

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -636,6 +636,8 @@ def _multiclass_roc_auc_score(
 
     # validation for multiclass parameter specifications
     average_options = ("macro", "weighted", None)
+    if multi_class == "ovr":
+        average_options += ("micro",)
     if average not in average_options:
         raise ValueError(
             "average must be one of {0} for multiclass problems".format(average_options)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -419,8 +419,9 @@ def roc_auc_score(
         If ``None``, the scores for each class are returned.
         Otherwise, this determines the type of averaging performed on the data.
         Note: multiclass ROC AUC currently only handles the 'macro' and
-        'weighted' averages. For multiclass targets, `average=None`
-        is only implemented for `multi_class='ovo'`.
+        'weighted' averages. For multiclass targets, `average=None` is only
+        implemented for `multi_class='ovo'` and `average='micro'` is only
+        implemented for `multi_class='ovr'`.
 
         ``'micro'``:
             Calculate metrics globally by considering each element of the label
@@ -622,6 +623,9 @@ def _multiclass_roc_auc_score(
         ``'weighted'``:
             Calculate metrics for each label, taking into account the
             prevalence of the classes.
+        ``'micro'``:
+            Calculate metrics for the binarized-raveled classes. Only supported
+            for `multi_class='ovr'`.
 
     sample_weight : array-like of shape (n_samples,) or None
         Sample weights.

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -641,7 +641,7 @@ def _multiclass_roc_auc_score(
     # validation for multiclass parameter specifications
     average_options = ("macro", "weighted", None)
     if multi_class == "ovr":
-        average_options += ("micro",)
+        average_options = ("micro",) + average_options
     if average not in average_options:
         raise ValueError(
             "average must be one of {0} for multiclass problems".format(average_options)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -613,9 +613,12 @@ def _multiclass_roc_auc_score(
             Calculate metrics for the multiclass case using the one-vs-one
             approach.
 
-    average : {'macro', 'weighted'}
+    average : {'micro', 'macro', 'weighted'}
         Determines the type of averaging performed on the pairwise binary
         metric scores
+        ``'micro'``:
+            Calculate metrics for the binarized-raveled classes. Only supported
+            for `multi_class='ovr'`.
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
             mean. This does not take label imbalance into account. Classes
@@ -623,9 +626,6 @@ def _multiclass_roc_auc_score(
         ``'weighted'``:
             Calculate metrics for each label, taking into account the
             prevalence of the classes.
-        ``'micro'``:
-            Calculate metrics for the binarized-raveled classes. Only supported
-            for `multi_class='ovr'`.
 
     sample_weight : array-like of shape (n_samples,) or None
         Sample weights.

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -619,6 +619,9 @@ def _multiclass_roc_auc_score(
         ``'micro'``:
             Calculate metrics for the binarized-raveled classes. Only supported
             for `multi_class='ovr'`.
+
+        .. versionadded:: 1.2
+
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
             mean. This does not take label imbalance into account. Classes

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -40,7 +40,6 @@ from sklearn.metrics import matthews_corrcoef
 from sklearn.metrics import precision_recall_fscore_support
 from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
-from sklearn.metrics import roc_auc_score
 from sklearn.metrics import zero_one_loss
 from sklearn.metrics import brier_score_loss
 from sklearn.metrics import multilabel_confusion_matrix
@@ -1875,18 +1874,6 @@ def test_precision_recall_f1_no_labels_average_none_warn():
         fbeta = fbeta_score(y_true, y_pred, beta=1, average=None)
 
     assert_array_almost_equal(fbeta, [0, 0, 0], 2)
-
-
-def test_assert_ovr_roc_auc_chance_level():
-    # Build equal probability predictions to multiclass problem
-    y_true = np.array([3, 1, 2, 0])
-    y_pred = 0.25 * np.ones((4, 4))
-
-    macro_roc_auc = roc_auc_score(y_true, y_pred, multi_class="ovr", average="macro")
-    assert_allclose(macro_roc_auc, 0.5)
-
-    micro_roc_auc = roc_auc_score(y_true, y_pred, multi_class="ovr", average="micro")
-    assert_allclose(micro_roc_auc, 0.5)
 
 
 def test_prf_warnings():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -40,6 +40,7 @@ from sklearn.metrics import matthews_corrcoef
 from sklearn.metrics import precision_recall_fscore_support
 from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
+from sklearn.metrics import roc_auc_score
 from sklearn.metrics import zero_one_loss
 from sklearn.metrics import brier_score_loss
 from sklearn.metrics import multilabel_confusion_matrix
@@ -1874,6 +1875,18 @@ def test_precision_recall_f1_no_labels_average_none_warn():
         fbeta = fbeta_score(y_true, y_pred, beta=1, average=None)
 
     assert_array_almost_equal(fbeta, [0, 0, 0], 2)
+
+
+def test_assert_ovr_roc_auc_chance_level():
+    # Build equal probability predictions to multiclass problem
+    y_true = np.array([3, 1, 2, 0])
+    y_pred = 0.25 * np.ones((4, 4))
+
+    macro_roc_auc = roc_auc_score(y_true, y_pred, multi_class="ovr", average="macro")
+    assert_allclose(macro_roc_auc, 0.5)
+
+    micro_roc_auc = roc_auc_score(y_true, y_pred, multi_class="ovr", average="micro")
+    assert_allclose(micro_roc_auc, 0.5)
 
 
 def test_prf_warnings():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -672,10 +672,7 @@ def test_micro_averaged_ovr_roc_auc(global_random_seed):
     fpr, tpr, _ = roc_curve(y_onehot.ravel(), y_pred.ravel())
     roc_auc_by_hand = auc(fpr, tpr)
     roc_auc_auto = roc_auc_score(y_true, y_pred, multi_class="ovr", average="micro")
-    assert_almost_equal(
-        roc_auc_by_hand,
-        roc_auc_auto,
-    )
+    assert roc_auc_by_hand == pytest.approx(roc_auc_auto)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -694,7 +694,7 @@ def test_roc_auc_score_multiclass_labels_error(msg, y_true, labels, multi_class)
         ),
         (
             (
-                r"average must be one of \('macro', 'weighted', None, 'micro'\) for "
+                r"average must be one of \('micro', 'macro', 'weighted', None\) for "
                 r"multiclass problems"
             ),
             {"average": "samples", "multi_class": "ovr"},
@@ -742,10 +742,10 @@ def test_assert_ovr_roc_auc_chance_level():
     y_pred = 0.25 * np.ones((4, 4))
 
     macro_roc_auc = roc_auc_score(y_true, y_pred, multi_class="ovr", average="macro")
-    assert_allclose(macro_roc_auc, 0.5)
+    assert macro_roc_auc == pytest.approx(0.5)
 
     micro_roc_auc = roc_auc_score(y_true, y_pred, multi_class="ovr", average="micro")
-    assert_allclose(micro_roc_auc, 0.5)
+    assert micro_roc_auc == pytest.approx(0.5)
 
 
 def test_auc_score_non_binary_class():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -658,8 +658,7 @@ def test_perfect_imperfect_chance_multiclass_roc_auc(multi_class, average):
 def test_micro_averaged_ovr_roc_auc(global_random_seed):
     seed = global_random_seed
     # Let's generate a set of random predictions and matching true labels such
-    # that the predictions are significantly better than chance, yet not perfect
-    # (close to the Bayes error rate). To make the problem more interesting,
+    # that the predictions are not perfect. To make the problem more interesting,
     # we use an imbalanced class distribution (by using different parameters
     # in the Dirichlet prior (conjugate prior of the multinomial distribution).
     y_pred = stats.dirichlet.rvs([2.0, 1.0, 0.5], size=1000, random_state=seed)
@@ -677,9 +676,6 @@ def test_micro_averaged_ovr_roc_auc(global_random_seed):
         roc_auc_by_hand,
         roc_auc_auto,
     )
-    # Check that the test case was not degen so that the equality does not
-    # happen by chance.
-    assert 0.55 < roc_auc_auto < 0.95
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -657,6 +657,11 @@ def test_perfect_imperfect_chance_multiclass_roc_auc(multi_class, average):
 
 def test_micro_averaged_ovr_roc_auc(global_random_seed):
     seed = global_random_seed
+    # Let's generate a set of random predictions and matching true labels such
+    # that the predictions are significantly better than chance, yet not perfect
+    # (close to the Bayes error rate). To make the problem more interesting,
+    # we use an imbalanced class distribution (by using different parameters
+    # in the Dirichlet prior (conjugate prior of the multinomial distribution).
     y_pred = stats.dirichlet.rvs([2.0, 1.0, 0.5], size=1000, random_state=seed)
     y_true = np.asarray(
         [
@@ -672,6 +677,9 @@ def test_micro_averaged_ovr_roc_auc(global_random_seed):
         roc_auc_by_hand,
         roc_auc_auto,
     )
+    # Check that the test case was not degen so that the equality does not
+    # happen by chance.
+    assert 0.55 < roc_auc_auto < 0.95
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -610,8 +610,8 @@ def test_multiclass_ovr_roc_auc_toydata(y_true, labels):
         result_weighted,
     )
 
-    # Perfect classifier has roc_auc_score = 1.0
-    y_perfect = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]
+    # Perfect classifier (from a ranking point of view) has roc_auc_score = 1.0
+    y_perfect = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.2, 0.05, 0.85]]
     assert_almost_equal(
         roc_auc_score(y_true, y_perfect, multi_class="ovr", labels=labels),
         1.0,

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -736,6 +736,18 @@ def test_roc_auc_score_multiclass_error(msg, kwargs):
         roc_auc_score(y_true, y_prob, **kwargs)
 
 
+def test_assert_ovr_roc_auc_chance_level():
+    # Build equal probability predictions to multiclass problem
+    y_true = np.array([3, 1, 2, 0])
+    y_pred = 0.25 * np.ones((4, 4))
+
+    macro_roc_auc = roc_auc_score(y_true, y_pred, multi_class="ovr", average="macro")
+    assert_allclose(macro_roc_auc, 0.5)
+
+    micro_roc_auc = roc_auc_score(y_true, y_pred, multi_class="ovr", average="micro")
+    assert_allclose(micro_roc_auc, 0.5)
+
+
 def test_auc_score_non_binary_class():
     # Test that roc_auc_score function returns an error when trying
     # to compute AUC for non-binary class values.

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -655,11 +655,12 @@ def test_perfect_imperfect_chance_multiclass_roc_auc(multi_class, average):
     ) == pytest.approx(0.5)
 
 
-def test_micro_averaged_ovr_roc_auc():
-    y_pred = stats.dirichlet.rvs([2.0, 1.0, 0.5], size=1000, random_state=0)
+def test_micro_averaged_ovr_roc_auc(global_random_seed):
+    seed = global_random_seed
+    y_pred = stats.dirichlet.rvs([2.0, 1.0, 0.5], size=1000, random_state=seed)
     y_true = np.asarray(
         [
-            stats.multinomial.rvs(n=1, p=y_pred_i, random_state=0).argmax()
+            stats.multinomial.rvs(n=1, p=y_pred_i, random_state=seed).argmax()
             for y_pred_i in y_pred
         ]
     )

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -736,7 +736,7 @@ def test_roc_auc_score_multiclass_error(msg, kwargs):
         roc_auc_score(y_true, y_prob, **kwargs)
 
 
-def test_assert_ovr_roc_auc_chance_level():
+def test_ovr_roc_auc_chance_level():
     # Build equal probability predictions to multiclass problem
     y_true = np.array([3, 1, 2, 0])
     y_pred = 0.25 * np.ones((4, 4))

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -593,7 +593,7 @@ def test_multiclass_ovr_roc_auc_toydata(y_true, labels):
         [out_0, out_1, out_2],
     )
 
-    # Compute unweighted results (default behaviour)
+    # Compute unweighted results (default behaviour is average="macro")
     result_unweighted = (out_0 + out_1 + out_2) / 3.0
     assert_almost_equal(
         roc_auc_score(y_true, y_scores, multi_class="ovr", labels=labels),
@@ -609,6 +609,17 @@ def test_multiclass_ovr_roc_auc_toydata(y_true, labels):
         ),
         result_weighted,
     )
+
+    # Perfect classifier has roc_auc_score = 1.0
+    y_perfect = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]
+    assert_almost_equal(
+        roc_auc_score(y_true, y_perfect, multi_class="ovr", labels=labels),
+        1.0,
+    )
+
+    # Imperfect classifier has roc_auc_score < 1.0
+    y_imperfect = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]
+    assert roc_auc_score(y_true, y_imperfect, multi_class="ovr", labels=labels) < 1.0
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -694,10 +694,10 @@ def test_roc_auc_score_multiclass_labels_error(msg, y_true, labels, multi_class)
         ),
         (
             (
-                r"average must be one of \('macro', 'weighted', None\) for "
+                r"average must be one of \('macro', 'weighted', None, 'micro'\) for "
                 r"multiclass problems"
             ),
-            {"average": "micro", "multi_class": "ovr"},
+            {"average": "samples", "multi_class": "ovr"},
         ),
         (
             (


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Relevant for simplifying #24200.

#### What does this implement/fix? Explain your changes.

Micro-averaging was not supported for the multiclass `roc_auc_score`. There is no reason for not doing so, as the `label_binarize` function is run internally.

This PR makes micro-averaging `roc_auc_score` accessible to the users without needing an external `label_binarize`.

#### Any other comments?

I added a test that covers this line of code and as side effect, checks for consistency with chance level.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
