### PR TITLE
DOC remove use_line_collection arg in plot_omp #24797

### DIFF
--- a/examples/linear_model/plot_omp.py
+++ b/examples/linear_model/plot_omp.py
@@ -41,7 +41,7 @@ plt.figure(figsize=(7, 7))
 plt.subplot(4, 1, 1)
 plt.xlim(0, 512)
 plt.title("Sparse signal")
-plt.stem(idx, w[idx], use_line_collection=True)
+plt.stem(idx, w[idx])
 
 # plot the noise-free reconstruction
 omp = OrthogonalMatchingPursuit(n_nonzero_coefs=n_nonzero_coefs)
@@ -51,7 +51,7 @@ coef = omp.coef_
 plt.subplot(4, 1, 2)
 plt.xlim(0, 512)
 plt.title("Recovered signal from noise-free measurements")
-plt.stem(idx_r, coef[idx_r], use_line_collection=True)
+plt.stem(idx_r, coef[idx_r])
 
 # plot the noisy reconstruction
 omp.fit(X, y_noisy)
@@ -60,7 +60,7 @@ coef = omp.coef_
 plt.subplot(4, 1, 3)
 plt.xlim(0, 512)
 plt.title("Recovered signal from noisy measurements")
-plt.stem(idx_r, coef[idx_r], use_line_collection=True)
+plt.stem(idx_r, coef[idx_r])
 
 # plot the noisy reconstruction with number of non-zeros set by CV
 omp_cv = OrthogonalMatchingPursuitCV()
@@ -70,7 +70,7 @@ coef = omp_cv.coef_
 plt.subplot(4, 1, 4)
 plt.xlim(0, 512)
 plt.title("Recovered signal from noisy measurements with CV")
-plt.stem(idx_r, coef[idx_r], use_line_collection=True)
+plt.stem(idx_r, coef[idx_r])
 
 plt.subplots_adjust(0.06, 0.04, 0.94, 0.90, 0.20, 0.38)
 plt.suptitle("Sparse signal recovery with Orthogonal Matching Pursuit", fontsize=16)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes the task [linear_model/plot_omp.html](https://scikit-learn.org/dev/auto_examples/linear_model/plot_omp.html) of issue [#24797](https://github.com/scikit-learn/scikit-learn/issues/24797).  

#### What does this implement/fix? Explain your changes.
This PR removes the deprecated `use_line_collection` argument of the matplotlib `stem` function. 

#### Any other comments?
The change made is the same fix as in [this PR](https://github.com/scikit-learn/scikit-learn/pull/24832). 