### PR TITLE
FIX accept param='all' in GenericUnivariateSelect

### DIFF
--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -958,7 +958,7 @@ class GenericUnivariateSelect(_BaseFilter):
     mode : {'percentile', 'k_best', 'fpr', 'fdr', 'fwe'}, default='percentile'
         Feature selection mode.
 
-    param : float or int depending on the feature selection mode, default=1e-5
+    param : "all", float or int, default=1e-5
         Parameter of the corresponding mode.
 
     Attributes
@@ -1018,7 +1018,7 @@ class GenericUnivariateSelect(_BaseFilter):
     _parameter_constraints: dict = {
         **_BaseFilter._parameter_constraints,
         "mode": [StrOptions(set(_selection_modes.keys()))],
-        "param": [Interval(Real, 0, None, closed="left")],
+        "param": [Interval(Real, 0, None, closed="left"), StrOptions({"all"})],
     }
 
     def __init__(self, score_func=f_classif, *, mode="percentile", param=1e-5):

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -440,6 +440,14 @@ def test_select_kbest_all():
     univariate_filter = SelectKBest(f_classif, k="all")
     X_r = univariate_filter.fit(X, y).transform(X)
     assert_array_equal(X, X_r)
+    # Non-regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/24949
+    X_r2 = (
+        GenericUnivariateSelect(f_classif, mode="k_best", param="all")
+        .fit(X, y)
+        .transform(X)
+    )
+    assert_array_equal(X_r, X_r2)
 
 
 @pytest.mark.parametrize("dtype_in", [np.float32, np.float64])


### PR DESCRIPTION
closes #24949 

Add the option `param="all"` to be compatible when using `SelectKBest` under the hood.

TODO:
- [x] add non-regression test

No need for a changelog entry since we did not release this bug.