### PR TITLE
CI Cancel in progress wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,6 +17,10 @@ on:
   # Manual run
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Check whether to build the wheels and the source tarball
   check_build_trigger:


### PR DESCRIPTION
This PR cancels wheel building tasks that were previously running when there is a new commit triggering it. This improves the turn around time when debugging wheels in PRs and save resources overall.

CC @lesteve 