### PR TITLE
MAINT Clean deprecation for 1.2: leftovers

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -737,29 +737,6 @@ class GraphicalLassoCV(BaseGraphicalLasso):
 
             .. versionadded:: 1.0
 
-        split(k)_score : ndarray of shape (n_alphas,)
-            Log-likelihood score on left-out data across (k)th fold.
-
-            .. deprecated:: 1.0
-                `split(k)_score` is deprecated in 1.0 and will be removed in 1.2.
-                Use `split(k)_test_score` instead.
-
-        mean_score : ndarray of shape (n_alphas,)
-            Mean of scores over the folds.
-
-            .. deprecated:: 1.0
-                `mean_score` is deprecated in 1.0 and will be removed in 1.2.
-                Use `mean_test_score` instead.
-
-        std_score : ndarray of shape (n_alphas,)
-            Standard deviation of scores over the folds.
-
-            .. deprecated:: 1.0
-                `std_score` is deprecated in 1.0 and will be removed in 1.2.
-                Use `std_test_score` instead.
-
-        .. versionadded:: 0.24
-
     n_iter_ : int
         Number of iterations run for the optimal alpha.
 

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -76,15 +76,6 @@ def _deprecate_normalize(normalize, estimator_name):
 
     Notes
     -----
-    This function should be updated in 1.2 depending on the value of
-    `normalize`:
-    - True, warning: `normalize` was deprecated in 1.2 and will be removed in
-      1.4. Suggest to use pipeline instead.
-    - False, `normalize` was deprecated in 1.2 and it will be removed in 1.4.
-      Leave normalize to its default value.
-    - `deprecated` - this should only be possible with default == False as from
-      1.2 `normalize` in all the linear models should be either removed or the
-      default should be set to False.
     This function should be completely removed in 1.4.
     """
 

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -707,8 +707,6 @@ def test_set_coef_multiclass(klass):
     clf = klass().fit(X2, Y2, intercept_init=np.zeros((3,)))
 
 
-# TODO: Remove filterwarnings in v1.2.
-@pytest.mark.filterwarnings("ignore:.*squared_loss.*:FutureWarning")
 @pytest.mark.parametrize("klass", [SGDClassifier, SparseSGDClassifier])
 def test_sgd_predict_proba_method_access(klass):
     # Checks that SGDClassifier predict_proba and predict_log_proba methods

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -647,8 +647,7 @@ def test_feature_names_in():
             warnings.simplefilter("error", UserWarning)
             trans.transform(X)
 
-    # TODO: Convert to a error in 1.2
-    # fit on dataframe with feature names that are mixed warns:
+    # fit on dataframe with feature names that are mixed raises an error:
     df_mixed = pd.DataFrame(X_np, columns=["a", "b", 1, 2])
     trans = NoOpTransformer()
     msg = re.escape(
@@ -658,7 +657,7 @@ def test_feature_names_in():
     with pytest.raises(TypeError, match=msg):
         trans.fit(df_mixed)
 
-    # transform on feature names that are mixed also warns:
+    # transform on feature names that are mixed also raises:
     with pytest.raises(TypeError, match=msg):
         trans.transform(df_mixed)
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -463,8 +463,6 @@ def test_check_param_validation(estimator):
     check_param_validation(name, estimator)
 
 
-# TODO: remove this filter in 1.2
-@pytest.mark.filterwarnings("ignore::FutureWarning:sklearn")
 @pytest.mark.parametrize(
     "Estimator",
     [

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -234,10 +234,9 @@ def test_fit_docstring_attributes(name, Estimator):
     ):
         # default="auto" raises an error with the shape of `X`
         est.set_params(n_components=2)
-
-    # FIXME: TO BE REMOVED for 1.2 (avoid FutureWarning)
-    if Estimator.__name__ == "TSNE":
-        est.set_params(learning_rate=200.0, init="random", perplexity=2)
+    elif Estimator.__name__ == "TSNE":
+        # default raises an error, perplexity must be less than n_samples
+        est.set_params(perplexity=2)
 
     # FIXME: TO BE REMOVED for 1.3 (avoid FutureWarning)
     if Estimator.__name__ == "SequentialFeatureSelector":


### PR DESCRIPTION
Follow-up PR for the deprecations clean-up for 1.2.
There are outdated comments / doc / code that should have been removed in the previous PRs but where missed.