### PR TITLE
DOC remove FutureWarnings for plot_release_highlights_0_23_0.py

### DIFF
--- a/examples/release_highlights/plot_release_highlights_0_23_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_23_0.py
@@ -105,7 +105,7 @@ rng = np.random.RandomState(0)
 X, y = make_blobs(random_state=rng)
 X = scipy.sparse.csr_matrix(X)
 X_train, X_test, _, y_test = train_test_split(X, y, random_state=rng)
-kmeans = KMeans(algorithm="elkan").fit(X_train)
+kmeans = KMeans(algorithm="elkan", n_init=10).fit(X_train)
 print(completeness_score(kmeans.predict(X_test), y_test))
 
 ##############################################################################

--- a/examples/release_highlights/plot_release_highlights_0_23_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_23_0.py
@@ -105,7 +105,7 @@ rng = np.random.RandomState(0)
 X, y = make_blobs(random_state=rng)
 X = scipy.sparse.csr_matrix(X)
 X_train, X_test, _, y_test = train_test_split(X, y, random_state=rng)
-kmeans = KMeans(algorithm="elkan", n_init=10).fit(X_train)
+kmeans = KMeans(n_init="auto").fit(X_train)
 print(completeness_score(kmeans.predict(X_test), y_test))
 
 ##############################################################################


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes the task [release_highlights/plot_release_highlights_0_23_0.html](https://scikit-learn.org/dev/auto_examples/release_highlights/plot_release_highlights_0_23_0.html) of the issue https://github.com/scikit-learn/scikit-learn/issues/24876 .
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR fixes the FutureWarning linked to usage of `KMeans` without `n_init` explicitly defined. Therefore I added `n_init=10` (previous default value) making the Depreciation Warning go away.


#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
