### PR TITLE
BLD Reduces size of wheels by stripping symbols

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -299,6 +299,13 @@ When this environment variable is set to a non zero value, the `Cython`
 derivative, `boundscheck` is set to `True`. This is useful for finding
 segfaults.
 
+`SKLEARN_BUILD_ENABLE_DEBUG_SYMBOLS`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When this environment variable is set to a non zero value, the debug symbols
+will be included in the compiled C extensions. Only debug symbols for POSIX
+systems is configured.
+
 `SKLEARN_PAIRWISE_DIST_CHUNK_SIZE`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ class build_ext_subclass(build_ext):
                 e.extra_compile_args += openmp_flag
                 e.extra_link_args += openmp_flag
 
-        # To build with debug symbols
+        # To build with debug symbols run:
         # python setup.py build_ext -i --debug
         if not self.debug and os.name == "posix":
             for e in self.extensions:

--- a/setup.py
+++ b/setup.py
@@ -503,7 +503,7 @@ def configure_extension_modules():
 
     optimization_level = "O2"
     if os.name == "posix":
-        default_extra_compile_args = [f"-{optimization_level}"]
+        default_extra_compile_args = [f"-{optimization_level}", "-g0"]
         default_libraries = ["m"]
     else:
         default_extra_compile_args = [f"/{optimization_level}"]

--- a/setup.py
+++ b/setup.py
@@ -195,12 +195,18 @@ class build_ext_subclass(build_ext):
                 e.extra_compile_args += openmp_flag
                 e.extra_link_args += openmp_flag
 
-        # To build with debug symbols run:
-        # python setup.py build_ext -i --debug
-        if not self.debug and os.name == "posix":
-            # Setting -g0 will strip symbols, reducing the binary size of extensions
+        build_with_debug_symbols = (
+            os.environ.get("SKLEARN_BUILD_ENABLE_DEBUG_SYMBOLS", "0") != "0"
+        )
+        if os.name == "posix":
+            if build_with_debug_symbols:
+                debug_compile_arg = ["-g"]
+            else:
+                # Setting -g0 will strip symbols, reducing the binary size of extensions
+                debug_compile_arg = ["-g0"]
+
             for e in self.extensions:
-                e.extra_compile_args += ["-g0"]
+                e.extra_compile_args += debug_compile_arg
 
         build_ext.build_extensions(self)
 

--- a/setup.py
+++ b/setup.py
@@ -195,6 +195,12 @@ class build_ext_subclass(build_ext):
                 e.extra_compile_args += openmp_flag
                 e.extra_link_args += openmp_flag
 
+        # To build with debug symbols
+        # python setup.py build_ext -i --debug
+        if not self.debug and os.name == "posix":
+            for e in self.extensions:
+                e.extra_compile_args += ["-g0"]
+
         build_ext.build_extensions(self)
 
     def run(self):
@@ -503,7 +509,7 @@ def configure_extension_modules():
 
     optimization_level = "O2"
     if os.name == "posix":
-        default_extra_compile_args = [f"-{optimization_level}", "-g0"]
+        default_extra_compile_args = [f"-{optimization_level}"]
         default_libraries = ["m"]
     else:
         default_extra_compile_args = [f"/{optimization_level}"]

--- a/setup.py
+++ b/setup.py
@@ -198,6 +198,7 @@ class build_ext_subclass(build_ext):
         # To build with debug symbols run:
         # python setup.py build_ext -i --debug
         if not self.debug and os.name == "posix":
+            # Setting -g0 will strip symbols, reducing the binary size of extensions
             for e in self.extensions:
                 e.extra_compile_args += ["-g0"]
 

--- a/setup.py
+++ b/setup.py
@@ -195,19 +195,6 @@ class build_ext_subclass(build_ext):
                 e.extra_compile_args += openmp_flag
                 e.extra_link_args += openmp_flag
 
-        build_with_debug_symbols = (
-            os.environ.get("SKLEARN_BUILD_ENABLE_DEBUG_SYMBOLS", "0") != "0"
-        )
-        if os.name == "posix":
-            if build_with_debug_symbols:
-                debug_compile_arg = ["-g"]
-            else:
-                # Setting -g0 will strip symbols, reducing the binary size of extensions
-                debug_compile_arg = ["-g0"]
-
-            for e in self.extensions:
-                e.extra_compile_args += debug_compile_arg
-
         build_ext.build_extensions(self)
 
     def run(self):
@@ -521,6 +508,16 @@ def configure_extension_modules():
     else:
         default_extra_compile_args = [f"/{optimization_level}"]
         default_libraries = []
+
+    build_with_debug_symbols = (
+        os.environ.get("SKLEARN_BUILD_ENABLE_DEBUG_SYMBOLS", "0") != "0"
+    )
+    if os.name == "posix":
+        if build_with_debug_symbols:
+            default_extra_compile_args.append("-g")
+        else:
+            # Setting -g0 will strip symbols, reducing the binary size of extensions
+            default_extra_compile_args.append("-g0")
 
     cython_exts = []
     for submodule, extensions in extension_config.items():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #25063

#### What does this implement/fix? Explain your changes.
This PR sets `-g0` to strip symbols and reduce the file size of the linux wheels.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
