### PR TITLE
MNT Optimize safe_indexing for slices

### DIFF
--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -405,7 +405,7 @@ def _get_column_indices(X, key):
                 stop = all_columns.get_loc(stop) + 1
             else:
                 stop = n_columns + 1
-            return list(range(n_columns)[slice(start, stop)])
+            return list(islice(range(n_columns), start, stop))
         else:
             columns = list(key)
 


### PR DESCRIPTION
This PR uses `islice` instead of creating the whole list and slicing it. Here is a quick benchmark:

```python
from itertools import islice
start, stop = 10, 400
n_columns = 10000

%%timeit
_ = list(range(n_columns))[slice(start, end)]
76.7 µs ± 409 ns per loop

%%timeit
_ = list(islice(range(n_columns), start, stop))
3.88 µs ± 40.6 ns per loop
```

