### PR TITLE
DOC remove FutureWarning in cluster/plot_bisect_kmeans.py

### DIFF
--- a/examples/cluster/plot_bisect_kmeans.py
+++ b/examples/cluster/plot_bisect_kmeans.py
@@ -44,7 +44,7 @@ axs = axs.T
 
 for i, (algorithm_name, Algorithm) in enumerate(clustering_algorithms.items()):
     for j, n_clusters in enumerate(n_clusters_list):
-        algo = Algorithm(n_clusters=n_clusters, random_state=random_state)
+        algo = Algorithm(n_clusters=n_clusters, random_state=random_state, n_init=3)
         algo.fit(X)
         centers = algo.cluster_centers_
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #24876

#### What does this implement/fix? Explain your changes.
Fixed future warning in `examples/cluster/plot_bisect_kmeans.py`

#### Any other comments?

`n_init`='auto' seems to be throwing an error when calling `.fit()` method of the `KMeans`/`BisectingKMeans` objects. I adapted `n_init`=3 from #24880 