### PR TITLE
MAINT Clean deprecation for 1.2: grid_scores_ in RFECV

### DIFF
--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -8,6 +8,7 @@ number of features selected with cross-validation.
 
 """
 
+import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.svm import SVC
 from sklearn.model_selection import StratifiedKFold
@@ -42,12 +43,17 @@ rfecv.fit(X, y)
 
 print("Optimal number of features : %d" % rfecv.n_features_)
 
+n_scores = len(rfecv.cv_results_["split0_test_score"])
+cv_scores = np.vstack(
+    (rfecv.cv_results_["split0_test_score"], rfecv.cv_results_["split1_test_score"])
+).T
+
 # Plot number of features VS. cross-validation scores
 plt.figure()
 plt.xlabel("Number of features selected")
 plt.ylabel("Cross validation score (accuracy)")
 plt.plot(
-    range(min_features_to_select, len(rfecv.grid_scores_) + min_features_to_select),
-    rfecv.grid_scores_,
+    range(min_features_to_select, n_scores + min_features_to_select),
+    cv_scores,
 )
 plt.show()

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -17,7 +17,6 @@ from ..utils._param_validation import HasMethods, Interval
 from ..utils._tags import _safe_tags
 from ..utils.validation import check_is_fitted
 from ..utils.fixes import delayed
-from ..utils.deprecation import deprecated
 from ..base import BaseEstimator
 from ..base import MetaEstimatorMixin
 from ..base import clone
@@ -542,15 +541,6 @@ class RFECV(RFE):
     estimator_ : ``Estimator`` instance
         The fitted estimator used to select features.
 
-    grid_scores_ : ndarray of shape (n_subsets_of_features,)
-        The cross-validation scores such that
-        ``grid_scores_[i]`` corresponds to
-        the CV score of the i-th subset of features.
-
-        .. deprecated:: 1.0
-            The `grid_scores_` attribute is deprecated in version 1.0 in favor
-            of `cv_results_` and will be removed in version 1.2.
-
     cv_results_ : dict of ndarrays
         A dict with keys:
 
@@ -596,7 +586,7 @@ class RFECV(RFE):
 
     Notes
     -----
-    The size of ``grid_scores_`` is equal to
+    The size of all values in ``cv_results_`` is equal to
     ``ceil((n_features - min_features_to_select) / step) + 1``,
     where step is the number of features removed at each iteration.
 
@@ -773,17 +763,3 @@ class RFECV(RFE):
             self.cv_results_[f"split{i}_test_score"] = scores_rev[i]
 
         return self
-
-    # TODO: Remove in v1.2 when grid_scores_ is removed
-    # mypy error: Decorated property not supported
-    @deprecated(  # type: ignore
-        "The `grid_scores_` attribute is deprecated in version 1.0 in favor "
-        "of `cv_results_` and will be removed in version 1.2."
-    )
-    @property
-    def grid_scores_(self):
-        # remove 2 for mean_test_score, std_test_score
-        grid_size = len(self.cv_results_) - 2
-        return np.asarray(
-            [self.cv_results_[f"split{i}_test_score"] for i in range(grid_size)]
-        ).T

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -181,14 +181,6 @@ def test_rfecv():
     rfecv.fit(X, y)
     # non-regression test for missing worst feature:
 
-    # TODO: Remove in v1.2 when grid_scores_ is removed
-    msg = (
-        r"The `grid_scores_` attribute is deprecated in version 1\.0 in "
-        r"favor of `cv_results_` and will be removed in version 1\.2."
-    )
-    with pytest.warns(FutureWarning, match=msg):
-        assert len(rfecv.grid_scores_) == X.shape[1]
-
     for key in rfecv.cv_results_.keys():
         assert len(rfecv.cv_results_[key]) == X.shape[1]
 
@@ -226,10 +218,6 @@ def test_rfecv():
     rfecv = RFECV(estimator=SVC(kernel="linear"), step=1, scoring=test_scorer)
     rfecv.fit(X, y)
 
-    # TODO: Remove in v1.2 when grid_scores_ is removed
-    with pytest.warns(FutureWarning, match=msg):
-        assert_array_equal(rfecv.grid_scores_, np.ones(rfecv.grid_scores_.shape))
-
     # In the event of cross validation score ties, the expected behavior of
     # RFECV is to return the FEWEST features that maximize the CV score.
     # Because test_scorer always returns 1.0 in this example, RFECV should
@@ -239,10 +227,6 @@ def test_rfecv():
     # Same as the first two tests, but with step=2
     rfecv = RFECV(estimator=SVC(kernel="linear"), step=2)
     rfecv.fit(X, y)
-
-    # TODO: Remove in v1.2 when grid_scores_ is removed
-    with pytest.warns(FutureWarning, match=msg):
-        assert len(rfecv.grid_scores_) == 6
 
     for key in rfecv.cv_results_.keys():
         assert len(rfecv.cv_results_[key]) == 6
@@ -275,14 +259,6 @@ def test_rfecv_mockclassifier():
     rfecv = RFECV(estimator=MockClassifier(), step=1)
     rfecv.fit(X, y)
     # non-regression test for missing worst feature:
-
-    # TODO: Remove in v1.2 when grid_scores_ is removed
-    msg = (
-        r"The `grid_scores_` attribute is deprecated in version 1\.0 in "
-        r"favor of `cv_results_` and will be removed in version 1\.2."
-    )
-    with pytest.warns(FutureWarning, match=msg):
-        assert len(rfecv.grid_scores_) == X.shape[1]
 
     for key in rfecv.cv_results_.keys():
         assert len(rfecv.cv_results_[key]) == X.shape[1]
@@ -327,14 +303,6 @@ def test_rfecv_cv_results_size():
         rfecv.fit(X, y)
 
         score_len = np.ceil((X.shape[1] - min_features_to_select) / step) + 1
-
-        # TODO: Remove in v1.2 when grid_scores_ is removed
-        msg = (
-            r"The `grid_scores_` attribute is deprecated in version 1\.0 in "
-            r"favor of `cv_results_` and will be removed in version 1\.2."
-        )
-        with pytest.warns(FutureWarning, match=msg):
-            assert len(rfecv.grid_scores_) == score_len
 
         for key in rfecv.cv_results_.keys():
             assert len(rfecv.cv_results_[key]) == score_len
@@ -430,19 +398,6 @@ def test_number_of_subsets_of_features():
         rfecv = RFECV(estimator=SVC(kernel="linear"), step=step)
         rfecv.fit(X, y)
 
-        # TODO: Remove in v1.2 when grid_scores_ is removed
-        msg = (
-            r"The `grid_scores_` attribute is deprecated in version 1\.0 in "
-            r"favor of `cv_results_` and will be removed in version 1\.2."
-        )
-        with pytest.warns(FutureWarning, match=msg):
-            assert len(rfecv.grid_scores_) == formula1(
-                n_features, n_features_to_select, step
-            )
-            assert len(rfecv.grid_scores_) == formula2(
-                n_features, n_features_to_select, step
-            )
-
         for key in rfecv.cv_results_.keys():
             assert len(rfecv.cv_results_[key]) == formula1(
                 n_features, n_features_to_select, step
@@ -462,23 +417,11 @@ def test_rfe_cv_n_jobs():
     rfecv.fit(X, y)
     rfecv_ranking = rfecv.ranking_
 
-    # TODO: Remove in v1.2 when grid_scores_ is removed
-    msg = (
-        r"The `grid_scores_` attribute is deprecated in version 1\.0 in "
-        r"favor of `cv_results_` and will be removed in version 1\.2."
-    )
-    with pytest.warns(FutureWarning, match=msg):
-        rfecv_grid_scores = rfecv.grid_scores_
-
     rfecv_cv_results_ = rfecv.cv_results_
 
     rfecv.set_params(n_jobs=2)
     rfecv.fit(X, y)
     assert_array_almost_equal(rfecv.ranking_, rfecv_ranking)
-
-    # TODO: Remove in v1.2 when grid_scores_ is removed
-    with pytest.warns(FutureWarning, match=msg):
-        assert_array_almost_equal(rfecv.grid_scores_, rfecv_grid_scores)
 
     assert rfecv_cv_results_.keys() == rfecv.cv_results_.keys()
     for key in rfecv_cv_results_.keys():


### PR DESCRIPTION
There will be no more bugfix release before 1.2 which should be targeted for november/december, so we can now clean up the deprecations.

In this PR: the `grid_scores_`attribute of RFECV
