### PR TITLE
ENH Improves error message for mixed types for feature names

### DIFF
--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -651,8 +651,9 @@ def test_feature_names_in():
     df_mixed = pd.DataFrame(X_np, columns=["a", "b", 1, 2])
     trans = NoOpTransformer()
     msg = re.escape(
-        "Feature names only support names that are all strings. "
-        "Got feature names with dtypes: ['int', 'str']"
+        "Feature names only support column names that are all strings, but got dtypes:"
+        " ['int', 'str']. If you want support for feature names, convert the"
+        " columns to strings."
     )
     with pytest.raises(TypeError, match=msg):
         trans.fit(df_mixed)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -654,9 +654,8 @@ def test_feature_names_in():
         "Feature names are only supported if all input features have string names, "
         "but your input has ['int', 'str'] as feature name / column name types. "
         "If you want feature names to be stored and validated, you must convert "
-        "them all to strings. If you'd like to silence this warning, you can "
-        "remove the feature / column names from your input data, or convert them "
-        "all to a non-string data type."
+        "them all to strings, by using X.columns = X.columns.astype(str) for "
+        "example."
     )
     with pytest.raises(TypeError, match=msg):
         trans.fit(df_mixed)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -653,7 +653,7 @@ def test_feature_names_in():
     msg = re.escape(
         "Feature names only support column names that are all strings, but got dtypes:"
         " ['int', 'str']. If you want support for feature names, convert the"
-        " columns to strings."
+        " column names to strings."
     )
     with pytest.raises(TypeError, match=msg):
         trans.fit(df_mixed)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -655,7 +655,8 @@ def test_feature_names_in():
         "but your input has ['int', 'str'] as feature name / column name types. "
         "If you want feature names to be stored and validated, you must convert "
         "them all to strings, by using X.columns = X.columns.astype(str) for "
-        "example."
+        "example. Otherwise you can remove feature / column names from your input "
+        "data, or convert them all to a non-string data type."
     )
     with pytest.raises(TypeError, match=msg):
         trans.fit(df_mixed)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -651,9 +651,12 @@ def test_feature_names_in():
     df_mixed = pd.DataFrame(X_np, columns=["a", "b", 1, 2])
     trans = NoOpTransformer()
     msg = re.escape(
-        "Feature names only support column names that are all strings, but got dtypes:"
-        " ['int', 'str']. If you want support for feature names, convert the"
-        " column names to strings."
+        "Feature names are only supported if all input features have string names, "
+        "but your input has ['int', 'str'] as feature name / column name types. "
+        "If you want feature names to be stored and validated, you must convert "
+        "them all to strings. If you'd like to silence this warning, you can "
+        "remove the feature / column names from your input data, or convert them "
+        "all to a non-string data type."
     )
     with pytest.raises(TypeError, match=msg):
         trans.fit(df_mixed)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1675,9 +1675,12 @@ def test_get_feature_names_invalid_dtypes(names, dtypes):
     X = pd.DataFrame([[1, 2], [4, 5], [5, 6]], columns=names)
 
     msg = re.escape(
-        "Feature names only support column names that are all strings, but got dtypes:"
-        f" {dtypes}. If you want support for feature names, convert the"
-        " column names to strings."
+        "Feature names are only supported if all input features have string names, "
+        f"but your input has {dtypes} as feature name / column name types. "
+        "If you want feature names to be stored and validated, you must convert "
+        "them all to strings. If you'd like to silence this warning, you can "
+        "remove the feature / column names from your input data, or convert them "
+        "all to a non-string data type."
     )
     with pytest.raises(TypeError, match=msg):
         names = _get_feature_names(X)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1675,9 +1675,9 @@ def test_get_feature_names_invalid_dtypes(names, dtypes):
     X = pd.DataFrame([[1, 2], [4, 5], [5, 6]], columns=names)
 
     msg = re.escape(
-        "Feature names only support names that are all strings. Got feature names with"
-        f" dtypes: {dtypes}. Please convert to a common type, for example using"
-        " X.columns = X.columns.astype(str)"
+        "Feature names only support column names that are all strings, but got dtypes:"
+        f" {dtypes}. If you want support for feature names, convert the"
+        " columns to strings."
     )
     with pytest.raises(TypeError, match=msg):
         names = _get_feature_names(X)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1679,7 +1679,8 @@ def test_get_feature_names_invalid_dtypes(names, dtypes):
         f"but your input has {dtypes} as feature name / column name types. "
         "If you want feature names to be stored and validated, you must convert "
         "them all to strings, by using X.columns = X.columns.astype(str) for "
-        "example."
+        "example. Otherwise you can remove feature / column names from your input "
+        "data, or convert them all to a non-string data type."
     )
     with pytest.raises(TypeError, match=msg):
         names = _get_feature_names(X)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1678,9 +1678,8 @@ def test_get_feature_names_invalid_dtypes(names, dtypes):
         "Feature names are only supported if all input features have string names, "
         f"but your input has {dtypes} as feature name / column name types. "
         "If you want feature names to be stored and validated, you must convert "
