### PR TITLE
CI Fixes CI for windows

### DIFF
--- a/build_tools/azure/install_win.sh
+++ b/build_tools/azure/install_win.sh
@@ -7,9 +7,7 @@ set -x
 source build_tools/shared.sh
 
 if [[ "$DISTRIB" == "conda" ]]; then
-    conda update -n base conda -y
-    conda install pip -y
-    pip install "$(get_dep conda-lock min)"
+    conda install -c conda-forge "$(get_dep conda-lock min)" -y
     conda-lock install --name $VIRTUALENV $LOCK_FILE
     source activate $VIRTUALENV
 else


### PR DESCRIPTION
This PR fixes the Azure issue on the CI. I originally thought it was a `conda=22.11.0` issue, because `22.11.0` was released two days ago, but pinning `conda=22.9.0` on the `defaults` channel still fails the Windows CI.

I suspect `conda` from the defaults channel does not work well with `conda-lock` installed with pip.

This PR installs `conda-lock` using `conda` which will update `conda` to `22.9.0` from the `conda-forge` channel.
