### PR TITLE
DOC Ensures that sklearn.utils.extmath.safe_sparse_dot passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -14,7 +14,6 @@ numpydoc_validation = pytest.importorskip("numpydoc.validate")
 FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.extmath.fast_logdet",
     "sklearn.utils.extmath.randomized_svd",
-    "sklearn.utils.extmath.safe_sparse_dot",
     "sklearn.utils.extmath.svd_flip",
     "sklearn.utils.extmath.weighted_mode",
     "sklearn.utils.fixes.delayed",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350 
Ensures that `sklearn.utils.extmath.safe_sparse_dot` passes numpydoc validation.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

- The `sklearn.utils.extmath.safe_sparse_dot` docstring passed all tests without any changes.

- Removed `sklearn.utils.extmath.safe_sparse_dot` from the `FUNCTION_DOCSTRING_IGNORE_LIST` at `scikit-learn/sklearn/tests/test_docstrings.py`. 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
