### PR TITLE
DOC MatplotlibDeprecationWarnings for examples/decomposition/plot_pca_3d.py

### DIFF
--- a/examples/decomposition/plot_pca_3d.py
+++ b/examples/decomposition/plot_pca_3d.py
@@ -85,9 +85,9 @@ def plot_figs(fig_num, elev, azim):
     y_pca_plane.shape = (2, 2)
     z_pca_plane.shape = (2, 2)
     ax.plot_surface(x_pca_plane, y_pca_plane, z_pca_plane)
-    ax.w_xaxis.set_ticklabels([])
-    ax.w_yaxis.set_ticklabels([])
-    ax.w_zaxis.set_ticklabels([])
+    ax.xaxis.set_ticklabels([])
+    ax.yaxis.set_ticklabels([])
+    ax.zaxis.set_ticklabels([])
 
 
 elev = -40


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->Fixes the  task [decomposition/plot_pca_3d.html](https://scikit-learn.org/dev/auto_examples/decomposition/plot_pca_3d.html) of the issue #24797 .


#### What does this implement/fix? Explain your changes.
This PR fixes the MatplotlibDepreciationWarnings linked to the usage of `w_xaxis`, `w_yaxis` and `w_zaxis`. Those keywords are replaced by `xaxis`, `yaxis` and `zaxis` respectively make the Depreciation Warnings go away.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
