### PR TITLE
MAINT handle deprecations from `importlib.resources`

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -21,6 +21,7 @@ from ..preprocessing import scale
 from ..utils import Bunch
 from ..utils import check_random_state
 from ..utils import check_pandas_support
+from ..utils.fixes import _open_binary, _open_text, _read_text
 
 import numpy as np
 
@@ -315,7 +316,7 @@ def load_csv_data(
         Description of the dataset (the content of `descr_file_name`).
         Only returned if `descr_file_name` is not None.
     """
-    with resources.files(data_module).joinpath(data_file_name).open("r") as csv_file:
+    with _open_text(data_module, data_file_name) as csv_file:
         data_file = csv.reader(csv_file)
         temp = next(data_file)
         n_samples = int(temp[0])
@@ -388,7 +389,7 @@ def load_gzip_compressed_csv_data(
         Description of the dataset (the content of `descr_file_name`).
         Only returned if `descr_file_name` is not None.
     """
-    with resources.open_binary(data_module, data_file_name) as compressed_file:
+    with _open_binary(data_module, data_file_name) as compressed_file:
         compressed_file = gzip.open(compressed_file, mode="rt", encoding=encoding)
         data = np.loadtxt(compressed_file, **kwargs)
 
@@ -420,7 +421,7 @@ def load_descr(descr_file_name, *, descr_module=DESCR_MODULE):
     fdescr : str
         Content of `descr_file_name`.
     """
-    fdescr = resources.read_text(descr_module, descr_file_name)
+    fdescr = _read_text(descr_module, descr_file_name)
 
     return fdescr
 
@@ -1132,12 +1133,12 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
     target_filename = "linnerud_physiological.csv"
 
     # Read header and data
-    with resources.files(DATA_MODULE).joinpath(data_filename).open("r") as f:
+    with _open_text(DATA_MODULE, data_filename) as f:
         header_exercise = f.readline().split()
         f.seek(0)  # reset file obj
         data_exercise = np.loadtxt(f, skiprows=1)
 
-    with resources.files(DATA_MODULE).joinpath(target_filename).open("r") as f:
+    with _open_text(DATA_MODULE, target_filename) as f:
         header_physiological = f.readline().split()
         f.seek(0)  # reset file obj
         data_physiological = np.loadtxt(f, skiprows=1)
@@ -1218,7 +1219,7 @@ def load_sample_images():
     for filename in sorted(resources.contents(IMAGES_MODULE)):
         if filename.endswith(".jpg"):
             filenames.append(filename)
-            with resources.open_binary(IMAGES_MODULE, filename) as image_file:
+            with _open_binary(IMAGES_MODULE, filename) as image_file:
                 pil_image = Image.open(image_file)
                 image = np.asarray(pil_image)
             images.append(image)

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -315,7 +315,7 @@ def load_csv_data(
         Description of the dataset (the content of `descr_file_name`).
         Only returned if `descr_file_name` is not None.
     """
-    with resources.open_text(data_module, data_file_name) as csv_file:
+    with resources.files(data_module).joinpath(data_file_name).open("r") as csv_file:
         data_file = csv.reader(csv_file)
         temp = next(data_file)
         n_samples = int(temp[0])
@@ -1132,12 +1132,12 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
     target_filename = "linnerud_physiological.csv"
 
     # Read header and data
-    with resources.open_text(DATA_MODULE, data_filename) as f:
+    with resources.files(DATA_MODULE).joinpath(data_filename).open("r") as f:
         header_exercise = f.readline().split()
         f.seek(0)  # reset file obj
         data_exercise = np.loadtxt(f, skiprows=1)
 
-    with resources.open_text(DATA_MODULE, target_filename) as f:
+    with resources.files(DATA_MODULE).joinpath(target_filename).open("r") as f:
         header_physiological = f.readline().split()
         f.seek(0)  # reset file obj
         data_physiological = np.loadtxt(f, skiprows=1)

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -5,7 +5,6 @@ import warnings
 from pickle import loads
 from pickle import dumps
 from functools import partial
-from importlib import resources
 
 import pytest
 import numpy as np
@@ -26,6 +25,7 @@ from sklearn.datasets._base import (
 )
 from sklearn.preprocessing import scale
 from sklearn.utils import Bunch
+from sklearn.utils.fixes import _is_resource
 from sklearn.datasets.tests.test_common import check_as_frame
 
 
@@ -278,7 +278,7 @@ def test_loader(loader_func, data_shape, target_shape, n_target, has_descr, file
         assert "data_module" in bunch
         assert all(
             [
-                f in bunch and resources.is_resource(bunch["data_module"], bunch[f])
+                f in bunch and _is_resource(bunch["data_module"], bunch[f])
                 for f in filenames
             ]
         )

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -4,7 +4,6 @@ import json
 import os
 import re
 from functools import partial
-from importlib import resources
 from io import BytesIO
 from urllib.error import HTTPError
 
@@ -15,6 +14,7 @@ import pytest
 import sklearn
 from sklearn import config_context
 from sklearn.utils import Bunch, check_pandas_support
+from sklearn.utils.fixes import _open_binary
 from sklearn.utils._testing import (
     SkipTest,
     assert_allclose,
@@ -108,7 +108,7 @@ def _monkey_patch_webbased_functions(context, data_id, gzip_response):
 
         data_file_name = _file_name(url, suffix)
 
-        with resources.open_binary(data_module, data_file_name) as f:
+        with _open_binary(data_module, data_file_name) as f:
             if has_gzip_header and gzip_response:
                 fp = BytesIO(f.read())
                 return _MockHTTPResponse(fp, True)
@@ -147,7 +147,7 @@ def _monkey_patch_webbased_functions(context, data_id, gzip_response):
         data_file_name = _file_name(url, ".json")
 
         # load the file itself, to simulate a http error
-        with resources.open_binary(data_module, data_file_name) as f:
+        with _open_binary(data_module, data_file_name) as f:
             decompressed_f = read_fn(f, "rb")
             decoded_s = decompressed_f.read().decode("utf-8")
             json_data = json.loads(decoded_s)
@@ -156,7 +156,7 @@ def _monkey_patch_webbased_functions(context, data_id, gzip_response):
                 url=None, code=412, msg="Simulated mock error", hdrs=None, fp=None
             )
 
-        with resources.open_binary(data_module, data_file_name) as f:
+        with _open_binary(data_module, data_file_name) as f:
             if has_gzip_header:
                 fp = BytesIO(f.read())
                 return _MockHTTPResponse(fp, True)
@@ -1489,9 +1489,7 @@ def test_fetch_openml_verify_checksum(monkeypatch, as_frame, cache, tmpdir, pars
     original_data_module = OPENML_TEST_DATA_MODULE + "." + f"id_{data_id}"
     original_data_file_name = "data-v1-dl-1666876.arff.gz"
     corrupt_copy_path = tmpdir / "test_invalid_checksum.arff"
-    with resources.open_binary(
-        original_data_module, original_data_file_name
-    ) as orig_file:
+    with _open_binary(original_data_module, original_data_file_name) as orig_file:
         orig_gzip = gzip.open(orig_file, "rb")
         data = bytearray(orig_gzip.read())
         data[len(data) - 1] = 37

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -5,11 +5,11 @@ import numpy as np
 import scipy.sparse as sp
 import os
 import shutil
-from importlib import resources
 from tempfile import NamedTemporaryFile
 
 import pytest
 
+from sklearn.utils.fixes import _open_binary, _path
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_array_almost_equal, assert_allclose
 from sklearn.utils._testing import fails_if_pypy
@@ -31,7 +31,7 @@ def _load_svmlight_local_test_file(filename, **kwargs):
     """
     Helper to load resource `filename` with `importlib.resources`
     """
-    with resources.open_binary(TEST_DATA_MODULE, filename) as f:
+    with _open_binary(TEST_DATA_MODULE, filename) as f:
         return load_svmlight_file(f, **kwargs)
 
 
@@ -76,7 +76,7 @@ def test_load_svmlight_file_fd():
 
     # GH20081: testing equality between path-based and
     # fd-based load_svmlight_file
-    with resources.path(TEST_DATA_MODULE, datafile) as data_path:
+    with _path(TEST_DATA_MODULE, datafile) as data_path:
         data_path = str(data_path)
         X1, y1 = load_svmlight_file(data_path)
 
@@ -91,7 +91,7 @@ def test_load_svmlight_file_fd():
 
 def test_load_svmlight_pathlib():
     # test loading from file descriptor
-    with resources.path(TEST_DATA_MODULE, datafile) as data_path:
+    with _path(TEST_DATA_MODULE, datafile) as data_path:
         X1, y1 = load_svmlight_file(str(data_path))
         X2, y2 = load_svmlight_file(data_path)
 
@@ -105,7 +105,7 @@ def test_load_svmlight_file_multilabel():
 
 
 def test_load_svmlight_files():
-    with resources.path(TEST_DATA_MODULE, datafile) as data_path:
+    with _path(TEST_DATA_MODULE, datafile) as data_path:
         X_train, y_train, X_test, y_test = load_svmlight_files(
             [str(data_path)] * 2, dtype=np.float32
         )
@@ -114,7 +114,7 @@ def test_load_svmlight_files():
     assert X_train.dtype == np.float32
     assert X_test.dtype == np.float32
 
-    with resources.path(TEST_DATA_MODULE, datafile) as data_path:
+    with _path(TEST_DATA_MODULE, datafile) as data_path:
         X1, y1, X2, y2, X3, y3 = load_svmlight_files(
             [str(data_path)] * 3, dtype=np.float64
         )
@@ -146,7 +146,7 @@ def test_load_compressed():
 
     with NamedTemporaryFile(prefix="sklearn-test", suffix=".gz") as tmp:
         tmp.close()  # necessary under windows
-        with resources.open_binary(TEST_DATA_MODULE, datafile) as f:
+        with _open_binary(TEST_DATA_MODULE, datafile) as f:
             with gzip.open(tmp.name, "wb") as fh_out:
                 shutil.copyfileobj(f, fh_out)
         Xgz, ygz = load_svmlight_file(tmp.name)
@@ -158,7 +158,7 @@ def test_load_compressed():
 
     with NamedTemporaryFile(prefix="sklearn-test", suffix=".bz2") as tmp:
         tmp.close()  # necessary under windows
-        with resources.open_binary(TEST_DATA_MODULE, datafile) as f:
+        with _open_binary(TEST_DATA_MODULE, datafile) as f:
             with BZ2File(tmp.name, "wb") as fh_out:
                 shutil.copyfileobj(f, fh_out)
         Xbz, ybz = load_svmlight_file(tmp.name)
@@ -237,7 +237,7 @@ def test_load_large_qid():
 
 def test_load_invalid_file2():
     with pytest.raises(ValueError):
-        with resources.path(TEST_DATA_MODULE, datafile) as data_path, resources.path(
+        with _path(TEST_DATA_MODULE, datafile) as data_path, _path(
             TEST_DATA_MODULE, invalidfile
         ) as invalid_path:
             load_svmlight_files([str(data_path), str(invalid_path), str(data_path)])

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -11,7 +11,9 @@ at which the fix is no longer needed.
 # License: BSD 3 clause
 
 from functools import update_wrapper
+from importlib import resources
 import functools
+import sys
 
 import sklearn
 import numpy as np
@@ -170,3 +172,36 @@ def _mode(a, axis=0):
     if sp_version >= parse_version("1.9.0"):
         return scipy.stats.mode(a, axis=axis, keepdims=True)
     return scipy.stats.mode(a, axis=axis)
+
+
+###############################################################################
+# Backport of Python 3.9's importlib.resources
+# TODO: Remove when Python 3.9 is the minimum supported version
+
+
+def _open_text(data_module, data_file_name):
+    if sys.version_info >= (3, 9):
+        return resources.files(data_module).joinpath(data_file_name).open("r")
+    else:
+        return resources.open_text(data_module, data_file_name)
+
+
+def _open_binary(data_module, data_file_name):
+    if sys.version_info >= (3, 9):
+        return resources.files(data_module).joinpath(data_file_name).open("rb")
+    else:
+        return resources.open_binary(data_module, data_file_name)
+
+
+def _read_text(descr_module, descr_file_name):
+    if sys.version_info >= (3, 9):
+        return resources.files(descr_module).joinpath(descr_file_name).read_text()
+    else:
+        return resources.read_text(descr_module, descr_file_name)
+
+
+def _path(data_module, data_file_name):
+    if sys.version_info >= (3, 9):
+        return resources.as_file(resources.files(data_module).joinpath(data_file_name))
+    else:
+        return resources.path(data_module, data_file_name)

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -205,3 +205,10 @@ def _path(data_module, data_file_name):
         return resources.as_file(resources.files(data_module).joinpath(data_file_name))
     else:
         return resources.path(data_module, data_file_name)
+
+
+def _is_resource(data_module, data_file_name):
+    if sys.version_info >= (3, 9):
+        return resources.files(data_module).joinpath(data_file_name).is_file()
+    else:
+        return resources.is_resource(data_module, data_file_name)


### PR DESCRIPTION
#### Reference Issues/PRs

Fix a problem first observed in https://github.com/skops-dev/skops/pull/246

#### What does this implement/fix? Explain your changes.

Some utils from `importlib.resources` has been deprecated in Python 3.11:

See: https://docs.python.org/3/library/importlib.resources.html#importlib.resources.open_text

#### Any other comments?

cc @adrinjalali 