### PR TITLE
TST Remove remaining tests now covered by common param validation test

### DIFF
--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -11,7 +11,6 @@ from sklearn.cluster import Birch
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.datasets import make_blobs
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.linear_model import ElasticNet
 from sklearn.metrics import pairwise_distances_argmin, v_measure_score
 
 from sklearn.utils._testing import assert_almost_equal
@@ -82,13 +81,6 @@ def test_n_clusters():
     brc2.fit(X)
     assert_array_equal(brc1.subcluster_labels_, brc2.subcluster_labels_)
     assert_array_equal(brc1.labels_, brc2.labels_)
-
-    # Test that n_clusters being a non-cluster estimator raises an Error.
-    clf = ElasticNet()
-    brc3 = Birch(n_clusters=clf)
-    msg = r"The 'n_clusters' parameter of Birch must be .* Got .* instead."
-    with pytest.raises(ValueError, match=msg):
-        brc3.fit(X)
 
     # Test that a small number of clusters raises a warning.
     brc4 = Birch(threshold=10000.0)

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -136,18 +136,6 @@ def test_height_linkage_tree():
         assert len(children) + n_leaves == n_nodes
 
 
-def test_agglomerative_clustering_wrong_arg_memory():
-    # Test either if an error is raised when memory is not
-    # either a str or a joblib.Memory instance
-    rng = np.random.RandomState(0)
-    n_samples = 100
-    X = rng.randn(n_samples, 50)
-    memory = 5
-    clustering = AgglomerativeClustering(memory=memory)
-    with pytest.raises(ValueError):
-        clustering.fit(X)
-
-
 def test_zero_cosine_linkage_tree():
     # Check that zero vectors in X produce an error when
     # 'cosine' affinity is used

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -163,11 +163,6 @@ def test_affinities():
     labels = sp.fit(X).labels_
     assert (X.shape[0],) == labels.shape
 
-    # raise error on unknown affinity
-    sp = SpectralClustering(n_clusters=2, affinity="<unknown>")
-    with pytest.raises(ValueError):
-        sp.fit(X)
-
 
 def test_cluster_qr():
     # cluster_qr by itself should not be used for clustering generic data

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -716,17 +716,6 @@ def test_warm_start_clear(Cls):
 
 
 @pytest.mark.parametrize("Cls", GRADIENT_BOOSTING_ESTIMATORS)
-def test_warm_start_zero_n_estimators(Cls):
-    # Test if warm start with zero n_estimators raises error
-    X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
-    est = Cls(n_estimators=100, max_depth=1, warm_start=True)
-    est.fit(X, y)
-    est.set_params(n_estimators=0)
-    with pytest.raises(ValueError):
-        est.fit(X, y)
-
-
-@pytest.mark.parametrize("Cls", GRADIENT_BOOSTING_ESTIMATORS)
 def test_warm_start_smaller_n_estimators(Cls):
     # Test if warm start with smaller n_estimators raises error
     X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -528,7 +528,6 @@ def test_rfe_wrapped_estimator(importance_getter, selector, expected_n_features)
         ("auto", ValueError),
         ("random", AttributeError),
         (lambda x: x.importance, AttributeError),
-        ([0], ValueError),
     ],
 )
 @pytest.mark.parametrize("Selector", [RFE, RFECV])

--- a/sklearn/linear_model/tests/test_ransac.py
+++ b/sklearn/linear_model/tests/test_ransac.py
@@ -485,16 +485,6 @@ def test_ransac_dynamic_max_trials():
     assert _dynamic_max_trials(1, 100, 10, 0) == 0
     assert _dynamic_max_trials(1, 100, 10, 1) == float("inf")
 
-    estimator = LinearRegression()
-    ransac_estimator = RANSACRegressor(estimator, min_samples=2, stop_probability=-0.1)
-
-    with pytest.raises(ValueError):
-        ransac_estimator.fit(X, y)
-
-    ransac_estimator = RANSACRegressor(estimator, min_samples=2, stop_probability=1.1)
-    with pytest.raises(ValueError):
-        ransac_estimator.fit(X, y)
-
 
 def test_ransac_fit_sample_weight():
     ransac_estimator = RANSACRegressor(random_state=0)

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -885,14 +885,6 @@ def test_wrong_class_weight_label(klass):
 
 
 @pytest.mark.parametrize("klass", [SGDClassifier, SparseSGDClassifier])
-def test_wrong_class_weight_format(klass):
-    # ValueError due to wrong class_weight argument type.
-    clf = klass(alpha=0.1, max_iter=1000, class_weight=[0.5])
-    with pytest.raises(ValueError):
-        clf.fit(X, Y)
-
-
-@pytest.mark.parametrize("klass", [SGDClassifier, SparseSGDClassifier])
 def test_weights_multiplied(klass):
     # Tests that class_weight and sample_weight are multiplicative
     class_weights = {1: 0.6, 2: 0.3}

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -339,18 +339,6 @@ def test_pipeline_spectral_clustering(seed=36):
         )
 
 
-def test_spectral_embedding_unknown_eigensolver(seed=36):
-    # Test that SpectralClustering fails with an unknown eigensolver
-    se = SpectralEmbedding(
-        n_components=1,
-        affinity="precomputed",
-        random_state=np.random.RandomState(seed),
-        eigen_solver="<unknown>",
-    )
-    with pytest.raises(ValueError):
-        se.fit(S)
-
-
 def test_connectivity(seed=36):
     # Test that graph connectivity test works as expected
     graph = np.array(

--- a/sklearn/neighbors/tests/test_nca.py
+++ b/sklearn/neighbors/tests/test_nca.py
@@ -460,13 +460,6 @@ def test_one_class():
 
 
 def test_callback(capsys):
-    X = iris_data
-    y = iris_target
-
-    nca = NeighborhoodComponentsAnalysis(callback="my_cb")
-    with pytest.raises(ValueError):
-        nca.fit(X, y)
-
     max_iter = 10
 
     def my_cb(transformation, n_iter):

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -331,10 +331,6 @@ def test_lbfgs_regression_maxfun(X, y):
             mlp.fit(X, y)
             assert max_fun >= mlp.n_iter_
 
-    mlp.max_fun = -1
-    with pytest.raises(ValueError):
-        mlp.fit(X, y)
-
 
 def test_learning_rate_warmstart():
     # Tests that warm_start reuse past solutions.

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -218,20 +218,12 @@ def test_sparse_decision_function():
 
 def test_error():
     # Test that it gives proper exception on deficient input
-    # impossible value of C
-    with pytest.raises(ValueError):
-        svm.SVC(C=-1).fit(X, Y)
-
-    # impossible value of nu
-    clf = svm.NuSVC(nu=0.0)
-    with pytest.raises(ValueError):
-        clf.fit(X_sp, Y)
+    clf = svm.SVC()
 
     Y2 = Y[:-1]  # wrong dimensions for labels
     with pytest.raises(ValueError):
         clf.fit(X_sp, Y2)
 
-    clf = svm.SVC()
     clf.fit(X_sp, Y)
     assert_array_equal(clf.predict(T), true_result)
 


### PR DESCRIPTION
There are still some tests checking errors from param validation, that we missed in the reviews of the param validation PRs.
There are redundant with the common test and can be safely deleted now that all estimators implement `_parameter_constraints`.

To catch them I changed the type of the error raise by `validate_parameter_constraints` to make the `with pytest.raises()` statements fail, so I'm quite confident that there are no more such tests.