### PR TITLE
DOC Ensures that sklearn.utils.extmath.weighted_mode passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -16,7 +16,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.extmath.randomized_svd",
     "sklearn.utils.extmath.safe_sparse_dot",
     "sklearn.utils.extmath.svd_flip",
-    #"sklearn.utils.extmath.weighted_mode",
     "sklearn.utils.fixes.delayed",
     "sklearn.utils.fixes.linspace",
     # To be fixed in upstream issue:

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -16,7 +16,7 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.extmath.randomized_svd",
     "sklearn.utils.extmath.safe_sparse_dot",
     "sklearn.utils.extmath.svd_flip",
-    "sklearn.utils.extmath.weighted_mode",
+    #"sklearn.utils.extmath.weighted_mode",
     "sklearn.utils.fixes.delayed",
     "sklearn.utils.fixes.linspace",
     # To be fixed in upstream issue:

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -619,7 +619,8 @@ def weighted_mode(a, w, *, axis=0):
 
     See Also
     --------
-    scipy.stats.mode: Calculates the Modal (most common) value of array elements along specified axis.
+    scipy.stats.mode: Calculates the Modal (most common) value of array elements
+        along specified axis.
 
     Examples
     --------

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -595,7 +595,7 @@ def _randomized_eigsh(
 
 def weighted_mode(a, w, *, axis=0):
     """Return an array of the weighted modal (most common) value in the passed array.
-    
+
     If there is more than one such value, only the first is returned.
     The bin-count for the modal bins is also returned.
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -594,8 +594,8 @@ def _randomized_eigsh(
 
 
 def weighted_mode(a, w, *, axis=0):
-    """Returns an array of the weighted modal (most common) value in a.
-
+    """Return an array of the weighted modal (most common) value in the passed array.
+    
     If there is more than one such value, only the first is returned.
     The bin-count for the modal bins is also returned.
 
@@ -603,10 +603,10 @@ def weighted_mode(a, w, *, axis=0):
 
     Parameters
     ----------
-    a : array-like
-        n-dimensional array of which to find mode(s).
-    w : array-like
-        n-dimensional array of weights for each value.
+    a : array-like of shape (n_samples,)
+        Array of which values to find mode(s).
+    w : array-like of shape (n_samples,)
+        Array of weights for each value.
     axis : int, default=0
         Axis along which to operate. Default is 0, i.e. the first axis.
 
@@ -616,6 +616,10 @@ def weighted_mode(a, w, *, axis=0):
         Array of modal values.
     score : ndarray
         Array of weighted counts for each mode.
+        
+    See Also
+    --------
+    scipy.stats.mode: Calculates the Modal (most common) value of array elements along specified axis.
 
     Examples
     --------
@@ -634,10 +638,6 @@ def weighted_mode(a, w, *, axis=0):
 
     The value 2 has the highest score: it appears twice with weights of
     1.5 and 2: the sum of these is 3.5.
-
-    See Also
-    --------
-    scipy.stats.mode
     """
     if axis is None:
         a = np.ravel(a)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -616,7 +616,7 @@ def weighted_mode(a, w, *, axis=0):
         Array of modal values.
     score : ndarray
         Array of weighted counts for each mode.
-        
+
     See Also
     --------
     scipy.stats.mode: Calculates the Modal (most common) value of array elements along specified axis.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses #21350 
Ensures that `sklearn.utils.extmath.weighted_mode` passes numpydoc_validation.

#### What does this implement/fix? Explain your changes.

- Updated description to start with infinitive verb.
- Updated descriptions of parameters to represent shape of input.
- Reordered sections so that `See Also` is before `Examples`.
