### PR TITLE
MAINT catch deprecation and error for ragged array for NumPy >=1.24

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -300,12 +300,14 @@ def type_of_target(y, input_name=""):
 
     # DeprecationWarning will be replaced by ValueError, see NEP 34
     # https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
+    # We therefore catch both deprecation (NumPy < 1.24) warning and
+    # value error (NumPy >= 1.24).
     with warnings.catch_warnings():
         warnings.simplefilter("error", np.VisibleDeprecationWarning)
         if not issparse(y):
             try:
                 y = xp.asarray(y)
-            except np.VisibleDeprecationWarning:
+            except (np.VisibleDeprecationWarning, ValueError):
                 # dtype=object should be provided explicitly for ragged arrays,
                 # see NEP 34
                 y = xp.asarray(y, dtype=object)


### PR DESCRIPTION
This should fix some failures of #24424, in particular:
- `test__check_targets`
- `test_check_classification_targets`

Calling `asarray` without `dtype=object` and ragged array was previously raising a deprecation warning and now raise a `ValueError`.

This PR catches both the deprecation (as before) and the new `ValueError`.