### PR TITLE
MAINT Clean deprecation for 1.2: criterion="mse"/"mae" in trees

### DIFF
--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -16,7 +16,6 @@ from ..base import BaseEstimator
 from ..base import MetaEstimatorMixin
 from ..tree import (
     DecisionTreeRegressor,
-    ExtraTreeRegressor,
     BaseDecisionTree,
     DecisionTreeClassifier,
 )
@@ -147,15 +146,6 @@ class BaseEnsemble(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         """
         estimator = clone(self.base_estimator_)
         estimator.set_params(**{p: getattr(self, p) for p in self.estimator_params})
-
-        # TODO: Remove in v1.2
-        # criterion "mse" and "mae" would cause warnings in every call to
-        # DecisionTreeRegressor.fit(..)
-        if isinstance(estimator, (DecisionTreeRegressor, ExtraTreeRegressor)):
-            if getattr(estimator, "criterion", None) == "mse":
-                estimator.set_params(criterion="squared_error")
-            elif getattr(estimator, "criterion", None) == "mae":
-                estimator.set_params(criterion="absolute_error")
 
         # TODO(1.3): Remove
         # max_features = 'auto' would cause warnings in every call to

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -406,23 +406,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             n_samples_bootstrap = None
 
         self._validate_estimator()
-        # TODO(1.2): Remove "mse" and "mae"
         if isinstance(self, (RandomForestRegressor, ExtraTreesRegressor)):
-            if self.criterion == "mse":
-                warn(
-                    "Criterion 'mse' was deprecated in v1.0 and will be "
-                    "removed in version 1.2. Use `criterion='squared_error'` "
-                    "which is equivalent.",
-                    FutureWarning,
-                )
-            elif self.criterion == "mae":
-                warn(
-                    "Criterion 'mae' was deprecated in v1.0 and will be "
-                    "removed in version 1.2. Use `criterion='absolute_error'` "
-                    "which is equivalent.",
-                    FutureWarning,
-                )
-
             # TODO(1.3): Remove "auto"
             if self.max_features == "auto":
                 warn(
@@ -1496,14 +1480,6 @@ class RandomForestRegressor(ForestRegressor):
         .. versionadded:: 1.0
            Poisson criterion.
 
-        .. deprecated:: 1.0
-            Criterion "mse" was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion="squared_error"` which is equivalent.
-
-        .. deprecated:: 1.0
-            Criterion "mae" was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion="absolute_error"` which is equivalent.
-
     max_depth : int, default=None
         The maximum depth of the tree. If None, then nodes are expanded until
         all leaves are pure or until all leaves contain less than
@@ -2179,14 +2155,6 @@ class ExtraTreesRegressor(ForestRegressor):
 
         .. versionadded:: 0.18
            Mean Absolute Error (MAE) criterion.
-
-        .. deprecated:: 1.0
-            Criterion "mse" was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion="squared_error"` which is equivalent.
-
-        .. deprecated:: 1.0
-            Criterion "mae" was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion="absolute_error"` which is equivalent.
 
     max_depth : int, default=None
         The maximum depth of the tree. If None, then nodes are expanded until

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -139,9 +139,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         **DecisionTreeRegressor._parameter_constraints,
         "learning_rate": [Interval(Real, 0.0, None, closed="left")],
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
-        "criterion": [
-            StrOptions({"friedman_mse", "squared_error", "mse"}, deprecated={"mse"})
-        ],
+        "criterion": [StrOptions({"friedman_mse", "squared_error"})],
         "subsample": [Interval(Real, 0.0, 1.0, closed="right")],
         "verbose": ["verbose"],
         "warm_start": ["boolean"],
@@ -435,15 +433,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         self : object
             Fitted estimator.
         """
-        if self.criterion == "mse":
-            # TODO(1.2): Remove. By then it should raise an error.
-            warnings.warn(
-                "Criterion 'mse' was deprecated in v1.0 and will be "
-                "removed in version 1.2. Use `criterion='squared_error'` "
-                "which is equivalent.",
-                FutureWarning,
-            )
-
         self._validate_params()
 
         if not self.warm_start:
@@ -928,8 +917,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         and an increase in bias.
         Values must be in the range `(0.0, 1.0]`.
 
-    criterion : {'friedman_mse', 'squared_error', 'mse'}, \
-            default='friedman_mse'
+    criterion : {'friedman_mse', 'squared_error'}, default='friedman_mse'
         The function to measure the quality of a split. Supported criteria are
         'friedman_mse' for the mean squared error with improvement score by
         Friedman, 'squared_error' for mean squared error. The default value of
@@ -937,10 +925,6 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         approximation in some cases.
 
         .. versionadded:: 0.18
-
-        .. deprecated:: 1.0
-            Criterion 'mse' was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion='squared_error'` which is equivalent.
 
     min_samples_split : int or float, default=2
         The minimum number of samples required to split an internal node:
@@ -1511,8 +1495,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         and an increase in bias.
         Values must be in the range `(0.0, 1.0]`.
 
-    criterion : {'friedman_mse', 'squared_error', 'mse'}, \
-            default='friedman_mse'
+    criterion : {'friedman_mse', 'squared_error'}, default='friedman_mse'
         The function to measure the quality of a split. Supported criteria are
         "friedman_mse" for the mean squared error with improvement score by
         Friedman, "squared_error" for mean squared error. The default value of
@@ -1520,10 +1503,6 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         approximation in some cases.
 
         .. versionadded:: 0.18
-
-        .. deprecated:: 1.0
-            Criterion 'mse' was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion='squared_error'` which is equivalent.
 
     min_samples_split : int or float, default=2
         The minimum number of samples required to split an internal node:

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -25,7 +25,6 @@ from scipy.special import comb
 import pytest
 
 import joblib
-from numpy.testing import assert_allclose
 
 from sklearn.dummy import DummyRegressor
 from sklearn.metrics import mean_poisson_deviance
@@ -1736,27 +1735,6 @@ def test_max_features_deprecation(Estimator):
 
     with pytest.warns(FutureWarning, match=err_msg):
         est.fit(X, y)
-
-
-@pytest.mark.parametrize(
-    "old_criterion, new_criterion, Estimator",
-    [
-        # TODO(1.2): Remove "mse" and "mae"
-        ("mse", "squared_error", RandomForestRegressor),
-        ("mae", "absolute_error", RandomForestRegressor),
-    ],
-)
-def test_criterion_deprecated(old_criterion, new_criterion, Estimator):
-    est1 = Estimator(criterion=old_criterion, random_state=0)
-
-    with pytest.warns(
-        FutureWarning, match=f"Criterion '{old_criterion}' was deprecated"
-    ):
-        est1.fit(X, y)
-
-    est2 = Estimator(criterion=new_criterion, random_state=0)
-    est2.fit(X, y)
-    assert_allclose(est1.predict(X), est2.predict(X))
 
 
 @pytest.mark.parametrize("Forest", FOREST_REGRESSORS)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1291,22 +1291,6 @@ def test_n_features_deprecation(Estimator):
         est.n_features_
 
 
-# TODO: Remove in v1.2
-@pytest.mark.parametrize("Estimator", GRADIENT_BOOSTING_ESTIMATORS)
-def test_criterion_mse_deprecated(Estimator):
-    est1 = Estimator(criterion="mse", random_state=0)
-
-    with pytest.warns(FutureWarning, match="Criterion 'mse' was deprecated"):
-        est1.fit(X, y)
-
-    est2 = Estimator(criterion="squared_error", random_state=0)
-    est2.fit(X, y)
-    if hasattr(est1, "predict_proba"):
-        assert_allclose(est1.predict_proba(X), est2.predict_proba(X))
-    else:
-        assert_allclose(est1.predict(X), est2.predict(X))
-
-
 @pytest.mark.parametrize(
     "old_loss, new_loss, Estimator",
     [

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -69,13 +69,10 @@ CRITERIA_CLF = {
     "log_loss": _criterion.Entropy,
     "entropy": _criterion.Entropy,
 }
-# TODO(1.2): Remove "mse" and "mae".
 CRITERIA_REG = {
     "squared_error": _criterion.MSE,
-    "mse": _criterion.MSE,
     "friedman_mse": _criterion.FriedmanMSE,
     "absolute_error": _criterion.MAE,
-    "mae": _criterion.MAE,
     "poisson": _criterion.Poisson,
 }
 
@@ -332,21 +329,6 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                 )
             else:
                 criterion = CRITERIA_REG[self.criterion](self.n_outputs_, n_samples)
-            # TODO(1.2): Remove "mse" and "mae"
-            if self.criterion == "mse":
-                warnings.warn(
-                    "Criterion 'mse' was deprecated in v1.0 and will be "
-                    "removed in version 1.2. Use `criterion='squared_error'` "
-                    "which is equivalent.",
-                    FutureWarning,
-                )
-            elif self.criterion == "mae":
-                warnings.warn(
-                    "Criterion 'mae' was deprecated in v1.0 and will be "
-                    "removed in version 1.2. Use `criterion='absolute_error'` "
-                    "which is equivalent.",
-                    FutureWarning,
-                )
         else:
             # Make a deepcopy in case the criterion has mutable attributes that
             # might be shared and modified concurrently during parallel fitting
@@ -1032,14 +1014,6 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
         .. versionadded:: 0.24
             Poisson deviance criterion.
 
-        .. deprecated:: 1.0
-            Criterion "mse" was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion="squared_error"` which is equivalent.
-
-        .. deprecated:: 1.0
-            Criterion "mae" was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion="absolute_error"` which is equivalent.
-
     splitter : {"best", "random"}, default="best"
         The strategy used to choose the split at each node. Supported
         strategies are "best" to choose the best split and "random" to choose
@@ -1230,17 +1204,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
     _parameter_constraints: dict = {
         **BaseDecisionTree._parameter_constraints,
         "criterion": [
-            StrOptions(
-                {
-                    "squared_error",
-                    "friedman_mse",
-                    "absolute_error",
-                    "poisson",
-                    "mse",
-                    "mae",
-                },
-                deprecated={"mse", "mae"},
-            ),
+            StrOptions({"squared_error", "friedman_mse", "absolute_error", "poisson"}),
             Hidden(Criterion),
         ],
     }
@@ -1628,25 +1592,22 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
 
     Parameters
     ----------
-    criterion : {"squared_error", "friedman_mse"}, default="squared_error"
+    criterion : {"squared_error", "friedman_mse", "absolute_error", "poisson"}, \
+            default="squared_error"
         The function to measure the quality of a split. Supported criteria
         are "squared_error" for the mean squared error, which is equal to
-        variance reduction as feature selection criterion and "mae" for the
-        mean absolute error.
+        variance reduction as feature selection criterion and minimizes the L2
+        loss using the mean of each terminal node, "friedman_mse", which uses
+        mean squared error with Friedman's improvement score for potential
+        splits, "absolute_error" for the mean absolute error, which minimizes
+        the L1 loss using the median of each terminal node, and "poisson" which
+        uses reduction in Poisson deviance to find splits.
 
         .. versionadded:: 0.18
            Mean Absolute Error (MAE) criterion.
 
         .. versionadded:: 0.24
             Poisson deviance criterion.
-
-        .. deprecated:: 1.0
-            Criterion "mse" was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion="squared_error"` which is equivalent.
-
-        .. deprecated:: 1.0
-            Criterion "mae" was deprecated in v1.0 and will be removed in
-            version 1.2. Use `criterion="absolute_error"` which is equivalent.
 
     splitter : {"random", "best"}, default="random"
         The strategy used to choose the split at each node. Supported

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2103,28 +2103,6 @@ def test_criterion_entropy_same_as_log_loss(Tree, n_classes):
     assert_allclose(tree_log_loss.predict(X), tree_entropy.predict(X))
 
 
-@pytest.mark.parametrize(
-    "old_criterion, new_criterion, Tree",
-    [
-        # TODO(1.2): Remove "mse" and "mae"
-        ("mse", "squared_error", DecisionTreeRegressor),
-        ("mse", "squared_error", ExtraTreeRegressor),
-        ("mae", "absolute_error", DecisionTreeRegressor),
-        ("mae", "absolute_error", ExtraTreeRegressor),
-    ],
-)
-def test_criterion_deprecated(old_criterion, new_criterion, Tree):
-    tree = Tree(criterion=old_criterion)
-
-    with pytest.warns(
-        FutureWarning, match=f"Criterion '{old_criterion}' was deprecated"
-    ):
-        tree.fit(X, y)
-
-    tree_new = Tree(criterion=new_criterion).fit(X, y)
-    assert_allclose(tree.predict(X), tree_new.predict(X))
-
-
 @pytest.mark.parametrize("Tree", ALL_TREES.values())
 def test_n_features_deprecated(Tree):
     # check that we raise a deprecation warning when accessing `n_features_`.


### PR DESCRIPTION
There will be no more bugfix release before 1.2 which should be targeted for november/december, so we can now clean up the deprecations.

In this PR: `criterion="mse"/"mae"` in DecionTreeRegressor and all inherited estimators.