### PR TITLE
ENH cartesian accepts mixed dtypes arrays

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -698,7 +698,7 @@ Changelog
 
 - |Enhancement| :func:`utils.extmath.cartesian` now accepts arrays with different
   `dtype` and will cast the ouptut to the most permissive `dtype`.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`25067` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 - |Fix| :func:`utils.multiclass.type_of_target` now properly handles sparse matrices.
   :pr:`14862` by :user:`Léonard Binet <leonardbinet>`.

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -696,6 +696,10 @@ Changelog
 - |Enhancement| :func:`utils.validation.column_or_1d` now accepts a `dtype`
   parameter to specific `y`'s dtype. :pr:`22629` by `Thomas Fan`_.
 
+- |Enhancement| :func:`utils.extmath.cartesian` now accepts arrays with different
+  `dtype` and will cast the ouptut to the most permissive `dtype`.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 - |Fix| :func:`utils.multiclass.type_of_target` now properly handles sparse matrices.
   :pr:`14862` by :user:`Léonard Binet <leonardbinet>`.
 

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -676,7 +676,7 @@ def test_plot_partial_dependence_does_not_override_ylabel(
 def test_plot_partial_dependence_with_categorical(
     pyplot, categorical_features, array_type
 ):
-    X = [["A", 1, "A"], ["B", 0, "C"], ["C", 2, "B"]]
+    X = [[1, 1, "A"], [2, 0, "C"], [3, 2, "B"]]
     column_name = ["col_A", "col_B", "col_C"]
     X = _convert_container(X, array_type, columns_name=column_name)
     y = np.array([1.2, 0.5, 0.45]).T

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -719,7 +719,8 @@ def cartesian(arrays, out=None):
     out : ndarray of shape (M, len(arrays))
         Array containing the cartesian products formed of input arrays.
         If not provided, the `dtype` of the output array is set to the most
-        permissive `dtype` of the input arrays.
+        permissive `dtype` of the input arrays, according to NumPy type
+        promotion.
 
         .. versionadded:: 1.2
            Add support for arrays of different types.

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -11,7 +11,6 @@ Extended math utilities.
 #          Giorgio Patrini
 # License: BSD 3 clause
 
-import itertools
 import warnings
 
 import numpy as np
@@ -754,15 +753,7 @@ def cartesian(arrays, out=None):
     ix = ix.reshape(len(arrays), -1).T
 
     if out is None:
-        # find the most permissive dtype among all input arrays
-        dtypes = list({x.dtype for x in arrays})
-        can_cast = [
-            np.can_cast(from_, to_, casting="safe")
-            for from_, to_ in itertools.product(dtypes, repeat=2)
-        ]
-        # The most permissive dtype is the one that has a column full of True
-        can_cast = np.reshape(can_cast, (len(dtypes), len(dtypes))).all(axis=0)
-        dtype = dtypes[can_cast.argmax()]
+        dtype = np.result_type(*arrays)  # find the most permissive dtype
 
         out = np.empty_like(ix, dtype=dtype)
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -754,7 +754,6 @@ def cartesian(arrays, out=None):
 
     if out is None:
         dtype = np.result_type(*arrays)  # find the most permissive dtype
-
         out = np.empty_like(ix, dtype=dtype)
 
     for n, arr in enumerate(arrays):

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -722,7 +722,7 @@ def cartesian(arrays, out=None):
         permissive `dtype` of the input arrays.
 
         .. versionadded:: 1.2
-           Add support for mixed type arrays.
+           Add support for arrays of different types.
 
     Notes
     -----

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -637,6 +637,30 @@ def test_cartesian():
     assert_array_equal(x[:, np.newaxis], cartesian((x,)))
 
 
+@pytest.mark.parametrize(
+    "arrays, output_dtype",
+    [
+        (
+            [np.array([1, 2, 3], dtype=np.int32), np.array([4, 5], dtype=np.int64)],
+            np.dtype(np.int64),
+        ),
+        (
+            [np.array([1, 2, 3], dtype=np.int32), np.array([4, 5], dtype=np.float64)],
+            np.dtype(np.float64),
+        ),
+        (
+            [np.array([1, 2, 3], dtype=np.int32), np.array(["x", "y"], dtype=object)],
+            np.dtype(object),
+        ),
+    ],
+)
+def test_cartesian_mix_types(arrays, output_dtype):
+    """Check that the cartesian product works with mixed types."""
+    output = cartesian(arrays)
+
+    assert output.dtype == output_dtype
+
+
 def test_logistic_sigmoid():
     # Check correctness and robustness of logistic sigmoid implementation
     def naive_log_logistic(x):


### PR DESCRIPTION
Fixes issues found when submitting #25065

`cartesian` was using the `dtype` of the first array to decide the `dtype` of the output array.
Now, we select the most permissive `dtype` from the passed input arrays.

I don't think that it was the original plan to support mixed `dtype` at first.