### PR TITLE
Changed **cmap** value.

### DIFF
--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -82,7 +82,7 @@ class ConfusionMatrixDisplay:
         self,
         *,
         include_values=True,
-        cmap="viridis",
+        cmap="Pastel1",
         xticks_rotation="horizontal",
         values_format=None,
         ax=None,
@@ -97,7 +97,7 @@ class ConfusionMatrixDisplay:
         include_values : bool, default=True
             Includes values in confusion matrix.
 
-        cmap : str or matplotlib Colormap, default='viridis'
+        cmap : str or matplotlib Colormap, default='Pastel1'
             Colormap recognized by matplotlib.
 
         xticks_rotation : {'vertical', 'horizontal'} or float, \
@@ -206,7 +206,7 @@ class ConfusionMatrixDisplay:
         include_values=True,
         xticks_rotation="horizontal",
         values_format=None,
-        cmap="viridis",
+        cmap="Pastel1",
         ax=None,
         colorbar=True,
         im_kw=None,
@@ -266,7 +266,7 @@ class ConfusionMatrixDisplay:
             Format specification for values in confusion matrix. If `None`, the
             format specification is 'd' or '.2g' whichever is shorter.
 
-        cmap : str or matplotlib Colormap, default='viridis'
+        cmap : str or matplotlib Colormap, default='Pastel1'
             Colormap recognized by matplotlib.
 
         ax : matplotlib Axes, default=None
@@ -347,7 +347,7 @@ class ConfusionMatrixDisplay:
         include_values=True,
         xticks_rotation="horizontal",
         values_format=None,
-        cmap="viridis",
+        cmap="Pastel1",
         ax=None,
         colorbar=True,
         im_kw=None,
@@ -404,7 +404,7 @@ class ConfusionMatrixDisplay:
             Format specification for values in confusion matrix. If `None`, the
             format specification is 'd' or '.2g' whichever is shorter.
 
-        cmap : str or matplotlib Colormap, default='viridis'
+        cmap : str or matplotlib Colormap, default='Pastel1'
             Colormap recognized by matplotlib.
 
         ax : matplotlib Axes, default=None


### PR DESCRIPTION
I have changed the **cmap** value from `viridis` to `Pastel1` because it really makes the confusion matrix much clearer to read. `Viridis` really made it difficult to read and I think `Pastel1` is a really good and much better choice.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Fixes #24458
-->


#### What does this implement/fix? Explain your changes.
This changed the confusion matrix cmap from **viridis** to **Pastel1**, which I think is a great change.


#### Any other comments?
Well, I'd be very happy if this gets accepted, as I the current cmap really hurts the eye and is not worth it.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
