### PR TITLE
DOC MatplotlibDeprecationWarnings for examples/decomposition/plot_pca_iris.py

### DIFF
--- a/examples/decomposition/plot_pca_iris.py
+++ b/examples/decomposition/plot_pca_iris.py
@@ -52,8 +52,8 @@ for name, label in [("Setosa", 0), ("Versicolour", 1), ("Virginica", 2)]:
 y = np.choose(y, [1, 2, 0]).astype(float)
 ax.scatter(X[:, 0], X[:, 1], X[:, 2], c=y, cmap=plt.cm.nipy_spectral, edgecolor="k")
 
-ax.w_xaxis.set_ticklabels([])
-ax.w_yaxis.set_ticklabels([])
-ax.w_zaxis.set_ticklabels([])
+ax.xaxis.set_ticklabels([])
+ax.yaxis.set_ticklabels([])
+ax.zaxis.set_ticklabels([])
 
 plt.show()

--- a/examples/decomposition/plot_pca_iris.py
+++ b/examples/decomposition/plot_pca_iris.py
@@ -21,6 +21,9 @@ import matplotlib.pyplot as plt
 from sklearn import decomposition
 from sklearn import datasets
 
+# unused but required import for doing 3d projections with matplotlib < 3.2
+import mpl_toolkits.mplot3d  # noqa: F401
+
 np.random.seed(5)
 
 iris = datasets.load_iris()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->Fixes the  task [decomposition/plot_pca_iris.html](https://scikit-learn.org/dev/auto_examples/decomposition/plot_pca_iris.html) of the issue #24797 .


#### What does this implement/fix? Explain your changes.
This PR fixes the MatplotlibDepreciationWarnings linked to the usage of `w_xaxis`, `w_yaxis` and `w_zaxis`. Those keywords are replaced by `xaxis`, `yaxis` and `zaxis` respectively make the Depreciation Warnings go away.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
