### PR TITLE
MAINT: Replace np.find_common_type with np.result_type.

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -851,7 +851,7 @@ def _pre_fit(
         Xy = None  # cannot use Xy if precompute is not Gram
 
     if hasattr(precompute, "__array__") and Xy is None:
-        common_dtype = np.find_common_type([X.dtype, y.dtype], [])
+        common_dtype = np.result_type(X.dtype, y.dtype)
         if y.ndim == 1:
             # Xy is 1d, make sure it is contiguous.
             Xy = np.empty(shape=n_features, dtype=common_dtype, order="C")

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -950,7 +950,7 @@ class OneHotEncoder(_BaseEncoder):
         ]
 
         # create resulting array of appropriate dtype
-        dt = np.find_common_type([cat.dtype for cat in transformed_features], [])
+        dt = np.result_type(*[cat.dtype for cat in transformed_features])
         X_tr = np.empty((n_samples, n_features), dtype=dt)
 
         j = 0
@@ -1346,7 +1346,7 @@ class OrdinalEncoder(OneToOneFeatureMixin, _BaseEncoder):
             raise ValueError(msg.format(n_features, X.shape[1]))
 
         # create resulting array of appropriate dtype
-        dt = np.find_common_type([cat.dtype for cat in self.categories_], [])
+        dt = np.result_type(*[cat.dtype for cat in self.categories_])
         X_tr = np.empty((n_samples, n_features), dtype=dt)
 
         found_unknown = {}


### PR DESCRIPTION
There is a proposal to deprecate `np.find_common_type`: see numpy/numpy#22539. Fortunately the only uses in `scikit-learn` can easily be replaced by `np.result_type`, which is preferred.