### PR TITLE
SLEP006: ClassifierChain and RegressorChain routing

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -660,6 +660,8 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
 
         del Y_pred_chain
 
+        routed_params = process_routing(obj=self, method="fit", other_params=fit_params)
+
         for chain_idx, estimator in enumerate(self.estimators_):
             message = self._log_message(
                 estimator_idx=chain_idx + 1,
@@ -668,7 +670,12 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
             )
             y = Y[:, self.order_[chain_idx]]
             with _print_elapsed_time("Chain", message):
-                estimator.fit(X_aug[:, : (X.shape[1] + chain_idx)], y, **fit_params)
+                estimator.fit(
+                    X_aug[:, : (X.shape[1] + chain_idx)],
+                    y,
+                    **routed_params.estimator.fit,
+                )
+
             if self.cv is not None and chain_idx < len(self.estimators_) - 1:
                 col_idx = X.shape[1] + chain_idx
                 cv_result = cross_val_predict(
@@ -713,6 +720,24 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
         Y_pred = Y_pred_chain[:, inv_order]
 
         return Y_pred
+
+    def get_metadata_routing(self):
+        """Get metadata routing of this object.
+
+        Please check :ref:`User Guide <metadata_routing>` on how the routing
+        mechanism works.
+
+        Returns
+        -------
+        routing : MetadataRouter
+            A :class:`~utils.metadata_routing.MetadataRouter` encapsulating
+            routing information.
+        """
+        router = MetadataRouter(owner=self.__class__.__name__).add(
+            estimator=self.base_estimator,
+            method_mapping=MethodMapping().add(callee="fit", caller="fit"),
+        )
+        return router
 
 
 class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
@@ -831,7 +856,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
            [0.0321..., 0.9935..., 0.0625...]])
     """
 
-    def fit(self, X, Y):
+    def fit(self, X, Y, **fit_params):
         """Fit the model to data matrix X and targets Y.
 
         Parameters
@@ -842,6 +867,11 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         Y : array-like of shape (n_samples, n_classes)
             The target values.
 
+        **fit_params : dict of string -> object
+            Parameters passed to the `fit` method of each step.
+
+            .. versionadded:: 1.2
+
         Returns
         -------
         self : object
@@ -849,7 +879,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         """
         self._validate_params()
 
-        super().fit(X, Y)
+        super().fit(X, Y, **fit_params)
         self.classes_ = [
             estimator.classes_ for chain_idx, estimator in enumerate(self.estimators_)
         ]

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -721,28 +721,6 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
 
         return Y_pred
 
-    def get_metadata_routing(self):
-        """Get metadata routing of this object.
-
-        Please check :ref:`User Guide <metadata_routing>` on how the routing
-        mechanism works.
-
-        Returns
-        -------
-        routing : MetadataRouter
-            A :class:`~utils.metadata_routing.MetadataRouter` encapsulating
-            routing information.
-        """
-        router = (
-            MetadataRouter(owner=self.__class__.__name__)
-            .add(
-                estimator=self.base_estimator,
-                method_mapping=MethodMapping().add(callee="fit", caller="fit"),
-            )
-            .warn_on(child="estimator", method="fit", params=None)
-        )
-        return router
-
 
 class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
     """A multi-label model that arranges binary classifiers into a chain.
@@ -953,6 +931,24 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         return Y_decision
 
+    def get_metadata_routing(self):
+        """Get metadata routing of this object.
+
+        Please check :ref:`User Guide <metadata_routing>` on how the routing
+        mechanism works.
+
+        Returns
+        -------
+        routing : MetadataRouter
+            A :class:`~utils.metadata_routing.MetadataRouter` encapsulating
+            routing information.
+        """
+        router = MetadataRouter(owner=self.__class__.__name__).add(
+            estimator=self.base_estimator,
+            method_mapping=MethodMapping().add(callee="fit", caller="fit"),
+        )
+        return router
+
     def _more_tags(self):
         return {"_skip_test": True, "multioutput_only": True}
 
@@ -1079,6 +1075,28 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
 
         super().fit(X, Y, **fit_params)
         return self
