### PR TITLE
DOC correct link for image in the PDP documentation

### DIFF
--- a/doc/modules/partial_dependence.rst
+++ b/doc/modules/partial_dependence.rst
@@ -33,7 +33,7 @@ The figure below shows two one-way and one two-way partial dependence plots for
 the bike sharing dataset, with a
 :class:`~sklearn.ensemble.HistGradientBoostingRegressor`:
 
-.. figure:: ../auto_examples/inspection/images/sphx_glr_plot_partial_dependence_005.png
+.. figure:: ../auto_examples/inspection/images/sphx_glr_plot_partial_dependence_006.png
    :target: ../auto_examples/inspection/plot_partial_dependence.html
    :align: center
    :scale: 70


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Bug introduced in commit https://github.com/scikit-learn/scikit-learn/commit/c1cfc4d4f36f9c00413e20d0ef85bed208a502ca (PR: https://github.com/scikit-learn/scikit-learn/pull/18298, issue: https://github.com/scikit-learn/scikit-learn/issues/14969)
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The text in the example https://scikit-learn.org/dev/modules/partial_dependence.html says
> The figure below shows two one-way and one two-way partial dependence plots for the bike sharing dataset, with a [HistGradientBoostingRegressor](https://scikit-learn.org/dev/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html#sklearn.ensemble.HistGradientBoostingRegressor)

However, a figure with just two one-way PDPs is shown. This PR links the correct figure containing two one-way and one two-way PDPs.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
