### PR TITLE
FIX Introduces `utils.fixes.csr_hstack` 

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -512,6 +512,13 @@ Changelog
   :func:`utils.discovery.all_functions`) in scikit-learn.
   :pr:`21469` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |FIX| Introduced :func:`utils.fixes.csr_hstack` to mitigate bugs present in
+  `scipy.sparse.hstack` when stacking matrices with large shape, or very-many
+  non-zero elements. The function either aliases
+  `scipy.sparse.hstack(..., format='csr')` when the detected `scipy` version
+  is at least `1.9.2` or falls back to a vendored implementation.
+  :pr:`24595` by :user:`Meekail Zain <micky774>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -17,6 +17,7 @@ from ..utils.validation import check_is_fitted, FLOAT_DTYPES, _check_sample_weig
 from ..utils.validation import _check_feature_names_in
 from ..utils._param_validation import Interval, StrOptions
 from ..utils.stats import _weighted_percentile
+from ..utils.fixes import csr_hstack
 
 from ._csr_polynomial_expansion import _csr_polynomial_expansion
 
@@ -365,7 +366,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
                 # edge case: deal with empty matrix
                 XP = sparse.csr_matrix((n_samples, 0), dtype=X.dtype)
             else:
-                XP = sparse.hstack(to_stack, format="csr")
+                XP = csr_hstack(to_stack)
         elif sparse.isspmatrix_csc(X) and self._max_degree < 4:
             return self.transform(X.tocsr()).tocsc()
         elif sparse.isspmatrix(X):
@@ -386,7 +387,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
                 else:
                     bias = sparse.csc_matrix(np.ones((X.shape[0], 1)))
                     columns.append(bias)
-            XP = sparse.hstack(columns, dtype=X.dtype).tocsc()
+            XP = csr_hstack(columns, dtype=X.dtype).tocsc()
         else:
             # Do as if _min_degree = 0 and cut down array after the
             # computation, i.e. use _n_out_full instead of n_output_features_.

--- a/sklearn/utils/_csr_hstack.pyx
+++ b/sklearn/utils/_csr_hstack.pyx
@@ -1,0 +1,87 @@
+# Based on `scipy.sparse.sparsetools.csr.h` under the BSD license.
+
+cimport cython
+from libc.stdlib cimport malloc, free
+from libcpp.vector cimport vector
+
+cimport numpy as cnp
+
+# Fused type for data
+ctypedef fused DATA_t:
+    cython.integral
+    cython.floating
+
+# Fused types for indices and indptr.
+# Need uniquely named fused types to generate full cross-product for all four
+# input/output array combinations
+
+# Input CSR indices and indptr type.
+# In the Python layer, SciPy's implementation sets indices and indptr
+# type to smallest one necessary to maintain indices values
+# representability, determined by the maximum value across
+# all input blocks after concatenation.
+ctypedef fused IND_t:
+    cnp.int32_t
+    cnp.int64_t
+
+# TODO: `const`-qualify fused-typed memoryviews when Cython>=3.0 is released.
+cpdef _csr_hstack(
+    const Py_ssize_t n_blocks,      # Number of matrices to stack
+    const Py_ssize_t n_rows,        # Number of rows (same across all matrices)
+    const cnp.int64_t[:] n_cols,    # Number of columns (one per matrix)
+    IND_t[:] indptr_cat,            # Input concatenated array of indptrs
+    IND_t[:] indices_cat,           # Input concatenated array of indices
+    DATA_t[:] data_cat,             # Input concatenated array of data
+    IND_t[:] indptr,                # Output array to write indptr into
+    IND_t[:] indices,               # Output array to write indices into
+    DATA_t[:] data,                 # Output array to write data into
+    ):
+
+    cdef:
+        Py_ssize_t offset, row_start, row_end, row_sum
+        Py_ssize_t idx, jdx, kdx, cat_index
+
+        vector[Py_ssize_t] col_offset = vector[Py_ssize_t](n_blocks)
+        vector[Py_ssize_t] indptr_bound = vector[Py_ssize_t](n_blocks)
+        vector[Py_ssize_t] indices_bound = vector[Py_ssize_t](n_blocks)
+
+    # The bounds will store the locations/indices of the flat concatenated
+    # arrays that correspond to each block.
+    with nogil:
+
+        # We set the initial index values here and update iteratively
+        col_offset[0] = 0
+        indptr_bound[0] = 0
+        indices_bound[0] = 0
+
+        # We populate the bounds iteratively
+        for idx in range(1, n_blocks):
+            col_offset[idx] = col_offset[idx - 1] + n_cols[idx - 1]
+            indptr_bound[idx] = indptr_bound[idx - 1] + n_rows + 1
+            indices_bound[idx] = indices_bound[idx - 1] + indptr_cat[indptr_bound[idx - 1] + n_rows]
+
+        # Now we populate the full output matrix
+        indptr[0] = 0
+        row_sum = 0
+
+        # We iterate across rows for convenience
+        for idx in range(n_rows):
+            # For each row, in each matrix we find the valid indices to iterate
+            for jdx in range(n_blocks):
+                row_start = indptr_cat[indptr_bound[jdx] + idx]
+                row_end = indptr_cat[indptr_bound[jdx] + idx + 1]
+
+                # We account for the offset due to horizontal concatenation
+                offset = col_offset[jdx]
+
+                # We iterate over the valid indices, updating the indices and
+                # data
+                for kdx in range(row_end - row_start):
+                    cat_index = indices_bound[jdx] + row_start + kdx
+                    indices[row_sum + kdx] = indices_cat[cat_index] + offset
+                    data[row_sum + kdx] = data_cat[cat_index]
+                row_sum += row_end - row_start
+
+            # Cumulative row index (indptr)
+            indptr[idx + 1] = row_sum
+    return

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -170,3 +170,90 @@ def _mode(a, axis=0):
     if sp_version >= parse_version("1.9.0"):
         return scipy.stats.mode(a, axis=axis, keepdims=True)
     return scipy.stats.mode(a, axis=axis)
+
+
+# TODO: Remove when SciPy 1.10 is the minimum supported version
+if sp_version >= parse_version("1.9.2"):
+    csr_hstack = scipy.sparse.hstack
+else:
+
+    def csr_hstack(columns, dtype=np.float64):
+        """
+        Parameters
+        ----------
+        columns : list
+            List of `CSR` matrices to horizontally (column-wise) stack. All
+            matrices must have the same number of rows.
+        dtype : dtype, default=np.float64
+            The type of feature values. The output of the stacking operation is
+            cast to this type if this type is wider (i.e. `float32`-->`float64`).
+        Returns
+        -------
+        X : CSR matrix of shape (`n_rows`, `n_features_out_`)
+            A CSR sparse matrix that is the result of horizontally (column-wise)
+            stacking the matrices contained in `columns`.
+        """
+        from ._csr_hstack import _csr_hstack as cython_csr_hstack
+
+        n_blocks = len(columns)
+        if n_blocks == 0:
+            raise ValueError("No matrices were provided to stack")
+        if n_blocks == 1:
+            return columns[0]
+        other_axis_dims = set(mat.shape[0] for mat in columns)
+        if len(other_axis_dims) > 1:
+            raise ValueError(
+                f"Mismatching dimensions along axis {0}: {other_axis_dims}"
+            )
+        (constant_dim,) = other_axis_dims
+
+        # Do the stacking
+        indptr_list = [mat.indptr for mat in columns]
+        data_cat = np.concatenate([mat.data for mat in columns])
+
+        # Need to check if any indices/indptr, would be too large post-
+        # concatenation for np.int32. We must sum the dimensions along the axis we
+        # use to stack since even empty matrices will contribute to a large post-
+        # stack index value. At this point the matrices contained in `columns` may
+        # be a mix of {32,64}bit integers, but this covers the case that each are
+        # only 32bit while their concatenation would need to be 64bit.
+        max_output_index = 0
+        max_indptr = 0
+        for mat in columns[:-1]:
+            max_output_index += mat.shape[1]
+            max_indptr = max(max_indptr, mat.indptr.max())
+        if columns[-1].indices.size > 0:
+            max_output_index += int(columns[-1].indices.max())
+            max_indptr = max(max_indptr, columns[-1].indptr.max())
+        max_int32 = np.iinfo(np.int32).max
+        needs_64bit = max(max_output_index, max_indptr) > max_int32
+        idx_dtype = np.int64 if needs_64bit else np.int32
+
+        stack_dim_cat = np.array([mat.shape[1] for mat in columns], dtype=np.int64)
+        if data_cat.size > 0:
+            indptr_cat = np.concatenate(indptr_list).astype(idx_dtype)
+            indices_cat = np.concatenate([mat.indices for mat in columns]).astype(
+                idx_dtype
+            )
+            indptr = np.empty(constant_dim + 1, dtype=idx_dtype)
+            indices = np.empty_like(indices_cat)
+            data = np.empty_like(data_cat)
+            cython_csr_hstack(
+                n_blocks,
+                constant_dim,
+                stack_dim_cat,
+                indptr_cat,
+                indices_cat,
+                data_cat,
+                indptr,
+                indices,
+                data,
+            )
+        else:
+            indptr = np.zeros(constant_dim + 1, dtype=idx_dtype)
+            indices = np.empty(0, dtype=idx_dtype)
+            data = np.empty(0, dtype=data_cat.dtype)
+        sum_dim = stack_dim_cat.sum()
+        return scipy.sparse.csr_matrix(
+            (data.astype(dtype), indices, indptr), shape=(constant_dim, sum_dim)
+        )

--- a/sklearn/utils/setup.py
+++ b/sklearn/utils/setup.py
@@ -122,6 +122,14 @@ def configuration(parent_package="", top_path=None):
         libraries=libraries,
     )
 
+    config.add_extension(
+        "_csr_hstack",
+        sources=["_csr_hstack.pyx"],
+        include_dirs=[numpy.get_include()],
+        libraries=libraries,
+        language="c++",
+    )
+
     config.add_subpackage("tests")
 
     return config

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -12,7 +12,7 @@ import scipy.stats
 from sklearn.utils._testing import assert_array_equal
 
 from sklearn.utils.fixes import _object_dtype_isnan, loguniform, csr_hstack
-from scipy.sparse import random as sparse_random
+from scipy.sparse import random as sparse_random, csr_matrix, hstack
 
 
 @pytest.mark.parametrize("dtype, val", ([object, 1], [object, "a"], [float, 1]))
@@ -48,6 +48,7 @@ def test_loguniform(low, high, base):
     ).rvs(random_state=0)
 
 
+# TODO: Remove when SciPy 1.10 is the minimum supported version
 def test_csr_hstack():
     n_rows = 10
     msg = "No matrices were provided to stack"
@@ -66,3 +67,60 @@ def test_csr_hstack():
     assert X_stacked.data.size == 0
     assert X_stacked.indices.size == 0
     assert_array_equal(X_stacked.indptr, np.zeros(n_rows + 1, dtype=np.int64))
+
+
+# TODO: Remove when SciPy 1.10 is the minimum supported version
+def test_csr_hstack_int64():
+    """
+    Tests if hstack properly promotes to indices and indptr arrays to np.int64
+    when using np.int32 during concatenation would result in either array
+    overflowing.
+    """
+    max_int32 = np.iinfo(np.int32).max
+
+    # First case: indices would overflow with int32
+    data = [1.0]
+    row = [0]
+
+    max_indices_1 = max_int32 - 1
+    max_indices_2 = 3
+
+    # Individual indices arrays are representable with int32
+    col_1 = [max_indices_1 - 1]
+    col_2 = [max_indices_2 - 1]
+
+    X_1 = csr_matrix((data, (row, col_1)))
+    X_2 = csr_matrix((data, (row, col_2)))
+
+    assert max(max_indices_1 - 1, max_indices_2 - 1) < max_int32
+    assert X_1.indices.dtype == X_1.indptr.dtype == np.int32
+    assert X_2.indices.dtype == X_2.indptr.dtype == np.int32
+
+    # ... but when concatenating their CSR matrices, the resulting indices
+    # array can't be represented with int32 and must be promoted to int64.
+    X_hs = hstack([X_1, X_2], format="csr")
+
+    assert X_hs.indices.max() == max_indices_1 + max_indices_2 - 1
+    assert max_indices_1 + max_indices_2 - 1 > max_int32
+    assert X_hs.indices.dtype == X_hs.indptr.dtype == np.int64
+
+    # Even if the matrices are empty, we must account for their size
+    # contribution so that we may safely set the final elements.
+    X_1_empty = csr_matrix(X_1.shape)
+    X_2_empty = csr_matrix(X_2.shape)
+    X_hs_empty = hstack([X_1_empty, X_2_empty], format="csr")
+
+    assert X_hs_empty.shape == X_hs.shape
+    assert X_hs_empty.indices.dtype == np.int64
+
+    # Should be just small enough to stay in int32 after stack. Note that
+    # we theoretically could support indices.max() == max_int32, but due to an
+    # edge-case in the underlying sparsetools code
+    # (namely the `coo_tocsr` routine),
+    # we require that max(X_hs_32.shape) < max_int32 as well.
+    # Hence we can only support max_int32 - 1.
+    col_3 = [max_int32 - max_indices_1 - 1]
+    X_3 = csr_matrix((data, (row, col_3)))
+    X_hs_32 = hstack([X_1, X_3], format="csr")
+    assert X_hs_32.indices.dtype == np.int32
+    assert X_hs_32.indices.max() == max_int32 - 1


### PR DESCRIPTION
#### Reference Issues/PRs
This is a subset of the changes initially introduced in #23731, broken up for easier review (and since really the functionality is orthogonal).

#### What does this implement/fix? Explain your changes.
`scipy.sparse.hstack` has some bugs surrounding edge-cases for large-shape matrices, as detailed in https://github.com/scipy/scipy/issues/16569.

These were addressed in https://github.com/scipy/scipy/pull/16628 and will be included in `scipy>=1.9.2` however until our minimum supported version catches up, this PR introduces a fix to keep the new behavior.

#### Any other comments?