### PR TITLE
DOC Update "Parallelism, resource management, and configuration" section

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -189,15 +189,16 @@ in `this document from Thomas J. Fan <https://thomasjpfan.github.io/parallelism-
 Configuration switches
 -----------------------
 
-Python runtime
-..............
+Python API
+..........
 
-:func:`sklearn.set_config` controls the following behaviors.
+:func:`sklearn.set_config` and :func:`sklearn.config_context` can be used to change
+parameters of the configuration which control aspect of parallelism.
 
 .. _environment_variable:
 
 Environment variables
-......................
+.....................
 
 These environment variables should be set before importing scikit-learn.
 
@@ -297,3 +298,14 @@ float64 data.
 When this environment variable is set to a non zero value, the `Cython`
 derivative, `boundscheck` is set to `True`. This is useful for finding
 segfaults.
+
+`SKLEARN_PAIRWISE_DIST_CHUNK_SIZE`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This sets the size of chunk to be used by the underlying `PairwiseDistancesReductions`
+implementations. The default value is `256` which has been showed to be adequate on
+most machines.
+
+Users looking for the best performance might want to tune this variable using
+powers of 2 so as to get the best parallelism behavior for their hardware,
+especially with respect to their caches' sizes.

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -102,6 +102,7 @@ such as MKL, OpenBLAS or BLIS.
 
 You can control the exact number of threads used by BLAS for each library
 using environment variables, namely:
+
   - ``MKL_NUM_THREADS`` sets the number of thread MKL uses,
   - ``OPENBLAS_NUM_THREADS`` sets the number of threads OpenBLAS uses
   - ``BLIS_NUM_THREADS`` sets the number of threads BLIS uses

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -17,14 +17,17 @@ Depending on the type of estimator and sometimes the values of the
 constructor parameters, this is either done:
 
 - with higher-level parallelism via `joblib <https://joblib.readthedocs.io/en/latest/>`_.
-  In this case, the number of threads or processes can be controlled with the
-  ``n_jobs`` parameter.
 - with lower-level parallelism via OpenMP, used in C or Cython code.
-  In this case, parallelism is always done using threads and specifying
-  ``n_jobs`` *has no effect*. Implementations relying on this parallelism are generally
-  more performant than joblib-based implementations by up to two orders of magnitude.
 - with lower-level parallelism via BLAS, used by NumPy and SciPy for generic operations
   on arrays.
+
+The `n_jobs` parameters of estimators always controls the amount of parallelism
+managed by joblib (processes or threads depending on the joblib backend).
+The thread-level parallelism managed by OpenMP in scikit-learn's own Cython code
+or by BLAS & LAPACK libraries used by NumPy and SciPy operations used in scikit-learn
+is always controlled by environment variables or `threadpoolctl` as explained below.
+Note that some estimators can leverage all three kinds of parallelism at different
+points of their training and prediction methods.
 
 We describe these 3 types of parallelism in the following subsections in more details.
 

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -21,7 +21,7 @@ This can be either done:
 - with lower-level parallelism via OpenMP, used in C or Cython code.
   In this case, parallelism is always done using threads and specifying
   ``n_jobs`` *has no effect*. Implementations relying on this parallelism are generally
-  more performant by several orders of magnitude.
+  more performant than joblib-based implementations by up to two orders of magnitude.
 - with lower-level parallelism via BLAS, used by NumPy and SciPy for generic operations
   on arrays.
 

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -83,7 +83,7 @@ will use as many threads as possible, i.e. as many threads as logical cores.
 
 You can control the exact number of threads that are used either:
 
