### PR TITLE
DOC Ensures that sklearn.tree._export.plot_tree passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -12,7 +12,6 @@ from sklearn.utils.discovery import all_functions
 numpydoc_validation = pytest.importorskip("numpydoc.validate")
 
 FUNCTION_DOCSTRING_IGNORE_LIST = [
-    "sklearn.tree._export.plot_tree",
     "sklearn.utils.axis0_safe_slice",
     "sklearn.utils.extmath.fast_logdet",
     "sklearn.utils.extmath.randomized_svd",

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -113,7 +113,7 @@ def plot_tree(
         The maximum depth of the representation. If None, the tree is fully
         generated.
 
-    feature_names : list of strings, default=None
+    feature_names : list of str, default=None
         Names of each of the features.
         If None, generic names will be used ("x[0]", "x[1]", ...).
 
@@ -174,7 +174,6 @@ def plot_tree(
     >>> clf = clf.fit(iris.data, iris.target)
     >>> tree.plot_tree(clf)
     [...]
-
     """
 
     check_is_fitted(decision_tree)


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #21350 

#### What does this implement/fix? Explain your changes.
Deletes unnecessary empty lines in docstring and renames return type in `sklearn.tree._export.plot_tree`.