### PR TITLE
DOC changed xticks, line type, and legend location

### DIFF
--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -2,7 +2,6 @@
 ======================================
 Gradient Boosting Out-of-Bag estimates
 ======================================
-
 Out-of-bag (OOB) estimates can be a useful heuristic to estimate
 the "optimal" number of boosting iterations.
 OOB estimates are almost identical to cross-validation estimates but
@@ -14,7 +13,6 @@ in loss based on the examples not included in the bootstrap sample
 (the so-called out-of-bag examples).
 The OOB estimator is a pessimistic estimator of the true
 test loss, but remains a fairly good approximation for a small number of trees.
-
 The figure shows the cumulative sum of the negative OOB improvements
 as a function of the boosting iteration. As you can see, it tracks the test
 loss for the first hundred iterations but then diverges in a
@@ -22,7 +20,6 @@ pessimistic way.
 The figure also shows the performance of 3-fold cross validation which
 usually gives a better estimate of the test loss
 but is computationally more demanding.
-
 """
 
 # Author: Peter Prettenhofer <peter.prettenhofer@gmail.com>
@@ -116,13 +113,19 @@ oob_color = list(map(lambda x: x / 256.0, (190, 174, 212)))
 test_color = list(map(lambda x: x / 256.0, (127, 201, 127)))
 cv_color = list(map(lambda x: x / 256.0, (253, 192, 134)))
 
+# line type for the three curves
+oob_line = "dashed"
+test_line = "solid"
+cv_line = "dashdot"
+
 # plot curves and vertical lines for best iterations
-plt.plot(x, cumsum, label="OOB loss", color=oob_color)
-plt.plot(x, test_score, label="Test loss", color=test_color)
-plt.plot(x, cv_score, label="CV loss", color=cv_color)
-plt.axvline(x=oob_best_iter, color=oob_color)
-plt.axvline(x=test_best_iter, color=test_color)
-plt.axvline(x=cv_best_iter, color=cv_color)
+plt.figure(figsize=(8, 4.8))
+plt.plot(x, cumsum, label="OOB loss", color=oob_color, linestyle=oob_line)
+plt.plot(x, test_score, label="Test loss", color=test_color, linestyle=test_line)
+plt.plot(x, cv_score, label="CV loss", color=cv_color, linestyle=cv_line)
+plt.axvline(x=oob_best_iter, color=oob_color, linestyle=oob_line)
+plt.axvline(x=test_best_iter, color=test_color, linestyle=test_line)
+plt.axvline(x=cv_best_iter, color=cv_color, linestyle=cv_line)
 
 # add three vertical lines to xticks
 xticks = plt.xticks()
@@ -133,9 +136,9 @@ xticks_label = np.array(list(map(lambda t: int(t), xticks[0])) + ["OOB", "CV", "
 ind = np.argsort(xticks_pos)
 xticks_pos = xticks_pos[ind]
 xticks_label = xticks_label[ind]
-plt.xticks(xticks_pos, xticks_label)
+plt.xticks(xticks_pos, xticks_label, rotation=90)
 
-plt.legend(loc="upper right")
+plt.legend(loc="upper center")
 plt.ylabel("normalized loss")
 plt.xlabel("number of iterations")
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

1. Rotated the xticks by 90 degrees, so they don't overlap each other.
2. Changed the linestyle of the three lines to make them easier to identify.
3. Moved the legend to upper center to avoid blocking the lines.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
