### PR TITLE
CI Correctly define configuration for flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,17 +31,28 @@ max-line-length = 88
 target-version = ['py37']
 # Default flake8 3.5 ignored flags
 ignore=
-    E24,   # check ignored by default in flake8. Meaning unclear.
-    E121,  # continuation line under-indented
-    E123,  # closing bracket does not match indentation
-    E126,  # continuation line over-indented for hanging indent
-    E203,  # space before : (needed for how black formats slicing)
-    E226,  # missing whitespace around arithmetic operator
-    E704,  # multiple statements on one line (def)
-    E731,  # do not assign a lambda expression, use a def
-    E741,  # do not use variables named 'l', 'O', or 'I'
-    W503,  # line break before binary operator
-    W504   # line break after binary operator
+    # check ignored by default in flake8. Meaning unclear.
+    E24,
+    # continuation line under-indented
+    E121,
+    # closing bracket does not match indentation
+    E123,
+    # continuation line over-indented for hanging indent
+    E126,
+    # space before : (needed for how black formats slicing)
+    E203,
+    # missing whitespace around arithmetic operator
+    E226,
+    # multiple statements on one line (def)
+    E704,
+    # do not assign a lambda expression, use a def
+    E731,
+    # do not use variables named 'l', 'O', or 'I'
+    E741,
+    # line break before binary operator
+    W503,
+    # line break after binary operator
+    W504
 exclude=
     .git,
     __pycache__,


### PR DESCRIPTION
This PR fixes the linting issue in CI in flake8.

According to the [flake8 docs](https://flake8.pycqa.org/en/latest/user/configuration.html), we were incorrect placing comments inline.