### PR TITLE
Metric.ndcg score

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -369,7 +369,9 @@ Changelog
 
 - |Feature| :func:`metrics.roc_auc_score` now supports micro-averaging
   (`average="micro"`) for the One-vs-Rest multiclass case (`multi_class="ovr"`).
-  :pr:`24338` by :user:`Arturo Amor <ArturoAmorQ>`.
+
+- |Fix| :func: `metrics.ndcg_score` and `metrics.dcg_score` will raise error if `y_true` is a single value.
+  :pr:`24482` by :user:`Madi Ebersole <mae5357>`.
 
 :mod:`sklearn.model_selection`
 ..............................

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1541,6 +1541,10 @@ def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
     dcg_score : Discounted Cumulative Gain (not normalized).
 
     """
+    # raise value error if y_true or y_score is single input
+    if y_true.ndim == 1 & y_true.shape[0] == 1:
+        raise ValueError("Expected y_true to have an array >1")
+
     gain = _dcg_sample_scores(y_true, y_score, k, ignore_ties=ignore_ties)
     # Here we use the order induced by y_true so we can ignore ties since
     # the gain associated to tied indices is the same (permuting ties doesn't

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1746,6 +1746,14 @@ def _test_dcg_score_for(y_true, y_score):
     assert ideal == pytest.approx((np.sort(y_true)[:, ::-1] / discount).sum(axis=1))
 
 
+def _test_dcg_score_errors():
+    # raise error if y_true is single value
+    y_true = np.array([1])
+    y_score = np.array([1])
+    with pytest.raises(ValueError, match="Cannot compute DCG for a single sample."):
+        dcg_score(y_true, y_score)
+
+
 def test_dcg_ties():
     y_true = np.asarray([np.arange(5)])
     y_score = np.zeros(y_true.shape)
@@ -1857,6 +1865,14 @@ def _test_ndcg_score_for(y_true, y_score):
     assert score[all_zero] == pytest.approx(np.zeros(all_zero.sum()))
     assert ideal.shape == (y_true.shape[0],)
     assert score.shape == (y_true.shape[0],)
+
+
+def _test_ndcg_score_errors():
+    # raise error if y_true is single value
+    y_true = np.array([1])
+    y_score = np.array([1])
+    with pytest.raises(ValueError, match="Cannot compute DCG for a single sample."):
+        ndcg_score(y_true, y_score)
 
 
 def test_partial_roc_auc_score():


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes  #21335 and #20119

#### What does this implement/fix? Explain your changes.

Computing [Normalized Discounted Cumulative Gain (NDCG)](https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Normalized_DCG) does not make sense for single predictions. Throw an error if `y_true` is a list of length 1 for NDCG and DCG.

#### Any other comments?

Test that this throws the appropriate error by running:
```python
from sklearn.metrics import ndcg_score

y_true = [[1]]
y_pred = [[1]]

print(ndcg_score(y_true, y_pred))
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