- - via the ``OMP_NUM_THREADS`` environment variable, e.g. for instance when:
+ - via the ``OMP_NUM_THREADS`` environment variable, for instance when:
    running a python script:
 
    .. prompt:: bash $

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -688,9 +688,12 @@ def pairwise_distances_argmin_min(
         values = values.flatten()
         indices = indices.flatten()
     else:
-        # TODO: once BaseDistanceReductionDispatcher supports distance metrics
-        # for boolean datasets, we won't need to fallback to
-        # pairwise_distances_chunked anymore.
+        # Joblib-based backend, which is used when user-defined callable
+        # are passed for metric.
+
+        # This won't be used in the future once PairwiseDistancesReductions support:
+        #   - DistanceMetrics which work on supposedly binary data
+        #   - CSR-dense and dense-CSR case if 'euclidean' in metric.
 
         # Turn off check for finiteness because this is costly and because arrays
         # have already been validated.
@@ -800,9 +803,12 @@ def pairwise_distances_argmin(X, Y, *, axis=1, metric="euclidean", metric_kwargs
         )
         indices = indices.flatten()
     else:
-        # TODO: once BaseDistanceReductionDispatcher supports distance metrics
-        # for boolean datasets, we won't need to fallback to
-        # pairwise_distances_chunked anymore.
+        # Joblib-based backend, which is used when user-defined callable
+        # are passed for metric.
+
+        # This won't be used in the future once PairwiseDistancesReductions support:
+        #   - DistanceMetrics which work on supposedly binary data
+        #   - CSR-dense and dense-CSR case if 'euclidean' in metric.
 
         # Turn off check for finiteness because this is costly and because arrays
         # have already been validated.

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -843,7 +843,7 @@ class KNeighborsMixin:
             # are passed for metric.
 
             # This won't be used in the future once PairwiseDistancesReductions
-            # supports:
+            # support:
             #   - DistanceMetrics which work on supposedly binary data
             #   - CSR-dense and dense-CSR case if 'euclidean' in metric.
             reduce_func = partial(
@@ -1181,7 +1181,7 @@ class RadiusNeighborsMixin:
             # are passed for metric.
 
             # This won't be used in the future once PairwiseDistancesReductions
-            # supports:
+            # support:
             #   - DistanceMetrics which work on supposedly binary data
             #   - CSR-dense and dense-CSR case if 'euclidean' in metric.
 

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -842,7 +842,8 @@ class KNeighborsMixin:
             # Joblib-based backend, which is used when user-defined callable
             # are passed for metric.
 
-            # This won't be used in the future once PairwiseDistancesReductions support:
+            # This won't be used in the future once PairwiseDistancesReductions
+            # supports:
             #   - DistanceMetrics which work on supposedly binary data
             #   - CSR-dense and dense-CSR case if 'euclidean' in metric.
             reduce_func = partial(
@@ -1179,7 +1180,8 @@ class RadiusNeighborsMixin:
             # Joblib-based backend, which is used when user-defined callable
             # are passed for metric.
 
-            # This won't be used in the future once PairwiseDistancesReductions support:
+            # This won't be used in the future once PairwiseDistancesReductions
+            # supports:
             #   - DistanceMetrics which work on supposedly binary data
             #   - CSR-dense and dense-CSR case if 'euclidean' in metric.
 

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -839,9 +839,12 @@ class KNeighborsMixin:
             )
 
         elif self._fit_method == "brute":
-            # TODO: should no longer be needed once ArgKmin
-            # is extended to accept sparse and/or float32 inputs.
+            # Joblib-based backend, which is used when user-defined callable
+            # are passed for metric.
 
+            # This won't be used in the future once PairwiseDistancesReductions support:
+            #   - DistanceMetrics which work on supposedly binary data
+            #   - CSR-dense and dense-CSR case if 'euclidean' in metric.
             reduce_func = partial(
                 self._kneighbors_reduce_func,
                 n_neighbors=n_neighbors,
@@ -1173,9 +1176,12 @@ class RadiusNeighborsMixin:
             )
 
         elif self._fit_method == "brute":
-            # TODO: should no longer be needed once we have Cython-optimized
-            # implementation for radius queries, with support for sparse and/or
-            # float32 inputs.
+            # Joblib-based backend, which is used when user-defined callable
+            # are passed for metric.
+
+            # This won't be used in the future once PairwiseDistancesReductions support:
+            #   - DistanceMetrics which work on supposedly binary data
+            #   - CSR-dense and dense-CSR case if 'euclidean' in metric.
 
             # for efficiency, use squared euclidean distances
             if self.effective_metric_ == "euclidean":


### PR DESCRIPTION
#### Reference Issues/PRs

Relates to #22587.

#### What does this implement/fix? Explain your changes.

Update this section of the documentation regarding latest changes, new back-ends introductions and `threadpoolctl`.

#### Any other comments?

I am thinking that it would be nice to have a list of implementations that are relying on OpenMP for parallelisation so that user which specific workflow can set appropriate values for environement variables.

Also, it would be nice to have a "label" in the documentation to know if interfaces have their implementations parallelized using `joblib` or `OpenMP`.

Note that interfaces backed by #22587 probably should have a comment in their docstrings to indicate cases where `n_jobs` do not apply anymore.

What do you think, @jeremiedbb, @thomasjpfan and @ogrisel?