### PR TITLE
MAINT Remove -Wcpp warnings when compiling sklearn.svm._libsvm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.metrics._pairwise_distances_reduction._radius_neighbors",
     "sklearn.metrics._pairwise_fast",
     "sklearn.neighbors._partition_nodes",
+    "sklearn.svm._libsvm",
     "sklearn.tree._splitter",
     "sklearn.tree._utils",
     "sklearn.utils._cython_blas",

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -716,7 +716,7 @@ def decision_function(
     model = set_model(
         &param,
         <int> nSV.shape[0],
-        <char*> &SV[0, 0],
+        <char*> &SV[0, 0] if SV.size > 0 else NULL,
         <cnp.npy_intp*> SV.shape,
         <char*> &support[0],
         <cnp.npy_intp*> support.shape,

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -285,11 +285,19 @@ def fit(
         if svm_type < 2: # SVC and NuSVC
             probA = np.empty(int(n_class*(n_class-1)/2), dtype=np.float64)
             probB = np.empty(int(n_class*(n_class-1)/2), dtype=np.float64)
-            copy_probB(<char*> &probB[0], model, <cnp.npy_intp*> probB.shape)
+            copy_probB(
+                <char*> &probB[0],
+                model,
+                <cnp.npy_intp*> probB.shape
+            )
         else:
             probA = np.empty(1, dtype=np.float64)
             probB = np.empty(0, dtype=np.float64)
-        copy_probA(<char*> &probA[0], model, <cnp.npy_intp*> probA.shape)
+        copy_probA(
+            <char*> &probA[0],
+            model,
+            <cnp.npy_intp*> probA.shape
+        )
     else:
         probA = np.empty(0, dtype=np.float64)
         probB = np.empty(0, dtype=np.float64)
@@ -442,18 +450,18 @@ def predict(
         cache_size,
         0,
         <int>class_weight.shape[0],
-        <char*> &class_weight_label[0],
-        <char*> &class_weight[0],
+        <char*> &class_weight_label[0] if class_weight_label.size > 0 else NULL,
+        <char*> &class_weight[0] if class_weight.size > 0 else NULL,
     )
     model = set_model(
         &param,
         <int> nSV.shape[0],
-        <char*> &SV[0, 0],
+        <char*> &SV[0, 0] if SV.size > 0 else NULL,
         <cnp.npy_intp*> SV.shape,
-        <char*> &support[0],
+        <char*> &support[0] if support.size > 0 else NULL,
         <cnp.npy_intp*> support.shape,
         <cnp.npy_intp*> sv_coef.strides,
-        <char*> &sv_coef[0, 0],
+        <char*> &sv_coef[0, 0] if sv_coef.size > 0 else NULL,
         <char*> &intercept[0],
         <char*> &nSV[0],
         <char*> &probA[0],

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -358,44 +358,47 @@ cdef void set_predict_params(
     )
 
 
-def predict(cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] X,
-            cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] support,
-            cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] SV,
-            cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] nSV,
-            cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] sv_coef,
-            cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] intercept,
-            cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probA=np.empty(0),
-            cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] probB=np.empty(0),
-            int svm_type=0, kernel='rbf', int degree=3,
-            double gamma=0.1, double coef0=0.,
-            cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
-                class_weight=np.empty(0),
-            cnp.ndarray[cnp.float64_t, ndim=1, mode='c']
-                sample_weight=np.empty(0),
-            double cache_size=100.):
+def predict(
+    const cnp.float64_t[:, ::1] X,
+    const cnp.int32_t[::1] support,
+    const cnp.float64_t[:, ::1] SV,
+    const cnp.int32_t[::1] nSV,
+    const cnp.float64_t[:, ::1] sv_coef,
+    const cnp.float64_t[::1] intercept,
+    const cnp.float64_t[::1] probA=np.empty(0),
+    const cnp.float64_t[::1] probB=np.empty(0),
+    int svm_type=0,
+    kernel='rbf',
+    int degree=3,
+    double gamma=0.1,
+    double coef0=0.,
+    const cnp.float64_t[::1] class_weight=np.empty(0),
+    const cnp.float64_t[::1] sample_weight=np.empty(0),
+    double cache_size=100.
+):
     """
     Predict target values of X given a model (low-level method)
 
     Parameters
     ----------
-    X : array-like, dtype=float of shape (n_samples, n_features)
+    X : memory view on array, dtype=float of shape (n_samples, n_features)
 
-    support : array of shape (n_support,)
+    support : memory view on array of shape (n_support,)
         Index of support vectors in training set.
 
-    SV : array of shape (n_support, n_features)
+    SV : memory view on array of shape (n_support, n_features)
         Support vectors.
 
-    nSV : array of shape (n_class,)
+    nSV : memory view on array of shape (n_class,)
         Number of support vectors in each class.
 
-    sv_coef : array of shape (n_class-1, n_support)
+    sv_coef : memory view on array of shape (n_class-1, n_support)
         Coefficients of support vectors in decision function.
 
-    intercept : array of shape (n_class*(n_class-1)/2)
+    intercept : memory view on array of shape (n_class*(n_class-1)/2)
         Intercept in decision function.
 
-    probA, probB : array of shape (n_class*(n_class-1)/2,)
+    probA, probB : memory view on array of shape (n_class*(n_class-1)/2,)
         Probability estimates.
 
     svm_type : {0, 1, 2, 3, 4}, default=0
@@ -422,33 +425,59 @@ def predict(cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] X,
     dec_values : array
         Predicted values.
     """
