### PR TITLE
DOC MatplotlibDeprecationWarnings for examples/datasets/plot_iris_dataset.py

### DIFF
--- a/examples/datasets/plot_iris_dataset.py
+++ b/examples/datasets/plot_iris_dataset.py
@@ -67,10 +67,10 @@ ax.scatter(
 
 ax.set_title("First three PCA directions")
 ax.set_xlabel("1st eigenvector")
-ax.w_xaxis.set_ticklabels([])
+ax.xaxis.set_ticklabels([])
 ax.set_ylabel("2nd eigenvector")
-ax.w_yaxis.set_ticklabels([])
+ax.yaxis.set_ticklabels([])
 ax.set_zlabel("3rd eigenvector")
-ax.w_zaxis.set_ticklabels([])
+ax.zaxis.set_ticklabels([])
 
 plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->Fixes the  task [datasets/plot_iris_dataset.html](https://scikit-learn.org/dev/auto_examples/datasets/plot_iris_dataset.html) of the issue #24797 .


#### What does this implement/fix? Explain your changes.
This PR fixes the MatplotlibDepreciationWarnings linked to the usage of `w_xaxis`, `w_yaxis` and `w_zaxis`. The last keywords are replaced by `xaxis`, `yaxis` and `zaxis` respectively make the Depreciation Warnings go away.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
