### PR TITLE
DOC - Add objective function in `Lasso` docstrings for target matrix

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1211,11 +1211,10 @@ class Lasso(ElasticNet):
     The target can be a 2-dimensional array, resulting in the optimization of the
     following objective:
     :math:`(1 / (2 * n_samples)) * ||Y - XW||^2_F + alpha * ||W||_{1,1}`, where
-    :math:`||W||_{1,1}` denotes the :math:`\ell_1` norm of the matrix :math:`W` - that
-    is, the sum of the magnitude of its coefficients. It should not be confounded with
-    :class:`~sklearn.linear_model.MultiTaskLasso` which instead optimizes the
-    :math:`L_{2,1}` norm of the coefficients, yielding structured sparsity in the
-    coefficients.
+    :math:`||W||_{1,1}` is the sum of the magnitude of the matrix coefficients.
+    It should not be confounded with :class:`~sklearn.linear_model.MultiTaskLasso` which
+    instead optimizes the :math:`L_{2,1}` norm of the coefficients, yielding structured
+    sparsity in the coefficients.
 
     Examples
     --------

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1213,7 +1213,7 @@ class Lasso(ElasticNet):
     :math:`(1 / (2 * n_samples)) * ||Y - XW||^2_F + alpha * ||W||_{1,1}`, where
     :math:`||W||_{1,1}` is the sum of the magnitude of the matrix coefficients.
     It should not be confounded with :class:`~sklearn.linear_model.MultiTaskLasso` which
-    instead optimizes the :math:`L_{2,1}` norm of the coefficients, yielding structured
+    instead penalizes the :math:`L_{2,1}` norm of the coefficients, yielding row-wise
     sparsity in the coefficients.
 
     Examples

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1210,7 +1210,7 @@ class Lasso(ElasticNet):
 
     The target can be a 2-dimensional array, resulting in the optimization of the
     following objective:
-    :math:`(1 / (2 * n_samples)) * ||Y - XW||^2_F + alpha * ||W||_{1,1}`, where
+    :math:`(1 / (2 * n_{samples})) * ||Y - XW||^2_F + \alpha * ||W||_{1,1}`, where
     :math:`||W||_{1,1}` is the sum of the magnitude of the matrix coefficients.
     It should not be confused with :class:`~sklearn.linear_model.MultiTaskLasso` which
     instead penalizes the :math:`L_{2,1}` norm of the coefficients, yielding row-wise

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1214,7 +1214,7 @@ class Lasso(ElasticNet):
     :math:`||W||_{1,1}` denotes the :math:`\ell_1` norm of the matrix :math:`W` - that
     is, the sum of the magnitude of its coefficients. It should not be confounded with
     :class:`~sklearn.linear_model.MultiTaskLasso` which instead optimizes the
-    :math:`\ell_{2,1}` norm of the coefficients, yielding structured sparsity in the
+    :math:`L_{2,1}` norm of the coefficients, yielding structured sparsity in the
     coefficients.
 
     Examples

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1208,6 +1208,15 @@ class Lasso(ElasticNet):
     If so, then additionally check whether the dual gap is smaller than `tol` times
     :math:`||y||_2^2 / n_{\text{samples}}`.
 
+    The target can be a 2-dimensional array, resulting in the optimization of the
+    following objective:
+    :math:`(1 / (2 * n_samples)) * ||Y - XW||^2_F + alpha * ||W||_{1,1}`, where
+    :math:`||W||_{1,1}` denotes the :math:`\ell_1` norm of the matrix :math:`W` - that
+    is, the sum of the magnitude of its coefficients. It should not be confounded with
+    :class:`~sklearn.linear_model.MultiTaskLasso` which instead optimizes the
+    :math:`\ell_{2,1}` norm of the coefficients, yielding structured sparsity in the
+    coefficients.
+
     Examples
     --------
     >>> from sklearn import linear_model

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1206,12 +1206,14 @@ class Lasso(ElasticNet):
     that maximum coordinate update, i.e. :math:`\\max_j |w_j^{new} - w_j^{old}|`
     is smaller than `tol` times the maximum absolute coefficient, :math:`\\max_j |w_j|`.
     If so, then additionally check whether the dual gap is smaller than `tol` times
-    :math:`||y||_2^2 / n_{\text{samples}}`.
+    :math:`||y||_2^2 / n_{\\text{samples}}`.
 
     The target can be a 2-dimensional array, resulting in the optimization of the
-    following objective:
-    :math:`(1 / (2 * n_{samples})) * ||Y - XW||^2_F + \alpha * ||W||_{1,1}`, where
-    :math:`||W||_{1,1}` is the sum of the magnitude of the matrix coefficients.
+    following objective::
+
+        (1 / (2 * n_samples)) * ||Y - XW||^2_F + alpha * ||W||_11
+
+    where :math:`||W||_{1,1}` is the sum of the magnitude of the matrix coefficients.
     It should not be confused with :class:`~sklearn.linear_model.MultiTaskLasso` which
     instead penalizes the :math:`L_{2,1}` norm of the coefficients, yielding row-wise
     sparsity in the coefficients.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1212,7 +1212,7 @@ class Lasso(ElasticNet):
     following objective:
     :math:`(1 / (2 * n_samples)) * ||Y - XW||^2_F + alpha * ||W||_{1,1}`, where
     :math:`||W||_{1,1}` is the sum of the magnitude of the matrix coefficients.
-    It should not be confounded with :class:`~sklearn.linear_model.MultiTaskLasso` which
+    It should not be confused with :class:`~sklearn.linear_model.MultiTaskLasso` which
     instead penalizes the :math:`L_{2,1}` norm of the coefficients, yielding row-wise
     sparsity in the coefficients.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Not linked to any exiting issue or PR.

#### What does this implement/fix? Explain your changes.

When looking at the code for `DictionaryLearning`, I realized one could pass a target matrix to the `fit` method of `Lasso`. It is not documented at the moment on the Lasso page. Yet I feel it is a valuable feature to highlight and to reference in the doc, especially for practitioners not familiar with the difference between the $\ell_1$ and the $L_{2,1}$ norms of a matrix.

This PR adds a paragraph to the Lasso docstring, mentioning the optimized objective when passing a matrix as the target.

#### Any other comments?

No.