### PR TITLE
[MRG] Implement predict_proba() for OutputCodeClassifier

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -36,6 +36,11 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.multiclass`
+.......................
+- |Feature| :class:`multiclass.OutputCodeClassifier` supports `predict_proba()`
+  method for the class probability estimates now. :pr:`25148` by :user:`<dx2-66>`
+
 :mod:`sklearn.pipeline`
 .......................
 - |Feature| :class:`pipeline.FeatureUnion` can now use indexing notation (e.g.

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -37,7 +37,7 @@ Changelog
     where 123456 is the *pull request* number, not the issue number.
 
 :mod:`sklearn.multiclass`
-.......................
+.........................
 - |Feature| :class:`multiclass.OutputCodeClassifier` supports `predict_proba()`
   method for the class probability estimates now. :pr:`25148` by :user:`<dx2-66>`
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -1026,8 +1026,10 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         return self
 
     def predict_proba(self, X):
-        """Return faux probability estimates based upon euclidean distance
-        between the underlying estimators' predictions and the class code.
+        """Return faux probability estimates.
+
+        Estimates are based upon euclidean distance between the underlying
+        estimators' predictions and the class code.
 
         Parameters
         ----------

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -1046,7 +1046,8 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         Y = np.array([_predict_binary(e, X) for e in self.estimators_]).T
         distance = euclidean_distances(Y, self.code_book_)
         # Inverse distance weighting:
-        proba = (1. / distance) / np.sum(1. / distance, axis=1)[:, np.newaxis]
+        eps = 1e-16
+        proba = (1. / (distance + eps)) / np.sum(1. / (distance + eps), axis=1)[:, np.newaxis]
         return proba
 
     def predict(self, X):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -1044,10 +1044,10 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         """
         check_is_fitted(self)
         Y = np.array([_predict_binary(e, X) for e in self.estimators_]).T
-        distance = euclidean_distances(Y, self.code_book_)
+        dist = euclidean_distances(Y, self.code_book_)
         # Inverse distance weighting:
         eps = 1e-16
-        proba = (1. / (distance + eps)) / np.sum(1. / (distance + eps), axis=1)[:, np.newaxis]
+        proba = (1.0 / (dist + eps)) / np.sum(1.0 / (dist + eps), axis=1)[:, np.newaxis]
         return proba
 
     def predict(self, X):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -1031,7 +1031,7 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         return self
 
     def predict_proba(self, X):
-        """Return faux probability estimates.
+        """Return probability estimates.
 
         Estimates are based upon euclidean distance between the underlying
         estimators' predictions and the class code.

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -1052,7 +1052,7 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         dist = euclidean_distances(Y, self.code_book_)
         # Inverse distance weighting:
         eps = np.finfo(dist.dtype).eps
-        proba = (1.0 / (dist + eps)) / np.sum(1.0 / (dist + eps), axis=1)[:, np.newaxis]
+        proba = (1.0 / (dist + eps)) / np.sum(1.0 / (dist + eps), axis=1, keepdims=True)
         return proba
 
     def predict(self, X):

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -1033,12 +1033,12 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : (sparse) array-like of shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Data.
 
         Returns
         -------
-        T : (sparse) array-like of shape (n_samples, n_classes)
+        T : ndarray of shape (n_samples, n_classes) or (n_samples,)
             Returns the score of the sample for each class in the model,
             where classes are ordered as they are in `self.classes_`.
         """

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -1046,7 +1046,7 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         Y = np.array([_predict_binary(e, X) for e in self.estimators_]).T
         dist = euclidean_distances(Y, self.code_book_)
         # Inverse distance weighting:
-        eps = 1e-16
+        eps = np.finfo(dist.dtype).eps
         proba = (1.0 / (dist + eps)) / np.sum(1.0 / (dist + eps), axis=1)[:, np.newaxis]
         return proba
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -18,14 +18,19 @@ All classifiers in scikit-learn implement multiclass classification; you
 only need to use this module if you want to experiment with custom multiclass
 strategies.
 
-The one-vs-the-rest meta-classifier also implements a `predict_proba` method,
-so long as such a method is implemented by the base classifier. This method
-returns probabilities of class membership in both the single label and
-multilabel case.  Note that in the multilabel case, probabilities are the
+The one-vs-the-rest and error correcting output codes meta-classifiers also
+implement a `predict_proba` method, returning the probabilities of class
+membership.
+For one-vs-the-rest classifier, it requires such a method to be
+implemented by the base classifier and supports both the single label and
+multilabel case. Note that in the multilabel case, probabilities are the
 marginal probability that a given sample falls in the given class. As such, in
 the multilabel case the sum of these probabilities over all possible labels
 for a given sample *will not* sum to unity, as they do in the single label
 case.
+Error correcting output codes classifier only supports single label multiclass
+target. Its `predict_proba` method imposes no additional requirements on the
+base estimator.
 """
 
 # Author: Mathieu Blondel <mathieu@mblondel.org>
@@ -1038,7 +1043,7 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
 
         Returns
         -------
-        T : ndarray of shape (n_samples, n_classes) or (n_samples,)
+        T : ndarray of shape (n_samples, n_classes)
             Returns the score of the sample for each class in the model,
             where classes are ordered as they are in `self.classes_`.
         """

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -714,7 +714,7 @@ def test_ecoc_predict_proba():
     assert_almost_equal(np.sum(proba, axis=1), np.ones(proba.shape[0]))
 
     # Regression test for the new proba-based predict against the old one
-    preds = np.array([_predict_binary(e, iris_data) for e in ecoc.estimators_]).T
+    preds = np.array([_predict_binary(e, iris.data) for e in ecoc.estimators_]).T
     prediction = euclidean_distances(preds, ecoc.code_book_).argmin(axis=1)
     assert prediction == proba.argmax(axis=1)
 

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -716,7 +716,7 @@ def test_ecoc_predict_proba():
     # Regression test for the new proba-based predict against the old one
     preds = np.array([_predict_binary(e, iris.data) for e in ecoc.estimators_]).T
     prediction = euclidean_distances(preds, ecoc.code_book_).argmin(axis=1)
-    assert prediction == proba.argmax(axis=1)
+    assert_array_equal(prediction, ecoc.predict(iris.data))
 
 
 def test_ecoc_gridsearch():

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -710,8 +710,7 @@ def test_ecoc_predict_proba():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0), random_state=0)
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     proba = ecoc.predict_proba(iris.data)
-    # Test that the scores sum to 1
-    assert_almost_equal(np.sum(proba, axis=1), np.ones(proba.shape[0]))
+    assert_allclose(proba.sum(axis=1), 1)
 
     # Regression test for the new proba-based predict against the old one
     preds = np.array([_predict_binary(e, iris.data) for e in ecoc.estimators_]).T

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -11,7 +11,6 @@ from sklearn.utils._mocking import CheckingClassifier
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.multiclass import OneVsOneClassifier
 from sklearn.multiclass import OutputCodeClassifier
-from sklearn.multiclass import _predict_binary
 from sklearn.utils.multiclass import check_classification_targets, type_of_target
 from sklearn.utils import (
     check_array,
@@ -20,7 +19,6 @@ from sklearn.utils import (
 
 from sklearn.metrics import precision_score
 from sklearn.metrics import recall_score
-from sklearn.metrics.pairwise import euclidean_distances
 
 from sklearn.svm import LinearSVC, SVC
 from sklearn.naive_bayes import MultinomialNB

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -711,6 +711,7 @@ def test_ecoc_predict_proba():
     assert_allclose(proba.sum(axis=1), 1)
     assert len(proba[0]) == len(ecoc.classes_)
 
+
 def test_ecoc_gridsearch():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0), random_state=0)
     Cs = [0.1, 0.5, 0.8]

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -711,12 +711,7 @@ def test_ecoc_predict_proba():
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     proba = ecoc.predict_proba(iris.data)
     assert_allclose(proba.sum(axis=1), 1)
-
-    # Regression test for the new proba-based predict against the old one
-    preds = np.array([_predict_binary(e, iris.data) for e in ecoc.estimators_]).T
-    prediction = euclidean_distances(preds, ecoc.code_book_).argmin(axis=1)
-    assert_array_equal(prediction, ecoc.predict(iris.data))
-
+    assert len(proba[0]) == len(ecoc.classes_)
 
 def test_ecoc_gridsearch():
     ecoc = OutputCodeClassifier(LinearSVC(random_state=0), random_state=0)


### PR DESCRIPTION
#### Reference Issues/PRs
None found, albeit it was briefly mentioned in #389

#### What does this implement/fix? Explain your changes.
In its present state, `sklearn.multiclass.OutputCodeClassifier()` is only able to `predict()`. Having access to the underlying class scores/probabilities is required for a good part of validation metrics. Those can also be used for model calibration and improved decision making (though that might be considered redundant for the ECOC classifier usecases).

#### What does it do / how does it work?
This PR implements the (faux) probability estimates using the same base estimators' output <-> codebook euclidean distances that are currently used by the `predict()` method using inverse distance weighting. Distance calculation is moved to the new `predict_proba()` method, and `predict()` is adjusted accordingly.

#### Any other comments?
**Possible cons:**

The probabilistic interpretation of said distances might be questionable. However, lots of other classification algorithms that do implement `predict_proba()` aren't guaranteed to have its output well-calibrated either.

**QA:**

- Precautions taken to avoid zero division in IDW calculation.
- ~~A non-regression test to ensure the `predict()` results are the same as before is provided,~~ as well as the sanity test of class scores summing to 1.
- pytest/black/flake8/mypy tests passed.
- The scores returned by the new `predict_proba()` appear to yield sane OvR ROC and PR curves, as well as calibration curves of an acceptable shape.