### PR TITLE
MAINT Clean deprecation for 1.2: learning_rate and init in TSNE

### DIFF
--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -28,7 +28,6 @@ representation of the data in the low-dimensional space.
 #
 # We start by generating the S-curve dataset.
 
-from numpy.random import RandomState
 import matplotlib.pyplot as plt
 from matplotlib import ticker
 
@@ -37,10 +36,8 @@ import mpl_toolkits.mplot3d  # noqa: F401
 
 from sklearn import manifold, datasets
 
-rng = RandomState(0)
-
 n_samples = 1500
-S_points, S_color = datasets.make_s_curve(n_samples, random_state=rng)
+S_points, S_color = datasets.make_s_curve(n_samples, random_state=0)
 
 # %%
 # Let's look at the original data. Also define some helping
@@ -110,7 +107,7 @@ params = {
     "n_neighbors": n_neighbors,
     "n_components": n_components,
     "eigen_solver": "auto",
-    "random_state": rng,
+    "random_state": 0,
 }
 
 lle_standard = manifold.LocallyLinearEmbedding(method="standard", **params)
@@ -166,7 +163,7 @@ plot_2d(S_isomap, S_color, "Isomap Embedding")
 # Read more in the :ref:`User Guide <multidimensional_scaling>`.
 
 md_scaling = manifold.MDS(
-    n_components=n_components, max_iter=50, n_init=4, random_state=rng
+    n_components=n_components, max_iter=50, n_init=4, random_state=0
 )
 S_scaling = md_scaling.fit_transform(S_points)
 
@@ -199,12 +196,13 @@ plot_2d(S_spectral, S_color, "Spectral Embedding")
 
 t_sne = manifold.TSNE(
     n_components=n_components,
-    learning_rate="auto",
     perplexity=30,
-    n_iter=250,
     init="random",
-    random_state=rng,
+    n_iter=250,
+    random_state=0,
 )
 S_t_sne = t_sne.fit_transform(S_points)
 
 plot_2d(S_t_sne, S_color, "T-distributed Stochastic  \n Neighbor Embedding")
+
+# %%

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -144,8 +144,6 @@ embeddings = {
     ),
     "t-SNE embeedding": TSNE(
         n_components=2,
-        init="pca",
-        learning_rate="auto",
         n_iter=500,
         n_iter_without_progress=150,
         n_jobs=2,

--- a/examples/manifold/plot_manifold_sphere.py
+++ b/examples/manifold/plot_manifold_sphere.py
@@ -38,7 +38,6 @@ from sklearn.utils import check_random_state
 
 # Unused but required import for doing 3d projections with matplotlib < 3.2
 import mpl_toolkits.mplot3d  # noqa: F401
-import warnings
 
 # Variables for manifold learning.
 n_neighbors = 10
@@ -139,17 +138,10 @@ ax.yaxis.set_major_formatter(NullFormatter())
 plt.axis("tight")
 
 # Perform t-distributed stochastic neighbor embedding.
-# TODO(1.2) Remove warning handling.
-with warnings.catch_warnings():
-    warnings.filterwarnings(
-        "ignore", message="The PCA initialization", category=FutureWarning
-    )
-    t0 = time()
-    tsne = manifold.TSNE(
-        n_components=2, init="pca", random_state=0, learning_rate="auto"
-    )
-    trans_data = tsne.fit_transform(sphere_data).T
-    t1 = time()
+t0 = time()
+tsne = manifold.TSNE(n_components=2, random_state=0)
+trans_data = tsne.fit_transform(sphere_data).T
+t1 = time()
 print("t-SNE: %.2g sec" % (t1 - t0))
 
 ax = fig.add_subplot(2, 5, 10)

--- a/examples/manifold/plot_swissroll.py
+++ b/examples/manifold/plot_swissroll.py
@@ -44,9 +44,9 @@ sr_lle, sr_err = manifold.locally_linear_embedding(
     sr_points, n_neighbors=12, n_components=2
 )
 
-sr_tsne = manifold.TSNE(
-    n_components=2, learning_rate="auto", perplexity=40, init="pca", random_state=0
-).fit_transform(sr_points)
+sr_tsne = manifold.TSNE(n_components=2, perplexity=40, random_state=0).fit_transform(
+    sr_points
+)
 
 fig, axs = plt.subplots(figsize=(8, 8), nrows=2)
 axs[0].scatter(sr_lle[:, 0], sr_lle[:, 1], c=sr_color)
@@ -96,7 +96,7 @@ sh_lle, sh_err = manifold.locally_linear_embedding(
 )
 
 sh_tsne = manifold.TSNE(
-    n_components=2, learning_rate="auto", perplexity=40, init="random", random_state=0
+    n_components=2, perplexity=40, init="random", random_state=0
 ).fit_transform(sh_points)
 
 fig, axs = plt.subplots(figsize=(8, 8), nrows=2)

--- a/examples/manifold/plot_t_sne_perplexity.py
+++ b/examples/manifold/plot_t_sne_perplexity.py
@@ -62,7 +62,6 @@ for i, perplexity in enumerate(perplexities):
         init="random",
         random_state=0,
         perplexity=perplexity,
-        learning_rate="auto",
         n_iter=300,
     )
     Y = tsne.fit_transform(X)
