### PR TITLE
FEA implement max precision@recall K / recall@precision K

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -966,6 +966,8 @@ details.
    metrics.ndcg_score
    metrics.precision_recall_curve
    metrics.precision_recall_fscore_support
+   metrics.max_precision_at_recall_k
+   metrics.max_recall_at_precision_k
    metrics.precision_score
    metrics.recall_score
    metrics.roc_auc_score

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -62,6 +62,8 @@ Scoring                                Function                                 
 'balanced_accuracy'                    :func:`metrics.balanced_accuracy_score`
 'top_k_accuracy'                       :func:`metrics.top_k_accuracy_score`
 'average_precision'                    :func:`metrics.average_precision_score`
+'max_precision_at_recall_k'            :func:`metrics.max_precision_at_recall_k`          for binary targets
+'max_recall_at_precision_k'            :func:`metrics.max_recall_at_precision_k`          for binary targets
 'neg_brier_score'                      :func:`metrics.brier_score_loss`
 'f1'                                   :func:`metrics.f1_score`                           for binary targets
 'f1_micro'                             :func:`metrics.f1_score`                           micro-averaged
@@ -313,6 +315,8 @@ Some of these are restricted to the binary classification case:
    roc_curve
    class_likelihood_ratios
    det_curve
+   max_precision_at_recall_k
+   max_recall_at_precision_k
 
 
 Others also work in the multiclass case:
@@ -795,6 +799,8 @@ score:
    precision_recall_fscore_support
    precision_score
    recall_score
+   max_precision_at_recall_k
+   max_recall_at_precision_k
 
 Note that the :func:`precision_recall_curve` function is restricted to the
 binary case. The :func:`average_precision_score` function works only in

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -410,7 +410,7 @@ Changelog
 - |Feature| Added :func:`max_recall_at_precision_k` and :func:`max_precision_at_recall_k`
   to calculate the 'maximum precision for thresholds where recall >= k' and 'maximum
   precision for thresholds where precision >= k' respectively.
-  :pr:`TODO` by :user:`Kshitij Mathur <Kshitij68>`.
+  :pr:`24671` by :user:`Kshitij Mathur <Kshitij68>`.
 
 - |Feature| :func:`metrics.ConfusionMatrixDisplay.from_estimator`,
   :func:`metrics.ConfusionMatrixDisplay.from_predictions`, and

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -406,6 +406,12 @@ Changelog
 :mod:`sklearn.metrics`
 ......................
 
+
+- |Feature| Added :func:`max_recall_at_precision_k` and :func:`max_precision_at_recall_k`
+  to calculate the 'maximum precision for thresholds where recall >= k' and 'maximum
+  precision for thresholds where precision >= k' respectively.
+  :pr:`TODO` by :user:`Kshitij Mathur <Kshitij68>`.
+
 - |Feature| :func:`metrics.ConfusionMatrixDisplay.from_estimator`,
   :func:`metrics.ConfusionMatrixDisplay.from_predictions`, and
   :meth:`metrics.ConfusionMatrixDisplay.plot` accepts a `text_kw` parameter which is passed to

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -36,7 +36,8 @@ from ._classification import recall_score
 from ._classification import zero_one_loss
 from ._classification import brier_score_loss
 from ._classification import multilabel_confusion_matrix
-
+from ._classification import max_precision_at_recall_k
+from ._classification import max_recall_at_precision_k
 from ._dist_metrics import DistanceMetric
 
 from . import cluster
