### PR TITLE
Update _search_successive_halving.py

### DIFF
--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -27,14 +27,14 @@ class _SubsampleMetaSplitter:
 
     def split(self, X, y, groups=None):
         for train_idx, test_idx in self.base_cv.split(X, y, groups):
-            train_idx = resample(
+            if self.fraction < 1:train_idx = resample(
                 train_idx,
                 replace=False,
                 random_state=self.random_state,
                 n_samples=int(self.fraction * train_idx.shape[0]),
             )
             if self.subsample_test:
-                test_idx = resample(
+                if self.fraction < 1:test_idx = resample(
                     test_idx,
                     replace=False,
                     random_state=self.random_state,


### PR DESCRIPTION
When self.fraction=1, which means to use the entire train_idx. But if sampling randomly, the order of samples will be changed, which means their corresponding samples are the same, but the order is different. This will affect model like random forest, which is sensitive to the sample order. So, I suggest that when self.fraction=1, train_idx should be used directly instead of randomly sampling all the train_idx.

```python
from sklearn.datasets import load_iris
from sklearn.ensemble import RandomForestClassifier
from sklearn.model_selection import KFold, cross_val_score
from sklearn.experimental import enable_halving_search_cv
from sklearn.model_selection import  HalvingRandomSearchCV

X, y = load_iris(return_X_y=True)
clf = RandomForestClassifier(n_estimators=20, random_state=2)  
kf = KFold(shuffle=False)

param_distributions = {"max_depth": [2, 3, 5], "min_samples_split": list(range(2, 12))}
search = HalvingRandomSearchCV(clf, param_distributions, min_resources=50, max_resources=150,factor=3,
                            random_state=111, n_jobs=1,cv=kf, resource='n_samples'
                            ).fit(X, y)

for p, c, s in zip(search.cv_results_['params'], search.cv_results_['mean_test_score'], search.cv_results_['n_resources']):
    clf = clf.set_params(**p)
    if s == len(X):
        print(params, s)
        print(np.mean(cross_val_score(clf , X, y, cv=kf))-c)
```

**Actual output**：Although the samples used are the same, the order is different, resulting in different results.

```
{'min_samples_split': 5, 'max_depth': 2} 150
**0.020000000000000018**
```
**Expected output**

```
{'min_samples_split': 5, 'max_depth': 2} 150
**0.0**
```
