### PR TITLE
MAINT Remove `_arr` suffixes from `_binary_tree`

### DIFF
--- a/sklearn/neighbors/_ball_tree.pyx
+++ b/sklearn/neighbors/_ball_tree.pyx
@@ -38,8 +38,8 @@ cdef class BallTree(BinaryTree):
 cdef int allocate_data(BinaryTree tree, ITYPE_t n_nodes,
                        ITYPE_t n_features) except -1:
     """Allocate arrays needed for the KD Tree"""
-    tree.node_bounds_arr = np.zeros((1, n_nodes, n_features), dtype=DTYPE)
-    tree.node_bounds = tree.node_bounds_arr
+    tree.node_bounds = np.zeros((1, n_nodes, n_features), dtype=DTYPE)
+    tree.node_bounds = tree.node_bounds
     return 0
 
 

--- a/sklearn/neighbors/_ball_tree.pyx
+++ b/sklearn/neighbors/_ball_tree.pyx
@@ -39,7 +39,6 @@ cdef int allocate_data(BinaryTree tree, ITYPE_t n_nodes,
                        ITYPE_t n_features) except -1:
     """Allocate arrays needed for the KD Tree"""
     tree.node_bounds = np.zeros((1, n_nodes, n_features), dtype=DTYPE)
-    tree.node_bounds = tree.node_bounds
     return 0
 
 

--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -794,6 +794,9 @@ cdef class BinaryTree:
 
     # Use cinit to initialize all arrays to empty: this will prevent memory
     # errors and seg-faults in rare cases where __init__ is not called
+    # A one-elements array is used as a placeholder to prevent
+    # any problem due to potential access to this attribute
+    # (e.g. assigning to NULL or a to value in another segment).
     def __cinit__(self):
         self.data = np.empty((1, 1), dtype=DTYPE, order='C')
         self.sample_weight = np.empty(1, dtype=DTYPE, order='C')

--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -639,18 +639,15 @@ cdef class NodeHeap:
 
         heap[i].val < min(heap[2 * i + 1].val, heap[2 * i + 2].val)
     """
-    cdef NodeHeapData_t[:] data_arr
     cdef NodeHeapData_t[:] data
     cdef ITYPE_t n
 
     def __cinit__(self):
-        self.data_arr = np.zeros(1, dtype=NodeHeapData, order='C')
-        self.data = self.data_arr
+        self.data = np.zeros(1, dtype=NodeHeapData, order='C')
 
     def __init__(self, size_guess=100):
         size_guess = max(size_guess, 1)  # need space for at least one item
-        self.data_arr = np.zeros(size_guess, dtype=NodeHeapData, order='C')
-        self.data = self.data_arr
+        self.data = np.zeros(size_guess, dtype=NodeHeapData, order='C')
         self.n = size_guess
         self.clear()
 
@@ -661,11 +658,10 @@ cdef class NodeHeap:
             NodeHeapData_t *new_data_ptr
             ITYPE_t i
             ITYPE_t size = self.data.shape[0]
-            NodeHeapData_t[:] new_data_arr = np.zeros(
+            NodeHeapData_t[:] new_data = np.zeros(
                 new_size,
                 dtype=NodeHeapData,
             )
-            NodeHeapData_t[:] new_data = new_data_arr
 
         if size > 0 and new_size > 0:
             data_ptr = &self.data[0]
@@ -677,7 +673,6 @@ cdef class NodeHeap:
             self.n = new_size
 
         self.data = new_data
-        self.data_arr = new_data_arr
         return 0
 
     cdef int push(self, NodeHeapData_t data) except -1:

--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -549,7 +549,7 @@ cdef class NeighborsHeap:
         """push (val, i_val) into the given row"""
         return heap_push(
             values=&self.distances[row, 0],
-            indices-&self.indices[row, 0],
+            indices=&self.indices[row, 0],
             size=self.distances.shape[1],
             val=val,
             val_idx=i_val,

--- a/sklearn/neighbors/_binary_tree.pxi
+++ b/sklearn/neighbors/_binary_tree.pxi
@@ -523,8 +523,9 @@ cdef class NeighborsHeap:
         self.indices = np.zeros((1, 1), dtype=ITYPE, order='C')
 
     def __init__(self, n_pts, n_nbrs):
-        self.distances = np.full((n_pts, n_nbrs), np.inf, dtype=DTYPE,
-                                     order='C')
+        self.distances = np.full(
+            (n_pts, n_nbrs), np.inf, dtype=DTYPE, order='C'
+        )
         self.indices = np.zeros((n_pts, n_nbrs), dtype=ITYPE, order='C')
 
     def get_arrays(self, sort=True):

--- a/sklearn/neighbors/_kd_tree.pyx
+++ b/sklearn/neighbors/_kd_tree.pyx
@@ -33,7 +33,6 @@ cdef int allocate_data(BinaryTree tree, ITYPE_t n_nodes,
                        ITYPE_t n_features) except -1:
     """Allocate arrays needed for the KD Tree"""
     tree.node_bounds = np.zeros((2, n_nodes, n_features), dtype=DTYPE)
-    tree.node_bounds = tree.node_bounds
     return 0
 
 

--- a/sklearn/neighbors/_kd_tree.pyx
+++ b/sklearn/neighbors/_kd_tree.pyx
@@ -32,8 +32,8 @@ cdef class KDTree(BinaryTree):
 cdef int allocate_data(BinaryTree tree, ITYPE_t n_nodes,
                        ITYPE_t n_features) except -1:
     """Allocate arrays needed for the KD Tree"""
-    tree.node_bounds_arr = np.zeros((2, n_nodes, n_features), dtype=DTYPE)
-    tree.node_bounds = tree.node_bounds_arr
+    tree.node_bounds = np.zeros((2, n_nodes, n_features), dtype=DTYPE)
+    tree.node_bounds = tree.node_bounds
     return 0
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follows up #24965
Towards #24875

#### What does this implement/fix? Explain your changes.
- Remove duplicate memoryviews `data_arr`, `sample_weight_arr`, `idx_array_arr`, `node_data_arr`, and `node_bounds_arr` now that we convert their `cnp.array` counterparts to memoryviews directly.
- Remove `_update_memviews` method

#### Any other comments?
#24965 needs to be merged first to shrink the number of changes on this PR

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
