### PR TITLE
FIX do not try to inspect estimator object

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -494,6 +494,10 @@ Changelog
   :func:`utils.discovery.all_functions`) in scikit-learn.
   :pr:`21469` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |Fix| Do not try to call `get_params` on estimator class when creating the
+  HTML representation.
+  :pr:`24548` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -1,4 +1,5 @@
 from contextlib import closing
+from inspect import isclass
 from io import StringIO
 from string import Template
 import html
@@ -125,7 +126,7 @@ def _get_visual_block(estimator):
         estimators = [
             (key, est)
             for key, est in estimator.get_params(deep=False).items()
-            if hasattr(est, "get_params") and hasattr(est, "fit")
+            if not isclass(est) and hasattr(est, "get_params") and hasattr(est, "fit")
         ]
         if estimators:
             return _VisualBlock(


### PR DESCRIPTION
closes #24545 

We should not try to call `get_params` on the estimator class object but only instances.
Otherwise, `self` is not defined and it does not make sense to get any not yet created parameters.

TODO:

- [ ] add a non-regression test