### PR TITLE
MAINT Make param validation more lenient towards downstream dependencies

### DIFF
--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -50,13 +50,6 @@ def validate_parameter_constraints(parameter_constraints, params, caller_name):
     caller_name : str
         The name of the estimator or function or method that called this function.
     """
-    if len(set(parameter_constraints) - set(params)) != 0:
-        raise ValueError(
-            f"The parameter constraints {list(parameter_constraints)}"
-            " contain unexpected parameters"
-            f" {set(parameter_constraints) - set(params)}"
-        )
-
     for param_name, param_val in params.items():
         # We allow parameters to not have a constraint so that third party estimators
         # can inherit from sklearn estimators without having to necessarily use the

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -453,20 +453,6 @@ def test_validate_params():
         _func(0, *[1, 2, 3], c="four", **{"e": 5})
 
 
-def test_validate_params_match_error():
-    """Check that an informative error is raised when there are constraints
-    that have no matching function paramaters
-    """
-
-    @validate_params({"a": [int], "c": [int]})
-    def func(a, b):
-        pass
-
-    match = r"The parameter constraints .* contain unexpected parameters {'c'}"
-    with pytest.raises(ValueError, match=match):
-        func(1, 2)
-
-
 def test_validate_params_missing_params():
     """Check that no error is raised when there are parameters without
     constraints

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -619,3 +619,22 @@ def test_cv_objects():
     assert constraint.is_satisfied_by([([1, 2], [3, 4]), ([3, 4], [1, 2])])
     assert constraint.is_satisfied_by(None)
     assert not constraint.is_satisfied_by("not a CV object")
+
+
+def test_third_party_estimator():
+    """Check that the validation from a scikit-learn estimator inherited by a third
+    party estimator does not impose a match between the dict of constraints and the
+    parameters of the estimator.
+    """
+
+    class ThirdPartyEstimator(_Estimator):
+        def __init__(self, b):
+            self.b = b
+            super().__init__(a=0)
+
+        def fit(self, X=None, y=None):
+            super().fit(X, y)
+
+    # does not raise, niether because "b" is not in the constraints dict, neither
+    # because "a" is not a parameter of the estimator.
+    ThirdPartyEstimator(b=0).fit()

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -635,6 +635,6 @@ def test_third_party_estimator():
         def fit(self, X=None, y=None):
             super().fit(X, y)
 
-    # does not raise, niether because "b" is not in the constraints dict, neither
-    # because "a" is not a parameter of the estimator.
+    # does not raise, even though "b" is not in the constraints dict and "a" is not
+    # a parameter of the estimator.
     ThirdPartyEstimator(b=0).fit()


### PR DESCRIPTION
Currently `validate_params` checks that all entries in the constraints dict are actual parameters of the class. It can break third party estimators (it was actually catched trying imbalanced-learn with the 1.2.0rc1). For instance if someone does:

```py
from sklearn.cluster import KMeans

class MyKMeans(KMeans):
    # this estimator does not expose "algorithm"                      should be here v
    def __init__(self, n_clusters, init, n_init, max_iter, tol, verbose, random_state):
        super().__init__(...)

    def fit(self, X):
        super().fit(X)
        return self
```
then it would raise an error because "algorithm" is in the constraint dict or the base class but not a param of the new class.

I think we should not enforce that for third party estimators. For scikit-learn estimators we do want to enforce it but we already check that we have a 1 to 1 matching in the common tests: https://github.com/scikit-learn/scikit-learn/blob/2b34dfde2453743fa046312a49cc312a5586ea04/sklearn/utils/estimator_checks.py#L4047-L4055

cc/ @glemaitre 