### PR TITLE
DOC moved legend to center

### DIFF
--- a/examples/semi_supervised/plot_label_propagation_structure.py
+++ b/examples/semi_supervised/plot_label_propagation_structure.py
@@ -62,7 +62,7 @@ plt.scatter(
     label="unlabeled",
 )
 plt.legend(scatterpoints=1, shadow=False, loc="center")
-plt.title("Raw data (2 classes=outer and inner)")
+_ = plt.title("Raw data (2 classes=outer and inner)")
 
 # %%
 #

--- a/examples/semi_supervised/plot_label_propagation_structure.py
+++ b/examples/semi_supervised/plot_label_propagation_structure.py
@@ -61,7 +61,7 @@ plt.scatter(
     marker=".",
     label="unlabeled",
 )
-plt.legend(scatterpoints=1, shadow=False, loc="upper right")
+plt.legend(scatterpoints=1, shadow=False, loc="center")
 plt.title("Raw data (2 classes=outer and inner)")
 
 # %%
@@ -100,6 +100,6 @@ plt.scatter(
     s=10,
     label="inner learned",
 )
-plt.legend(scatterpoints=1, shadow=False, loc="upper right")
+plt.legend(scatterpoints=1, shadow=False, loc="center")
 plt.title("Labels learned with Label Spreading (KNN)")
 plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Moved the legend to the center of the circle, so the legend won't block the plot.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
