### PR TITLE
DOC Fix -- make OPTICS plots consistent 

### DIFF
--- a/examples/cluster/plot_optics.py
+++ b/examples/cluster/plot_optics.py
@@ -88,10 +88,10 @@ ax2.plot(X[clust.labels_ == -1, 0], X[clust.labels_ == -1, 1], "k+", alpha=0.1)
 ax2.set_title("Automatic Clustering\nOPTICS")
 
 # DBSCAN at 0.5
-colors = ["g", "greenyellow", "olive", "r", "b", "c"]
-for klass, color in zip(range(0, 6), colors):
+colors = ["g.", "r.", "b.", "c."]
+for klass, color in zip(range(0, 4), colors):
     Xk = X[labels_050 == klass]
-    ax3.plot(Xk[:, 0], Xk[:, 1], color, alpha=0.3, marker=".")
+    ax3.plot(Xk[:, 0], Xk[:, 1], color, alpha=0.3)
 ax3.plot(X[labels_050 == -1, 0], X[labels_050 == -1, 1], "k+", alpha=0.1)
 ax3.set_title("Clustering at 0.5 epsilon cut\nDBSCAN")
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Update/fix documentation... fix vaguely related to #12421 

#### What does this implement/fix? Explain your changes.

Makes cluster colors consistent so they match the reachability graph!

We had a different plot while pushing out OPTICS 2+ years ago; the original had 6 clusters at the 0.5 epsilon cut, but changes to fix the predecessor bug #12421 introduced subtle changes to the cluster example output, and two of the smaller clusters disappeared, which changed the ordering. The original cluster colors were as shown by this update, but when the cluster number went from 6 to 4, we lost clusters in the middle, and never got the red and blue values at the end of the list. 

#### Any other comments?

Sorry for not fixing this sooner!
