### PR TITLE
BLD Import from numpy/arrayobject.h directly

### DIFF
--- a/sklearn/metrics/_dist_metrics.pyx.tp
+++ b/sklearn/metrics/_dist_metrics.pyx.tp
@@ -37,7 +37,7 @@ cnp.import_array()  # required in order to use C-API
 
 
 # First, define a function to get an ndarray from a memory buffer
-cdef extern from "arrayobject.h":
+cdef extern from "numpy/arrayobject.h":
     object PyArray_SimpleNewFromData(int nd, cnp.npy_intp* dims,
                                      int typenum, void* data)
 

--- a/sklearn/metrics/_dist_metrics.pyx.tp
+++ b/sklearn/metrics/_dist_metrics.pyx.tp
@@ -35,13 +35,6 @@ cimport numpy as cnp
 
 cnp.import_array()  # required in order to use C-API
 
-
-# First, define a function to get an ndarray from a memory buffer
-cdef extern from "numpy/arrayobject.h":
-    object PyArray_SimpleNewFromData(int nd, cnp.npy_intp* dims,
-                                     int typenum, void* data)
-
-
 from libc.math cimport fabs, sqrt, exp, pow, cos, sin, asin
 
 from scipy.sparse import csr_matrix, issparse
@@ -127,7 +120,7 @@ cdef inline cnp.ndarray _buffer_to_ndarray{{name_suffix}}(const {{INPUT_DTYPE_t}
     # a possibility of this for our use-case, this should be safe.
 
     # Note: this Segfaults unless np.import_array() is called above
-    return PyArray_SimpleNewFromData(1, &n, DTYPECODE, <void*>x)
+    return cnp.PyArray_SimpleNewFromData(1, &n, DTYPECODE, <void*>x)
 
 
 cdef {{INPUT_DTYPE_t}} INF{{name_suffix}} = np.inf

--- a/sklearn/metrics/setup.py
+++ b/sklearn/metrics/setup.py
@@ -32,7 +32,7 @@ def configuration(parent_package="", top_path=None):
     config.add_extension(
         "_dist_metrics",
         sources=["_dist_metrics.pyx"],
-        include_dirs=[np.get_include(), os.path.join(np.get_include(), "numpy")],
+        include_dirs=[np.get_include()],
         libraries=libraries,
     )
 


### PR DESCRIPTION
We can cdef directly from `numpy/arrayobject.h` instead of including another directory during setup. This makes this part of the code consistent with other places such as `_trees.pyx`:

https://github.com/scikit-learn/scikit-learn/blob/d2c713bce62974f7a17aab3e556d0bf14eebab3c/sklearn/tree/_tree.pyx#L38

CC @jjerphan 