-        "them all to strings. If you'd like to silence this warning, you can "
-        "remove the feature / column names from your input data, or convert them "
-        "all to a non-string data type."
+        "them all to strings, by using X.columns = X.columns.astype(str) for "
+        "example."
     )
     with pytest.raises(TypeError, match=msg):
         names = _get_feature_names(X)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1675,8 +1675,9 @@ def test_get_feature_names_invalid_dtypes(names, dtypes):
     X = pd.DataFrame([[1, 2], [4, 5], [5, 6]], columns=names)
 
     msg = re.escape(
-        "Feature names only support names that are all strings. "
-        f"Got feature names with dtypes: {dtypes}."
+        "Feature names only support names that are all strings. Got feature names with"
+        f" dtypes: {dtypes}. Please convert to a common type, for example using"
+        " X.columns = X.columns.astype(str)"
     )
     with pytest.raises(TypeError, match=msg):
         names = _get_feature_names(X)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1677,7 +1677,7 @@ def test_get_feature_names_invalid_dtypes(names, dtypes):
     msg = re.escape(
         "Feature names only support column names that are all strings, but got dtypes:"
         f" {dtypes}. If you want support for feature names, convert the"
-        " columns to strings."
+        " column names to strings."
     )
     with pytest.raises(TypeError, match=msg):
         names = _get_feature_names(X)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1886,7 +1886,7 @@ def _get_feature_names(X):
         raise TypeError(
             "Feature names only support column names that are all strings, but got"
             f" dtypes: {types}. If you want support for feature names, convert the"
-            " columns to strings. For example, by using X.columns ="
+            " column names to strings. For example, by using X.columns ="
             " X.columns.astype(str)."
         )
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1884,8 +1884,9 @@ def _get_feature_names(X):
     # mixed type of string and non-string is not supported
     if len(types) > 1 and "str" in types:
         raise TypeError(
-            "Feature names only support names that are all strings. "
-            f"Got feature names with dtypes: {types}."
+            "Feature names only support names that are all strings. Got feature names"
+            f" with dtypes: {types}. Please convert to a common type, for example using"
+            " X.columns = X.columns.astype(str)"
         )
 
     # Only feature names of all strings are supported

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1888,7 +1888,8 @@ def _get_feature_names(X):
             f"but your input has {types} as feature name / column name types. "
             "If you want feature names to be stored and validated, you must convert "
             "them all to strings, by using X.columns = X.columns.astype(str) for "
-            "example."
+            "example. Otherwise you can remove feature / column names from your input "
+            "data, or convert them all to a non-string data type."
         )
 
     # Only feature names of all strings are supported

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1884,9 +1884,10 @@ def _get_feature_names(X):
     # mixed type of string and non-string is not supported
     if len(types) > 1 and "str" in types:
         raise TypeError(
-            "Feature names only support names that are all strings. Got feature names"
-            f" with dtypes: {types}. Please convert to a common type, for example using"
-            " X.columns = X.columns.astype(str)"
+            "Feature names only support column names that are all strings, but got"
+            f" dtypes: {types}. If you want support for feature names, convert the"
+            " columns to strings. For example, by using X.columns ="
+            " X.columns.astype(str)."
         )
 
     # Only feature names of all strings are supported

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1887,9 +1887,8 @@ def _get_feature_names(X):
             "Feature names are only supported if all input features have string names, "
             f"but your input has {types} as feature name / column name types. "
             "If you want feature names to be stored and validated, you must convert "
-            "them all to strings. If you'd like to silence this warning, you can "
-            "remove the feature / column names from your input data, or convert them "
-            "all to a non-string data type."
+            "them all to strings, by using X.columns = X.columns.astype(str) for "
+            "example."
         )
 
     # Only feature names of all strings are supported

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1884,10 +1884,12 @@ def _get_feature_names(X):
     # mixed type of string and non-string is not supported
     if len(types) > 1 and "str" in types:
         raise TypeError(
-            "Feature names only support column names that are all strings, but got"
-            f" dtypes: {types}. If you want support for feature names, convert the"
-            " column names to strings. For example, by using X.columns ="
-            " X.columns.astype(str)."
+            "Feature names are only supported if all input features have string names, "
+            f"but your input has {types} as feature name / column name types. "
+            "If you want feature names to be stored and validated, you must convert "
+            "them all to strings. If you'd like to silence this warning, you can "
+            "remove the feature / column names from your input data, or convert them "
+            "all to a non-string data type."
         )
 
     # Only feature names of all strings are supported


### PR DESCRIPTION
This PR improves the error message for feature names that have mixed dtypes. This was issue was raised in https://gitter.im/scikit-learn/dev by @amueller