### PR TITLE
ENH expose publicly `beta_divergence`

### DIFF
--- a/benchmarks/bench_plot_nmf.py
+++ b/benchmarks/bench_plot_nmf.py
@@ -20,7 +20,7 @@ from sklearn.utils._testing import ignore_warnings
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.decomposition import NMF
 from sklearn.decomposition._nmf import _initialize_nmf
-from sklearn.decomposition._nmf import _beta_divergence
+from sklearn.decomposition import beta_divergence
 from sklearn.decomposition._nmf import _check_init
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.extmath import safe_sparse_dot, squared_norm
@@ -369,7 +369,7 @@ def bench_one(
     end = time()
     H = clf.components_
 
-    this_loss = _beta_divergence(X, W, H, 2.0, True)
+    this_loss = beta_divergence(X, W, H, 2.0, True)
     duration = end - st
     return this_loss, duration
 

--- a/examples/decomposition/plot_beta_divergence.py
+++ b/examples/decomposition/plot_beta_divergence.py
@@ -10,7 +10,7 @@ the Multiplicative-Update ('mu') solver in :class:`~sklearn.decomposition.NMF`.
 
 import numpy as np
 import matplotlib.pyplot as plt
-from sklearn.decomposition._nmf import _beta_divergence
+from sklearn.decomposition import beta_divergence
 
 x = np.linspace(0.001, 4, 1000)
 y = np.zeros(x.shape)
@@ -18,7 +18,7 @@ y = np.zeros(x.shape)
 colors = "mbgyr"
 for j, beta in enumerate((0.0, 0.5, 1.0, 1.5, 2.0)):
     for i, xi in enumerate(x):
-        y[i] = _beta_divergence(1, xi, 1, beta)
+        y[i] = beta_divergence(1, xi, 1, beta)
     name = "beta = %1.1f" % beta
     plt.plot(x, y, label=name, color=colors[j])
 

--- a/sklearn/decomposition/__init__.py
+++ b/sklearn/decomposition/__init__.py
@@ -9,6 +9,7 @@ from ._nmf import (
     NMF,
     MiniBatchNMF,
     non_negative_factorization,
+    beta_divergence,
 )
 from ._pca import PCA
 from ._incremental_pca import IncrementalPCA
@@ -50,4 +51,5 @@ __all__ = [
     "FactorAnalysis",
     "TruncatedSVD",
     "LatentDirichletAllocation",
+    "beta_divergence",
 ]

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -74,7 +74,7 @@ def _check_init(A, shape, whom):
         raise ValueError("Array passed to %s is full of zeros." % whom)
 
 
-def _beta_divergence(X, W, H, beta, square_root=False):
+def beta_divergence(X, W, H, beta, square_root=False):
     """Compute the beta-divergence of X and dot(W, H).
 
     Parameters
@@ -816,7 +816,7 @@ def _fit_multiplicative_update(
         gamma = 1.0
 
     # used for the convergence criterion
-    error_at_init = _beta_divergence(X, W, H, beta_loss, square_root=True)
+    error_at_init = beta_divergence(X, W, H, beta_loss, square_root=True)
     previous_error = error_at_init
 
     H_sum, HHt, XHt = None, None, None
@@ -862,7 +862,7 @@ def _fit_multiplicative_update(
 
         # test convergence criterion every 10 iterations
         if tol > 0 and n_iter % 10 == 0:
-            error = _beta_divergence(X, W, H, beta_loss, square_root=True)
+            error = beta_divergence(X, W, H, beta_loss, square_root=True)
 
             if verbose:
                 iter_time = time.time()
@@ -1582,7 +1582,7 @@ class NMF(_BaseNMF):
         with config_context(assume_finite=True):
             W, H, n_iter = self._fit_transform(X, W=W, H=H)
 
-        self.reconstruction_err_ = _beta_divergence(
+        self.reconstruction_err_ = beta_divergence(
             X, W, H, self._beta_loss, square_root=True
         )
 
@@ -2038,7 +2038,7 @@ class MiniBatchNMF(_BaseNMF):
             W[W < np.finfo(np.float64).eps] = 0.0
 
         batch_cost = (
-            _beta_divergence(X, W, H, self._beta_loss)
+            beta_divergence(X, W, H, self._beta_loss)
             + l1_reg_W * W.sum()
             + l1_reg_H * H.sum()
             + l2_reg_W * (W**2).sum()
@@ -2159,7 +2159,7 @@ class MiniBatchNMF(_BaseNMF):
         with config_context(assume_finite=True):
             W, H, n_iter, n_steps = self._fit_transform(X, W=W, H=H)
 
-        self.reconstruction_err_ = _beta_divergence(
+        self.reconstruction_err_ = beta_divergence(
             X, W, H, self._beta_loss, square_root=True
         )
 

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -461,8 +461,8 @@ def test_beta_divergence():
 
     for beta in beta_losses:
         ref = _beta_divergence_dense(X, W, H, beta)
-        loss = nmf._beta_divergence(X, W, H, beta)
-        loss_csr = nmf._beta_divergence(X_csr, W, H, beta)
+        loss = nmf.beta_divergence(X, W, H, beta)
+        loss_csr = nmf.beta_divergence(X_csr, W, H, beta)
 
         assert_almost_equal(ref, loss, decimal=7)
         assert_almost_equal(ref, loss_csr, decimal=7)
@@ -740,7 +740,7 @@ def test_nmf_decreasing(solver):
             )
 
             loss = (
-                nmf._beta_divergence(X, W, H, beta_loss)
+                nmf.beta_divergence(X, W, H, beta_loss)
                 + alpha * l1_ratio * n_features * W.sum()
                 + alpha * l1_ratio * n_samples * H.sum()
                 + alpha * (1 - l1_ratio) * n_features * (W**2).sum()
@@ -760,9 +760,9 @@ def test_nmf_underflow():
     H = np.abs(rng.randn(n_components, n_features))
 
     X[0, 0] = 0
-    ref = nmf._beta_divergence(X, W, H, beta=1.0)
+    ref = nmf.beta_divergence(X, W, H, beta=1.0)
     X[0, 0] = 1e-323
-    res = nmf._beta_divergence(X, W, H, beta=1.0)
+    res = nmf.beta_divergence(X, W, H, beta=1.0)
     assert_almost_equal(res, ref)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #21402  
Beta-divergence example promotes the usage of a non-public API

#### What does this implement/fix? Explain your changes.
1. Changed sklearn.decomposition._nmf._beta_divergence functiion to public function beta_divergence.
2.  Made beta_divergence available directly from skearn.decomposition module.
3. Updated  examples/decomposition/plot_beta_divergence.py using public function.
4. Changed refrences of _beta_divergence in test cases/benchmarks,

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
