### PR TITLE
DOC FIX MatplotlibDeprecationWarnings for `plot_gmm_covariances.py`

### DIFF
--- a/examples/mixture/plot_gmm_covariances.py
+++ b/examples/mixture/plot_gmm_covariances.py
@@ -59,7 +59,7 @@ def make_ellipses(gmm, ax):
         angle = 180 * angle / np.pi  # convert to degrees
         v = 2.0 * np.sqrt(2.0) * np.sqrt(v)
         ell = mpl.patches.Ellipse(
-            gmm.means_[n, :2], v[0], v[1], 180 + angle, color=color
+            gmm.means_[n, :2], v[0], v[1], angle=180 + angle, color=color
         )
         ell.set_clip_box(ax.bbox)
         ell.set_alpha(0.5)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes the task [mixture/plot_gmm_covariances.html](https://scikit-learn.org/dev/auto_examples/mixture/plot_gmm_covariances.html) of the issue https://github.com/scikit-learn/scikit-learn/issues/24797.


#### What does this implement/fix? Explain your changes.
Added angle as a keyword argument.
The current implementation passes angle as a positional argument to matplotlib.patches.Ellipse, which is depreciated, and since 3.6, angle can only be passed as a keyword argument.
