### PR TITLE
TST Remove ConvergenceWarnings in test_logistic

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -250,7 +250,7 @@ def test_multinomial_binary_probabilities():
     # Test multinomial LR gives expected probabilities based on the
     # decision function, for a binary problem.
     X, y = make_classification()
-    clf = LogisticRegression(multi_class="multinomial", solver="saga")
+    clf = LogisticRegression(multi_class="multinomial", solver="saga", tol=1e-3)
     clf.fit(X, y)
 
     decision = clf.decision_function(X)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1943,11 +1943,10 @@ def test_multinomial_identifiability_on_iris(fit_intercept):
     clf = LogisticRegression(
         C=len(iris.data),
         solver="lbfgs",
-        max_iter=300,
         multi_class="multinomial",
         fit_intercept=fit_intercept,
     )
-    clf.fit(iris.data, target)
+    clf.fit(scale(iris.data), target)
 
     # axis=0 is sum over classes
     assert_allclose(clf.coef_.sum(axis=0), 0, atol=1e-10)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1946,7 +1946,9 @@ def test_multinomial_identifiability_on_iris(fit_intercept):
         multi_class="multinomial",
         fit_intercept=fit_intercept,
     )
-    clf.fit(scale(iris.data), target)
+    # Scaling X to ease convergence.
+    X_scaled = scale(iris.data)
+    clf.fit(X_scaled, target)
 
     # axis=0 is sum over classes
     assert_allclose(clf.coef_.sum(axis=0), 0, atol=1e-10)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24819


#### What does this implement/fix? Explain your changes.
This PR:

- Removes the `ConvergenceWarnings` in `test_logistic.py`
- Converts all `ConvergenceWarnings` to errors in `test_logistic.py`. This way we can ensure that all future tests will also not raise convergence warnings.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
