### PR TITLE
DOC Use notebook style in plot_gpr_on_structured_data.py

### DIFF
--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -38,8 +38,8 @@ four correct classifications and fails on one.
 
 """
 
+# %%
 import numpy as np
-import matplotlib.pyplot as plt
 from sklearn.gaussian_process.kernels import Kernel, Hyperparameter
 from sklearn.gaussian_process.kernels import GenericKernelMixin
 from sklearn.gaussian_process import GaussianProcessRegressor
@@ -102,10 +102,11 @@ class SequenceKernel(GenericKernelMixin, Kernel):
 
 kernel = SequenceKernel()
 
-"""
-Sequence similarity matrix under the kernel
-===========================================
-"""
+# %%
+# Sequence similarity matrix under the kernel
+# ===========================================
+
+import matplotlib.pyplot as plt
 
 X = np.array(["AGCT", "AGC", "AACT", "TAA", "AAA", "GAACA"])
 
@@ -117,11 +118,11 @@ plt.imshow(np.diag(D**-0.5).dot(K).dot(np.diag(D**-0.5)))
 plt.xticks(np.arange(len(X)), X)
 plt.yticks(np.arange(len(X)), X)
 plt.title("Sequence similarity under the kernel")
+plt.show()
 
-"""
-Regression
-==========
-"""
+# %%
+# Regression
+# ==========
 
 X = np.array(["AGCT", "AGC", "AACT", "TAA", "AAA", "GAACA"])
 Y = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
@@ -136,11 +137,11 @@ plt.bar(training_idx, Y[training_idx], width=0.2, color="r", alpha=1, label="tra
 plt.xticks(np.arange(len(X)), X)
 plt.title("Regression on sequences")
 plt.legend()
+plt.show()
 
-"""
-Classification
-==============
-"""
+# %%
+# Classification
+# ==============
 
 X_train = np.array(["AGCT", "CGA", "TAAC", "TCG", "CTTT", "TGCT"])
 # whether there are 'A's in the sequence
@@ -176,7 +177,7 @@ plt.scatter(
     [1.0 if c else -1.0 for c in gp.predict(X_test)],
     s=100,
     marker="x",
-    edgecolor=(0, 1.0, 0.3),
+    facecolor="b",
     linewidth=2,
     label="prediction",
 )
@@ -184,5 +185,4 @@ plt.xticks(np.arange(len(X_train) + len(X_test)), np.concatenate((X_train, X_tes
 plt.yticks([-1, 1], [False, True])
 plt.title("Classification on sequences")
 plt.legend()
-
 plt.show()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Related to #22406.

#### What does this implement/fix? Explain your changes.

The [Gaussian processes on discrete data structures](https://scikit-learn.org/dev/auto_examples/gaussian_process/plot_gpr_on_structured_data.html) example is raising a Matplotlib `UserWarning`. This PR fixes it while implementing notebook style.

#### Any other comments?

The example still raises a `ConvergenceWarning`. I am open to suggestions on how to fix it without making the code too charged.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
