### PR TITLE
MAINT Handle `Tree.sample_weight` using a memoryview 

### DIFF
--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -22,7 +22,7 @@ cdef class Criterion:
 
     # Internal structures
     cdef const DOUBLE_t[:, ::1] y        # Values of y
-    cdef DOUBLE_t* sample_weight         # Sample weights
+    cdef const DOUBLE_t[:] sample_weight # Sample weights
 
     cdef SIZE_t* samples                 # Sample indices in X, y
     cdef SIZE_t start                    # samples[start:pos] are the samples in the left node
@@ -41,7 +41,7 @@ cdef class Criterion:
     # statistics correspond to samples[start:pos] and samples[pos:end].
 
     # Methods
-    cdef int init(self, const DOUBLE_t[:, ::1] y, DOUBLE_t* sample_weight,
+    cdef int init(self, const DOUBLE_t[:, ::1] y, const DOUBLE_t[:] sample_weight,
                   double weighted_n_samples, SIZE_t* samples, SIZE_t start,
                   SIZE_t end) nogil except -1
     cdef int reset(self) nogil except -1

--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -41,19 +41,34 @@ cdef class Criterion:
     # statistics correspond to samples[start:pos] and samples[pos:end].
 
     # Methods
-    cdef int init(self, const DOUBLE_t[:, ::1] y, const DOUBLE_t[:] sample_weight,
-                  double weighted_n_samples, SIZE_t* samples, SIZE_t start,
-                  SIZE_t end) nogil except -1
+    cdef int init(
+        self,
+        const DOUBLE_t[:, ::1] y,
+        const DOUBLE_t[:] sample_weight,
+        double weighted_n_samples,
+        SIZE_t* samples,
+        SIZE_t start,
+        SIZE_t end
+    ) nogil except -1
     cdef int reset(self) nogil except -1
     cdef int reverse_reset(self) nogil except -1
     cdef int update(self, SIZE_t new_pos) nogil except -1
     cdef double node_impurity(self) nogil
-    cdef void children_impurity(self, double* impurity_left,
-                                double* impurity_right) nogil
-    cdef void node_value(self, double* dest) nogil
-    cdef double impurity_improvement(self, double impurity_parent,
-                                     double impurity_left,
-                                     double impurity_right) nogil
+    cdef void children_impurity(
+        self,
+        double* impurity_left,
+        double* impurity_right
+    ) nogil
+    cdef void node_value(
+        self,
+        double* dest
+    ) nogil
+    cdef double impurity_improvement(
+        self,
+        double impurity_parent,
+        double impurity_left,
+        double impurity_right
+    ) nogil
     cdef double proxy_impurity_improvement(self) nogil
 
 cdef class ClassificationCriterion(Criterion):

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -250,9 +250,15 @@ cdef class ClassificationCriterion(Criterion):
         return (type(self),
                 (self.n_outputs, np.asarray(self.n_classes)), self.__getstate__())
 
-    cdef int init(self, const DOUBLE_t[:, ::1] y,
-                  const DOUBLE_t[:] sample_weight, double weighted_n_samples,
-                  SIZE_t* samples, SIZE_t start, SIZE_t end) nogil except -1:
+    cdef int init(
+        self,
+        const DOUBLE_t[:, ::1] y,
+        const DOUBLE_t[:] sample_weight,
+        double weighted_n_samples,
+        SIZE_t* samples,
+        SIZE_t start,
+        SIZE_t end
+    ) nogil except -1:
         """Initialize the criterion.
 
         This initializes the criterion at node samples[start:end] and children

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -41,9 +41,15 @@ cdef class Criterion:
     def __setstate__(self, d):
         pass
 
-    cdef int init(self, const DOUBLE_t[:, ::1] y, const DOUBLE_t[:] sample_weight,
-                  double weighted_n_samples, SIZE_t* samples, SIZE_t start,
-                  SIZE_t end) nogil except -1:
+    cdef int init(
+        self,
+        const DOUBLE_t[:, ::1] y,
+        const DOUBLE_t[:] sample_weight,
+        double weighted_n_samples,
+        SIZE_t* samples,
+        SIZE_t start,
+        SIZE_t end,
+    ) nogil except -1:
         """Placeholder for a method which will initialize the criterion.
 
         Returns -1 in case of failure to allocate memory (and raise MemoryError)
@@ -293,7 +299,6 @@ cdef class ClassificationCriterion(Criterion):
 
             # w is originally set to be 1.0, meaning that if no sample weights
             # are given, the default weight of each sample is 1.0.
-            # see: https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html#syntax
             if sample_weight is not None:
                 w = sample_weight[i]
 
@@ -633,9 +638,15 @@ cdef class RegressionCriterion(Criterion):
     def __reduce__(self):
         return (type(self), (self.n_outputs, self.n_samples), self.__getstate__())
 
-    cdef int init(self, const DOUBLE_t[:, ::1] y, const DOUBLE_t[:] sample_weight,
-                  double weighted_n_samples, SIZE_t* samples, SIZE_t start,
-                  SIZE_t end) nogil except -1:
+    cdef int init(
+        self,
+        const DOUBLE_t[:, ::1] y,
+        const DOUBLE_t[:] sample_weight,
+        double weighted_n_samples,
+        SIZE_t* samples,
+        SIZE_t start,
+        SIZE_t end,
+    ) nogil except -1:
         """Initialize the criterion.
 
         This initializes the criterion at node samples[start:end] and children
@@ -908,9 +919,15 @@ cdef class MAE(RegressionCriterion):
             self.left_child[k] = WeightedMedianCalculator(n_samples)
             self.right_child[k] = WeightedMedianCalculator(n_samples)
 
-    cdef int init(self, const DOUBLE_t[:, ::1] y, const DOUBLE_t[:] sample_weight ,
-                  double weighted_n_samples, SIZE_t* samples, SIZE_t start,
-                  SIZE_t end) nogil except -1:
+    cdef int init(
+        self,
+        const DOUBLE_t[:, ::1] y,
+        const DOUBLE_t[:] sample_weight,
+        double weighted_n_samples,
+        SIZE_t* samples,
+        SIZE_t start,
+        SIZE_t end,
+    ) nogil except -1:
         """Initialize the criterion.
 
         This initializes the criterion at node samples[start:end] and children

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -259,7 +259,7 @@ cdef class ClassificationCriterion(Criterion):
         y : array-like, dtype=DOUBLE_t
             The target stored as a buffer for memory efficiency
         sample_weight : array-like, dtype=DOUBLE_t
-            The weight of each sample stored as a buffer for memory efficiency.
+            The weight of each sample.
         weighted_n_samples : double
             The total weight of all samples
         samples : array-like, dtype=SIZE_t
@@ -292,8 +292,8 @@ cdef class ClassificationCriterion(Criterion):
 
             # w is originally set to be 1.0, meaning that if no sample weights
             # are given, the default weight of each sample is 1.0.
-            # see: https://stackoverflow.com/questions/63144139/how-to-check-whether-a-memmoryview-in-null-in-cython
-            if sample_weight != None:
+            # see: https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html#syntax
+            if sample_weight is not None:
                 w = sample_weight[i]
 
             # Count weighted class frequency for each target
@@ -376,7 +376,7 @@ cdef class ClassificationCriterion(Criterion):
             for p in range(pos, new_pos):
                 i = samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
@@ -390,7 +390,7 @@ cdef class ClassificationCriterion(Criterion):
             for p in range(end - 1, new_pos - 1, -1):
                 i = samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
@@ -662,7 +662,7 @@ cdef class RegressionCriterion(Criterion):
         for p in range(start, end):
             i = samples[p]
 
-            if sample_weight != None:
+            if sample_weight is not None:
                 w = sample_weight[i]
 
             for k in range(self.n_outputs):
@@ -722,7 +722,7 @@ cdef class RegressionCriterion(Criterion):
             for p in range(pos, new_pos):
                 i = samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
@@ -735,7 +735,7 @@ cdef class RegressionCriterion(Criterion):
             for p in range(end - 1, new_pos - 1, -1):
                 i = samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
@@ -844,7 +844,7 @@ cdef class MSE(RegressionCriterion):
         for p in range(start, pos):
             i = samples[p]
 
-            if sample_weight != None:
+            if sample_weight is not None:
                 w = sample_weight[i]
 
             for k in range(self.n_outputs):
@@ -941,7 +941,7 @@ cdef class MAE(RegressionCriterion):
         for p in range(start, end):
             i = samples[p]
 
-            if sample_weight != None:
+            if sample_weight is not None:
                 w = sample_weight[i]
 
             for k in range(self.n_outputs):
@@ -1044,7 +1044,7 @@ cdef class MAE(RegressionCriterion):
             for p in range(pos, new_pos):
                 i = samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
@@ -1060,7 +1060,7 @@ cdef class MAE(RegressionCriterion):
             for p in range(end - 1, new_pos - 1, -1):
                 i = samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 for k in range(self.n_outputs):
@@ -1098,7 +1098,7 @@ cdef class MAE(RegressionCriterion):
             for p in range(self.start, self.end):
                 i = samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 impurity += fabs(self.y[i, k] - self.node_medians[k]) * w
@@ -1133,7 +1133,7 @@ cdef class MAE(RegressionCriterion):
             for p in range(start, pos):
                 i = samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 impurity_left += fabs(self.y[i, k] - median) * w
@@ -1145,7 +1145,7 @@ cdef class MAE(RegressionCriterion):
             for p in range(pos, end):
                 i = samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 impurity_right += fabs(self.y[i, k] - median) * w
@@ -1331,7 +1331,7 @@ cdef class Poisson(RegressionCriterion):
             for p in range(start, end):
                 i = self.samples[p]
 
-                if sample_weight != None:
+                if sample_weight is not None:
                     w = sample_weight[i]
 
                 poisson_loss += w * xlogy(y[i, k], y[i, k] / y_mean)

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -19,7 +19,6 @@ from libc.math cimport fabs
 import numpy as np
 cimport numpy as cnp
 cnp.import_array()
-from cpython.ref cimport PyObject
 
 from numpy.math cimport INFINITY
 from scipy.special.cython_special cimport xlogy

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -51,10 +51,11 @@ cdef class Criterion:
 
         Parameters
         ----------
-        y : array-like, dtype=DOUBLE_t
+        y : ndarray, dtype=DOUBLE_t
             y is a buffer that can store values for n_outputs target variables
-        sample_weight : array-like, dtype=DOUBLE_t
-            The weight of each sample
+            stored as a Cython memoryview.
+        sample_weight : ndarray, dtype=DOUBLE_t
+            The weight of each sample stored as a Cython memoryview.
         weighted_n_samples : double
             The total weight of the samples being considered
         samples : array-like, dtype=SIZE_t
@@ -256,10 +257,10 @@ cdef class ClassificationCriterion(Criterion):
 
         Parameters
         ----------
-        y : array-like, dtype=DOUBLE_t
-            The target stored as a buffer for memory efficiency
-        sample_weight : array-like, dtype=DOUBLE_t
-            The weight of each sample.
+        y : ndarray, dtype=DOUBLE_t
+            The target stored as a buffer for memory efficiency.
+        sample_weight : ndarray, dtype=DOUBLE_t
+            The weight of each sample stored as a Cython memoryview.
         weighted_n_samples : double
             The total weight of all samples
         samples : array-like, dtype=SIZE_t

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -74,16 +74,26 @@ cdef class Splitter:
     # This allows optimization with depth-based tree building.
 
     # Methods
-    cdef int init(self, object X, const DOUBLE_t[:, ::1] y,
-                  const DOUBLE_t[:] sample_weight) except -1
+    cdef int init(
+        self,
+        object X,
+        const DOUBLE_t[:, ::1] y,
+        const DOUBLE_t[:] sample_weight
+    ) except -1
 
-    cdef int node_reset(self, SIZE_t start, SIZE_t end,
-                        double* weighted_n_node_samples) nogil except -1
+    cdef int node_reset(
+        self,
+        SIZE_t start,
+        SIZE_t end,
+        double* weighted_n_node_samples
+    ) nogil except -1
 
-    cdef int node_split(self,
-                        double impurity,   # Impurity of the node
-                        SplitRecord* split,
-                        SIZE_t* n_constant_features) nogil except -1
+    cdef int node_split(
+        self,
+        double impurity,   # Impurity of the node
+        SplitRecord* split,
+        SIZE_t* n_constant_features
+    ) nogil except -1
 
     cdef void node_value(self, double* dest) nogil
 

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -55,7 +55,7 @@ cdef class Splitter:
     cdef SIZE_t end                      # End position for the current node
 
     cdef const DOUBLE_t[:, ::1] y
-    cdef DOUBLE_t* sample_weight
+    cdef const DOUBLE_t[:] sample_weight
 
     # The samples vector `samples` is maintained by the Splitter object such
     # that the samples contained in a node are contiguous. With this setting,
@@ -75,7 +75,7 @@ cdef class Splitter:
 
     # Methods
     cdef int init(self, object X, const DOUBLE_t[:, ::1] y,
-                  DOUBLE_t* sample_weight) except -1
+                  const DOUBLE_t[:] sample_weight) except -1
 
     cdef int node_reset(self, SIZE_t start, SIZE_t end,
                         double* weighted_n_node_samples) nogil except -1

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -15,6 +15,7 @@ from ._criterion cimport Criterion
 
 from libc.stdlib cimport qsort
 from libc.string cimport memcpy
