### PR TITLE
MAINT Allow partial param validation for functions

### DIFF
--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -820,7 +820,6 @@ def _fit_multiplicative_update(
     previous_error = error_at_init
 
     H_sum, HHt, XHt = None, None, None
-
     for n_iter in range(1, max_iter + 1):
         # update W
         # H_sum, HHt and XHt are saved and reused if not update_H

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -485,8 +485,6 @@ def _fit_coordinate_descent(
 
     rng = check_random_state(random_state)
 
-    n_iter = 0  # To allow max_iter = 0
-
     for n_iter in range(1, max_iter + 1):
         violation = 0.0
 
@@ -822,8 +820,6 @@ def _fit_multiplicative_update(
     previous_error = error_at_init
 
     H_sum, HHt, XHt = None, None, None
-
-    n_iter = 0  # To allow max_iter = 0
 
     for n_iter in range(1, max_iter + 1):
         # update W

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -1094,9 +1094,6 @@ def non_negative_factorization(
     >>> W, H, n_iter = non_negative_factorization(
     ...     X, n_components=2, init='random', random_state=0)
     """
-    if H is None and not update_H:
-        raise ValueError("H should be passed when update_H=False")
-
     est = NMF(
         n_components=n_components,
         init=init,

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -1089,8 +1089,6 @@ def non_negative_factorization(
     >>> W, H, n_iter = non_negative_factorization(
     ...     X, n_components=2, init='random', random_state=0)
     """
-    X = check_array(X, accept_sparse=("csr", "csc"), dtype=[np.float64, np.float32])
-
     est = NMF(
         n_components=n_components,
         init=init,
@@ -1106,6 +1104,8 @@ def non_negative_factorization(
         shuffle=shuffle,
     )
     est._validate_params()
+
+    X = check_array(X, accept_sparse=("csr", "csc"), dtype=[np.float64, np.float32])
 
     with config_context(assume_finite=True):
         W, H, n_iter = est._fit_transform(X, W=W, H=H, update_H=update_H)

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -488,8 +488,11 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                     try:
                         self.init_.fit(X, y, sample_weight=sample_weight)
                     except TypeError as e:
-                        # regular estimator without SW support
-                        raise ValueError(msg) from e
+                        if "unexpected keyword argument 'sample_weight'" in str(e):
+                            # regular estimator without SW support
+                            raise ValueError(msg) from e
+                        else:  # regular estimator whose input checking failed
+                            raise
                     except ValueError as e:
                         if (
                             "pass parameters to specific steps of "

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -59,10 +59,6 @@ def _make_dumb_dataset(n_samples):
     "params, err_msg",
     [
         (
-            {"interaction_cst": "string"},
-            "",
-        ),
-        (
             {"interaction_cst": [0, 1]},
             "Interaction constraints must be a sequence of tuples or lists",
         ),

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -27,6 +27,7 @@ from sklearn.utils._mocking import NoSampleWeightWrapper
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import skip_if_32bit
+from sklearn.utils._param_validation import InvalidParameterError
 from sklearn.exceptions import DataConversionWarning
 from sklearn.exceptions import NotFittedError
 from sklearn.dummy import DummyClassifier, DummyRegressor
@@ -1265,14 +1266,14 @@ def test_gradient_boosting_with_init_pipeline():
 
     # Passing sample_weight to a pipeline raises a ValueError. This test makes
     # sure we make the distinction between ValueError raised by a pipeline that
-    # was passed sample_weight, and a ValueError raised by a regular estimator
-    # whose input checking failed.
+    # was passed sample_weight, and a InvalidParameterError raised by a regular
+    # estimator whose input checking failed.
     invalid_nu = 1.5
     err_msg = (
         "The 'nu' parameter of NuSVR must be a float in the"
         f" range (0.0, 1.0]. Got {invalid_nu} instead."
     )
-    with pytest.raises(ValueError, match=re.escape(err_msg)):
+    with pytest.raises(InvalidParameterError, match=re.escape(err_msg)):
         # Note that NuSVR properly supports sample_weight
         init = NuSVR(gamma="auto", nu=invalid_nu)
         gb = GradientBoostingRegressor(init=init)

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -89,3 +89,93 @@ def test_function_param_validation(func_module):
 
             with pytest.raises(ValueError, match=match):
                 func(**{**valid_required_params, param_name: bad_value})
+
+
+PARAM_VALIDATION_CLASS_WRAPPER_LIST = [
+    ("sklearn.decomposition.non_negative_factorization", "sklearn.decomposition.NMF"),
+]
+
+
+@pytest.mark.parametrize("func_module, class_module", PARAM_VALIDATION_CLASS_WRAPPER_LIST)
+def test_class_wrapper_param_validation(func_module, class_module):
+    """Check that an informative error is raised when the value of a parameter does not
+    have an appropriate type or value.
+    """
+    module_name, func_name = func_module.rsplit(".", 1)
+    module = import_module(module_name)
+    func = getattr(module, func_name)
+
+    m_name, class_name = class_module.rsplit(".", 1)
+    m = import_module(m_name)
+    klass = getattr(m, class_name)
+
+    func_sig = signature(func)
+    func_params = [
+        p.name
+        for p in func_sig.parameters.values()
+        if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+    ]
+
+    parameter_constraints_func = getattr(func, "_skl_parameter_constraints")
+    parameter_constraints_class = getattr(klass, "_parameter_constraints")
+    parameter_constraints = {**parameter_constraints_class, **parameter_constraints_func}
+    parameter_constraints = {
+        k: v for k, v in parameter_constraints.items() if k in func_params
+    }
+
+    # generate valid values for the required parameters
+    required_params = [
+        p.name for p in func_sig.parameters.values() if p.default is p.empty
+    ]
+    valid_required_params = {}
+    for param_name in required_params:
+        if parameter_constraints[param_name] == "no_validation":
+            valid_required_params[param_name] = 1
+        else:
+            valid_required_params[param_name] = generate_valid_param(
+                make_constraint(parameter_constraints[param_name][0])
+            )
+
+    # check that there is a constraint for each parameter
+    if func_params:
+        validation_params = parameter_constraints.keys()
+        unexpected_params = set(validation_params) - set(func_params)
+        missing_params = set(func_params) - set(validation_params)
+        err_msg = (
+            "Mismatch between _parameter_constraints and the parameters of"
+            f" {func_name}.\nConsider the unexpected parameters {unexpected_params} and"
+            f" expected but missing parameters {missing_params}\n"
+        )
+        assert set(validation_params) == set(func_params), err_msg
+
+    # this object does not have a valid type for sure for all params
+    param_with_bad_type = type("BadType", (), {})()
+
+    for param_name in func_params:
+        constraints = parameter_constraints[param_name]
+
+        if constraints == "no_validation":
+            # This parameter is not validated
+            continue
+
+        match = (
+            rf"The '{param_name}' parameter of {func_name} must be .* Got .* instead."
+        )
+
+        # First, check that the error is raised if param doesn't match any valid type.
+        with pytest.raises(ValueError, match=match):
+            func(**{**valid_required_params, param_name: param_with_bad_type})
+
+        # Then, for constraints that are more than a type constraint, check that the
+        # error is raised if param does match a valid type but does not match any valid
+        # value for this type.
+        constraints = [make_constraint(constraint) for constraint in constraints]
+
+        for constraint in constraints:
+            try:
+                bad_value = generate_invalid_param_val(constraint)
+            except NotImplementedError:
+                continue
+
+            with pytest.raises(ValueError, match=match):
+                func(**{**valid_required_params, param_name: bad_value})

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -6,6 +6,87 @@ import pytest
 from sklearn.utils._param_validation import generate_invalid_param_val
 from sklearn.utils._param_validation import generate_valid_param
 from sklearn.utils._param_validation import make_constraint
+from sklearn.utils._param_validation import InvalidParameterError
+
+
+def _get_func_info(func_module):
+    module_name, func_name = func_module.rsplit(".", 1)
+    module = import_module(module_name)
+    func = getattr(module, func_name)
+
+    func_sig = signature(func)
+    func_params = [
+        p.name
+        for p in func_sig.parameters.values()
+        if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+    ]
+
+    required_params = [
+        p.name for p in func_sig.parameters.values() if p.default is p.empty
+    ]
+
+    return func, func_name, func_params, required_params
+
+
+def _check_function_param_validation(
+    func, func_name, func_params, required_params, parameter_constraints
+):
+    """Check that an informative error is raised when the value of a parameter does not
+    have an appropriate type or value.
+    """
+    # generate valid values for the required parameters
+    valid_required_params = {}
+    for param_name in required_params:
+        if parameter_constraints[param_name] == "no_validation":
+            valid_required_params[param_name] = 1
+        else:
+            valid_required_params[param_name] = generate_valid_param(
+                make_constraint(parameter_constraints[param_name][0])
+            )
+
+    # check that there is a constraint for each parameter
+    if func_params:
+        validation_params = parameter_constraints.keys()
+        unexpected_params = set(validation_params) - set(func_params)
+        missing_params = set(func_params) - set(validation_params)
+        err_msg = (
+            "Mismatch between _parameter_constraints and the parameters of"
+            f" {func_name}.\nConsider the unexpected parameters {unexpected_params} and"
+            f" expected but missing parameters {missing_params}\n"
+        )
+        assert set(validation_params) == set(func_params), err_msg
+
+    # this object does not have a valid type for sure for all params
+    param_with_bad_type = type("BadType", (), {})()
+
+    for param_name in func_params:
+        constraints = parameter_constraints[param_name]
+
+        if constraints == "no_validation":
+            # This parameter is not validated
+            continue
+
+        match = (
+            rf"The '{param_name}' parameter of {func_name} must be .* Got .* instead."
+        )
+
+        # First, check that the error is raised if param doesn't match any valid type.
+        with pytest.raises(InvalidParameterError, match=match):
+            func(**{**valid_required_params, param_name: param_with_bad_type})
+
+        # Then, for constraints that are more than a type constraint, check that the
+        # error is raised if param does match a valid type but does not match any valid
+        # value for this type.
+        constraints = [make_constraint(constraint) for constraint in constraints]
+
+        for constraint in constraints:
+            try:
+                bad_value = generate_invalid_param_val(constraint)
+            except NotImplementedError:
+                continue
+
+            with pytest.raises(InvalidParameterError, match=match):
+                func(**{**valid_required_params, param_name: bad_value})
 
 
 PARAM_VALIDATION_FUNCTION_LIST = [
@@ -18,77 +99,16 @@ PARAM_VALIDATION_FUNCTION_LIST = [
 
 @pytest.mark.parametrize("func_module", PARAM_VALIDATION_FUNCTION_LIST)
 def test_function_param_validation(func_module):
-    """Check that an informative error is raised when the value of a parameter does not
-    have an appropriate type or value.
+    """Check param validation for public functions that are not wrappers around
+    estimators.
     """
-    module_name, func_name = func_module.rsplit(".", 1)
-    module = import_module(module_name)
-    func = getattr(module, func_name)
+    func, func_name, func_params, required_params = _get_func_info(func_module)
 
-    func_sig = signature(func)
-    func_params = [
-        p.name
-        for p in func_sig.parameters.values()
-        if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
-    ]
     parameter_constraints = getattr(func, "_skl_parameter_constraints")
 
-    # generate valid values for the required parameters
-    required_params = [
-        p.name for p in func_sig.parameters.values() if p.default is p.empty
-    ]
-    valid_required_params = {}
-    for param_name in required_params:
-        if parameter_constraints[param_name] == "no_validation":
-            valid_required_params[param_name] = 1
-        else:
-            valid_required_params[param_name] = generate_valid_param(
-                make_constraint(parameter_constraints[param_name][0])
-            )
-
-    # check that there is a constraint for each parameter
-    if func_params:
-        validation_params = parameter_constraints.keys()
-        unexpected_params = set(validation_params) - set(func_params)
-        missing_params = set(func_params) - set(validation_params)
-        err_msg = (
-            "Mismatch between _parameter_constraints and the parameters of"
-            f" {func_name}.\nConsider the unexpected parameters {unexpected_params} and"
-            f" expected but missing parameters {missing_params}\n"
-        )
-        assert set(validation_params) == set(func_params), err_msg
-
-    # this object does not have a valid type for sure for all params
-    param_with_bad_type = type("BadType", (), {})()
-
-    for param_name in func_params:
-        constraints = parameter_constraints[param_name]
-
-        if constraints == "no_validation":
-            # This parameter is not validated
-            continue
-
-        match = (
-            rf"The '{param_name}' parameter of {func_name} must be .* Got .* instead."
-        )
-
-        # First, check that the error is raised if param doesn't match any valid type.
-        with pytest.raises(ValueError, match=match):
-            func(**{**valid_required_params, param_name: param_with_bad_type})
-
-        # Then, for constraints that are more than a type constraint, check that the
-        # error is raised if param does match a valid type but does not match any valid
-        # value for this type.
-        constraints = [make_constraint(constraint) for constraint in constraints]
-
-        for constraint in constraints:
-            try:
-                bad_value = generate_invalid_param_val(constraint)
-            except NotImplementedError:
-                continue
-
-            with pytest.raises(ValueError, match=match):
-                func(**{**valid_required_params, param_name: bad_value})
+    _check_function_param_validation(
+        func, func_name, func_params, required_params, parameter_constraints
+    )
 
 
 PARAM_VALIDATION_CLASS_WRAPPER_LIST = [
@@ -96,86 +116,29 @@ PARAM_VALIDATION_CLASS_WRAPPER_LIST = [
 ]
 
 
-@pytest.mark.parametrize("func_module, class_module", PARAM_VALIDATION_CLASS_WRAPPER_LIST)
+@pytest.mark.parametrize(
+    "func_module, class_module", PARAM_VALIDATION_CLASS_WRAPPER_LIST
+)
 def test_class_wrapper_param_validation(func_module, class_module):
-    """Check that an informative error is raised when the value of a parameter does not
-    have an appropriate type or value.
+    """Check param validation for public functions that are wrappers around
+    estimators.
     """
-    module_name, func_name = func_module.rsplit(".", 1)
+    func, func_name, func_params, required_params = _get_func_info(func_module)
+
+    module_name, class_name = class_module.rsplit(".", 1)
     module = import_module(module_name)
-    func = getattr(module, func_name)
-
-    m_name, class_name = class_module.rsplit(".", 1)
-    m = import_module(m_name)
-    klass = getattr(m, class_name)
-
-    func_sig = signature(func)
-    func_params = [
-        p.name
-        for p in func_sig.parameters.values()
-        if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
-    ]
+    klass = getattr(module, class_name)
 
     parameter_constraints_func = getattr(func, "_skl_parameter_constraints")
     parameter_constraints_class = getattr(klass, "_parameter_constraints")
-    parameter_constraints = {**parameter_constraints_class, **parameter_constraints_func}
+    parameter_constraints = {
+        **parameter_constraints_class,
+        **parameter_constraints_func,
+    }
     parameter_constraints = {
         k: v for k, v in parameter_constraints.items() if k in func_params
     }
 
-    # generate valid values for the required parameters
-    required_params = [
-        p.name for p in func_sig.parameters.values() if p.default is p.empty
-    ]
-    valid_required_params = {}
-    for param_name in required_params:
-        if parameter_constraints[param_name] == "no_validation":
-            valid_required_params[param_name] = 1
-        else:
-            valid_required_params[param_name] = generate_valid_param(
-                make_constraint(parameter_constraints[param_name][0])
-            )
-
-    # check that there is a constraint for each parameter
-    if func_params:
-        validation_params = parameter_constraints.keys()
-        unexpected_params = set(validation_params) - set(func_params)
-        missing_params = set(func_params) - set(validation_params)
-        err_msg = (
-            "Mismatch between _parameter_constraints and the parameters of"
-            f" {func_name}.\nConsider the unexpected parameters {unexpected_params} and"
-            f" expected but missing parameters {missing_params}\n"
-        )
-        assert set(validation_params) == set(func_params), err_msg
-
-    # this object does not have a valid type for sure for all params
-    param_with_bad_type = type("BadType", (), {})()
-
-    for param_name in func_params:
-        constraints = parameter_constraints[param_name]
-
-        if constraints == "no_validation":
-            # This parameter is not validated
-            continue
-
-        match = (
-            rf"The '{param_name}' parameter of {func_name} must be .* Got .* instead."
-        )
-
-        # First, check that the error is raised if param doesn't match any valid type.
-        with pytest.raises(ValueError, match=match):
-            func(**{**valid_required_params, param_name: param_with_bad_type})
-
-        # Then, for constraints that are more than a type constraint, check that the
-        # error is raised if param does match a valid type but does not match any valid
-        # value for this type.
-        constraints = [make_constraint(constraint) for constraint in constraints]
-
-        for constraint in constraints:
-            try:
-                bad_value = generate_invalid_param_val(constraint)
-            except NotImplementedError:
-                continue
-
-            with pytest.raises(ValueError, match=match):
-                func(**{**valid_required_params, param_name: bad_value})
+    _check_function_param_validation(
+        func, func_name, func_params, required_params, parameter_constraints
+    )

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -17,10 +17,11 @@ from scipy.sparse import csr_matrix
 from .validation import _is_arraylike_not_scalar
 
 
-class InvalidParameterError(Exception):
+class InvalidParameterError(ValueError, TypeError):
     """Custom exception to be raised when the parameter of a class/method/function
     does not have a valid type or value.
     """
+    ### Inherits from ValueError and TypeError to keep backward compatibility.
 
 
 def validate_parameter_constraints(parameter_constraints, params, caller_name):

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -22,7 +22,7 @@ class InvalidParameterError(ValueError, TypeError):
     does not have a valid type or value.
     """
 
-    ### Inherits from ValueError and TypeError to keep backward compatibility.
+    # Inherits from ValueError and TypeError to keep backward compatibility.
 
 
 def validate_parameter_constraints(parameter_constraints, params, caller_name):

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -21,6 +21,7 @@ class InvalidParameterError(ValueError, TypeError):
     """Custom exception to be raised when the parameter of a class/method/function
     does not have a valid type or value.
     """
+
     ### Inherits from ValueError and TypeError to keep backward compatibility.
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -61,6 +61,7 @@ from ..utils.fixes import parse_version
 from ..utils.validation import check_is_fitted
 from ..utils._param_validation import make_constraint
 from ..utils._param_validation import generate_invalid_param_val
+from ..utils._param_validation import InvalidParameterError
 
 from . import shuffle
 from ._tags import (
@@ -4082,7 +4083,7 @@ def check_param_validation(name, estimator_orig):
                 # the method is not accessible with the current set of parameters
                 continue
 
-            with raises(ValueError, match=match, err_msg=err_msg):
+            with raises(InvalidParameterError, match=match, err_msg=err_msg):
                 if any(
                     isinstance(X_type, str) and X_type.endswith("labels")
                     for X_type in _safe_tags(estimator, key="X_types")
@@ -4110,7 +4111,7 @@ def check_param_validation(name, estimator_orig):
                     # the method is not accessible with the current set of parameters
                     continue
 
-                with raises(ValueError, match=match, err_msg=err_msg):
+                with raises(InvalidParameterError, match=match, err_msg=err_msg):
                     if any(
                         X_type.endswith("labels")
                         for X_type in _safe_tags(estimator, key="X_types")

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -28,6 +28,7 @@ from sklearn.utils._param_validation import make_constraint
 from sklearn.utils._param_validation import generate_invalid_param_val
 from sklearn.utils._param_validation import generate_valid_param
 from sklearn.utils._param_validation import validate_params
+from sklearn.utils._param_validation import InvalidParameterError
 
 
 # Some helpers for the tests
@@ -433,23 +434,35 @@ def test_make_constraint_unknown():
 
 def test_validate_params():
     """Check that validate_params works no matter how the arguments are passed"""
-    with pytest.raises(ValueError, match="The 'a' parameter of _func must be"):
+    with pytest.raises(
+        InvalidParameterError, match="The 'a' parameter of _func must be"
+    ):
         _func("wrong", c=1)
 
-    with pytest.raises(ValueError, match="The 'b' parameter of _func must be"):
+    with pytest.raises(
+        InvalidParameterError, match="The 'b' parameter of _func must be"
+    ):
         _func(*[1, "wrong"], c=1)
 
-    with pytest.raises(ValueError, match="The 'c' parameter of _func must be"):
+    with pytest.raises(
+        InvalidParameterError, match="The 'c' parameter of _func must be"
+    ):
         _func(1, **{"c": "wrong"})
 
-    with pytest.raises(ValueError, match="The 'd' parameter of _func must be"):
+    with pytest.raises(
+        InvalidParameterError, match="The 'd' parameter of _func must be"
+    ):
         _func(1, c=1, d="wrong")
 
     # check in the presence of extra positional and keyword args
-    with pytest.raises(ValueError, match="The 'b' parameter of _func must be"):
+    with pytest.raises(
+        InvalidParameterError, match="The 'b' parameter of _func must be"
+    ):
         _func(0, *["wrong", 2, 3], c=4, **{"e": 5})
 
-    with pytest.raises(ValueError, match="The 'c' parameter of _func must be"):
+    with pytest.raises(
+        InvalidParameterError, match="The 'c' parameter of _func must be"
+    ):
         _func(0, *[1, 2, 3], c="four", **{"e": 5})
 
 
@@ -488,19 +501,24 @@ def test_decorate_validated_function():
 
     # outer decorator does not interfer with validation
     with pytest.warns(FutureWarning, match="Function _func is deprecated"):
-        with pytest.raises(ValueError, match=r"The 'c' parameter of _func must be"):
+        with pytest.raises(
+            InvalidParameterError, match=r"The 'c' parameter of _func must be"
+        ):
             decorated_function(1, 2, c="wrong")
 
 
 def test_validate_params_method():
     """Check that validate_params works with methods"""
-    with pytest.raises(ValueError, match="The 'a' parameter of _Class._method must be"):
+    with pytest.raises(
+        InvalidParameterError, match="The 'a' parameter of _Class._method must be"
+    ):
         _Class()._method("wrong")
 
     # validated method can be decorated
     with pytest.warns(FutureWarning, match="Function _deprecated_method is deprecated"):
         with pytest.raises(
-            ValueError, match="The 'a' parameter of _Class._deprecated_method must be"
+            InvalidParameterError,
+            match="The 'a' parameter of _Class._deprecated_method must be",
         ):
             _Class()._deprecated_method("wrong")
 
@@ -510,7 +528,9 @@ def test_validate_params_estimator():
     # no validation in init
     est = _Estimator("wrong")
 
-    with pytest.raises(ValueError, match="The 'a' parameter of _Estimator must be"):
+    with pytest.raises(
+        InvalidParameterError, match="The 'a' parameter of _Estimator must be"
+    ):
         est.fit()
 
 
@@ -531,7 +551,9 @@ def test_hidden_constraint():
     f({"a": 1, "b": 2, "c": 3})
     f([1, 2, 3])
 
-    with pytest.raises(ValueError, match="The 'param' parameter") as exc_info:
+    with pytest.raises(
+        InvalidParameterError, match="The 'param' parameter"
+    ) as exc_info:
         f(param="bad")
 
     # the list option is not exposed in the error message
@@ -551,7 +573,9 @@ def test_hidden_stroptions():
     f("auto")
     f("warn")
 
-    with pytest.raises(ValueError, match="The 'param' parameter") as exc_info:
+    with pytest.raises(
+        InvalidParameterError, match="The 'param' parameter"
+    ) as exc_info:
         f(param="bad")
 
     # the "warn" option is not exposed in the error message
@@ -596,7 +620,7 @@ def test_no_validation():
         pass
 
     # param1 is validated
-    with pytest.raises(ValueError, match="The 'param1' parameter"):
+    with pytest.raises(InvalidParameterError, match="The 'param1' parameter"):
         f(param1="wrong")
 
     # param2 is not validated: any type is valid.


### PR DESCRIPTION
Fixes #25058 

We have public functions that are just wrappers around estimators, e.g `k_means`, `fast_ica`, `non_negative_factorization`, `dict_learning_online`, ... Adding full param validation for these estimators is not satisfying because it means that we need to keep in sync the dict of constraints in the class and in the function.

Current common tests ensure that we have as many constraints as parameters. To allow partial validation, this PR proposes to split the test for public functions, one for normal functions and one for functions that are wrappers around estimators. For the later, we don't enforce that the constraint dict of the function has as many entries as the number of params. Instead, we join the dict of the class and the dict of the function and make sure that at least one of them raises the appropriate error. This way, the function can delegate validation to the class for some parameters.

The issue with delegating validation to the class is that the error message mentions the name of the estimator instead of the name of the function which can be confusing. To avoid that, we catch the error raised and switch the estimator name by the function name in the error message. To make sure that we can only catch the error from param validation, I think it's better to change the `ValueError` that we used until now by a custom exception `InvalidParameterError`.

This PR also implements this for `non_negative_factorization` to show how it works. It already had the double validation but was not in the list of tested functions.

cc/ @glemaitre @thomasjpfan @adrinjalali 