### PR TITLE
DOC use log_loss instead of defining deviance

### DIFF
--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -32,6 +32,7 @@ import matplotlib.pyplot as plt
 from sklearn import ensemble
 from sklearn.model_selection import KFold
 from sklearn.model_selection import train_test_split
+from sklearn.metrics import log_loss
 
 from scipy.special import expit
 
@@ -69,15 +70,13 @@ n_estimators = params["n_estimators"]
 x = np.arange(n_estimators) + 1
 
 
-def binomial_deviance(y, raw_predictions):
-    return -2 * np.mean((y * raw_predictions) - np.logaddexp(0, raw_predictions))
-
-
 def heldout_score(clf, X_test, y_test):
     """compute deviance scores on ``X_test`` and ``y_test``."""
     score = np.zeros((n_estimators,), dtype=np.float64)
     for i, y_pred in enumerate(clf.staged_decision_function(X_test)):
-        score[i] = binomial_deviance(y_test, y_pred.ravel())
+        # transform raw predictions into probabilities estimates
+        y_proba = 1.0 / (1.0 + np.exp(-y_pred.ravel()))
+        score[i] = 2 * log_loss(y_test, y_proba)
     return score
 
 

--- a/examples/ensemble/plot_gradient_boosting_oob.py
+++ b/examples/ensemble/plot_gradient_boosting_oob.py
@@ -73,10 +73,8 @@ x = np.arange(n_estimators) + 1
 def heldout_score(clf, X_test, y_test):
     """compute deviance scores on ``X_test`` and ``y_test``."""
     score = np.zeros((n_estimators,), dtype=np.float64)
-    for i, y_pred in enumerate(clf.staged_decision_function(X_test)):
-        # transform raw predictions into probabilities estimates
-        y_proba = 1.0 / (1.0 + np.exp(-y_pred.ravel()))
-        score[i] = 2 * log_loss(y_test, y_proba)
+    for i, y_proba in enumerate(clf.staged_predict_proba(X_test)):
+        score[i] = 2 * log_loss(y_test, y_proba[:, 1])
     return score
 
 


### PR DESCRIPTION
In a previous PR, we redefined binomial deviance. As a second thought, it could be easier to transform the raw predictions and convert them to probabilities and then call the `log_loss` which is an already defined function from scikit-learn.