### PR TITLE
DOC Improve format in docstring code examples of splitters

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -833,7 +833,7 @@ class StratifiedGroupKFold(_BaseKFold):
       Train: index=[ 4  5  6  7  8  9 10 11 12 13 14], group=[3 3 3 4 5 5 5 5 6 6 7]
       Test:  index=[ 0  1  2  3 15 16], group=[1 1 2 2 8 8]
     Fold 2:
-      Train: index=[ 0  1  2  3  4  5  6 12 13 14 15 16], group=[1 1 2 2 3 3 3 6 6 7 8 8]  # noqa: E501
+      Train: index=[ 0  1  2  3  4  5  6 12 13 14 15 16], group=[1 1 2 2 3 3 3 6 6 7 8 8]
       Test:  index=[ 7  8  9 10 11], group=[4 5 5 5 5]
 
     Notes
@@ -857,7 +857,7 @@ class StratifiedGroupKFold(_BaseKFold):
         tasks).
 
     GroupKFold: K-fold iterator variant with non-overlapping groups.
-    """
+    """  # noqa: E501
 
     def __init__(self, n_splits=5, shuffle=False, random_state=None):
         super().__init__(n_splits=n_splits, shuffle=shuffle, random_state=random_state)
@@ -1895,11 +1895,11 @@ class GroupShuffleSplit(ShuffleSplit):
     ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
     ...     print(f"  Test:  index={test_index}, group={groups[test_index]}")
     Fold 0:
-      Train: index=[3 5 1], group=[2 3 1]
-      Test:  index=[2 4], group=[2 2]
+      Train: index=[2 3 4 5 6 7], group=[2 2 2 3 3 3]
+      Test:  index=[0 1], group=[1 1]
     Fold 1:
-      Train: index=[3 5 1], group=[2 3 1]
-      Test:  index=[2 4], group=[2 2]
+      Train: index=[0 1 5 6 7], group=[1 1 3 3 3]
+      Test:  index=[2 3 4], group=[2 2 2]
 
     See Also
     --------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2272,12 +2272,16 @@ class PredefinedSplit(BaseCrossValidator):
     2
     >>> print(ps)
     PredefinedSplit(test_fold=array([ 0,  1, -1,  1]))
