### PR TITLE
Use `check_array` to validate `y`

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1167,7 +1167,10 @@ def column_or_1d(y, *, dtype=None, warn=False):
         If `y` is not a 1D array or a 2D array with a single row or column.
     """
     xp, _ = get_namespace(y)
-    y = xp.asarray(y, dtype=dtype)
+    y = check_array(
+        y, ensure_2d=False, dtype=dtype, input_name="y", force_all_finite=False
+    )
+
     shape = y.shape
     if len(shape) == 1:
         return _asarray_with_order(xp.reshape(y, -1), order="C", xp=xp)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1177,7 +1177,12 @@ def column_or_1d(y, *, dtype=None, warn=False):
     """
     xp, _ = get_namespace(y)
     y = check_array(
-        y, ensure_2d=False, dtype=dtype, input_name="y", force_all_finite=False
+        y,
+        ensure_2d=False,
+        dtype=dtype,
+        input_name="y",
+        force_all_finite=False,
+        ensure_min_samples=0,
     )
 
     shape = y.shape


### PR DESCRIPTION
#### Reference Issues/PRs
closes #25073 (more precisely this PR combined with #25080 closes it)


#### What does this implement/fix? Explain your changes.
Uses `check_array` in `_check_y` so that we get the same behaviour for converting pandas special data types (that can represent missing values) like `Int64` as for `X`. This is done in the part of the code around `pandas_requires_conversion`.

Is this what you had in mind?

cc @glemaitre 