### PR TITLE
[MAINT] Update conda-lock version and regenerate lock files

### DIFF
--- a/build_tools/azure/py38_conda_defaults_openblas_linux-64_conda.lock
+++ b/build_tools/azure/py38_conda_defaults_openblas_linux-64_conda.lock
@@ -48,7 +48,7 @@ https://repo.anaconda.com/pkgs/main/linux-64/libclang-10.0.1-default_hb85057a_2.
 https://repo.anaconda.com/pkgs/main/linux-64/libtiff-4.4.0-hecacb30_2.conda#debd52cb518dce3d4f48833cdc1032e4
 https://repo.anaconda.com/pkgs/main/linux-64/libxkbcommon-1.0.1-hfa300c1_0.conda#913e6c7c04026ff341960a9700889498
 https://repo.anaconda.com/pkgs/main/linux-64/libxslt-1.1.35-h4e12654_0.conda#328c111d87dccd5a3e471a691833f670
-https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.39.3-h5082296_0.conda#1fd3c10003776a5c0ebd14205327f541
+https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.40.0-h5082296_0.conda#d1300b056e728ea61a0bf135b035e60d
 https://repo.anaconda.com/pkgs/main/linux-64/fontconfig-2.13.1-hef1e5e3_1.conda#104cd6f83a6edd3e1fd662887f4bc215
 https://repo.anaconda.com/pkgs/main/linux-64/gst-plugins-base-1.14.0-h8213a91_2.conda#838648422452405b86699e780e293c1d
 https://repo.anaconda.com/pkgs/main/linux-64/lcms2-2.12-h3be6417_0.conda#719db47afba9f6586eecb5eacac70bff

--- a/build_tools/azure/py38_conda_forge_mkl_win-64_conda.lock
+++ b/build_tools/azure/py38_conda_forge_mkl_win-64_conda.lock
@@ -67,7 +67,7 @@ https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.ta
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
 https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2#076becd9e05608f8dc72757d5f3a91ff
 https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2#e8fbc1b54b25f4b08281467bc13b70cc
-https://conda.anaconda.org/conda-forge/noarch/setuptools-65.6.0-pyhd8ed1ab_0.conda#a78be949ee957032a2efeadec53e3d7d
+https://conda.anaconda.org/conda-forge/noarch/setuptools-65.5.1-pyhd8ed1ab_0.tar.bz2#cfb8dc4d9d285ca5fb1177b9dd450e33
 https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.1.0-pyh8a188c0_0.tar.bz2#a2995ee828f65687ac5b1e71a2ab1e0c
 https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f832c45a477c78bebd107098db465095

--- a/build_tools/azure/py38_conda_forge_openblas_ubuntu_2204_linux-64_conda.lock
+++ b/build_tools/azure/py38_conda_forge_openblas_ubuntu_2204_linux-64_conda.lock
@@ -101,7 +101,7 @@ https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b46
 https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2#e8fbc1b54b25f4b08281467bc13b70cc
 https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-4.19.18-py38h709712a_8.tar.bz2#11b72f5b1cc15427c89232321172a0bc
 https://conda.anaconda.org/conda-forge/noarch/pytz-2022.6-pyhd8ed1ab_0.tar.bz2#b1f26ad83328e486910ef7f6e81dc061
-https://conda.anaconda.org/conda-forge/noarch/setuptools-65.6.0-pyhd8ed1ab_0.conda#a78be949ee957032a2efeadec53e3d7d
+https://conda.anaconda.org/conda-forge/noarch/setuptools-65.5.1-pyhd8ed1ab_0.tar.bz2#cfb8dc4d9d285ca5fb1177b9dd450e33
 https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.1.0-pyh8a188c0_0.tar.bz2#a2995ee828f65687ac5b1e71a2ab1e0c
 https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2#5844808ffab9ebdb694585b50ba02a96
