### PR TITLE
FIX acc_find_split_time and acc_compute_hist_time of root nodes in HistGradientBoosting*

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -415,9 +415,11 @@ class TreeGrower:
             self._finalize_leaf(self.root)
             return
 
+        tic = time()
         self.root.histograms = self.histogram_builder.compute_histograms_brute(
             self.root.sample_indices
         )
+        self.total_compute_hist_time += time() - tic
 
         if self.interaction_cst is not None:
             self.root.interaction_cst_indices = range(len(self.interaction_cst))
@@ -426,7 +428,9 @@ class TreeGrower:
                 allowed_features, dtype=np.uint32, count=len(allowed_features)
             )
 
+        tic = time()
         self._compute_best_split_and_push(self.root)
+        self.total_find_split_time += time() - tic
 
     def _compute_best_split_and_push(self, node):
         """Compute the best possible split (SplitInfo) of a given node.


### PR DESCRIPTION
#### Reference Issues/PRs
`HistGradientBoostingClassifier` and `HistGradientBoostingRegressor`, with `verbose>=1`, print detailed timing information on computing histograms and finding best splits. The current implementation neglects the computations of `acc_find_split_time` as well as `acc_compute_hist_time` for the root nodes.

#### What does this implement/fix? Explain your changes.
Add additional time spent in root nodes.
