### PR TITLE
MAINT Parameters validation for affinity_propagation

### DIFF
--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -13,7 +13,9 @@ import numpy as np
 from ..exceptions import ConvergenceWarning
 from ..base import BaseEstimator, ClusterMixin
 from ..utils import as_float_array, check_random_state
-from ..utils._param_validation import Interval, StrOptions
+from ..utils._param_validation import Interval
+from ..utils._param_validation import StrOptions
+from ..utils._param_validation import validate_params
 from ..utils.validation import check_is_fitted
 from ..metrics import euclidean_distances
 from ..metrics import pairwise_distances_argmin
@@ -34,6 +36,23 @@ def _equal_similarities_and_preferences(S, preference):
     return all_equal_preferences() and all_equal_similarities()
 
 
+@validate_params(
+    {
+        "S": ["array-like"],
+        "preference": [
+            "array-like",
+            Interval(Real, None, None, closed="neither"),
+            None,
+        ],
+        "convergence_iter": [Interval(Integral, 1, None, closed="left")],
+        "max_iter": [Interval(Integral, 1, None, closed="left")],
+        "damping": [Interval(Real, 0.5, 1.0, closed="both")],
+        "copy": ["boolean"],
+        "verbose": ["boolean"],
+        "return_n_iter": ["boolean"],
+        "random_state": ["random_state"],
+    }
+)
 def affinity_propagation(
     S,
     *,

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -10,6 +10,7 @@ from sklearn.utils._param_validation import make_constraint
 
 PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.cluster.kmeans_plusplus",
+    "sklearn.cluster.affinity_propagation",
 ]
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #24862

#### What does this implement/fix? Explain your changes.
Added ```@validate_params decorator``` for affinity_propagation public function.

#### Any other comments?
According to @glemaitre this PR may not be useful as a ```_parameters_constraints``` is present in the ```AffinityPropagation``` class (present in same file, the class calls the public function).
He still advised me to create corresponding pull request as it may need some deeper look to know if it could be of use or not.

First open source contribution, please let me know how I can improve this work =)