### PR TITLE
Limit interaction_cst to list/tuple of lists/tuples/sets in `HistGradientBoosting*`

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -2,7 +2,6 @@
 # Author: Nicolas Hug
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
 from functools import partial
 from numbers import Real, Integral
 import warnings

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -92,11 +92,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         "min_samples_leaf": [Interval(Integral, 1, None, closed="left")],
         "l2_regularization": [Interval(Real, 0, None, closed="left")],
         "monotonic_cst": ["array-like", dict, None],
-        "interaction_cst": [
-            list,
-            tuple,
-            None,
-        ],
+        "interaction_cst": [list, tuple, None],
         "n_iter_no_change": [Interval(Integral, 1, None, closed="left")],
         "validation_fraction": [
             Interval(Real, 0, 1, closed="neither"),

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -64,7 +64,7 @@ def _make_dumb_dataset(n_samples):
         ),
         (
             {"interaction_cst": [0, 1]},
-            "Interaction constraints must be None or an iterable of iterables",
+            "Interaction constraints must be a sequence of tuples or lists",
         ),
         (
             {"interaction_cst": [{0, 9999}]},


### PR DESCRIPTION
Instead of allowing arbitrary "iterable of iterables" the interaction_cst parameter is constrained to be a sequence (list, tuple) of list/tuple/set of integers.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Closes #24899

#### Any other comments?

It feels more "pythonic" (but I hate that as an argument to justify coding choices) to try and iterate over the input and convert it into a list of sets. Instead of trying to nail down the exact allowed types of inputs. What we care about here is that the user's input can be turned into a list of sets of integers. 

The docstring says "sequence of tuples/list of ints", this was the best formulation I could find. Even though this "sequence" isn't meant to be the Python type `collections.abc.Sequence`. I think the chance of a user misunderstanding it (and sending their strict typing lawyers after us) is low.

I don't really like that we limit to `list` and `tuple` in the parameter validation, but I can't think of a better way. My preferred option would probably be to write `collections.abc.Sequence` in `_parameter_constraints` combined with the later checks in the class.