### PR TITLE
MAINT force NumPy version for building scikit-learn for CPython 3.10 in Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ requires = [
     # wheels on PyPI
     #
     # see: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; not (python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy')",
+    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
 
     "scipy>=1.3.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ requires = [
     "oldest-supported-numpy; python_version!='3.10' or platform_system!='Windows' or platform_python_implementation=='PyPy'",
     # For CPython 3.10 under Windows, SciPy requires NumPy 1.22.3 while the
     # oldest supported NumPy is defined as 1.21.6. We therefore need to force
-    # it for this specific configuration.
+    # it for this specific configuration. For details, see
+    # https://github.com/scipy/scipy/blob/c58b608c83d30800aceee6a4dab5c3464cb1de7d/pyproject.toml#L38-L41
     "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
 
     "scipy>=1.3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,11 @@ requires = [
     # wheels on PyPI
     #
     # see: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+    "oldest-supported-numpy; python_version!='3.10' or platform_system!='Windows' or platform_python_implementation=='PyPy'",
+    # For CPython 3.10 under Windows, SciPy requires NumPy 1.22.3 while the
+    # oldest supported NumPy is defined as 1.21.6. We therefore need to force
+    # it for this specific configuration.
     "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
-    "oldest-supported-numpy",
 
     "scipy>=1.3.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ requires = [
     # wheels on PyPI
     #
     # see: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
-    "oldest-supported-numpy; not (python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy')",
     "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
+    "oldest-supported-numpy",
 
     "scipy>=1.3.2",
 ]


### PR DESCRIPTION
closes https://github.com/scikit-learn/scikit-learn/issues/24604

As specified in https://github.com/scikit-learn/scikit-learn/issues/24604#issuecomment-1285227874, SciPy requires at least NumPy 1.22.3 with CPython 3.10 in Windows.
Unfortunately, `oldest-supported-numpy` set the minimum version to `1.21.6` in this configuration and we, therefore, need to overwrite the NumPy version for this configuration.