### PR TITLE
Add `fit_predict` to BaseLabelPropagation

### DIFF
--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -327,7 +327,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         return self
 
     def fit_predict(self, X, y):
-        """Fit a semi-supervised label propagation model to X and perform inductive inference.
+        """Fit semi-supervised label propagation to X and perform inductive inference.
 
         The input samples (labeled and unlabeled) are provided by matrix X,
         and target labels are provided by matrix y. We conventionally apply the

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -326,6 +326,33 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         self.transduction_ = transduction.ravel()
         return self
 
+    def fit_predict(self, X, y):
+        """Fit a semi-supervised label propagation model to X and perform inductive inference.
+
+        The input samples (labeled and unlabeled) are provided by matrix X,
+        and target labels are provided by matrix y. We conventionally apply the
+        label -1 to unlabeled samples in matrix y in a semi-supervised
+        classification.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data, where `n_samples` is the number of samples
+            and `n_features` is the number of features.
+
+        y : array-like of shape (n_samples,)
+            Target class values with unlabeled points marked as -1.
+            All unlabeled samples will be transductively assigned labels
+            internally.
+
+        Returns
+        -------
+        y : ndarray of shape (n_samples,)
+            Predictions for input data.
+        """
+        self.fit(X, y)
+        return self.transduction_
+
 
 class LabelPropagation(BaseLabelPropagation):
     """Label Propagation classifier.

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -62,11 +62,10 @@ def test_predict(global_dtype, Estimator, parameters):
 
 @pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)
 def test_fit_predict(global_dtype, Estimator, parameters):
-    samples = np.random.uniform(0, 1, (10, 2)).astype(global_dtype)
-    labels = np.random.choice([0, 1, -1], 10, replace=True)
-    clf = Estimator(**parameters)
-    fit_predict_preds = clf.fit_predict(samples, labels)
-    assert_array_equal(clf.predict(samples), fit_predict_preds)
+    samples = np.asarray([[1.0, 0.0], [0.0, 2.0], [1.0, 3.0]], dtype=global_dtype)
+    labels = [0, 1, -1]
+    clf = Estimator(**parameters).fit(samples, labels)
+    assert_array_equal(clf.predict(samples), clf.fit_predict(samples, labels))
 
 
 @pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -61,6 +61,14 @@ def test_predict(global_dtype, Estimator, parameters):
 
 
 @pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)
+def test_fit_predict(global_dtype, Estimator, parameters):
+    samples = np.random.uniform(0, 1, (10, 2), dtype=global_dtype)
+    labels = np.random.choice([0, 1, -1], 10, replace=True)
+    clf = Estimator(**parameters).fit(samples, labels)
+    assert_array_equal(clf.predict(samples), clf.fit_predict(samples, labels))
+
+
+@pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)
 def test_predict_proba(global_dtype, Estimator, parameters):
     samples = np.asarray([[1.0, 0.0], [0.0, 1.0], [1.0, 2.5]], dtype=global_dtype)
     labels = [0, 1, -1]

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -62,7 +62,7 @@ def test_predict(global_dtype, Estimator, parameters):
 
 @pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)
 def test_fit_predict(global_dtype, Estimator, parameters):
-    samples = np.random.uniform(0, 1, (10, 2), dtype=global_dtype)
+    samples = np.random.uniform(0, 1, (10, 2)).astype(global_dtype)
     labels = np.random.choice([0, 1, -1], 10, replace=True)
     clf = Estimator(**parameters).fit(samples, labels)
     assert_array_equal(clf.predict(samples), clf.fit_predict(samples, labels))

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -64,8 +64,9 @@ def test_predict(global_dtype, Estimator, parameters):
 def test_fit_predict(global_dtype, Estimator, parameters):
     samples = np.random.uniform(0, 1, (10, 2)).astype(global_dtype)
     labels = np.random.choice([0, 1, -1], 10, replace=True)
-    clf = Estimator(**parameters).fit(samples, labels)
-    assert_array_equal(clf.predict(samples), clf.fit_predict(samples, labels))
+    clf = Estimator(**parameters)
+    fit_predict_preds = clf.fit_predict(samples, labels)
+    assert_array_equal(clf.predict(samples), fit_predict_preds)
 
 
 @pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR adds a `fit_predict` method to `BaseLabelPropagation`. The predicted labels for `X` are already computed, but there is no documented way of accessing them without calling `predict` again, which causes redundant computation.