### PR TITLE
DOC improve statement regarding overfitting in decision trees

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -334,9 +334,7 @@ total cost over the entire trees (by summing the cost at each node) of
 Tips on practical use
 =====================
 
-  * Decision trees tend to overfit on data with a large number of features.
-    Getting the right ratio of samples to number of features is important, since
-    a tree with few samples in high dimensional space is very likely to overfit.
+  * For more complicated problems, you need a larger depth decision tree, which results in overfitting.
 
   * Consider performing  dimensionality reduction (:ref:`PCA <PCA>`,
     :ref:`ICA <ICA>`, or :ref:`feature_selection`) beforehand to


### PR DESCRIPTION
The original statement: "Decision Trees tend to overfit data with a large number of features" is wrong. The VC dimension of Decision Trees is logarithmic in the number of features. $$d_{vc} = O(klog(kd))$$ where d is the number of features [Corollary 10 in Decision trees as partitioning machines to characterize their generalization properties](https://arxiv.org/abs/2010.07374) NeurIPS 2020

The correct statement "For more complicated problems, you need a larger depth decision tree, which results in overfitting" is true due to $$d_{vc} = O(2^jjlogd)$$ where j is the depth of the tree Increasing the depth of the tree exponentially increases the VC dimension, thus increasing overfitting.