### PR TITLE
MAINT double brackets added by docutils >= 0.18

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -894,14 +894,6 @@ img.align-right, figure.align-right,
   margin-left: 1em;
 }
 
-a.brackets::after, span.brackets > a::after {
-  content: "]";
-}
-
-a.brackets::before, span.brackets > a::before {
-    content: "[";
-}
-
 /* copybutton */
 
 .copybutton {


### PR DESCRIPTION
In the documentation, the reference note contains a double pair of brackets (e.g. `[[1]]`) instead of a single pair bracket.

This is due to an update with `docutils >= 0.18`: https://github.com/sphinx-doc/sphinx/issues/10522

We probably did not spot it.

The fix here is to remove the part that injects it in our custom CSS and let `docutils` do the job.