### PR TITLE
DOC make `plot_mean_shift.py` more colourblind friendly

### DIFF
--- a/examples/cluster/plot_mean_shift.py
+++ b/examples/cluster/plot_mean_shift.py
@@ -42,20 +42,21 @@ print("number of estimated clusters : %d" % n_clusters_)
 # Plot result
 # -----------
 import matplotlib.pyplot as plt
-from itertools import cycle
 
 plt.figure(1)
 plt.clf()
 
-colors = cycle("bgrcmykbgrcmykbgrcmykbgrcmyk")
+colors = ['#dede00', '#377eb8', '#f781bf']
+markers = ["x", "o", "^"]
+
 for k, col in zip(range(n_clusters_), colors):
     my_members = labels == k
     cluster_center = cluster_centers[k]
-    plt.plot(X[my_members, 0], X[my_members, 1], col + ".")
+    plt.plot(X[my_members, 0], X[my_members, 1], markers[k], color = col)
     plt.plot(
         cluster_center[0],
         cluster_center[1],
-        "o",
+        markers[k],
         markerfacecolor=col,
         markeredgecolor="k",
         markersize=14,

--- a/examples/cluster/plot_mean_shift.py
+++ b/examples/cluster/plot_mean_shift.py
@@ -46,13 +46,13 @@ import matplotlib.pyplot as plt
 plt.figure(1)
 plt.clf()
 
-colors = ['#dede00', '#377eb8', '#f781bf']
+colors = ["#dede00", "#377eb8", "#f781bf"]
 markers = ["x", "o", "^"]
 
 for k, col in zip(range(n_clusters_), colors):
     my_members = labels == k
     cluster_center = cluster_centers[k]
-    plt.plot(X[my_members, 0], X[my_members, 1], markers[k], color = col)
+    plt.plot(X[my_members, 0], X[my_members, 1], markers[k], color=col)
     plt.plot(
         cluster_center[0],
         cluster_center[1],


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #5435 
Related to https://github.com/scikit-learn/scikit-learn/issues/5435#issuecomment-1209975045

#### What does this implement/fix? Explain your changes.
Includes markers and a more colourblind friendly palette

#### Any other comments?
<details>
<summary>Details</summary>

Original Image (Deuteranopia)
![image](https://user-images.githubusercontent.com/75483881/193311795-bc00f878-9b02-4a8b-b15f-3995da13f3d1.png)

Revised Image (Deutranopia)
![image](https://user-images.githubusercontent.com/75483881/193312030-967fec7d-2869-4b14-9b1b-8e663f026aef.png)

Original Image (Protanopia)
![image](https://user-images.githubusercontent.com/75483881/193312518-0b0bbfef-2239-493f-90b5-e8226f3399e0.png)

Revised Image (Protanopia)
![image](https://user-images.githubusercontent.com/75483881/193312342-92149e34-3e04-4a59-a509-dd224f3482cb.png)

Original Image (Tritanopia)
![image](https://user-images.githubusercontent.com/75483881/193312692-8ec7bec9-9606-4445-930b-2b086134b12a.png)

Revised Image (Tritanopia)
![image](https://user-images.githubusercontent.com/75483881/193312773-64dbaf21-16a9-44e8-bd44-b0b214026c20.png)
