### PR TITLE
Disambiguate agglomerative clustering distance threshold in docs

### DIFF
--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -815,7 +815,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
             Added the 'single' option
 
     distance_threshold : float, default=None
-        The linkage distance threshold above which, clusters will not be
+        The linkage distance threshold at or above which clusters will not be
         merged. If not ``None``, ``n_clusters`` must be ``None`` and
         ``compute_full_tree`` must be ``True``.
 
@@ -1180,7 +1180,7 @@ class FeatureAgglomeration(
         argument `axis=1`, and reduce it to an array of size [M].
 
     distance_threshold : float, default=None
-        The linkage distance threshold above which, clusters will not be
+        The linkage distance threshold at or above which clusters will not be
         merged. If not ``None``, ``n_clusters`` must be ``None`` and
         ``compute_full_tree`` must be ``True``.
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #24176.

**Edit:** #24460 addresses the same issue. It misses one of the two references to the `distance_threshold` in the documentation.

#### What does this implement/fix? Explain your changes.
As mentioned in #24176 , the current documentation implies that the `distance_threshold` for agglomerative clustering is still able to be merged; however, this is not true. This pull request fixes that.

#### Any other comments?

None yet.