### PR TITLE
ENH Add dtype preservation to SkewedChi2Sampler

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -162,7 +162,7 @@ Changelog
 ............................
 
 - |Enhancement| :class:`kernel_approximation.SkewedChi2Sampler` now preserves
-  dtype for `numpy.float32` inputs. :pr:`24348` by `Rahil Parikh <rprkh>`.
+  dtype for `numpy.float32` inputs. :pr:`24349` by `Rahil Parikh <rprkh>`.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -158,6 +158,12 @@ Changelog
   :pr:`11860` by :user:`Pierre Ablin <pierreablin>`,
   :pr:`22527` by :user:`Meekail Zain <micky774>` and `Thomas Fan`_.
 
+:mod:`sklearn.kernel_approximation`
+............................
+
+- |Enhancement| :class:`kernel_approximation.SkewedChi2Sampler` now preserves
+  dtype for `numpy.float32` inputs. :pr:`24348` by `Rahil Parikh <rprkh>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -444,6 +444,9 @@ class SkewedChi2Sampler(
     1.0
     """
 
+    def _more_tags(self):
+        return {"preserves_dtype": [np.float64, np.float32]}
+
     def __init__(self, *, skewedness=1.0, n_components=100, random_state=None):
         self.skewedness = skewedness
         self.n_components = n_components
@@ -477,6 +480,12 @@ class SkewedChi2Sampler(
         # transform by inverse CDF of sech
         self.random_weights_ = 1.0 / np.pi * np.log(np.tan(np.pi / 2.0 * uniform))
         self.random_offset_ = random_state.uniform(0, 2 * np.pi, size=self.n_components)
+
+        # With this we preserve the dtype of X in transform() later
+        if X.dtype == np.float32:
+            self.random_weights_ = self.random_weights_.astype(X.dtype, copy=False)
+            self.random_offset_ = self.random_offset_.astype(X.dtype, copy=False)
+
         self._n_features_out = self.n_components
         return self
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #11000 

#### What does this implement/fix? Explain your changes.
`SkewedChi2Sampler` uses `float32` when the input `X` is `float32`, otherwise it uses `float64` as before.

#### Any other comments?
Creating another PR for this due to merge conflicts that cannot be resolved.
```
From https://github.com/rprkh/scikit-learn
 * branch                preserve_dtype_skewedchi2sampler -> FETCH_HEAD
Auto-merging sklearn/kernel_approximation.py
CONFLICT (content): Merge conflict in sklearn/kernel_approximation.py
Auto-merging doc/whats_new/v1.2.rst
CONFLICT (content): Merge conflict in doc/whats_new/v1.2.rst
Automatic merge failed; fix conflicts and then commit the result.