### PR TITLE
MNT Require matplotlib in test_input_data_dimension test

### DIFF
--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -38,7 +38,7 @@ def fitted_clf():
     return LogisticRegression().fit(X, y)
 
 
-def test_input_data_dimension():
+def test_input_data_dimension(pyplot):
     """Check that we raise an error when `X` does not have exactly 2 features."""
     X, y = make_classification(n_samples=10, n_features=4, random_state=0)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/25103

#### What does this implement/fix? Explain your changes.
This PR skips `test_input_data_dimension` when matplotlib is not installed. This test was recently added in https://github.com/scikit-learn/scikit-learn/pull/25077

#### Any other comments?
I think we should not have matplotlib installed in one of the CI jobs, so we can catch these issues in PRs.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
