### PR TITLE
DOC Add `plotly` dependancy for documentation in the docs

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -713,7 +713,7 @@ Building the documentation requires installing some additional packages:
 
     pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas \
                 scikit-image packaging seaborn sphinx-prompt \
-                sphinxext-opengraph
+                sphinxext-opengraph plotly
 
 To build the documentation, you need to be in the ``doc`` folder:
 


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
Adds the `plotly` dependency to the `pip install` command for documentation building

#### Any other comments?