### PR TITLE
FIX __init_subclass__ should call super()'s method

### DIFF
--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -171,6 +171,8 @@ class _SetOutputMixin:
     """
 
     def __init_subclass__(cls, auto_wrap_output_keys=("transform",), **kwargs):
+        super().__init_subclass__(**kwargs)
+
         # Dynamically wraps `transform` and `fit_transform` and configure it's
         # output based on `set_output`.
         if not (


### PR DESCRIPTION
After adding `set_output` CI on `sample-props` branch started to fail.

This was due to `__init_subclass__` in `_SetOutputMixin` not calling `super().__init_subclass__`.

This PR adds the call, but there's a catch:

We cannot pass extra args to the parent's `__init_subclass__`, since the signature for `object.__init_subclass__` doesn't accept any args. So by the time we get to calling that one, we should have emptied whatever's in `kwargs`.

Now the issue is if there's a third party developer having some parent class implementing a `__init_subclass__` which accepts the same args as the ones we have in `sklearn`, things would break. The call chain therefore assumes there are no conflicts between the signatures.

cc @thomasjpfan @glemaitre @jnothman 