### PR TITLE
MAINT Fix full doc build by avoiding plot_set_output.py side-effect

### DIFF
--- a/examples/miscellaneous/plot_set_output.py
+++ b/examples/miscellaneous/plot_set_output.py
@@ -109,3 +109,8 @@ import pandas as pd
 log_reg = clf[-1]
 coef = pd.Series(log_reg.coef_.ravel(), index=log_reg.feature_names_in_)
 _ = coef.sort_values().plot.barh()
+
+# %%
+# This resets `transform_output` to its default value to avoid impacting other
+# examples when generating the scikit-learn documentation
+set_config(transform_output="default")


### PR DESCRIPTION
This should fix #24652 by avoiding setting `transform_output` to examples running after `plot_set_output.py` 