### PR TITLE
DOC only use chi2 on binary and counts features

### DIFF
--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -94,7 +94,7 @@ and p-values (or only scores for :class:`SelectKBest` and
 The methods based on F-test estimate the degree of linear dependency between
 two random variables. On the other hand, mutual information methods can capture
 any kind of statistical dependency, but being nonparametric, they require more
-samples for accurate estimation. Note that the :math:`\chi^2`-test should be
+samples for accurate estimation. Note that the :math:`\chi^2`-test should only be
 applied to non-negative features, such as frequencies.
 
 .. topic:: Feature selection with sparse data

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -70,16 +70,16 @@ as objects that implement the ``transform`` method:
    selection with a configurable strategy. This allows to select the best
    univariate selection strategy with hyper-parameter search estimator.
 
-For instance, we can perform a :math:`\chi^2` test to the samples
-to retrieve only the two best features as follows:
+For instance, we can perform a F-test to the samples to retrieve only the two
+best features as follows:
 
   >>> from sklearn.datasets import load_iris
   >>> from sklearn.feature_selection import SelectKBest
-  >>> from sklearn.feature_selection import chi2
+  >>> from sklearn.feature_selection import f_classif
   >>> X, y = load_iris(return_X_y=True)
   >>> X.shape
   (150, 4)
-  >>> X_new = SelectKBest(chi2, k=2).fit_transform(X, y)
+  >>> X_new = SelectKBest(f_classif, k=2).fit_transform(X, y)
   >>> X_new.shape
   (150, 2)
 
@@ -94,7 +94,8 @@ and p-values (or only scores for :class:`SelectKBest` and
 The methods based on F-test estimate the degree of linear dependency between
 two random variables. On the other hand, mutual information methods can capture
 any kind of statistical dependency, but being nonparametric, they require more
-samples for accurate estimation.
+samples for accurate estimation. Note that the :math:`\chi^2`-test should be
+applied to non-negative features, such as frequencies.
 
 .. topic:: Feature selection with sparse data
 

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -70,8 +70,8 @@ as objects that implement the ``transform`` method:
    selection with a configurable strategy. This allows to select the best
    univariate selection strategy with hyper-parameter search estimator.
 
-For instance, we can perform a F-test to the samples to retrieve only the two
-best features as follows:
+For instance, we can use a F-test to retrieve the two
+best features for a dataset as follows:
 
   >>> from sklearn.datasets import load_iris
   >>> from sklearn.feature_selection import SelectKBest

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -179,10 +179,9 @@ selector(dtype_include="category")(X_train)
 # hyperparameters as part of the ``Pipeline``.
 # We will search for both the imputer strategy of the numeric preprocessing
 # and the regularization parameter of the logistic regression using
-# :class:`~sklearn.model_selection.RandomizedSearchCV`. This type of
-# hyperparameter search allows to define the time budget through the `n_iter`
-# parameter. Note that you can increase the `n_iter` parameter if you want to
-# test more combinations. Alternatively, one can use the
+# :class:`~sklearn.model_selection.RandomizedSearchCV`. This
+# hyperparameter search randomly selects a fixed number of parameter
+# settings configured by `n_iter`. Alternatively, one can use the
 # :class:`~sklearn.model_selection.GridSearchCV` but the cartesian product of
 # the parameter space will be evaluated.
 

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -181,7 +181,7 @@ selector(dtype_include="category")(X_train)
 # and the regularization parameter of the logistic regression using
 # :class:`~sklearn.model_selection.RandomizedSearchCV`. This
 # hyperparameter search randomly selects a fixed number of parameter
-# settings configured by `n_iter`. Alternatively, one can use the
+# settings configured by `n_iter`. Alternatively, one can use
 # :class:`~sklearn.model_selection.GridSearchCV` but the cartesian product of
 # the parameter space will be evaluated.
 

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -82,7 +82,7 @@ categorical_features = ["embarked", "sex", "pclass"]
 categorical_transformer = Pipeline(
     steps=[
         ("encoder", OneHotEncoder(handle_unknown="ignore")),
-        ("selecter", SelectPercentile(chi2, percentile=50)),
+        ("selector", SelectPercentile(chi2, percentile=50)),
     ]
 )
 preprocessor = ColumnTransformer(
@@ -187,7 +187,7 @@ selector(dtype_include="category")(X_train)
 
 param_grid = {
     "preprocessor__num__imputer__strategy": ["mean", "median"],
-    "preprocessor__cat__selecter__percentile": [10, 30, 50, 70],
+    "preprocessor__cat__selector__percentile": [10, 30, 50, 70],
     "classifier__C": [0.1, 1.0, 10, 100],
 }
 
@@ -218,7 +218,7 @@ cv_results[
         "mean_test_score",
         "std_test_score",
         "param_preprocessor__num__imputer__strategy",
-        "param_preprocessor__cat__selecter__percentile",
+        "param_preprocessor__cat__selector__percentile",
         "param_classifier__C",
     ]
 ].head(5)

--- a/examples/compose/plot_column_transformer_mixed_types.py
+++ b/examples/compose/plot_column_transformer_mixed_types.py
@@ -229,5 +229,6 @@ cv_results[
 # not used for hyperparameter tuning.
 #
 print(
-    f"best logistic regression from grid search: {search_cv.score(X_test, y_test):.3f}"
+    "accuracy of the best model from randomized search: "
+    f"{search_cv.score(X_test, y_test):.3f}"
 )

--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 =================================================================
 Selecting dimensionality reduction with Pipeline and GridSearchCV
@@ -21,11 +20,13 @@ fitting of a transformer is costly.
 
 """
 
+# Authors: Robert McGibbon
+#          Joel Nothman
+#          Guillaume Lemaitre
+
 # %%
 # Illustration of ``Pipeline`` and ``GridSearchCV``
 ###############################################################################
-
-# Authors: Robert McGibbon, Joel Nothman, Guillaume Lemaitre
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -34,7 +35,9 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
 from sklearn.svm import LinearSVC
 from sklearn.decomposition import PCA, NMF
-from sklearn.feature_selection import SelectKBest, chi2
+from sklearn.feature_selection import SelectKBest, mutual_info_classif
+
+X, y = load_digits(return_X_y=True)
 
 pipe = Pipeline(
     [
@@ -53,35 +56,35 @@ param_grid = [
         "classify__C": C_OPTIONS,
     },
     {
-        "reduce_dim": [SelectKBest(chi2)],
+        "reduce_dim": [SelectKBest(mutual_info_classif)],
         "reduce_dim__k": N_FEATURES_OPTIONS,
         "classify__C": C_OPTIONS,
     },
 ]
-reducer_labels = ["PCA", "NMF", "KBest(chi2)"]
+reducer_labels = ["PCA", "NMF", "KBest(mutual_info_classif)"]
 
 grid = GridSearchCV(pipe, n_jobs=1, param_grid=param_grid)
-X, y = load_digits(return_X_y=True)
 grid.fit(X, y)
+
+# %%
+import pandas as pd
 
 mean_scores = np.array(grid.cv_results_["mean_test_score"])
 # scores are in the order of param_grid iteration, which is alphabetical
 mean_scores = mean_scores.reshape(len(C_OPTIONS), -1, len(N_FEATURES_OPTIONS))
 # select score for best C
 mean_scores = mean_scores.max(axis=0)
-bar_offsets = np.arange(len(N_FEATURES_OPTIONS)) * (len(reducer_labels) + 1) + 0.5
+# create a dataframe to ease plotting
+mean_scores = pd.DataFrame(
+    mean_scores.T, index=N_FEATURES_OPTIONS, columns=reducer_labels
+)
 
-plt.figure()
-COLORS = "bgrcmyk"
-for i, (label, reducer_scores) in enumerate(zip(reducer_labels, mean_scores)):
-    plt.bar(bar_offsets + i, reducer_scores, label=label, color=COLORS[i])
-
-plt.title("Comparing feature reduction techniques")
-plt.xlabel("Reduced number of features")
-plt.xticks(bar_offsets + len(reducer_labels) / 2, N_FEATURES_OPTIONS)
-plt.ylabel("Digit classification accuracy")
-plt.ylim((0, 1))
-plt.legend(loc="upper left")
+ax = mean_scores.plot.bar()
+ax.set_title("Comparing feature reduction techniques")
+ax.set_xlabel("Reduced number of features")
+ax.set_ylabel("Digit classification accuracy")
+ax.set_ylim((0, 1))
+ax.legend(loc="upper left")
 
 plt.show()
 

--- a/examples/compose/plot_compare_reduction.py
+++ b/examples/compose/plot_compare_reduction.py
@@ -36,11 +36,13 @@ from sklearn.pipeline import Pipeline
 from sklearn.svm import LinearSVC
 from sklearn.decomposition import PCA, NMF
 from sklearn.feature_selection import SelectKBest, mutual_info_classif
+from sklearn.preprocessing import MinMaxScaler
 
 X, y = load_digits(return_X_y=True)
 
 pipe = Pipeline(
     [
+        ("scaling", MinMaxScaler()),
         # the reduce_dim stage is populated by the param_grid
         ("reduce_dim", "passthrough"),
         ("classify", LinearSVC(dual=False, max_iter=10000)),
@@ -51,7 +53,7 @@ N_FEATURES_OPTIONS = [2, 4, 8]
 C_OPTIONS = [1, 10, 100, 1000]
 param_grid = [
     {
-        "reduce_dim": [PCA(iterated_power=7), NMF()],
+        "reduce_dim": [PCA(iterated_power=7), NMF(max_iter=1_000)],
         "reduce_dim__n_components": N_FEATURES_OPTIONS,
         "classify__C": C_OPTIONS,
     },

--- a/examples/svm/plot_svm_anova.py
+++ b/examples/svm/plot_svm_anova.py
@@ -26,7 +26,7 @@ X = np.hstack((X, 2 * rng.random((X.shape[0], 36))))
 # Create the pipeline
 # -------------------
 from sklearn.pipeline import Pipeline
-from sklearn.feature_selection import SelectPercentile, chi2
+from sklearn.feature_selection import SelectPercentile, f_classif
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
@@ -35,7 +35,7 @@ from sklearn.svm import SVC
 
 clf = Pipeline(
     [
-        ("anova", SelectPercentile(chi2)),
+        ("anova", SelectPercentile(f_classif)),
         ("scaler", StandardScaler()),
         ("svc", SVC(gamma="auto")),
     ]

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -170,9 +170,9 @@ def _chisquare(f_obs, f_exp):
 def chi2(X, y):
     """Compute chi-squared stats between each non-negative feature and class.
 
-    This score can be used to select the n_features features with the
+    This score can be used to select the `n_features` features with the
     highest values for the test chi-squared statistic from X, which must
-    contain only non-negative features such as booleans or frequencies
+    contain only **non-negative features** such as booleans or frequencies
     (e.g., term counts in document classification), relative to the classes.
 
     Recall that the chi-square test measures dependence between stochastic


### PR DESCRIPTION
closes #24593
closes #21455

Improve the documentation linked to `chi2`. From the following issue https://github.com/scikit-learn/scikit-learn/issues/21455#issuecomment-977968841, we should:


TODO:

- [x] (Already in `main`) Improve the documentation in the meanwhile to mention that it is only for the above use case.
- [x] Improve the examples by using `chi2` only on the expected features type.
- [x] Improve the user guide where we should explicitly show when to use this statistic.
