### PR TITLE
FIX Convert boolean pd.Series to boolean ndarrays

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -2,6 +2,31 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_1_2_1:
+
+Version 1.2.1
+=============
+
+**In Development**
+
+Changed models
+--------------
+
+The following estimators and functions, when fit with the same data and
+parameters, may produce different models from the previous version. This often
+occurs due to changes in the modelling logic (bug fixes or enhancements), or in
+random sampling procedures.
+
+Changelog
+---------
+
+:mod:`sklearn.utils`
+...................
+
+- |Fix| Restore :func:`utils.check_array`'s behaviour for pandas Series of type
+  boolean. The type is maintained, instead of converting to `float64.`
+  :pr:`25147` by `Tim Head`_.
+
 .. _changes_1_2:
 
 Version 1.2.0

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -17,7 +17,7 @@ Changelog
 
 - |Fix| Restore :func:`utils.check_array`'s behaviour for pandas Series of type
   boolean. The type is maintained, instead of converting to `float64.`
-  :pr:`25147` by `Tim Head`_.
+  :pr:`25147` by :user:`Tim Head <betatim>`.
 
 .. _changes_1_2:
 

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -9,19 +9,11 @@ Version 1.2.1
 
 **In Development**
 
-Changed models
---------------
-
-The following estimators and functions, when fit with the same data and
-parameters, may produce different models from the previous version. This often
-occurs due to changes in the modelling logic (bug fixes or enhancements), or in
-random sampling procedures.
-
 Changelog
 ---------
 
 :mod:`sklearn.utils`
-...................
+....................
 
 - |Fix| Restore :func:`utils.check_array`'s behaviour for pandas Series of type
   boolean. The type is maintained, instead of converting to `float64.`

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1749,3 +1749,13 @@ def test_check_feature_names_in_pandas():
 
     with pytest.raises(ValueError, match="input_features is not equal to"):
         est.get_feature_names_out(["x1", "x2", "x3"])
+
+
+def test_boolean_series_remains_boolean():
+    """Regression test for GH25145"""
+    pd = importorskip("pandas")
+    res = check_array(pd.Series([True, False]), ensure_2d=False)
+    expected = np.array([True, False])
+
+    assert res.dtype == expected.dtype
+    assert_array_equal(res, expected)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1752,7 +1752,7 @@ def test_check_feature_names_in_pandas():
 
 
 def test_boolean_series_remains_boolean():
-    """Regression test for GH25145"""
+    """Regression test for gh-25145"""
     pd = importorskip("pandas")
     res = check_array(pd.Series([True, False]), ensure_2d=False)
     expected = np.array([True, False])

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -780,9 +780,15 @@ def check_array(
     elif hasattr(array, "iloc") and hasattr(array, "dtype"):
         # array is a pandas series
         pandas_requires_conversion = _pandas_dtype_needs_early_conversion(array.dtype)
-        if pandas_requires_conversion:
-            # Set to None, to convert to a np.dtype that works with array.dtype
+        from pandas.api.types import is_extension_array_dtype, is_categorical_dtype
+
+        if (
+            pandas_requires_conversion and is_extension_array_dtype(array)
+        ) or is_categorical_dtype(array):
+            # Set to None, to let asarray() work out the best dtype
             dtype_orig = None
+        else:
+            dtype_orig = np.result_type(array.dtype)
 
     if dtype_numeric:
         if dtype_orig is not None and dtype_orig.kind == "O":

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -780,15 +780,10 @@ def check_array(
     elif hasattr(array, "iloc") and hasattr(array, "dtype"):
         # array is a pandas series
         pandas_requires_conversion = _pandas_dtype_needs_early_conversion(array.dtype)
-        from pandas.api.types import is_extension_array_dtype, is_categorical_dtype
-
-        if (
-            pandas_requires_conversion and is_extension_array_dtype(array)
-        ) or is_categorical_dtype(array):
-            # Set to None, to let asarray() work out the best dtype
-            dtype_orig = None
-        else:
+        if isinstance(array.dtype, np.dtype):
             dtype_orig = np.result_type(array.dtype)
+        else:
+            dtype_orig = None
 
     if dtype_numeric:
         if dtype_orig is not None and dtype_orig.kind == "O":

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -781,8 +781,9 @@ def check_array(
         # array is a pandas series
         pandas_requires_conversion = _pandas_dtype_needs_early_conversion(array.dtype)
         if isinstance(array.dtype, np.dtype):
-            dtype_orig = np.result_type(array.dtype)
+            dtype_orig = array.dtype
         else:
+            # Set to None to let array.astype work out the best dtype
             dtype_orig = None
 
     if dtype_numeric:


### PR DESCRIPTION
For types that are not pandas extension dtypes, we should ask numpy to tell us the best dtype, so that we preserve the behaviour of boolean Series being converted to boolean arrays.

The story is a bit confused by categorical dtypes :-/ So while this fixes the regression and doesn't break any existing tests in `test_validation.py`, it feels like we are adding a layer on top of several layers of "fixes" and exceptions in the conversion logic. Ideas welcome.

Closes #25145
