### PR TITLE
DOC ensures sklearn.utils.multiclass.class_distribution passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -43,7 +43,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.is_scalar_nan",
     "sklearn.utils.metaestimators.available_if",
     "sklearn.utils.metaestimators.if_delegate_has_method",
-    "sklearn.utils.multiclass.class_distribution",
     "sklearn.utils.multiclass.type_of_target",
     "sklearn.utils.multiclass.unique_labels",
     "sklearn.utils.sparsefuncs.count_nonzero",

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -394,7 +394,6 @@ def class_distribution(y, sample_weight=None):
 
     class_prior : list of size n_outputs of ndarray of size (n_classes,)
         Class distribution of each column.
-
     """
     classes = []
     n_classes = []


### PR DESCRIPTION
Reference Issues/PRs

Towards https://github.com/scikit-learn/scikit-learn/issues/21350.

What does this implement/fix? Explain your changes.

DOC ensures sklearn.utils.multiclass.class_distribution passes numpydoc validation.