+from cpython.ref cimport PyObject
 
 import numpy as np
 
@@ -80,8 +81,6 @@ cdef class Splitter:
         self.n_samples = 0
         self.n_features = 0
 
-        self.sample_weight = NULL
-
         self.max_features = max_features
         self.min_samples_leaf = min_samples_leaf
         self.min_weight_leaf = min_weight_leaf
@@ -96,7 +95,7 @@ cdef class Splitter:
     cdef int init(self,
                    object X,
                    const DOUBLE_t[:, ::1] y,
-                   DOUBLE_t* sample_weight) except -1:
+                   const DOUBLE_t[:] sample_weight) except -1:
         """Initialize the splitter.
 
         Take in the input data X, the target Y, and optional sample weights.
@@ -112,7 +111,7 @@ cdef class Splitter:
         y : ndarray, dtype=DOUBLE_t
             This is the vector of targets, or true labels, for the samples
 
-        sample_weight : DOUBLE_t*
+        sample_weight : ndarray, dtype=DOUBLE_t
             The weights of the samples, where higher weighted samples are fit
             closer than lower weight samples. If not provided, all samples
             are assumed to have uniform weight.
@@ -132,11 +131,11 @@ cdef class Splitter:
 
         for i in range(n_samples):
             # Only work with positively weighted samples
-            if sample_weight == NULL or sample_weight[i] != 0.0:
+            if sample_weight == None or sample_weight[i] != 0.0:
                 samples[j] = i
                 j += 1
 
-            if sample_weight != NULL:
+            if sample_weight != None:
                 weighted_n_samples += sample_weight[i]
             else:
                 weighted_n_samples += 1.0
@@ -218,7 +217,7 @@ cdef class BaseDenseSplitter(Splitter):
     cdef int init(self,
                   object X,
                   const DOUBLE_t[:, ::1] y,
-                  DOUBLE_t* sample_weight) except -1:
+                  const DOUBLE_t[:] sample_weight) except -1:
         """Initialize the splitter
 
         Returns -1 in case of failure to allocate memory (and raise MemoryError)
