### PR TITLE
ENH Adds FeatureUnion.__getitem__ to access transformers

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -39,7 +39,7 @@ Changelog
 :mod:`sklearn.pipeline`
 .......................
 - |Feature| :class:`pipeline.FeatureUnion` can now use indexing notation (e.g.
-  `feature_union["scalar"]`) to access transformers by name. :pr:`xxxxx` by
+  `feature_union["scalar"]`) to access transformers by name. :pr:`25093` by
   `Thomas Fan`_.
 
 Code and Documentation Contributors

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -36,6 +36,12 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.pipeline`
+.......................
+- |Feature| :class:`pipeline.FeatureUnion` can now use indexing notation (e.g.
+  `feature_union["scalar"]`) to access transformers by name. :pr:`xxxxx` by
+  `Thomas Fan`_.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1286,6 +1286,10 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         names, transformers = zip(*self.transformer_list)
         return _VisualBlock("parallel", transformers, names=names)
 
+    def __getitem__(self, name):
+        """Return transformer with name."""
+        return self.named_transformers[name]
+
 
 def make_union(*transformers, n_jobs=None, verbose=False):
     """Construct a FeatureUnion from the given transformers.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1288,6 +1288,8 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
 
     def __getitem__(self, name):
         """Return transformer with name."""
+        if not isinstance(name, str):
+            raise KeyError("Only string keys are supported")
         return self.named_transformers[name]
 
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1674,5 +1674,5 @@ def test_feature_union_getitem():
     )
     assert union["scalar"] is scalar
     assert union["pca"] is pca
-    assert union["scalar"] is scalar
     assert union["pass"] == "passthrough"
+    assert union["drop_me"] == "drop"

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1676,3 +1676,14 @@ def test_feature_union_getitem():
     assert union["pca"] is pca
     assert union["pass"] == "passthrough"
     assert union["drop_me"] == "drop"
+
+
+@pytest.mark.parametrize("key", [0, slice(0, 2)])
+def test_feature_union_getitem_error(key):
+    """Raise error when __getitem__ gets a non-string input."""
+
+    union = FeatureUnion([("scalar", StandardScaler()), ("pca", PCA())])
+
+    msg = "Only string keys are supported"
+    with pytest.raises(KeyError, match=msg):
+        union[key]

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1658,3 +1658,21 @@ def test_feature_union_set_output():
     assert isinstance(X_trans, pd.DataFrame)
     assert_array_equal(X_trans.columns, union.get_feature_names_out())
     assert_array_equal(X_trans.index, X_test.index)
+
+
+def test_feature_union_getitem():
+    """Check FeatureUnion.__getitem__ returns expected results."""
+    scalar = StandardScaler()
+    pca = PCA()
+    union = FeatureUnion(
+        [
+            ("scalar", scalar),
+            ("pca", pca),
+            ("pass", "passthrough"),
+            ("drop_me", "drop"),
+        ]
+    )
+    assert union["scalar"] is scalar
+    assert union["pca"] is pca
+    assert union["scalar"] is scalar
+    assert union["pass"] == "passthrough"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #24906


#### What does this implement/fix? Explain your changes.
This PR adds `__getitem__` to `FeatureUnion` to access transformers.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
