### PR TITLE
MNT Do not update docs with deprecated decorator

### DIFF
--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -424,7 +424,11 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
     )
     @property
     def family(self):
-        """Ensure backward compatibility for the time of deprecation."""
+        """Ensure backward compatibility for the time of deprecation.
+
+        .. deprecated:: 1.1
+            Will be removed in 1.3
+        """
         if isinstance(self, PoissonRegressor):
             return "poisson"
         elif isinstance(self, GammaRegressor):

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -71,7 +71,10 @@ def filter_errors(errors, method, Klass=None):
 
         # Ignore PR02: Unknown parameters for properties. We sometimes use
         # properties for ducktyping, i.e. SGDClassifier.predict_proba
-        if code == "PR02" and Klass is not None and method is not None:
+        # Ignore GL08: Parsing of the method signature failed, possibly because this is
+        # a property. Properties are sometimes used for deprecated attributes and the
+        # attribute is already documented in the class docstring.
+        if code in ("PR02", "GL08") and Klass is not None and method is not None:
             method_obj = getattr(Klass, method)
             if isinstance(method_obj, property):
                 continue

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -74,6 +74,9 @@ def filter_errors(errors, method, Klass=None):
         # Ignore GL08: Parsing of the method signature failed, possibly because this is
         # a property. Properties are sometimes used for deprecated attributes and the
         # attribute is already documented in the class docstring.
+        #
+        # All error codes:
+        # https://numpydoc.readthedocs.io/en/latest/validation.html#built-in-validation-checks
         if code in ("PR02", "GL08") and Klass is not None and method is not None:
             method_obj = getattr(Klass, method)
             if isinstance(method_obj, property):

--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -70,7 +70,6 @@ class deprecated:
         cls.__init__ = wrapped
 
         wrapped.__name__ = "__init__"
-        wrapped.__doc__ = self._update_doc(init.__doc__)
         wrapped.deprecated_original = init
 
         return cls
@@ -87,7 +86,6 @@ class deprecated:
             warnings.warn(msg, category=FutureWarning)
             return fun(*args, **kwargs)
 
-        wrapped.__doc__ = self._update_doc(wrapped.__doc__)
         # Add a reference to the wrapped function so that we can introspect
         # on function arguments in Python 2 (already works in Python 3)
         wrapped.__wrapped__ = fun
@@ -103,17 +101,7 @@ class deprecated:
             warnings.warn(msg, category=FutureWarning)
             return prop.fget(*args, **kwargs)
 
-        wrapped.__doc__ = self._update_doc(wrapped.__doc__)
-
         return wrapped
-
-    def _update_doc(self, olddoc):
-        newdoc = "DEPRECATED"
-        if self.extra:
-            newdoc = "%s: %s" % (newdoc, self.extra)
-        if olddoc:
-            newdoc = "%s\n\n    %s" % (newdoc, olddoc)
-        return newdoc
 
 
 def _is_deprecated(func):

--- a/sklearn/utils/tests/test_deprecation.py
+++ b/sklearn/utils/tests/test_deprecation.py
@@ -65,12 +65,3 @@ def test_is_deprecated():
 
 def test_pickle():
     pickle.loads(pickle.dumps(mock_function))
-
-
-def test_deprecated_property_docstring_exists():
-    """Deprecated property contains the original docstring."""
-    mock_class_property = getattr(MockClass2, "n_features_")
-    assert (
-        "DEPRECATED: n_features_ is deprecated\n\n    Number of input features."
-        == mock_class_property.__doc__
-    )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/24328

#### What does this implement/fix? Explain your changes.
This PR removes the `_update_doc` from the `deprecated` decorator. I did not update because they will be removed in 1.2:

- All get_feature_names methods
- load_boston
- plot_confusion_matrix
- plot_roc_curve
- graph_shortest_path


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
