### PR TITLE
CI Race condition work around for doc-min-dependencies

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -37,6 +37,9 @@ jobs:
           OMP_NUM_THREADS: 2
           MKL_NUM_THREADS: 2
           CONDA_ENV_NAME: testenv
+          # Sphinx race condition in doc-min-dependencies is causing job to stall
+          # Here we run the job serially
+          SPHINX_NUMJOBS: 1
           LOCK_FILE: build_tools/github/doc_min_dependencies_linux-64_conda.lock
 
       - name: Upload documentation

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,9 +9,9 @@ BUILDDIR      = _build
 
 # Disable multiple jobs on OSX
 ifeq ($(shell uname), Darwin)
-	SPHINX_NUMJOBS = 1
+	SPHINX_NUMJOBS ?= 1
 else
-	SPHINX_NUMJOBS = auto
+	SPHINX_NUMJOBS ?= auto
 endif
 
 ifneq ($(EXAMPLES_PATTERN),)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Race condition seen in https://github.com/scikit-learn/scikit-learn/pull/24399 and https://github.com/scikit-learn/scikit-learn/pull/24397


#### What does this implement/fix? Explain your changes.
If the job is continuing to stall, this PR forces `doc-min-dependencies` to run serially.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
