### PR TITLE
FIX Calls super().init_subclass in _SetOutputMixin

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -670,7 +670,10 @@ when defining a custom subclass::
             ...
 
 The default value for `auto_wrap_output_keys` is `("transform",)`, which automatically
-wraps `fit_transform` and `transform`.
+wraps `fit_transform` and `transform`. The `TransformerMixin` uses the
+`__init_subclass__` mechanism to consume `auto_wrap_output_keys` and pass all other
+keyword arguments to it's super class. Super classes' `__init_subclass__` should
+**not** depend on `auto_wrap_output_keys`.
 
 For transformers that return multiple arrays in `transform`, auto wrapping will
 only wrap the first array and not alter the other arrays.

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -171,6 +171,8 @@ class _SetOutputMixin:
     """
 
     def __init_subclass__(cls, auto_wrap_output_keys=("transform",), **kwargs):
+        super().__init_subclass__(**kwargs)
+
         # Dynamically wraps `transform` and `fit_transform` and configure it's
         # output based on `set_output`.
         if not (

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -199,3 +199,20 @@ def test_auto_wrap_output_keys_errors_with_incorrect_input():
 
         class BadEstimator(_SetOutputMixin, auto_wrap_output_keys="bad_parameter"):
             pass
+
+
+class AnotherMixin:
+    def __init_subclass__(cls, custom_parameter, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.custom_parameter = custom_parameter
+
+
+def test_set_output_mixin_custom_mixin():
+    """Check that multiple init_subclasses passes parameters up."""
+
+    class BothMixinEstimator(_SetOutputMixin, AnotherMixin, custom_parameter=123):
+        def transform(self, X, y=None):
+            return X
+
+    est = BothMixinEstimator()
+    assert est.custom_parameter == 123

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -214,5 +214,9 @@ def test_set_output_mixin_custom_mixin():
         def transform(self, X, y=None):
             return X
 
+        def get_feature_names_out(self, input_features=None):
+            return input_features
+
     est = BothMixinEstimator()
     assert est.custom_parameter == 123
+    assert hasattr(est, "set_output")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #24854


#### What does this implement/fix? Explain your changes.
This PR calls `init_subclass` in `_SetOutputMixin`, which allows other mixins to be defined with their own parameters.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
