### PR TITLE
MAINT Clean deprecation for 1.2: cv_results_ keys

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -78,29 +78,6 @@ def alpha_max(emp_cov):
     return np.max(np.abs(A))
 
 
-class _DictWithDeprecatedKeys(dict):
-    """Dictionary with deprecated keys.
-
-    Currently only be used in GraphicalLassoCV to deprecate keys"""
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._deprecated_key_to_new_key = {}
-
-    def __getitem__(self, key):
-        if key in self._deprecated_key_to_new_key:
-            warnings.warn(
-                f"Key: '{key}', is deprecated in 1.0 and will be "
-                f"removed in 1.2. Use '{self._deprecated_key_to_new_key[key]}' instead",
-                FutureWarning,
-            )
-        return super().__getitem__(key)
-
-    def _set_deprecated(self, value, *, new_key, deprecated_key):
-        self._deprecated_key_to_new_key[deprecated_key] = new_key
-        self[new_key] = self[deprecated_key] = value
-
-
 # The g-lasso algorithm
 def graphical_lasso(
     emp_cov,
@@ -1018,26 +995,13 @@ class GraphicalLassoCV(BaseGraphicalLasso):
         )
         grid_scores = np.array(grid_scores)
 
-        # TODO(1.2): Use normal dict for cv_results_ instead of _DictWithDeprecatedKeys
-        self.cv_results_ = _DictWithDeprecatedKeys(alphas=np.array(alphas))
+        self.cv_results_ = {"alphas": np.array(alphas)}
 
         for i in range(grid_scores.shape[1]):
-            self.cv_results_._set_deprecated(
-                grid_scores[:, i],
-                new_key=f"split{i}_test_score",
-                deprecated_key=f"split{i}_score",
-            )
+            self.cv_results_[f"split{i}_test_score"] = grid_scores[:, i]
 
-        self.cv_results_._set_deprecated(
-            np.mean(grid_scores, axis=1),
-            new_key="mean_test_score",
-            deprecated_key="mean_score",
-        )
-        self.cv_results_._set_deprecated(
-            np.std(grid_scores, axis=1),
-            new_key="std_test_score",
-            deprecated_key="std_score",
-        )
+        self.cv_results_["mean_test_score"] = np.mean(grid_scores, axis=1)
+        self.cv_results_["std_test_score"] = np.std(grid_scores, axis=1)
 
         best_alpha = alphas[best_index]
         self.alpha_ = best_alpha

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -238,5 +238,5 @@ def test_graphical_lasso_cv_scores():
     expected_mean = cv_scores.mean(axis=0)
     expected_std = cv_scores.std(axis=0)
 
-    assert_allclose(cov.cv_results_[f"mean_test_score"], expected_mean)
-    assert_allclose(cov.cv_results_[f"std_test_score"], expected_std)
+    assert_allclose(cov.cv_results_["mean_test_score"], expected_mean)
+    assert_allclose(cov.cv_results_["std_test_score"], expected_std)

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -206,10 +206,7 @@ def test_graphical_lasso_cv_alphas_invalid_array(alphas, err_type, err_msg):
         GraphicalLassoCV(alphas=alphas, tol=1e-1, n_jobs=1).fit(X)
 
 
-# TODO: Remove `score` and `test_score` suffix in 1.2
-@pytest.mark.parametrize("suffix", ["score", "test_score"])
-@pytest.mark.filterwarnings("ignore:Key*:FutureWarning:sklearn")
-def test_graphical_lasso_cv_scores(suffix):
+def test_graphical_lasso_cv_scores():
     splits = 4
     n_alphas = 5
     n_refinements = 3
@@ -232,7 +229,7 @@ def test_graphical_lasso_cv_scores(suffix):
 
     total_alphas = n_refinements * n_alphas + 1
     keys = ["alphas"]
-    split_keys = [f"split{i}_{suffix}" for i in range(splits)]
+    split_keys = [f"split{i}_test_score" for i in range(splits)]
     for key in keys + split_keys:
         assert key in cv_results
         assert len(cv_results[key]) == total_alphas
@@ -241,41 +238,5 @@ def test_graphical_lasso_cv_scores(suffix):
     expected_mean = cv_scores.mean(axis=0)
     expected_std = cv_scores.std(axis=0)
 
-    assert_allclose(cov.cv_results_[f"mean_{suffix}"], expected_mean)
-    assert_allclose(cov.cv_results_[f"std_{suffix}"], expected_std)
-
-
-# TODO: Remove in 1.2 when mean_score, std_score, and split(k)_score is removed.
-def test_graphical_lasso_cv_scores_deprecated():
-    """Check that the following keys in cv_results_ are deprecated: `mean_score`,
-    `std_score`, and `split(k)_score`."""
-    splits = 4
-    n_alphas = 5
-    n_refinements = 3
-    true_cov = np.array(
-        [
-            [0.8, 0.0, 0.2, 0.0],
-            [0.0, 0.4, 0.0, 0.0],
-            [0.2, 0.0, 0.3, 0.1],
-            [0.0, 0.0, 0.1, 0.7],
-        ]
-    )
-    rng = np.random.RandomState(0)
-    X = rng.multivariate_normal(mean=[0, 0, 0, 0], cov=true_cov, size=200)
-    cov = GraphicalLassoCV(cv=splits, alphas=n_alphas, n_refinements=n_refinements).fit(
-        X
-    )
-    cv_results = cov.cv_results_
-
-    deprecated_keys = ["mean_score", "std_score"] + [
-        f"split{k}_score" for k in range(splits)
-    ]
-
-    for deprecated_key in deprecated_keys:
-        new_key = deprecated_key.replace("_score", "_test_score")
-        msg = (
-            f"Key: '{deprecated_key}', is deprecated in 1.0 and will be removed in 1.2."
-            f" Use '{new_key}' instead"
-        )
-        with pytest.warns(FutureWarning, match=msg):
-            cv_results[deprecated_key]
+    assert_allclose(cov.cv_results_[f"mean_test_score"], expected_mean)
+    assert_allclose(cov.cv_results_[f"std_test_score"], expected_std)


### PR DESCRIPTION
The `"mean_score"`, `"std_score"` and `"split{i}_score"` keys of `cv_results_` were deprecated in GraphicalLassoCV.