### PR TITLE
MAINT add support for dataframe in parameter validation

### DIFF
--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -30,6 +30,7 @@ def validate_parameter_constraints(parameter_constraints, params, caller_name):
         - an Interval object, representing a continuous or discrete range of numbers
         - the string "array-like"
         - the string "sparse matrix"
+        - the string "dataframe"
         - the string "random_state"
         - callable
         - None, meaning that None is a valid value for the parameter
@@ -108,6 +109,8 @@ def make_constraint(constraint):
         return _ArrayLikes()
     if isinstance(constraint, str) and constraint == "sparse matrix":
         return _SparseMatrices()
+    if isinstance(constraint, str) and constraint == "dataframe":
+        return _DataFrames()
     if isinstance(constraint, str) and constraint == "random_state":
         return _RandomStates()
     if constraint is callable:
@@ -461,6 +464,16 @@ class _SparseMatrices(_Constraint):
 
     def __str__(self):
         return "a sparse matrix"
+
+
+class _DataFrames(_Constraint):
+    """Constraint representing a DataFrame."""
+
+    def is_satisfied_by(self, val):
+        return hasattr(val, "__dataframe__")
+
+    def __str__(self):
+        return "a DataFrame"
 
 
 class _Callables(_Constraint):
@@ -850,6 +863,11 @@ def generate_valid_param(constraint):
 
     if isinstance(constraint, _SparseMatrices):
         return csr_matrix([[0, 1], [1, 0]])
+
+    if isinstance(constraint, _DataFrames):
+        import pandas as pd
+
+        return pd.DataFrame({"a": [1, 2, 3]})
 
     if isinstance(constraint, _RandomStates):
         return np.random.RandomState(42)

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -470,7 +470,9 @@ class _DataFrames(_Constraint):
     """Constraint representing a DataFrame."""
 
     def is_satisfied_by(self, val):
-        return hasattr(val, "__dataframe__")
+        # Let's first try the dataframe protocol and then duck-typing for the older
+        # pandas versions.
+        return hasattr(val, "__dataframe__") or hasattr(val, "iloc")
 
     def __str__(self):
         return "a DataFrame"

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -15,6 +15,7 @@ from sklearn.utils._param_validation import _ArrayLikes
 from sklearn.utils._param_validation import _Booleans
 from sklearn.utils._param_validation import _Callables
 from sklearn.utils._param_validation import _CVObjects
+from sklearn.utils._param_validation import _DataFrames
 from sklearn.utils._param_validation import _InstancesOf
 from sklearn.utils._param_validation import _MissingValues
 from sklearn.utils._param_validation import _PandasNAConstraint
@@ -28,6 +29,15 @@ from sklearn.utils._param_validation import make_constraint
 from sklearn.utils._param_validation import generate_invalid_param_val
 from sklearn.utils._param_validation import generate_valid_param
 from sklearn.utils._param_validation import validate_params
+
+
+def has_pandas():
+    try:
+        import pandas as pd
+
+        return True, pd.DataFrame({"a": [1, 2, 3]})
+    except ImportError:
+        return False, None
 
 
 # Some helpers for the tests
@@ -311,6 +321,12 @@ def test_generate_invalid_param_val_2_intervals(integer_interval, real_interval)
     "constraints",
     [
         [_ArrayLikes()],
+        pytest.param(
+            [_DataFrames()],
+            marks=pytest.mark.skipif(
+                not has_pandas()[0], reason="Pandas is not installed"
+            ),
+        ),
         [_InstancesOf(list)],
         [_Callables()],
         [_NoneConstraint()],
@@ -336,6 +352,12 @@ def test_generate_invalid_param_val_all_valid(constraints):
     "constraint",
     [
         _ArrayLikes(),
+        pytest.param(
+            _DataFrames(),
+            marks=pytest.mark.skipif(
+                not has_pandas()[0], reason="Pandas is not installed"
+            ),
+        ),
         _Callables(),
         _InstancesOf(list),
         _NoneConstraint(),
@@ -375,6 +397,13 @@ def test_generate_valid_param(constraint):
         (None, None),
         ("array-like", [[1, 2], [3, 4]]),
         ("array-like", np.array([[1, 2], [3, 4]])),
+        pytest.param(
+            "dataframe",
+            has_pandas()[1],
+            marks=pytest.mark.skipif(
+                not has_pandas()[0], reason="Pandas is not installed"
+            ),
+        ),
         ("sparse matrix", csr_matrix([[1, 2], [3, 4]])),
         ("random_state", 0),
         ("random_state", np.random.RandomState(0)),
@@ -407,6 +436,13 @@ def test_is_satisfied_by(constraint_declaration, value):
         (StrOptions({"option1", "option2"}), StrOptions),
         (Options(Real, {0.42, 1.23}), Options),
         ("array-like", _ArrayLikes),
+        pytest.param(
+            "dataframe",
+            _DataFrames,
+            marks=pytest.mark.skipif(
+                not has_pandas()[0], reason="Pandas is not installed"
+            ),
+        ),
         ("sparse matrix", _SparseMatrices),
         ("random_state", _RandomStates),
         (None, _NoneConstraint),


### PR DESCRIPTION
Add support for DataFrame checking in the parameter validation framework.
Particularly useful once we add the parameter validation to the `ColumnTransformer`.