### PR TITLE
MAINT Clean deprecation for 1.2: n_features_in_ in Dummy

### DIFF
--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -12,7 +12,6 @@ import scipy.sparse as sp
 from .base import BaseEstimator, ClassifierMixin, RegressorMixin
 from .base import MultiOutputMixin
 from .utils import check_random_state
-from .utils import deprecated
 from .utils._param_validation import StrOptions, Interval
 from .utils.validation import _num_samples
 from .utils.validation import check_array
@@ -105,13 +104,6 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
 
     n_outputs_ : int
         Number of outputs.
-
-    n_features_in_ : `None`
-        Always set to `None`.
-
-        .. versionadded:: 0.24
-        .. deprecated:: 1.0
-            Will be removed in 1.0
 
     sparse_output_ : bool
         True if the array returned from predict is to be in sparse CSC format.
@@ -449,16 +441,6 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
             X = np.zeros(shape=(len(y), 1))
         return super().score(X, y, sample_weight)
 
-    # TODO: Remove in 1.2
-    # mypy error: Decorated property not supported
-    @deprecated(  # type: ignore
-        "`n_features_in_` is deprecated in 1.0 and will be removed in 1.2."
-    )
-    @property
-    def n_features_in_(self):
-        check_is_fitted(self)
-        return None
-
 
 class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     """Regressor that makes predictions using simple rules.
@@ -496,13 +478,6 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     constant_ : ndarray of shape (1, n_outputs)
         Mean or median or quantile of the training targets or constant value
         given by the user.
-
-    n_features_in_ : `None`
-        Always set to `None`.
-
-        .. versionadded:: 0.24
-        .. deprecated:: 1.0
-            Will be removed in 1.0
 
     n_outputs_ : int
         Number of outputs.
@@ -697,13 +672,3 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         if X is None:
             X = np.zeros(shape=(len(y), 1))
         return super().score(X, y, sample_weight)
-
-    # TODO: Remove in 1.2
-    # mypy error: Decorated property not supported
-    @deprecated(  # type: ignore
-        "`n_features_in_` is deprecated in 1.0 and will be removed in 1.2."
-    )
-    @property
-    def n_features_in_(self):
-        check_is_fitted(self)
-        return None

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -691,18 +691,3 @@ def test_dtype_of_classifier_probas(strategy):
     probas = model.fit(X, y).predict_proba(X)
 
     assert probas.dtype == np.float64
-
-
-# TODO: remove in 1.2
-@pytest.mark.filterwarnings("ignore:`n_features_in_` is deprecated")
-@pytest.mark.parametrize("Dummy", (DummyRegressor, DummyClassifier))
-def test_n_features_in_(Dummy):
-    X = [[1, 2]]
-    y = [0]
-    d = Dummy()
-    assert not hasattr(d, "n_features_in_")
-    d.fit(X, y)
-
-    with pytest.warns(FutureWarning, match="`n_features_in_` is deprecated"):
-        n_features_in = d.n_features_in_
-    assert n_features_in is None


### PR DESCRIPTION
There will be no more bugfix release before 1.2 which should be targeted for november/december, so we can now clean up the deprecations.

In this PR: `n_features_in_` attribute in DummyClassifier/Regressor
