### PR TITLE
MAINT Remove all -Woverflow warnings

### DIFF
--- a/sklearn/utils/_random.pxd
+++ b/sklearn/utils/_random.pxd
@@ -8,12 +8,6 @@ ctypedef cnp.npy_uint32 UINT32_t
 
 cdef inline UINT32_t DEFAULT_SEED = 1
 
-cdef enum:
-    # Max value for our rand_r replacement (near the bottom).
-    # We don't use RAND_MAX because it's different across platforms and
-    # particularly tiny on Windows/MSVC.
-    RAND_R_MAX = 0x7FFFFFFF
-
 cpdef sample_without_replacement(cnp.int_t n_population,
                                  cnp.int_t n_samples,
                                  method=*,
@@ -30,14 +24,4 @@ cdef inline UINT32_t our_rand_r(UINT32_t* seed) nogil:
     seed[0] ^= <UINT32_t>(seed[0] >> 17)
     seed[0] ^= <UINT32_t>(seed[0] << 5)
 
-    # Note: we must be careful with the final line cast to np.uint32 so that
-    # the function behaves consistently across platforms.
-    #
-    # The following cast might yield different results on different platforms:
-    # wrong_cast = <UINT32_t> RAND_R_MAX + 1
-    #
-    # We can use:
-    # good_cast = <UINT32_t>(RAND_R_MAX + 1)
-    # or:
-    # cdef np.uint32_t another_good_cast = <UINT32_t>RAND_R_MAX + 1
-    return seed[0] % <UINT32_t>(RAND_R_MAX + 1)
+    return seed[0]


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Towards #24875 for `-Woverflow`

Relates to https://github.com/scikit-learn/scikit-learn/pull/13422 and https://github.com/scikit-learn/scikit-learn/pull/24895

#### What does this implement/fix? Explain your changes.

This removes the -Woverflow warnings observed when building scikit-learn.

`RAND_R_MAX` is the max value for uint8, incrementing it causes an overflow (hence the warning).

    Elements were originally mentioned but seem to
    have been left unreviewed, see:
    https://github.com/scikit-learn/scikit-learn/pull/13422#issuecomment-472894022


I think this commit fixes the implementation, yet I comes with a backwards incompatible results and tests for implementation relying on `our_rand_r` fails because results are now different.

I see several alternatives to remove the warning while having tests pass:

  - preferred solution: adapt the test suite using the new results so that all tests pass and acknowledge the change of behavior for impacted user-facing APIs in the change-log
  - accept the quirk of this implementation but hardcode and rename the effective constant
  - silent the `-Woverflow` warning by another mean

#### Any other comments?

Any other alternative one can think of?

@glemaitre and I, have been _capilotracting_ ourselves on finding the reason of using the modulo as the source linked for the 32bit XorShift generator does not mention.

Any memory @ClemDoum?