### PR TITLE
FIX Fixes check_array for pd.NA in a series

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -2,21 +2,6 @@
 
 .. currentmodule:: sklearn
 
-Version 1.2.1
-=============
-
-**In Development**
-
-Changelog
----------
-
-:mod:`sklearn.utils`
-....................
-
-- |Fix| :func:`utils.check_array` now supports Pandas Series with `pd.NA`
-  by raising a better error message or returning a compatible `ndarray`.
-  :pr:`25080` by `Thomas Fan`_.
-
 .. _changes_1_2:
 
 Version 1.2.0
@@ -723,6 +708,10 @@ Changelog
 
 - |Fix| :func:`utils.estimator_checks.check_estimator` now takes into account
   the `requires_positive_X` tag correctly. :pr:`24667` by `Thomas Fan`_.
+
+- |Fix| :func:`utils.check_array` now supports Pandas Series with `pd.NA`
+  by raising a better error message or returning a compatible `ndarray`.
+  :pr:`25080` by `Thomas Fan`_.
 
 - |API| The extra keyword parameters of :func:`utils.extmath.density` are deprecated
   and will be removed in 1.4.

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -15,7 +15,7 @@ Changelog
 
 - |Fix| :func:`utils.check_array` now supports Pandas Series with `pd.NA`
   by raising a better error message or returning a compatible `ndarray`.
-  :pr:`xxxxx` by `Thomas Fan`_.
+  :pr:`25080` by `Thomas Fan`_.
 
 .. _changes_1_2:
 

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -2,6 +2,21 @@
 
 .. currentmodule:: sklearn
 
+Version 1.2.1
+=============
+
+**In Development**
+
+Changelog
+---------
+
+:mod:`sklearn.utils`
+....................
+
+- |Fix| :func:`utils.check_array` now supports Pandas Series with `pd.NA`
+  by raising a better error message or returning a compatible `ndarray`.
+  :pr:`xxxxx` by `Thomas Fan`_.
+
 .. _changes_1_2:
 
 Version 1.2.0

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -459,11 +459,13 @@ def test_check_array_panadas_na_support_series():
 
     X_out = check_array(X_int64, force_all_finite=False, ensure_2d=False)
     assert_allclose(X_out, [1, 2, np.nan])
+    assert X_out.dtype == np.float64
 
     X_out = check_array(
         X_int64, force_all_finite=False, ensure_2d=False, dtype=np.float32
     )
     assert_allclose(X_out, [1, 2, np.nan])
+    assert X_out.dtype == np.float32
 
 
 def test_check_array_pandas_dtype_casting():

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -447,6 +447,25 @@ def test_check_array_pandas_na_support(pd_dtype, dtype, expected_dtype):
         check_array(X, force_all_finite=True)
 
 
+def test_check_array_panadas_na_support_series():
+    """Check check_array is correct with pd.NA in a series."""
+    pd = pytest.importorskip("pandas")
+
+    X_int64 = pd.Series([1, 2, pd.NA], dtype="Int64")
+
+    msg = "Input contains NaN"
+    with pytest.raises(ValueError, match=msg):
+        check_array(X_int64, force_all_finite=True, ensure_2d=False)
+
+    X_out = check_array(X_int64, force_all_finite=False, ensure_2d=False)
+    assert_allclose(X_out, [1, 2, np.nan])
+
+    X_out = check_array(
+        X_int64, force_all_finite=False, ensure_2d=False, dtype=np.float32
+    )
+    assert_allclose(X_out, [1, 2, np.nan])
+
+
 def test_check_array_pandas_dtype_casting():
     # test that data-frames with homogeneous dtype are not upcast
     pd = pytest.importorskip("pandas")

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -777,6 +777,13 @@ def check_array(
         if all(isinstance(dtype_iter, np.dtype) for dtype_iter in dtypes_orig):
             dtype_orig = np.result_type(*dtypes_orig)
 
+    elif hasattr(array, "iloc") and hasattr(array, "dtype"):
+        # array is a pandas series
+        pandas_requires_conversion = _pandas_dtype_needs_early_conversion(array.dtype)
+        if pandas_requires_conversion:
+            # Set to None, to convert to a np.dtype that works with array.dtype
+            dtype_orig = None
+
     if dtype_numeric:
         if dtype_orig is not None and dtype_orig.kind == "O":
             # if input is object, convert to float.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/25078


#### What does this implement/fix? Explain your changes.
This PR updates `check_array` to properly raise the correct error and casts pandas Series with `pd.NA`. Note that `check_array` already has the correct behavior with DataFrames which is tested here:

https://github.com/scikit-learn/scikit-learn/blob/f2f3b3cef02df0365ebebadde4a51f2f98f9154d/sklearn/utils/tests/test_validation.py#L421

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
