### PR TITLE
FIX Array validation for DecisionBoundaryDisplay

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -416,6 +416,10 @@ Changelog
   :pr:`18298` by :user:`Madhura Jayaratne <madhuracj>` and
   :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |Fix| :class:`inspection.DecisionBoundaryDisplay` now raises error if input
+  data is not 2-dimensional.
+  :pr:`25077` by :user:`Arturo Amor <ArturoAmorQ>`.
+
 :mod:`sklearn.kernel_approximation`
 ...................................
 

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -6,9 +6,11 @@ from ...preprocessing import LabelEncoder
 from ...utils import check_matplotlib_support
 from ...utils import _safe_indexing
 from ...base import is_regressor
-from ...utils.validation import check_is_fitted
-from ...utils.validation import _is_arraylike_not_scalar
-from ...utils.validation import _num_features
+from ...utils.validation import (
+    check_is_fitted,
+    _is_arraylike_not_scalar,
+    _num_features,
+)
 
 
 def _check_boundary_response_method(estimator, response_method):

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from ...preprocessing import LabelEncoder
 from ...utils import check_matplotlib_support
+from ...utils import check_array
 from ...utils import _safe_indexing
 from ...base import is_regressor
 from ...utils.validation import check_is_fitted, _is_arraylike_not_scalar
@@ -296,6 +297,7 @@ class DecisionBoundaryDisplay:
         """
         check_matplotlib_support(f"{cls.__name__}.from_estimator")
         check_is_fitted(estimator)
+        X = check_array(X)
 
         if not grid_resolution > 1:
             raise ValueError(

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -6,7 +6,9 @@ from ...preprocessing import LabelEncoder
 from ...utils import check_matplotlib_support
 from ...utils import _safe_indexing
 from ...base import is_regressor
-from ...utils.validation import check_is_fitted, _is_arraylike_not_scalar
+from ...utils.validation import check_is_fitted
+from ...utils.validation import _is_arraylike_not_scalar
+from ...utils.validation import _num_features
 
 
 def _check_boundary_response_method(estimator, response_method):
@@ -316,6 +318,12 @@ class DecisionBoundaryDisplay:
                 f"Got {plot_method} instead."
             )
 
+        num_features = _num_features(X)
+        if num_features != 2:
+            raise ValueError(
+                f"n_features must be equal to 2. Got {num_features} instead."
+            )
+
         x0, x1 = _safe_indexing(X, 0, axis=1), _safe_indexing(X, 1, axis=1)
 
         x0_min, x0_max = x0.min() - eps, x0.max() + eps
@@ -326,11 +334,6 @@ class DecisionBoundaryDisplay:
             np.linspace(x1_min, x1_max, grid_resolution),
         )
         if hasattr(X, "iloc"):
-            _, features_to_plot = X.shape
-            if features_to_plot != 2:
-                raise ValueError(
-                    f"n_features must be equal to 2. Got {features_to_plot} instead."
-                )
             # we need to preserve the feature names and therefore get an empty dataframe
             X_grid = X.iloc[[], :].copy()
             X_grid.iloc[:, 0] = xx0.ravel()

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from ...preprocessing import LabelEncoder
 from ...utils import check_matplotlib_support
-from ...utils import check_array
 from ...utils import _safe_indexing
 from ...base import is_regressor
 from ...utils.validation import check_is_fitted, _is_arraylike_not_scalar
@@ -297,7 +296,6 @@ class DecisionBoundaryDisplay:
         """
         check_matplotlib_support(f"{cls.__name__}.from_estimator")
         check_is_fitted(estimator)
-        X = check_array(X)
 
         if not grid_resolution > 1:
             raise ValueError(
@@ -328,6 +326,11 @@ class DecisionBoundaryDisplay:
             np.linspace(x1_min, x1_max, grid_resolution),
         )
         if hasattr(X, "iloc"):
+            _, features_to_plot = X.shape
+            if features_to_plot != 2:
+                raise ValueError(
+                    f"n_features must be equal to 2. Got {features_to_plot} instead."
+                )
             # we need to preserve the feature names and therefore get an empty dataframe
             X_grid = X.iloc[[], :].copy()
             X_grid.iloc[:, 0] = xx0.ravel()

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -38,6 +38,18 @@ def fitted_clf():
     return LogisticRegression().fit(X, y)
 
 
+def test_input_data_dimension():
+    n_features, n_samples = 4, 10
+    X = np.random.randn(n_samples, n_features)
+    y = np.random.randint(0, 2, n_samples)
+
+    clf = LogisticRegression()
+    clf.fit(X, y)
+    msg = "n_features must be equal to 2. Got 4 instead."
+    with pytest.raises(ValueError, match=msg):
+        DecisionBoundaryDisplay.from_estimator(estimator=clf, X=X)
+
+
 def test_check_boundary_response_method_auto():
     """Check _check_boundary_response_method behavior with 'auto'."""
 

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -40,9 +40,7 @@ def fitted_clf():
 
 def test_input_data_dimension():
     """Check that we raise an error when `X` does not have exactly 2 features."""
-    n_features, n_samples = 4, 10
-    X = np.random.randn(n_samples, n_features)
-    y = np.random.randint(0, 2, n_samples)
+    X, y = make_classification(n_samples=10, n_features=4, random_state=0)
 
     clf = LogisticRegression().fit(X, y)
     msg = "n_features must be equal to 2. Got 4 instead."

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -39,12 +39,12 @@ def fitted_clf():
 
 
 def test_input_data_dimension():
+    """Check that we raise an error when `X` does not have exactly 2 features."""
     n_features, n_samples = 4, 10
     X = np.random.randn(n_samples, n_features)
     y = np.random.randint(0, 2, n_samples)
 
-    clf = LogisticRegression()
-    clf.fit(X, y)
+    clf = LogisticRegression().fit(X, y)
     msg = "n_features must be equal to 2. Got 4 instead."
     with pytest.raises(ValueError, match=msg):
         DecisionBoundaryDisplay.from_estimator(estimator=clf, X=X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

`DecisionBoundaryDisplay` expects the input data `X` to be of shape (`n_samples`, 2), but this is not ensured by an internal validation. Because of this, the following code will output an unintuitive `ValueError` message:
```python
import numpy as np
import pandas as pd
from sklearn.neighbors import KNeighborsClassifier
from sklearn.inspection import DecisionBoundaryDisplay

rng = np.random.RandomState(0)
X = pd.DataFrame(np.random.randn(5, 4))
y = pd.Series(rng.randint(0, 2, 5))

model = KNeighborsClassifier()
model.fit(X, y)

DecisionBoundaryDisplay.from_estimator(estimator=model, X=X)
```

Even worse, a further
```python
from sklearn.ensemble import HistGradientBoostingClassifier

model = HistGradientBoostingClassifier()
model.fit(X, y)

DecisionBoundaryDisplay.from_estimator(estimator=model, X=X)
```
makes a plot!

This PR is a simple fix to solve the issue.

#### Any other comments?

A meta comment: I am wondering if we could add a parameter `column_values` (or similar) that accepts dictionaries to fix values for `n_features - 2` of the variables, allowing then for surface curves of the decision boundary display.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
