### PR TITLE
MAINT Remove -Wmaybe-uninitialized warnings when compiling _fast_dict

### DIFF
--- a/sklearn/utils/_fast_dict.pyx
+++ b/sklearn/utils/_fast_dict.pyx
@@ -136,7 +136,7 @@ cdef class IntFloatDict:
 def argmin(IntFloatDict d):
     cdef cpp_map[ITYPE_t, DTYPE_t].iterator it = d.my_map.begin()
     cdef cpp_map[ITYPE_t, DTYPE_t].iterator end = d.my_map.end()
-    cdef ITYPE_t min_key
+    cdef ITYPE_t min_key = -1
     cdef DTYPE_t min_value = np.inf
     while it != end:
         if deref(it).second < min_value:


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #24875.

#### What does this implement/fix? Explain your changes.

`min_key` was uninitialized, and this raised a compilation warning.