### PR TITLE
TST Make test_function_docstrings ignore functions from utils.fixes

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -45,7 +45,9 @@ def get_all_methods():
 def get_all_functions_names():
     functions = all_functions()
     for _, func in functions:
-        yield f"{func.__module__}.{func.__name__}"
+        # exclude functions from utils.fixex since they come from external packages
+        if "utils.fixes" not in func.__module__:
+            yield f"{func.__module__}.{func.__name__}"
 
 
 def filter_errors(errors, method, Klass=None):

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -15,11 +15,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.extmath.fast_logdet",
     "sklearn.utils.extmath.randomized_svd",
     "sklearn.utils.extmath.svd_flip",
-    "sklearn.utils.fixes.delayed",
-    # To be fixed in upstream issue:
-    # https://github.com/joblib/threadpoolctl/issues/108
-    "sklearn.utils.fixes.threadpool_info",
-    "sklearn.utils.fixes.threadpool_limits",
     "sklearn.utils.gen_batches",
     "sklearn.utils.gen_even_slices",
     "sklearn.utils.metaestimators.if_delegate_has_method",

--- a/sklearn/utils/discovery.py
+++ b/sklearn/utils/discovery.py
@@ -208,8 +208,6 @@ def all_functions():
                 (func.__name__, func)
                 for name, func in functions
                 if not name.startswith("_")
-                # exclude functions from utils.fixex: they come from external packages
-                and "utils.fixes" not in func.__module__
             ]
             all_functions.extend(functions)
 

--- a/sklearn/utils/discovery.py
+++ b/sklearn/utils/discovery.py
@@ -208,6 +208,8 @@ def all_functions():
                 (func.__name__, func)
                 for name, func in functions
                 if not name.startswith("_")
+                # exclude functions from utils.fixex: they come from external packages
+                and "utils.fixes" not in func.__module__
             ]
             all_functions.extend(functions)
 


### PR DESCRIPTION
functions in `utils.fixes` are redefinitions of functions from external packages. I don't think we want to force them to adopt the same formatting of the docstrings.