### PR TITLE
MAINT Extend dtype preserved common test to check transform

### DIFF
--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -399,11 +399,6 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         """
         check_is_fitted(self)
 
-        if self.metric == "precomputed":
-            X = _check_precomputed(X)
-        else:
-            X = self._validate_data(X, accept_sparse="csr", order="C", reset=False)
-
         if self.n_neighbors is not None:
             distances, indices = self.nbrs_.kneighbors(X, return_distance=True)
         else:
@@ -416,7 +411,13 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
 
         n_samples_fit = self.nbrs_.n_samples_fit_
         n_queries = distances.shape[0]
-        G_X = np.zeros((n_queries, n_samples_fit), X.dtype)
+
+        if hasattr(X, "dtype") and X.dtype == np.float32:
+            dtype = np.float32
+        else:
+            dtype = np.float64
+
+        G_X = np.zeros((n_queries, n_samples_fit), dtype)
         for i in range(n_queries):
             G_X[i] = np.min(self.dist_matrix_[indices[i]] + distances[i][:, None], 0)
 

--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -14,6 +14,7 @@ from scipy.sparse.csgraph import connected_components
 from ..base import BaseEstimator, TransformerMixin, ClassNamePrefixFeaturesOutMixin
 from ..neighbors import NearestNeighbors, kneighbors_graph
 from ..neighbors import radius_neighbors_graph
+from ..neighbors._base import _check_precomputed
 from ..utils.validation import check_is_fitted
 from ..decomposition import KernelPCA
 from ..preprocessing import KernelCenterer
@@ -397,6 +398,12 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
             X transformed in the new space.
         """
         check_is_fitted(self)
+
+        if self.metric == "precomputed":
+            X = _check_precomputed(X)
+        else:
+            X = self._validate_data(X, accept_sparse="csr", order="C", reset=False)
+
         if self.n_neighbors is not None:
             distances, indices = self.nbrs_.kneighbors(X, return_distance=True)
         else:
@@ -409,7 +416,7 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
 
         n_samples_fit = self.nbrs_.n_samples_fit_
         n_queries = distances.shape[0]
-        G_X = np.zeros((n_queries, n_samples_fit))
+        G_X = np.zeros((n_queries, n_samples_fit), X.dtype)
         for i in range(n_queries):
             G_X[i] = np.min(self.dist_matrix_[indices[i]] + distances[i][:, None], 0)
 

--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -14,7 +14,6 @@ from scipy.sparse.csgraph import connected_components
 from ..base import BaseEstimator, TransformerMixin, ClassNamePrefixFeaturesOutMixin
 from ..neighbors import NearestNeighbors, kneighbors_graph
 from ..neighbors import radius_neighbors_graph
-from ..neighbors._base import _check_precomputed
 from ..utils.validation import check_is_fitted
 from ..decomposition import KernelPCA
 from ..preprocessing import KernelCenterer
@@ -398,7 +397,6 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
             X transformed in the new space.
         """
         check_is_fitted(self)
-
         if self.n_neighbors is not None:
             distances, indices = self.nbrs_.kneighbors(X, return_distance=True)
         else:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1743,18 +1743,20 @@ def check_transformer_preserve_dtypes(name, transformer_orig):
         X_cast = X.astype(dtype)
         transformer = clone(transformer_orig)
         set_random_state(transformer)
-        X_trans = transformer.fit_transform(X_cast, y)
+        X_trans1 = transformer.fit_transform(X_cast, y)
+        X_trans2 = transformer.fit(X_cast, y).transform(X_cast)
 
-        if isinstance(X_trans, tuple):
-            # cross-decompostion returns a tuple of (x_scores, y_scores)
-            # when given y with fit_transform; only check the first element
-            X_trans = X_trans[0]
+        for Xt, method in zip([X_trans1, X_trans2], ["fit_transform", "transform"]):
+            if isinstance(Xt, tuple):
+                # cross-decompostion returns a tuple of (x_scores, y_scores)
+                # when given y with fit_transform; only check the first element
+                Xt = Xt[0]
 
-        # check that the output dtype is preserved
-        assert X_trans.dtype == dtype, (
-            f"Estimator transform dtype: {X_trans.dtype} - "
-            f"original/expected dtype: {dtype.__name__}"
-        )
+            # check that the output dtype is preserved
+            assert Xt.dtype == dtype, (
+                f"{name} (method={method}) does not preserve dtype. "
+                f"Original/Expected dtype={dtype.__name__}, got dtype={Xt.dtype}."
+            )
 
 
 @ignore_warnings(category=FutureWarning)


### PR DESCRIPTION
The common test only checks fit_transform. It turns out that the transform method of Isomap does not preserve dtype which was missed in https://github.com/scikit-learn/scikit-learn/pull/24714 because of that.

This PR proposes to extend this test to check both methods.
Of course it's currently failing because of Isomap. I'll try to fix it as part of this PR.

Related to https://github.com/scikit-learn/scikit-learn/pull/22673