### PR TITLE
DOC Ensures plot_precision_recall_curve passes the numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -18,6 +18,8 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     # sklearn.deprecation._update_doc is updating the doc against the numpydoc.
     # This will be fixed with issue: #24328
     "sklearn.metrics._plot.det_curve.plot_det_curve",
+    # sklearn.deprecation._update_doc is updating the doc against the numpydoc.
+    # This will be fixed with issue: #24328
     "sklearn.metrics._plot.precision_recall_curve.plot_precision_recall_curve",
     "sklearn.metrics.pairwise.pairwise_distances_chunked",
     "sklearn.tree._export.plot_tree",


### PR DESCRIPTION
Addresses https://github.com/scikit-learn/scikit-learn/issues/21350

This PR ensures plot_precision_recall_curve is compatible with numpydoc:

What does this implement/fix? Explain your changes.

    Remove sklearn.metrics._plot.precision_recall_curve.plot_precision_recall_curve from DOCSTRING_IGNORE_LIST.
    Verify that all tests are passing.
    
In #21547, and #22247 it was discussed about removing the depreciated docstrings to avoid the `GL09` warning