### PR TITLE
Doc Ensures that sklearn.util.fixes.linspace passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -18,7 +18,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.extmath.svd_flip",
     "sklearn.utils.extmath.weighted_mode",
     "sklearn.utils.fixes.delayed",
-    "sklearn.utils.fixes.linspace",
     # To be fixed in upstream issue:
     # https://github.com/joblib/threadpoolctl/issues/108
     "sklearn.utils.fixes.threadpool_info",


### PR DESCRIPTION
**Reference Issues/PRs**
Addresses https://github.com/scikit-learn/scikit-learn/issues/21350

**What does this implement/fix? Explain your changes.**
Removed sklearn.util.fixes.linspace from docstring ignore list as this function has already been removed in PR https://github.com/scikit-learn/scikit-learn/commit/34f9dbf54164e3c62d68765fe45f27f067a45562#diff-861011cf3c620527b29aa12afb1b31212d7b6782e71f5b8ceca6e84199bf86be





