### PR TITLE
MAINT Fix some broken asv benchmarks

### DIFF
--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -76,7 +76,8 @@
         "scipy": [],
         "cython": [],
         "joblib": [],
-        "threadpoolctl": []
+        "threadpoolctl": [],
+        "pandas": []
     },
 
     // Combinations of libraries/python versions can be excluded/included

--- a/asv_benchmarks/benchmarks/cluster.py
+++ b/asv_benchmarks/benchmarks/cluster.py
@@ -37,7 +37,7 @@ class KMeansBenchmark(Predictor, Transformer, Estimator, Benchmark):
             init=init,
             n_init=1,
             max_iter=max_iter,
-            tol=-1,
+            tol=0,
             random_state=0,
         )
 

--- a/asv_benchmarks/benchmarks/decomposition.py
+++ b/asv_benchmarks/benchmarks/decomposition.py
@@ -51,6 +51,7 @@ class DictionaryLearningBenchmark(Transformer, Estimator, Benchmark):
             n_components=15,
             fit_algorithm=fit_algorithm,
             alpha=0.1,
+            transform_alpha=1,
             max_iter=20,
             tol=1e-16,
             random_state=0,

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,11 @@ exclude=
     doc/_build,
     doc/auto_examples,
     doc/tutorial,
-    build
+    build,
+    asv_benchmarks/env,
+    asv_benchmarks/html,
+    asv_benchmarks/results,
+    asv_benchmarks/benchmarks/cache
 
 # It's fine not to put the import at the top of the file in the examples
 # folder.


### PR DESCRIPTION
- tol = -1 is not valid for KMeans
- default transform_alpha will change soon, so we need to set it explicitly to avoid change of behavior
- pandas is required by fetch_openml to get the mnist dataset

Also, avoid running flake8 on auto generated files. It will happen if you run the benchmarks locally on your feature branch and then check that it's flake8 compliant before pushing.