### PR TITLE
[MRG] DOC Ensures that inplace_swap_row_csc passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -32,7 +32,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.is_scalar_nan",
     "sklearn.utils.metaestimators.available_if",
     "sklearn.utils.metaestimators.if_delegate_has_method",
-    "sklearn.utils.sparsefuncs.inplace_swap_row_csc",
     "sklearn.utils.sparsefuncs.inplace_swap_row_csr",
 ]
 FUNCTION_DOCSTRING_IGNORE_LIST = set(FUNCTION_DOCSTRING_IGNORE_LIST)

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -265,8 +265,7 @@ def inplace_row_scale(X, scale):
 
 
 def inplace_swap_row_csc(X, m, n):
-    """
-    Swaps two rows of a CSC matrix in-place.
+    """Swap two rows of a CSC matrix in-place.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Ensure that [`sklearn.utils.sparsefuncs.inplace_swap_row_csc`](https://github.com/scikit-learn/scikit-learn/blob/f9a856d72c0d754323f1023e0a97639f7177c9f3/sklearn/utils/sparsefuncs.py#L267) docstring pass numpydoc validation.