@@ -119,7 +119,7 @@ https://conda.anaconda.org/conda-forge/linux-64/scipy-1.9.3-py38h8ce737c_2.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/blas-2.116-openblas.tar.bz2#02f34bcf0aceb6fae4c4d1ecb71c852a
 https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.20.3-hd4edc92_2.tar.bz2#153cfb02fb8be7dd7cabcbcb58a63053
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.6.2-py38hb021067_0.tar.bz2#72422499195d8aded0dfd461c6e3e86f
-https://conda.anaconda.org/conda-forge/linux-64/pandas-1.5.1-py38h8f669ce_1.tar.bz2#75f37fc81d6513ba5db1e05301671a2e
+https://conda.anaconda.org/conda-forge/linux-64/pandas-1.5.2-py38h8f669ce_0.conda#dbc17622f9d159be987bd21959d5494e
 https://conda.anaconda.org/conda-forge/linux-64/pyamg-4.2.3-py38h4e30db6_2.tar.bz2#71e8ccc750d0e6e9a55c63bc39a4e5b8
 https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.0-pyhd8ed1ab_2.tar.bz2#ac82c7aebc282e6ac0450fca012ca78c
 https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.20.2-hcf0ee16_0.tar.bz2#79d7fca692d224dc29a72bda90f78a7b

--- a/build_tools/azure/pylatest_conda_forge_mkl_linux-64_conda.lock
+++ b/build_tools/azure/pylatest_conda_forge_mkl_linux-64_conda.lock
@@ -124,7 +124,7 @@ https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz
 https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2#e8fbc1b54b25f4b08281467bc13b70cc
 https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2#2a7de29fb590ca14b5243c4c812c8025
 https://conda.anaconda.org/conda-forge/noarch/pytz-2022.6-pyhd8ed1ab_0.tar.bz2#b1f26ad83328e486910ef7f6e81dc061
-https://conda.anaconda.org/conda-forge/noarch/setuptools-65.6.0-pyhd8ed1ab_0.conda#a78be949ee957032a2efeadec53e3d7d
+https://conda.anaconda.org/conda-forge/noarch/setuptools-65.5.1-pyhd8ed1ab_0.tar.bz2#cfb8dc4d9d285ca5fb1177b9dd450e33
 https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.1.0-pyh8a188c0_0.tar.bz2#a2995ee828f65687ac5b1e71a2ab1e0c
 https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f832c45a477c78bebd107098db465095

--- a/build_tools/azure/pylatest_conda_forge_mkl_no_coverage_linux-64_conda.lock
+++ b/build_tools/azure/pylatest_conda_forge_mkl_no_coverage_linux-64_conda.lock
@@ -120,7 +120,7 @@ https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2#7205635cd715
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
 https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2#e8fbc1b54b25f4b08281467bc13b70cc
 https://conda.anaconda.org/conda-forge/noarch/pytz-2022.6-pyhd8ed1ab_0.tar.bz2#b1f26ad83328e486910ef7f6e81dc061
-https://conda.anaconda.org/conda-forge/noarch/setuptools-65.6.0-pyhd8ed1ab_0.conda#a78be949ee957032a2efeadec53e3d7d
+https://conda.anaconda.org/conda-forge/noarch/setuptools-65.5.1-pyhd8ed1ab_0.tar.bz2#cfb8dc4d9d285ca5fb1177b9dd450e33
 https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.1.0-pyh8a188c0_0.tar.bz2#a2995ee828f65687ac5b1e71a2ab1e0c
 https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f832c45a477c78bebd107098db465095

--- a/build_tools/azure/pylatest_conda_forge_mkl_osx-64_conda.lock
+++ b/build_tools/azure/pylatest_conda_forge_mkl_osx-64_conda.lock
@@ -76,7 +76,7 @@ https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz
 https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2#e8fbc1b54b25f4b08281467bc13b70cc
 https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2#2a7de29fb590ca14b5243c4c812c8025
 https://conda.anaconda.org/conda-forge/noarch/pytz-2022.6-pyhd8ed1ab_0.tar.bz2#b1f26ad83328e486910ef7f6e81dc061
-https://conda.anaconda.org/conda-forge/noarch/setuptools-65.6.0-pyhd8ed1ab_0.conda#a78be949ee957032a2efeadec53e3d7d
+https://conda.anaconda.org/conda-forge/noarch/setuptools-65.5.1-pyhd8ed1ab_0.tar.bz2#cfb8dc4d9d285ca5fb1177b9dd450e33
 https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.1.0-pyh8a188c0_0.tar.bz2#a2995ee828f65687ac5b1e71a2ab1e0c
 https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2#f832c45a477c78bebd107098db465095
@@ -106,7 +106,7 @@ https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.0-pyhd8ed1ab_2.tar.bz2#
 https://conda.anaconda.org/conda-forge/osx-64/blas-devel-3.9.0-16_osx64_mkl.tar.bz2#2fb6331f94446754c896d1f11d3afa1c
 https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-14.0.6-hab78ec2_0.tar.bz2#4fdde3f4ed31722a1c811723f5db82f0
 https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.0.6-py311hd2070f0_0.tar.bz2#7aff06dca8dc89b96ba3b8caeb6dc2c9
