### PR TITLE
DOC fix typos in set_output docstrings

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -255,7 +255,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             self.transformers = value
 
     def set_output(self, transform=None):
-        """Set the output container when `"transform`" and `"fit_transform"` are called.
+        """Set the output container when `"transform"` and `"fit_transform"` are called.
 
         Calling `set_output` will set the output of all estimators in `transformers`
         and `transformers_`.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -149,7 +149,7 @@ class Pipeline(_BaseComposition):
         self.verbose = verbose
 
     def set_output(self, transform=None):
-        """Set the output container when `"transform`" and `"fit_transform"` are called.
+        """Set the output container when `"transform"` and `"fit_transform"` are called.
 
         Calling `set_output` will set the output of all estimators in `steps`.
 
@@ -1002,7 +1002,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         self.verbose = verbose
 
     def set_output(self, transform=None):
-        """Set the output container when `"transform`" and `"fit_transform"` are called.
+        """Set the output container when `"transform"` and `"fit_transform"` are called.
 
         `set_output` will set the output of all estimators in `transformer_list`.
 


### PR DESCRIPTION
#### Reference Issues/PRs

This fixes a typo in `.set_output()` docstrings.
