### PR TITLE
DOC fix deprecated log loss argument in user guide

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -284,7 +284,7 @@ General Concepts
               >>> from sklearn.model_selection import GridSearchCV
               >>> from sklearn.linear_model import SGDClassifier
               >>> clf = GridSearchCV(SGDClassifier(),
-              ...                    param_grid={'loss': ['log', 'hinge']})
+              ...                    param_grid={'loss': ['log_loss', 'hinge']})
 
           This means that we can only check for duck-typed attributes after
           fitting, and that we must be careful to make :term:`meta-estimators`

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -126,9 +126,9 @@ its ``coef_`` member::
     >>> reg.intercept_
     0.13636...
 
-Note that the class :class:`Ridge` allows for the user to specify that the 
-solver be automatically chosen by setting `solver="auto"`. When this option 
-is specified, :class:`Ridge` will choose between the `"lbfgs"`, `"cholesky"`, 
+Note that the class :class:`Ridge` allows for the user to specify that the
+solver be automatically chosen by setting `solver="auto"`. When this option
+is specified, :class:`Ridge` will choose between the `"lbfgs"`, `"cholesky"`,
 and `"sparse_cg"` solvers. :class:`Ridge` will begin checking the conditions
 shown in the following table from top to bottom. If the condition is true,
 the corresponding solver is chosen.
@@ -1020,7 +1020,7 @@ The following table summarizes the penalties supported by each solver:
 The "lbfgs" solver is used by default for its robustness. For large datasets
 the "saga" solver is usually faster.
 For large dataset, you may also consider using :class:`SGDClassifier`
-with 'log' loss, which might be even faster but requires more tuning.
+with `loss="log_loss"`, which might be even faster but requires more tuning.
 
 .. topic:: Examples:
 


### PR DESCRIPTION
#### Reference Issues/PRs
Follow up of #23046.

#### What does this implement/fix? Explain your changes.
2 instances of loss `"log"` for `SGDClassifier` remained uncatched and are now replaced by `"log_loss"`.
