### PR TITLE
DOC Ensures that utils.extmath.density passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -15,7 +15,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.metrics.pairwise.pairwise_distances_chunked",
     "sklearn.tree._export.plot_tree",
     "sklearn.utils.axis0_safe_slice",
-    "sklearn.utils.extmath.density",
     "sklearn.utils.extmath.fast_logdet",
     "sklearn.utils.extmath.randomized_svd",
     "sklearn.utils.extmath.safe_sparse_dot",

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -106,7 +106,7 @@ def density(w, **kwargs):
     w : array-like
         The sparse vector.
     **kwargs : keyword arguments
-        Keyword arguments passed to the accumulator function.
+        Ignored.
 
     Returns
     -------

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -105,6 +105,8 @@ def density(w, **kwargs):
     ----------
     w : array-like
         The sparse vector.
+    **kwargs : keyword arguments
+        Keyword arguments passed to the accumulator function.
 
     Returns
     -------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350

#### What does this implement/fix? Explain your changes.
Adds **kwargs documentation. 

#### Any other comments?
Not sure why kwargs is not used in function but is included as a parameter

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