+
+    def get_metadata_routing(self):
+        """Get metadata routing of this object.
+
+        Please check :ref:`User Guide <metadata_routing>` on how the routing
+        mechanism works.
+
+        Returns
+        -------
+        routing : MetadataRouter
+            A :class:`~utils.metadata_routing.MetadataRouter` encapsulating
+            routing information.
+        """
+        router = (
+            MetadataRouter(owner=self.__class__.__name__)
+            .add(
+                estimator=self.base_estimator,
+                method_mapping=MethodMapping().add(callee="fit", caller="fit"),
+            )
+            .warn_on(child="estimator", method="fit", params=None)
+        )
+        return router
 
     def _more_tags(self):
         return {"multioutput_only": True}

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -733,9 +733,13 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
             A :class:`~utils.metadata_routing.MetadataRouter` encapsulating
             routing information.
         """
-        router = MetadataRouter(owner=self.__class__.__name__).add(
-            estimator=self.base_estimator,
-            method_mapping=MethodMapping().add(callee="fit", caller="fit"),
+        router = (
+            MetadataRouter(owner=self.__class__.__name__)
+            .add(
+                estimator=self.base_estimator,
+                method_mapping=MethodMapping().add(callee="fit", caller="fit"),
+            )
+            .warn_on(child="estimator", method="fit", params=None)
         )
         return router
 

--- a/sklearn/tests/test_metaestimators_metadata_routing.py
+++ b/sklearn/tests/test_metaestimators_metadata_routing.py
@@ -193,7 +193,7 @@ METAESTIMATORS = [
         "X": X,
         "y": y_multi,
         "routing_methods": ["fit"],
-        "warns_on": {},
+        "warns_on": {"fit": ["sample_weight", "metadata"]},
     },
     {
         "metaestimator": RegressorChain,
@@ -202,7 +202,7 @@ METAESTIMATORS = [
         "X": X,
         "y": y_multi,
         "routing_methods": ["fit"],
-        "warns_on": {},
+        "warns_on": {"fit": ["sample_weight", "metadata"]},
     },
 ]
 """List containing all metaestimators to be tested and their settings

--- a/sklearn/tests/test_metaestimators_metadata_routing.py
+++ b/sklearn/tests/test_metaestimators_metadata_routing.py
@@ -193,7 +193,7 @@ METAESTIMATORS = [
         "X": X,
         "y": y_multi,
         "routing_methods": ["fit"],
-        "warns_on": {"fit": ["sample_weight", "metadata"]},
+        "warns_on": {},
     },
     {
         "metaestimator": RegressorChain,

--- a/sklearn/tests/test_metaestimators_metadata_routing.py
+++ b/sklearn/tests/test_metaestimators_metadata_routing.py
@@ -7,7 +7,12 @@ import pytest
 from sklearn.base import RegressorMixin, ClassifierMixin, BaseEstimator
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.exceptions import UnsetMetadataPassedError
-from sklearn.multioutput import MultiOutputRegressor, MultiOutputClassifier
+from sklearn.multioutput import (
+    MultiOutputRegressor,
+    MultiOutputClassifier,
+    ClassifierChain,
+    RegressorChain,
+)
 from sklearn.utils.metadata_routing import MetadataRouter
 from sklearn.tests.test_metadata_routing import (
     record_metadata,
@@ -180,6 +185,24 @@ METAESTIMATORS = [
         "routing_methods": ["fit"],
         "warns_on": {"fit": ["sample_weight", "metadata"]},
         "preserves_metadata": False,
+    },
+    {
+        "metaestimator": ClassifierChain,
+        "estimator_name": "base_estimator",
+        "estimator": ConsumingClassifier,
+        "X": X,
+        "y": y_multi,
+        "routing_methods": ["fit"],
+        "warns_on": {},
+    },
+    {
+        "metaestimator": RegressorChain,
+        "estimator_name": "base_estimator",
+        "estimator": ConsumingRegressor,
+        "X": X,
+        "y": y_multi,
+        "routing_methods": ["fit"],
+        "warns_on": {},
     },
 ]
 """List containing all metaestimators to be tested and their settings

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -656,6 +656,7 @@ def test_regressor_chain_w_fit_params():
     for est in model.estimators_:
         assert est.sample_weight_ is weight
 
+    # TODO(1.4): Remove check for FutureWarning
     # Test that the existing behavior works and raises a FutureWarning
     # when the underlying estimator used has a sample_weight parameter
     # defined in it's fit method.

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -646,7 +646,7 @@ def test_regressor_chain_w_fit_params():
             self.sample_weight_ = fit_params["sample_weight"]
             super().fit(X, y, **fit_params)
 
-    model = RegressorChain(MySGD())
+    model = RegressorChain(MySGD().set_fit_request(sample_weight=True))
 
     # Fitting with params
     fit_param = {"sample_weight": weight}

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -28,6 +28,7 @@ from sklearn.linear_model import (
     Ridge,
     SGDClassifier,
     SGDRegressor,
+    QuantileRegressor,
 )
 from sklearn.metrics import jaccard_score, mean_squared_error
 from sklearn.model_selection import GridSearchCV, train_test_split
@@ -654,6 +655,15 @@ def test_regressor_chain_w_fit_params():
 
     for est in model.estimators_:
         assert est.sample_weight_ is weight
+
+    # Test that the existing behavior works and raises a FutureWarning
+    # when the underlying estimator used has a sample_weight parameter
+    # defined in it's fit method.
+    model = RegressorChain(QuantileRegressor())
+    fit_param = {"sample_weight": weight}
+
+    with pytest.warns(FutureWarning):
+        model.fit(X, y, **fit_param)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards: #22893

#### What does this implement/fix? Explain your changes.
- Added meta data routing to ClassifierChain and RegressorChain meta estimator's fit methods
- Added the main meta data routing code in _BaseChain which is then inherited by the ClassifierChain and RegressorChain.
- Updated tests to account for the new additions

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