-    >>> for train_index, test_index in ps.split():
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [1 2 3] TEST: [0]
-    TRAIN: [0 2] TEST: [1 3]
+    >>> for i, (train_index, test_index) in enumerate(ps.split()):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[1 2 3]
+      Test:  index=[0]
+    Fold 1:
+      Train: index=[0 2]
+      Test:  index=[1 3]
     """
 
     def __init__(self, test_fold):

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -824,8 +824,8 @@ class StratifiedGroupKFold(_BaseKFold):
     StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
     >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
     ...     print(f"Fold {i}:")
-    ...     print(f"  Train: index={train_index}\\n\t group={groups[train_index]}")
-    ...     print(f"  Test:  index={test_index}\\n\t group={groups[test_index]}")
+    ...     print(f"""  Train: index={train_index}\n\t group={groups[train_index]}""")
+    ...     print(f"""  Test:  index={test_index}\n\t group={groups[test_index]}""")
     Fold 0:
       Train: index=[ 0  1  2  3  7  8  9 10 11 15 16]
              group=[1 1 2 2 4 5 5 5 5 8 8]

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -824,8 +824,8 @@ class StratifiedGroupKFold(_BaseKFold):
     StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
     >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
     ...     print(f"Fold {i}:")
-    ...     print(f"  Train: index={train_index}\n\t group={groups[train_index]}")
-    ...     print(f"  Test:  index={test_index}\n\t group={groups[test_index]}")
+    ...     print(f"  Train: index={train_index}\n\\t group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}\n\\t group={groups[test_index]}")
     Fold 0:
       Train: index=[ 0  1  2  3  7  8  9 10 11 15 16]
              group=[1 1 2 2 4 5 5 5 5 8 8]

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -833,7 +833,7 @@ class StratifiedGroupKFold(_BaseKFold):
       Train: index=[ 4  5  6  7  8  9 10 11 12 13 14], group=[3 3 3 4 5 5 5 5 6 6 7]
       Test:  index=[ 0  1  2  3 15 16], group=[1 1 2 2 8 8]
     Fold 2:
-      Train: index=[ 0  1  2  3  4  5  6 12 13 14 15 16], group=[1 1 2 2 3 3 3 6 6 7 8 8]
+      Train: index=[ 0  1  2  3  4  5  6 12 13 14 15 16], group=[1 1 2 2 3 3 3 6 6 7 8 8]  # noqa: E501
       Test:  index=[ 7  8  9 10 11], group=[4 5 5 5 5]
 
     Notes
@@ -1754,7 +1754,7 @@ class ShuffleSplit(BaseShuffleSplit):
     >>> rs.get_n_splits(X)
     5
     >>> print(rs)
-    ShuffleSplit(n_splits=5, test_size=0.25, train_size=None, random_state=0)
+    ShuffleSplit(n_splits=5, random_state=0, test_size=0.25, train_size=None)
     >>> for i, (train_index, test_index) in enumerate(rs.split(X)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")
@@ -1890,7 +1890,7 @@ class GroupShuffleSplit(ShuffleSplit):
     2
     >>> print(gss)
     GroupShuffleSplit(n_splits=2, random_state=42, test_size=None, train_size=0.7)
-    >>> for i, (train_idx, test_idx) in enumerate(gss.split(X, y, groups)):
+    >>> for i, (train_index, test_index) in enumerate(gss.split(X, y, groups)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
     ...     print(f"  Test:  index={test_index}, group={groups[test_index]}")

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -824,8 +824,10 @@ class StratifiedGroupKFold(_BaseKFold):
     StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
     >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
     ...     print(f"Fold {i}:")
-    ...     print(f"""  Train: index={train_index}\n\t group={groups[train_index]}""")
-    ...     print(f"""  Test:  index={test_index}\n\t group={groups[test_index]}""")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"         group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}")
+    ...     print(f"         group={groups[test_index]}")
     Fold 0:
       Train: index=[ 0  1  2  3  7  8  9 10 11 15 16]
              group=[1 1 2 2 4 5 5 5 5 8 8]

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -824,17 +824,23 @@ class StratifiedGroupKFold(_BaseKFold):
     StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
     >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
     ...     print(f"Fold {i}:")
-    ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
-    ...     print(f"  Test:  index={test_index}, group={groups[test_index]}")
+    ...     print(f"  Train: index={train_index}\n\t group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}\n\t group={groups[test_index]}")
     Fold 0:
-      Train: index=[ 0  1  2  3  7  8  9 10 11 15 16], group=[1 1 2 2 4 5 5 5 5 8 8]
-      Test:  index=[ 4  5  6 12 13 14], group=[3 3 3 6 6 7]
+      Train: index=[ 0  1  2  3  7  8  9 10 11 15 16]
+             group=[1 1 2 2 4 5 5 5 5 8 8]
+      Test:  index=[ 4  5  6 12 13 14]
+             group=[3 3 3 6 6 7]
     Fold 1:
-      Train: index=[ 4  5  6  7  8  9 10 11 12 13 14], group=[3 3 3 4 5 5 5 5 6 6 7]
-      Test:  index=[ 0  1  2  3 15 16], group=[1 1 2 2 8 8]
+      Train: index=[ 4  5  6  7  8  9 10 11 12 13 14]
+             group=[3 3 3 4 5 5 5 5 6 6 7]
+      Test:  index=[ 0  1  2  3 15 16]
+             group=[1 1 2 2 8 8]
     Fold 2:
-      Train: index=[ 0  1  2  3  4  5  6 12 13 14 15 16], group=[1 1 2 2 3 3 3 6 6 7 8 8]
-      Test:  index=[ 7  8  9 10 11], group=[4 5 5 5 5]
+      Train: index=[ 0  1  2  3  4  5  6 12 13 14 15 16]
+             group=[1 1 2 2 3 3 3 6 6 7 8 8]
+      Test:  index=[ 7  8  9 10 11]
+             group=[4 5 5 5 5]
 
     Notes
     -----
@@ -857,7 +863,7 @@ class StratifiedGroupKFold(_BaseKFold):
         tasks).
 
     GroupKFold: K-fold iterator variant with non-overlapping groups.
-    """  # noqa: E501
+    """
 
     def __init__(self, n_splits=5, shuffle=False, random_state=None):
         super().__init__(n_splits=n_splits, shuffle=shuffle, random_state=random_state)

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -140,16 +140,15 @@ class LeaveOneOut(BaseCrossValidator):
     >>> print(loo)
     LeaveOneOut()
     >>> for i, (train_index, test_index) in enumerate(loo.split(X)):
-    ...     X_train, X_test = X[train_index], X[test_index]
     ...     print(f"Fold {i}:")
-    ...     print(f"  Train: index={train_index}, data={X_train}")
-    ...     print(f"  Test:  index={test_index}, data={X_test}")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
     Fold 0:
-      Train: index=[1], data=[[3 4]]
-      Test:  index=[0], data=[[1 2]]
+      Train: index=[1]
+      Test:  index=[0]
     Fold 1:
-      Train: index=[0], data=[[1 2]]
-      Test:  index=[1], data=[[3 4]]
+      Train: index=[0]
+      Test:  index=[1]
 
     See Also
     --------
@@ -225,16 +224,28 @@ class LeavePOut(BaseCrossValidator):
     6
     >>> print(lpo)
     LeavePOut(p=2)
-    >>> for train_index, test_index in lpo.split(X):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [2 3] TEST: [0 1]
-    TRAIN: [1 3] TEST: [0 2]
-    TRAIN: [1 2] TEST: [0 3]
-    TRAIN: [0 3] TEST: [1 2]
-    TRAIN: [0 2] TEST: [1 3]
-    TRAIN: [0 1] TEST: [2 3]
+    >>> for i, (train_index, test_index) in enumerate(lpo.split(X)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[2 3]
+      Test:  index=[0 1]
+    Fold 1:
+      Train: index=[1 3]
+      Test:  index=[0 2]
+    Fold 2:
+      Train: index=[1 2]
+      Test:  index=[0 3]
+    Fold 3:
+      Train: index=[0 3]
+      Test:  index=[1 2]
+    Fold 4:
+      Train: index=[0 2]
+      Test:  index=[1 3]
+    Fold 5:
+      Train: index=[0 1]
+      Test:  index=[2 3]
     """
 
     def __init__(self, p):
