### PR TITLE
DOC Fix image reference in DBSCAN example

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -880,7 +880,7 @@ indicating core samples found by the algorithm. Smaller circles are non-core
 samples that are still part of a cluster. Moreover, the outliers are indicated
 by black points below.
 
-.. |dbscan_results| image:: ../auto_examples/cluster/images/sphx_glr_plot_dbscan_001.png
+.. |dbscan_results| image:: ../auto_examples/cluster/images/sphx_glr_plot_dbscan_002.png
         :target: ../auto_examples/cluster/plot_dbscan.html
         :scale: 50
 
@@ -2110,5 +2110,5 @@ diagonal entries::
 
 .. topic:: References
 
- * :doi:`"Comparing Partitions" <10.1007/BF01908075>` 
+ * :doi:`"Comparing Partitions" <10.1007/BF01908075>`
    L. Hubert and P. Arabie, Journal of Classification 1985


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Related to #24874.

#### What does this implement/fix? Explain your changes.

I introduced an extra plot in #24874 and the reference to the correct figure on the user guide should have been changed accordingly. This PR fixes it.

#### Any other comments?

This PR also fixes an unrelated trailing whitespace that was automatically modified by `pre-commit`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
