### PR TITLE
CI Use GITHUB_OUTPUT instead of deprecated set-output

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,7 +38,7 @@ jobs:
 
       - id: check_build_trigger
         name: Check build trigger
-        run: bash build_tools/github/check_build_trigger.sh >> $GITHUB_ENV
+        run: bash build_tools/github/check_build_trigger.sh
 
   # Build the wheels for Linux, Windows and macOS for Python 3.8 and newer
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,7 +38,7 @@ jobs:
 
       - id: check_build_trigger
         name: Check build trigger
-        run: bash build_tools/github/check_build_trigger.sh
+        run: bash build_tools/github/check_build_trigger.sh >> $GITHUB_ENV
 
   # Build the wheels for Linux, Windows and macOS for Python 3.8 and newer
   build_wheels:

--- a/build_tools/github/check_build_trigger.sh
+++ b/build_tools/github/check_build_trigger.sh
@@ -9,5 +9,5 @@ COMMIT_MSG=$(git log --no-merges -1 --oneline)
 if [[ "$GITHUB_EVENT_NAME" == schedule ||
       "$COMMIT_MSG" =~ \[cd\ build\] ||
       "$COMMIT_MSG" =~ \[cd\ build\ gh\] ]]; then
-    echo "build=true"
+    echo "build=true" >> $GITHUB_OUTPUT
 fi

--- a/build_tools/github/check_build_trigger.sh
+++ b/build_tools/github/check_build_trigger.sh
@@ -9,5 +9,5 @@ COMMIT_MSG=$(git log --no-merges -1 --oneline)
 if [[ "$GITHUB_EVENT_NAME" == schedule ||
       "$COMMIT_MSG" =~ \[cd\ build\] ||
       "$COMMIT_MSG" =~ \[cd\ build\ gh\] ]]; then
-    echo "::set-output name=build::true"
+    echo "build=true" >> $GITHUB_ENV
 fi

--- a/build_tools/github/check_build_trigger.sh
+++ b/build_tools/github/check_build_trigger.sh
@@ -9,5 +9,5 @@ COMMIT_MSG=$(git log --no-merges -1 --oneline)
 if [[ "$GITHUB_EVENT_NAME" == schedule ||
       "$COMMIT_MSG" =~ \[cd\ build\] ||
       "$COMMIT_MSG" =~ \[cd\ build\ gh\] ]]; then
-    echo "build=true" >> $GITHUB_ENV
+    echo "build=true"
 fi


### PR DESCRIPTION
`set-output` is being [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) in GitHub Actions. This PR updates it to use the [GITHUB_ENV](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files) instead.