-https://conda.anaconda.org/conda-forge/osx-64/pandas-1.5.1-py311hd84f3f5_1.tar.bz2#350619c6699839575eaf7fbf64d4199f
+https://conda.anaconda.org/conda-forge/osx-64/pandas-1.5.2-py311hd84f3f5_0.conda#c061bfc7a65e7b7a1757d2476056acc3
 https://conda.anaconda.org/conda-forge/noarch/pyopenssl-22.1.0-pyhd8ed1ab_0.tar.bz2#fbfa0a180d48c800f922a10a114a8632
 https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.0.0-pyhd8ed1ab_0.tar.bz2#c9e3f8bfdb9bfc34aa1836a6ed4b25d7
 https://conda.anaconda.org/conda-forge/noarch/pytest-forked-1.4.0-pyhd8ed1ab_1.tar.bz2#60958bab291681d9c3ba69e80f1434cf

--- a/build_tools/azure/pylatest_conda_mkl_no_openmp_osx-64_conda.lock
+++ b/build_tools/azure/pylatest_conda_mkl_no_openmp_osx-64_conda.lock
@@ -32,7 +32,7 @@ https://repo.anaconda.com/pkgs/main/osx-64/tk-8.6.12-h5d9f67b_0.conda#047f0af548
 https://repo.anaconda.com/pkgs/main/osx-64/brotli-bin-1.0.9-hca72f7f_7.conda#110bdca1a20710820e61f7fa3047f737
 https://repo.anaconda.com/pkgs/main/osx-64/freetype-2.12.1-hd8bbffd_0.conda#1f276af321375ee7fe8056843044fa76
 https://repo.anaconda.com/pkgs/main/osx-64/libgfortran-5.0.0-11_3_0_hecd8cb5_28.conda#2eb13b680803f1064e53873ae0aaafb3
-https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.39.3-h707629a_0.conda#7e44227c561267c7f514e5777dd54e55
+https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.40.0-h880c91c_0.conda#21b5dd3ef31a6b4daaafb7763170137b
 https://repo.anaconda.com/pkgs/main/osx-64/zstd-1.5.2-hcb37349_0.conda#d3ba225e3bc4285d8efd8cdfd7aa6112
 https://repo.anaconda.com/pkgs/main/osx-64/brotli-1.0.9-hca72f7f_7.conda#68e54d12ec67591deb2ffd70348fb00f
 https://repo.anaconda.com/pkgs/main/osx-64/libtiff-4.4.0-h2cd0358_2.conda#3ca4a08eea7fd9cd88453d35915693a3

--- a/build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock
+++ b/build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock
@@ -18,7 +18,7 @@ https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.conda#333e31
 https://repo.anaconda.com/pkgs/main/linux-64/ccache-3.7.9-hfe4627d_0.conda#bef6fc681c273bb7bd0c67d1a591365e
 https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.conda#be42180685cce6e6b0329201d9f48efb
 https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.conda#fa10ff4aa631fa4aa090a6234d7770b9
-https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.39.3-h5082296_0.conda#1fd3c10003776a5c0ebd14205327f541
+https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.40.0-h5082296_0.conda#d1300b056e728ea61a0bf135b035e60d
 https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.15-haa1d7c7_0.conda#dacae2189e4ec6083804b07b44f1a342
 https://repo.anaconda.com/pkgs/main/linux-64/certifi-2022.9.24-py39h06a4308_0.conda#1e3ca01764ce78e609ab61b8067734eb
 https://repo.anaconda.com/pkgs/main/noarch/wheel-0.37.1-pyhd3eb1b0_0.conda#ab85e96e26da8d5797c2458232338b86
