### PR TITLE
MAINT Remove -Wcpp warnings when compiling sklearn.svm._liblinear

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.metrics._pairwise_distances_reduction._radius_neighbors",
     "sklearn.metrics._pairwise_fast",
     "sklearn.neighbors._partition_nodes",
+    "sklearn.svm._liblinear",
     "sklearn.tree._splitter",
     "sklearn.tree._utils",
     "sklearn.utils._cython_blas",

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -34,29 +34,79 @@ def train_wrap(
     cdef char_const_ptr error_msg
     cdef int len_w
 
+    # The implementation for float32 and float64 uses a single interface.
+    # This is done by accepting the data as a pointer to a buffer of bytes.
+    # In this regard, we define a pointer to pass the address of the first
+    # element of the buffer seen as raw bytes (hence the use of `char *`).
+    #
+    # We proceed in two steps using intermediate memory views to have Cython
+    # have sufficient typing information not to use PyObjects.
+    cdef cnp.float64_t[::1] X_data_64
+    cdef cnp.float32_t[::1] X_data_32
+    cdef char * X_data_as_bytes_ptr = NULL
+
+    # The same is done for `indices` and `indptr` in the CSR case.
+    cdef cnp.int32_t[::1] X_indices
+    cdef char * X_indices_as_bytes_ptr = NULL
+
+    cdef cnp.int32_t[::1] X_indptr
+    cdef char * X_indptr_as_bytes_ptr = NULL
+
+    cdef bint X_stores_float64_data = X.dtype == np.float64
+
     if is_sparse:
+        # X is a CSR matrix here, a format which stores the values
+        # as a contiguous buffer via a NumPy array in a `data` attribute.
+        # We get the address of the first element of the buffer which
+        # we reference using a pointer to bytes.
+        if X_stores_float64_data:
+            X_data_64 = X.data
+            X_data_as_bytes_ptr = <char*> &X_data_64[0]
+        else:
+            X_data_32 = X.data
+            X_data_as_bytes_ptr = <char*> &X_data_32[0]
+
+        # Similar operations are to be performed for `indices` and `indptr`.
+        X_indices = X.indices
+        X_indices_as_bytes_ptr = <char *> &X_indices[0]
+
+        X_indptr = X.indptr
+        X_indptr_as_bytes_ptr = <char *> &X_indptr[0]
+
         problem = csr_set_problem(
-            X.data.tobytes(),
-            X.dtype == np.float64,
-            X.indices.tobytes(),
-            X.indptr.tobytes(),
+            # Underneath, the data will be statically re-interpreted as
+            # either float32 or float64 depending on the boolean passed as
+            # the second argument.
+            X_data_as_bytes_ptr,
+            X_stores_float64_data,
+            X_indices_as_bytes_ptr,
+            X_indptr_as_bytes_ptr,
             (<cnp.int32_t>X.shape[0]),
             (<cnp.int32_t>X.shape[1]),
             (<cnp.int32_t>X.nnz),
             bias,
-            <char*> &sample_weight[0],
-            <char*> &Y[0]
+            <char *> &sample_weight[0],
+            <char *> &Y[0]
         )
     else:
+        # X simply is a 2D NumPy array in this case.
+        # This is reshapeable to a 1D NumPy array in O(1) (only strides are changed).
+        if X_stores_float64_data:
+            X_data_64 = X.reshape(-1)
+            X_data_as_bytes_ptr = <char*> &X_data_64[0]
+        else:
+            X_data_32 = X.reshape(-1)
+            X_data_as_bytes_ptr = <char*> &X_data_32[0]
+
         problem = set_problem(
-            X.tobytes(),
+            X_data_as_bytes_ptr,
             X.dtype == np.float64,
             (<cnp.int32_t>X.shape[0]),
             (<cnp.int32_t>X.shape[1]),
             (<cnp.int32_t>np.count_nonzero(X)),
             bias,
-            <char*> &sample_weight[0],
-            <char*> &Y[0]
+            <char *> &sample_weight[0],
+            <char *> &Y[0]
         )
 
     cdef cnp.int32_t[::1] class_weight_label = np.arange(class_weight.shape[0], dtype=np.intc)

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -14,36 +14,71 @@ include "_liblinear.pxi"
 cnp.import_array()
 
 
-def train_wrap(X, cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] Y,
-               bint is_sparse, int solver_type, double eps, double bias,
-               double C, cnp.ndarray[cnp.float64_t, ndim=1] class_weight,
-               int max_iter, unsigned random_seed, double epsilon,
-               cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] sample_weight):
+def train_wrap(
+    object X,
+    cnp.float64_t[::1] Y,
+    bint is_sparse,
+    int solver_type,
+    double eps,
+    double bias,
+    double C,
+    cnp.float64_t[:] class_weight,
+    int max_iter,
+    unsigned random_seed,
+    double epsilon,
+    cnp.float64_t[::1] sample_weight
+):
     cdef parameter *param
     cdef problem *problem
     cdef model *model
     cdef char_const_ptr error_msg
     cdef int len_w
