### PR TITLE
MAINT Clean deprecation for 1.2: graph_shortest_path

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -29,7 +29,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.fixes.threadpool_limits",
     "sklearn.utils.gen_batches",
     "sklearn.utils.gen_even_slices",
-    "sklearn.utils.graph.graph_shortest_path",
     "sklearn.utils.graph.single_source_shortest_path_length",
     "sklearn.utils.is_scalar_nan",
     "sklearn.utils.metaestimators.available_if",

--- a/sklearn/utils/graph.py
+++ b/sklearn/utils/graph.py
@@ -13,7 +13,6 @@ sparse matrices.
 import numpy as np
 from scipy import sparse
 
-from .deprecation import deprecated
 from ..metrics.pairwise import pairwise_distances
 
 
@@ -69,53 +68,6 @@ def single_source_shortest_path_length(graph, source, *, cutoff=None):
             break
         level += 1
     return seen  # return all path lengths as dictionary
-
-
-@deprecated(
-    "`graph_shortest_path` is deprecated in 1.0 (renaming of 0.25) and will "
-    "be removed in 1.2. Use `scipy.sparse.csgraph.shortest_path` instead."
-)
-def graph_shortest_path(dist_matrix, directed=True, method="auto"):
-    """Shortest-path graph search on a positive directed or undirected graph.
-
-    Parameters
-    ----------
-    dist_matrix : arraylike or sparse matrix, shape = (N,N)
-        Array of positive distances.
-        If vertex i is connected to vertex j, then dist_matrix[i,j] gives
-        the distance between the vertices.
-        If vertex i is not connected to vertex j, then dist_matrix[i,j] = 0
-
-    directed : boolean
-        if True, then find the shortest path on a directed graph: only
-        progress from a point to its neighbors, not the other way around.
-        if False, then find the shortest path on an undirected graph: the
-        algorithm can progress from a point to its neighbors and vice versa.
-
-    method : {'auto', 'FW', 'D'}, default='auto'
-        method to use.  Options are
-        'auto' : attempt to choose the best method for the current problem
-        'FW' : Floyd-Warshall algorithm.  O[N^3]
-        'D' : Dijkstra's algorithm with Fibonacci stacks.  O[(k+log(N))N^2]
-
-    Returns
-    -------
-    G : np.ndarray, float, shape = [N,N]
-        G[i,j] gives the shortest distance from point i to point j
-        along the graph.
-
-    Notes
-    -----
-    As currently implemented, Dijkstra's algorithm does not work for
-    graphs with direction-dependent distances when directed == False.
-    i.e., if dist_matrix[i,j] and dist_matrix[j,i] are not equal and
-    both are nonzero, method='D' will not necessarily yield the correct
-    result.
-    Also, these routines have not been tested for graphs with negative
-    distances.  Negative distances can lead to infinite cycles that must
-    be handled by specialized algorithms.
-    """
-    return sparse.csgraph.shortest_path(dist_matrix, method=method, directed=directed)
 
 
 def _fix_connected_components(

--- a/sklearn/utils/tests/test_shortest_path.py
+++ b/sklearn/utils/tests/test_shortest_path.py
@@ -1,17 +1,8 @@
 from collections import defaultdict
 
 import numpy as np
-import pytest
 from numpy.testing import assert_array_almost_equal
-from sklearn.utils.graph import graph_shortest_path, single_source_shortest_path_length
-
-
-# FIXME: to be removed in 1.2
-def test_graph_shortest_path_deprecation():
-    dist_matrix = generate_graph(20)
-
-    with pytest.warns(FutureWarning, match="deprecated"):
-        _ = graph_shortest_path(dist_matrix)
+from sklearn.utils.graph import single_source_shortest_path_length
 
 
 def floyd_warshall_slow(graph, directed=False):
@@ -54,28 +45,6 @@ def generate_graph(N=20):
     return dist_matrix
 
 
-@pytest.mark.filterwarnings("ignore:Function graph_shortest_path is deprecated")
-def test_floyd_warshall():
-    dist_matrix = generate_graph(20)
-
-    for directed in (True, False):
-        graph_FW = graph_shortest_path(dist_matrix, directed, "FW")
-        graph_py = floyd_warshall_slow(dist_matrix.copy(), directed)
-
-        assert_array_almost_equal(graph_FW, graph_py)
-
-
-@pytest.mark.filterwarnings("ignore:Function graph_shortest_path is deprecated")
-def test_dijkstra():
-    dist_matrix = generate_graph(20)
-
-    for directed in (True, False):
-        graph_D = graph_shortest_path(dist_matrix, directed, "D")
-        graph_py = floyd_warshall_slow(dist_matrix.copy(), directed)
-
-        assert_array_almost_equal(graph_D, graph_py)
-
-
 def test_shortest_path():
     dist_matrix = generate_graph(20)
     # We compare path length and not costs (-> set distances to 0 or 1)
@@ -93,11 +62,3 @@ def test_shortest_path():
 
             for j in range(graph_py[i].shape[0]):
                 assert_array_almost_equal(dist_dict[j], graph_py[i, j])
-
-
-@pytest.mark.filterwarnings("ignore:Function graph_shortest_path is deprecated")
-def test_dijkstra_bug_fix():
-    X = np.array([[0.0, 0.0, 4.0], [1.0, 0.0, 2.0], [0.0, 5.0, 0.0]])
-    dist_FW = graph_shortest_path(X, directed=False, method="FW")
-    dist_D = graph_shortest_path(X, directed=False, method="D")
-    assert_array_almost_equal(dist_D, dist_FW)


### PR DESCRIPTION
Remove deprecated function ``graph_sortest_path``.