### PR TITLE
ENH Add gamma='scale' option to RBFSampler

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -350,6 +350,9 @@ Changelog
 - |Enhancement| :class:`kernel_approximation.SkewedChi2Sampler` now preserves
   dtype for `numpy.float32` inputs. :pr:`24350` by :user:`Rahil Parikh <rprkh>`.
 
+- |Enhancement| :class:`kernel_approximation.RBFSampler` now accepts
+  'scale' option for parameter `gamma`. :pr:`24755` by `Gleb Levitski <GLevV>`
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -351,7 +351,8 @@ Changelog
   dtype for `numpy.float32` inputs. :pr:`24350` by :user:`Rahil Parikh <rprkh>`.
 
 - |Enhancement| :class:`kernel_approximation.RBFSampler` now accepts
-  'scale' option for parameter `gamma`. :pr:`24755` by `Gleb Levitski <GLevV>`
+  `'scale'` option for parameter `gamma`.
+  :pr:`24755` by :user:`Gleb Levitski <GLevV>`
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -356,15 +356,16 @@ class RBFSampler(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
         """
         self._validate_params()
 
-        if self.gamma == "scale":
-            # var = E[X^2] - E[X]^2 if sparse
-            X_var = (X.multiply(X)).mean() - (X.mean()) ** 2 if sparse else X.var()
-            self._gamma = 1.0 / (X.shape[1] * X_var) if X_var != 0 else 1.0
-        else:
-            self._gamma = self.gamma
         X = self._validate_data(X, accept_sparse="csr")
         random_state = check_random_state(self.random_state)
         n_features = X.shape[1]
+        sparse = sp.isspmatrix(X)
+        if self.gamma == "scale":
+            # var = E[X^2] - E[X]^2 if sparse
+            X_var = (X.multiply(X)).mean() - (X.mean()) ** 2 if sparse else X.var()
+            self._gamma = 1.0 / (n_features * X_var) if X_var != 0 else 1.0
+        else:
+            self._gamma = self.gamma
         # sqrt(2 * gamma) * N(0,1)
         self.random_weights_ = (2.0 * self._gamma) ** 0.5 * random_state.normal(
             size=(n_features, self.n_components)

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -369,7 +369,6 @@ class RBFSampler(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
             self._gamma = 1.0 / (n_features * X_var) if X_var != 0 else 1.0
         else:
             self._gamma = self.gamma
-        # sqrt(2 * gamma) * N(0,1)
         self.random_weights_ = (2.0 * self._gamma) ** 0.5 * random_state.normal(
             size=(n_features, self.n_components)
         )
@@ -405,7 +404,6 @@ class RBFSampler(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
         projection = safe_sparse_dot(X, self.random_weights_)
         projection += self.random_offset_
         np.cos(projection, projection)
-        # sqrt(2) / sqrt(n_components)
         projection *= (2.0 / self.n_components) ** 0.5
         return projection
 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -374,9 +374,7 @@ class RBFSampler(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
             size=(n_features, self.n_components)
         )
 
-        self.random_offset_ = random_state.uniform(
-            0.0, 2.0 * np.pi, size=self.n_components
-        )
+        self.random_offset_ = random_state.uniform(0, 2 * np.pi, size=self.n_components)
 
         if X.dtype == np.float32:
             # Setting the data type of the fitted attribute will ensure the

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -253,7 +253,7 @@ class RBFSampler(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
         Parameter of RBF kernel: exp(-gamma * x^2).
         If ``gamma='scale'`` is passed then it uses
         1 / (n_features * X.var()) as value of gamma.
-        
+
         .. versionadded:: 1.2
            The option `"scale"` was added in 1.2.
 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -253,6 +253,9 @@ class RBFSampler(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
         Parameter of RBF kernel: exp(-gamma * x^2).
         If ``gamma='scale'`` is passed then it uses
         1 / (n_features * X.var()) as value of gamma.
+        
+        .. versionadded:: 1.2
+           The option `"scale"` was added in 1.2.
 
     n_components : int, default=100
         Number of Monte Carlo samples per original feature.

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -4,7 +4,6 @@ import numpy as np
 from scipy.sparse import csr_matrix
 import pytest
 
-from numpy.testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_allclose
@@ -244,10 +243,11 @@ def test_rbf_sampler_dtype_equivalence():
 
 
 def test_rbf_sampler_gamma_scale():
+    """Check the inner value computed when `gamma='scale'`."""
     X, y = [[0.0], [1.0]], [0, 1]
     rbf = RBFSampler(gamma="scale")
     rbf.fit(X, y)
-    assert_almost_equal(rbf._gamma, 4)
+    assert rbf._gamma == pytest.approx(4)
 
 
 def test_skewed_chi2_sampler_fitted_attributes_dtype(global_dtype):

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.sparse import csr_matrix
 import pytest
 
+from numpy.testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_allclose
@@ -240,6 +241,13 @@ def test_rbf_sampler_dtype_equivalence():
 
     assert_allclose(rbf32.random_offset_, rbf64.random_offset_)
     assert_allclose(rbf32.random_weights_, rbf64.random_weights_)
+
+
+def test_rbf_sampler_gamma_scale():
+    X, y = [[0.0], [1.0]], [0, 1]
+    rbf = RBFSampler(gamma="scale")
+    rbf.fit(X, y)
+    assert_almost_equal(rbf._gamma, 4)
 
 
 def test_skewed_chi2_sampler_fitted_attributes_dtype(global_dtype):


### PR DESCRIPTION
Fixes #24748 

#### What does this implement/fix? Explain your changes.
Added gamma='scale' option to RBFSampler;
Added small test for scale calculation, just like in svm test file (maybe excessive?);
Changed userdocs and parameter constraints accordingly.

#### Any other comments?
Also took the liberty to replace numpy calls on numbers to python functions, which should be faster. If it was unnecessary, I'll revert it.
