### PR TITLE
FIX Fix ranking for scipy >= 1.10.

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -969,7 +969,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                 # keep previous behaviour nans are set to be smaller than the
                 # minimum value in the array before ranking
                 min_array_means = min(array_means) - 1
-                np.nan_to_num(array_means, copy=False, nan=min_array_means)
+                array_means = np.nan_to_num(array_means, copy=True, nan=min_array_means)
                 rank_result = rankdata(-array_means, method="min")
                 rank_result = np.asarray(rank_result, dtype=np.int32)
                 results["rank_%s" % key_name] = rank_result

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -966,7 +966,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
             if rank:
                 # when input is nan, scipy >= 1.10 rankdata returns nan. To
-                # keep previous behaviour nans are set to the
+                # keep previous behaviour nans are set to be smaller than the
                 # minimum value in the array before ranking
                 min_array_means = min(array_means) - 1
                 np.nan_to_num(array_means, copy=False, nan=min_array_means)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -968,9 +968,8 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                 # when input is nan, scipy >= 1.10 rankdata returns nan. To
                 # keep previous behaviour nans are set to the
                 # minimum value in the array before ranking
-                array_means = np.asarray(
-                    [min(array_means) - 1 if np.isnan(a) else a for a in array_means]
-                )
+                min_array_means = min(array_means) - 1
+                np.nan_to_num(array_means, copy=False, nan=min_array_means)
                 rank_result = rankdata(-array_means, method="min")
                 rank_result = np.asarray(rank_result, dtype=np.int32)
                 results["rank_%s" % key_name] = rank_result

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -965,11 +965,13 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             results["std_%s" % key_name] = array_stds
 
             if rank:
-                rank_result = rankdata(-array_means, method="min")
                 # when input is nan, scipy >= 1.10 rankdata returns nan. To
                 # keep previous behaviour nans are set to the
-                # maximum possible rank
-                rank_result[np.isnan(rank_result)] = len(rank_result)
+                # minimum value in the array before ranking
+                array_means = np.asarray(
+                    [min(array_means) - 1 if np.isnan(a) else a for a in array_means]
+                )
+                rank_result = rankdata(-array_means, method="min")
                 rank_result = np.asarray(rank_result, dtype=np.int32)
                 results["rank_%s" % key_name] = rank_result
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses `test_grid_search_failing_classifier` failure reported in #24424 and #24446.

#### What does this implement/fix? Explain your changes.
when input is nan, scipy >= 1.10 rankdata new default returns all nan.
To keep previous behaviour nans are set to the minimum value in the array before ranking.

#### Any other comments?
@ogrisel, @lesteve please let me know if this is a too naive way of fixing.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
