### PR TITLE
DOC Fix FutureWarning in manifold/plot_compare_methods.py

### DIFF
--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -163,7 +163,7 @@ plot_2d(S_isomap, S_color, "Isomap Embedding")
 # Read more in the :ref:`User Guide <multidimensional_scaling>`.
 
 md_scaling = manifold.MDS(
-    n_components=n_components, max_iter=50, n_init=4, random_state=0
+    n_components=n_components, max_iter=50, n_init=4, random_state=0, normalized_stress=False
 )
 S_scaling = md_scaling.fit_transform(S_points)
 

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -167,7 +167,7 @@ md_scaling = manifold.MDS(
     max_iter=50,
     n_init=4,
     random_state=0,
-    normalized_stress=False
+    normalized_stress=False,
 )
 S_scaling = md_scaling.fit_transform(S_points)
 

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -163,7 +163,11 @@ plot_2d(S_isomap, S_color, "Isomap Embedding")
 # Read more in the :ref:`User Guide <multidimensional_scaling>`.
 
 md_scaling = manifold.MDS(
-    n_components=n_components, max_iter=50, n_init=4, random_state=0, normalized_stress=False
+    n_components=n_components,
+    max_iter=50,
+    n_init=4,
+    random_state=0,
+    normalized_stress=False
 )
 S_scaling = md_scaling.fit_transform(S_points)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Related to #24876

#### What does this implement/fix? Explain your changes.

Fix FutureWarning in manifold/plot_compare_methods.py

```
/home/runner/work/scikit-learn/scikit-learn/sklearn/manifold/_mds.py:299: FutureWarning:

The default value of `normalized_stress` will change to `'auto'` in version 1.4. To suppress this warning, manually set the value of `normalized_stress`.
```

by explicit passing `normalized_stress=False`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
