### PR TITLE
TST Speed up tests for pairwise distances reductions

### DIFF
--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -868,28 +868,24 @@ def test_format_agnosticism(
         )
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
-@pytest.mark.parametrize("n_samples", [100, 1000])
-@pytest.mark.parametrize("metric", BaseDistanceReductionDispatcher.valid_metrics())
-@pytest.mark.parametrize(
-    "Dispatcher",
-    [ArgKmin, RadiusNeighbors],
-)
+@pytest.mark.parametrize("n_samples_X, n_samples_Y", [(100, 100), (100, 500), (500, 100)])
+@pytest.mark.parametrize("metric", ['euclidean', 'minkowski', 'manhattan', 'infinity', 'seuclidean', 'haversine'])
+@pytest.mark.parametrize("Dispatcher", [ArgKmin, RadiusNeighbors])
 @pytest.mark.parametrize("dtype", [np.float64, np.float32])
 def test_strategies_consistency(
     global_random_seed,
     Dispatcher,
     metric,
-    n_samples,
+    n_samples_X,
+    n_samples_Y,
     dtype,
     n_features=10,
 ):
 
     rng = np.random.RandomState(global_random_seed)
     spread = 100
-    X = rng.rand(n_samples, n_features).astype(dtype) * spread
-    Y = rng.rand(n_samples, n_features).astype(dtype) * spread
+    X = rng.rand(n_samples_X, n_features).astype(dtype) * spread
+    Y = rng.rand(n_samples_Y, n_features).astype(dtype) * spread
 
     # Haversine distance only accepts 2D data
     if metric == "haversine":
@@ -917,7 +913,7 @@ def test_strategies_consistency(
             metric, n_features, seed=global_random_seed
         )[0],
         # To be sure to use parallelization
-        chunk_size=n_samples // 4,
+        chunk_size=n_samples_X // 4,
         strategy="parallel_on_X",
         return_distance=True,
         **compute_parameters,
@@ -933,7 +929,7 @@ def test_strategies_consistency(
             metric, n_features, seed=global_random_seed
         )[0],
         # To be sure to use parallelization
-        chunk_size=n_samples // 4,
+        chunk_size=n_samples_Y // 4,
         strategy="parallel_on_Y",
         return_distance=True,
         **compute_parameters,

--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -801,24 +801,23 @@ def test_n_threads_agnosticism(
 
 
 @pytest.mark.parametrize(
-    "n_samples, Dispatcher, dtype",
+    "Dispatcher, dtype",
     [
-        (100, ArgKmin, np.float64),
-        (100, RadiusNeighbors, np.float32),
-        (100, ArgKmin, np.float32),
-        (100, RadiusNeighbors, np.float64),
+        (ArgKmin, np.float64),
+        (RadiusNeighbors, np.float32),
+        (ArgKmin, np.float32),
+        (RadiusNeighbors, np.float64),
     ],
 )
 def test_format_agnosticism(
     global_random_seed,
-    n_samples,
     Dispatcher,
     dtype,
 ):
     """Check that results do not depend on the format (dense, sparse) of the input."""
     rng = np.random.RandomState(global_random_seed)
     spread = 100
-    n_features = 100
+    n_samples, n_features = 100, 100
 
     X = rng.rand(n_samples, n_features).astype(dtype) * spread
     Y = rng.rand(n_samples, n_features).astype(dtype) * spread


### PR DESCRIPTION
Some recently added tests in ``test_pairwise_distances_reduction.py`` are too slow due to over parametrization or too big datasets.
The tests for the whole file take (locally) **1min45s** on main, with ``test_strategies_consistency`` taking almost 1min on its own.

This PR reduces the whole time (locally) for this file to **17s**. There's probably still room for improvement but it's already a lot more reasonable.

The main source for the speed up is thanks to avoiding the 1000x1000 dist matrix

cc/ @jjerphan to make sure some change did not remove a key part / param combination that really needs to be tested.

ref #23211