### PR TITLE
DOC Ensures that dcg_score & roc_curve passes numpydoc validation

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -976,7 +976,6 @@ def roc_curve(
     array([0. , 0.5, 0.5, 1. , 1. ])
     >>> thresholds
     array([1.8 , 0.8 , 0.4 , 0.35, 0.1 ])
-
     """
     fps, tps, thresholds = _binary_clf_curve(
         y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
@@ -1475,7 +1474,6 @@ def dcg_score(
     >>> dcg_score(true_relevance,
     ...           scores, k=1, ignore_ties=True)
     5.0
-
     """
     y_true = check_array(y_true, ensure_2d=False)
     y_score = check_array(y_score, ensure_2d=False)

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -20,8 +20,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     # This will be fixed with issue: #24328
     "sklearn.metrics._plot.det_curve.plot_det_curve",
     "sklearn.metrics._plot.precision_recall_curve.plot_precision_recall_curve",
-    "sklearn.metrics._ranking.dcg_score",
-    "sklearn.metrics._ranking.roc_curve",
     "sklearn.metrics.cluster._supervised.adjusted_mutual_info_score",
     "sklearn.metrics.cluster._supervised.entropy",
     "sklearn.metrics.cluster._supervised.fowlkes_mallows_score",


### PR DESCRIPTION
**Reference Issues/PRs**

Addresses https://github.com/scikit-learn/scikit-learn/issues/21350

**What does this implement/fix? Explain your changes.**

Fixed docstring to allow `sklearn.metrics._ranking.dcg_score` and `sklearn.metrics._ranking.roc_curve` docstring to pass numpydoc validation.

**Any other comments?**