### PR TITLE
MAINT warn for Windows 32bits OS and Python regarding build dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -387,40 +387,39 @@ def setup_package():
 def _warn_about_win32_support():
     """Warn about dropping win32 support."""
 
-    def is_os_64bit():
-        """Check if the OS is 64bit."""
-        return platform.machine().endswith("64")
+    is_os_64bit = platform.machine().endswith("64")
+    is_python_64bit = sys.maxsize > 2**32
 
-    def is_python_64bit():
-        """Check if the Python interpreter is 64bit."""
-        return sys.maxsize > 2**32
-
-    if platform.system() != "Windows" or (is_os_64bit() and is_python_64bit()):
+    if platform.system() != "Windows" or (is_os_64bit and is_python_64bit):
         # Not a Windows platform or a Windows 64 bit platform with a 64 bit Python
         # Nothing to warn about
         return
 
     warn_msg = (
-        "{}. The recent version of SciPy cannot "
+        "Scikit-learn does not provides official support for 32 bit Windows platform. "
+        "It means that no wheels 'win32' wheels are provided for "
+        "scikit-learn >= 1.1.2. {problem}. The recent version of SciPy cannot "
         "be build with this Python bitness. The latest supported version is "
         "SciPy 1.9.1 for Python below 3.9. If you want to build scikit-learn "
         "from source, you will need to satisfy this configuration. Alternatively, "
-        "you can install {}."
+        "you can install {solution}."
     )
 
-    if not is_os_64bit():
+    if not is_os_64bit:
         warnings.warn(
             warn_msg.format(
-                "Your operating system is Windows 32 bit",
-                "a Windows 64 bit operating system and a 64 bit Python interpreter",
+                problem="Your operating system is Windows 32 bit",
+                solution=(
+                    "a Windows 64 bit operating system and a 64 bit Python interpreter"
+                ),
             ),
             RuntimeWarning,
         )
-    elif not is_python_64bit():
+    elif not is_python_64bit:
         warnings.warn(
             warn_msg.format(
-                "Your Python interpreter is 32 bit",
-                "a 64 bit Python interpreter",
+                problem="Your Python interpreter is 32 bit",
+                solution="a 64 bit Python interpreter",
             ),
             RuntimeWarning,
         )

--- a/setup.py
+++ b/setup.py
@@ -387,17 +387,15 @@ def setup_package():
 def _warn_about_win32_support():
     """Warn about dropping win32 support."""
 
+    if platform.system() != "Windows":
+        return
+        
     is_os_64bit = platform.machine().endswith("64")
     is_python_64bit = sys.maxsize > 2**32
 
-    if platform.system() != "Windows" or (is_os_64bit and is_python_64bit):
-        # Not a Windows platform or a Windows 64 bit platform with a 64 bit Python
-        # Nothing to warn about
-        return
-
     warn_msg = (
-        "Scikit-learn does not provides official support for 32 bit Windows platform. "
-        "It means that no wheels 'win32' wheels are provided for "
+        "Scikit-learn does not provide official support for 32-bit Windows. "
+        "This means that there are no 'win32' wheels for "
         "scikit-learn >= 1.1.2. {problem}. The recent version of SciPy cannot "
         "be build with this Python bitness. The latest supported version is "
         "SciPy 1.9.1 for Python below 3.9. If you want to build scikit-learn "

--- a/setup.py
+++ b/setup.py
@@ -389,7 +389,7 @@ def _warn_about_win32_support():
 
     if platform.system() != "Windows":
         return
-        
+
     is_os_64bit = platform.machine().endswith("64")
     is_python_64bit = sys.maxsize > 2**32
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import sys
 import os
 import platform
 import shutil
+import warnings
 
 # We need to import setuptools before because it monkey-patches distutils
 import setuptools  # noqa
@@ -383,5 +384,48 @@ def setup_package():
     setup(**metadata)
 
 
+def _warn_about_win32_support():
+    """Warn about dropping win32 support."""
+
+    def is_os_64bit():
+        """Check if the OS is 64bit."""
+        return platform.machine().endswith("64")
+
+    def is_python_64bit():
+        """Check if the Python interpreter is 64bit."""
+        return sys.maxsize > 2**32
+
+    if platform.system() != "Windows" or (is_os_64bit() and is_python_64bit()):
+        # Not a Windows platform or a Windows 64 bit platform with a 64 bit Python
+        # Nothing to warn about
+        return
+
+    warn_msg = (
+        "{}. The recent version of SciPy cannot "
+        "be build with this Python bitness. The latest supported version is "
+        "SciPy 1.9.1 for Python below 3.9. If you want to build scikit-learn "
+        "from source, you will need to satisfy this configuration. Alternatively, "
+        "you can install {}."
+    )
+
+    if not is_os_64bit():
+        warnings.warn(
+            warn_msg.format(
+                "Your operating system is Windows 32 bit",
+                "a Windows 64 bit operating system and a 64 bit Python interpreter",
+            ),
+            RuntimeWarning,
+        )
+    elif not is_python_64bit():
+        warnings.warn(
+            warn_msg.format(
+                "Your Python interpreter is 32 bit",
+                "a 64 bit Python interpreter",
+            ),
+            RuntimeWarning,
+        )
+
+
 if __name__ == "__main__":
+    _warn_about_win32_support()
     setup_package()


### PR DESCRIPTION
Linked to https://github.com/scikit-learn/scikit-learn/issues/24604

Windows 32 bits or Python 32 bits on Windows 64 bits will have issues building scikit-learn with recent SciPy. This PR detects those cases and warns about the issue and gives hints to resolve the problem:

- Installing an older SciPy and a Python version
- Installing 64 bits OS