### PR TITLE
DOC Fixes link to sigmoid in calibration example

### DIFF
--- a/examples/calibration/plot_calibration_curve.py
+++ b/examples/calibration/plot_calibration_curve.py
@@ -124,7 +124,7 @@ plt.show()
 # typical transposed-sigmoid curve. Calibration of the probabilities of
 # :class:`~sklearn.naive_bayes.GaussianNB` with :ref:`isotonic` can fix
 # this issue as can be seen from the nearly diagonal calibration curve.
-# :ref:sigmoid regression `<sigmoid_regressor>` also improves calibration
+# :ref:`Sigmoid regression <sigmoid_regressor>` also improves calibration
 # slightly,
 # albeit not as strongly as the non-parametric isotonic regression. This can be
 # attributed to the fact that we have plenty of calibration data such that the


### PR DESCRIPTION
This PR fixes link to `sigmoid_regressor` in calibration curve example.