### PR TITLE
Specify the constraints for `metric="precomputed"`

### DIFF
--- a/sklearn/neighbors/_unsupervised.py
+++ b/sklearn/neighbors/_unsupervised.py
@@ -49,7 +49,8 @@ class NearestNeighbors(KNeighborsMixin, RadiusNeighborsMixin, NeighborsBase):
 
         If metric is "precomputed", X is assumed to be a distance matrix and
         must be square during fit. X may be a :term:`sparse graph`, in which
-        case only "nonzero" elements may be considered neighbors.
+        case only "nonzero" elements may be considered neighbors. Note that
+        X must satisfy metric axioms in any case.
 
         If metric is a callable function, it takes two arrays representing 1D
         vectors as inputs and must return one value indicating the distance


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
No Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
This PR adds a small note to the documentation of `sklearn.neighbors.NearestNeighbors` to emphasize that a precomputed distance matrix should be a proper metric even if it is passed as a graph and the algorithm is set to `brute`. For instance, the following simple example does not work because the [`NearestNeighbors.kneighobrs` implementation](https://github.com/scikit-learn/scikit-learn/blob/f3f51f9b611bf873bd5836748647221480071a87/sklearn/neighbors/_base.py#L670) assumes that every point is necessarily one of its nearest neighbours.
```
from sklearn.neighbors import NearestNeighbors
from scipy.sparse.csgraph import csgraph_from_dense

neigh = NearestNeighbors(n_neighbors=1, metric='precomputed', algorithm='brute')
dist_mat = pd.DataFrame([
    [100.0,   1.0,      3.0],
    [1.0,  100.0,      2.0],
    [3.0,      2.0,  100.0],
])
graph = csgraph_from_dense(dist_mat)
neigh.fit(graph)
print(neigh.kneighbors_graph().indices)
>>> [2 2 0]
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
