### PR TITLE
DOC remove FutureWarning in plot_colour_quantization example

### DIFF
--- a/examples/cluster/plot_color_quantization.py
+++ b/examples/cluster/plot_color_quantization.py
@@ -52,7 +52,9 @@ image_array = np.reshape(china, (w * h, d))
 print("Fitting model on a small sub-sample of the data")
 t0 = time()
 image_array_sample = shuffle(image_array, random_state=0, n_samples=1_000)
-kmeans = KMeans(n_clusters=n_colors, random_state=0).fit(image_array_sample)
+kmeans = KMeans(n_clusters=n_colors, n_init="auto", random_state=0).fit(
+    image_array_sample
+)
 print(f"done in {time() - t0:0.3f}s.")
 
 # Get labels for all points


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#24876 - specifically cluster/colour_quantization.html

#### What does this implement/fix? Explain your changes.

I've changed the example so that when k_means is called n_init is set as "auto", which prevents the future warning

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
