### PR TITLE
FIX remove np.divide with where and without out argument in `precision_recall_curve`

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -872,7 +872,7 @@ def precision_recall_curve(y_true, probas_pred, *, pos_label=None, sample_weight
 
     ps = tps + fps
     # Initialize the result array with zeros to make sure that precision[ps == 0]
-    # does not contain uninitialized values. 
+    # does not contain uninitialized values.
     precision = np.zeros_like(tps)
     np.divide(tps, ps, out=precision, where=(ps != 0))
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -871,6 +871,8 @@ def precision_recall_curve(y_true, probas_pred, *, pos_label=None, sample_weight
     )
 
     ps = tps + fps
+    # Initialize the result array with zeros to make sure that precision[ps == 0]
+    # does not contain uninitialized values. 
     precision = np.zeros_like(tps)
     np.divide(tps, ps, out=precision, where=(ps != 0))
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -871,7 +871,8 @@ def precision_recall_curve(y_true, probas_pred, *, pos_label=None, sample_weight
     )
 
     ps = tps + fps
-    precision = np.divide(tps, ps, where=(ps != 0))
+    precision = np.zeros_like(tps)
+    np.divide(tps, ps, out=precision, where=(ps != 0))
 
     # When no positive label in y_true, recall is set to 1 for all thresholds
     # tps[-1] == 0 <=> y_true == all negative labels


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`np.divide` with `where` and wihtout an `out` argument has unitialised values outside of the where condition. After https://github.com/scikit-learn/scikit-learn/pull/24245 I think this PR removes the only place where we use this in scikit-learn.

See https://numpy.org/doc/stable/reference/ufuncs.html#ufunc and search "where" (sorry no direct link)
> Note that if an uninitialized return array is created, values of where=False will leave those values uninitialized.

#### Any other comments?

This `np.divide` was introduced in #19085 to fix the recall when `y_true` has only zeros this did not affect precision. The behaviour was to have zeros so I used this an an initialisation.

Having looked at the code I am fairly confident that actually `tps + fps` can not be zero (unless strictly negative sample weights) but it seems like this is a bit tricky to convince yourself so maybe leave the `np.divide(..., where=denominator != 0)`? Alternatively I could add a comment trying to summarise the following (not that easy).

The code is in `_binary_clf_curve`: https://github.com/scikit-learn/scikit-learn/blob/fd0e8158a408b79bc7c43b4de7891640bb0fe809/sklearn/metrics/_ranking.py#L703

- no `sample_weight` case: `tps + fps = 1 + threshold_idxs` which is never zero
- `sample_weight` case is a bit more tricky:
   ```
   tps + fps = stable_cumsum(y_true * weight) + stable_cumsum((1 - y_true) * weight)
   ```
   + if `(sample_weight > 0).all()`, `tps + fps` > 0 we are all good
   + if `(sample_weight == 0).any()`, zero `sample_weight` get actually masked out in https://github.com/scikit-learn/scikit-learn/blob/fd0e8158a408b79bc7c43b4de7891640bb0fe809/sklearn/metrics/_ranking.py#L748-L755 so you never see them in the cumulative sum
   + if `(sample_weight < 0).any()` `tps + fps` could be zero, but the consensus is that it does not make any sense to have negative sample weights :shrug:. There seem to be some use cases in High Energy Physics but I assume that this is more for an estimator than computing a precision-recall curve. Let's leave this discussion for a separate PR anyway this is a can full of worms. 

I tried pragmatically to find a case where `tps + fps == 0` and the only way I managed to get this is with negative `sample_weight`. Here is a snippet if you want to try for yourself:

```py
from sklearn.metrics._ranking import _binary_clf_curve, precision_recall_curve

y_true = [0, 0, 0, 0]
probas_pred = [0.7, 0.6, 0.5, 0.4]
sample_weight = [-1, 1, -1, 1]
fps, tps, thresholds = _binary_clf_curve(
    y_true, probas_pred, pos_label=1, sample_weight=sample_weight
)
print(f"{fps=}")
print(f"{tps=}")
print(f"{thresholds=}")
print(f"{fps+tps == 0=}")

precision, recall, threshold = precision_recall_curve(y_true, probas_pred, pos_label=1, sample_weight=sample_weight)
print(f"{precision=}")
```

Output:
```
fps=array([-1.,  0., -1.,  0.])
tps=array([-0.,  0.,  0.,  0.])
thresholds=array([0.7, 0.6, 0.5, 0.4])
fps+tps == 0=array([False,  True, False,  True])
```