### PR TITLE
DOC RandomizedSearchCV verbosity parameter description

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1511,6 +1511,12 @@ class RandomizedSearchCV(BaseSearchCV):
     verbose : int
         Controls the verbosity: the higher, the more messages.
 
+        - >1 : the computation time for each fold and parameter candidate is
+          displayed;
+        - >2 : the score is also displayed;
+        - >3 : the fold and candidate parameter indexes are also displayed
+          together with the starting time of the computation.
+
     pre_dispatch : int, or str, default='2*n_jobs'
         Controls the number of jobs that get dispatched during parallel
         execution. Reducing this number can be useful to avoid an


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #23254 

#### What does this implement/fix? Explain your changes.
Describes the `verbose` parameter of RandomizedSearchCV, similar to how it was done for GridSearchCV

#### Any other comments?