@@ -762,7 +761,7 @@ cdef class BaseSparseSplitter(Splitter):
     cdef int init(self,
                   object X,
                   const DOUBLE_t[:, ::1] y,
-                  DOUBLE_t* sample_weight) except -1:
+                  const DOUBLE_t[:] sample_weight) except -1:
         """Initialize the splitter
 
         Returns -1 in case of failure to allocate memory (and raise MemoryError)

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -91,10 +91,12 @@ cdef class Splitter:
     def __setstate__(self, d):
         pass
 
-    cdef int init(self,
-                   object X,
-                   const DOUBLE_t[:, ::1] y,
-                   const DOUBLE_t[:] sample_weight) except -1:
+    cdef int init(
+        self,
+        object X,
+        const DOUBLE_t[:, ::1] y,
+        const DOUBLE_t[:] sample_weight
+    ) except -1:
         """Initialize the splitter.
 
         Take in the input data X, the target Y, and optional sample weights.
@@ -215,10 +217,12 @@ cdef class BaseDenseSplitter(Splitter):
 
     cdef SIZE_t n_total_samples
 
-    cdef int init(self,
-                  object X,
-                  const DOUBLE_t[:, ::1] y,
-                  const DOUBLE_t[:] sample_weight) except -1:
+    cdef int init(
+        self,
+        object X,
+        const DOUBLE_t[:, ::1] y,
+        const DOUBLE_t[:] sample_weight
+    ) except -1:
         """Initialize the splitter
 
         Returns -1 in case of failure to allocate memory (and raise MemoryError)
@@ -759,10 +763,12 @@ cdef class BaseSparseSplitter(Splitter):
         # Parent __cinit__ is automatically called
         self.n_total_samples = 0
 
-    cdef int init(self,
-                  object X,
-                  const DOUBLE_t[:, ::1] y,
-                  const DOUBLE_t[:] sample_weight) except -1:
+    cdef int init(
+        self,
+        object X,
+        const DOUBLE_t[:, ::1] y,
+        const DOUBLE_t[:] sample_weight
+    ) except -1:
         """Initialize the splitter
 
         Returns -1 in case of failure to allocate memory (and raise MemoryError)

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -108,12 +108,14 @@ cdef class Splitter:
             This contains the inputs. Usually it is a 2d numpy array.
 
         y : ndarray, dtype=DOUBLE_t
