### PR TITLE
[Refactor, Tree] Python tree class for modularity and consistency of BaseEstimator

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -321,14 +321,16 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             min_weight_leaf = self.min_weight_fraction_leaf * np.sum(sample_weight)
 
         # Build tree
-        # set the Cython criterion functionality 
+        # set the Cython criterion functionality
         criterion = self._set_criterion(n_samples, is_classification)
 
-        # set the Cython splitter functionality 
+        # set the Cython splitter functionality
         X_issparse = issparse(X)
-        splitter = self._set_splitter(X_issparse, criterion, min_samples_leaf, min_weight_leaf, random_state)
-        
-        # set the Cython tree functionality 
+        splitter = self._set_splitter(
+            X_issparse, criterion, min_samples_leaf, min_weight_leaf, random_state
+        )
+
+        # set the Cython tree functionality
         tree = self._set_tree()
         self.tree_ = tree
 
@@ -362,7 +364,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         self._prune_tree()
 
         return self
-    
+
     def _set_criterion(self, n_samples, is_classification):
         criterion = self.criterion
         if not isinstance(criterion, Criterion):
@@ -390,7 +392,9 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             )
         return tree
 
-    def _set_splitter(self, X_issparse, criterion, min_samples_leaf, min_weight_leaf, random_state):
+    def _set_splitter(
+        self, X_issparse, criterion, min_samples_leaf, min_weight_leaf, random_state
+    ):
         SPLITTERS = SPARSE_SPLITTERS if X_issparse else DENSE_SPLITTERS
 
         splitter = self.splitter
@@ -603,10 +607,6 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         check_is_fitted(self)
 
         return self.tree_.compute_feature_importances()
-
-
-class SupervisedDecisionTree(BaseDecisionTree):
-    def
 
 
 # =============================================================================


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Addresses the Python interface issue in #24000 
Also is a follow up to refactoring of Criterion in #24678 

This should be reviewed and merged after #24678 

#### What does this implement/fix? Explain your changes.
This implements a change to the `BaseDecisionTree` class to enable i) consistency with the assumptions of a `BaseEstimator` and ii) modularity for subclassing of the `BaseDecisionTree` class.

consistency:
- `y=None` is now the default in `fit()`, which is in line w/ the assumptions of a `BaseEstimator` that is not supervised/unsupervised yet. This enables someone to subclass `BaseDecisionTree` and define a completely unsupervised tree as described in #24577 

modularity:
- three private functions are introduced: `_set_criterion()`, `_set_splitter()`, and `_set_tree()`. As demonstrated in #22754 any subclass of the Tree and Splitter class is sufficient to build up a tree using the existing TreeBuilder cython class.

#### Any other comments?
n/a
