### PR TITLE
DOC use https links when possible

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -32,7 +32,7 @@ and maintenance:
 
 Please do not email the authors directly to ask for assistance or report issues.
 Instead, please see `What's the best way to ask questions about scikit-learn
-<http://scikit-learn.org/stable/faq.html#what-s-the-best-way-to-get-help-on-scikit-learn-usage>`_
+<https://scikit-learn.org/stable/faq.html#what-s-the-best-way-to-get-help-on-scikit-learn-usage>`_
 in the FAQ.
 
 .. seealso::
@@ -83,7 +83,7 @@ If you use scikit-learn in a scientific publication, we would appreciate
 citations to the following paper:
 
   `Scikit-learn: Machine Learning in Python
-  <http://jmlr.csail.mit.edu/papers/v12/pedregosa11a.html>`_, Pedregosa
+  <https://jmlr.csail.mit.edu/papers/v12/pedregosa11a.html>`_, Pedregosa
   *et al.*, JMLR 12, pp. 2825-2830, 2011.
 
   Bibtex entry::

--- a/doc/computing/computational_performance.rst
+++ b/doc/computing/computational_performance.rst
@@ -290,7 +290,7 @@ Optimized BLAS / LAPACK implementations include:
 
 More information can be found on the `NumPy install page <https://numpy.org/install/>`_
 and in this
-`blog post <http://danielnouri.org/notes/2012/12/19/libblas-and-liblapack-issues-and-speed,-with-scipy-and-ubuntu/>`_
+`blog post <https://danielnouri.org/notes/2012/12/19/libblas-and-liblapack-issues-and-speed,-with-scipy-and-ubuntu/>`_
 from Daniel Nouri which has some nice step by step install instructions for
 Debian / Ubuntu.
 

--- a/doc/developers/bug_triaging.rst
+++ b/doc/developers/bug_triaging.rst
@@ -40,7 +40,7 @@ The following actions are typically useful:
 
    Overall, it is useful to stay positive and assume good will. `The
    following article
-   <http://gael-varoquaux.info/programming/technical-discussions-are-hard-a-few-tips.html>`_
+   <https://gael-varoquaux.info/programming/technical-discussions-are-hard-a-few-tips.html>`_
    explores how to lead online discussions in the context of open source.
 
 Working on PRs to help review

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -126,7 +126,7 @@ following rules before submitting:
 -  If you are submitting an algorithm or feature request, please verify that
    the algorithm fulfills our
    `new algorithm requirements
-   <http://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new-algorithms>`_.
+   <https://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new-algorithms>`_.
 
 -  If you are submitting a bug report, we strongly encourage you to follow the guidelines in
    :ref:`filing_bugs`.

--- a/doc/developers/maintainer.rst
+++ b/doc/developers/maintainer.rst
@@ -332,7 +332,7 @@ Before merging,
 The scikit-learn.org web site
 -----------------------------
 
