### PR TITLE
MAINT remove redundant items from iterable

### DIFF
--- a/examples/cluster/plot_mean_shift.py
+++ b/examples/cluster/plot_mean_shift.py
@@ -47,7 +47,7 @@ from itertools import cycle
 plt.figure(1)
 plt.clf()
 
-colors = cycle("bgrcmykbgrcmykbgrcmykbgrcmyk")
+colors = cycle("bgrcmyk")
 for k, col in zip(range(n_clusters_), colors):
     my_members = labels == k
     cluster_center = cluster_centers[k]


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This commit removes redundant repetitions of the sequence `bgrcmyk` inside a call to `itertools.cycle`. This repeating pattern is handled by `cycle` already, so the repetition is redundant.