@@ -404,12 +415,16 @@ class KFold(_BaseKFold):
     2
     >>> print(kf)
     KFold(n_splits=2, random_state=None, shuffle=False)
-    >>> for train_index, test_index in kf.split(X):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [2 3] TEST: [0 1]
-    TRAIN: [0 1] TEST: [2 3]
+    >>> for i, (train_index, test_index) in enumerate(kf.split(X)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[2 3]
+      Test:  index=[0 1]
+    Fold 1:
+      Train: index=[0 1]
+      Test:  index=[2 3]
 
     Notes
     -----
@@ -616,12 +631,16 @@ class StratifiedKFold(_BaseKFold):
     2
     >>> print(skf)
     StratifiedKFold(n_splits=2, random_state=None, shuffle=False)
-    >>> for train_index, test_index in skf.split(X, y):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [1 3] TEST: [0 2]
-    TRAIN: [0 2] TEST: [1 3]
+    >>> for i, (train_index, test_index) in enumerate(skf.split(X, y)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[1 3]
+      Test:  index=[0 2]
+    Fold 1:
+      Train: index=[0 2]
+      Test:  index=[1 3]
 
     Notes
     -----
@@ -798,24 +817,24 @@ class StratifiedGroupKFold(_BaseKFold):
     >>> X = np.ones((17, 2))
     >>> y = np.array([0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
     >>> groups = np.array([1, 1, 2, 2, 3, 3, 3, 4, 5, 5, 5, 5, 6, 6, 7, 8, 8])
-    >>> cv = StratifiedGroupKFold(n_splits=3)
-    >>> for train_idxs, test_idxs in cv.split(X, y, groups):
-    ...     print("TRAIN:", groups[train_idxs])
-    ...     print("      ", y[train_idxs])
-    ...     print(" TEST:", groups[test_idxs])
-    ...     print("      ", y[test_idxs])
-    TRAIN: [1 1 2 2 4 5 5 5 5 8 8]
-           [0 0 1 1 1 0 0 0 0 0 0]
-     TEST: [3 3 3 6 6 7]
-           [1 1 1 0 0 0]
-    TRAIN: [3 3 3 4 5 5 5 5 6 6 7]
-           [1 1 1 1 0 0 0 0 0 0 0]
-     TEST: [1 1 2 2 8 8]
-           [0 0 1 1 0 0]
-    TRAIN: [1 1 2 2 3 3 3 6 6 7 8 8]
-           [0 0 1 1 1 1 1 0 0 0 0 0]
-     TEST: [4 5 5 5 5]
-           [1 0 0 0 0]
+    >>> sgkf = StratifiedGroupKFold(n_splits=3)
+    >>> sgkf.get_n_splits(X, y)
+    3
+    >>> print(sgkf)
+    StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
+    >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}, group={groups[test_index]}")
+    Fold 0:
+      Train: index=[ 0  1  2  3  7  8  9 10 11 15 16], group=[1 1 2 2 4 5 5 5 5 8 8]
+      Test:  index=[ 4  5  6 12 13 14], group=[3 3 3 6 6 7]
+    Fold 1:
+      Train: index=[ 4  5  6  7  8  9 10 11 12 13 14], group=[3 3 3 4 5 5 5 5 6 6 7]
+      Test:  index=[ 0  1  2  3 15 16], group=[1 1 2 2 8 8]
+    Fold 2:
+      Train: index=[ 0  1  2  3  4  5  6 12 13 14 15 16], group=[1 1 2 2 3 3 3 6 6 7 8 8]
+      Test:  index=[ 7  8  9 10 11], group=[4 5 5 5 5]
 
     Notes
     -----
@@ -999,35 +1018,57 @@ class TimeSeriesSplit(_BaseKFold):
     >>> tscv = TimeSeriesSplit()
     >>> print(tscv)
     TimeSeriesSplit(gap=0, max_train_size=None, n_splits=5, test_size=None)
-    >>> for train_index, test_index in tscv.split(X):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [0] TEST: [1]
-    TRAIN: [0 1] TEST: [2]
-    TRAIN: [0 1 2] TEST: [3]
-    TRAIN: [0 1 2 3] TEST: [4]
-    TRAIN: [0 1 2 3 4] TEST: [5]
+    >>> for i, (train_index, test_index) in enumerate(tscv.split(X)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[0]
+      Test:  index=[1]
+    Fold 1:
+      Train: index=[0 1]
+      Test:  index=[2]
+    Fold 2:
+      Train: index=[0 1 2]
+      Test:  index=[3]
+    Fold 3:
+      Train: index=[0 1 2 3]
+      Test:  index=[4]
+    Fold 4:
+      Train: index=[0 1 2 3 4]
+      Test:  index=[5]
     >>> # Fix test_size to 2 with 12 samples
     >>> X = np.random.randn(12, 2)
     >>> y = np.random.randint(0, 2, 12)
     >>> tscv = TimeSeriesSplit(n_splits=3, test_size=2)
-    >>> for train_index, test_index in tscv.split(X):
-    ...    print("TRAIN:", train_index, "TEST:", test_index)
-    ...    X_train, X_test = X[train_index], X[test_index]
-    ...    y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [0 1 2 3 4 5] TEST: [6 7]
-    TRAIN: [0 1 2 3 4 5 6 7] TEST: [8 9]
-    TRAIN: [0 1 2 3 4 5 6 7 8 9] TEST: [10 11]
+    >>> for i, (train_index, test_index) in enumerate(tscv.split(X)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[0 1 2 3 4 5]
+      Test:  index=[6 7]
+    Fold 1:
+      Train: index=[0 1 2 3 4 5 6 7]
+      Test:  index=[8 9]
+    Fold 2:
+      Train: index=[0 1 2 3 4 5 6 7 8 9]
+      Test:  index=[10 11]
     >>> # Add in a 2 period gap
     >>> tscv = TimeSeriesSplit(n_splits=3, test_size=2, gap=2)
-    >>> for train_index, test_index in tscv.split(X):
-    ...    print("TRAIN:", train_index, "TEST:", test_index)
-    ...    X_train, X_test = X[train_index], X[test_index]
-    ...    y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [0 1 2 3] TEST: [6 7]
-    TRAIN: [0 1 2 3 4 5] TEST: [8 9]
-    TRAIN: [0 1 2 3 4 5 6 7] TEST: [10 11]
+    >>> for i, (train_index, test_index) in enumerate(tscv.split(X)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[0 1 2 3]
+      Test:  index=[6 7]
+    Fold 1:
+      Train: index=[0 1 2 3 4 5]
+      Test:  index=[8 9]
+    Fold 2:
+      Train: index=[0 1 2 3 4 5 6 7]
+      Test:  index=[10 11]
 
     Notes
     -----
@@ -1137,19 +1178,16 @@ class LeaveOneGroupOut(BaseCrossValidator):
     2
     >>> print(logo)
     LeaveOneGroupOut()
-    >>> for train_index, test_index in logo.split(X, y, groups):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    ...     print(X_train, X_test, y_train, y_test)
-    TRAIN: [2 3] TEST: [0 1]
-    [[5 6]
-     [7 8]] [[1 2]
-     [3 4]] [1 2] [1 2]
-    TRAIN: [0 1] TEST: [2 3]
-    [[1 2]
-     [3 4]] [[5 6]
-     [7 8]] [1 2] [1 2]
+    >>> for i, (train_index, test_index) in enumerate(logo.split(X, y, groups)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}, group={groups[test_index]}")
+    Fold 0:
+      Train: index=[2 3], group=[2 2]
+      Test:  index=[0 1], group=[1 1]
+    Fold 1:
+      Train: index=[0 1], group=[1 1]
+      Test:  index=[2 3], group=[2 2]
 
     See also
     --------
@@ -1262,20 +1300,19 @@ class LeavePGroupsOut(BaseCrossValidator):
     3
     >>> print(lpgo)
     LeavePGroupsOut(n_groups=2)
-    >>> for train_index, test_index in lpgo.split(X, y, groups):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    ...     print(X_train, X_test, y_train, y_test)
-    TRAIN: [2] TEST: [0 1]
-    [[5 6]] [[1 2]
-     [3 4]] [1] [1 2]
-    TRAIN: [1] TEST: [0 2]
-    [[3 4]] [[1 2]
-     [5 6]] [2] [1 1]
-    TRAIN: [0] TEST: [1 2]
-    [[1 2]] [[3 4]
-     [5 6]] [1] [2 1]
+    >>> for i, (train_index, test_index) in enumerate(lpgo.split(X, y, groups)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}, group={groups[test_index]}")
+    Fold 0:
+      Train: index=[2], group=[3]
+      Test:  index=[0 1], group=[1 2]
+    Fold 1:
+      Train: index=[1], group=[2]
+      Test:  index=[0 2], group=[1 3]
+    Fold 2:
+      Train: index=[0], group=[1]
+      Test:  index=[1 2], group=[2 3]
 
     See Also
     --------
@@ -1488,15 +1525,27 @@ class RepeatedKFold(_RepeatedSplits):
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([0, 0, 1, 1])
     >>> rkf = RepeatedKFold(n_splits=2, n_repeats=2, random_state=2652124)
-    >>> for train_index, test_index in rkf.split(X):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
+    >>> rkf.get_n_splits(X, y)
+    4
+    >>> print(rkf)
+    RepeatedKFold(n_repeats=2, n_splits=2, random_state=2652124)
+    >>> for i, (train_index, test_index) in enumerate(rkf.split(X)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
     ...
-    TRAIN: [0 1] TEST: [2 3]
-    TRAIN: [2 3] TEST: [0 1]
-    TRAIN: [1 2] TEST: [0 3]
-    TRAIN: [0 3] TEST: [1 2]
+    Fold 0:
+      Train: index=[0 1]
+      Test:  index=[2 3]
+    Fold 1:
+      Train: index=[2 3]
+      Test:  index=[0 1]
+    Fold 2:
+      Train: index=[1 2]
+      Test:  index=[0 3]
+    Fold 3:
+      Train: index=[0 3]
+      Test:  index=[1 2]
 
     Notes
     -----
@@ -1544,15 +1593,27 @@ class RepeatedStratifiedKFold(_RepeatedSplits):
     >>> y = np.array([0, 0, 1, 1])
     >>> rskf = RepeatedStratifiedKFold(n_splits=2, n_repeats=2,
     ...     random_state=36851234)
-    >>> for train_index, test_index in rskf.split(X, y):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
+    >>> rskf.get_n_splits(X, y)
+    4
+    >>> print(rskf)
+    RepeatedStratifiedKFold(n_repeats=2, n_splits=2, random_state=36851234)
+    >>> for i, (train_index, test_index) in enumerate(rskf.split(X, y)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
     ...
-    TRAIN: [1 2] TEST: [0 3]
-    TRAIN: [0 3] TEST: [1 2]
-    TRAIN: [1 3] TEST: [0 2]
-    TRAIN: [0 2] TEST: [1 3]
+    Fold 0:
+      Train: index=[1 2]
+      Test:  index=[0 3]
+    Fold 1:
+      Train: index=[0 3]
+      Test:  index=[1 2]
+    Fold 2:
+      Train: index=[1 3]
+      Test:  index=[0 2]
+    Fold 3:
+      Train: index=[0 2]
+      Test:  index=[1 3]
 
     Notes
     -----
@@ -1693,23 +1754,48 @@ class ShuffleSplit(BaseShuffleSplit):
     >>> rs.get_n_splits(X)
     5
     >>> print(rs)
-    ShuffleSplit(n_splits=5, random_state=0, test_size=0.25, train_size=None)
-    >>> for train_index, test_index in rs.split(X):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    TRAIN: [1 3 0 4] TEST: [5 2]
-    TRAIN: [4 0 2 5] TEST: [1 3]
-    TRAIN: [1 2 4 0] TEST: [3 5]
-    TRAIN: [3 4 1 0] TEST: [5 2]
-    TRAIN: [3 5 1 0] TEST: [2 4]
+    ShuffleSplit(n_splits=5, test_size=0.25, train_size=None, random_state=0)
+    >>> for i, (train_index, test_index) in enumerate(rs.split(X)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[1 3 0 4]
+      Test:  index=[5 2]
+    Fold 1:
+      Train: index=[4 0 2 5]
+      Test:  index=[1 3]
+    Fold 2:
+      Train: index=[1 2 4 0]
+      Test:  index=[3 5]
+    Fold 3:
+      Train: index=[3 4 1 0]
+      Test:  index=[5 2]
+    Fold 4:
+      Train: index=[3 5 1 0]
+      Test:  index=[2 4]
+    >>> # Specify train and test size
     >>> rs = ShuffleSplit(n_splits=5, train_size=0.5, test_size=.25,
     ...                   random_state=0)
-    >>> for train_index, test_index in rs.split(X):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    TRAIN: [1 3 0] TEST: [5 2]
-    TRAIN: [4 0 2] TEST: [1 3]
-    TRAIN: [1 2 4] TEST: [3 5]
-    TRAIN: [3 4 1] TEST: [5 2]
-    TRAIN: [3 5 1] TEST: [2 4]
+    >>> for i, (train_index, test_index) in enumerate(rs.split(X)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[1 3 0]
+      Test:  index=[5 2]
+    Fold 1:
+      Train: index=[4 0 2]
+      Test:  index=[1 3]
+    Fold 2:
+      Train: index=[1 2 4]
+      Test:  index=[3 5]
+    Fold 3:
+      Train: index=[3 4 1]
+      Test:  index=[5 2]
+    Fold 4:
+      Train: index=[3 5 1]
+      Test:  index=[2 4]
     """
 
     def __init__(
@@ -1802,10 +1888,18 @@ class GroupShuffleSplit(ShuffleSplit):
     >>> gss = GroupShuffleSplit(n_splits=2, train_size=.7, random_state=42)
     >>> gss.get_n_splits()
     2
-    >>> for train_idx, test_idx in gss.split(X, y, groups):
-    ...     print("TRAIN:", train_idx, "TEST:", test_idx)
-    TRAIN: [2 3 4 5 6 7] TEST: [0 1]
-    TRAIN: [0 1 5 6 7] TEST: [2 3 4]
+    >>> print(gss)
+    GroupShuffleSplit(n_splits=2, random_state=42, test_size=None, train_size=0.7)
+    >>> for i, (train_idx, test_idx) in enumerate(gss.split(X, y, groups)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}, group={groups[test_index]}")
+    Fold 0:
+      Train: index=[3 5 1], group=[2 3 1]
+      Test:  index=[2 4], group=[2 2]
+    Fold 1:
+      Train: index=[3 5 1], group=[2 3 1]
+      Test:  index=[2 4], group=[2 2]
 
     See Also
     --------
@@ -1921,15 +2015,25 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     5
     >>> print(sss)
     StratifiedShuffleSplit(n_splits=5, random_state=0, ...)
-    >>> for train_index, test_index in sss.split(X, y):
-    ...     print("TRAIN:", train_index, "TEST:", test_index)
-    ...     X_train, X_test = X[train_index], X[test_index]
-    ...     y_train, y_test = y[train_index], y[test_index]
-    TRAIN: [5 2 3] TEST: [4 1 0]
-    TRAIN: [5 1 4] TEST: [0 2 3]
-    TRAIN: [5 0 2] TEST: [4 3 1]
-    TRAIN: [4 1 0] TEST: [2 3 5]
-    TRAIN: [0 5 1] TEST: [3 4 2]
+    >>> for i, (train_index, test_index) in enumerate(sss.split(X, y)):
+    ...     print(f"Fold {i}:")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"  Test:  index={test_index}")
+    Fold 0:
+      Train: index=[5 2 3]
+      Test:  index=[4 1 0]
+    Fold 1:
+      Train: index=[5 1 4]
+      Test:  index=[0 2 3]
+    Fold 2:
+      Train: index=[5 0 2]
+      Test:  index=[4 3 1]
+    Fold 3:
+      Train: index=[4 1 0]
+      Test:  index=[2 3 5]
+    Fold 4:
+      Train: index=[0 5 1]
+      Test:  index=[3 4 2]
     """
 
     def __init__(

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -824,8 +824,10 @@ class StratifiedGroupKFold(_BaseKFold):
     StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
     >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
     ...     print(f"Fold {i}:")
-    ...     print(f"  Train: index={train_index}\ \n\t group={groups[train_index]}")
-    ...     print(f"  Test:  index={test_index}\ \n\t group={groups[test_index]}")
+    ...     print(f"  Train: index={train_index}")
+    ...     print(f"         group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}")
+    ...     print(f"         group={groups[test_index]}")
     Fold 0:
       Train: index=[ 0  1  2  3  7  8  9 10 11 15 16]
              group=[1 1 2 2 4 5 5 5 5 8 8]

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -824,10 +824,8 @@ class StratifiedGroupKFold(_BaseKFold):
     StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
     >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
     ...     print(f"Fold {i}:")
-    ...     print(f"  Train: index={train_index}")
-    ...     print(f"         group={groups[train_index]}")
-    ...     print(f"  Test:  index={test_index}")
-    ...     print(f"         group={groups[test_index]}")
+    ...     print(f"  Train: index={train_index}\\n\t group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}\\n\t group={groups[test_index]}")
     Fold 0:
       Train: index=[ 0  1  2  3  7  8  9 10 11 15 16]
              group=[1 1 2 2 4 5 5 5 5 8 8]

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -824,8 +824,8 @@ class StratifiedGroupKFold(_BaseKFold):
     StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
     >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
     ...     print(f"Fold {i}:")
-    ...     print(f"  Train: index={train_index}\n\\t group={groups[train_index]}")
-    ...     print(f"  Test:  index={test_index}\n\\t group={groups[test_index]}")
+    ...     print(f"  Train: index={train_index}\ \n\t group={groups[train_index]}")
+    ...     print(f"  Test:  index={test_index}\ \n\t group={groups[test_index]}")
     Fold 0:
       Train: index=[ 0  1  2  3  7  8  9 10 11 15 16]
              group=[1 1 2 2 4 5 5 5 5 8 8]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Relates to: https://github.com/scikit-learn/scikit-learn/pull/24104#discussion_r966071617
Continuation of #24466
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
* Improved print format of docstring examples
* Includes index and group (if relevant) values. Some examples previously printed out the data values as well but this seems messy and not necessarily helpful (see https://github.com/scikit-learn/scikit-learn/pull/24104#discussion_r938265301) so removed
* Added to some examples for consistency - so `get_n_splits()` and `print()` of the splitter was always shown

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
