### PR TITLE
DOC Add `sphinx_highlight.js` to the search page.

### DIFF
--- a/doc/themes/scikit-learn-modern/search.html
+++ b/doc/themes/scikit-learn-modern/search.html
@@ -5,4 +5,5 @@
   <script src="{{ pathto('_static/doctools.js', 1) }}"></script>
   <script src="{{ pathto('_static/language_data.js', 1) }}"></script>
   <script src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+  <script src="{{ pathto('_static/sphinx_highlight.js', 1) }}"></script>
 {% endblock %}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.

Currently the search on the [dev documentation](https://scikit-learn.org/dev/search.html) is broken, with the error
```
Uncaught ReferenceError: SPHINX_HIGHLIGHT_ENABLED is not defined
    query https://scikit-learn.org/dev/_static/searchtools.js:271
    performSearch https://scikit-learn.org/dev/_static/searchtools.js:230
    init https://scikit-learn.org/dev/_static/searchtools.js:171
```

This is because the dev documentation is built with `sphinx == 5.2.3` (see eg this [recent built](https://github.com/scikit-learn/scikit-learn/actions/runs/3290384067/jobs/5423150843)).
Since [sphinx 5.2.0](https://github.com/sphinx-doc/sphinx/releases/tag/v5.2.0) `searchtools.js` has been [splitted](https://github.com/sphinx-doc/sphinx/commit/c7c0e4048d72d4125a63ba9b83effe59d253774c): `sphinx_highlight.js` should be loaded too.
That's what this PR does.
Thanks for considering it. 
