### PR TITLE
MAINT test globally setting output via context manager

### DIFF
--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -6,6 +6,7 @@ import warnings
 from scipy import stats
 import numpy as np
 
+from .. import config_context
 from ..base import clone
 from ..exceptions import ConvergenceWarning
 from ..preprocessing import normalize
@@ -566,15 +567,16 @@ class IterativeImputer(_BaseImputer):
 
         X_missing_mask = _get_mask(X, self.missing_values)
         mask_missing_values = X_missing_mask.copy()
-        if self.initial_imputer_ is None:
-            self.initial_imputer_ = SimpleImputer(
-                missing_values=self.missing_values,
-                strategy=self.initial_strategy,
-                keep_empty_features=self.keep_empty_features,
-            )
-            X_filled = self.initial_imputer_.fit_transform(X)
-        else:
-            X_filled = self.initial_imputer_.transform(X)
+        with config_context(transform_output="default"):
+            if self.initial_imputer_ is None:
+                self.initial_imputer_ = SimpleImputer(
+                    missing_values=self.missing_values,
+                    strategy=self.initial_strategy,
+                    keep_empty_features=self.keep_empty_features,
+                )
+                X_filled = self.initial_imputer_.fit_transform(X)
+            else:
+                X_filled = self.initial_imputer_.transform(X)
 
         valid_mask = np.flatnonzero(
             np.logical_not(np.isnan(self.initial_imputer_.statistics_))

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -417,8 +417,6 @@ class IterativeImputer(_BaseImputer):
         if hasattr(self, "iloc"):
             X_filled.iloc[missing_row_mask, feat_idx] = imputed_values
         else:
-            print(X_filled[missing_row_mask, feat_idx].shape)
-            print(imputed_values.shape)
             X_filled[missing_row_mask, feat_idx] = imputed_values
         return X_filled, estimator
 

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -730,7 +730,7 @@ class IterativeImputer(_BaseImputer):
                 Xt, estimator = self._impute_one_feature(
                     Xt,
                     mask_missing_values,
-                    int(feat_idx),
+                    feat_idx,
                     neighbor_feat_idx,
                     estimator=None,
                     fit_mode=True,

--- a/sklearn/impute/tests/test_base.py
+++ b/sklearn/impute/tests/test_base.py
@@ -2,8 +2,11 @@ import pytest
 
 import numpy as np
 
-from sklearn.impute._base import _BaseImputer
 from sklearn.utils._mask import _get_mask
+from sklearn.utils._testing import _convert_container, assert_allclose
+
+from sklearn.impute._base import _BaseImputer
+from sklearn.impute._iterative import _assign_where
 
 
 @pytest.fixture
@@ -87,3 +90,20 @@ def test_base_no_precomputed_mask_transform(data):
         imputer.transform(data)
     with pytest.raises(ValueError, match=err_msg):
         imputer.fit_transform(data)
+
+
+@pytest.mark.parametrize("X1_type", ["array", "dataframe"])
+def test_assign_where(X1_type):
+    """Check the behaviour of the private helpers `_assign_where`."""
+    rng = np.random.RandomState(0)
+
+    n_samples, n_features = 10, 5
+    X1 = _convert_container(rng.randn(n_samples, n_features), constructor_name=X1_type)
+    X2 = rng.randn(n_samples, n_features)
+    mask = rng.randint(0, 2, size=(n_samples, n_features)).astype(bool)
+
+    _assign_where(X1, X2, mask)
+
+    if X1_type == "dataframe":
+        X1 = X1.to_numpy()
+    assert_allclose(X1[mask], X2[mask])

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -16,6 +16,7 @@ from ..utils.extmath import cartesian
 from ..utils import check_array
 from ..utils import check_matplotlib_support  # noqa
 from ..utils import _safe_indexing
+from ..utils import _safe_assign
 from ..utils import _determine_key_type
 from ..utils import _get_column_indices
 from ..utils.validation import check_is_fitted
@@ -149,10 +150,7 @@ def _partial_dependence_brute(est, grid, features, X, response_method):
     X_eval = X.copy()
     for new_values in grid:
         for i, variable in enumerate(features):
-            if hasattr(X_eval, "iloc"):
-                X_eval.iloc[:, variable] = new_values[i]
-            else:
-                X_eval[:, variable] = new_values[i]
+            _safe_assign(X_eval, new_values[i], column_indexer=variable)
 
         try:
             # Note: predictions is of shape

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -58,16 +58,13 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
         X_columns = []
 
         for i in range(n_features):
-            Xi = self._get_feature(X, feature_idx=i)
+            Xi = _safe_indexing(X, indices=i, axis=1)
             Xi = check_array(
                 Xi, ensure_2d=False, dtype=None, force_all_finite=needs_validation
             )
             X_columns.append(Xi)
 
         return X_columns, n_samples, n_features
-
-    def _get_feature(self, X, feature_idx):
-        return _safe_indexing(X, feature_idx, axis=1)
 
     def _fit(
         self, X, handle_unknown="error", force_all_finite=True, return_counts=False

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -10,7 +10,7 @@ import numpy as np
 from scipy import sparse
 
 from ..base import BaseEstimator, TransformerMixin, OneToOneFeatureMixin
-from ..utils import check_array, is_scalar_nan
+from ..utils import check_array, is_scalar_nan, _safe_indexing
 from ..utils.validation import check_is_fitted
 from ..utils.validation import _check_feature_names_in
 from ..utils._param_validation import Interval, StrOptions, Hidden
@@ -67,11 +67,7 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
         return X_columns, n_samples, n_features
 
     def _get_feature(self, X, feature_idx):
-        if hasattr(X, "iloc"):
-            # pandas dataframes
-            return X.iloc[:, feature_idx]
-        # numpy arrays, sparse arrays
-        return X[:, feature_idx]
+        return _safe_indexing(X, feature_idx, axis=1)
 
     def _fit(
         self, X, handle_unknown="error", force_all_finite=True, return_counts=False

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -76,6 +76,7 @@ from sklearn.utils.estimator_checks import (
     check_transformer_get_feature_names_out_pandas,
     check_set_output_transform,
     check_set_output_transform_pandas,
+    check_global_ouptut_transform_pandas,
 )
 
 
@@ -541,3 +542,18 @@ def test_set_output_transform_pandas(estimator):
     _set_checking_parameters(estimator)
     with ignore_warnings(category=(FutureWarning)):
         check_set_output_transform_pandas(estimator.__class__.__name__, estimator)
+
+
+@pytest.mark.parametrize(
+    "estimator", SET_OUTPUT_ESTIMATORS, ids=_get_check_estimator_ids
+)
+def test_global_output_transform_pandas(estimator):
+    name = estimator.__class__.__name__
+    if not hasattr(estimator, "set_output"):
+        pytest.skip(
+            f"Skipping check_global_ouptut_transform_pandas for {name}: Does not"
+            " support set_output API yet"
+        )
+    _set_checking_parameters(estimator)
+    with ignore_warnings(category=(FutureWarning)):
+        check_global_ouptut_transform_pandas(estimator.__class__.__name__, estimator)

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -362,6 +362,36 @@ def _safe_indexing(X, indices, *, axis=0):
         return _list_indexing(X, indices, indices_dtype)
 
 
+def _safe_assign(X, values, *, row_indexer=None, column_indexer=None):
+    """Safe assignment to a numpy array, sparse matrix, or pandas dataframe.
+
+    Parameters
+    ----------
+    X : {ndarray, sparse-matrix, dataframe}
+        Array to be modified. It is expected to be 2-dimensional.
+
+    values : ndarray
+        The values to be assigned to `X`.
+
+    row_indexer : array-like, dtype={int, bool}, default=None
+        A 1-dimensional array to select the rows of interest. If `None`, all
+        rows are selected.
+
+    column_indexer : array-like, dtype={int, bool}, default=None
+        A 1-dimensional array to select the columns of interest. If `None`, all
+        columns are selected.
+    """
+    row_indexer = slice(None, None, None) if row_indexer is None else row_indexer
+    column_indexer = (
+        slice(None, None, None) if column_indexer is None else column_indexer
+    )
+
+    if hasattr(X, "iloc"):
+        X.iloc[row_indexer, column_indexer] = values
+    else:
+        X[row_indexer, column_indexer] = values
+
+
 def _get_column_indices(X, key):
     """Get feature column indices for input data X and key.
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -186,12 +186,7 @@ def _array_indexing(array, key, key_dtype, axis):
 
 def _pandas_indexing(X, key, key_dtype, axis):
     """Index a pandas dataframe or a series."""
-    if hasattr(key, "shape"):
-        # Work-around for indexing with read-only key in pandas
-        # FIXME: solved in pandas 0.25
-        key = np.asarray(key)
-        key = key if key.flags.writeable else key.copy()
-    elif isinstance(key, tuple):
+    if isinstance(key, tuple):
         key = list(key)
 
     if key_dtype == "int" and not (isinstance(key, slice) or np.isscalar(key)):

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -186,7 +186,14 @@ def _array_indexing(array, key, key_dtype, axis):
 
 def _pandas_indexing(X, key, key_dtype, axis):
     """Index a pandas dataframe or a series."""
-    if isinstance(key, tuple):
+    if hasattr(key, "shape") and not np.isscalar(key):
+        # Surprisingly `np.int64` will have a `shape` attribute while being
+        # a scalar.
+        # Work-around for indexing with read-only key in pandas
+        # FIXME: solved in pandas 0.25
+        key = np.asarray(key)
+        key = key if key.flags.writeable else key.copy()
+    elif isinstance(key, tuple):
         key = list(key)
 
     if key_dtype == "int" and not (isinstance(key, slice) or np.isscalar(key)):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -4163,6 +4163,12 @@ def check_set_output_transform(name, transformer_orig):
 
 
 def _output_from_fit_transform(transformer, name, X, df, y):
+    """Generate output to set test `set_output` for different configuration:
+
+    - calling either `fit.transform` or `fit_transform`;
+    - passing either a dataframe or a numpy array to fit;
+    - passing either a dataframe or a numpy array to transform.
+    """
     outputs = {}
 
     # fit then transform case:
@@ -4201,6 +4207,9 @@ def _check_generated_dataframe(name, case, outputs_default, outputs_pandas):
     df_trans, feature_names_pandas = outputs_pandas
 
     assert isinstance(df_trans, pd.DataFrame)
+    # We always rely on the output of `get_feature_names_out` of the
+    # transformer used to generate the dataframe as a ground-truth of the
+    # columns.
     expected_dataframe = pd.DataFrame(X_trans, columns=feature_names_pandas)
 
     try:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -4163,7 +4163,7 @@ def check_set_output_transform(name, transformer_orig):
 
 
 def _output_from_fit_transform(transformer, name, X, df, y):
-    """Generate output to set test `set_output` for different configuration:
+    """Generate output to test `set_output` for different configuration:
 
     - calling either `fit.transform` or `fit_transform`;
     - passing either a dataframe or a numpy array to fit;
@@ -4173,28 +4173,33 @@ def _output_from_fit_transform(transformer, name, X, df, y):
 
     # fit then transform case:
     cases = [
-        "fit.transform/fit_df/transform_df",
-        "fit.transform/fit_df/transform_array",
-        "fit.transform/fit_array/transform_df",
-        "fit.transform/fit_array/transform_array",
+        ("fit.transform/df/df", df, df),
+        ("fit.transform/df/array", df, X),
+        ("fit.transform/array/df", X, df),
+        ("fit.transform/array/array", X, X),
     ]
-    for case, data_fit, data_transform, target in zip(
-        cases, [df, df, X, X], [df, X, df, X], [y, y, y, y]
-    ):
-        transformer.fit(data_fit, target)
+    for (
+        case,
+        data_fit,
+        data_transform,
+    ) in cases:
+        transformer.fit(data_fit, y)
         if name in CROSS_DECOMPOSITION:
-            X_trans = transformer.transform(data_transform, target)[0]
+            X_trans, _ = transformer.transform(data_transform, y)
         else:
             X_trans = transformer.transform(data_transform)
         outputs[case] = (X_trans, transformer.get_feature_names_out())
 
     # fit_transform case:
-    cases = ["fit_transform/df", "fit_transform/array"]
-    for case, data, target in zip(cases, [df, X], [y, y]):
+    cases = [
+        ("fit_transform/df", df),
+        ("fit_transform/array", X),
+    ]
+    for case, data in cases:
         if name in CROSS_DECOMPOSITION:
-            X_trans = transformer.fit_transform(data, target)[0]
+            X_trans, _ = transformer.fit_transform(data, y)
         else:
-            X_trans = transformer.fit_transform(data, target)
+            X_trans = transformer.fit_transform(data, y)
         outputs[case] = (X_trans, transformer.get_feature_names_out())
 
     return outputs

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -23,6 +23,7 @@ from sklearn.utils import resample
 from sklearn.utils import safe_mask
 from sklearn.utils import column_or_1d
 from sklearn.utils import _safe_indexing
+from sklearn.utils import _safe_assign
 from sklearn.utils import shuffle
 from sklearn.utils import gen_even_slices
 from sklearn.utils import _message_with_time, _print_elapsed_time
@@ -742,3 +743,37 @@ def test_to_object_array(sequence):
     assert isinstance(out, np.ndarray)
     assert out.dtype.kind == "O"
     assert out.ndim == 1
+
+
+@pytest.mark.parametrize("array_type", ["array", "sparse", "dataframe"])
+def test_safe_assign(array_type):
+    """Check that `_safe_assign` works as expected."""
+    rng = np.random.RandomState(0)
+    X_array = rng.randn(10, 5)
+
+    row_indexer = [1, 2]
+    values = rng.randn(len(row_indexer), X_array.shape[1])
+    X = _convert_container(X_array, array_type)
+    _safe_assign(X, values, row_indexer=row_indexer)
+
+    assigned_portion = _safe_indexing(X, row_indexer, axis=0)
+    assert_allclose_dense_sparse(
+        assigned_portion, _convert_container(values, array_type)
+    )
+
+    column_indexer = [1, 2]
+    values = rng.randn(X_array.shape[0], len(column_indexer))
+    X = _convert_container(X_array, array_type)
+    _safe_assign(X, values, column_indexer=column_indexer)
+
+    assigned_portion = _safe_indexing(X, column_indexer, axis=1)
+    assert_allclose_dense_sparse(
+        assigned_portion, _convert_container(values, array_type)
+    )
+
+    row_indexer, column_indexer = None, None
+    values = rng.randn(*X.shape)
+    X = _convert_container(X_array, array_type)
+    _safe_assign(X, values, column_indexer=column_indexer)
+
+    assert_allclose_dense_sparse(X, _convert_container(values, array_type))


### PR DESCRIPTION
closes #24931
closes #24923

Requires a merge of https://github.com/scikit-learn/scikit-learn/pull/24930 to test all estimators

This PR uses the `config_context` to set globally the output of estimators.

TODO:

- [x] merge #24930 
- [x] Fix `IterativeImputer`
- add the following cases:
  - [x] request pandas output without providing dataframe at `fit` and `transform`
  - [x] request pandas output without providing dataframe at `transform`