### PR TITLE
[MRG] DOC Ensure that gen_even_slices passes numpydoc validation

### DIFF
--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -16,7 +16,6 @@ FUNCTION_DOCSTRING_IGNORE_LIST = [
     "sklearn.utils.extmath.randomized_svd",
     "sklearn.utils.extmath.svd_flip",
     "sklearn.utils.gen_batches",
-    "sklearn.utils.gen_even_slices",
     "sklearn.utils.metaestimators.if_delegate_has_method",
 ]
 FUNCTION_DOCSTRING_IGNORE_LIST = set(FUNCTION_DOCSTRING_IGNORE_LIST)

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -748,7 +748,7 @@ def gen_batches(n, batch_size, *, min_batch_size=0):
 def gen_even_slices(n, n_packs, *, n_samples=None):
     """Generator to create `n_packs` evenly spaced slices going up to `n`.
 
-    If `n_packs` does not divide `n`, except for the first `n % n_packs` 
+    If `n_packs` does not divide `n`, except for the first `n % n_packs`
     slices, remaining slices may contain fewer elements.
 
     Parameters

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -746,21 +746,25 @@ def gen_batches(n, batch_size, *, min_batch_size=0):
 
 
 def gen_even_slices(n, n_packs, *, n_samples=None):
-    """Generator to create n_packs slices going up to n.
+    """Generator to create `n_packs` evenly spaced slices going up to `n`.
+
+    If `n_packs` does not divide `n`, except for the first `n % n_packs` 
+    slices, remaining slices may contain fewer elements.
 
     Parameters
     ----------
     n : int
+        Size of the sequence.
     n_packs : int
         Number of slices to generate.
     n_samples : int, default=None
-        Number of samples. Pass n_samples when the slices are to be used for
+        Number of samples. Pass `n_samples` when the slices are to be used for
         sparse matrix indexing; slicing off-the-end raises an exception, while
         it works for NumPy arrays.
 
     Yields
     ------
-    slice
+    `slice` representing a set of indices from 0 to n.
 
     See Also
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses #21350 
Ensures that sklearn.utils.gen_even_slices passes numpydoc validation.

#### What does this implement/fix? Explain your changes.
- Modified documentation for gen_even_slices
- Removed gen_even_slices from FUNCTION_DOCSTRING_IGNORE_LIST (sklearn/tests/test_docstrings.py)

#### Any other comments?
- The docstring passed all tests in sklearn/tests/test_docstrings.py



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
