### PR TITLE
ENH type_of_target raises ValueError for invalid inputs

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -417,7 +417,7 @@ Changelog
   :pr:`20617` by :user:`Srinath Kailasa <skailasa>`
 
 - |Enhancement| :func:`utils.multiclass.type_of_target` now raises an
-  informative error message on receiving invalid inputs. :pr:`xxxxx`
+  informative error message on receiving invalid inputs. :pr:`24448`
   by :user:`Rahil Parikh <rprkh>`. 
 
 Code and Documentation Contributors

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -416,6 +416,10 @@ Changelog
   deterministic SVD used by the randomized SVD algorithm.
   :pr:`20617` by :user:`Srinath Kailasa <skailasa>`
 
+- |Enhancement| :func:`utils.multiclass.type_of_target` now raises an
+  informative error message on receiving invalid inputs. :pr:`xxxxx`
+  by :user:`Rahil Parikh <rprkh>`. 
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -316,7 +316,8 @@ def type_of_target(y, input_name=""):
 
     # Invalid inputs
     if y.ndim > 2 or (y.dtype == object and len(y) and not isinstance(y.flat[0], str)):
-        raise ValueError( # [[[1, 2]]] or [obj_1] and not ["label_1"]
+        # [[[1, 2]]] or [obj_1] and not ["label_1"]
+        raise ValueError(
             "Use an object array containing strings or encode the values in a"
             " contiguous numerical array."
         ) 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -316,7 +316,10 @@ def type_of_target(y, input_name=""):
 
     # Invalid inputs
     if y.ndim > 2 or (y.dtype == object and len(y) and not isinstance(y.flat[0], str)):
-        return "unknown"  # [[[1, 2]]] or [obj_1] and not ["label_1"]
+        raise ValueError( # [[[1, 2]]] or [obj_1] and not ["label_1"]
+            "Use an object array containing strings or encode the values in a"
+            " contiguous numerical array."
+        ) 
 
     if y.ndim == 2 and y.shape[1] == 0:
         return "unknown"  # [[]]

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -317,7 +317,7 @@ def type_of_target(y, input_name=""):
     # Invalid inputs
     if y.ndim > 2 or (y.dtype == object and len(y) and not isinstance(y.flat[0], str)):
         # [[[1, 2]]] or [obj_1] and not ["label_1"]
-        raise ValueError(
+        return (
             "Unkown label type. Use an object array containing strings or encode the"
             " values in a contiguous numerical array."
         )

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -318,8 +318,8 @@ def type_of_target(y, input_name=""):
     if y.ndim > 2 or (y.dtype == object and len(y) and not isinstance(y.flat[0], str)):
         # [[[1, 2]]] or [obj_1] and not ["label_1"]
         raise ValueError(
-            "Use an object array containing strings or encode the values in a"
-            " contiguous numerical array."
+            "Unkown label type. Use an object array containing strings or encode the"
+            " values in a contiguous numerical array."
         )
 
     if y.ndim == 2 and y.shape[1] == 0:

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -320,7 +320,7 @@ def type_of_target(y, input_name=""):
         raise ValueError(
             "Use an object array containing strings or encode the values in a"
             " contiguous numerical array."
-        ) 
+        )
 
     if y.ndim == 2 and y.shape[1] == 0:
         return "unknown"  # [[]]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #24355 

#### What does this implement/fix? Explain your changes.
A more informative message is displayed when `type_of_target` receives invalid inputs.

#### Any other comments?
There seems to be a mechanism in `../utils/tests/test_multiclass.py` that doesnt allow anything else to be returned except for "unknown" or the other accepted target types. Using ValueError instead of return also causes the checks to fail.