### PR TITLE
DOCremove FutureWarning in manifold/plot_mds.html

### DIFF
--- a/examples/manifold/plot_mds.py
+++ b/examples/manifold/plot_mds.py
@@ -45,6 +45,7 @@ mds = manifold.MDS(
     random_state=seed,
     dissimilarity="precomputed",
     n_jobs=1,
+    normalized_stress="auto",
 )
 pos = mds.fit(similarities).embedding_
 
@@ -57,6 +58,7 @@ nmds = manifold.MDS(
     random_state=seed,
     n_jobs=1,
     n_init=1,
+    normalized_stress="auto"
 )
 npos = nmds.fit_transform(similarities, init=pos)
 

--- a/examples/manifold/plot_mds.py
+++ b/examples/manifold/plot_mds.py
@@ -58,7 +58,7 @@ nmds = manifold.MDS(
     random_state=seed,
     n_jobs=1,
     n_init=1,
-    normalized_stress="auto"
+    normalized_stress="auto",
 )
 npos = nmds.fit_transform(similarities, init=pos)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Related to #24876

#### What does this implement/fix? Explain your changes.

Fix FutureWarning in manifold/plot_mds.html

```
/home/runner/work/scikit-learn/scikit-learn/sklearn/manifold/_mds.py:299: FutureWarning:

The default value of `normalized_stress` will change to `'auto'` in version 1.4. To suppress this warning, manually set the value of `normalized_stress`.

/home/runner/work/scikit-learn/scikit-learn/sklearn/manifold/_mds.py:299: FutureWarning:

The default value of `normalized_stress` will change to `'auto'` in version 1.4. To suppress this warning, manually set the value of `normalized_stress`.
```

by explicit passing `normalized_stress="auto"`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
