### PR TITLE
Log loss 16 32bit input

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2612,6 +2612,7 @@ def log_loss(
             DataConversionWarning,
         )
         eps = np.finfo(np.float32).eps
+    # following elif section can be removed if float16 support is not wanted
     elif (type(y_pred[0]) == np.float16) and (eps < np.finfo(np.float16).eps):
         # eps increased to np.float16 precision
         warnings.warn(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #24315.

#### What does this implement/fix? Explain your changes.
fix the nan result when the input is np.float32 and np.float16

#### Any other comments?
- added documentation explaining that eps will be automatically modified if the input is detected to be numpy array containing np.float32 or np.float16
- added warning message to alert the user that eps is changed if input of type np.float32 or np.float16 detected

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
