### PR TITLE
MAINT Clean deprecation for 1.2: KernelPCA

### DIFF
--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -16,7 +16,6 @@ from ..utils.validation import (
     _check_psd_eigenvalues,
 )
 from ..utils._param_validation import Interval, StrOptions
-from ..utils.deprecation import deprecated
 from ..exceptions import NotFittedError
 from ..base import BaseEstimator, TransformerMixin, _ClassNamePrefixFeaturesOutMixin
 from ..preprocessing import KernelCenterer

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -155,23 +155,9 @@ class KernelPCA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
         If `n_components` and `remove_zero_eig` are not set,
         then all values are stored.
 
-    lambdas_ : ndarray of shape (n_components,)
-        Same as `eigenvalues_` but this attribute is deprecated.
-
-        .. deprecated:: 1.0
-           `lambdas_` was renamed to `eigenvalues_` in version 1.0 and will be
-           removed in 1.2.
-
     eigenvectors_ : ndarray of shape (n_samples, n_components)
         Eigenvectors of the centered kernel matrix. If `n_components` and
         `remove_zero_eig` are not set, then all components are stored.
-
-    alphas_ : ndarray of shape (n_samples, n_components)
-        Same as `eigenvectors_` but this attribute is deprecated.
-
-        .. deprecated:: 1.0
-           `alphas_` was renamed to `eigenvectors_` in version 1.0 and will be
-           removed in 1.2.
 
     dual_coef_ : ndarray of shape (n_samples, n_features)
         Inverse transform matrix. Only available when
@@ -309,25 +295,6 @@ class KernelPCA(_ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
         self.random_state = random_state
         self.n_jobs = n_jobs
         self.copy_X = copy_X
-
-    # TODO: Remove in 1.2
-    # mypy error: Decorated property not supported
-    @deprecated(  # type: ignore
-        "Attribute `lambdas_` was deprecated in version 1.0 and will be "
-        "removed in 1.2. Use `eigenvalues_` instead."
-    )
-    @property
-    def lambdas_(self):
-        return self.eigenvalues_
-
-    # mypy error: Decorated property not supported
-    @deprecated(  # type: ignore
-        "Attribute `alphas_` was deprecated in version 1.0 and will be "
-        "removed in 1.2. Use `eigenvectors_` instead."
-    )
-    @property
-    def alphas_(self):
-        return self.eigenvectors_
 
     def _get_kernel(self, X, Y=None):
         if callable(self.kernel):

--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -516,24 +516,6 @@ def test_32_64_decomposition_shape():
     assert kpca.fit_transform(X).shape == kpca.fit_transform(X.astype(np.float32)).shape
 
 
-# TODO: Remove in 1.2
-def test_kernel_pca_lambdas_deprecated():
-    kp = KernelPCA()
-    kp.eigenvalues_ = None
-    msg = r"Attribute `lambdas_` was deprecated in version 1\.0"
-    with pytest.warns(FutureWarning, match=msg):
-        kp.lambdas_
-
-
-# TODO: Remove in 1.2
-def test_kernel_pca_alphas_deprecated():
-    kp = KernelPCA(kernel="precomputed")
-    kp.eigenvectors_ = None
-    msg = r"Attribute `alphas_` was deprecated in version 1\.0"
-    with pytest.warns(FutureWarning, match=msg):
-        kp.alphas_
-
-
 def test_kernel_pca_feature_names_out():
     """Check feature names out for KernelPCA."""
     X, *_ = make_blobs(n_samples=100, n_features=4, random_state=0)


### PR DESCRIPTION
There will be no more bugfix release before 1.2 which should be targeted for november/december, so we can now clean up the deprecations.

In this PR: the `lambdas_` and `alphas_` attributes of KernelPCA
