### PR TITLE
BLD Reduce binary size of wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [options]
-packages = find_namespace:
+packages = find:
 
 [options.packages.find]
 include = sklearn*

--- a/setup.py
+++ b/setup.py
@@ -499,7 +499,7 @@ def configure_extension_modules():
     is_pypy = platform.python_implementation() == "PyPy"
     np_include = numpy.get_include()
     default_libraries = ["m"] if os.name == "posix" else []
-    default_extra_compile_args = ["-O3"]
+    default_extra_compile_args = ["-O2"]
 
     cython_exts = []
     for submodule, extensions in extension_config.items():

--- a/setup.py
+++ b/setup.py
@@ -499,7 +499,7 @@ def configure_extension_modules():
     is_pypy = platform.python_implementation() == "PyPy"
     np_include = numpy.get_include()
     default_libraries = ["m"] if os.name == "posix" else []
-    default_extra_compile_args = ["-O3"]
+    default_extra_compile_args = ["-O2"]
 
     cython_exts = []
     for submodule, extensions in extension_config.items():
@@ -609,9 +609,8 @@ def setup_package():
         cmdclass=cmdclass,
         python_requires=python_requires,
         install_requires=min_deps.tag_to_packages["install"],
-        package_data={"": ["*.pxd"]},
+        package_data={"": ["*.csv", "*.gz", "*.txt", "*.pxd", "*.rst"]},
         zip_safe=False,  # the package can run out of an .egg file
-        include_package_data=True,
         extras_require={
             key: min_deps.tag_to_packages[key]
             for key in ["examples", "docs", "tests", "benchmark"]

--- a/setup.py
+++ b/setup.py
@@ -609,7 +609,7 @@ def setup_package():
         cmdclass=cmdclass,
         python_requires=python_requires,
         install_requires=min_deps.tag_to_packages["install"],
-        package_data={"": ["*.csv", "*.gz", "*.txt", "*.pxd", "*.rst"]},
+        package_data={"": ["*.csv", "*.gz", "*.txt", "*.pxd", "*.rst", "*.jpg"]},
         zip_safe=False,  # the package can run out of an .egg file
         extras_require={
             key: min_deps.tag_to_packages[key]

--- a/setup.py
+++ b/setup.py
@@ -499,7 +499,7 @@ def configure_extension_modules():
     is_pypy = platform.python_implementation() == "PyPy"
     np_include = numpy.get_include()
     default_libraries = ["m"] if os.name == "posix" else []
-    default_extra_compile_args = ["-O2"]
+    default_extra_compile_args = ["-O3"]
 
     cython_exts = []
     for submodule, extensions in extension_config.items():

--- a/setup.py
+++ b/setup.py
@@ -498,11 +498,13 @@ def configure_extension_modules():
 
     is_pypy = platform.python_implementation() == "PyPy"
     np_include = numpy.get_include()
+
+    optimization_level = "O2"
     if os.name == "posix":
-        default_extra_compile_args = ["-O2"]
+        default_extra_compile_args = [f"-{optimization_level}"]
         default_libraries = ["m"]
     else:
-        default_extra_compile_args = ["/O2"]
+        default_extra_compile_args = [f"/{optimization_level}"]
         default_libraries = []
 
     cython_exts = []

--- a/setup.py
+++ b/setup.py
@@ -498,8 +498,12 @@ def configure_extension_modules():
 
     is_pypy = platform.python_implementation() == "PyPy"
     np_include = numpy.get_include()
-    default_libraries = ["m"] if os.name == "posix" else []
-    default_extra_compile_args = ["-O2"]
+    if os.name == "posix":
+        default_extra_compile_args = ["-O2"]
+        default_libraries = ["m"]
+    else:
+        default_extra_compile_args = ["/O2"]
+        default_libraries = []
 
     cython_exts = []
     for submodule, extensions in extension_config.items():


### PR DESCRIPTION
This PR reduces the wheel size back to the sizes seen in 1.1.3. The changes include:

- Removes the `.c`, `.cpp`, and `.pyx` files from the wheel

- Uses -O2 optimization to reduce size of compiled files. It is [documented](https://wiki.gentoo.org/wiki/GCC_optimization) that `-O3` is not great:

> Compiling with -O3 is not a guaranteed way to improve performance, and in fact, in many cases, can slow down a system due to larger binaries and increased memory usage.

CC @jeremiedbb 