### PR TITLE
DOC changed n_iter to max_iter to resolve a deprecation warning

### DIFF
--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -153,7 +153,7 @@ plot_gallery(
 
 # %%
 batch_pca_estimator = decomposition.MiniBatchSparsePCA(
-    n_components=n_components, alpha=0.1, n_iter=100, batch_size=3, random_state=rng
+    n_components=n_components, alpha=0.1, max_iter=100, batch_size=3, random_state=rng
 )
 batch_pca_estimator.fit(faces_centered)
 plot_gallery(
@@ -171,7 +171,7 @@ plot_gallery(
 
 # %%
 batch_dict_estimator = decomposition.MiniBatchDictionaryLearning(
-    n_components=n_components, alpha=0.1, n_iter=50, batch_size=3, random_state=rng
+    n_components=n_components, alpha=0.1, max_iter=50, batch_size=3, random_state=rng
 )
 batch_dict_estimator.fit(faces_centered)
 plot_gallery("Dictionary learning", batch_dict_estimator.components_[:n_components])
@@ -272,7 +272,7 @@ plot_gallery("Faces from dataset", faces_centered[:n_components], cmap=plt.cm.Rd
 dict_pos_dict_estimator = decomposition.MiniBatchDictionaryLearning(
     n_components=n_components,
     alpha=0.1,
-    n_iter=50,
+    max_iter=50,
     batch_size=3,
     random_state=rng,
     positive_dict=True,
@@ -294,7 +294,7 @@ plot_gallery(
 dict_pos_code_estimator = decomposition.MiniBatchDictionaryLearning(
     n_components=n_components,
     alpha=0.1,
-    n_iter=50,
+    max_iter=50,
     batch_size=3,
     fit_algorithm="cd",
     random_state=rng,
@@ -318,7 +318,7 @@ plot_gallery(
 dict_pos_estimator = decomposition.MiniBatchDictionaryLearning(
     n_components=n_components,
     alpha=0.1,
-    n_iter=50,
+    max_iter=50,
     batch_size=3,
     fit_algorithm="cd",
     random_state=rng,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Changed `n_iter` to `max_iter` to resolve the deprecation warning below:

```
/home/runner/work/scikit-learn/scikit-learn/sklearn/decomposition/_dict_learning.py:2290: FutureWarning:

'n_iter' is deprecated in version 1.1 and will be removed in version 1.4. Use 'max_iter' and let 'n_iter' to its default value instead. 'n_iter' is also ignored if 'max_iter' is specified.
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
