### PR TITLE
FEA Allow string input for pairwise distances

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -539,6 +539,11 @@ Changelog
 :mod:`sklearn.metrics`
 ......................
 
+- |Feature| :func:`metrics.pairwise_distances` accepts calculating pairwise distance
+  for arrays containing strings as well. This is supported only with custom functions
+  and the user is expected to pass `check_length_only=False` for this to work
+  :pr:`TODO` by :user:`Kshitij Mathur <Kshitij68>`.
+
 - |Feature| :func:`metrics.ConfusionMatrixDisplay.from_estimator`,
   :func:`metrics.ConfusionMatrixDisplay.from_predictions`, and
   :meth:`metrics.ConfusionMatrixDisplay.plot` accepts a `text_kw` parameter which is

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -26,6 +26,15 @@ Changelog
   boolean. The type is maintained, instead of converting to `float64.`
   :pr:`25147` by :user:`Tim Head <betatim>`.
 
+:mod:`sklearn.metrics`
+......................
+
+- |Feature| :func:`metrics.pairwise_distances` accepts calculating pairwise distance
+  for arrays containing strings as well. This is supported only with custom functions
+  and the user is expected to pass `check_length_only=True` to be lenient
+  regarding the input validation.
+  :pr:`24674` by :user: `Venkatachalam N <venkyyuvy>` and :user:`Kshitij Mathur <Kshitij68>`.
+
 .. _changes_1_2:
 
 Version 1.2.0
@@ -538,12 +547,6 @@ Changelog
 
 :mod:`sklearn.metrics`
 ......................
-
-- |Feature| :func:`metrics.pairwise_distances` accepts calculating pairwise distance
-  for arrays containing strings as well. This is supported only with custom functions
-  and the user is expected to pass `check_length_only=True` to be lenient
-  regarding the input validation
-  :pr:`24674` by :user: `Venkatachalam N <venkyyuvy>` and :user:`Kshitij Mathur <Kshitij68>`.
 
 - |Feature| :func:`metrics.ConfusionMatrixDisplay.from_estimator`,
   :func:`metrics.ConfusionMatrixDisplay.from_predictions`, and

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -541,8 +541,9 @@ Changelog
 
 - |Feature| :func:`metrics.pairwise_distances` accepts calculating pairwise distance
   for arrays containing strings as well. This is supported only with custom functions
-  and the user is expected to pass `check_length_only=False` for this to work
-  :pr:`24674` by :user:`Kshitij Mathur <Kshitij68>`.
+  and the user is expected to pass `check_length_only=True` to be lenient
+  regarding the input validation
+  :pr:`24674` by :user: `Venkatachalam N <venkyyuvy>` and :user:`Kshitij Mathur <Kshitij68>`.
 
 - |Feature| :func:`metrics.ConfusionMatrixDisplay.from_estimator`,
   :func:`metrics.ConfusionMatrixDisplay.from_predictions`, and

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -542,7 +542,7 @@ Changelog
 - |Feature| :func:`metrics.pairwise_distances` accepts calculating pairwise distance
   for arrays containing strings as well. This is supported only with custom functions
   and the user is expected to pass `check_length_only=False` for this to work
