### PR TITLE
ANN add Tim Head in contributor experience team

### DIFF
--- a/doc/contributor_experience_team.rst
+++ b/doc/contributor_experience_team.rst
@@ -45,4 +45,8 @@
     <a href='https://github.com/albertcthomas'><img src='https://avatars.githubusercontent.com/u/15966638?v=4' class='avatar' /></a> <br />
     <p>Albert Thomas</p>
     </div>
+    <div>
+    <a href='https://github.com/betatim'><img src='https://avatars.githubusercontent.com/u/1448859?v=4' class='avatar' /></a> <br />
+    <p>Tim Head</p>
+    </div>
     </div>


### PR DESCRIPTION
Adding @betatim to the listing of members of the Contributor Experience Team