### PR TITLE
DOC Use a pipeline to avoid data leakage

### DIFF
--- a/examples/classification/plot_classifier_comparison.py
+++ b/examples/classification/plot_classifier_comparison.py
@@ -30,6 +30,7 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import make_pipeline
 from sklearn.datasets import make_moons, make_circles, make_classification
 from sklearn.neural_network import MLPClassifier
 from sklearn.neighbors import KNeighborsClassifier
@@ -87,7 +88,6 @@ i = 1
 for ds_cnt, ds in enumerate(datasets):
     # preprocess dataset, split into training and test part
     X, y = ds
-    X = StandardScaler().fit_transform(X)
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.4, random_state=42
     )
@@ -116,6 +116,8 @@ for ds_cnt, ds in enumerate(datasets):
     # iterate over classifiers
     for name, clf in zip(names, classifiers):
         ax = plt.subplot(len(datasets), len(classifiers) + 1, i)
+
+        clf = make_pipeline(StandardScaler(), clf)
         clf.fit(X_train, y_train)
         score = clf.score(X_test, y_test)
         DecisionBoundaryDisplay.from_estimator(


### PR DESCRIPTION
The `StandardScaler` should not be fit on the full dataset. Instead it should be part of a pipeline and only see the training data.

#### Reference Issues/PRs
Closes #24390

#### What does this implement/fix? Explain your changes.
This moves the `StandardScaler` into a pipeline with the classifier. This way the scaler does not see the full dataset. Implementing the best practice that all your preprocessing steps should be treated just like the classifier when it comes to the train/test split.

#### Any other comments?
I didn't quite understand the goal of https://github.com/scikit-learn/scikit-learn/issues/24390#issuecomment-1240493508 and https://github.com/scikit-learn/scikit-learn/issues/24390#issuecomment-1240496886 compared to creating a pipeline where I did it in this PR. Is  there an advantage to having `classifiers` contain pipelines instead?
