### PR TITLE
DOC Improve format in code examples of splitters

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -139,15 +139,17 @@ class LeaveOneOut(BaseCrossValidator):
     2
     >>> print(loo)
     LeaveOneOut()
-    >>> for train_index, test_index in loo.split(X):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
+    >>> for i, (train_index, test_index) in enumerate(loo.split(X)):
     ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    ...     print(X_train, X_test, y_train, y_test)
-    TRAIN: [1] TEST: [0]
-    [[3 4]] [[1 2]] [2] [1]
-    TRAIN: [0] TEST: [1]
-    [[1 2]] [[3 4]] [1] [2]
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}, data={X_train}")
+    ...     print(f"  Test:  index={test_index}, data={X_test}")
+    Fold 0:
+      Train: index=[1], data=[[3 4]]
+      Test:  index=[0], data=[[1 2]]
+    Fold 1:
+      Train: index=[0], data=[[1 2]]
+      Test:  index=[1], data=[[3 4]]
 
     See Also
     --------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -489,11 +489,11 @@ class GroupKFold(_BaseKFold):
     ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
     ...     print(f"  Test:  index={test_index}, group={groups[test_index]}")
     Fold 0:
-    Train: index=[2 3], group=[2 2]
-    Test:  index=[0 1 4 5], group=[0 0 3 3]
+      Train: index=[2 3], group=[2 2]
+      Test:  index=[0 1 4 5], group=[0 0 3 3]
     Fold 1:
-    Train: index=[0 1 4 5], group=[0 0 3 3]
-    Test:  index=[2 3], group=[2 2]
+      Train: index=[0 1 4 5], group=[0 0 3 3]
+      Test:  index=[2 3], group=[2 2]
 
     See Also
     --------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -484,23 +484,16 @@ class GroupKFold(_BaseKFold):
     2
     >>> print(group_kfold)
     GroupKFold(n_splits=2)
-    >>> for train_index, test_index in group_kfold.split(X, y, groups):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    ...     print(X_train, X_test, y_train, y_test)
-    TRAIN: [2 3] TEST: [0 1 4 5]
-    [[5 6]
-    [7 8]] [[ 1  2]
-    [ 3  4]
-    [ 9 10]
-    [11 12]] [3 4] [1 2 5 6]
-    TRAIN: [0 1 4 5] TEST: [2 3]
-    [[ 1  2]
-    [ 3  4]
-    [ 9 10]
-    [11 12]] [[5 6]
-    [7 8]] [1 2 5 6] [3 4]
+    >>> for i, (train_index, test_index) in enumerate(group_kfold.split(X, y, groups)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}, group={groups[test_index]}")
+    Fold 0:
+    Train: index=[2 3], group=[2 2]
+    Test:  index=[0 1 4 5], group=[0 0 3 3]
+    Fold 1:
+    Train: index=[0 1 4 5], group=[0 0 3 3]
+    Test:  index=[2 3], group=[2 2]
 
     See Also
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Relates to: https://github.com/scikit-learn/scikit-learn/pull/24104#discussion_r966071617

 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Improve format in code examples of group splitters and add fold number when printing

#### Any other comments?
Have amended for just `GroupKFold` and `LeaveOneOut` (with and without group) so can get feedback on format. If no objections will amend for all similar code examples in a few days.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
