### PR TITLE
ENH Add support for feature names in monotonic_cst

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -301,6 +301,13 @@ Changelog
   :user:`Nestor Navarro <nestornav>`, :user:`Nati Tomattis <natitomattis>`,
   and :user:`Vincent Maladiere <Vincent-Maladiere>`.
 
+- |Enhancement| :class:`ensemble.HistGradientBoostingClassifier` and
+  :class:`ensemble.HistGradientBoostingClassifier` now accept their
+  `monotonic_cst` parameter to be passed as a dictionary with feature names as
+  keys in addition the previously supported format that used an array of
+  ternary integers to specify monotonicity constraints by feature position.
+  :pr:`24855` by :user:`Olivier Grisel <ogrisel>`.
+
 - |Fix| Fixed the issue where :class:`ensemble.AdaBoostClassifier` outputs
   NaN in feature importance when fitted with very small sample weight.
   :pr:`20415` by :user:`Zhehao Liu <MaxwellLZH>`.

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -307,9 +307,10 @@ Changelog
 
 - |Enhancement| :class:`ensemble.HistGradientBoostingClassifier` and
   :class:`ensemble.HistGradientBoostingClassifier` now accept their
-  `monotonic_cst` parameter to be passed as a dictionary with feature names as
-  keys in addition the previously supported format that used an array of
-  ternary integers to specify monotonicity constraints by feature position.
+  `monotonic_cst` parameter to be passed as a dictionary in addition
+  to the previously supported array-like format.
+  Such dictionary have feature names as keys and one of `-1`, `0`, `1`
+  as value to specify monotonicity constraints for each feature.
   :pr:`24855` by :user:`Olivier Grisel <ogrisel>`.
 
 - |Fix| Fixed the issue where :class:`ensemble.AdaBoostClassifier` outputs

--- a/examples/ensemble/plot_monotonic_constraints.py
+++ b/examples/ensemble/plot_monotonic_constraints.py
@@ -88,7 +88,7 @@ plt.show()
 # trend and ignores the local variations.
 
 # %%
-# .. monotonic_cst_features_names:
+# .. _monotonic_cst_features_names:
 #
 # Using feature names to specify monotonic constraints
 # ----------------------------------------------------

--- a/examples/ensemble/plot_monotonic_constraints.py
+++ b/examples/ensemble/plot_monotonic_constraints.py
@@ -39,14 +39,15 @@ y = 5 * f_0 + np.sin(10 * np.pi * f_0) - 5 * f_1 - np.cos(10 * np.pi * f_1) + no
 
 
 # %%
-# Fit a first model on this dataset without any constraint
+# Fit a first model on this dataset without any constraints.
 gbdt_no_cst = HistGradientBoostingRegressor()
 gbdt_no_cst.fit(X, y)
 
 # %%
-# With monotonic increase (1) and a monotonic decrease (-1) constraints, respectively.
-gbdt_monotonic = HistGradientBoostingRegressor(monotonic_cst=[1, -1])
-gbdt_monotonic.fit(X, y)
+# Fit a second model on this dataset with monotonic increase (1)
+# and a monotonic decrease (-1) constraints, respectively.
+gbdt_with_monotonic_cst = HistGradientBoostingRegressor(monotonic_cst=[1, -1])
+gbdt_with_monotonic_cst.fit(X, y)
 
 
 # %%