@@ -130,7 +129,6 @@ for i, perplexity in enumerate(perplexities):
         init="random",
         random_state=0,
         perplexity=perplexity,
-        learning_rate="auto",
         n_iter=400,
     )
     Y = tsne.fit_transform(X)

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -706,7 +706,7 @@ class TSNE(BaseEstimator):
 
     learning_rate_ : float
         Effective learning rate.
-        
+
         .. versionadded:: 1.2
 
     n_iter_ : int

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -706,6 +706,8 @@ class TSNE(BaseEstimator):
 
     learning_rate_ : float
         Effective learning rate.
+        
+        .. versionadded:: 1.2
 
     n_iter_ : int
         Number of iterations run.

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -592,7 +592,7 @@ class TSNE(BaseEstimator):
         following [4] and [5].
 
         .. versionchanged:: 1.2
-           The default value chaned to `"auto"`.
+           The default value changed to `"auto"`.
 
     n_iter : int, default=1000
         Maximum number of iterations for the optimization. Should be at

--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -577,7 +577,7 @@ class TSNE(BaseEstimator):
         optimization, the early exaggeration factor or the learning rate
         might be too high.
 
-    learning_rate : float or 'auto', default=200.0
+    learning_rate : float or "auto", default="auto"
         The learning rate for t-SNE is usually in the range [10.0, 1000.0]. If
         the learning rate is too high, the data may look like a 'ball' with any
         point approximately equidistant from its nearest neighbours. If the
@@ -589,7 +589,10 @@ class TSNE(BaseEstimator):
         ours. So our learning_rate=200 corresponds to learning_rate=800 in
         those other implementations. The 'auto' option sets the learning_rate
         to `max(N / early_exaggeration / 4, 50)` where N is the sample size,
-        following [4] and [5]. This will become default in 1.2.
+        following [4] and [5].
+
+        .. versionchanged:: 1.2
+           The default value chaned to `"auto"`.
 
     n_iter : int, default=1000
         Maximum number of iterations for the optimization. Should be at
@@ -625,13 +628,14 @@ class TSNE(BaseEstimator):
 
         .. versionadded:: 1.1
 
-    init : {'random', 'pca'} or ndarray of shape (n_samples, n_components), \
-            default='random'
-        Initialization of embedding. Possible options are 'random', 'pca',
-        and a numpy array of shape (n_samples, n_components).
+    init : {"random", "pca"} or ndarray of shape (n_samples, n_components), \
+            default="pca"
+        Initialization of embedding.
         PCA initialization cannot be used with precomputed distances and is
-        usually more globally stable than random initialization. `init='pca'`
-        will become default in 1.2.
+        usually more globally stable than random initialization.
+
+        .. versionchanged:: 1.2
+           The default value changed to `"pca"`.
 
     verbose : int, default=0
         Verbosity level.
@@ -700,6 +704,9 @@ class TSNE(BaseEstimator):
 
         .. versionadded:: 1.0
 
+    learning_rate_ : float
+        Effective learning rate.
+
     n_iter_ : int
         Number of iterations run.
 
@@ -752,7 +759,6 @@ class TSNE(BaseEstimator):
         "early_exaggeration": [Interval(Real, 1, None, closed="left")],
         "learning_rate": [
             StrOptions({"auto"}),
-            Hidden(StrOptions({"warn"})),
             Interval(Real, 0, None, closed="neither"),
         ],
         "n_iter": [Interval(Integral, 250, None, closed="left")],
@@ -762,7 +768,6 @@ class TSNE(BaseEstimator):
         "metric_params": [dict, None],
         "init": [
             StrOptions({"pca", "random"}),
-            Hidden(StrOptions({"warn"})),
             np.ndarray,
         ],
         "verbose": ["verbose"],
