### PR TITLE
DOC Fix typo in cross_validate doc

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -112,7 +112,7 @@ def cross_validate(
 
         For int/None inputs, if the estimator is a classifier and ``y`` is
         either binary or multiclass, :class:`StratifiedKFold` is used. In all
-        other cases, :class:`.Fold` is used. These splitters are instantiated
+        other cases, :class:`KFold` is used. These splitters are instantiated
         with `shuffle=False` so the splits will be the same across calls.
 
         Refer :ref:`User Guide <cross_validation>` for the various


### PR DESCRIPTION
`.Fold` -> `KFold`

This was introduced in https://github.com/scikit-learn/scikit-learn/pull/19776/files#diff-24fbe29b336ea0ad7ef67d54c362bfebd086d2367337526fb99dae4583891c2dR97 and looking at the PR (just in case) it does look like a typo.