### PR TITLE
FIX Make sure that set_output is keyword only everywhere

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -254,7 +254,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         except (TypeError, ValueError):
             self.transformers = value
 
-    def set_output(self, transform=None):
+    def set_output(self, *, transform=None):
         """Set the output container when `"transform"` and `"fit_transform"` are called.
 
         Calling `set_output` will set the output of all estimators in `transformers`

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -148,7 +148,7 @@ class Pipeline(_BaseComposition):
         self.memory = memory
         self.verbose = verbose
 
-    def set_output(self, transform=None):
+    def set_output(self, *, transform=None):
         """Set the output container when `"transform"` and `"fit_transform"` are called.
 
         Calling `set_output` will set the output of all estimators in `steps`.
@@ -1001,7 +1001,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         self.transformer_weights = transformer_weights
         self.verbose = verbose
 
-    def set_output(self, transform=None):
+    def set_output(self, *, transform=None):
         """Set the output container when `"transform"` and `"fit_transform"` are called.
 
         `set_output` will set the output of all estimators in `transformer_list`.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Saw this while reviewing #24889

#### What does this implement/fix? Explain your changes.
This PR makes the meta-estimators' `set_output` method use keyword only arguments, which is consistent with the `_SetOutputMixin`.

CC @glemaitre @ogrisel 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
