### PR TITLE
Ensure invariance of KMeans tests to randomness and tie-breaking of numpy.argpartition

### DIFF
--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -102,7 +102,7 @@ def test_kmeans_relocated_clusters(array_constr, algo):
     assert kmeans.n_iter_ == expected_n_iter
 
     # There are two acceptable ways of relocating clusters in this example, the output
-    # depends on how the argpartition strategy break ties. We accept both outputs.
+    # depends on how the argpartition strategy breaks ties. We accept both outputs.
     try:
         expected_labels = [0, 0, 1, 1]
         expected_centers = [[0.25, 0], [0.75, 1]]

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -702,7 +702,7 @@ def test_integer_input(Estimator, array_constr, dtype, init, global_random_seed)
     assert km.cluster_centers_.dtype == np.float64
 
     expected_labels = [0, 1, 1, 0, 0, 1]
-    assert v_measure_score(km.labels_, expected_labels) == 1.0
+    assert_allclose(v_measure_score(km.labels_, expected_labels), 1.0)
 
     # Same with partial_fit (#14314)
     if Estimator is MiniBatchKMeans:
@@ -843,7 +843,7 @@ def test_kmeans_warns_less_centers_than_unique_points(global_random_seed):
         km.fit(X)
         # only three distinct points, so only three clusters
         # can have points assigned to them
-        assert len(set(km.labels_)) == 3
+        assert set(km.labels_) == set(range(3))
 
 
 def _sort_centers(centers):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Some kmeans unit test assertions rely on specific behavior regarding the seed, or how `np.argpartition` break ties. I propose to relax those assertions to accept other valid outcomes that can happen for different seeds or different tie breaking strategies.

#### Any other comments?

The main motivation for this is to make it easier to test plugins against sklearn unit tests (see https://github.com/scikit-learn/scikit-learn/pull/24497/ ). Different implementations can't pass the tests if they implement different RNG or rely on backend that break ties differently (or, even, in non-deterministic ways if it relies in concurrency for multi threaded backends).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
