### PR TITLE
DOC FIX MatplotlibDeprecationWarnings for `plot_gmm.py`

### DIFF
--- a/examples/mixture/plot_gmm.py
+++ b/examples/mixture/plot_gmm.py
@@ -52,7 +52,7 @@ def plot_results(X, Y_, means, covariances, index, title):
         # Plot an ellipse to show the Gaussian component
         angle = np.arctan(u[1] / u[0])
         angle = 180.0 * angle / np.pi  # convert to degrees
-        ell = mpl.patches.Ellipse(mean, v[0], v[1], 180.0 + angle, color=color)
+        ell = mpl.patches.Ellipse(mean, v[0], v[1], angle=180.0 + angle, color=color)
         ell.set_clip_box(splot.bbox)
         ell.set_alpha(0.5)
         splot.add_artist(ell)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes the task [mixture/plot_gmm.html](https://scikit-learn.org/dev/auto_examples/mixture/plot_gmm.html) of the issue https://github.com/scikit-learn/scikit-learn/issues/24797.

#### What does this implement/fix? Explain your changes.
Added angle as a keyword argument.
The current implementation passes angle as a positional argument to matplotlib.patches.Ellipse, which is depreciated, and since 3.6, angle can only be passed as a keyword argument.