### PR TITLE
MAINT Clean deprecation for 1.2: losses in gradient boosting

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -275,22 +275,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         return raw_predictions
 
     def _check_params(self):
-        # TODO(1.2): Remove
-        if self.loss == "ls":
-            warnings.warn(
-                "The loss 'ls' was deprecated in v1.0 and "
-                "will be removed in version 1.2. Use 'squared_error'"
-                " which is equivalent.",
-                FutureWarning,
-            )
-        elif self.loss == "lad":
-            warnings.warn(
-                "The loss 'lad' was deprecated in v1.0 and "
-                "will be removed in version 1.2. Use "
-                "'absolute_error' which is equivalent.",
-                FutureWarning,
-            )
-
         # TODO(1.3): Remove
         if self.loss == "deviance":
             warnings.warn(
@@ -1468,14 +1452,6 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         combination of the two. 'quantile' allows quantile regression (use
         `alpha` to specify the quantile).
 
-        .. deprecated:: 1.0
-            The loss 'ls' was deprecated in v1.0 and will be removed in
-            version 1.2. Use `loss='squared_error'` which is equivalent.
-
-        .. deprecated:: 1.0
-            The loss 'lad' was deprecated in v1.0 and will be removed in
-            version 1.2. Use `loss='absolute_error'` which is equivalent.
-
     learning_rate : float, default=0.1
         Learning rate shrinks the contribution of each tree by `learning_rate`.
         There is a trade-off between learning_rate and n_estimators.
@@ -1763,15 +1739,9 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     0.4...
     """
 
-    # TODO(1.2): remove "ls" and "lad"
     _parameter_constraints: dict = {
         **BaseGradientBoosting._parameter_constraints,
-        "loss": [
-            StrOptions(
-                {"squared_error", "ls", "absolute_error", "lad", "huber", "quantile"},
-                deprecated={"ls", "lad"},
-            )
-        ],
+        "loss": [StrOptions({"squared_error", "absolute_error", "huber", "quantile"})],
         "init": [StrOptions({"zero"}), None, HasMethods(["fit", "predict"])],
         "alpha": [Interval(Real, 0.0, 1.0, closed="neither")],
     }

--- a/sklearn/ensemble/_gb_losses.py
+++ b/sklearn/ensemble/_gb_losses.py
@@ -992,6 +992,7 @@ LOSS_FUNCTIONS = {
     "absolute_error": LeastAbsoluteError,
     "huber": HuberLossFunction,
     "quantile": QuantileLossFunction,
+    # TODO(1.3): Remove deviance
     "deviance": None,  # for both, multinomial and binomial
     "log_loss": None,  # for both, multinomial and binomial
     "exponential": ExponentialLoss,

--- a/sklearn/ensemble/_gb_losses.py
+++ b/sklearn/ensemble/_gb_losses.py
@@ -987,12 +987,9 @@ class ExponentialLoss(ClassificationLossFunction):
         return raw_predictions.reshape(-1, 1).astype(np.float64)
 
 
-# TODO: Remove entry 'ls' and 'lad' in version 1.2.
 LOSS_FUNCTIONS = {
     "squared_error": LeastSquaresError,
-    "ls": LeastSquaresError,
     "absolute_error": LeastAbsoluteError,
-    "lad": LeastAbsoluteError,
     "huber": HuberLossFunction,
     "quantile": QuantileLossFunction,
     "deviance": None,  # for both, multinomial and binomial

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -1082,13 +1082,10 @@ def test_uint8_predict(Est):
     est.predict(X)
 
 
+# TODO(1.3): Remove
 @pytest.mark.parametrize(
     "old_loss, new_loss, Estimator",
     [
-        # TODO(1.2): Remove
-        ("least_squares", "squared_error", HistGradientBoostingRegressor),
-        ("least_absolute_deviation", "absolute_error", HistGradientBoostingRegressor),
-        # TODO(1.3): Remove
         ("auto", "log_loss", HistGradientBoostingClassifier),
         ("binary_crossentropy", "log_loss", HistGradientBoostingClassifier),
         ("categorical_crossentropy", "log_loss", HistGradientBoostingClassifier),

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1280,13 +1280,10 @@ def test_n_features_deprecation(Estimator):
         est.n_features_
 
 
+# TODO(1.3): Remove
 @pytest.mark.parametrize(
     "old_loss, new_loss, Estimator",
     [
-        # TODO(1.2): Remove
-        ("ls", "squared_error", GradientBoostingRegressor),
-        ("lad", "absolute_error", GradientBoostingRegressor),
-        # TODO(1.3): Remove
         ("deviance", "log_loss", GradientBoostingClassifier),
     ],
 )

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1281,19 +1281,13 @@ def test_n_features_deprecation(Estimator):
 
 
 # TODO(1.3): Remove
-@pytest.mark.parametrize(
-    "old_loss, new_loss, Estimator",
-    [
-        ("deviance", "log_loss", GradientBoostingClassifier),
-    ],
-)
-def test_loss_deprecated(old_loss, new_loss, Estimator):
-    est1 = Estimator(loss=old_loss, random_state=0)
+def test_loss_deprecated():
+    est1 = GradientBoostingClassifier(loss="deviance", random_state=0)
 
-    with pytest.warns(FutureWarning, match=rf"The loss.* '{old_loss}' was deprecated"):
+    with pytest.warns(FutureWarning, match=r"The loss.* 'deviance' was deprecated"):
         est1.fit(X, y)
 
-    est2 = Estimator(loss=new_loss, random_state=0)
+    est2 = GradientBoostingClassifier(loss="log_loss", random_state=0)
     est2.fit(X, y)
     assert_allclose(est1.predict(X), est2.predict(X))
 


### PR DESCRIPTION
There will be no more bugfix release before 1.2 which should be targeted for november/december, so we can now clean up the deprecations.

In this PR: `loss="ls"/"least_squares"` and `lost="lad"/"least_absolute_deviation"` in (Hist)GradientBoostingRegressor.
