### PR TITLE
[MRG] DOC Mention pandas dataframe support in ColumnTransformer in FAQ

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -377,8 +377,10 @@ The homogeneous NumPy and SciPy data objects currently expected are most
 efficient to process for most operations. Extensive work would also be needed
 to support Pandas categorical types. Restricting input to homogeneous
 types therefore reduces maintenance cost and encourages usage of efficient
-data structures. But `ColumnTransformer https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html#sklearn.compose.ColumnTransformer`
-can be used with pandas DataFrame.
+data structures. But :class:`~sklearn.compose.ColumnTransformer`
+can be used with pandas DataFrame because this meta estimator makes it convenient
+to map related subsets of dataframe columns selected by name or dtype to 
+dedicated scikit-learn transformers.
 
 Do you plan to implement transform for target y in a pipeline?
 ----------------------------------------------------------------------------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -377,7 +377,8 @@ The homogeneous NumPy and SciPy data objects currently expected are most
 efficient to process for most operations. Extensive work would also be needed
 to support Pandas categorical types. Restricting input to homogeneous
 types therefore reduces maintenance cost and encourages usage of efficient
-data structures.
+data structures. But `ColumnTransformer https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html#sklearn.compose.ColumnTransformer`
+can be used with pandas DataFrame.
 
 Do you plan to implement transform for target y in a pipeline?
 ----------------------------------------------------------------------------


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #24469 

#### What does this implement/fix? Explain your changes.

Mentioned support of pandas DataFrame in [ColumnTransformer](https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html#sklearn.compose.ColumnTransformer).