### PR TITLE
DOC fix link to images in KMeans tutorial

### DIFF
--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -50,8 +50,8 @@ algorithms. The simplest clustering algorithm is :ref:`k_means`.
     For instance, on the image above, we can observe the difference between the
     ground-truth (bottom right figure) and different clustering. We do not
     recover the expected labels, either because the number of cluster was
-    chosen to be to large (top left figure) or suffer from a bad initialization
-    (top right figure).
+    chosen to be to large (top right figure) or suffer from a bad initialization
+    (top left figure).
 
     **It is therefore important to not over-interpret clustering results.**
 
@@ -78,20 +78,20 @@ algorithms. The simplest clustering algorithm is :ref:`k_means`.
     	>>> face_compressed = np.choose(labels, values)
     	>>> face_compressed.shape = face.shape
 
-       **Raw image**
+**Raw image**
 
-    .. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_001.png
-       :target: ../../auto_examples/cluster/plot_face_compress.html
+.. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_001.png
+   :target: ../../auto_examples/cluster/plot_face_compress.html
 
-       **K-means quantization**
+**K-means quantization**
 
-    .. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_004.png
-       :target: ../../auto_examples/cluster/plot_face_compress.html
+.. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_004.png
+   :target: ../../auto_examples/cluster/plot_face_compress.html
 
-       **Equal bins**
+**Equal bins**
 
-    .. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_002.png
-       :target: ../../auto_examples/cluster/plot_face_compress.html
+.. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_002.png
+   :target: ../../auto_examples/cluster/plot_face_compress.html
 
 Hierarchical agglomerative clustering: Ward
 ---------------------------------------------

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -50,8 +50,8 @@ algorithms. The simplest clustering algorithm is :ref:`k_means`.
     For instance, on the image above, we can observe the difference between the
     ground-truth (bottom right figure) and different clustering. We do not
     recover the expected labels, either because the number of cluster was
-    chosen to be to large (top right figure) or suffer from a bad initialization
-    (top left figure).
+    chosen to be to large (top left figure) or suffer from a bad initialization
+    (bottom left figure).
 
     **It is therefore important to not over-interpret clustering results.**
 

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -23,11 +23,6 @@ K-means clustering
 Note that there exist a lot of different clustering criteria and associated
 algorithms. The simplest clustering algorithm is :ref:`k_means`.
 
-.. image:: /auto_examples/cluster/images/sphx_glr_plot_cluster_iris_002.png
-   :target: ../../auto_examples/cluster/plot_cluster_iris.html
-   :scale: 70
-   :align: center
-
 ::
 
     >>> from sklearn import cluster, datasets
@@ -41,6 +36,10 @@ algorithms. The simplest clustering algorithm is :ref:`k_means`.
     >>> print(y_iris[::10])
     [0 0 0 0 0 1 1 1 1 1 2 2 2 2 2]
 
+.. figure:: /auto_examples/cluster/images/sphx_glr_plot_cluster_iris_001.png
+   :target: ../../auto_examples/cluster/plot_cluster_iris.html
+   :scale: 63
+
 .. warning::
 
     There is absolutely no guarantee of recovering a ground truth. First,
@@ -48,27 +47,13 @@ algorithms. The simplest clustering algorithm is :ref:`k_means`.
     is sensitive to initialization, and can fall into local minima,
     although scikit-learn employs several tricks to mitigate this issue.
 
-    |
+    For instance, on the image above, we can observe the difference between the
+    ground-truth (bottom right figure) and different clustering. We do not
+    recover the expected labels, either because the number of cluster was
+    chosen to be to large (top left figure) or suffer from a bad initialization
+    (top right figure).
 
-    .. figure:: /auto_examples/cluster/images/sphx_glr_plot_cluster_iris_003.png
-       :target: ../../auto_examples/cluster/plot_cluster_iris.html
-       :scale: 63
-
-       **Bad initialization**
-
-    .. figure:: /auto_examples/cluster/images/sphx_glr_plot_cluster_iris_001.png
-       :target: ../../auto_examples/cluster/plot_cluster_iris.html
-       :scale: 63
-
-       **8 clusters**
-
-    .. figure:: /auto_examples/cluster/images/sphx_glr_plot_cluster_iris_004.png
-       :target: ../../auto_examples/cluster/plot_cluster_iris.html
-       :scale: 63
-
-       **Ground truth**
-
-    **Don't over-interpret clustering results**
+    **It is therefore important to not over-interpret clustering results.**
 
 .. topic:: **Application example: vector quantization**
 