-            This is the vector of targets, or true labels, for the samples
+            This is the vector of targets, or true labels, for the samples represented
+            as a Cython memoryview.
 
         sample_weight : ndarray, dtype=DOUBLE_t
             The weights of the samples, where higher weighted samples are fit
             closer than lower weight samples. If not provided, all samples
-            are assumed to have uniform weight.
+            are assumed to have uniform weight. This is represented
+            as a Cython memoryview.
         """
 
         self.rand_r_state = self.random_state.randint(0, RAND_R_MAX)

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -130,11 +130,11 @@ cdef class Splitter:
 
         for i in range(n_samples):
             # Only work with positively weighted samples
-            if sample_weight == None or sample_weight[i] != 0.0:
+            if sample_weight is None or sample_weight[i] != 0.0:
                 samples[j] = i
                 j += 1
 
-            if sample_weight != None:
+            if sample_weight is not None:
                 weighted_n_samples += sample_weight[i]
             else:
                 weighted_n_samples += 1.0

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -15,7 +15,6 @@ from ._criterion cimport Criterion
 
 from libc.stdlib cimport qsort
 from libc.string cimport memcpy
-from cpython.ref cimport PyObject
 
 import numpy as np
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -151,10 +151,6 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
         # check input
         X, y, sample_weight = self._check_input(X, y, sample_weight)
 
-        cdef DOUBLE_t* sample_weight_ptr = NULL
-        if sample_weight is not None:
-            sample_weight_ptr = <DOUBLE_t*> sample_weight.data
-
         # Initial capacity
         cdef int init_capacity
 
@@ -174,7 +170,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
         cdef double min_impurity_decrease = self.min_impurity_decrease
 
         # Recursive partition (without actual recursion)
-        splitter.init(X, y, sample_weight_ptr)
+        splitter.init(X, y, sample_weight)
 
         cdef SIZE_t start
         cdef SIZE_t end
@@ -346,16 +342,12 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
         # check input
         X, y, sample_weight = self._check_input(X, y, sample_weight)
 
-        cdef DOUBLE_t* sample_weight_ptr = NULL
-        if sample_weight is not None:
-            sample_weight_ptr = <DOUBLE_t*> sample_weight.data
-
         # Parameters
         cdef Splitter splitter = self.splitter
         cdef SIZE_t max_leaf_nodes = self.max_leaf_nodes
 
         # Recursive partition (without actual recursion)
-        splitter.init(X, y, sample_weight_ptr)
+        splitter.init(X, y, sample_weight)
 
         cdef vector[FrontierRecord] frontier
         cdef FrontierRecord record


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes: #24987 

#### What does this implement/fix? Explain your changes.
Refactors all instances where `sample_weight` was a DOUBLE_t pointer to a Cython DOUBLE_t memoryview.

@jshinm will assist in running asv benchmarks to confirm that there is no performance regression once #24678 is merged and this is rebased on top of those changes.

Note that changing LOC `if sample_weight != NULL:` to `if sample_weight != None:` should not impact nogil performance. See this thread: https://stackoverflow.com/questions/63144139/how-to-check-whether-a-memmoryview-in-null-in-cython#comment131530483_63167895.

#### Any other comments?
This should be rebased and merged after #24678 is reviewed and merged.
