### PR TITLE
ENH filter nan before constructing Python set

### DIFF
--- a/sklearn/utils/_encode.py
+++ b/sklearn/utils/_encode.py
@@ -98,7 +98,10 @@ def _extract_set_with_possibly_nan(values):
 
     We first filter out NaN values and later add it back to the set if needed.
     """
-    values_filtered = list(filterfalse(is_scalar_nan, values))
+    if any(map(is_scalar_nan, values)):
+        values_filtered = list(filterfalse(is_scalar_nan, values))
+    else:
+        values_filtered = values
     uniques_set = set(values_filtered)
     if len(values_filtered) != len(values):
         uniques_set.add(float("nan"))


### PR DESCRIPTION
closes #24840 

Adding a function that will filter `nan` values before constructing a Python set. In this way, `nan` is not added to the set and the comparison will be speed-up in case of numerous `nan` values in the original array.

However, the filtering will slow down the `OrdinalEncoder` in the case of features without missing values (~x10).

#### Benchmark

`main` branch:

Case without missing values: 2.01 ms ± 5.52 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Case with 99% missing values: 2min 45s ± 3.4 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

This PR:

Case without missing values: 17.8 ms ± 152 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
Case with 99% missing values: 30.5 ms ± 37.6 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

With Python > 3.10 and `main`:

Case without missing values: 189 µs ± 281 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)
Case with 99% missing values: 3.85 ms ± 7.34 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)