### PR TITLE
DOC ensures sklearn.utils.multiclass.type_of_target passes numpydoc validation.

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -34,7 +34,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.is_scalar_nan",
     "sklearn.utils.metaestimators.available_if",
     "sklearn.utils.metaestimators.if_delegate_has_method",
-    "sklearn.utils.multiclass.type_of_target",
     "sklearn.utils.multiclass.unique_labels",
     "sklearn.utils.sparsefuncs.csc_median_axis_0",
     "sklearn.utils.sparsefuncs.incr_mean_variance_axis",

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -215,6 +215,7 @@ def type_of_target(y, input_name=""):
     Parameters
     ----------
     y : array-like
+        Target values.
 
     input_name : str, default=""
         The data name used to construct the error message.


### PR DESCRIPTION
Reference Issues/PRs

Towards https://github.com/scikit-learn/scikit-learn/issues/21350.

What does this implement/fix? Explain your changes.

DOC ensures sklearn.utils.multiclass.type_of_target passes numpydoc validation.