-    cdef cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] dec_values
+    cdef cnp.float64_t[::1] dec_values
     cdef svm_parameter param
     cdef svm_model *model
     cdef int rv
 
-    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
-        class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
+    cdef cnp.int32_t[::1] class_weight_label = np.arange(class_weight.shape[0], dtype=np.int32)
 
-    set_predict_params(&param, svm_type, kernel, degree, gamma, coef0,
-                       cache_size, 0, <int>class_weight.shape[0],
-                       class_weight_label.data, class_weight.data)
-    model = set_model(&param, <int> nSV.shape[0], SV.data, SV.shape,
-                      support.data, support.shape, sv_coef.strides,
-                      sv_coef.data, intercept.data, nSV.data, probA.data, probB.data)
+    set_predict_params(
+        &param,
+        svm_type,
+        kernel,
+        degree,
+        gamma,
+        coef0,
+        cache_size,
+        0,
+        <int>class_weight.shape[0],
+        <char*> &class_weight_label[0],
+        <char*> &class_weight[0],
+    )
+    model = set_model(
+        &param,
+        <int> nSV.shape[0],
+        <char*> &SV[0, 0],
+        <cnp.npy_intp*> SV.shape,
+        <char*> &support[0],
+        <cnp.npy_intp*> support.shape,
+        <cnp.npy_intp*> sv_coef.strides,
+        <char*> &sv_coef[0, 0],
+        <char*> &intercept[0],
+        <char*> &nSV[0],
+        <char*> &probA[0],
+        <char*> &probB[0],
+    )
     cdef BlasFunctions blas_functions
     blas_functions.dot = _dot[double]
     #TODO: use check_model
     try:
         dec_values = np.empty(X.shape[0])
         with nogil:
-            rv = copy_predict(X.data, model, X.shape, dec_values.data, &blas_functions)
+            rv = copy_predict(
+                <char*> &X[0, 0],
+                model,
+                <cnp.npy_intp*> X.shape,
+                <char*> &dec_values[0],
+                &blas_functions,
+            )
         if rv < 0:
             raise MemoryError("We've run out of memory")
     finally:
         free_model(model)
 