-  :pr:`TODO` by :user:`Kshitij Mathur <Kshitij68>`.
+  :pr:`24674` by :user:`Kshitij Mathur <Kshitij68>`.
 
 - |Feature| :func:`metrics.ConfusionMatrixDisplay.from_estimator`,
   :func:`metrics.ConfusionMatrixDisplay.from_predictions`, and

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1918,8 +1918,7 @@ def pairwise_distances(
     If the input is a vector array, the distances are computed.
     If the input is a distances matrix, it is returned instead.
     If the input is list of strings, a custom metric must be passed and
-    `check_length_only` should be set to `True` for distances to be computed
-
+    `check_length_only` should be set to `True` for distances to be computed.
 
     This method provides a safe way to take a distance matrix as input, while
     preserving compatibility with many other algorithms that take a vector

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -127,7 +127,7 @@ def check_pairwise_arrays(
         Whether to only check the length of the array.
         When `True`, `dtype` is ignored and the check for 2D array is not performed.
         This is particularly useful when passing non-numerical inputs and a custom
-        metric
+        metric.
 
          .. versionadded:: 1.2
 
@@ -198,8 +198,8 @@ def check_pairwise_arrays(
         )
     elif check_length_only and len(X) != len(Y):
         raise ValueError(
-            "Incompatible length for X and Y matrices: len(X) == %d while len(Y) == %d"
-            % (len(X), len(Y))
+            f"Incompatible length for X and Y matrices: len(X) == {len(X)} while len(Y)"
+            f" == {len(Y)}"
         )
     return X, Y
 
@@ -2002,7 +2002,7 @@ def pairwise_distances(
         Whether to only check the length of the array.
         When `True`, check for 2D array is not performed.
         This is particularly useful when passing non-numerical inputs and a custom
-        metric
+        metric.
 
          .. versionadded:: 1.2
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -130,7 +130,7 @@ def check_pairwise_arrays(
 
     check_length_only : bool, default=False
         Whether to only check the length of the array
-        When true, dtype is ignored
+        When true, dtype is ignored and the check for 2D array is not performed.
 
          .. versionadded:: 1.2
 
@@ -146,6 +146,10 @@ def check_pairwise_arrays(
 
     X, Y, dtype_float = _return_float_dtype(X, Y)
     estimator = "check_pairwise_arrays"
+    if dtype is None and check_length_only is False:
+        dtype = dtype_float
+    elif check_length_only:
+        dtype = None
     ensure_2d = True
     if check_length_only:
         ensure_2d = False

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -129,7 +129,7 @@ def check_pairwise_arrays(
         This is particularly useful when passing non-numerical inputs and a custom
         metric.
 
-         .. versionadded:: 1.2
+         .. versionadded:: 1.2.1
 
     copy : bool, default=False
         Whether a forced copy will be triggered. If copy=False, a copy might
@@ -2004,7 +2004,7 @@ def pairwise_distances(
         This is particularly useful when passing non-numerical inputs and a custom
         metric.
 
-         .. versionadded:: 1.2
+         .. versionadded:: 1.2.1
 
     **kwds : optional keyword parameters
         Any further parameters are passed directly to the distance function.

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -1549,3 +1549,17 @@ def test_numeric_pairwise_distances_datatypes(metric, global_dtype, y_is_x):
     dist = pairwise_distances(X, Y, metric=metric, **params)
 
     assert_allclose(dist, expected_dist)
+
+
+def test_pairwise_dist_custom_scoring_for_string():
+    X = [
+        "This is my first sentences",
+        "my second dummy sentence",
+        "This is my third one",
+    ]
+
+    def dummy_string_similarity(x, y):
+        return np.abs(len(x) - len(y))
+
+    dist = pairwise_distances(X, metric=dummy_string_similarity, check_length_only=True)
+    assert dist.max() == 6.0

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -1,4 +1,3 @@
-import re
 import warnings
 from types import GeneratorType
 
@@ -1552,46 +1551,44 @@ def test_numeric_pairwise_distances_datatypes(metric, global_dtype, y_is_x):
     assert_allclose(dist, expected_dist)
 
 
-def test_pairwise_dist_custom_scoring_for_string():
-    X = [
-        "a",
-        "ab",
-        "abc",
-    ]
+@pytest.mark.parametrize(
+    "X,Y,expected_distance",
+    [
+        (["a", "ab", "abc"], None, [[0.0, 1.0, 2.0], [1.0, 0.0, 1.0], [2.0, 1.0, 0.0]]),
+        (
+            ["a", "ab", "abc"],
+            [
+                "a",
+                "a",
+                "a",
+            ],
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [2.0, 2.0, 2.0]],
+        ),
+    ],
+)
+def test_pairwise_dist_custom_scoring_for_string(X, Y, expected_distance):
+    """
+    Checks the pairwise distance between any two matrices containing strings.
+    This is done by passing a metric to calculate the similarity and
+    also setting `check_length_only` to True to avoid
+    checks expecting float/int objects in input array
+    """
 
     def dummy_string_similarity(x, y):
         return np.abs(len(x) - len(y))
 
     actual_distance = pairwise_distances(
-        X, metric=dummy_string_similarity, check_length_only=True
-    )
-    expected_distance = np.array(
-        [
-            [0.0, 1.0, 2.0],
-            [1.0, 0.0, 1.0],
-            [2.0, 1.0, 0.0],
-        ]
+        X=X, Y=Y, metric=dummy_string_similarity, check_length_only=True
     )
     assert_array_equal(actual_distance, expected_distance)
 
-    Y = ["a", "a", "a"]
-    actual_distance = pairwise_distances(
-        X, Y, metric=dummy_string_similarity, check_length_only=True
-    )
 
-    expected_distance = np.array(
-        [
-            [0.0, 0.0, 0.0],
-            [1.0, 1.0, 1.0],
-            [2.0, 2.0, 2.0],
-        ]
-    )
-    assert_array_equal(actual_distance, expected_distance)
+def test_pairwise_distances_raises_error_for_incompatible_length():
+    def dummy_string_similarity(x, y):
+        return np.abs(len(x) - len(y))
 
-    Y.append("a")
-    msg = re.escape(
-        "Incompatible length for X and Y matrices: len(X) == %d while len(Y) == %d"
-        % (len(X), len(Y))
-    )
+    X = ["a"]
+    Y = ["a", "a"]
+    msg = "Incompatible length for X and Y matrices"
     with pytest.raises(ValueError, match=msg):
         pairwise_distances(X, Y, metric=dummy_string_similarity, check_length_only=True)


### PR DESCRIPTION
#### Reference Issues/PRs
closes #15932
closes #17991
supersede #17991 

#### What does this implement/fix? Explain your changes.
This allows the user to compute pairwise distance using a custom metric for strings.