### PR TITLE
TST use global_random_seed in sklearn/cluster/tests/test_dbscan.py

### DIFF
--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -286,7 +286,7 @@ def test_boundaries():
     assert 0 not in core
 
 
-def test_weighted_dbscan():
+def test_weighted_dbscan(global_random_seed):
     # ensure sample_weight is validated
     with pytest.raises(ValueError):
         dbscan([[0], [1]], sample_weight=[2])
@@ -320,7 +320,7 @@ def test_weighted_dbscan():
     )
 
     # for non-negative sample_weight, cores should be identical to repetition
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     sample_weight = rng.randint(0, 5, X.shape[0])
     core1, label1 = dbscan(X, sample_weight=sample_weight)
     assert len(label1) == len(X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards: #22827

#### What does this implement/fix? Explain your changes.
- Added the global_random_seed fixture in test_dbscan.py
- The only addition is in test_weighted_dbscan.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
