### PR TITLE
BLD Remove vcruntime dll from Windows wheels [cd build gh]

### DIFF
--- a/build_tools/github/vendor.py
+++ b/build_tools/github/vendor.py
@@ -1,8 +1,4 @@
-"""Embed vcomp140.dll, vcruntime140.dll and vcruntime140_1.dll.
-
-Note that vcruntime140_1.dll is only required (and available)
-for 64-bit architectures.
-"""
+"""Embed vcomp140.dll and msvcp140.dll."""
 
 
 import os
@@ -15,34 +11,29 @@ import textwrap
 TARGET_FOLDER = op.join("sklearn", ".libs")
 DISTRIBUTOR_INIT = op.join("sklearn", "_distributor_init.py")
 VCOMP140_SRC_PATH = "C:\\Windows\\System32\\vcomp140.dll"
-VCRUNTIME140_SRC_PATH = "C:\\Windows\\System32\\vcruntime140.dll"
-VCRUNTIME140_1_SRC_PATH = "C:\\Windows\\System32\\vcruntime140_1.dll"
 MSVCP140_SRC_PATH = "C:\\Windows\\System32\\msvcp140.dll"
 
 
 def make_distributor_init_64_bits(
     distributor_init,
     vcomp140_dll_filename,
-    vcruntime140_dll_filename,
-    vcruntime140_1_dll_filename,
     msvcp140_dll_filename,
 ):
     """Create a _distributor_init.py file for 64-bit architectures.
 
     This file is imported first when importing the sklearn package
-    so as to pre-load the vendored vcomp140.dll, vcruntime140.dll,
-    vcruntime140_1.dll and msvcp140.dll.
+    so as to pre-load the vendored vcomp140.dll and msvcp140.dll.
     """
     with open(distributor_init, "wt") as f:
         f.write(
             textwrap.dedent(
                 """
-            '''Helper to preload vcomp140.dll, vcruntime140.dll and
-            vcruntime140_1.dll to prevent "not found" errors.
+            '''Helper to preload vcomp140.dll and msvcp140.dll to prevent
+            "not found" errors.
 
-            Once vcomp140.dll, vcruntime140.dll and vcruntime140_1.dll are
+            Once vcomp140.dll and msvcp140.dll are
             preloaded, the namespace is made available to any subsequent
-            vcomp140.dll, vcruntime140.dll and vcruntime140_1.dll. This is
+            vcomp140.dll and msvcp140.dll. This is
             created as part of the scripts that build the wheel.
             '''
 
@@ -53,20 +44,13 @@ def make_distributor_init_64_bits(
 
 
             if os.name == "nt":
-                # Load vcomp140.dll, vcruntime140.dll and vcruntime140_1.dll
                 libs_path = op.join(op.dirname(__file__), ".libs")
                 vcomp140_dll_filename = op.join(libs_path, "{0}")
-                vcruntime140_dll_filename = op.join(libs_path, "{1}")
-                vcruntime140_1_dll_filename = op.join(libs_path, "{2}")
-                msvcp140_dll_filename = op.join(libs_path, "{3}")
+                msvcp140_dll_filename = op.join(libs_path, "{1}")
                 WinDLL(op.abspath(vcomp140_dll_filename))
-                WinDLL(op.abspath(vcruntime140_dll_filename))
-                WinDLL(op.abspath(vcruntime140_1_dll_filename))
                 WinDLL(op.abspath(msvcp140_dll_filename))
             """.format(
                     vcomp140_dll_filename,
-                    vcruntime140_dll_filename,
-                    vcruntime140_1_dll_filename,
                     msvcp140_dll_filename,
                 )
             )
@@ -74,15 +58,9 @@ def make_distributor_init_64_bits(
 
 
 def main(wheel_dirname):
-    """Embed vcomp140.dll, vcruntime140.dll and vcruntime140_1.dll."""
+    """Embed vcomp140.dll and msvcp140.dll."""
     if not op.exists(VCOMP140_SRC_PATH):
         raise ValueError(f"Could not find {VCOMP140_SRC_PATH}.")
-
-    if not op.exists(VCRUNTIME140_SRC_PATH):
-        raise ValueError(f"Could not find {VCRUNTIME140_SRC_PATH}.")
-
-    if not op.exists(VCRUNTIME140_1_SRC_PATH):
-        raise ValueError(f"Could not find {VCRUNTIME140_1_SRC_PATH}.")
 
     if not op.exists(MSVCP140_SRC_PATH):
         raise ValueError(f"Could not find {MSVCP140_SRC_PATH}.")
@@ -91,8 +69,6 @@ def main(wheel_dirname):
         raise RuntimeError(f"Could not find {wheel_dirname} file.")
 
     vcomp140_dll_filename = op.basename(VCOMP140_SRC_PATH)
-    vcruntime140_dll_filename = op.basename(VCRUNTIME140_SRC_PATH)
-    vcruntime140_1_dll_filename = op.basename(VCRUNTIME140_1_SRC_PATH)
     msvcp140_dll_filename = op.basename(MSVCP140_SRC_PATH)
 
     target_folder = op.join(wheel_dirname, TARGET_FOLDER)
@@ -105,12 +81,6 @@ def main(wheel_dirname):
     print(f"Copying {VCOMP140_SRC_PATH} to {target_folder}.")
     shutil.copy2(VCOMP140_SRC_PATH, target_folder)
 
-    print(f"Copying {VCRUNTIME140_SRC_PATH} to {target_folder}.")
-    shutil.copy2(VCRUNTIME140_SRC_PATH, target_folder)
-
-    print(f"Copying {VCRUNTIME140_1_SRC_PATH} to {target_folder}.")
-    shutil.copy2(VCRUNTIME140_1_SRC_PATH, target_folder)
-
     print(f"Copying {MSVCP140_SRC_PATH} to {target_folder}.")
     shutil.copy2(MSVCP140_SRC_PATH, target_folder)
 
@@ -119,8 +89,6 @@ def main(wheel_dirname):
     make_distributor_init_64_bits(
         distributor_init,
         vcomp140_dll_filename,
-        vcruntime140_dll_filename,
-        vcruntime140_1_dll_filename,
         msvcp140_dll_filename,
     )
 


### PR DESCRIPTION
This PR removes the `vcruntime14*.dll` from our Windows wheels. According to [cibuildwheel's docs](https://cibuildwheel.readthedocs.io/en/stable/faq/#windows-importerror-dll-load-failed-the-specific-module-could-not-be-found), CPython >= 3.8.3 already contains the DLL. Since scikit-learn's minimum supported Python version is now 3.8, I think we can drop the DLL.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