@@ -140,6 +141,8 @@ __all__ = [
     "nan_euclidean_distances",
     "matthews_corrcoef",
     "max_error",
+    "max_precision_at_recall_k",
+    "max_recall_at_precision_k",
     "mean_absolute_error",
     "mean_squared_error",
     "mean_squared_log_error",

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2887,10 +2887,9 @@ def brier_score_loss(y_true, y_prob, *, sample_weight=None, pos_label=None):
 def max_precision_at_recall_k(
     y_true, probas_pred, k, *, pos_label=None, sample_weight=None
 ):
-    """
-    Computes maximum precision for a recall greater than `k`
+    """Compute maximum precision for a recall greater than `k`.
 
-    Note: This implementation is restricted to binary classification task
+    Note: This implementation is restricted to binary classification task.
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
     true positives and ``fp`` the number of false positives. The precision is
@@ -2913,8 +2912,7 @@ def max_precision_at_recall_k(
         `decision_function` on some classifiers).
 
     k : float
-        Minimum value of recall.
-        Should be between [0,1]
+        Minimum value of recall. Should be between [0,1].
 
     pos_label : int or str, default=None
         The label of the positive class.
@@ -2931,7 +2929,6 @@ def max_precision_at_recall_k(
         is greater than or equal to `k` with thresholds applied
         to the `pos_label` or to the label 1 if `pos_label=None`.
 
-
     See Also
     --------
     precision_recall_curve : Compute precision-recall curve.
@@ -2943,7 +2940,7 @@ def max_precision_at_recall_k(
     Examples
     --------
     >>> import numpy as np
-    >>> from sklearn.metrics import max_recall_at_precision_k
+    >>> from sklearn.metrics import max_precision_at_recall_k
     >>> y_true = np.array([0, 0, 1, 1, 1, 1])
     >>> y_prob = np.array([0.1, 0.8, 0.9, 0.3, 1.0, 0.95])
     >>> k = 0.8
@@ -2967,10 +2964,9 @@ def max_precision_at_recall_k(
 def max_recall_at_precision_k(
     y_true, probas_pred, k, *, pos_label=None, sample_weight=None
 ):
-    """
-    Computes maximum recall for a precision greater than `k`
+    """Compute maximum recall for a precision greater than `k`.
 
-    Note: This implementation is restricted to binary classification task
+    Note: This implementation is restricted to binary classification task.
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
     true positives and ``fp`` the number of false positives. The precision is
@@ -2993,8 +2989,7 @@ def max_recall_at_precision_k(
         `decision_function` on some classifiers).
 
     k : float
-        Minimum value of recall.
-        Should be between [0,1]
+        Minimum value of recall. Should be between [0,1].
 
     pos_label : int or str, default=None
         The label of the positive class.
@@ -3004,14 +2999,12 @@ def max_recall_at_precision_k(
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
 
-
     Returns
     -------
     max_recall_at_precision_k : float
         Maximum Recall corresponding to precision threshold
         is greater than or equal to `k` with thresholds applied
         to the `pos_label` or to the label 1 if `pos_label=None`.
-
 
     See Also
     --------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3007,7 +3007,7 @@ def max_recall_at_precision_k(
 
     Returns
     -------
-    max_precision_at_recall_k : float
+    max_recall_at_precision_k : float
         Maximum Recall corresponding to precision threshold
         is greater than or equal to `k` with thresholds applied
         to the `pos_label` or to the label 1 if `pos_label=None`.
@@ -3028,7 +3028,7 @@ def max_recall_at_precision_k(
     >>> y_true = np.array([0, 0, 1, 1, 1, 1])
     >>> y_prob = np.array([0.1, 0.8, 0.9, 0.3, 1.0, 0.95])
     >>> k = 1
-    >>> max_precision_at_recall_k(y_true, y_prob, k)
+    >>> max_recall_at_precision_k(y_true, y_prob, k)
     0.75
     """
     if k < 0 or k > 1:


### PR DESCRIPTION
#### Reference Issues/PRs
This PR fixes #20266
A similar PR #20877 for this was opened long time back, but currently exists in stalled state.
Refering #21718 so this PR is also visible to people following that thread

#### What does this implement/fix? Explain your changes.
This PR adds two new metrics `max_precision_at_recall_k` & `max_recall_at_precision_k`.

#### Any other comments?
There were several comments under previous PR by @glemaitre . I've been able to resolve most of them, but I would like some clarifications about two points:-
- https://github.com/scikit-learn/scikit-learn/pull/20877#discussion_r700377969 -> There are two ways to approach this
     - Extend this page -> https://scikit-learn.org/stable/auto_examples/model_selection/plot_precision_recall.html? 
     - Extend documentation of these newly introduced functions (Similar to how it is done for e.g. in here https://scikit-learn.org/dev/modules/generated/sklearn.metrics.class_likelihood_ratios.html#sklearn.metrics.class_likelihood_ratios) 
- https://github.com/scikit-learn/scikit-learn/pull/20877#discussion_r700378428 -> Do you have anything in mind to avoid copying defination of precision and recall. We currently have the defination referenced at 4 different places
    - `precision_recall_fscore_support`
    - `precision_score`
    - `recall_score`
    - `max_precision_at_recall_k`
    - `max_recall_at_precision_k`
    - `precision_recall_curve`
