### PR TITLE
DOC ensures sklearn.utils.safe_mask passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -46,7 +46,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.multiclass.class_distribution",
     "sklearn.utils.multiclass.type_of_target",
     "sklearn.utils.multiclass.unique_labels",
-    "sklearn.utils.safe_mask",
     "sklearn.utils.safe_sqr",
     "sklearn.utils.sparsefuncs.count_nonzero",
     "sklearn.utils.sparsefuncs.csc_median_axis_0",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -129,7 +129,8 @@ def safe_mask(X, mask):
 
     Returns
     -------
-        mask
+    mask : ndarray
+        Array that is safe to use on X.
     """
     mask = np.asarray(mask)
     if np.issubdtype(mask.dtype, np.signedinteger):


### PR DESCRIPTION
Reference Issues/PRs

Towards #21350.
What does this implement/fix? Explain your changes.

DOC ensures sklearn.utils.safe_mask passes numpydoc validation