@@ -785,13 +790,13 @@ class TSNE(BaseEstimator):
         *,
         perplexity=30.0,
         early_exaggeration=12.0,
-        learning_rate="warn",
+        learning_rate="auto",
         n_iter=1000,
         n_iter_without_progress=300,
         min_grad_norm=1e-7,
         metric="euclidean",
         metric_params=None,
-        init="warn",
+        init="pca",
         verbose=0,
         random_state=None,
         method="barnes_hut",
@@ -823,28 +828,7 @@ class TSNE(BaseEstimator):
     def _fit(self, X, skip_num_points=0):
         """Private function to fit the model using X as training data."""
 
-        if isinstance(self.init, str) and self.init == "warn":
-            # See issue #18018
-            warnings.warn(
-                "The default initialization in TSNE will change "
-                "from 'random' to 'pca' in 1.2.",
-                FutureWarning,
-            )
-            self._init = "random"
-        else:
-            self._init = self.init
-        if self.learning_rate == "warn":
-            # See issue #18018
-            warnings.warn(
-                "The default learning rate in TSNE will change "
-                "from 200.0 to 'auto' in 1.2.",
-                FutureWarning,
-            )
-            self._learning_rate = 200.0
-        else:
-            self._learning_rate = self.learning_rate
-
-        if isinstance(self._init, str) and self._init == "pca" and issparse(X):
+        if isinstance(self.init, str) and self.init == "pca" and issparse(X):
             raise TypeError(
                 "PCA initialization is currently not supported "
                 "with the sparse input matrix. Use "
@@ -856,10 +840,12 @@ class TSNE(BaseEstimator):
                 "removed in version 1.3.",
                 FutureWarning,
             )
-        if self._learning_rate == "auto":
+        if self.learning_rate == "auto":
             # See issue #18018
-            self._learning_rate = X.shape[0] / self.early_exaggeration / 4
-            self._learning_rate = np.maximum(self._learning_rate, 50)
+            self.learning_rate_ = X.shape[0] / self.early_exaggeration / 4
+            self.learning_rate_ = np.maximum(self.learning_rate_, 50)
+        else:
+            self.learning_rate_ = self.learning_rate
 
         if self.method == "barnes_hut":
             X = self._validate_data(
@@ -873,7 +859,7 @@ class TSNE(BaseEstimator):
                 X, accept_sparse=["csr", "csc", "coo"], dtype=[np.float32, np.float64]
             )
         if self.metric == "precomputed":
-            if isinstance(self._init, str) and self._init == "pca":
+            if isinstance(self.init, str) and self.init == "pca":
                 raise ValueError(
                     'The parameter init="pca" cannot be used with metric="precomputed".'
                 )
@@ -993,26 +979,19 @@ class TSNE(BaseEstimator):
             # compute the joint probability distribution for the input space
             P = _joint_probabilities_nn(distances_nn, self.perplexity, self.verbose)
 
-        if isinstance(self._init, np.ndarray):
-            X_embedded = self._init
-        elif self._init == "pca":
+        if isinstance(self.init, np.ndarray):
+            X_embedded = self.init
+        elif self.init == "pca":
             pca = PCA(
                 n_components=self.n_components,
                 svd_solver="randomized",
                 random_state=random_state,
             )
             X_embedded = pca.fit_transform(X).astype(np.float32, copy=False)
-            # TODO: Update in 1.2
             # PCA is rescaled so that PC1 has standard deviation 1e-4 which is
             # the default value for random initialization. See issue #18018.
-            warnings.warn(
-                "The PCA initialization in TSNE will change to "
-                "have the standard deviation of PC1 equal to 1e-4 "
-                "in 1.2. This will ensure better convergence.",
-                FutureWarning,
-            )
-            # X_embedded = X_embedded / np.std(X_embedded[:, 0]) * 1e-4
-        elif self._init == "random":
+            X_embedded = X_embedded / np.std(X_embedded[:, 0]) * 1e-4
+        elif self.init == "random":
             # The embedding is initialized with iid samples from Gaussians with
             # standard deviation 1e-4.
             X_embedded = 1e-4 * random_state.standard_normal(
@@ -1055,7 +1034,7 @@ class TSNE(BaseEstimator):
             "it": 0,
             "n_iter_check": self._N_ITER_CHECK,
             "min_grad_norm": self.min_grad_norm,
-            "learning_rate": self._learning_rate,
+            "learning_rate": self.learning_rate_,
             "verbose": self.verbose,
             "kwargs": dict(skip_num_points=skip_num_points),
             "args": [P, degrees_of_freedom, n_samples, self.n_components],

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import scipy.sparse as sp
 import pytest
-import warnings
 
 from sklearn.neighbors import NearestNeighbors
 from sklearn.neighbors import kneighbors_graph
@@ -42,10 +41,6 @@ X_2d_grid = np.hstack(
         xx.ravel().reshape(-1, 1),
         yy.ravel().reshape(-1, 1),
     ]
-)
-
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The PCA initialization in TSNE will change to have the standard deviation",
 )
 
 
