### PR TITLE
MAINT Remove -Wcpp warnings when compiling sklearn.cluster._dbscan_inner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ DEFINE_MACRO_NUMPY_C_API = (
 USE_NEWEST_NUMPY_C_API = (
     "sklearn.__check_build._check_build",
     "sklearn._loss._loss",
-    "sklearn.clusters._dbscan_inner",
+    "sklearn.cluster._dbscan_inner",
     "sklearn.cluster._k_means_common",
     "sklearn.cluster._k_means_lloyd",
     "sklearn.cluster._k_means_elkan",

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ DEFINE_MACRO_NUMPY_C_API = (
 USE_NEWEST_NUMPY_C_API = (
     "sklearn.__check_build._check_build",
     "sklearn._loss._loss",
+    "sklearn.clusters._dbscan_inner",
     "sklearn.cluster._k_means_common",
     "sklearn.cluster._k_means_lloyd",
     "sklearn.cluster._k_means_elkan",
@@ -110,7 +111,6 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.utils._isfinite",
     "sklearn.svm._newrand",
     "sklearn._isotonic",
-    "sklearn.clusters._dbscan_inner",
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.utils._isfinite",
     "sklearn.svm._newrand",
     "sklearn._isotonic",
+    "sklearn.clusters._dbscan_inner",
 )
 
 

--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -7,7 +7,7 @@ cimport numpy as cnp
 
 cnp.import_array()
 
-def dbscan_inner(cnp.uint8_t[::1] is_core,
+def dbscan_inner(const cnp.uint8_t[::1] is_core,
                  object[:] neighborhoods,
                  cnp.npy_intp[::1] labels):
     cdef cnp.npy_intp i, label_num = 0, v

--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -5,10 +5,12 @@
 from libcpp.vector cimport vector
 cimport numpy as cnp
 
+cnp.import_array()
 
-def dbscan_inner(cnp.uint8_t[::1] is_core,
-                 object[:] neighborhoods,
-                 cnp.npy_intp[::1] labels):
+
+def dbscan_inner(cnp.ndarray[cnp.uint8_t, ndim=1, mode='c'] is_core,
+                 cnp.ndarray[object, ndim=1] neighborhoods,
+                 cnp.ndarray[cnp.npy_intp, ndim=1, mode='c'] labels):
     cdef cnp.npy_intp i, label_num = 0, v
     cdef cnp.npy_intp[:] neighb
     cdef vector[cnp.npy_intp] stack

--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -5,14 +5,12 @@
 from libcpp.vector cimport vector
 cimport numpy as cnp
 
-cnp.import_array()
 
-
-def dbscan_inner(cnp.ndarray[cnp.uint8_t, ndim=1, mode='c'] is_core,
-                 cnp.ndarray[object, ndim=1] neighborhoods,
-                 cnp.ndarray[cnp.npy_intp, ndim=1, mode='c'] labels):
+def dbscan_inner(cnp.uint8_t[::1] is_core,
+                 object[:] neighborhoods,
+                 cnp.npy_intp[::1] labels):
     cdef cnp.npy_intp i, label_num = 0, v
-    cdef cnp.ndarray[cnp.npy_intp, ndim=1] neighb
+    cdef cnp.npy_intp[:] neighb
     cdef vector[cnp.npy_intp] stack
 
     for i in range(labels.shape[0]):

--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -7,10 +7,9 @@ cimport numpy as cnp
 
 cnp.import_array()
 
-
-def dbscan_inner(cnp.ndarray[cnp.uint8_t, ndim=1, mode='c'] is_core,
-                 cnp.ndarray[object, ndim=1] neighborhoods,
-                 cnp.ndarray[cnp.npy_intp, ndim=1, mode='c'] labels):
+def dbscan_inner(cnp.uint8_t[::1] is_core,
+                 object[:] neighborhoods,
+                 cnp.npy_intp[::1] labels):
     cdef cnp.npy_intp i, label_num = 0, v
     cdef cnp.npy_intp[:] neighb
     cdef vector[cnp.npy_intp] stack


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24875 

#### What does this implement/fix? Explain your changes.
- Fix compilation warnings in sklearn.cluster._dbscan_inner by using memory views in place of the deprecated cnp.ndarray. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
