### PR TITLE
MAINT Parameters validation for make_sparse_coded_signal

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -6,7 +6,6 @@ Generate samples of synthetic data sets.
 #          G. Louppe, J. Nothman
 # License: BSD 3 clause
 
-
 from numbers import Integral
 import numbers
 import array
@@ -19,7 +18,6 @@ import scipy.sparse as sp
 
 from ..preprocessing import MultiLabelBinarizer
 from ..utils import check_array, check_random_state
-
 from ..utils._param_validation import Interval, validate_params
 from ..utils import shuffle as util_shuffle
 from ..utils.random import sample_without_replacement
@@ -1253,11 +1251,7 @@ def make_low_rank_matrix(
         "n_components": [Interval(Integral, 0, None, closed="neither")],
         "n_features": [Interval(Integral, 0, None, closed="neither")],
         "n_nonzero_coefs": [Interval(Integral, 0, None, closed="neither")],
-        "random_state": [
-            "random_state",
-            Interval(Integral, 0, None, closed="neither"),
-            None,
-        ],
+        "random_state": ["random_state"],
         "data_transposed": ["boolean"],
     }
 )
@@ -1272,10 +1266,10 @@ def make_sparse_coded_signal(
 ):
     """Generate a signal as a sparse combination of dictionary elements.
 
-    Returns a matrix Y = DX, such that D is (n_features, n_components),
-    X is (n_components, n_samples) and each column of X has exactly
-    n_nonzero_coefs non-zero elements.
-
+    Returns a matrix `Y = DX`, such that `D` is of shape `(n_features, n_components)`,
+    `X` is of shape `(n_components, n_samples)` and each column of `X` has exactly
+    `n_nonzero_coefs` non-zero elements.
+    
     Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -18,7 +18,7 @@ import scipy.sparse as sp
 
 from ..preprocessing import MultiLabelBinarizer
 from ..utils import check_array, check_random_state
-from ..utils._param_validation import Interval, validate_params
+from ..utils._param_validation import Interval, validate_params, Hidden, StrOptions
 from ..utils import shuffle as util_shuffle
 from ..utils.random import sample_without_replacement
 
@@ -1252,7 +1252,7 @@ def make_low_rank_matrix(
         "n_features": [Interval(Integral, 0, None, closed="neither")],
         "n_nonzero_coefs": [Interval(Integral, 0, None, closed="neither")],
         "random_state": ["random_state"],
-        "data_transposed": ["boolean"],
+        "data_transposed": ["boolean", Hidden(StrOptions({"warn"}))],
     }
 )
 def make_sparse_coded_signal(
@@ -1269,7 +1269,7 @@ def make_sparse_coded_signal(
     Returns a matrix `Y = DX`, such that `D` is of shape `(n_features, n_components)`,
     `X` is of shape `(n_components, n_samples)` and each column of `X` has exactly
     `n_nonzero_coefs` non-zero elements.
-    
+
     Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1244,12 +1244,13 @@ def make_low_rank_matrix(
 # TODO(1.3): Change argument `data_transposed` default from True to False.
 # TODO(1.3): Deprecate data_transposed, always return data not transposed.
 
+
 @validate_params(
     {
-        "n_samples": [Interval(Integral, 0, None, closed="neither")],
-        "n_components": [Interval(Integral, 0, None, closed="neither")],
-        "n_features": [Interval(Integral, 0, None, closed="neither")],
-        "n_nonzero_coefs": [Interval(Integral, 0, None, closed="neither")],
+        "n_samples": [Interval(Integral, 1, None, closed="left")],
+        "n_components": [Interval(Integral, 1, None, closed="left")],
+        "n_features": [Interval(Integral, 1, None, closed="left")],
+        "n_nonzero_coefs": [Interval(Integral, 1, None, closed="left")],
         "random_state": ["random_state"],
         "data_transposed": ["boolean", Hidden(StrOptions({"warn"}))],
     }

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1244,7 +1244,6 @@ def make_low_rank_matrix(
 # TODO(1.3): Change argument `data_transposed` default from True to False.
 # TODO(1.3): Deprecate data_transposed, always return data not transposed.
 
-
 @validate_params(
     {
         "n_samples": [Interval(Integral, 0, None, closed="neither")],

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -6,6 +6,8 @@ Generate samples of synthetic data sets.
 #          G. Louppe, J. Nothman
 # License: BSD 3 clause
 
+
+from numbers import Integral
 import numbers
 import array
 import warnings
@@ -17,6 +19,8 @@ import scipy.sparse as sp
 
 from ..preprocessing import MultiLabelBinarizer
 from ..utils import check_array, check_random_state
+
+from ..utils._param_validation import Interval, validate_params
 from ..utils import shuffle as util_shuffle
 from ..utils.random import sample_without_replacement
 
@@ -1241,6 +1245,22 @@ def make_low_rank_matrix(
 
 # TODO(1.3): Change argument `data_transposed` default from True to False.
 # TODO(1.3): Deprecate data_transposed, always return data not transposed.
+
+
+@validate_params(
+    {
+        "n_samples": [Interval(Integral, 0, None, closed="neither")],
+        "n_components": [Interval(Integral, 0, None, closed="neither")],
+        "n_features": [Interval(Integral, 0, None, closed="neither")],
+        "n_nonzero_coefs": [Interval(Integral, 0, None, closed="neither")],
+        "random_state": [
+            "random_state",
+            Interval(Integral, 0, None, closed="neither"),
+            None,
+        ],
+        "data_transposed": ["boolean"],
+    }
+)
 def make_sparse_coded_signal(
     n_samples,
     *,

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -94,10 +94,10 @@ def _check_function_param_validation(
 
 
 PARAM_VALIDATION_FUNCTION_LIST = [
-    "sklearn.datasets.make_sparse_coded_signal",
     "sklearn.cluster.estimate_bandwidth",
     "sklearn.cluster.kmeans_plusplus",
     "sklearn.covariance.empirical_covariance",
+    "sklearn.datasets.make_sparse_coded_signal",
     "sklearn.feature_extraction.grid_to_graph",
     "sklearn.feature_extraction.img_to_graph",
     "sklearn.metrics.accuracy_score",

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -94,6 +94,7 @@ def _check_function_param_validation(
 
 
 PARAM_VALIDATION_FUNCTION_LIST = [
+    "sklearn.datasets.make_sparse_coded_signal",
     "sklearn.cluster.estimate_bandwidth",
     "sklearn.cluster.kmeans_plusplus",
     "sklearn.covariance.empirical_covariance",
@@ -106,7 +107,6 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.zero_one_loss",
     "sklearn.model_selection.train_test_split",
     "sklearn.svm.l1_min_c",
-    "sklearn.datasets.make_sparse_coded_signal",
 ]
 
 

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -106,6 +106,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.zero_one_loss",
     "sklearn.model_selection.train_test_split",
     "sklearn.svm.l1_min_c",
+    "sklearn.datasets.make_sparse_coded_signal",
 ]
 
 


### PR DESCRIPTION
Towards #24862 add parameter validation to sklearn.datasets.make_sparse_coded_signal