### PR TITLE
modified docstrings to mention "greedy k-means++"

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -72,7 +72,7 @@ from ._k_means_elkan import elkan_iter_chunked_sparse
 def kmeans_plusplus(
     X, n_clusters, *, x_squared_norms=None, random_state=None, n_local_trials=None
 ):
-    """Init n_clusters seeds according to greedy k-means++ (default) or k-means++.
+    """Init n_clusters seeds according to k-means++.
 
     .. versionadded:: 0.24
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1176,9 +1176,9 @@ class KMeans(_BaseKMeans):
 
         'k-means++' : selects initial cluster centroids using sampling based on
         an empirical probability distribution of the points' contribution to the
-        overall inertia. This technique speeds up convergence. The algorithm 
+        overall inertia. This technique speeds up convergence. The algorithm
         implemented is "greedy k-means++". It differs from the vanilla k-means++
-        by making several trials at each sampling step and choosing the best centroid
+        by making several trials at each sampling step and choosing the bestcentroid
         among them.
 
         'random': choose `n_clusters` observations (rows) at random from data
@@ -1652,7 +1652,7 @@ class MiniBatchKMeans(_BaseKMeans):
 
         'k-means++' : selects initial cluster centroids using sampling based on
         an empirical probability distribution of the points' contribution to the
-        overall inertia. This technique speeds up convergence. The algorithm 
+        overall inertia. This technique speeds up convergence. The algorithm
         implemented is "greedy k-means++". It differs from the vanilla k-means++
         by making several trials at each sampling step and choosing the best centroid
         among them.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -72,7 +72,7 @@ from ._k_means_elkan import elkan_iter_chunked_sparse
 def kmeans_plusplus(
     X, n_clusters, *, x_squared_norms=None, random_state=None, n_local_trials=None
 ):
-    """Init n_clusters seeds according to k-means++.
+    """Init n_clusters seeds according to greedy k-means++ (default) or k-means++.
 
     .. versionadded:: 0.24
 
@@ -96,7 +96,8 @@ def kmeans_plusplus(
         The number of seeding trials for each center (except the first),
         of which the one reducing inertia the most is greedily chosen.
         Set to None to make the number of trials depend logarithmically
-        on the number of seeds (2+log(k)).
+        on the number of seeds (2+log(k)). Set to 1 to obtain the original
+        k-means++ algorithm. Set to > 1 (or None) to obtain greedy k-means++.
 
     Returns
     -------
@@ -1173,9 +1174,9 @@ class KMeans(_BaseKMeans):
 
         'k-means++' : selects initial cluster centroids using sampling based on
         an empirical probability distribution of the points' contribution to the
-        overall inertia. This technique speeds up convergence, and is
-        theoretically proven to be :math:`\\mathcal{O}(\\log k)`-optimal.
-        See the description of `n_init` for more details.
+        overall inertia. This technique speeds up convergence. The algorithm 
+        implemented is "greedy k-means++". It differs from the original k-means++
+        by making several trials at each sampling step and chosing the best centroid among them.
 
         'random': choose `n_clusters` observations (rows) at random from data
         for the initial centroids.
@@ -1648,9 +1649,9 @@ class MiniBatchKMeans(_BaseKMeans):
 
         'k-means++' : selects initial cluster centroids using sampling based on
         an empirical probability distribution of the points' contribution to the
-        overall inertia. This technique speeds up convergence, and is
-        theoretically proven to be :math:`\\mathcal{O}(\\log k)`-optimal.
-        See the description of `n_init` for more details.
+        overall inertia. This technique speeds up convergence. The algorithm 
+        implemented is "greedy k-means++". It differs from the original k-means++
+        by making several trials at each sampling step and chosing the best centroid among them.
 
         'random': choose `n_clusters` observations (rows) at random from data
         for the initial centroids.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -99,7 +99,7 @@ def kmeans_plusplus(
         on the number of seeds (2+log(k)) which is the recommend setting.
         Setting to 1 disables the greedy cluster selection and recovers the
         vanilla k-means++ algorithm which was empirically shown to work less
-        well than its greedy variant. 
+        well than its greedy variant.
 
     Returns
     -------

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -96,7 +96,7 @@ def kmeans_plusplus(
         The number of seeding trials for each center (except the first),
         of which the one reducing inertia the most is greedily chosen.
         Set to None to make the number of trials depend logarithmically
-        on the number of seeds (2+log(k)) which is the recommend setting.
+        on the number of seeds (2+log(k)) which is the recommended setting.
         Setting to 1 disables the greedy cluster selection and recovers the
         vanilla k-means++ algorithm which was empirically shown to work less
         well than its greedy variant.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1653,8 +1653,9 @@ class MiniBatchKMeans(_BaseKMeans):
         'k-means++' : selects initial cluster centroids using sampling based on
         an empirical probability distribution of the points' contribution to the
         overall inertia. This technique speeds up convergence. The algorithm 
-        implemented is "greedy k-means++". It differs from the original k-means++
-        by making several trials at each sampling step and chosing the best centroid among them.
+        implemented is "greedy k-means++". It differs from the vanilla k-means++
+        by making several trials at each sampling step and choosing the best centroid
+        among them.
 
         'random': choose `n_clusters` observations (rows) at random from data
         for the initial centroids.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1177,8 +1177,9 @@ class KMeans(_BaseKMeans):
         'k-means++' : selects initial cluster centroids using sampling based on
         an empirical probability distribution of the points' contribution to the
         overall inertia. This technique speeds up convergence. The algorithm 
-        implemented is "greedy k-means++". It differs from the original k-means++
-        by making several trials at each sampling step and chosing the best centroid among them.
+        implemented is "greedy k-means++". It differs from the vanilla k-means++
+        by making several trials at each sampling step and choosing the best centroid
+        among them.
 
         'random': choose `n_clusters` observations (rows) at random from data
         for the initial centroids.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -96,8 +96,10 @@ def kmeans_plusplus(
         The number of seeding trials for each center (except the first),
         of which the one reducing inertia the most is greedily chosen.
         Set to None to make the number of trials depend logarithmically
-        on the number of seeds (2+log(k)). Set to 1 to obtain the original
-        k-means++ algorithm. Set to > 1 (or None) to obtain greedy k-means++.
+        on the number of seeds (2+log(k)) which is the recommend setting.
+        Setting to 1 disables the greedy cluster selection and recovers the
+        vanilla k-means++ algorithm which was empirically shown to work less
+        well than its greedy variant. 
 
     Returns
     -------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #24973
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The class `sklearn.cluster.KMeans` with default setting `init='k-means++'` does not implement the original k-means++ algorithm but rather the variant "greedy k-means++" described in the same paper. For full details with code and paper references see #24973. "greedy k-means++" usually gives better results than the original k-means++ but lacks the theoretical guarantee proved for the original k-means++. The documentation (docstrings) of the function `kmeans_plusplus` and the classes `KMeans` and `MiniBatchKMeans` is adapted/corrected to reflect this.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