@@ -64,7 +65,7 @@ disp = PartialDependenceDisplay.from_estimator(
     ax=ax,
 )
 PartialDependenceDisplay.from_estimator(
-    gbdt_monotonic,
+    gbdt_with_monotonic_cst,
     X,
     features=[0, 1],
     line_kw={"linewidth": 4, "label": "constrained", "color": "tab:orange"},
@@ -83,7 +84,7 @@ plt.show()
 
 # %%
 # We can see that the predictions of the unconstrained model capture the
-# oscillations of the the data while the constrained model follows the general
+# oscillations of the data while the constrained model follows the general
 # trend and ignores the local variations.
 
 # %%
@@ -93,8 +94,8 @@ import pandas as pd
 
 X_df = pd.DataFrame(X, columns=["f_0", "f_1"])
 
-gbdt_monotonic_df = HistGradientBoostingRegressor(
+gbdt_with_monotonic_cst_df = HistGradientBoostingRegressor(
     monotonic_cst={"f_0": 1, "f_1": -1}
 ).fit(X_df, y)
 
-np.allclose(gbdt_monotonic_df.predict(X_df), gbdt_monotonic.predict(X))
+np.allclose(gbdt_with_monotonic_cst_df.predict(X_df), gbdt_monotonic.predict(X))

--- a/examples/ensemble/plot_monotonic_constraints.py
+++ b/examples/ensemble/plot_monotonic_constraints.py
@@ -88,6 +88,11 @@ plt.show()
 # trend and ignores the local variations.
 
 # %%
+# .. monotonic_cst_features_names:
+#
+# Using feature names to specify monotonic constraints
+# ----------------------------------------------------
+#
 # Note that if the training data has feature names, it's possible to specifiy the
 # monotonic constraints by passing a dictionary:
 import pandas as pd

--- a/examples/ensemble/plot_monotonic_constraints.py
+++ b/examples/ensemble/plot_monotonic_constraints.py
@@ -98,4 +98,6 @@ gbdt_with_monotonic_cst_df = HistGradientBoostingRegressor(
     monotonic_cst={"f_0": 1, "f_1": -1}
 ).fit(X_df, y)
 
-np.allclose(gbdt_with_monotonic_cst_df.predict(X_df), gbdt_monotonic.predict(X))
+np.allclose(
+    gbdt_with_monotonic_cst_df.predict(X_df), gbdt_with_monotonic_cst.predict(X)
+)

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1270,7 +1270,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         - -1: monotonic decrease
 
         If a dict with str keys, map feature to monotonic constraints by name.
-        If an array, the feature are mapped to constraints by position. See
+        If an array, the features are mapped to constraints by position. See
         :ref:`monotonic_cst_features_names` for a usage example.
 
         The constraints are only valid for binary classifications and hold
@@ -1618,7 +1618,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         - -1: monotonic decrease
 
         If a dict with str keys, map feature to monotonic constraints by name.
-        If an array, the feature are mapped to constraints by position. See
+        If an array, the features are mapped to constraints by position. See
         :ref:`monotonic_cst_features_names` for a usage example.
 
         The constraints are only valid for binary classifications and hold

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1581,8 +1581,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         .. versionadded:: 0.23
 
         .. versionchanged:: 1.2
-
-            Accept dict of constraints with feature names as keys.
+           Accept dict of constraints with feature names as keys.
 
     interaction_cst : iterable of iterables of int, default=None
         Specify interaction constraints, i.e. sets of features which can

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1577,9 +1577,10 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         Read more in the :ref:`User Guide <monotonic_cst_gbdt>`.
 
         .. versionadded:: 0.23
+           Support for monotonic constraints via array of integers.
 
         .. versionchanged:: 1.2
-            Accept dict of constraints with feature names as keys.
+           Accept dict of constraints with feature names as keys.
 
     interaction_cst : iterable of iterables of int, default=None
         Specify interaction constraints, i.e. sets of features which can

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1237,16 +1237,14 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         - 0: no constraint
         - -1: monotonic decrease
 
-        If a dict with str keys, map feature names to monotonic constraints by
-        feature names. If an array, the feature are mapped to constraints by
-        position.
+        If a dict with str keys, map feature to monotonic constraints by name.
+        If an array, the feature are mapped to constraints by position.
 
         The constraints are only valid for binary classifications and hold
         over the probability of the positive class.
         Read more in the :ref:`User Guide <monotonic_cst_gbdt>`.
 
         .. versionadded:: 0.23
-           Support for monotonic constraints via array of integers.
 
         .. versionchanged:: 1.2
            Accept dict of constraints with feature names as keys.
@@ -1581,16 +1579,14 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         - 0: no constraint
         - -1: monotonic decrease
 
-        If a dict with str keys, map feature names to monotonic constraints by
-        feature names. If an array, the feature are mapped to constraints by
-        position.
+        If a dict with str keys, map feature to monotonic constraints by name.
+        If an array, the feature are mapped to constraints by position.
 
         The constraints are only valid for binary classifications and hold
         over the probability of the positive class.
         Read more in the :ref:`User Guide <monotonic_cst_gbdt>`.
 
         .. versionadded:: 0.23
-           Support for monotonic constraints via array of integers.
 
         .. versionchanged:: 1.2
            Accept dict of constraints with feature names as keys.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1229,15 +1229,27 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
         .. versionadded:: 0.24
 
-    monotonic_cst : array-like of int of shape (n_features), default=None
-        Indicates the monotonic constraint to enforce on each feature.
-          - 1: monotonic increase
-          - 0: no constraint
-          - -1: monotonic decrease
+    monotonic_cst : array-like of int of shape (n_features) or dict, default=None
+        Monotonic constraint to enforce on each feature are specified using the
+        following integer values:
 
+        - 1: monotonic increase
+        - 0: no constraint
+        - -1: monotonic decrease
+
+        If a dict with str keys, map feature names to monotonic constraints by
+        feature names. If an array, the feature are mapped to constraints by
+        position.
+
+        The constraints are only valid for binary classifications and hold
+        over the probability of the positive class.
         Read more in the :ref:`User Guide <monotonic_cst_gbdt>`.
 
         .. versionadded:: 0.23
+           Support for monotonic constraints via array of integers.
+
+        .. versionchanged:: 1.2
+           Accept dict of constraints with feature names as keys.
 
     interaction_cst : iterable of iterables of int, default=None
         Specify interaction constraints, the sets of features which can
@@ -1564,6 +1576,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
     monotonic_cst : array-like of int of shape (n_features) or dict, default=None
         Monotonic constraint to enforce on each feature are specified using the
         following integer values:
+
         - 1: monotonic increase
         - 0: no constraint
         - -1: monotonic decrease

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1561,9 +1561,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
 
         .. versionadded:: 0.24
 
-    monotonic_cst : dict of str, array-like of int of shape (n_features), \
-            default=None
-
+    monotonic_cst : dict, array-like of int of shape (n_features), default=None
         If a dict with str keys, map feature names to monotonic constraints by
         feature names. If an array, the feature are mapped to constraints by
         position.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1561,16 +1561,16 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
 
         .. versionadded:: 0.24
 
-    monotonic_cst : dict, array-like of int of shape (n_features), default=None
-        If a dict with str keys, map feature names to monotonic constraints by
-        feature names. If an array, the feature are mapped to constraints by
-        position.
-
+    monotonic_cst : array-like of int of shape (n_features) or dict, default=None
         Monotonic constraint to enforce on each feature are specified using the
         following integer values:
           - 1: monotonic increase
           - 0: no constraint
           - -1: monotonic decrease
+
+        If a dict with str keys, map feature names to monotonic constraints by
+        feature names. If an array, the feature are mapped to constraints by
+        position.
 
         The constraints are only valid for binary classifications and hold
         over the probability of the positive class.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1579,7 +1579,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         .. versionadded:: 0.23
 
         .. versionchanged:: 1.2
-           Accept dict of constraints with feature names as keys.
+            Accept dict of constraints with feature names as keys.
 
     interaction_cst : iterable of iterables of int, default=None
         Specify interaction constraints, i.e. sets of features which can

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1239,7 +1239,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
         If a dict with str keys, map feature to monotonic constraints by name.
         If an array, the feature are mapped to constraints by position. See
-        example usage :ref:`monotonic_cst_features_names`.
+        :ref:`monotonic_cst_features_names` for a usage example.
 
         The constraints are only valid for binary classifications and hold
         over the probability of the positive class.
@@ -1582,7 +1582,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
 
         If a dict with str keys, map feature to monotonic constraints by name.
         If an array, the feature are mapped to constraints by position. See
-        example usage in :ref:`monotonic_cst_features_names`.
+        :ref:`monotonic_cst_features_names` for a usage example.
 
         The constraints are only valid for binary classifications and hold
         over the probability of the positive class.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1238,7 +1238,8 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         - -1: monotonic decrease
 
         If a dict with str keys, map feature to monotonic constraints by name.
-        If an array, the feature are mapped to constraints by position.
+        If an array, the feature are mapped to constraints by position. See
+        example usage :ref:`monotonic_cst_features_names`.
 
         The constraints are only valid for binary classifications and hold
         over the probability of the positive class.
@@ -1580,7 +1581,8 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         - -1: monotonic decrease
 
         If a dict with str keys, map feature to monotonic constraints by name.
-        If an array, the feature are mapped to constraints by position.
+        If an array, the feature are mapped to constraints by position. See
+        example usage in :ref:`monotonic_cst_features_names`.
 
         The constraints are only valid for binary classifications and hold
         over the probability of the positive class.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1564,9 +1564,9 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
     monotonic_cst : array-like of int of shape (n_features) or dict, default=None
         Monotonic constraint to enforce on each feature are specified using the
         following integer values:
-          - 1: monotonic increase
-          - 0: no constraint
-          - -1: monotonic decrease
+        - 1: monotonic increase
+        - 0: no constraint
+        - -1: monotonic decrease
 
         If a dict with str keys, map feature names to monotonic constraints by
         feature names. If an array, the feature are mapped to constraints by

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -264,8 +264,7 @@ class TreeGrower:
             has_missing_values = [has_missing_values] * X_binned.shape[1]
         has_missing_values = np.asarray(has_missing_values, dtype=np.uint8)
 
-        # Shallow validation of monotonic_cst to make TreeGrower easier to
-        # test. A more complete validation is done in _validate_monotonic_cst
+        # `monotonic_cst` validation is done in _validate_monotonic_cst
         # at the estimator level and therefore the following should not be
         # needed when using the public API.
         if monotonic_cst is None:

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -264,28 +264,19 @@ class TreeGrower:
             has_missing_values = [has_missing_values] * X_binned.shape[1]
         has_missing_values = np.asarray(has_missing_values, dtype=np.uint8)
 
+        # Shallow validation of monotonic_cst to make TreeGrower easier to
+        # test. A more complete validation is done in _validate_monotonic_cst
+        # at the estimator level and therefore the following should not be
+        # needed when using the public API.
         if monotonic_cst is None:
-            self.with_monotonic_cst = False
             monotonic_cst = np.full(
                 shape=X_binned.shape[1],
                 fill_value=MonotonicConstraint.NO_CST,
                 dtype=np.int8,
             )
         else:
-            self.with_monotonic_cst = True
             monotonic_cst = np.asarray(monotonic_cst, dtype=np.int8)
-
-            if monotonic_cst.shape[0] != X_binned.shape[1]:
-                raise ValueError(
-                    "monotonic_cst has shape {} but the input data "
-                    "X has {} features.".format(
-                        monotonic_cst.shape[0], X_binned.shape[1]
-                    )
-                )
-            if np.any(monotonic_cst < -1) or np.any(monotonic_cst > 1):
-                raise ValueError(
-                    "monotonic_cst must be None or an array-like of -1, 0 or 1."
-                )
+        self.with_monotonic_cst = np.any(monotonic_cst != MonotonicConstraint.NO_CST)
 
         if is_categorical is None:
             is_categorical = np.zeros(shape=X_binned.shape[1], dtype=np.uint8)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -296,7 +296,7 @@ def test_input_error_related_to_feature_names():
     monotonic_cst = {"d": 1, "a": 1, "c": -1}
     gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
     expected_msg = re.escape(
-        "monotonic_cst contains unexpected feature names: ['c', 'd']."
+        "monotonic_cst contains 2 unexpected feature names: ['c', 'd']."
     )
     with pytest.raises(ValueError, match=expected_msg):
         gbdt.fit(X, y)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -301,6 +301,15 @@ def test_input_error_related_to_feature_names():
     with pytest.raises(ValueError, match=expected_msg):
         gbdt.fit(X, y)
 
+    monotonic_cst = {k: 1 for k in list("abcdefghijklmnopqrstuvwxyz")}
+    gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
+    expected_msg = re.escape(
+        "monotonic_cst contains 24 unexpected feature names: "
+        "['c', 'd', 'e', 'f', 'g', '...']."
+    )
+    with pytest.raises(ValueError, match=expected_msg):
+        gbdt.fit(X, y)
+
     monotonic_cst = {"a": 1}
     gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
     expected_msg = re.escape(

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -285,6 +285,35 @@ def test_input_error():
         gbdt.fit(X, y)
 
 
+def test_input_error_related_to_feature_names():
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame({"a": [0, 1, 2], "b": [0, 1, 2]})
+    y = np.array([0, 1, 0])
+
+    monotonic_cst = {"d": 1, "a": 1, "c": -1}
+    gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
+    expected_msg = re.escape(
+        "monotonic_cst contains unexpected feature names: ['c', 'd']."
+    )
+    with pytest.raises(ValueError, match=expected_msg):
+        gbdt.fit(X, y)
+
+    monotonic_cst = {"a": 1}
+    gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
+    expected_msg = re.escape(
+        "HistGradientBoostingRegressor was not fitted on data with feature "
+        "names. Pass monotonic_cst as an integer array instead."
+    )
+    with pytest.raises(ValueError, match=expected_msg):
+        gbdt.fit(X.values, y)
+
+    monotonic_cst = {"b": -1, "a": "+"}
+    gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
+    expected_msg = re.escape("monotonic_cst[a] must be either -1, 0 or 1. Got '+'.")
+    with pytest.raises(ValueError, match=expected_msg):
+        gbdt.fit(X, y)
+
+
 def test_bounded_value_min_gain_to_split():
     # The purpose of this test is to show that when computing the gain at a
     # given split, the value of the current node should be properly bounded to

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -272,9 +272,12 @@ def test_input_error():
     ):
         gbdt.fit(X, y)
 
-    for monotonic_cst in ([1, 3], [1, -3]):
+    for monotonic_cst in ([1, 3], [1, -3], [0.3, -0.7]):
         gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
-        with pytest.raises(ValueError, match="must be an array-like of -1, 0 or 1"):
+        expected_msg = re.escape(
+            "must be an array-like of -1, 0 or 1. Observed values:"
+        )
+        with pytest.raises(ValueError, match=expected_msg):
             gbdt.fit(X, y)
 
     gbdt = HistGradientBoostingClassifier(monotonic_cst=[0, 1])

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -1,3 +1,4 @@
+import re
 import numpy as np
 import pytest
 
@@ -258,15 +259,13 @@ def test_input_error():
 
     gbdt = HistGradientBoostingRegressor(monotonic_cst=[1, 0, -1])
     with pytest.raises(
-        ValueError, match="monotonic_cst has shape 3 but the input data"
+        ValueError, match=re.escape("monotonic_cst has shape (3,) but the input data")
     ):
         gbdt.fit(X, y)
 
     for monotonic_cst in ([1, 3], [1, -3]):
         gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
-        with pytest.raises(
-            ValueError, match="must be None or an array-like of -1, 0 or 1"
-        ):
+        with pytest.raises(ValueError, match="must be an array-like of -1, 0 or 1"):
             gbdt.fit(X, y)
 
     gbdt = HistGradientBoostingClassifier(monotonic_cst=[0, 1])

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -321,7 +321,7 @@ def test_input_error_related_to_feature_names():
 
     monotonic_cst = {"b": -1, "a": "+"}
     gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
-    expected_msg = re.escape("monotonic_cst[a] must be either -1, 0 or 1. Got '+'.")
+    expected_msg = re.escape("monotonic_cst['a'] must be either -1, 0 or 1. Got '+'.")
     with pytest.raises(ValueError, match=expected_msg):
         gbdt.fit(X, y)
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -301,7 +301,7 @@ def test_input_error_related_to_feature_names():
     with pytest.raises(ValueError, match=expected_msg):
         gbdt.fit(X, y)
 
-    monotonic_cst = {k: 1 for k in list("abcdefghijklmnopqrstuvwxyz")}
+    monotonic_cst = {k: 1 for k in "abcdefghijklmnopqrstuvwxyz"}
     gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)
     expected_msg = re.escape(
         "monotonic_cst contains 24 unexpected feature names: "

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2046,17 +2046,17 @@ def _check_monotonic_cst(estimator, monotonic_cst=None):
                         )
                     monotonic_cst[feature_idx] = cst
     else:
-        monotonic_cst = np.asarray(monotonic_cst, dtype=np.int8)
-
-        if monotonic_cst.shape[0] != estimator.n_features_in_:
-            raise ValueError(
-                f"monotonic_cst has shape {monotonic_cst.shape} but the input data "
-                f"X has {estimator.n_features_in_} features."
-            )
         unexpected_cst = np.setdiff1d(monotonic_cst, [-1, 0, 1])
         if unexpected_cst.shape[0]:
             raise ValueError(
                 "monotonic_cst must be an array-like of -1, 0 or 1. Observed "
                 f"values: {unexpected_cst.tolist()}."
+            )
+
+        monotonic_cst = np.asarray(monotonic_cst, dtype=np.int8)
+        if monotonic_cst.shape[0] != estimator.n_features_in_:
+            raise ValueError(
+                f"monotonic_cst has shape {monotonic_cst.shape} but the input data "
+                f"X has {estimator.n_features_in_} features."
             )
     return monotonic_cst

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1979,3 +1979,84 @@ def _generate_get_feature_names_out(estimator, n_features_out, input_features=No
     return np.asarray(
         [f"{estimator_name}{i}" for i in range(n_features_out)], dtype=object
     )
+
+
+def _check_monotonic_cst(estimator, monotonic_cst=None):
+    """Check the monotonic constraints and return the corresponding array.
+
+    This helper function should be used in the `fit` method of an estimator
+    that supports monotonic constraints and called after the estimator has
+    introspected input data to set the `n_features_in_` and optionally the
+    `feature_names_in_` attributes.
+
+    .. versionadded:: 1.2
+
+    Parameters
+    ----------
+    estimator : estimator instance
+
+    monotonic_cst : array-like of int, dict of str or None, default=None
+        Monotonic constraints for the features.
+
+        - If array-like, then it should contain only -1, 0 or 1. Each value
+            will be checked to be in [-1, 0, 1]. If a value is -1, then the
+            corresponding feature is required to be monotonically decreasing.
+        - If dict, then it the keys should be the feature names occurring in
+            `estimator.feature_names_in_` and the values should be -1, 0 or 1.
+        - If None, then an array of 0s will be allocated.
+
+    Returns
+    -------
+    monotonic_cst : ndarray of int
+        Monotonic constraints for each feature.
+    """
+    original_monotonic_cst = monotonic_cst
+    if monotonic_cst is None or isinstance(monotonic_cst, dict):
+        monotonic_cst = np.full(
+            shape=estimator.n_features_in_,
+            fill_value=0,
+            dtype=np.int8,
+        )
+        if isinstance(original_monotonic_cst, dict):
+            if not hasattr(estimator, "feature_names_in_"):
+                raise ValueError(
+                    f"{estimator.__class__.__name__} was not fitted on data "
+                    "with feature names. Pass monotonic_cst as an integer "
+                    "array instead."
+                )
+            unexpected_feature_names = list(
+                set(original_monotonic_cst) - set(estimator.feature_names_in_)
+            )
+            unexpected_feature_names.sort()  # deterministic error message
+            if unexpected_feature_names:
+                if len(unexpected_feature_names) > 5:
+                    unexpected_feature_names = unexpected_feature_names[:5]
+                    unexpected_feature_names.append("...")
+                raise ValueError(
+                    "monotonic_cst contains unexpected feature names: "
+                    f"{unexpected_feature_names}"
+                )
+            for feature_idx, feature_name in estimator.feature_names_in_:
+                if feature_name in original_monotonic_cst:
+                    cst = original_monotonic_cst[feature_name]
+                    if cst not in [-1, 0, 1]:
+                        raise ValueError(
+                            f"monotonic_cst[{feature_name}] must be either "
+                            f"-1, 0 or 1. Got {cst}."
+                        )
+                    monotonic_cst[feature_idx] = cst
+    else:
+        monotonic_cst = np.asarray(monotonic_cst, dtype=np.int8)
+
+        if monotonic_cst.shape[0] != estimator.n_features_in_:
+            raise ValueError(
+                f"monotonic_cst has shape {monotonic_cst.shape} but the input data "
+                f"X has {estimator.n_features_in_} features."
+            )
+        unexpected_cst = np.setdiff1d(monotonic_cst, [-1, 0, 1])
+        if unexpected_cst.shape[0]:
+            raise ValueError(
+                "monotonic_cst must be an array-like of -1, 0 or 1. Observed "
+                f"values: {unexpected_cst.tolist()}."
+            )
+    return monotonic_cst

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2034,7 +2034,7 @@ def _check_monotonic_cst(estimator, monotonic_cst=None):
                     unexpected_feature_names.append("...")
                 raise ValueError(
                     "monotonic_cst contains unexpected feature names: "
-                    f"{unexpected_feature_names}"
+                    f"{unexpected_feature_names}."
                 )
             for feature_idx, feature_name in enumerate(estimator.feature_names_in_):
                 if feature_name in original_monotonic_cst:
@@ -2042,7 +2042,7 @@ def _check_monotonic_cst(estimator, monotonic_cst=None):
                     if cst not in [-1, 0, 1]:
                         raise ValueError(
                             f"monotonic_cst[{feature_name}] must be either "
-                            f"-1, 0 or 1. Got {cst}."
+                            f"-1, 0 or 1. Got {cst!r}."
                         )
                     monotonic_cst[feature_idx] = cst
     else:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2042,7 +2042,7 @@ def _check_monotonic_cst(estimator, monotonic_cst=None):
                     cst = original_monotonic_cst[feature_name]
                     if cst not in [-1, 0, 1]:
                         raise ValueError(
-                            f"monotonic_cst[{feature_name}] must be either "
+                            f"monotonic_cst['{feature_name}'] must be either "
                             f"-1, 0 or 1. Got {cst!r}."
                         )
                     monotonic_cst[feature_idx] = cst

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2036,7 +2036,7 @@ def _check_monotonic_cst(estimator, monotonic_cst=None):
                     "monotonic_cst contains unexpected feature names: "
                     f"{unexpected_feature_names}"
                 )
-            for feature_idx, feature_name in estimator.feature_names_in_:
+            for feature_idx, feature_name in enumerate(estimator.feature_names_in_):
                 if feature_name in original_monotonic_cst:
                     cst = original_monotonic_cst[feature_name]
                     if cst not in [-1, 0, 1]:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2028,13 +2028,14 @@ def _check_monotonic_cst(estimator, monotonic_cst=None):
                 set(original_monotonic_cst) - set(estimator.feature_names_in_)
             )
             unexpected_feature_names.sort()  # deterministic error message
+            n_unexpeced = len(unexpected_feature_names)
             if unexpected_feature_names:
                 if len(unexpected_feature_names) > 5:
                     unexpected_feature_names = unexpected_feature_names[:5]
                     unexpected_feature_names.append("...")
                 raise ValueError(
-                    "monotonic_cst contains unexpected feature names: "
-                    f"{unexpected_feature_names}."
+                    f"monotonic_cst contains {n_unexpeced} unexpected feature "
+                    f"names: {unexpected_feature_names}."
                 )
             for feature_idx, feature_name in enumerate(estimator.feature_names_in_):
                 if feature_name in original_monotonic_cst:


### PR DESCRIPTION
Towards #24852.

## TODO

- [x] update all the docstrings of the public API
- [x] add tests
- [x] update an example
- [x] changelog

I did not bother moving the `MonotonicConstraint` enum to the `sklearn.utils.validation` module. Not sure if I should do it or not. Maybe.