### PR TITLE
DOC make `plot_agglomerative_clustering_metrics.py` colorblind friendly

### DIFF
--- a/examples/cluster/plot_agglomerative_clustering_metrics.py
+++ b/examples/cluster/plot_agglomerative_clustering_metrics.py
@@ -131,7 +131,7 @@ for index, metric in enumerate(["cosine", "euclidean", "cityblock"]):
 # Plot clustering results
 for index, metric in enumerate(["cosine", "euclidean", "cityblock"]):
     model = AgglomerativeClustering(
-        n_clusters=n_clusters, linkage="average", affinity=metric
+        n_clusters=n_clusters, linkage="average", metric=metric
     )
     model.fit(X)
     plt.figure()

--- a/examples/cluster/plot_agglomerative_clustering_metrics.py
+++ b/examples/cluster/plot_agglomerative_clustering_metrics.py
@@ -38,6 +38,7 @@ thus the clustering puts them in the same cluster.
 # License: BSD 3-Clause or CC-0
 
 import matplotlib.pyplot as plt
+import matplotlib.patheffects as PathEffects
 import numpy as np
 
 from sklearn.cluster import AgglomerativeClustering
@@ -108,13 +109,14 @@ for index, metric in enumerate(["cosine", "euclidean", "cityblock"]):
     avg_dist /= avg_dist.max()
     for i in range(n_clusters):
         for j in range(n_clusters):
-            plt.text(
+            t = plt.text(
                 i,
                 j,
                 "%5.3f" % avg_dist[i, j],
                 verticalalignment="center",
                 horizontalalignment="center",
             )
+            t.set_path_effects([PathEffects.withStroke(linewidth=5, foreground='w', alpha=0.5)])
 
     plt.imshow(avg_dist, interpolation="nearest", cmap="cividis", vmin=0)
     plt.xticks(range(n_clusters), labels, rotation=45)

--- a/examples/cluster/plot_agglomerative_clustering_metrics.py
+++ b/examples/cluster/plot_agglomerative_clustering_metrics.py
@@ -116,7 +116,9 @@ for index, metric in enumerate(["cosine", "euclidean", "cityblock"]):
                 verticalalignment="center",
                 horizontalalignment="center",
             )
-            t.set_path_effects([PathEffects.withStroke(linewidth=5, foreground='w', alpha=0.5)])
+            t.set_path_effects(
+                [PathEffects.withStroke(linewidth=5, foreground="w", alpha=0.5)]
+            )
 
     plt.imshow(avg_dist, interpolation="nearest", cmap="cividis", vmin=0)
     plt.xticks(range(n_clusters), labels, rotation=45)

--- a/examples/cluster/plot_agglomerative_clustering_metrics.py
+++ b/examples/cluster/plot_agglomerative_clustering_metrics.py
@@ -80,18 +80,20 @@ n_clusters = 3
 
 labels = ("Waveform 1", "Waveform 2", "Waveform 3")
 
+colors = ["#f7bd01", "#377eb8", "#f781bf"]
+
 # Plot the ground-truth labelling
 plt.figure()
 plt.axes([0, 0, 1, 1])
-for l, c, n in zip(range(n_clusters), "rgb", labels):
-    lines = plt.plot(X[y == l].T, c=c, alpha=0.5)
+for l, color, n in zip(range(n_clusters), colors, labels):
+    lines = plt.plot(X[y == l].T, c=color, alpha=0.5)
     lines[0].set_label(n)
 
 plt.legend(loc="best")
 
 plt.axis("tight")
 plt.axis("off")
-plt.suptitle("Ground truth", size=20)
+plt.suptitle("Ground truth", size=20, y=1)
 
 
 # Plot the distances
@@ -114,27 +116,27 @@ for index, metric in enumerate(["cosine", "euclidean", "cityblock"]):
                 horizontalalignment="center",
             )
 
-    plt.imshow(avg_dist, interpolation="nearest", cmap=plt.cm.gnuplot2, vmin=0)
+    plt.imshow(avg_dist, interpolation="nearest", cmap="cividis", vmin=0)
     plt.xticks(range(n_clusters), labels, rotation=45)
     plt.yticks(range(n_clusters), labels)
     plt.colorbar()
-    plt.suptitle("Interclass %s distances" % metric, size=18)
+    plt.suptitle("Interclass %s distances" % metric, size=18, y=1)
     plt.tight_layout()
 
 
 # Plot clustering results
 for index, metric in enumerate(["cosine", "euclidean", "cityblock"]):
     model = AgglomerativeClustering(
-        n_clusters=n_clusters, linkage="average", metric=metric
+        n_clusters=n_clusters, linkage="average", affinity=metric
     )
     model.fit(X)
     plt.figure()
     plt.axes([0, 0, 1, 1])
-    for l, c in zip(np.arange(model.n_clusters), "rgbk"):
-        plt.plot(X[model.labels_ == l].T, c=c, alpha=0.5)
+    for l, color in zip(np.arange(model.n_clusters), colors):
+        plt.plot(X[model.labels_ == l].T, c=color, alpha=0.5)
     plt.axis("tight")
     plt.axis("off")
-    plt.suptitle("AgglomerativeClustering(metric=%s)" % metric, size=20)
+    plt.suptitle("AgglomerativeClustering(metric=%s)" % metric, size=20, y=1)
 
 
 plt.show()


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #5435 
Related to https://github.com/scikit-learn/scikit-learn/issues/5435#issuecomment-1209975045

#### What does this implement/fix? Explain your changes.
Includes a more colorblind friendly palette. I think this is the last example that needs to be corrected for the issue to be closed. If theres any example remaining I'd be happy to make a PR to address that as well.


#### Any other comments?
<details>
<summary>Details (First Image)</summary>

Original Image (Deuteranopia)
![image](https://user-images.githubusercontent.com/75483881/195654023-801002ef-fdbe-4b58-80dc-d64f42685d5f.png)

Revised Image (Deutranopia)
![image](https://user-images.githubusercontent.com/75483881/195654478-c60f6fb2-b086-489e-a46d-104465336839.png)

Original Image (Protanopia)
![image](https://user-images.githubusercontent.com/75483881/195654588-619f4803-a789-4c9c-858a-95712ba5cbb4.png)

Revised Image (Protanopia)
![image](https://user-images.githubusercontent.com/75483881/195654717-63d83672-c57d-497d-b725-2b72b3926b7d.png)

Original Image (Tritanopia)
![image](https://user-images.githubusercontent.com/75483881/195654793-7d3c6f0d-2e75-4a07-afe4-c6c7c00430f6.png)

Revised Image (Tritanopia)
![image](https://user-images.githubusercontent.com/75483881/195654857-47d68a1d-c12f-4340-bc71-1b382f204dda.png)