-The scikit-learn web site (http://scikit-learn.org) is hosted at GitHub,
+The scikit-learn web site (https://scikit-learn.org) is hosted at GitHub,
 but should rarely be updated manually by pushing to the
 https://github.com/scikit-learn/scikit-learn.github.io repository. Most
 updates can be made by pushing to master (for /dev) or a release branch

--- a/doc/developers/performance.rst
+++ b/doc/developers/performance.rst
@@ -335,8 +335,8 @@ TODO: html report, type declarations, bound checks, division by zero checks,
 memory alignment, direct blas calls...
 
 - https://www.youtube.com/watch?v=gMvkiQ-gOW8
-- http://conference.scipy.org/proceedings/SciPy2009/paper_1/
-- http://conference.scipy.org/proceedings/SciPy2009/paper_2/
+- https://conference.scipy.org/proceedings/SciPy2009/paper_1/
+- https://conference.scipy.org/proceedings/SciPy2009/paper_2/
 
 Using OpenMP
 ------------
@@ -383,7 +383,7 @@ Using yep and gperftools
 Easy profiling without special compilation options use yep:
 
 - https://pypi.org/project/yep/
-- http://fa.bianp.net/blog/2011/a-profiler-for-python-extensions
+- https://fa.bianp.net/blog/2011/a-profiler-for-python-extensions
 
 Using gprof
 -----------

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -180,7 +180,7 @@ Issue/Comment: Linking to comments
 PR-NEW: Better description and title
     ::
 
-        Thanks for the pull request! Please make the title of the PR more descriptive. The title will become the commit message when this is merged. You should state what issue (or PR) it fixes/resolves in the description using the syntax described [here](http://scikit-learn.org/dev/developers/contributing.html#contributing-pull-requests).
+        Thanks for the pull request! Please make the title of the PR more descriptive. The title will become the commit message when this is merged. You should state what issue (or PR) it fixes/resolves in the description using the syntax described [here](https://scikit-learn.org/dev/developers/contributing.html#contributing-pull-requests).
 
 PR-NEW: Fix #
     ::
@@ -190,7 +190,7 @@ PR-NEW: Fix #
 PR-NEW or Issue: Maintenance cost
     ::
 
-        Every feature we include has a [maintenance cost](http://scikit-learn.org/dev/faq.html#why-are-you-so-selective-on-what-algorithms-you-include-in-scikit-learn). Our maintainers are mostly volunteers. For a new feature to be included, we need evidence that it is often useful and, ideally, [well-established](http://scikit-learn.org/dev/faq.html#what-are-the-inclusion-criteria-for-new-algorithms) in the literature or in practice. Also, we expect PR authors to take part in the maintenance for the code they submit, at least initially. That doesn't stop you implementing it for yourself and publishing it in a separate repository, or even [scikit-learn-contrib](https://scikit-learn-contrib.github.io).
+        Every feature we include has a [maintenance cost](https://scikit-learn.org/dev/faq.html#why-are-you-so-selective-on-what-algorithms-you-include-in-scikit-learn). Our maintainers are mostly volunteers. For a new feature to be included, we need evidence that it is often useful and, ideally, [well-established](https://scikit-learn.org/dev/faq.html#what-are-the-inclusion-criteria-for-new-algorithms) in the literature or in practice. Also, we expect PR authors to take part in the maintenance for the code they submit, at least initially. That doesn't stop you implementing it for yourself and publishing it in a separate repository, or even [scikit-learn-contrib](https://scikit-learn-contrib.github.io).
 
 PR-WIP: What's needed before merge?
     ::
@@ -210,7 +210,7 @@ PR-WIP: PEP8
 PR-MRG: Patience
     ::
 
-        Before merging, we generally require two core developers to agree that your pull request is desirable and ready. [Please be patient](http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention), as we mostly rely on volunteered time from busy core developers. (You are also welcome to help us out with [reviewing other PRs](http://scikit-learn.org/dev/developers/contributing.html#code-review-guidelines).)
+        Before merging, we generally require two core developers to agree that your pull request is desirable and ready. [Please be patient](https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention), as we mostly rely on volunteered time from busy core developers. (You are also welcome to help us out with [reviewing other PRs](https://scikit-learn.org/dev/developers/contributing.html#code-review-guidelines).)
 
 PR-MRG: Add to what's new
     ::
@@ -258,7 +258,7 @@ code. Follow these steps:
 
   valgrind -v --suppressions=valgrind-python.supp python my_test_script.py
 
-.. _valgrind: http://valgrind.org
+.. _valgrind: https://valgrind.org
 .. _`README.valgrind`: https://github.com/python/cpython/blob/master/Misc/README.valgrind
 .. _`valgrind-python.supp`: https://github.com/python/cpython/blob/master/Misc/valgrind-python.supp
 
@@ -270,7 +270,7 @@ corresponding location in your .pyx source file. Hopefully the output will
 give you clues as to the source of your memory error.
 
 For more information on valgrind and the array of options it has, see the
-tutorials and documentation on the `valgrind web site <http://valgrind.org>`_.
+tutorials and documentation on the `valgrind web site <https://valgrind.org>`_.
 
 .. _arm64_dev_env:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -247,7 +247,7 @@ NetBSD
 scikit-learn is available via `pkgsrc-wip
 <http://pkgsrc-wip.sourceforge.net/>`_:
 
-    http://pkgsrc.se/math/py-scikit-learn
+    https://pkgsrc.se/math/py-scikit-learn
 
 
 MacPorts for Mac OSX

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -99,7 +99,7 @@ For reproducibility and quality control needs, when different architectures
 and environments should be taken into account, exporting the model in
 `Open Neural Network
 Exchange <https://onnx.ai/>`_ format or `Predictive Model Markup Language
-(PMML) <http://dmg.org/pmml/v4-4-1/GeneralStructure.html>`_ format
+(PMML) <https://dmg.org/pmml/v4-4-1/GeneralStructure.html>`_ format
 might be a better approach than using `pickle` alone.
 These are helpful where you may want to use your model for prediction in a
 different environment from where the model was trained.

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1479,7 +1479,7 @@ more broadly common names.
  .. [VEB2010] Vinh, Epps, and Bailey, (2010). "Information Theoretic Measures for
    Clusterings Comparison: Variants, Properties, Normalization and
    Correction for Chance". JMLR
-   <http://jmlr.csail.mit.edu/papers/volume11/vinh10a/vinh10a.pdf>
+   <https://jmlr.csail.mit.edu/papers/volume11/vinh10a/vinh10a.pdf>
 
  .. [YAT2016] Yang, Algesheimer, and Tessone, (2016). "A comparative analysis of
    community

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -445,7 +445,7 @@ fold cross validation should be preferred to LOO.
  * T. Hastie, R. Tibshirani, J. Friedman,  `The Elements of Statistical Learning
    <https://web.stanford.edu/~hastie/ElemStatLearn/>`_, Springer 2009
  * L. Breiman, P. Spector `Submodel selection and evaluation in regression: The X-random case
-   <http://digitalassets.lib.berkeley.edu/sdtr/ucb/text/197.pdf>`_, International Statistical Review 1992;
+   <https://digitalassets.lib.berkeley.edu/sdtr/ucb/text/197.pdf>`_, International Statistical Review 1992;
  * R. Kohavi, `A Study of Cross-Validation and Bootstrap for Accuracy Estimation and Model Selection
    <https://www.ijcai.org/Proceedings/95-2/Papers/016.pdf>`_, Intl. Jnt. Conf. AI
  * R. Bharat Rao, G. Fung, R. Rosales, `On the Dangers of Cross-Validation. An Experimental Evaluation

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -951,7 +951,7 @@ is not readily available from the start, or when the data does not fit into memo
       D. Lee, S. Seung, 1999
 
     .. [2] `"Non-negative Matrix Factorization with Sparseness Constraints"
-      <http://www.jmlr.org/papers/volume5/hoyer04a/hoyer04a.pdf>`_
+      <https://www.jmlr.org/papers/volume5/hoyer04a/hoyer04a.pdf>`_
       P. Hoyer, 2004
 
     .. [4] `"SVD based initialization: A head start for nonnegative
@@ -1069,7 +1069,7 @@ when data can be fetched sequentially.
 .. topic:: References:
 
     * `"Latent Dirichlet Allocation"
-      <http://www.jmlr.org/papers/volume3/blei03a/blei03a.pdf>`_
+      <https://www.jmlr.org/papers/volume3/blei03a/blei03a.pdf>`_
       D. Blei, A. Ng, M. Jordan, 2003
 
     * `"Online Learning for Latent Dirichlet Allocation”

--- a/doc/modules/kernel_approximation.rst
+++ b/doc/modules/kernel_approximation.rst
@@ -239,7 +239,7 @@ or store training examples.
     .. [LS2010] `"Random Fourier approximations for skewed multiplicative histogram kernels"
       <https://www.researchgate.net/publication/221114584_Random_Fourier_Approximations_for_Skewed_Multiplicative_Histogram_Kernels>`_
       Li, F., Ionescu, C., and Sminchisescu, C.
-      - Pattern Recognition,  DAGM 2010, Lecture Notes in Computer Science. 
+      - Pattern Recognition,  DAGM 2010, Lecture Notes in Computer Science.
     .. [VZ2010] `"Efficient additive kernels via explicit feature maps"
       <https://www.robots.ox.ac.uk/~vgg/publications/2011/Vedaldi11/vedaldi11.pdf>`_
       Vedaldi, A. and Zisserman, A. - Computer Vision and Pattern Recognition 2010
@@ -250,7 +250,7 @@ or store training examples.
       <10.1145/2487575.2487591>`
       Pham, N., & Pagh, R. - 2013
     .. [CCF2002] `"Finding frequent items in data streams"
-      <http://www.cs.princeton.edu/courses/archive/spring04/cos598B/bib/CharikarCF.pdf>`_
+      <https://www.cs.princeton.edu/courses/archive/spring04/cos598B/bib/CharikarCF.pdf>`_
       Charikar, M., Chen, K., & Farach-Colton - 2002
     .. [WIKICS] `"Wikipedia: Count sketch"
       <https://en.wikipedia.org/wiki/Count_sketch>`_

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -796,7 +796,7 @@ is more robust to ill-posed problems.
 
     * David J. C. MacKay, `Bayesian Interpolation <https://citeseerx.ist.psu.edu/doc_view/pid/b14c7cc3686e82ba40653c6dff178356a33e5e2c>`_, 1992.
 
-    * Michael E. Tipping, `Sparse Bayesian Learning and the Relevance Vector Machine <http://www.jmlr.org/papers/volume1/tipping01a/tipping01a.pdf>`_, 2001.
+    * Michael E. Tipping, `Sparse Bayesian Learning and the Relevance Vector Machine <https://www.jmlr.org/papers/volume1/tipping01a/tipping01a.pdf>`_, 2001.
 
 .. _automatic_relevance_determination:
 
@@ -838,7 +838,7 @@ Ridge Regression`_, see the example below.
 
     .. [2] David Wipf and Srikantan Nagarajan: `A New View of Automatic Relevance Determination <https://papers.nips.cc/paper/3372-a-new-view-of-automatic-relevance-determination.pdf>`_
 
-    .. [3] Michael E. Tipping: `Sparse Bayesian Learning and the Relevance Vector Machine <http://www.jmlr.org/papers/volume1/tipping01a/tipping01a.pdf>`_
+    .. [3] Michael E. Tipping: `Sparse Bayesian Learning and the Relevance Vector Machine <https://www.jmlr.org/papers/volume1/tipping01a/tipping01a.pdf>`_
 
     .. [4] Tristan Fletcher: `Relevance Vector Machines Explained <https://citeseerx.ist.psu.edu/doc_view/pid/3dc9d625404fdfef6eaccc3babddefe4c176abd4>`_
 
@@ -1161,13 +1161,13 @@ in the following figure,
    mass at :math:`Y=0` for the Poisson distribution and the Tweedie (power=1.5)
    distribution, but not for the Gamma distribution which has a strictly
    positive target domain.
-   
+
 The Bernoulli distribution is a discrete probability distribution modelling a
 Bernoulli trial - an event that has only two mutually exclusive outcomes.
 The Categorical distribution is a generalization of the Bernoulli distribution
 for a categorical random variable. While a random variable in a Bernoulli
 distribution has two possible outcomes, a Categorical random variable can take
-on one of K possible categories, with the probability of each category 
+on one of K possible categories, with the probability of each category
 specified separately.
 
 The choice of the distribution depends on the problem at hand:

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -642,7 +642,7 @@ the internal structure of the data.
 .. topic:: References:
 
   * `"Visualizing High-Dimensional Data Using t-SNE"
-    <http://jmlr.org/papers/v9/vandermaaten08a.html>`_
+    <https://jmlr.org/papers/v9/vandermaaten08a.html>`_
     van der Maaten, L.J.P.; Hinton, G. Journal of Machine Learning Research
     (2008)
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1066,7 +1066,7 @@ output by the `decision_function` method), then the hinge loss is defined as:
 
 If there are more than two labels, :func:`hinge_loss` uses a multiclass variant
 due to Crammer & Singer.
-`Here <http://jmlr.csail.mit.edu/papers/volume2/crammer01a/crammer01a.pdf>`_ is
+`Here <https://jmlr.csail.mit.edu/papers/volume2/crammer01a/crammer01a.pdf>`_ is
 the paper describing it.
 
 In this case the predicted decision is an array of shape (`n_samples`,
@@ -1547,7 +1547,7 @@ And the decision values do not require such processing.
        Pattern Recognition Letters, 27(8), pp. 861-874.
 
     .. [F2001] Fawcett, T., 2001. `Using rule sets to maximize
-       ROC performance <http://ieeexplore.ieee.org/document/989510/>`_
+       ROC performance <https://ieeexplore.ieee.org/document/989510/>`_
        In Data Mining, 2001.
        Proceedings IEEE International Conference, pp. 131-138.
 

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -199,7 +199,7 @@ the parameter space search.  :math:`Loss` is the loss function used
 for the network.
 
 More details can be found in the documentation of
-`SGD <http://scikit-learn.org/stable/modules/sgd.html>`_
+`SGD <https://scikit-learn.org/stable/modules/sgd.html>`_
 
 Adam is similar to SGD in a sense that it is a stochastic optimizer, but it can
 automatically adjust the amount to update parameters based on adaptive estimates

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -382,7 +382,7 @@ This strategy is illustrated below.
 
    *  Breunig, Kriegel, Ng, and Sander (2000)
       `LOF: identifying density-based local outliers.
-      <http://www.dbs.ifi.lmu.de/Publikationen/Papers/LOF.pdf>`_
+      <https://www.dbs.ifi.lmu.de/Publikationen/Papers/LOF.pdf>`_
       Proc. ACM SIGMOD
 
 .. _novelty_with_lof:

--- a/doc/presentations.rst
+++ b/doc/presentations.rst
@@ -73,6 +73,6 @@ Videos
     Presentation using the online tutorial, 45 minutes.
 
 
-.. _Gael Varoquaux: http://gael-varoquaux.info
+.. _Gael Varoquaux: https://gael-varoquaux.info
 .. _Jake Vanderplas: http://www.vanderplas.com
 .. _Olivier Grisel: https://twitter.com/ogrisel

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -310,7 +310,7 @@ Recommendation Engine packages
 - `Spotlight <https://github.com/maciejkula/spotlight>`_ Pytorch-based
   implementation of deep recommender models.
 
-- `Surprise Lib <http://surpriselib.com/>`_ Library for explicit feedback
+- `Surprise Lib <https://surpriselib.com/>`_ Library for explicit feedback
   datasets.
 
 Domain specific packages
@@ -362,4 +362,3 @@ and promote community efforts.
 
 .. [#f1] following `linux documentation Disclaimer
    <https://www.kernel.org/doc/html/latest/translations/index.html#disclaimer>`__
-

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -91,7 +91,7 @@ Documentation resources
 
 This documentation is relative to |release|. Documentation for
 other versions can be found `here
-<http://scikit-learn.org/dev/versions.html>`__.
+<https://scikit-learn.org/dev/versions.html>`__.
 
 Printable pdf documentation for old versions can be found `here
 <https://sourceforge.net/projects/scikit-learn/files/documentation/>`_.


### PR DESCRIPTION
This is mostly based on a `make linkcheck` info about redirected links.