### PR TITLE
DOC remove FutureWarnings from plot_stack_predictors

### DIFF
--- a/examples/ensemble/plot_stack_predictors.py
+++ b/examples/ensemble/plot_stack_predictors.py
@@ -76,7 +76,7 @@ def load_ames_housing():
     X, y = shuffle(X, y, random_state=0)
 
     X = X[:600]
-    y = y[:600]
+    y = y.iloc[:600]
     return X, np.log(y)
 
 

--- a/examples/ensemble/plot_stack_predictors.py
+++ b/examples/ensemble/plot_stack_predictors.py
@@ -72,10 +72,10 @@ def load_ames_housing():
         "MoSold",
     ]
 
-    X = X[features]
+    X = X.loc[:,features]
     X, y = shuffle(X, y, random_state=0)
 
-    X = X[:600]
+    X = X.iloc[:600]
     y = y.iloc[:600]
     return X, np.log(y)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixes the task [ensemble/plot_stack_predictors.html](https://scikit-learn.org/dev/auto_examples/ensemble/plot_stack_predictors.html) of the issue https://github.com/scikit-learn/scikit-learn/issues/24876 .

#### Any other comments?
This PR fixes the FutureWarning linked to the usage of series[i:j]. The last keyword is replaced by series.iloc[i:j] making the Depreciation Warning go away.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