@@ -73,7 +73,7 @@ https://repo.anaconda.com/pkgs/main/linux-64/pip-22.2.2-py39h06a4308_0.conda#cb9
 # pip scipy @ https://files.pythonhosted.org/packages/bb/b7/380c9e4cd71263f03d16f8a92c0e44c9bdef38777e1a7dde1f47ba996bac/scipy-1.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=c68db6b290cbd4049012990d7fe71a2abd9ffbe82c0056ebe0f01df8be5436b0
 # pip tifffile @ https://files.pythonhosted.org/packages/d2/cb/1ecf9f39113a7ad0529a0441a16982791e7b37a4efdba2f89a687fdf15c9/tifffile-2022.10.10-py3-none-any.whl#sha256=87f3aee8a0d06b74655269a105de75c1958a24653e1930d523eb516100043503
 # pip codecov @ https://files.pythonhosted.org/packages/dc/e2/964d0881eff5a67bf5ddaea79a13c7b34a74bc4efe917b368830b475a0b9/codecov-2.1.12-py2.py3-none-any.whl#sha256=585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47
-# pip pandas @ https://files.pythonhosted.org/packages/c9/80/207c30c09d0b650214f7826227d32236e3259e2ad2b8e0075b3feae4266c/pandas-1.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=b156a971bc451c68c9e1f97567c94fd44155f073e3bceb1b0d195fd98ed12048
+# pip pandas @ https://files.pythonhosted.org/packages/5e/ed/5c9cdaa5d48c7194bef4335eab3cdc2f8afa868a5546027e018ea9deb4c3/pandas-1.5.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=344021ed3e639e017b452aa8f5f6bf38a8806f5852e217a7594417fb9bbfa00e
 # pip pyamg @ https://files.pythonhosted.org/packages/8e/08/d512b6e34d502152723b5a4ad9d962a6141dfe83cd8bcd01af4cb6e84f28/pyamg-4.2.3-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl#sha256=18af99d2551df07951c35cf270dc76703f8c5d30b16ea8e61657fda098f57dd7
 # pip pytest @ https://files.pythonhosted.org/packages/67/68/a5eb36c3a8540594b6035e6cdae40c1ef1b6a2bfacbecc3d1a544583c078/pytest-7.2.0-py3-none-any.whl#sha256=892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71
 # pip scikit-image @ https://files.pythonhosted.org/packages/0f/29/d157cd648b87212e498189c183a32f0f48e24fe22e9673dacd97594f39fa/scikit_image-0.19.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=ff3b1025356508d41f4fe48528e509d95f9e4015e90cf158cd58c56dc63e0ac5

--- a/build_tools/azure/pylatest_pip_scipy_dev_linux-64_conda.lock
+++ b/build_tools/azure/pylatest_pip_scipy_dev_linux-64_conda.lock
@@ -20,7 +20,7 @@ https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.13-h5eee18b_0.conda#333e31
 https://repo.anaconda.com/pkgs/main/linux-64/ccache-3.7.9-hfe4627d_0.conda#bef6fc681c273bb7bd0c67d1a591365e
 https://repo.anaconda.com/pkgs/main/linux-64/readline-8.2-h5eee18b_0.conda#be42180685cce6e6b0329201d9f48efb
 https://repo.anaconda.com/pkgs/main/linux-64/tk-8.6.12-h1ccaba5_0.conda#fa10ff4aa631fa4aa090a6234d7770b9
-https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.39.3-h5082296_0.conda#1fd3c10003776a5c0ebd14205327f541
+https://repo.anaconda.com/pkgs/main/linux-64/sqlite-3.40.0-h5082296_0.conda#d1300b056e728ea61a0bf135b035e60d
 https://repo.anaconda.com/pkgs/main/linux-64/python-3.10.8-haa1d7c7_0.conda#f94e0ff0addc80d8746e04c6d9367012
 https://repo.anaconda.com/pkgs/main/linux-64/certifi-2022.9.24-py310h06a4308_0.conda#20f896f4142bbcf3f4e932082c40ee43
 https://repo.anaconda.com/pkgs/main/noarch/wheel-0.37.1-pyhd3eb1b0_0.conda#ab85e96e26da8d5797c2458232338b86

--- a/build_tools/azure/pypy3_linux-64_conda.lock
+++ b/build_tools/azure/pypy3_linux-64_conda.lock
@@ -72,7 +72,7 @@ https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2#
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
 https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2#e8fbc1b54b25f4b08281467bc13b70cc
 https://conda.anaconda.org/conda-forge/noarch/pypy-7.3.9-0_pypy39.tar.bz2#4f9efe821e2c2886da9c2fdc8b480738
