### PR TITLE
MAINT Clean deprecation for 1.2: DictionaryLearning

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1181,19 +1181,8 @@ class _BaseSparseCoding(_ClassNamePrefixFeaturesOutMixin, TransformerMixin):
         SparseCoder."""
         X = self._validate_data(X, reset=False)
 
-        # transform_alpha has to be changed in _transform
-        # this is done for consistency with the value of alpha
-        if (
-            hasattr(self, "alpha")
-            and self.alpha != 1.0
-            and self.transform_alpha is None
-        ):
-            warnings.warn(
-                "By default transform_alpha will be equal to"
-                "alpha instead of 1.0 starting from version 1.2",
-                FutureWarning,
-            )
-            transform_alpha = 1.0  # TODO change to self.alpha in 1.2
+        if (hasattr(self, "alpha") and self.transform_alpha is None):
+            transform_alpha = self.alpha
         else:
             transform_alpha = self.transform_alpha
 
@@ -1523,6 +1512,9 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
         threshold below which coefficients will be squashed to zero.
         If `None`, defaults to `alpha`.
 
+        .. versionchanged:: 1.2
+            When None, default value changed from 1.0 to `alpha`.
+
     n_jobs : int or None, default=None
         Number of parallel jobs to run.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
@@ -1834,6 +1826,11 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
           solution.
         - `'threshold'`: squashes to zero all coefficients less than alpha from
           the projection ``dictionary * X'``.
+        
+        If `None`, defaults to `alpha`.
+
+        .. versionchanged:: 1.2
+            When None, default value changed from 1.0 to `alpha`.
 
     transform_n_nonzero_coefs : int, default=None
         Number of nonzero coefficients to target in each column of the

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1826,7 +1826,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
           solution.
         - `'threshold'`: squashes to zero all coefficients less than alpha from
           the projection ``dictionary * X'``.
-        
+
         If `None`, defaults to `alpha`.
 
         .. versionchanged:: 1.2

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1181,7 +1181,7 @@ class _BaseSparseCoding(_ClassNamePrefixFeaturesOutMixin, TransformerMixin):
         SparseCoder."""
         X = self._validate_data(X, reset=False)
 
-        if (hasattr(self, "alpha") and self.transform_alpha is None):
+        if hasattr(self, "alpha") and self.transform_alpha is None:
             transform_alpha = self.alpha
         else:
             transform_alpha = self.transform_alpha

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1827,11 +1827,6 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         - `'threshold'`: squashes to zero all coefficients less than alpha from
           the projection ``dictionary * X'``.
 
-        If `None`, defaults to `alpha`.
-
-        .. versionchanged:: 1.2
-            When None, default value changed from 1.0 to `alpha`.
-
     transform_n_nonzero_coefs : int, default=None
         Number of nonzero coefficients to target in each column of the
         solution. This is only used by `algorithm='lars'` and
@@ -1844,6 +1839,9 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         If `algorithm='threshold'`, `alpha` is the absolute value of the
         threshold below which coefficients will be squashed to zero.
         If `None`, defaults to `alpha`.
+
+        .. versionchanged:: 1.2
+            When None, default value changed from 1.0 to `alpha`.
 
     verbose : bool or int, default=False
         To control the verbosity of the procedure.

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -762,15 +762,6 @@ def test_update_dict():
     assert_allclose(newd_batch, newd_online)
 
 
-# default value of batch_size changed. FIXME: remove in 1.3
-@pytest.mark.filterwarnings("ignore:The default value of batch_size will change")
-@pytest.mark.parametrize("Estimator", [DictionaryLearning, MiniBatchDictionaryLearning])
-def test_warning_default_transform_alpha(Estimator):
-    dl = Estimator(alpha=0.1, max_iter=5)
-    with pytest.warns(FutureWarning, match="default transform_alpha"):
-        dl.fit_transform(X)
-
-
 # FIXME: remove in 1.3
 def test_dict_learning_online_n_iter_deprecated():
     # Check that an error is raised when a deprecated argument is set when max_iter


### PR DESCRIPTION
Default value for ``transform_alpha`` now defaults to alpha instead of 1.0 in (MiniBatch)DictionaryLearning.
SparseCoder has no alpha parameter so it still defaults to 1.