### PR TITLE
MAINT Clean deprecation for 1.2: BIRCH attributes

### DIFF
--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -18,7 +18,6 @@ from ..base import (
     _ClassNamePrefixFeaturesOutMixin,
 )
 from ..utils.extmath import row_norms
-from ..utils import deprecated
 from ..utils._param_validation import Interval
 from ..utils.validation import check_is_fitted
 from ..exceptions import ConvergenceWarning
@@ -502,24 +501,6 @@ class Birch(
         self.compute_labels = compute_labels
         self.copy = copy
 
-    # TODO: Remove in 1.2
-    # mypy error: Decorated property not supported
-    @deprecated(  # type: ignore
-        "`fit_` is deprecated in 1.0 and will be removed in 1.2."
-    )
-    @property
-    def fit_(self):
-        return self._deprecated_fit
-
-    # TODO: Remove in 1.2
-    # mypy error: Decorated property not supported
-    @deprecated(  # type: ignore
-        "`partial_fit_` is deprecated in 1.0 and will be removed in 1.2."
-    )
-    @property
-    def partial_fit_(self):
-        return self._deprecated_partial_fit
-
     def fit(self, X, y=None):
         """
         Build a CF Tree for the input data.
@@ -540,8 +521,6 @@ class Birch(
 
         self._validate_params()
 
-        # TODO: Remove deprecated flags in 1.2
-        self._deprecated_fit, self._deprecated_partial_fit = True, False
         return self._fit(X, partial=False)
 
     def _fit(self, X, partial):
@@ -652,8 +631,6 @@ class Birch(
         """
         self._validate_params()
 
-        # TODO: Remove deprecated flags in 1.2
-        self._deprecated_partial_fit, self._deprecated_fit = True, False
         if X is None:
             # Perform just the final global clustering step.
             self._global_clustering()

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -166,18 +166,6 @@ def test_birch_n_clusters_long_int():
     Birch(n_clusters=n_clusters).fit(X)
 
 
-# TODO: Remove in 1.2
-@pytest.mark.parametrize("attribute", ["fit_", "partial_fit_"])
-def test_birch_fit_attributes_deprecated(attribute):
-    """Test that fit_ and partial_fit_ attributes are deprecated."""
-    msg = f"`{attribute}` is deprecated in 1.0 and will be removed in 1.2"
-    X, y = make_blobs(n_samples=10)
-    brc = Birch().fit(X, y)
-
-    with pytest.warns(FutureWarning, match=msg):
-        getattr(brc, attribute)
-
-
 def test_feature_names_out():
     """Check `get_feature_names_out` for `Birch`."""
     X, _ = make_blobs(n_samples=80, n_features=4, random_state=0)


### PR DESCRIPTION
There will be no more bugfix release before 1.2 which should be targeted for november/december, so we can now clean up the deprecations.

In this PR: `fit_` and `partial_fit_` attributes of BIRCH
