### PR TITLE
DOC ensures sklearn.utils.multiclass.unique_labels passes numpydoc validation.

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -34,7 +34,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.is_scalar_nan",
     "sklearn.utils.metaestimators.available_if",
     "sklearn.utils.metaestimators.if_delegate_has_method",
-    "sklearn.utils.multiclass.unique_labels",
     "sklearn.utils.sparsefuncs.incr_mean_variance_axis",
     "sklearn.utils.sparsefuncs.inplace_swap_row_csc",
     "sklearn.utils.sparsefuncs.inplace_swap_row_csr",

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -54,6 +54,7 @@ def unique_labels(*ys):
     Parameters
     ----------
     *ys : array-likes
+        Unique Label Values
 
     Returns
     -------

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -54,7 +54,7 @@ def unique_labels(*ys):
     Parameters
     ----------
     *ys : array-likes
-        Unique Label Values.
+        Label values.
 
     Returns
     -------

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -54,7 +54,7 @@ def unique_labels(*ys):
     Parameters
     ----------
     *ys : array-likes
-        Unique Label Values
+        Unique Label Values.
 
     Returns
     -------


### PR DESCRIPTION
Reference Issues/PRs

Towards https://github.com/scikit-learn/scikit-learn/issues/21350.

What does this implement/fix? Explain your changes.

DOC ensures sklearn.utils.multiclass.unique_labels passes numpydoc validation.