@@ -93,27 +78,20 @@ algorithms. The simplest clustering algorithm is :ref:`k_means`.
     	>>> face_compressed = np.choose(labels, values)
     	>>> face_compressed.shape = face.shape
 
+       **Raw image**
 
     .. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_001.png
        :target: ../../auto_examples/cluster/plot_face_compress.html
 
-       **Raw image**
-
-    .. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_003.png
-       :target: ../../auto_examples/cluster/plot_face_compress.html
-
        **K-means quantization**
-
-    .. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_002.png
-       :target: ../../auto_examples/cluster/plot_face_compress.html
-
-       **Equal bins**
-
 
     .. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_004.png
        :target: ../../auto_examples/cluster/plot_face_compress.html
 
-       **Image histogram**
+       **Equal bins**
+
+    .. figure:: /auto_examples/cluster/images/sphx_glr_plot_face_compress_002.png
+       :target: ../../auto_examples/cluster/plot_face_compress.html
 
 Hierarchical agglomerative clustering: Ward
 ---------------------------------------------

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -7,11 +7,14 @@ K-means Clustering
 The plot shows:
 
 - top left: What a K-means algorithm would yield using 8 clusters.
+
 - top right: What the effect of a bad initialization does
-on the classification process: By setting n_init to only 1
-(default is 10), the amount of times that the algorithm will
-be run with different centroid seeds is reduced.
+  on the classification process: By setting n_init to only 1
+  (default is 10), the amount of times that the algorithm will
+  be run with different centroid seeds is reduced.
+
 - bottom left: What using eight clusters would deliver.
+
 - bottom right: The ground truth.
 
 """

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -4,14 +4,15 @@
 K-means Clustering
 =========================================================
 
-The plots display firstly what a K-means algorithm would yield
-using three clusters. It is then shown what the effect of a bad
-initialization is on the classification process:
-By setting n_init to only 1 (default is 10), the amount of
-times that the algorithm will be run with different centroid
-seeds is reduced.
-The next plot displays what using eight clusters would deliver
-and finally the ground truth.
+The plot shows:
+
+- top left: What a K-means algorithm would yield using 8 clusters.
+- top right: What the effect of a bad initialization does
+on the classification process: By setting n_init to only 1
+(default is 10), the amount of times that the algorithm will
+be run with different centroid seeds is reduced.
+- bottom left: What using eight clusters would deliver.
+- bottom right: The ground truth.
 
 """
 

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -8,7 +8,7 @@ The plot shows:
 
 - top left: What a K-means algorithm would yield using 8 clusters.
 
-- top right: What the effect of a bad initialization does
+- top right: What the effect of a bad initialization is
   on the classification process: By setting n_init to only 1
   (default is 10), the amount of times that the algorithm will
   be run with different centroid seeds is reduced.

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -43,7 +43,7 @@ estimators = [
 
 fig = plt.figure(figsize=(10, 8))
 titles = ["8 clusters", "3 clusters", "3 clusters, bad initialization"]
-for idx, (name, est) in enumerate(estimators):
+for idx, ((name, est), title) in enumerate(zip(estimators, titles)):
     ax = fig.add_subplot(2, 2, idx + 1, projection="3d", elev=48, azim=134)
     est.fit(X)
     labels = est.labels_
@@ -56,7 +56,7 @@ for idx, (name, est) in enumerate(estimators):
     ax.set_xlabel("Petal width")
     ax.set_ylabel("Sepal length")
     ax.set_zlabel("Petal length")
-    ax.set_title(titles[idx - 1])
+    ax.set_title(title)
 
 # Plot the ground truth
 ax = fig.add_subplot(2, 2, 4, projection="3d", elev=48, azim=134)


### PR DESCRIPTION
closes #24791 

Adapt the tutorial on unsupervised learning based on recent changes in the examples from the gallery. There is also an additional fix on one of the examples where the titles of the subfigures are not the right ones.