### PR TITLE
TST Relax `test_gradient_boosting_early_stopping`

### DIFF
--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1102,49 +1102,49 @@ def test_sparse_input(EstimatorClass, sparse_matrix):
             assert_array_almost_equal(res_sparse, res)
 
 
-def test_gradient_boosting_early_stopping():
-    X, y = make_classification(n_samples=1000, random_state=0)
+@pytest.mark.parametrize(
+    "GradientBoostingEstimator", [GradientBoostingClassifier, GradientBoostingRegressor]
+)
+def test_gradient_boosting_early_stopping(GradientBoostingEstimator):
+    # Check if early stopping works as expected, that is empirically check that the
+    # number of trained estimators is increasing when the tolerance decreases.
 
-    gbc = GradientBoostingClassifier(
-        n_estimators=1000,
+    X, y = make_classification(n_samples=1000, random_state=0)
+    n_estimators = 1000
+
+    gb_large_tol = GradientBoostingEstimator(
+        n_estimators=n_estimators,
         n_iter_no_change=10,
         learning_rate=0.1,
         max_depth=3,
         random_state=42,
+        tol=1e-1,
     )
 
-    gbr = GradientBoostingRegressor(
-        n_estimators=1000,
+    gb_small_tol = GradientBoostingEstimator(
+        n_estimators=n_estimators,
         n_iter_no_change=10,
         learning_rate=0.1,
         max_depth=3,
         random_state=42,
+        tol=1e-3,
     )
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-    # Check if early_stopping works as expected, that is empirically check that the
-    # number of estimators is increasing when the tolerance decreases.
+    gb_large_tol.fit(X_train, y_train)
+    gb_small_tol.fit(X_train, y_train)
 
-    # Depending on platforms, the number of fitted estimators might slightly vary.
-    # Hence, we check for its inclusion in an interval centered in the expected
-    # number of fitted estimators rather than a strict equality.
-    delta_early_stop_n_estimators = 2
-    for est, tol, expected_early_stop_n_estimators in (
-        (gbc, 1e-1, 28),
-        (gbr, 1e-1, 13),
-        (gbc, 1e-3, 70),
-        (gbr, 1e-3, 28),
-    ):
-        est.set_params(tol=tol)
-        est.fit(X_train, y_train)
-        assert (
-            expected_early_stop_n_estimators - delta_early_stop_n_estimators
-            <= est.n_estimators_
-            <= expected_early_stop_n_estimators + delta_early_stop_n_estimators
-        )
-        assert est.score(X_test, y_test) > 0.7
+    assert gb_large_tol.n_estimators_ < gb_small_tol.n_estimators_ < n_estimators
 
-    # Without early stopping
+    assert gb_large_tol.score(X_test, y_test) > 0.7
+    assert gb_small_tol.score(X_test, y_test) > 0.7
+
+
+def test_gradient_boosting_without_early_stopping():
+    # When early stopping is not used, the number of trained estimators
+    # must be the one specified.
+    X, y = make_classification(n_samples=1000, random_state=0)
+
     gbc = GradientBoostingClassifier(
         n_estimators=50, learning_rate=0.1, max_depth=3, random_state=42
     )
@@ -1154,6 +1154,7 @@ def test_gradient_boosting_early_stopping():
     )
     gbr.fit(X, y)
 
+    # The number of trained estimators but be the one specified.
     assert gbc.n_estimators_ == 50
     assert gbr.n_estimators_ == 30
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1154,7 +1154,7 @@ def test_gradient_boosting_without_early_stopping():
     )
     gbr.fit(X, y)
 
-    # The number of trained estimators but be the one specified.
+    # The number of trained estimators must be the one specified.
     assert gbc.n_estimators_ == 50
     assert gbr.n_estimators_ == 30
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes a failure observed in https://github.com/scikit-learn/scikit-learn/pull/24446#issuecomment-1262165841


#### What does this implement/fix? Explain your changes.

Depending on platforms, the number of fitted estimators might slightly vary.
This makes `test_gradient_boosting_early_stopping` fails as it checks it against hard-coded expected values.

This PR proposes relaxing `test_gradient_boosting_early_stopping` by checking for an inclusion in an interval centered in the expected number of fitted estimators rather than a strict equality.

#### Any other comments?

Other (better) proposals are welcome!