### PR TITLE
OPTIM use pairwise_distances_argmin in NearestCentroid.predict

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -456,9 +456,9 @@ Changelog
   :pr:`10468` by :user:`Ruben <icfly2>` and :pr:`22993` by
   :user:`Jovan Stojanovic <jovan-stojanovic>`.
 
-- |Efficiency| :class:`neighbors.NearestCentroid` requires less memory and better
-  leverages the CPU cache to compute predictions.
-  :pr:`24645` by :user:`ogrisel`.
+- |Efficiency| :class:`neighbors.NearestCentroid` is faster and requires
+  less memory as it better leverages CPUs' caches to compute predictions.
+  :pr:`24645` by :user:`Olivier Grisel <ogrisel>`.
 
 - |Feature| Adds new function :func:`neighbors.sort_graph_by_row_values` to
   sort a CSR sparse graph such that each row is stored with increasing values.

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -456,6 +456,10 @@ Changelog
   :pr:`10468` by :user:`Ruben <icfly2>` and :pr:`22993` by
   :user:`Jovan Stojanovic <jovan-stojanovic>`.
 
+- |Efficiency| :class:`neighbors.NearestCentroid` requires less memory and better
+  leverages the CPU cache to compute predictions.
+  :pr:`24645` by :user:`ogrisel`.
+
 - |Feature| Adds new function :func:`neighbors.sort_graph_by_row_values` to
   sort a CSR sparse graph such that each row is stored with increasing values.
   This is useful to improve efficiency when using precomputed sparse distance

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -13,7 +13,7 @@ from numbers import Real
 from scipy import sparse as sp
 
 from ..base import BaseEstimator, ClassifierMixin
-from ..metrics.pairwise import pairwise_distances
+from ..metrics.pairwise import pairwise_distances_argmin
 from ..preprocessing import LabelEncoder
 from ..utils.validation import check_is_fitted
 from ..utils.sparsefuncs import csc_median_axis_0
@@ -234,5 +234,5 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
 
         X = self._validate_data(X, accept_sparse="csr", reset=False)
         return self.classes_[
-            pairwise_distances(X, self.centroids_, metric=self.metric).argmin(axis=1)
+            pairwise_distances_argmin(X, self.centroids_, metric=self.metric)
         ]


### PR DESCRIPTION
Small optim to reduce memory usage when both `X.shape[0]` and `centroids_.shape[0]` are large.