-https://conda.anaconda.org/conda-forge/noarch/setuptools-65.6.0-pyhd8ed1ab_0.conda#a78be949ee957032a2efeadec53e3d7d
+https://conda.anaconda.org/conda-forge/noarch/setuptools-65.5.1-pyhd8ed1ab_0.tar.bz2#cfb8dc4d9d285ca5fb1177b9dd450e33
 https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.1.0-pyh8a188c0_0.tar.bz2#a2995ee828f65687ac5b1e71a2ab1e0c
 https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2#5844808ffab9ebdb694585b50ba02a96

--- a/build_tools/circle/py39_conda_forge_linux-aarch64_conda.lock
+++ b/build_tools/circle/py39_conda_forge_linux-aarch64_conda.lock
@@ -65,7 +65,7 @@ https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.0-h9b6de37_1.t
 https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2#7d301a0d25f424d96175f810935f0da9
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
 https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2#e8fbc1b54b25f4b08281467bc13b70cc
-https://conda.anaconda.org/conda-forge/noarch/setuptools-65.6.0-pyhd8ed1ab_0.conda#a78be949ee957032a2efeadec53e3d7d
+https://conda.anaconda.org/conda-forge/noarch/setuptools-65.5.1-pyhd8ed1ab_0.tar.bz2#cfb8dc4d9d285ca5fb1177b9dd450e33
 https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.1.0-pyh8a188c0_0.tar.bz2#a2995ee828f65687ac5b1e71a2ab1e0c
 https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2#5844808ffab9ebdb694585b50ba02a96

--- a/build_tools/github/doc_linux-64_conda.lock
+++ b/build_tools/github/doc_linux-64_conda.lock
@@ -155,7 +155,7 @@ https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-4.19.18-py39he80948d_8
 https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2#2a7de29fb590ca14b5243c4c812c8025
 https://conda.anaconda.org/conda-forge/noarch/pytz-2022.6-pyhd8ed1ab_0.tar.bz2#b1f26ad83328e486910ef7f6e81dc061
 https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0-py39hb9d737c_5.tar.bz2#ef9db3c38ae7275f6b14491cfe61a248
-https://conda.anaconda.org/conda-forge/noarch/setuptools-65.6.0-pyhd8ed1ab_0.conda#a78be949ee957032a2efeadec53e3d7d
+https://conda.anaconda.org/conda-forge/noarch/setuptools-65.5.1-pyhd8ed1ab_0.tar.bz2#cfb8dc4d9d285ca5fb1177b9dd450e33
 https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2#e5f25f8dbc060e9a8d912e432202afc2
 https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2#4d22a9315e78c6827f806065957d566e
 https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.2-py_0.tar.bz2#20b2eaeaeea4ef9a9a0d99770620fd09
@@ -232,4 +232,4 @@ https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.12.3-py39hf3d152e_8.tar.b
 https://conda.anaconda.org/conda-forge/noarch/sphinx-gallery-0.11.1-pyhd8ed1ab_0.tar.bz2#729254314a5d178eefca50acbc2687b8
 https://conda.anaconda.org/conda-forge/noarch/sphinx-prompt-1.4.0-pyhd8ed1ab_0.tar.bz2#88ee91e8679603f2a5bd036d52919cc2
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.6.2-py39hf3d152e_0.tar.bz2#03225b4745d1dee7bb19d81e41c773a0
-# pip sphinxext-opengraph @ https://files.pythonhosted.org/packages/04/59/47649f66430592a59e09042b5ffa8a810b64232cf3701b87b89c4b910d33/sphinxext_opengraph-0.7.2-py3-none-any.whl#sha256=7a33e13a1e1d6afa66744c24d1f5aabdde77ba70018403f9137a2d8dbe958c24
+# pip sphinxext-opengraph @ https://files.pythonhosted.org/packages/d0/74/196f5da691be83ab02f8e9bd2c8acc2a3b0712da0a871f4aa2b7a023f90f/sphinxext_opengraph-0.7.3-py3-none-any.whl#sha256=edbfb21f1d31f572fc87a6ccc347cac502a3b8bb04c312bc2fa4888542f8505d

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -51,7 +51,7 @@ dependent_packages = {
     "plotly": ("5.10.0", "docs, examples"),
     # XXX: Pin conda-lock to the latest released version (needs manual update
     # from time to time)
-    "conda-lock": ("1.1.3", "maintenance"),
+    "conda-lock": ("1.2.1", "maintenance"),
 }
 
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This updates the conda-lock version to the latest released version and regenerates the lock files.

Somehow there are some changes in the packages, either more recent (an update since yesterday and #25002?) or an older version (setuptools for example not sure why). I don't think this is an issue.

