### PR TITLE
MAINT renable Linux + Python 3.8 build with OpenBLAS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -204,15 +204,13 @@ jobs:
         LOCK_FILE: './build_tools/azure/ubuntu_atlas_lock.txt'
         COVERAGE: 'false'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '1'  # non-default seed
-      # TODO: reenable build once
-      # https://github.com/ContinuumIO/anaconda-issues/issues/13075 is fixed
       # Linux + Python 3.8 build with OpenBLAS
-      # py38_conda_defaults_openblas:
-      #   DISTRIB: 'conda'
-      #   LOCK_FILE: './build_tools/azure/py38_conda_defaults_openblas_linux-64_conda.lock'
-      #   SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
-      #   SKLEARN_RUN_FLOAT32_TESTS: '1'
-      #   SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '2'  # non-default seed
+      py38_conda_defaults_openblas:
+        DISTRIB: 'conda'
+        LOCK_FILE: './build_tools/azure/py38_conda_defaults_openblas_linux-64_conda.lock'
+        SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
+        SKLEARN_RUN_FLOAT32_TESTS: '1'
+        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '2'  # non-default seed
       # Linux environment to test the latest available dependencies.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:


### PR DESCRIPTION
It seems that the `blas` package is not corrupted anymore.
Let's try the CI.