@@ -385,7 +380,6 @@ def test_trustworthiness_not_euclidean_metric():
     )
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
 @pytest.mark.parametrize(
     "method, retype",
     [
@@ -413,7 +407,6 @@ def test_bad_precomputed_distances(method, D, retype, message_regex):
         tsne.fit_transform(retype(D))
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
 def test_exact_no_precomputed_sparse():
     tsne = TSNE(
         metric="precomputed",
@@ -426,7 +419,6 @@ def test_exact_no_precomputed_sparse():
         tsne.fit_transform(sp.csr_matrix([[0, 5], [5, 0]]))
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
 def test_high_perplexity_precomputed_sparse_distances():
     # Perplexity should be less than 50
     dist = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
@@ -458,8 +450,6 @@ def test_sparse_precomputed_distance():
         assert_almost_equal(Xt_dense, Xt_sparse)
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
-@pytest.mark.filterwarnings("ignore:The default initialization in TSNE")
 def test_non_positive_computed_distances():
     # Computed distance matrices must be positive.
     def metric(x, y):
@@ -490,7 +480,6 @@ def test_init_ndarray_precomputed():
     tsne.fit(np.zeros((100, 100)))
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
 def test_pca_initialization_not_compatible_with_precomputed_kernel():
     # Precomputed distance matrices cannot use PCA initialization.
     tsne = TSNE(metric="precomputed", init="pca", perplexity=1)
@@ -508,8 +497,6 @@ def test_pca_initialization_not_compatible_with_sparse_input():
         tsne.fit_transform(sp.csr_matrix([[0, 5], [5, 0]]))
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
-@pytest.mark.filterwarnings("ignore:The default initialization in TSNE")
 def test_n_components_range():
     # barnes_hut method should only be used with n_components <= 3
     tsne = TSNE(n_components=4, method="barnes_hut", perplexity=1)
@@ -674,8 +661,6 @@ def _run_answer_test(
     assert_array_almost_equal(grad_bh, grad_output, decimal=4)
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
-@pytest.mark.filterwarnings("ignore:The default initialization in TSNE")
 def test_verbose():
     # Verbose options write to stdout.
     random_state = check_random_state(0)
@@ -698,8 +683,6 @@ def test_verbose():
     assert "early exaggeration" in out
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
-@pytest.mark.filterwarnings("ignore:The default initialization in TSNE")
 def test_chebyshev_metric():
     # t-SNE should allow metrics that cannot be squared (issue #3526).
     random_state = check_random_state(0)
@@ -708,8 +691,6 @@ def test_chebyshev_metric():
     tsne.fit_transform(X)
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
-@pytest.mark.filterwarnings("ignore:The default initialization in TSNE")
 def test_reduction_to_one_component():
     # t-SNE should allow reduction to one component (issue #4154).
     random_state = check_random_state(0)
@@ -839,8 +820,6 @@ def test_n_iter_without_progress():
         assert "did not make any progress during the last -1 episodes. Finished." in out
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
-@pytest.mark.filterwarnings("ignore:The default initialization in TSNE")
 def test_min_grad_norm():
     # Make sure that the parameter min_grad_norm is used correctly
     random_state = check_random_state(0)
@@ -884,8 +863,6 @@ def test_min_grad_norm():
     assert n_smaller_gradient_norms <= 1
 
 
-@pytest.mark.filterwarnings("ignore:The default learning rate in TSNE")
-@pytest.mark.filterwarnings("ignore:The default initialization in TSNE")
 def test_accessible_kl_divergence():
     # Ensures that the accessible kl_divergence matches the computed value
     random_state = check_random_state(0)
@@ -1098,49 +1075,6 @@ def test_tsne_with_different_distance_metrics(metric, dist_func, method):
     assert_array_equal(X_transformed_tsne, X_transformed_tsne_precomputed)
 
 
-# TODO: Remove in 1.2
-@pytest.mark.parametrize("init", [None, "random", "pca"])
-def test_tsne_init_futurewarning(init):
-    """Make sure that a FutureWarning is only raised when the
-    init is not specified or is 'pca'."""
-    random_state = check_random_state(0)
-
-    X = random_state.randn(5, 2)
-    kwargs = dict(learning_rate=200.0, init=init, perplexity=4)
-    tsne = TSNE(**{k: v for k, v in kwargs.items() if v is not None})
-
-    if init is None:
-        with pytest.warns(FutureWarning, match="The default initialization.*"):
-            tsne.fit_transform(X)
-    elif init == "pca":
-        with pytest.warns(FutureWarning, match="The PCA initialization.*"):
-            tsne.fit_transform(X)
-    else:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
-            tsne.fit_transform(X)
-
-
-# TODO: Remove in 1.2
-@pytest.mark.parametrize("learning_rate", [None, 200.0])
-def test_tsne_learning_rate_futurewarning(learning_rate):
-    """Make sure that a FutureWarning is only raised when the learning rate
-    is not specified"""
-    random_state = check_random_state(0)
-
-    X = random_state.randn(5, 2)
-    kwargs = dict(learning_rate=learning_rate, init="random", perplexity=4)
-    tsne = TSNE(**{k: v for k, v in kwargs.items() if v is not None})
-
-    if learning_rate is None:
-        with pytest.warns(FutureWarning, match="The default learning rate.*"):
-            tsne.fit_transform(X)
-    else:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
-            tsne.fit_transform(X)
-
-
 @pytest.mark.parametrize("method", ["exact", "barnes_hut"])
 def test_tsne_n_jobs(method):
     """Make sure that the n_jobs parameter doesn't impact the output"""
@@ -1171,8 +1105,6 @@ def test_tsne_n_jobs(method):
     assert_allclose(X_tr_ref, X_tr)
 
 
-# TODO: Remove filterwarnings in 1.2
-@pytest.mark.filterwarnings("ignore:.*TSNE will change.*:FutureWarning")
 def test_tsne_with_mahalanobis_distance():
     """Make sure that method_parameters works with mahalanobis distance."""
     random_state = check_random_state(0)
@@ -1182,6 +1114,7 @@ def test_tsne_with_mahalanobis_distance():
         "perplexity": 40,
         "n_iter": 250,
         "learning_rate": "auto",
+        "init": "random",
         "n_components": 3,
         "random_state": 0,
     }
@@ -1202,7 +1135,6 @@ def test_tsne_with_mahalanobis_distance():
     assert_allclose(X_trans, X_trans_expected)
 
 
-@pytest.mark.filterwarnings("ignore:The PCA initialization in TSNE will change")
 # FIXME: remove in 1.3 after deprecation of `square_distances`
 def test_tsne_deprecation_square_distances():
     """Check that we raise a warning regarding the removal of

--- a/sklearn/neighbors/tests/test_neighbors_pipeline.py
+++ b/sklearn/neighbors/tests/test_neighbors_pipeline.py
@@ -6,7 +6,6 @@ neighbors.
 """
 
 import numpy as np
-import pytest
 
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.cluster.tests.common import generate_clustered_data
@@ -123,8 +122,6 @@ def test_isomap():
     assert_array_almost_equal(Xt_chain, Xt_compact)
 
 
-# TODO: Remove filterwarning in 1.2
-@pytest.mark.filterwarnings("ignore:.*TSNE will change.*:FutureWarning")
 def test_tsne():
     # Test chaining KNeighborsTransformer and TSNE
     n_iter = 250
@@ -142,6 +139,7 @@ def test_tsne():
                 n_neighbors=n_neighbors, mode="distance", metric=metric
             ),
             TSNE(
+                init="random",
                 metric="precomputed",
                 perplexity=perplexity,
                 method="barnes_hut",
@@ -150,6 +148,7 @@ def test_tsne():
             ),
         )
         est_compact = TSNE(
+            init="random",
             metric=metric,
             perplexity=perplexity,
             n_iter=n_iter,


### PR DESCRIPTION
Handle the ending deprecation for `learning_rate` and `init` by:

- adding `versionchanged`
- removing the `filterwarnings` in the tests.
- checking the examples and removing unnecessary parameter settings.