+    cdef cnp.float64_t[::1] x_data
+    cdef cnp.int32_t[::1] x_indices
+    cdef cnp.int32_t[::1] x_indptr
+    cdef cnp.float64_t[:, ::1] x_array
 
     if is_sparse:
+        x_data = X.data
+        x_indices = X.indices
+        x_indptr = X.indptr
         problem = csr_set_problem(
-                (<cnp.ndarray>X.data).data, X.dtype == np.float64,
-                (<cnp.ndarray[cnp.int32_t,   ndim=1, mode='c']>X.indices).data,
-                (<cnp.ndarray[cnp.int32_t,   ndim=1, mode='c']>X.indptr).data,
-                (<cnp.int32_t>X.shape[0]), (<cnp.int32_t>X.shape[1]),
-                (<cnp.int32_t>X.nnz), bias, sample_weight.data, Y.data)
+            <char*> &x_data[0],
+            X.dtype == np.float64,
+            <char*> &x_indices[0],
+            <char*> &x_indptr[0],
+            (<cnp.int32_t>X.shape[0]),
+            (<cnp.int32_t>X.shape[1]),
+            (<cnp.int32_t>X.nnz),
+            bias,
+            <char*> &sample_weight[0],
+            <char*> &Y[0]
+        )
     else:
+        x_array = X
         problem = set_problem(
-                (<cnp.ndarray>X).data, X.dtype == np.float64,
-                (<cnp.int32_t>X.shape[0]), (<cnp.int32_t>X.shape[1]),
-                (<cnp.int32_t>np.count_nonzero(X)), bias, sample_weight.data,
-                Y.data)
+            <char*> &x_array[0, 0],
+            X.dtype == np.float64,
+            (<cnp.int32_t>X.shape[0]),
+            (<cnp.int32_t>X.shape[1]),
+            (<cnp.int32_t>np.count_nonzero(X)),
+            bias,
+            <char*> &sample_weight[0],
+            <char*> &Y[0]
+        )
 
-    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] \
-        class_weight_label = np.arange(class_weight.shape[0], dtype=np.intc)
-    param = set_parameter(solver_type, eps, C, class_weight.shape[0],
-                          class_weight_label.data, class_weight.data,
-                          max_iter, random_seed, epsilon)
+    cdef cnp.int32_t[::1] class_weight_label = np.arange(class_weight.shape[0], dtype=np.intc)
+    param = set_parameter(
+        solver_type,
+        eps,
+        C,
+        class_weight.shape[0],
+        <char*> &class_weight_label[0],
+        <char*> &class_weight[0],
+        max_iter,
+        random_seed,
+        epsilon
+    )
 
     error_msg = check_parameter(problem, param)
     if error_msg:
