### PR TITLE
MAINT Remove -Wcpp warnings when compiling sklearn.linear_model._sgd_fast

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.ensemble._hist_gradient_boosting.common",
     "sklearn.ensemble._hist_gradient_boosting.utils",
     "sklearn.feature_extraction._hashing_fast",
+    "sklearn.linear_model._sgd_fast",
     "sklearn.manifold._barnes_hut_tsne",
     "sklearn.metrics.cluster._expected_mutual_info_fast",
     "sklearn.metrics._pairwise_distances_reduction._datasets_pair",
@@ -110,7 +111,6 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.utils._isfinite",
     "sklearn.svm._newrand",
     "sklearn._isotonic",
-    "sklearn.linear_model._sgd_fast",
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.utils._isfinite",
     "sklearn.svm._newrand",
     "sklearn._isotonic",
+    "sklearn.linear_model._sgd_fast",
 )
 
 

--- a/sklearn/linear_model/_sgd_fast.pyx
+++ b/sklearn/linear_model/_sgd_fast.pyx
@@ -18,6 +18,7 @@ cdef extern from "_sgd_fast_helpers.h":
 from ..utils._weight_vector cimport WeightVector64 as WeightVector
 from ..utils._seq_dataset cimport SequentialDataset64 as SequentialDataset
 
+cnp.import_array()
 
 # Penalty constants
 DEF NO_PENALTY = 0

--- a/sklearn/linear_model/_sgd_fast.pyx
+++ b/sklearn/linear_model/_sgd_fast.pyx
@@ -536,7 +536,7 @@ def _plain_sgd(double[::1] weights,
 
     t_start = time()
     with nogil:
-        for epoch in range(max_iter):
+        for epoch in range(<Py_ssize_t>max_iter):
             sumloss = 0
             if verbose > 0:
                 with gil:
@@ -679,7 +679,13 @@ def _plain_sgd(double[::1] weights,
 
     w.reset_wscale()
 
-    return np.asarray(weights), intercept, np.asarray(average_weights), average_intercept, epoch + 1
+    return (
+        np.asarray(weights),
+        intercept,
+        np.asarray(average_weights),
+        average_intercept,
+        epoch + 1
+    )
 
 
 cdef bint any_nonfinite(double *w, int n) nogil:

--- a/sklearn/linear_model/_sgd_fast.pyx
+++ b/sklearn/linear_model/_sgd_fast.pyx
@@ -372,7 +372,7 @@ def _plain_sgd(const double[::1] weights,
                const unsigned char[::1] validation_mask,
                bint early_stopping, validation_score_cb,
                int n_iter_no_change,
-               int max_iter, double tol, int fit_intercept,
+               unsigned int max_iter, double tol, int fit_intercept,
                int verbose, bint shuffle, cnp.uint32_t seed,
                double weight_pos, double weight_neg,
                int learning_rate, double eta0,
@@ -499,7 +499,7 @@ def _plain_sgd(const double[::1] weights,
     cdef double class_weight = 1.0
     cdef unsigned int count = 0
     cdef unsigned int train_count = n_samples - np.sum(validation_mask)
-    cdef int epoch = 0
+    cdef unsigned int epoch = 0
     cdef unsigned int i = 0
     cdef int is_hinge = isinstance(loss, Hinge)
     cdef double optimal_init = 0.0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24875 


#### What does this implement/fix? Explain your changes.
- Fix Use of the deprecated NumPy API (via Cython) (-Wcpp) warnings in sklearn.linear_model._sgd_fast


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