-    return dec_values
+    return dec_values.base
 
 
 def predict_proba(

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -587,7 +587,7 @@ def predict_proba(
     model = set_model(
         &param,
         <int> nSV.shape[0],
-        <char*> &SV[0, 0],
+        <char*> &SV[0, 0] if SV.size > 0 else NULL,
         <cnp.npy_intp*> SV.shape,
         <char*> &support[0],
         <cnp.npy_intp*> support.shape,

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -247,7 +247,10 @@ def fit(
 
     cdef cnp.int32_t[::1] support
     support = np.empty (SV_len, dtype=np.int32)
-    copy_support (<char*> &support[0], model)
+    copy_support (
+        <char*> &support[0] if support.size > 0 else NULL,
+        model
+    )
 
     # copy model.SV
     cdef cnp.float64_t[:, ::1] support_vectors

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -74,7 +74,7 @@ def fit(
 
     Parameters
     ----------
-    X : 2d memory view on array, dtype=float64 of shape (n_samples, n_features)
+    X : memory view on array, dtype=float64 of shape (n_samples, n_features)
 
     Y : memory view on array, dtype=float64 of shape (n_samples,)
         target vector
@@ -229,24 +229,27 @@ def fit(
     SV_len  = get_l(model)
     n_class = get_nr(model)
 
-    cdef int[::1] n_iter
-    n_iter = np.empty(max(1, n_class * (n_class - 1) // 2), dtype=np.intc)
-    copy_n_iter(<char*> &n_iter[0], model)
+    cdef int[::1] n_iter = np.empty(max(1, n_class * (n_class - 1) // 2), dtype=np.intc)
+    copy_n_iter(
+        <char*> &n_iter[0],
+        model
+    )
 
-    cdef cnp.float64_t[:, ::1] sv_coef
-    sv_coef = np.empty((n_class-1, SV_len), dtype=np.float64)
+    cdef cnp.float64_t[:, ::1] sv_coef = np.empty((n_class-1, SV_len), dtype=np.float64)
     copy_sv_coef (
         <char*> &sv_coef[0, 0] if sv_coef.size > 0 else NULL,
         model
     )
 
     # the intercept is just model.rho but with sign changed
-    cdef cnp.float64_t[::1] intercept
-    intercept = np.empty(int((n_class*(n_class-1))/2), dtype=np.float64)
-    copy_intercept (<char*> &intercept[0], model, <cnp.npy_intp*> intercept.shape)
+    cdef cnp.float64_t[::1] intercept = np.empty(int((n_class*(n_class-1))/2), dtype=np.float64)
+    copy_intercept (
+        <char*> &intercept[0],
+        model,
+        <cnp.npy_intp*> intercept.shape
+    )
 
-    cdef cnp.int32_t[::1] support
-    support = np.empty (SV_len, dtype=np.int32)
+    cdef cnp.int32_t[::1] support = np.empty (SV_len, dtype=np.int32)
     copy_support (
         <char*> &support[0] if support.size > 0 else NULL,
         model

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -259,12 +259,19 @@ def fit(
         support_vectors = np.empty((0, 0), dtype=np.float64)
     else:
         support_vectors = np.empty((SV_len, X.shape[1]), dtype=np.float64)
-        copy_SV(<char*> &support_vectors[0, 0], model, <cnp.npy_intp*> support_vectors.shape)
+        copy_SV(
+            <char*> &support_vectors[0, 0] if support_vectors.size > 0 else NULL,
+            model,
+            <cnp.npy_intp*> support_vectors.shape
+        )
 
     cdef cnp.int32_t[::1] n_class_SV
     if svm_type == 0 or svm_type == 1:
         n_class_SV = np.empty(n_class, dtype=np.int32)
-        copy_nSV(<char*> &n_class_SV[0], model)
+        copy_nSV(
+            <char*> &n_class_SV[0] if n_class_SV.size > 0 else NULL,
+            model
+        )
     else:
         # OneClass and SVR are considered to have 2 classes
         n_class_SV = np.array([SV_len, SV_len], dtype=np.int32)

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -206,7 +206,7 @@ def fit(
         shrinking,
         probability,
         <int> class_weight.shape[0],
-        <char*> &class_weight_label[0],
+        <char*> &class_weight_label[0] if class_weight_label.size > 0 else NULL,
         <char*> &class_weight[0],
         max_iter,
         random_seed

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -235,7 +235,10 @@ def fit(
 
     cdef cnp.float64_t[:, ::1] sv_coef
     sv_coef = np.empty((n_class-1, SV_len), dtype=np.float64)
-    copy_sv_coef (<char*> &sv_coef[0, 0], model)
+    copy_sv_coef (
+        <char*> &sv_coef[0, 0] if sv_coef.size > 0 else NULL,
+        model
+    )
 
     # the intercept is just model.rho but with sign changed
     cdef cnp.float64_t[::1] intercept

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -74,9 +74,9 @@ def fit(
 
     Parameters
     ----------
-    X : memory view on array, dtype=float64 of shape (n_samples, n_features)
+    X : array-like, dtype=float64 of shape (n_samples, n_features)
 
-    Y : memory view on array, dtype=float64 of shape (n_samples,)
+    Y : array, dtype=float64 of shape (n_samples,)
         target vector
 
     svm_type : {0, 1, 2, 3, 4}, default=0
@@ -111,13 +111,13 @@ def fit(
     epsilon : double, default=0.1
         Epsilon parameter in the epsilon-insensitive loss function.
 
-    class_weight : memory view on array, dtype=float64, shape (n_classes,), \
+    class_weight : array, dtype=float64, shape (n_classes,), \
             default=np.empty(0)
         Set the parameter C of class i to class_weight[i]*C for
         SVC. If not given, all classes are supposed to have
         weight one.
 
-    sample_weight : memory view on array, dtype=float64, shape (n_samples,), \
+    sample_weight : array, dtype=float64, shape (n_samples,), \
             default=np.empty(0)
         Weights assigned to each sample.
 
@@ -389,24 +389,24 @@ def predict(
 
     Parameters
     ----------
-    X : memory view on array, dtype=float of shape (n_samples, n_features)
+    X : array-like, dtype=float of shape (n_samples, n_features)
 
-    support : memory view on array of shape (n_support,)
+    support : array of shape (n_support,)
         Index of support vectors in training set.
 
-    SV : memory view on array of shape (n_support, n_features)
+    SV : array of shape (n_support, n_features)
         Support vectors.
 
-    nSV : memory view on array of shape (n_class,)
+    nSV : array of shape (n_class,)
         Number of support vectors in each class.
 
-    sv_coef : memory view on array of shape (n_class-1, n_support)
+    sv_coef : array of shape (n_class-1, n_support)
         Coefficients of support vectors in decision function.
 
-    intercept : memory view on array of shape (n_class*(n_class-1)/2)
+    intercept : array of shape (n_class*(n_class-1)/2)
         Intercept in decision function.
 
-    probA, probB : memory view on array of shape (n_class*(n_class-1)/2,)
+    probA, probB : array of shape (n_class*(n_class-1)/2,)
         Probability estimates.
 
     svm_type : {0, 1, 2, 3, 4}, default=0
@@ -521,24 +521,24 @@ def predict_proba(
 
     Parameters
     ----------
-    X : memory view on array, dtype=float of shape (n_samples, n_features)
+    X : array-like, dtype=float of shape (n_samples, n_features)
 
-    support : memory view on array of shape (n_support,)
+    support : array of shape (n_support,)
         Index of support vectors in training set.
 
-    SV : memory view on array of shape (n_support, n_features)
+    SV : array of shape (n_support, n_features)
         Support vectors.
 
-    nSV : memory view on array of shape (n_class,)
+    nSV : array of shape (n_class,)
         Number of support vectors in each class.
 
-    sv_coef : memory view on array of shape (n_class-1, n_support)
+    sv_coef : array of shape (n_class-1, n_support)
         Coefficients of support vectors in decision function.
 
-    intercept : memory view on array of shape (n_class*(n_class-1)/2,)
+    intercept : array of shape (n_class*(n_class-1)/2,)
         Intercept in decision function.
 
-    probA, probB : memory view on array of shape (n_class*(n_class-1)/2,)
+    probA, probB : array of shape (n_class*(n_class-1)/2,)
         Probability estimates.
 
     svm_type : {0, 1, 2, 3, 4}, default=0
@@ -646,24 +646,24 @@ def decision_function(
 
     Parameters
     ----------
-    X : memory view on array, dtype=float, size=[n_samples, n_features]
+    X : array-like, dtype=float, size=[n_samples, n_features]
 
-    support : memory view on array, shape=[n_support]
+    support : array, shape=[n_support]
         Index of support vectors in training set.
 
-    SV : memory view on array, shape=[n_support, n_features]
+    SV : array, shape=[n_support, n_features]
         Support vectors.
 
-    nSV : memory view on array, shape=[n_class]
+    nSV : array, shape=[n_class]
         Number of support vectors in each class.
 
-    sv_coef : memory view on array, shape=[n_class-1, n_support]
+    sv_coef : array, shape=[n_class-1, n_support]
         Coefficients of support vectors in decision function.
 
-    intercept : memory view on array, shape=[n_class*(n_class-1)/2]
+    intercept : array, shape=[n_class*(n_class-1)/2]
         Intercept in decision function.
 
-    probA, probB : memory view on array, shape=[n_class*(n_class-1)/2]
+    probA, probB : array, shape=[n_class*(n_class-1)/2]
         Probability estimates.
 
     svm_type : {0, 1, 2, 3, 4}, optional
@@ -781,9 +781,9 @@ def cross_validation(
     Parameters
     ----------
 
-    X : memory view on array, dtype=float of shape (n_samples, n_features)
+    X : array-like, dtype=float of shape (n_samples, n_features)
 
-    Y : memory view on array, dtype=float of shape (n_samples,)
+    Y : array, dtype=float of shape (n_samples,)
         target vector
 
     n_fold : int32
@@ -821,13 +821,13 @@ def cross_validation(
     epsilon : double, default=0.1
         Epsilon parameter in the epsilon-insensitive loss function.
 
-    class_weight : memory view on array, dtype=float64, shape (n_classes,), \
+    class_weight : array, dtype=float64, shape (n_classes,), \
             default=np.empty(0)
         Set the parameter C of class i to class_weight[i]*C for
         SVC. If not given, all classes are supposed to have
         weight one.
 
-    sample_weight : memory view on array, dtype=float64, shape (n_samples,), \
+    sample_weight : array, dtype=float64, shape (n_samples,), \
             default=np.empty(0)
         Weights assigned to each sample.
 

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -311,9 +311,18 @@ def fit(
 
 
 cdef void set_predict_params(
-    svm_parameter *param, int svm_type, kernel, int degree, double gamma,
-    double coef0, double cache_size, int probability, int nr_weight,
-    char *weight_label, char *weight) except *:
+    svm_parameter *param,
+    int svm_type,
+    kernel,
+    int degree,
+    double gamma,
+    double coef0,
+    double cache_size,
+    int probability,
+    int nr_weight,
+    char *weight_label,
+    char *weight
+) except *:
     """Fill param with prediction time-only parameters."""
 
     # training-time only parameters
@@ -327,9 +336,26 @@ cdef void set_predict_params(
 
     kernel_index = LIBSVM_KERNEL_TYPES.index(kernel)
 
-    set_parameter(param, svm_type, kernel_index, degree, gamma, coef0, nu,
-                         cache_size, C, tol, epsilon, shrinking, probability,
-                         nr_weight, weight_label, weight, max_iter, random_seed)
+    set_parameter(
+        param,
+        svm_type,
+        kernel_index,
+        degree,
+        gamma,
+        coef0,
+        nu,
+        cache_size,
+        C,
+        tol,
+        epsilon,
+        shrinking,
+        probability,
+        nr_weight,
+        weight_label,
+        weight,
+        max_iter,
+        random_seed
+    )
 
 
 def predict(cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] X,

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -207,7 +207,7 @@ def fit(
         probability,
         <int> class_weight.shape[0],
         <char*> &class_weight_label[0] if class_weight_label.size > 0 else NULL,
-        <char*> &class_weight[0],
+        <char*> &class_weight[0] if class_weight.size > 0 else NULL,
         max_iter,
         random_seed
     )

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -464,8 +464,8 @@ def predict(
         <char*> &sv_coef[0, 0] if sv_coef.size > 0 else NULL,
         <char*> &intercept[0],
         <char*> &nSV[0],
-        <char*> &probA[0],
-        <char*> &probB[0],
+        <char*> &probA[0] if probA.size > 0 else NULL,
+        <char*> &probB[0] if probB.size > 0 else NULL,
     )
     cdef BlasFunctions blas_functions
     blas_functions.dot = _dot[double]

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -748,7 +748,7 @@ def cross_validation(
     kernel='rbf',
     int degree=3,
     double gamma=0.1,
-    double coef0=0.,
+    double coef0=0.0,
     double tol=1e-3,
     double C=1.0,
     double nu=0.5,

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -56,9 +56,9 @@ def fit(
     kernel='rbf',
     int degree=3,
     double gamma=0.1,
-    double coef0=0.,
+    double coef0=0.0,
     double tol=1e-3,
-    double C=1.,
+    double C=1.0,
     double nu=0.5,
     double epsilon=0.1,
     const cnp.float64_t[::1] class_weight=np.empty(0),
@@ -175,9 +175,8 @@ def fit(
     else:
         assert (
             sample_weight.shape[0] == X.shape[0],
-            f"sample_weight and X have incompatible shapes: "
-            f"sample_weight has {sample_weight.shape[0]} samples while "
-            f"X has {X.shape[0]}"
+            f"sample_weight and X have incompatible shapes: sample_weight has "
+            f"{sample_weight.shape[0]} samples while X has {X.shape[0]}"
         )
 
     kernel_index = LIBSVM_KERNEL_TYPES.index(kernel)
@@ -212,7 +211,7 @@ def fit(
         <char*> &class_weight_label[0] if class_weight_label.size > 0 else NULL,
         <char*> &class_weight[0] if class_weight.size > 0 else NULL,
         max_iter,
-        random_seed
+        random_seed,
     )
 
     error_msg = svm_check_parameter(&problem, &param)
@@ -233,10 +232,7 @@ def fit(
     n_class = get_nr(model)
 
     cdef int[::1] n_iter = np.empty(max(1, n_class * (n_class - 1) // 2), dtype=np.intc)
-    copy_n_iter(
-        <char*> &n_iter[0],
-        model
-    )
+    copy_n_iter(<char*> &n_iter[0], model)
 
     cdef cnp.float64_t[:, ::1] sv_coef = np.empty((n_class-1, SV_len), dtype=np.float64)
     copy_sv_coef(<char*> &sv_coef[0, 0] if sv_coef.size > 0 else NULL, model)
@@ -318,12 +314,12 @@ cdef void set_predict_params(
     """Fill param with prediction time-only parameters."""
 
     # training-time only parameters
-    cdef double C = .0
-    cdef double epsilon = .1
+    cdef double C = 0.0
+    cdef double epsilon = 0.1
     cdef int max_iter = 0
-    cdef double nu = .5
+    cdef double nu = 0.5
     cdef int shrinking = 0
-    cdef double tol = .1
+    cdef double tol = 0.1
     cdef int random_seed = -1
 
     kernel_index = LIBSVM_KERNEL_TYPES.index(kernel)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24875

#### What does this implement/fix? Explain your changes.
- Used memory views to replace cnp.ndarray
- Casted the addresses of memory views to the appropriate types of pointers as expected by the libsvm functions
- Applied some black formatting 

#### Any other comments?
@jjerphan Since this file is a bit long I only handled the fit function to start with. I think once we can finalize the changes here we can apply a similar pattern to the other functions. This should hopefully make it easier to review.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
