### PR TITLE
DOC ensures sklearn.utils.safe_sqr passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -46,7 +46,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.multiclass.class_distribution",
     "sklearn.utils.multiclass.type_of_target",
     "sklearn.utils.multiclass.unique_labels",
-    "sklearn.utils.safe_sqr",
     "sklearn.utils.sparsefuncs.count_nonzero",
     "sklearn.utils.sparsefuncs.csc_median_axis_0",
     "sklearn.utils.sparsefuncs.incr_mean_variance_axis",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -668,6 +668,7 @@ def safe_sqr(X, *, copy=True):
     Returns
     -------
     X ** 2 : element wise square
+         Return the element-wise square of the input.
     """
     X = check_array(X, accept_sparse=["csr", "csc", "coo"], ensure_2d=False)
     if issparse(X):


### PR DESCRIPTION
Reference Issues/PRs

Towards #21350.

What does this implement/fix? Explain your changes.

DOC ensures sklearn.utils.safe_sqr passes numpydoc validation.