@@ -67,28 +102,28 @@ def train_wrap(X, cnp.ndarray[cnp.float64_t, ndim=1, mode='c'] Y,
     # destroy_param(param)  don't call this or it will destroy class_weight_label and class_weight
 
     # coef matrix holder created as fortran since that's what's used in liblinear
-    cdef cnp.ndarray[cnp.float64_t, ndim=2, mode='fortran'] w
+    cdef cnp.float64_t[::1, :] w
     cdef int nr_class = get_nr_class(model)
 
     cdef int labels_ = nr_class
     if nr_class == 2:
         labels_ = 1
-    cdef cnp.ndarray[cnp.int32_t, ndim=1, mode='c'] n_iter = np.zeros(labels_, dtype=np.intc)
-    get_n_iter(model, <int *>n_iter.data)
+    cdef cnp.int32_t[::1] n_iter = np.zeros(labels_, dtype=np.intc)
+    get_n_iter(model, <int *> &n_iter[0])
 
     cdef int nr_feature = get_nr_feature(model)
     if bias > 0: nr_feature = nr_feature + 1
     if nr_class == 2 and solver_type != 4:  # solver is not Crammer-Singer
-        w = np.empty((1, nr_feature),order='F')
-        copy_w(w.data, model, nr_feature)
+        w = np.empty((1, nr_feature), order='F')
+        copy_w(&w[0, 0], model, nr_feature)
     else:
         len_w = (nr_class) * nr_feature
-        w = np.empty((nr_class, nr_feature),order='F')
-        copy_w(w.data, model, len_w)
+        w = np.empty((nr_class, nr_feature), order='F')
+        copy_w(&w[0, 0], model, len_w)
 
     free_and_destroy_model(&model)
 
-    return w, n_iter
+    return w.base, n_iter.base
 
 
 def set_verbosity_wrap(int verbosity):

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -66,7 +66,7 @@ def train_wrap(
         C,
         class_weight.shape[0],
         <char*> &class_weight_label[0] if class_weight_label.size > 0 else NULL,
-        <char*> &class_weight[0],
+        <char*> &class_weight[0] if class_weight.size > 0 else NULL,
         max_iter,
         random_seed,
         epsilon

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -73,7 +73,7 @@ def train_wrap(
 
         problem = set_problem(
             x_data_bytes_ptr,
-            X.dtype == np.float64,
+            x_has_type_float64,
             (<cnp.int32_t>X.shape[0]),
             (<cnp.int32_t>X.shape[1]),
             (<cnp.int32_t>np.count_nonzero(X)),

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -33,28 +33,28 @@ def train_wrap(
     cdef model *model
     cdef char_const_ptr error_msg
     cdef int len_w
-    cdef bint x_has_type_float64 = X.dtype == np.float64
-    cdef char * x_data_bytes_ptr
-    cdef const cnp.float64_t[::1] x_data_64
-    cdef const cnp.float32_t[::1] x_data_32
-    cdef cnp.int32_t[::1] x_indices
-    cdef cnp.int32_t[::1] x_indptr
+    cdef bint X_has_type_float64 = X.dtype == np.float64
+    cdef char * X_data_bytes_ptr
+    cdef const cnp.float64_t[::1] X_data_64
+    cdef const cnp.float32_t[::1] X_data_32
+    cdef cnp.int32_t[::1] X_indices
+    cdef cnp.int32_t[::1] X_indptr
 
     if is_sparse:
-        x_indices = X.indices
-        x_indptr = X.indptr
-        if x_has_type_float64:
-            x_data_64 = X.data
-            x_data_bytes_ptr = <char *> &x_data_64[0]
+        X_indices = X.indices
+        X_indptr = X.indptr
+        if X_has_type_float64:
+            X_data_64 = X.data
+            X_data_bytes_ptr = <char *> &X_data_64[0]
         else:
-            x_data_32 = X.data
-            x_data_bytes_ptr = <char *> &x_data_32[0]
+            X_data_32 = X.data
+            X_data_bytes_ptr = <char *> &X_data_32[0]
 
         problem = csr_set_problem(
-            x_data_bytes_ptr,
-            x_has_type_float64,
-            <char *> &x_indices[0],
-            <char *> &x_indptr[0],
+            X_data_bytes_ptr,
+            X_has_type_float64,
+            <char *> &X_indices[0],
+            <char *> &X_indptr[0],
             (<cnp.int32_t>X.shape[0]),
             (<cnp.int32_t>X.shape[1]),
             (<cnp.int32_t>X.nnz),
@@ -63,17 +63,17 @@ def train_wrap(
             <char *> &Y[0]
         )
     else:
-        x_as_1d_array = X.reshape(-1)
-        if x_has_type_float64:
-            x_data_64 = x_as_1d_array
-            x_data_bytes_ptr = <char *> &x_data_64[0]
+        X_as_1d_array = X.reshape(-1)
+        if X_has_type_float64:
+            X_data_64 = X_as_1d_array
+            X_data_bytes_ptr = <char *> &X_data_64[0]
         else:
-            x_data_32 = x_as_1d_array
-            x_data_bytes_ptr = <char *> &x_data_32[0]
+            X_data_32 = X_as_1d_array
+            X_data_bytes_ptr = <char *> &X_data_32[0]
 
         problem = set_problem(
-            x_data_bytes_ptr,
-            x_has_type_float64,
+            X_data_bytes_ptr,
+            X_has_type_float64,
             (<cnp.int32_t>X.shape[0]),
             (<cnp.int32_t>X.shape[1]),
             (<cnp.int32_t>np.count_nonzero(X)),

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -65,7 +65,7 @@ def train_wrap(
         eps,
         C,
         class_weight.shape[0],
-        <char*> &class_weight_label[0],
+        <char*> &class_weight_label[0] if class_weight_label.size > 0 else NULL,
         <char*> &class_weight[0],
         max_iter,
         random_seed,

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -33,20 +33,13 @@ def train_wrap(
     cdef model *model
     cdef char_const_ptr error_msg
     cdef int len_w
-    cdef cnp.float64_t[::1] x_data
-    cdef cnp.int32_t[::1] x_indices
-    cdef cnp.int32_t[::1] x_indptr
-    cdef cnp.float64_t[:, ::1] x_array
 
     if is_sparse:
-        x_data = X.data
-        x_indices = X.indices
-        x_indptr = X.indptr
         problem = csr_set_problem(
-            <char*> &x_data[0],
+            X.data.tobytes(),
             X.dtype == np.float64,
-            <char*> &x_indices[0],
-            <char*> &x_indptr[0],
+            X.indices.tobytes(),
+            X.indptr.tobytes(),
             (<cnp.int32_t>X.shape[0]),
             (<cnp.int32_t>X.shape[1]),
             (<cnp.int32_t>X.nnz),
@@ -55,9 +48,8 @@ def train_wrap(
             <char*> &Y[0]
         )
     else:
-        x_array = X
         problem = set_problem(
-            <char*> &x_array[0, 0],
+            X.tobytes(),
             X.dtype == np.float64,
             (<cnp.int32_t>X.shape[0]),
             (<cnp.int32_t>X.shape[1]),

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -16,17 +16,17 @@ cnp.import_array()
 
 def train_wrap(
     object X,
-    cnp.float64_t[::1] Y,
+    const cnp.float64_t[::1] Y,
     bint is_sparse,
     int solver_type,
     double eps,
     double bias,
     double C,
-    cnp.float64_t[:] class_weight,
+    const cnp.float64_t[:] class_weight,
     int max_iter,
     unsigned random_seed,
     double epsilon,
-    cnp.float64_t[::1] sample_weight
+    const cnp.float64_t[::1] sample_weight
 ):
     cdef parameter *param
     cdef problem *problem

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -37,8 +37,8 @@ def train_wrap(
     cdef char * X_data_bytes_ptr
     cdef const cnp.float64_t[::1] X_data_64
     cdef const cnp.float32_t[::1] X_data_32
-    cdef cnp.int32_t[::1] X_indices
-    cdef cnp.int32_t[::1] X_indptr
+    cdef const cnp.int32_t[::1] X_indices
+    cdef const cnp.int32_t[::1] X_indptr
 
     if is_sparse:
         X_indices = X.indices


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24875

#### What does this implement/fix? Explain your changes.
- Used memory views to replace the deprecated cnp.ndarray in sklearn.svm._liblinear

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
