### PR TITLE
MAINT run common tests on IterativeImputer

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -45,6 +45,10 @@ from sklearn.utils.estimator_checks import check_estimator
 
 import sklearn
 
+# make it possible to discover experimental estimators when calling `all_estimators`
+from sklearn.experimental import enable_iterative_imputer  # noqa
+from sklearn.experimental import enable_halving_search_cv  # noqa
+
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler, MinMaxScaler, OneHotEncoder
 from sklearn.linear_model._base import LinearClassifierMixin
@@ -52,7 +56,6 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import Ridge
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import RandomizedSearchCV
-from sklearn.experimental import enable_halving_search_cv  # noqa
 from sklearn.model_selection import HalvingGridSearchCV
 from sklearn.model_selection import HalvingRandomSearchCV
 from sklearn.pipeline import make_pipeline

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -11,6 +11,10 @@ from inspect import signature
 
 import numpy as np
 
+# make it possible to discover experimental estimators when calling `all_estimators`
+from sklearn.experimental import enable_iterative_imputer  # noqa
+from sklearn.experimental import enable_halving_search_cv  # noqa
+
 import sklearn
 from sklearn.utils import IS_PYPY
 from sklearn.utils._testing import check_docstring_parameters

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -4,6 +4,10 @@ from typing import Optional
 
 import pytest
 
+# make it possible to discover experimental estimators when calling `all_estimators`
+from sklearn.experimental import enable_iterative_imputer  # noqa
+from sklearn.experimental import enable_halving_search_cv  # noqa
+
 from sklearn.utils.discovery import all_estimators
 from sklearn.utils.discovery import all_displays
 from sklearn.utils.discovery import all_functions

--- a/sklearn/utils/discovery.py
+++ b/sklearn/utils/discovery.py
@@ -48,9 +48,6 @@ def all_estimators(type_filter=None):
         ClusterMixin,
     )
 
-    # make it possible to discover experimental estimators
-    from ..experimental import enable_iterative_imputer  # noqa
-
     def is_abstract(c):
         if not (hasattr(c, "__abstractmethods__")):
             return False

--- a/sklearn/utils/discovery.py
+++ b/sklearn/utils/discovery.py
@@ -48,6 +48,9 @@ def all_estimators(type_filter=None):
         ClusterMixin,
     )
 
+    # make it possible to discover experimental estimators
+    from ..experimental import enable_iterative_imputer  # noqa
+
     def is_abstract(c):
         if not (hasattr(c, "__abstractmethods__")):
             return False


### PR DESCRIPTION
Related to #24923

When debugging #24923, I found out that we don't run the common tests on `IterativeImputer` because we don't explicitly enable it.