### PR TITLE
DOC FIX MatplotlibDeprecationWarnings for `plot_concentration_prior.py`

### DIFF
--- a/examples/mixture/plot_concentration_prior.py
+++ b/examples/mixture/plot_concentration_prior.py
@@ -50,7 +50,7 @@ def plot_ellipses(ax, weights, means, covars):
         # eigenvector normalization
         eig_vals = 2 * np.sqrt(2) * np.sqrt(eig_vals)
         ell = mpl.patches.Ellipse(
-            means[n], eig_vals[0], eig_vals[1], 180 + angle, edgecolor="black"
+            means[n], eig_vals[0], eig_vals[1], angle=180 + angle, edgecolor="black"
         )
         ell.set_clip_box(ax.bbox)
         ell.set_alpha(weights[n])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes the task [mixture/plot_concentration_prior.html](https://scikit-learn.org/dev/auto_examples/mixture/plot_concentration_prior.html) of the issue https://github.com/scikit-learn/scikit-learn/issues/24797.


#### What does this implement/fix? Explain your changes.
Added angle as a keyword argument.
The current implementation passes angle as a positional argument to matplotlib.patches.Ellipse, which is depreciated, and since 3.6, angle can only be passed as a [keyword argument](https://matplotlib.org/stable/api/_as_gen/matplotlib.patches.Ellipse.html).