### PR TITLE
CI Update to python 3.11 docker windows image.

### DIFF
--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -14,12 +14,6 @@ cp $WHEEL_PATH $WHEEL_NAME
 # Dot the Python version for identyfing the base Docker image
 PYTHON_VERSION=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
 
-# TODO: Remove when 3.11 images will be available for
-# windows (for now the docker image is tagged as 3.11-rc)
-if [[ "$PYTHON_VERSION" == "3.11" ]]; then
-    PYTHON_VERSION=$(echo ${PYTHON_VERSION}-rc)
-fi
-
 # Build a minimal Windows Docker image for testing the wheels
 docker build --build-arg PYTHON_VERSION=$PYTHON_VERSION \
              --build-arg WHEEL_NAME=$WHEEL_NAME \


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The docker windows image shipping python 3.11 is now available on docker hub.
This pull request removes the reference to the 3.11-rc image.