### PR TITLE
fix uniform rng im kmeans test_scaled_weights

### DIFF
--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -886,7 +886,7 @@ def test_unit_weights_vs_no_weights(Estimator, data, global_random_seed):
 def test_scaled_weights(Estimator, data, global_random_seed):
     # Check that scaling all sample weights by a common factor
     # shouldn't change the result
-    sample_weight = np.random.RandomState(global_random_seed).uniform(n_samples)
+    sample_weight = np.random.RandomState(global_random_seed).uniform(size=n_samples)
 
     km = Estimator(n_clusters=n_clusters, random_state=global_random_seed, n_init=1)
     km_orig = clone(km).fit(data, sample_weight=sample_weight)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
`uniform(n_sample)` is equivalent to `uniform(low=n_sample)` and only generate one float lower than `n_sample`, I'm pretty sure that we want `uniform(size=n_sample)` there.

Not sure why it's working at all if `sample_weight` is a float, is it OK that it passes input validation ?

#### Any other comments?
No

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
