### PR TITLE
ENH Euclidean specialization of `DatasetsPair` instead of `ArgKmin` and `RadiusNeighbors`

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pxd.tp
@@ -6,7 +6,6 @@ cnp.import_array()
 {{for name_suffix in ['64', '32']}}
 
 from ._base cimport BaseDistancesReduction{{name_suffix}}
-from ._middle_term_computer cimport MiddleTermComputer{{name_suffix}}
 
 cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
     """float{{name_suffix}} implementation of the ArgKmin."""
@@ -20,15 +19,5 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
         # Used as array of pointers to private datastructures used in threads.
         DTYPE_t ** heaps_r_distances_chunks
         ITYPE_t ** heaps_indices_chunks
-
-
-cdef class EuclideanArgKmin{{name_suffix}}(ArgKmin{{name_suffix}}):
-    """EuclideanDistance-specialisation of ArgKmin{{name_suffix}}."""
-    cdef:
-        MiddleTermComputer{{name_suffix}} middle_term_computer
-        const DTYPE_t[::1] X_norm_squared
-        const DTYPE_t[::1] Y_norm_squared
-
-        bint use_squared_distances
 
 {{endfor}}

--- a/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx.tp
@@ -145,8 +145,9 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
                     val=self.datasets_pair.surrogate_dist(
                         X_start,
                         Y_start,
-                        X_start + i,
-                        Y_start + j,
+                        i,
+                        j,
+                        n_samples_Y,
                         thread_num,
                     ),
                     val_idx=Y_start + j,

--- a/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx.tp
@@ -143,6 +143,8 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
                     indices=heaps_indices + i * self.k,
                     size=self.k,
                     val=self.datasets_pair.surrogate_dist(
+                        X_start,
+                        Y_start,
                         X_start + i,
                         Y_start + j,
                         thread_num,

--- a/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx.tp
@@ -14,7 +14,8 @@ import warnings
 
 from numbers import Integral
 from scipy.sparse import issparse
-from ...utils import check_array, check_scalar, _in_unstable_openblas_configuration
+# TODO: reintroduce _in_unstable... warning
+from ...utils import check_scalar, _in_unstable_openblas_configuration
 from ...utils.fixes import threadpool_limits
 from ...utils._typedefs import ITYPE, DTYPE
 
@@ -23,14 +24,7 @@ cnp.import_array()
 
 {{for name_suffix in ['64', '32']}}
 
-from ._base cimport (
-    BaseDistancesReduction{{name_suffix}},
-    _sqeuclidean_row_norms{{name_suffix}},
-)
-
-from ._datasets_pair cimport DatasetsPair{{name_suffix}}
-
-from ._middle_term_computer cimport MiddleTermComputer{{name_suffix}}
+from ._base cimport BaseDistancesReduction{{name_suffix}}
 
 
 cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
@@ -61,36 +55,14 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
 
         No instance should directly be created outside of this class method.
         """
-        if (
-            metric in ("euclidean", "sqeuclidean")
-            and not (issparse(X) ^ issparse(Y))  # "^" is the XOR operator
-        ):
-            # Specialized implementation of ArgKmin for the Euclidean distance
-            # for the dense-dense and sparse-sparse cases.
-            # This implementation computes the distances by chunk using
-            # a decomposition of the Squared Euclidean distance.
-            # This specialisation has an improved arithmetic intensity for both
-            # the dense and sparse settings, allowing in most case speed-ups of
-            # several orders of magnitude compared to the generic ArgKmin
-            # implementation.
-            # For more information see MiddleTermComputer.
-            use_squared_distances = metric == "sqeuclidean"
-            pda = EuclideanArgKmin{{name_suffix}}(
-                X=X, Y=Y, k=k,
-                use_squared_distances=use_squared_distances,
-                chunk_size=chunk_size,
-                strategy=strategy,
-                metric_kwargs=metric_kwargs,
-            )
-        else:
-            # Fall back on a generic implementation that handles most scipy
-            # metrics by computing the distances between 2 vectors at a time.
-            pda = ArgKmin{{name_suffix}}(
-                datasets_pair=DatasetsPair{{name_suffix}}.get_for(X, Y, metric, metric_kwargs),
-                k=k,
-                chunk_size=chunk_size,
-                strategy=strategy,
-            )
+        pda = ArgKmin{{name_suffix}}(
+            X, Y,
+            chunk_size=chunk_size,
+            strategy=strategy,
+            k=k,
+            metric=metric,
+            metric_kwargs=metric_kwargs,
+        )
 
         # Limit the number of threads in second level of nested parallelism for BLAS
         # to avoid threads over-subscription (in GEMM for instance).
@@ -104,15 +76,19 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
 
     def __init__(
         self,
-        DatasetsPair{{name_suffix}} datasets_pair,
+        X, Y,
         chunk_size=None,
         strategy=None,
         ITYPE_t k=1,
+        metric="euclidean",
+        metric_kwargs=None,
     ):
         super().__init__(
-            datasets_pair=datasets_pair,
+            X, Y,
             chunk_size=chunk_size,
             strategy=strategy,
+            metric=metric,
+            metric_kwargs=metric_kwargs
         )
         self.k = check_scalar(k, "k", Integral, min_val=1)
 
@@ -166,9 +142,19 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
                     values=heaps_r_distances + i * self.k,
                     indices=heaps_indices + i * self.k,
                     size=self.k,
-                    val=self.datasets_pair.surrogate_dist(X_start + i, Y_start + j),
+                    val=self.datasets_pair.surrogate_dist(
+                        X_start + i,
+                        Y_start + j,
+                        thread_num,
+                    ),
                     val_idx=Y_start + j,
                 )
+
+    cdef void _parallel_on_X_parallel_init(
+        self,
+        ITYPE_t thread_num
+    ) nogil:
+        self.datasets_pair._parallel_on_X_parallel_init(thread_num)
 
     cdef void _parallel_on_X_init_chunk(
         self,
@@ -180,6 +166,20 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
         # thread's heaps pointer to the proper position on the main heaps.
         self.heaps_r_distances_chunks[thread_num] = &self.argkmin_distances[X_start, 0]
         self.heaps_indices_chunks[thread_num] = &self.argkmin_indices[X_start, 0]
+        self.datasets_pair._parallel_on_X_init_chunk(thread_num, X_start, X_end)
+
+    @final
+    cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        self.datasets_pair._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+            X_start, X_end, Y_start, Y_end, thread_num,
+        )
 
     @final
     cdef void _parallel_on_X_prange_iter_finalize(
@@ -224,6 +224,7 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
             self.heaps_indices_chunks[thread_num] = <ITYPE_t *> malloc(
                 heaps_size * sizeof(ITYPE_t)
             )
+        self.datasets_pair._parallel_on_Y_init()
 
     cdef void _parallel_on_Y_parallel_init(
         self,
@@ -235,6 +236,23 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
         for idx in range(self.X_n_samples_chunk * self.k):
             self.heaps_r_distances_chunks[thread_num][idx] = DBL_MAX
             self.heaps_indices_chunks[thread_num][idx] = -1
+        self.datasets_pair._parallel_on_Y_parallel_init(thread_num, X_start, X_end)
+
+    cdef void _parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        self.datasets_pair._parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
 
     @final
     cdef void _parallel_on_Y_synchronize(
@@ -289,13 +307,17 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
         cdef:
             ITYPE_t i, j
             DTYPE_t[:, ::1] distances = self.argkmin_distances
-        for i in prange(self.n_samples_X, schedule='static', nogil=True,
-                        num_threads=self.effective_n_threads):
-            for j in range(self.k):
-                distances[i, j] = self.datasets_pair.distance_metric._rdist_to_dist(
-                    # Guard against potential -0., causing nan production.
-                    max(distances[i, j], 0.)
-                )
+            bint need_to_compute_exact_dist = (
+                self.datasets_pair.need_to_compute_exact_dist()
+            )
+        if need_to_compute_exact_dist:
+            for i in prange(self.n_samples_X, schedule='static', nogil=True,
+                            num_threads=self.effective_n_threads):
+                for j in range(self.k):
+                    distances[i, j] = self.datasets_pair.distance_metric._rdist_to_dist(
+                        # Guard against potential -0., causing nan production.
+                        max(distances[i, j], 0.)
+                    )
 
     def _finalize_results(self, bint return_distance=False):
         if return_distance:
@@ -310,209 +332,5 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
 
         return np.asarray(self.argkmin_indices)
 
-
-cdef class EuclideanArgKmin{{name_suffix}}(ArgKmin{{name_suffix}}):
-    """EuclideanDistance-specialisation of ArgKmin{{name_suffix}}."""
-
-    @classmethod
-    def is_usable_for(cls, X, Y, metric) -> bool:
-        return (ArgKmin{{name_suffix}}.is_usable_for(X, Y, metric) and
-                not _in_unstable_openblas_configuration())
-
-    def __init__(
-        self,
-        X,
-        Y,
-        ITYPE_t k,
-        bint use_squared_distances=False,
-        chunk_size=None,
-        strategy=None,
-        metric_kwargs=None,
-    ):
-        if (
-            metric_kwargs is not None and
-            len(metric_kwargs) > 0 and (
-                "Y_norm_squared" not in metric_kwargs or
-                "X_norm_squared" not in metric_kwargs
-            )
-        ):
-            warnings.warn(
-                f"Some metric_kwargs have been passed ({metric_kwargs}) but aren't "
-                f"usable for this case (EuclideanArgKmin64) and will be ignored.",
-                UserWarning,
-                stacklevel=3,
-            )
-
-        super().__init__(
-            # The datasets pair here is used for exact distances computations
-            datasets_pair=DatasetsPair{{name_suffix}}.get_for(X, Y, metric="euclidean"),
-            chunk_size=chunk_size,
-            strategy=strategy,
-            k=k,
-        )
-        cdef:
-            ITYPE_t dist_middle_terms_chunks_size = self.Y_n_samples_chunk * self.X_n_samples_chunk
-
-        self.middle_term_computer = MiddleTermComputer{{name_suffix}}.get_for(
-            X,
-            Y,
-            self.effective_n_threads,
-            self.chunks_n_threads,
-            dist_middle_terms_chunks_size,
-            n_features=X.shape[1],
-            chunk_size=self.chunk_size,
-        )
-
-        if metric_kwargs is not None and "Y_norm_squared" in metric_kwargs:
-            self.Y_norm_squared = check_array(
-                metric_kwargs.pop("Y_norm_squared"),
-                ensure_2d=False,
-                input_name="Y_norm_squared",
-                dtype=np.float64,
-            )
-        else:
-            self.Y_norm_squared = _sqeuclidean_row_norms{{name_suffix}}(
-                Y,
-                self.effective_n_threads,
-            )
-
-        if metric_kwargs is not None and "X_norm_squared" in metric_kwargs:
-            self.X_norm_squared = check_array(
-                metric_kwargs.pop("X_norm_squared"),
-                ensure_2d=False,
-                input_name="X_norm_squared",
-                dtype=np.float64,
-            )
-        else:
-            # Do not recompute norms if datasets are identical.
-            self.X_norm_squared = (
-                self.Y_norm_squared if X is Y else
-                _sqeuclidean_row_norms{{name_suffix}}(
-                    X,
-                    self.effective_n_threads,
-                )
-            )
-
-        self.use_squared_distances = use_squared_distances
-
-    @final
-    cdef void compute_exact_distances(self) nogil:
-        if not self.use_squared_distances:
-            ArgKmin{{name_suffix}}.compute_exact_distances(self)
-
-    @final
-    cdef void _parallel_on_X_parallel_init(
-        self,
-        ITYPE_t thread_num,
-    ) nogil:
-        ArgKmin{{name_suffix}}._parallel_on_X_parallel_init(self, thread_num)
-        self.middle_term_computer._parallel_on_X_parallel_init(thread_num)
-
-    @final
-    cdef void _parallel_on_X_init_chunk(
-        self,
-        ITYPE_t thread_num,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-    ) nogil:
-        ArgKmin{{name_suffix}}._parallel_on_X_init_chunk(self, thread_num, X_start, X_end)
-        self.middle_term_computer._parallel_on_X_init_chunk(thread_num, X_start, X_end)
-
-    @final
-    cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
-        self,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-        ITYPE_t Y_start,
-        ITYPE_t Y_end,
-        ITYPE_t thread_num,
-    ) nogil:
-        ArgKmin{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
-            self,
-            X_start, X_end,
-            Y_start, Y_end,
-            thread_num,
-        )
-        self.middle_term_computer._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
-            X_start, X_end, Y_start, Y_end, thread_num,
-        )
-
-    @final
-    cdef void _parallel_on_Y_init(
-        self,
-    ) nogil:
-        ArgKmin{{name_suffix}}._parallel_on_Y_init(self)
-        self.middle_term_computer._parallel_on_Y_init()
-
-    @final
-    cdef void _parallel_on_Y_parallel_init(
-        self,
-        ITYPE_t thread_num,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-    ) nogil:
-        ArgKmin{{name_suffix}}._parallel_on_Y_parallel_init(self, thread_num, X_start, X_end)
-        self.middle_term_computer._parallel_on_Y_parallel_init(thread_num, X_start, X_end)
-
-    @final
-    cdef void _parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
-        self,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-        ITYPE_t Y_start,
-        ITYPE_t Y_end,
-        ITYPE_t thread_num,
-    ) nogil:
-        ArgKmin{{name_suffix}}._parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
-            self,
-            X_start, X_end,
-            Y_start, Y_end,
-            thread_num,
-        )
-        self.middle_term_computer._parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
-            X_start, X_end, Y_start, Y_end, thread_num
-        )
-
-    @final
-    cdef void _compute_and_reduce_distances_on_chunks(
-        self,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-        ITYPE_t Y_start,
-        ITYPE_t Y_end,
-        ITYPE_t thread_num,
-    ) nogil:
-        cdef:
-            ITYPE_t i, j
-            DTYPE_t sqeuclidean_dist_i_j
-            ITYPE_t n_X = X_end - X_start
-            ITYPE_t n_Y = Y_end - Y_start
-            DTYPE_t * dist_middle_terms = self.middle_term_computer._compute_dist_middle_terms(
-                X_start, X_end, Y_start, Y_end, thread_num
-            )
-            DTYPE_t * heaps_r_distances = self.heaps_r_distances_chunks[thread_num]
-            ITYPE_t * heaps_indices = self.heaps_indices_chunks[thread_num]
-
-        # Pushing the distance and their associated indices on heaps
-        # which keep tracks of the argkmin.
-        for i in range(n_X):
-            for j in range(n_Y):
-                sqeuclidean_dist_i_j = (
-                    self.X_norm_squared[i + X_start] +
-                    dist_middle_terms[i * n_Y + j] +
-                    self.Y_norm_squared[j + Y_start]
-                )
-
-                # Catastrophic cancellation might cause -0. to be present,
-                # e.g. when computing d(x_i, y_i) when X is Y.
-                sqeuclidean_dist_i_j = max(0., sqeuclidean_dist_i_j)
-
-                heap_push(
-                    values=heaps_r_distances + i * self.k,
-                    indices=heaps_indices + i * self.k,
-                    size=self.k,
-                    val=sqeuclidean_dist_i_j,
-                    val_idx=j + Y_start,
-                )
 
 {{endfor}}

--- a/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
@@ -26,6 +26,7 @@ from ...utils._typedefs cimport ITYPE_t, DTYPE_t
 
 import numpy as np
 
+import warnings
 from scipy.sparse import issparse
 from numbers import Integral
 from sklearn import get_config
@@ -131,7 +132,7 @@ cpdef DTYPE_t[::1] _sqeuclidean_row_norms{{name_suffix}}(
 ):
     if issparse(X):
         # TODO: remove this instruction which is a cast in the float32 case
-        # by moving squared row norms computations in MiddleTermComputer. 
+        # by moving squared row norms computations in MiddleTermComputer.
         X_data = np.asarray(X.data, dtype=DTYPE)
         X_indptr = np.asarray(X.indptr, dtype=SPARSE_INDEX_TYPE)
         return _sqeuclidean_row_norms64_sparse(X_data, X_indptr, num_threads)
@@ -151,9 +152,11 @@ cdef class BaseDistancesReduction{{name_suffix}}:
 
     def __init__(
         self,
-        DatasetsPair{{name_suffix}} datasets_pair,
+        X, Y,
         chunk_size=None,
         strategy=None,
+        metric="euclidean",
+        metric_kwargs=None,
      ):
         cdef:
             ITYPE_t X_n_full_chunks, Y_n_full_chunks
@@ -165,9 +168,7 @@ cdef class BaseDistancesReduction{{name_suffix}}:
 
         self.effective_n_threads = _openmp_effective_n_threads()
 
-        self.datasets_pair = datasets_pair
-
-        self.n_samples_X = datasets_pair.n_samples_X()
+        self.n_samples_X = X.shape[0]
         self.X_n_samples_chunk = min(self.n_samples_X, self.chunk_size)
         X_n_full_chunks = self.n_samples_X // self.X_n_samples_chunk
         X_n_samples_remainder = self.n_samples_X % self.X_n_samples_chunk
@@ -178,7 +179,7 @@ cdef class BaseDistancesReduction{{name_suffix}}:
         else:
             self.X_n_samples_last_chunk = self.X_n_samples_chunk
 
-        self.n_samples_Y = datasets_pair.n_samples_Y()
+        self.n_samples_Y = Y.shape[0]
         self.Y_n_samples_chunk = min(self.n_samples_Y, self.chunk_size)
         Y_n_full_chunks = self.n_samples_Y // self.Y_n_samples_chunk
         Y_n_samples_remainder = self.n_samples_Y % self.Y_n_samples_chunk
@@ -222,6 +223,52 @@ cdef class BaseDistancesReduction{{name_suffix}}:
             self.Y_n_chunks if self.execute_in_parallel_on_Y else self.X_n_chunks,
             self.effective_n_threads,
         )
+
+        if metric in ["euclidean", "sqeuclidean"]:
+
+            X_norm_squared = (
+                metric_kwargs.pop("X_norm_squared", None)
+                if metric_kwargs is not None
+                else None
+            )
+
+            Y_norm_squared = (
+                metric_kwargs.pop("Y_norm_squared", None)
+                if metric_kwargs is not None
+                else None
+            )
+
+            euclidean_kwargs = dict(
+                effective_n_threads=self.effective_n_threads,
+                chunks_n_threads=self.chunks_n_threads,
+                dist_middle_terms_chunks_size=(self.Y_n_samples_chunk * self.X_n_samples_chunk),
+                X_norm_squared=X_norm_squared,
+                Y_norm_squared=Y_norm_squared,
+                X_n_chunks=self.X_n_chunks,
+                Y_n_samples_chunk=self.Y_n_samples_chunk,
+                Y_n_samples_last_chunk=self.Y_n_samples_last_chunk,
+                chunk_size=self.chunk_size,
+            )
+
+            if isinstance(metric_kwargs, dict) and metric_kwargs.keys():
+                warnings.warn(
+                    f"Some metric_kwargs have been passed ({metric_kwargs}) but aren't "
+                    f"usable for this case (euclidean) and will be ignored.",
+                UserWarning,
+                stacklevel=3,
+            )
+            metric_kwargs = None
+
+        else:
+            euclidean_kwargs = None
+
+        self.datasets_pair = DatasetsPair{{name_suffix}}.get_for(
+            X, Y,
+            metric,
+            metric_kwargs,
+            euclidean_kwargs,
+        )
+
 
     @final
     cdef void _parallel_on_X(self) nogil:

--- a/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
@@ -244,7 +244,7 @@ cdef class BaseDistancesReduction{{name_suffix}}:
                 dist_middle_terms_chunks_size=(self.Y_n_samples_chunk * self.X_n_samples_chunk),
                 X_norm_squared=X_norm_squared,
                 Y_norm_squared=Y_norm_squared,
-                X_n_chunks=self.X_n_chunks,
+                Y_n_chunks=self.Y_n_chunks,
                 Y_n_samples_chunk=self.Y_n_samples_chunk,
                 Y_n_samples_last_chunk=self.Y_n_samples_last_chunk,
                 chunk_size=self.chunk_size,

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
@@ -35,7 +35,14 @@ cdef class DatasetsPair{{name_suffix}}:
 
     cdef DTYPE_t dist(self, ITYPE_t i, ITYPE_t j) nogil
 
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=*) nogil
+    cdef DTYPE_t surrogate_dist(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t Y_start,
+        ITYPE_t i,
+        ITYPE_t j,
+        ITYPE_t thread_num=*
+    ) nogil
 
     cdef void _parallel_on_X_parallel_init(self, ITYPE_t thread_num) nogil
 
@@ -84,9 +91,10 @@ cdef class DenseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
 
 cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair{{name_suffix}}):
     cdef:
-        ITYPE_t X_n_chunks
+        ITYPE_t Y_n_chunks
         ITYPE_t Y_n_samples_chunk
         ITYPE_t Y_n_samples_last_chunk
+        ITYPE_t Y_n_samples_fixed_size
 
         bint use_squared_distances
 
@@ -109,9 +117,10 @@ cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
 
 cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasetsPair{{name_suffix}}):
     cdef:
-        ITYPE_t X_n_chunks
+        ITYPE_t Y_n_chunks
         ITYPE_t Y_n_samples_chunk
         ITYPE_t Y_n_samples_last_chunk
+        ITYPE_t Y_n_samples_fixed_size
 
         bint use_squared_distances
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
@@ -41,6 +41,7 @@ cdef class DatasetsPair{{name_suffix}}:
         ITYPE_t Y_start,
         ITYPE_t i,
         ITYPE_t j,
+        ITYPE_t n_Y,
         ITYPE_t thread_num=*
     ) nogil
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
@@ -43,7 +43,7 @@ cdef class DatasetsPair{{name_suffix}}:
         ITYPE_t i,
         ITYPE_t j,
         ITYPE_t n_Y,
-        ITYPE_t thread_num=*
+        ITYPE_t thread_num,
     ) nogil
 
     cdef void _parallel_on_X_parallel_init(self, ITYPE_t thread_num) nogil

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
@@ -13,6 +13,7 @@ implementation_specific_values = [
 
 }}
 cimport numpy as cnp
+from libcpp.vector cimport vector
 
 from ...utils._typedefs cimport DTYPE_t, ITYPE_t, SPARSE_INDEX_TYPE_t
 from ...metrics._dist_metrics cimport DistanceMetric, DistanceMetric32
@@ -97,7 +98,12 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         ITYPE_t Y_n_samples_last_chunk
         ITYPE_t Y_n_samples_fixed_size
 
+        ITYPE_t chunks_n_threads
+
         bint use_squared_distances
+
+        vector[vector[DTYPE_t]] dist_middle_terms_chunks
+        ITYPE_t dist_middle_terms_chunks_size
 
         DenseDenseMiddleTermComputer{{name_suffix}} middle_term_computer
 
@@ -123,7 +129,12 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         ITYPE_t Y_n_samples_last_chunk
         ITYPE_t Y_n_samples_fixed_size
 
+        ITYPE_t chunks_n_threads
+
         bint use_squared_distances
+
+        vector[vector[DTYPE_t]] dist_middle_terms_chunks
+        ITYPE_t dist_middle_terms_chunks_size
 
         SparseSparseMiddleTermComputer{{name_suffix}} middle_term_computer
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd.tp
@@ -19,6 +19,10 @@ from ...metrics._dist_metrics cimport DistanceMetric, DistanceMetric32
 
 {{for name_suffix, DistanceMetric, INPUT_DTYPE_t in implementation_specific_values}}
 
+from ._middle_term_computer cimport (
+    DenseDenseMiddleTermComputer{{name_suffix}},
+    SparseSparseMiddleTermComputer{{name_suffix}},
+)
 
 cdef class DatasetsPair{{name_suffix}}:
     cdef:
@@ -31,13 +35,65 @@ cdef class DatasetsPair{{name_suffix}}:
 
     cdef DTYPE_t dist(self, ITYPE_t i, ITYPE_t j) nogil
 
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j) nogil
+    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=*) nogil
+
+    cdef void _parallel_on_X_parallel_init(self, ITYPE_t thread_num) nogil
+
+    cdef void _parallel_on_X_init_chunk(
+        self,
+        ITYPE_t thread_num,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+    ) nogil
+
+    cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil
+
+    cdef void _parallel_on_Y_init(self) nogil
+
+    cdef void _parallel_on_Y_parallel_init(
+        self,
+        ITYPE_t thread_num,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+    ) nogil
+
+    cdef void _parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil
+
+    cdef bint need_to_compute_exact_dist(self) nogil
 
 
 cdef class DenseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
     cdef:
         const {{INPUT_DTYPE_t}}[:, ::1] X
         const {{INPUT_DTYPE_t}}[:, ::1] Y
+
+
+cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair{{name_suffix}}):
+    cdef:
+        ITYPE_t X_n_chunks
+        ITYPE_t Y_n_samples_chunk
+        ITYPE_t Y_n_samples_last_chunk
+
+        bint use_squared_distances
+
+        DenseDenseMiddleTermComputer{{name_suffix}} middle_term_computer
+
+        const DTYPE_t[::1] X_norm_squared
+        const DTYPE_t[::1] Y_norm_squared
 
 
 cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
@@ -49,6 +105,20 @@ cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         const {{INPUT_DTYPE_t}}[:] Y_data
         const SPARSE_INDEX_TYPE_t[:] Y_indices
         const SPARSE_INDEX_TYPE_t[:] Y_indptr
+
+
+cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasetsPair{{name_suffix}}):
+    cdef:
+        ITYPE_t X_n_chunks
+        ITYPE_t Y_n_samples_chunk
+        ITYPE_t Y_n_samples_last_chunk
+
+        bint use_squared_distances
+
+        SparseSparseMiddleTermComputer{{name_suffix}} middle_term_computer
+
+        const DTYPE_t[::1] X_norm_squared
+        const DTYPE_t[::1] Y_norm_squared
 
 
 cdef class SparseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -221,7 +221,7 @@ cdef class DatasetsPair{{name_suffix}}:
         ITYPE_t i,
         ITYPE_t j,
         ITYPE_t n_Y,
-        ITYPE_t thread_num=0
+        ITYPE_t thread_num,
     ) nogil:
         return self.dist(i, j)
 
@@ -329,7 +329,7 @@ cdef class DenseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         ITYPE_t i,
         ITYPE_t j,
         ITYPE_t n_Y,
-        ITYPE_t thread_num=0,
+        ITYPE_t thread_num,
     ) nogil:
         return self.distance_metric.rdist(
             &self.X[X_start+i, 0],
@@ -558,14 +558,14 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
                 )
 
     @final
-    cdef DTYPE_t surrogate_dist(
+    cdef inline DTYPE_t surrogate_dist(
         self,
         ITYPE_t X_start,
         ITYPE_t Y_start,
         ITYPE_t i,
         ITYPE_t j,
         ITYPE_t n_Y,
-        ITYPE_t thread_num=0,
+        ITYPE_t thread_num,
     ) nogil:
         return self.dist_middle_terms_chunks[thread_num][i * n_Y + j]
 
@@ -615,7 +615,7 @@ cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         ITYPE_t i,
         ITYPE_t j,
         ITYPE_t n_Y,
-        ITYPE_t thread_num=0
+        ITYPE_t thread_num
     ) nogil:
         i += X_start
         j += Y_start
@@ -853,7 +853,7 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         ITYPE_t i,
         ITYPE_t j,
         ITYPE_t n_Y,
-        ITYPE_t thread_num=0,
+        ITYPE_t thread_num,
     ) nogil:
         # Y_chunk_size is constant except for the last chunk that can be smaller.
         # cdef:
@@ -947,7 +947,7 @@ cdef class SparseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         ITYPE_t i,
         ITYPE_t j,
         ITYPE_t n_Y,
-        ITYPE_t thread_num=0,
+        ITYPE_t thread_num,
     ) nogil:
         i += X_start
         j += Y_start
@@ -1023,7 +1023,7 @@ cdef class DenseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         ITYPE_t i,
         ITYPE_t j,
         ITYPE_t n_Y,
-        ITYPE_t thread_num=0,
+        ITYPE_t thread_num,
     ) nogil:
         # Swapping arguments on the same interface
         return self.datasets_pair.surrogate_dist(Y_start, X_start, j, i, n_Y)

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -448,6 +448,12 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         ITYPE_t Y_end,
         ITYPE_t thread_num,
     ) nogil:
+        cdef:
+            ITYPE_t i, j, k, l
+            ITYPE_t n_X = X_end - X_start
+            ITYPE_t n_Y = Y_end - Y_start
+            DTYPE_t *dist_middle_terms = self.dist_middle_terms_chunks[thread_num].data()
+
         DatasetsPair{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
             self, X_start, X_end, Y_start, Y_end, thread_num
         )
@@ -464,8 +470,19 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
             Y_start,
             Y_end,
             thread_num,
-            self.dist_middle_terms_chunks[thread_num].data(),
+            dist_middle_terms,
         )
+        for i in range(n_X):
+            k = i * n_Y
+            for j in range(n_Y):
+                l = k + j
+                # Catastrophic cancellation might cause -0. to be present,
+                # e.g. when computing d(x_i, y_i) when X is Y.
+                dist_middle_terms[l] = max(0,
+                    dist_middle_terms[l]
+                    + self.X_norm_squared[X_start + i]
+                    + self.Y_norm_squared[Y_start + j]
+                )
 
     @final
     cdef void _parallel_on_Y_init(self) nogil:
@@ -501,6 +518,11 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         ITYPE_t Y_end,
         ITYPE_t thread_num,
     ) nogil:
+        cdef:
+            ITYPE_t i, j, k, l
+            ITYPE_t n_X = X_end - X_start
+            ITYPE_t n_Y = Y_end - Y_start
+            DTYPE_t *dist_middle_terms = self.dist_middle_terms_chunks[thread_num].data()
         DatasetsPair{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
             self, X_start, X_end, Y_start, Y_end, thread_num
         )
@@ -517,8 +539,19 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
             Y_start,
             Y_end,
             thread_num,
-            self.dist_middle_terms_chunks[thread_num].data(),
+            dist_middle_terms,
         )
+        for i in range(n_X):
+            k = i * n_Y
+            for j in range(n_Y):
+                l = k + j
+                # Catastrophic cancellation might cause -0. to be present,
+                # e.g. when computing d(x_i, y_i) when X is Y.
+                dist_middle_terms[l] = max(0,
+                    dist_middle_terms[l]
+                    + self.X_norm_squared[X_start + i]
+                    + self.Y_norm_squared[Y_start + j]
+                )
 
     @final
     cdef DTYPE_t surrogate_dist(
@@ -530,18 +563,7 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         ITYPE_t n_Y,
         ITYPE_t thread_num=0,
     ) nogil:
-        #cdef:
-        #    # Y_chunk_size is constant except for the last chunk that can be smaller.
-        #    DTYPE_t dist_middle_term = (
-        #        self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * n_Y + j]
-        #    )
-        # Catastrophic cancellation might cause -0. to be present,
-        # e.g. when computing d(x_i, y_i) when X is Y.
-        return max(0.,
-            self.X_norm_squared[X_start + i]
-            + self.dist_middle_terms_chunks[thread_num][i * n_Y + j]
-            + self.Y_norm_squared[Y_start + j]
-        )
+        return self.dist_middle_terms_chunks[thread_num][i * n_Y + j]
 
     @final
     cdef bint need_to_compute_exact_dist(self) nogil:

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -202,7 +202,13 @@ cdef class DatasetsPair{{name_suffix}}:
         # TODO: add "with gil: raise" here when supporting Cython 3.0
         return -999
 
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
+    cdef DTYPE_t surrogate_dist(self,
+        ITYPE_t X_start,
+        ITYPE_t Y_start,
+        ITYPE_t i,
+        ITYPE_t j,
+        ITYPE_t thread_num=0
+    ) nogil:
         return self.dist(i, j)
 
     cdef DTYPE_t dist(self, ITYPE_t i, ITYPE_t j) nogil:
@@ -302,8 +308,19 @@ cdef class DenseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         return self.Y.shape[0]
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
-        return self.distance_metric.rdist(&self.X[i, 0], &self.Y[j, 0], self.n_features)
+    cdef DTYPE_t surrogate_dist(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t Y_start,
+        ITYPE_t i,
+        ITYPE_t j,
+        ITYPE_t thread_num=0,
+    ) nogil:
+        return self.distance_metric.rdist(
+            &self.X[i, 0],
+            &self.Y[j, 0],
+            self.n_features,
+        )
 
     @final
     cdef DTYPE_t dist(self, ITYPE_t i, ITYPE_t j) nogil:
@@ -319,7 +336,7 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         Y,
         {{DistanceMetric}} distance_metric,
         bint use_squared_distances,
-        ITYPE_t X_n_chunks,
+        ITYPE_t Y_n_chunks,
         ITYPE_t Y_n_samples_chunk,
         ITYPE_t Y_n_samples_last_chunk,
         ITYPE_t effective_n_threads,
@@ -328,9 +345,11 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         super().__init__(X, Y, distance_metric)
 
         # Used to compute the surrogate distance
-        self.X_n_chunks = X_n_chunks
+        self.Y_n_chunks = Y_n_chunks
         self.Y_n_samples_chunk = Y_n_samples_chunk
         self.Y_n_samples_last_chunk = Y_n_samples_last_chunk
+        # The number of samples belonging to the all-but-last chunks of fixed width.
+        self.Y_n_samples_fixed_size = (Y_n_chunks - 1) * Y_n_samples_chunk
 
         self.use_squared_distances = use_squared_distances
 
@@ -476,21 +495,39 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         )
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
+    cdef DTYPE_t surrogate_dist(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t Y_start,
+        ITYPE_t i,
+        ITYPE_t j,
+        ITYPE_t thread_num=0,
+    ) nogil:
         cdef:
+            # We need to find the chunk-relative index, i_c, j_c
+            # and also the total index i_t, j_t so that:
+            # i_t = X_start + i_c
+            # j_t = Y_start + j_c
+            ITYPE_t i_c = (i < X_start) * i + (i >= X_start) * (i - X_start)
+            ITYPE_t j_c = (j < Y_start) * j + (j >= Y_start) * (j - Y_start)
+
+            ITYPE_t i_t = X_start + i_c
+            ITYPE_t j_t = Y_start + j_c
+
+            # Y_chunk_size is constant except for the last chunk that can be smaller.
             ITYPE_t Y_chunk_size = (
-                (i < (self.X_n_chunks - 1)) * self.Y_n_samples_chunk
-                + (i == (self.X_n_chunks - 1)) * self.Y_n_samples_last_chunk
+                (j_t <= self.Y_n_samples_fixed_size) * self.Y_n_samples_chunk
+                + (j_t > self.Y_n_samples_fixed_size) * self.Y_n_samples_last_chunk
             )
             DTYPE_t dist_middle_term = (
-                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * Y_chunk_size + j]
+                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i_c * Y_chunk_size + j_c]
             )
         # Catastrophic cancellation might cause -0. to be present,
         # e.g. when computing d(x_i, y_i) when X is Y.
         return max(0.,
-            self.X_norm_squared[i]
+            self.X_norm_squared[i_t]
             + dist_middle_term
-            + self.Y_norm_squared[j]
+            + self.Y_norm_squared[j_t]
         )
 
     @final
@@ -532,7 +569,14 @@ cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         return self.Y_indptr.shape[0] - 1
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
+    cdef DTYPE_t surrogate_dist(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t Y_start,
+        ITYPE_t i,
+        ITYPE_t j,
+        ITYPE_t thread_num=0
+    ) nogil:
         return self.distance_metric.rdist_csr(
             x1_data=&self.X_data[0],
             x1_indices=self.X_indices,
@@ -569,7 +613,7 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         Y,
         {{DistanceMetric}} distance_metric,
         bint use_squared_distances,
-        ITYPE_t X_n_chunks,
+        ITYPE_t Y_n_chunks,
         ITYPE_t Y_n_samples_chunk,
         ITYPE_t Y_n_samples_last_chunk,
         ITYPE_t effective_n_threads
@@ -578,9 +622,11 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         super().__init__(X, Y, distance_metric)
 
         # Used to compute the surrogate distance.
-        self.X_n_chunks = X_n_chunks
+        self.Y_n_chunks = Y_n_chunks
         self.Y_n_samples_chunk = Y_n_samples_chunk
         self.Y_n_samples_last_chunk = Y_n_samples_last_chunk
+        # The number of samples belonging to the all-but-last chunks of fixed width.
+        self.Y_n_samples_fixed_size = (Y_n_chunks - 1) * Y_n_samples_chunk
 
         self.use_squared_distances = use_squared_distances
 
@@ -733,22 +779,39 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         )
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
+    cdef DTYPE_t surrogate_dist(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t Y_start,
+        ITYPE_t i,
+        ITYPE_t j,
+        ITYPE_t thread_num=0,
+    ) nogil:
         # Y_chunk_size is constant except for the last chunk that can be smaller.
         cdef:
+            # We need to find the chunk-relative index, i_c, j_c
+            # and also the total index i_t, j_t so that:
+            # i_t = X_start + i_c
+            # j_t = Y_start + j_c
+            ITYPE_t i_c = (i < X_start) * i + (i >= X_start) * (i - X_start)
+            ITYPE_t j_c = (j < Y_start) * j + (j >= Y_start) * (j - Y_start)
+
+            ITYPE_t i_t = X_start + i_c
+            ITYPE_t j_t = Y_start + j_c
+
             ITYPE_t Y_chunk_size = (
-                (i < (self.X_n_chunks - 1)) * self.Y_n_samples_chunk
-                + (i == (self.X_n_chunks - 1)) * self.Y_n_samples_last_chunk
+                (j_t <= self.Y_n_samples_fixed_size) * self.Y_n_samples_chunk
+                + (j_t > self.Y_n_samples_fixed_size) * self.Y_n_samples_last_chunk
             )
             DTYPE_t dist_middle_term = (
-                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * Y_chunk_size + j]
+                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i_c * Y_chunk_size + j_c]
             )
         # Catastrophic cancellation might cause -0. to be present,
         # e.g. when computing d(x_i, y_i) when X is Y.
         return max(0.,
-            self.X_norm_squared[i]
+            self.X_norm_squared[i_t]
             + dist_middle_term
-            + self.Y_norm_squared[j]
+            + self.Y_norm_squared[j_t]
         )
 
     @final
@@ -824,7 +887,13 @@ cdef class SparseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         return self.n_Y
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
+    cdef DTYPE_t surrogate_dist(self,
+        ITYPE_t X_start,
+        ITYPE_t Y_start,
+        ITYPE_t i,
+        ITYPE_t j,
+        ITYPE_t thread_num=0,
+    ) nogil:
         return self.distance_metric.rdist_csr(
             x1_data=&self.X_data[0],
             x1_indices=self.X_indices,
@@ -890,9 +959,16 @@ cdef class DenseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         return self.datasets_pair.n_samples_X()
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
+    cdef DTYPE_t surrogate_dist(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t Y_start,
+        ITYPE_t i,
+        ITYPE_t j,
+        ITYPE_t thread_num=0,
+    ) nogil:
         # Swapping arguments on the same interface
-        return self.datasets_pair.surrogate_dist(j, i)
+        return self.datasets_pair.surrogate_dist(Y_start, X_start, j, i)
 
     @final
     cdef DTYPE_t dist(self, ITYPE_t i, ITYPE_t j) nogil:

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -15,10 +15,19 @@ implementation_specific_values = [
 import numpy as np
 cimport numpy as cnp
 
+from libcpp.vector cimport vector
+
 from cython cimport final
 
 from ...utils._typedefs cimport DTYPE_t, ITYPE_t
 from ...metrics._dist_metrics cimport DistanceMetric
+
+# TODO: change for `libcpp.algorithm.fill` once Cython 3 is used
+# Introduction in Cython:
+#
+# https://github.com/cython/cython/blob/05059e2a9b89bf6738a7750b905057e5b1e3fe2e/Cython/Includes/libcpp/algorithm.pxd#L50 #noqa
+cdef extern from "<algorithm>" namespace "std" nogil:
+    void fill[Iter, T](Iter first, Iter last, const T& value) except + #noqa
 
 from scipy.sparse import issparse, csr_matrix
 from ...utils import check_array
@@ -342,6 +351,8 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         ITYPE_t Y_n_samples_chunk,
         ITYPE_t Y_n_samples_last_chunk,
         ITYPE_t effective_n_threads,
+        ITYPE_t dist_middle_terms_chunks_size,
+        ITYPE_t chunks_n_threads,
         **euclidean_kwargs,
     ):
         super().__init__(X, Y, distance_metric)
@@ -350,10 +361,16 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         self.Y_n_chunks = Y_n_chunks
         self.Y_n_samples_chunk = Y_n_samples_chunk
         self.Y_n_samples_last_chunk = Y_n_samples_last_chunk
+
+        self.chunks_n_threads = chunks_n_threads
+
         # The number of samples belonging to the all-but-last chunks of fixed width.
         self.Y_n_samples_fixed_size = (Y_n_chunks - 1) * Y_n_samples_chunk
 
         self.use_squared_distances = use_squared_distances
+
+        self.dist_middle_terms_chunks = vector[vector[DTYPE_t]](effective_n_threads)
+        self.dist_middle_terms_chunks_size = dist_middle_terms_chunks_size
 
         Y_norm_squared = (euclidean_kwargs or {}).pop("Y_norm_squared")
         if Y_norm_squared is not None:
@@ -403,7 +420,8 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         DatasetsPair{{name_suffix}}._parallel_on_X_parallel_init(
             self, thread_num
         )
-        self.middle_term_computer._parallel_on_X_parallel_init(thread_num)
+        self.dist_middle_terms_chunks[thread_num].resize(self.dist_middle_terms_chunks_size)
+        #self.middle_term_computer._parallel_on_X_parallel_init(thread_num)
 
     @final
     cdef void _parallel_on_X_init_chunk(
@@ -446,11 +464,16 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
             Y_start,
             Y_end,
             thread_num,
+            self.dist_middle_terms_chunks[thread_num].data(),
         )
 
     @final
     cdef void _parallel_on_Y_init(self) nogil:
         DatasetsPair{{name_suffix}}._parallel_on_Y_init(self)
+        for thread_num in range(self.chunks_n_threads):
+            self.dist_middle_terms_chunks[thread_num].resize(
+                self.dist_middle_terms_chunks_size
+            )
         self.middle_term_computer._parallel_on_Y_init()
 
     @final
@@ -494,6 +517,7 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
             Y_start,
             Y_end,
             thread_num,
+            self.dist_middle_terms_chunks[thread_num].data(),
         )
 
     @final
@@ -506,16 +530,16 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         ITYPE_t n_Y,
         ITYPE_t thread_num=0,
     ) nogil:
-        cdef:
-            # Y_chunk_size is constant except for the last chunk that can be smaller.
-            DTYPE_t dist_middle_term = (
-                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * n_Y + j]
-            )
+        #cdef:
+        #    # Y_chunk_size is constant except for the last chunk that can be smaller.
+        #    DTYPE_t dist_middle_term = (
+        #        self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * n_Y + j]
+        #    )
         # Catastrophic cancellation might cause -0. to be present,
         # e.g. when computing d(x_i, y_i) when X is Y.
         return max(0.,
             self.X_norm_squared[X_start + i]
-            + dist_middle_term
+            + self.dist_middle_terms_chunks[thread_num][i * n_Y + j]
             + self.Y_norm_squared[Y_start + j]
         )
 
@@ -608,7 +632,9 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         ITYPE_t Y_n_chunks,
         ITYPE_t Y_n_samples_chunk,
         ITYPE_t Y_n_samples_last_chunk,
-        ITYPE_t effective_n_threads
+        ITYPE_t effective_n_threads,
+        ITYPE_t dist_middle_terms_chunks_size,
+        ITYPE_t chunks_n_threads,
         **euclidean_kwargs,
     ):
         super().__init__(X, Y, distance_metric)
@@ -617,10 +643,16 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         self.Y_n_chunks = Y_n_chunks
         self.Y_n_samples_chunk = Y_n_samples_chunk
         self.Y_n_samples_last_chunk = Y_n_samples_last_chunk
+
+        self.chunks_n_threads = chunks_n_threads
+
         # The number of samples belonging to the all-but-last chunks of fixed width.
         self.Y_n_samples_fixed_size = (Y_n_chunks - 1) * Y_n_samples_chunk
 
         self.use_squared_distances = use_squared_distances
+
+        self.dist_middle_terms_chunks = vector[vector[DTYPE_t]](effective_n_threads)
+        self.dist_middle_terms_chunks_size = dist_middle_terms_chunks_size
 
         euclidean_kwargs = euclidean_kwargs or {}
         Y_norm_squared = euclidean_kwargs.pop("Y_norm_squared", None)
@@ -677,7 +709,8 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         DatasetsPair{{name_suffix}}._parallel_on_X_parallel_init(
             self, thread_num
         )
-        self.middle_term_computer._parallel_on_X_parallel_init(thread_num)
+        #self.middle_term_computer._parallel_on_X_parallel_init(thread_num)
+        self.dist_middle_terms_chunks[thread_num].resize(self.dist_middle_terms_chunks_size)
 
     @final
     cdef void _parallel_on_X_init_chunk(
@@ -707,6 +740,11 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         DatasetsPair{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
             self, X_start, X_end, Y_start, Y_end, thread_num
         )
+        fill(
+            self.dist_middle_terms_chunks[thread_num].begin(),
+            self.dist_middle_terms_chunks[thread_num].end(),
+            0.0,
+        )
         self.middle_term_computer._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
             X_start,
             X_end,
@@ -720,11 +758,16 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
             Y_start,
             Y_end,
             thread_num,
+            self.dist_middle_terms_chunks[thread_num].data(),
         )
 
     @final
     cdef void _parallel_on_Y_init(self) nogil:
         DatasetsPair{{name_suffix}}._parallel_on_Y_init(self)
+        for thread_num in range(self.chunks_n_threads):
+            self.dist_middle_terms_chunks[thread_num].resize(
+                self.dist_middle_terms_chunks_size
+            )
         self.middle_term_computer._parallel_on_Y_init()
 
     @final
@@ -755,6 +798,11 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         DatasetsPair{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
             self, X_start, X_end, Y_start, Y_end, thread_num
         )
+        fill(
+            self.dist_middle_terms_chunks[thread_num].begin(),
+            self.dist_middle_terms_chunks[thread_num].end(),
+            0.0,
+        )
         self.middle_term_computer._parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
             X_start,
             X_end,
@@ -768,6 +816,7 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
             Y_start,
             Y_end,
             thread_num,
+            self.dist_middle_terms_chunks[thread_num].data(),
         )
 
     @final
@@ -781,15 +830,15 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         ITYPE_t thread_num=0,
     ) nogil:
         # Y_chunk_size is constant except for the last chunk that can be smaller.
-        cdef:
-            DTYPE_t dist_middle_term = (
-                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * n_Y + j]
-            )
+        # cdef:
+        #    DTYPE_t dist_middle_term = (
+        #        self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * n_Y + j]
+        #    )
         # Catastrophic cancellation might cause -0. to be present,
         # e.g. when computing d(x_i, y_i) when X is Y.
         return max(0.,
             self.X_norm_squared[i + X_start]
-            + dist_middle_term
+            + self.dist_middle_terms_chunks[thread_num][i * n_Y + j]
             + self.Y_norm_squared[j + Y_start]
         )
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -207,6 +207,7 @@ cdef class DatasetsPair{{name_suffix}}:
         ITYPE_t Y_start,
         ITYPE_t i,
         ITYPE_t j,
+        ITYPE_t n_Y,
         ITYPE_t thread_num=0
     ) nogil:
         return self.dist(i, j)
@@ -314,11 +315,12 @@ cdef class DenseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         ITYPE_t Y_start,
         ITYPE_t i,
         ITYPE_t j,
+        ITYPE_t n_Y,
         ITYPE_t thread_num=0,
     ) nogil:
         return self.distance_metric.rdist(
-            &self.X[i, 0],
-            &self.Y[j, 0],
+            &self.X[X_start+i, 0],
+            &self.Y[Y_start+j, 0],
             self.n_features,
         )
 
@@ -501,33 +503,20 @@ cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair
         ITYPE_t Y_start,
         ITYPE_t i,
         ITYPE_t j,
+        ITYPE_t n_Y,
         ITYPE_t thread_num=0,
     ) nogil:
         cdef:
-            # We need to find the chunk-relative index, i_c, j_c
-            # and also the total index i_t, j_t so that:
-            # i_t = X_start + i_c
-            # j_t = Y_start + j_c
-            ITYPE_t i_c = (i < X_start) * i + (i >= X_start) * (i - X_start)
-            ITYPE_t j_c = (j < Y_start) * j + (j >= Y_start) * (j - Y_start)
-
-            ITYPE_t i_t = X_start + i_c
-            ITYPE_t j_t = Y_start + j_c
-
             # Y_chunk_size is constant except for the last chunk that can be smaller.
-            ITYPE_t Y_chunk_size = (
-                (j_t <= self.Y_n_samples_fixed_size) * self.Y_n_samples_chunk
-                + (j_t > self.Y_n_samples_fixed_size) * self.Y_n_samples_last_chunk
-            )
             DTYPE_t dist_middle_term = (
-                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i_c * Y_chunk_size + j_c]
+                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * n_Y + j]
             )
         # Catastrophic cancellation might cause -0. to be present,
         # e.g. when computing d(x_i, y_i) when X is Y.
         return max(0.,
-            self.X_norm_squared[i_t]
+            self.X_norm_squared[X_start + i]
             + dist_middle_term
-            + self.Y_norm_squared[j_t]
+            + self.Y_norm_squared[Y_start + j]
         )
 
     @final
@@ -575,8 +564,11 @@ cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         ITYPE_t Y_start,
         ITYPE_t i,
         ITYPE_t j,
+        ITYPE_t n_Y,
         ITYPE_t thread_num=0
     ) nogil:
+        i += X_start
+        j += Y_start
         return self.distance_metric.rdist_csr(
             x1_data=&self.X_data[0],
             x1_indices=self.X_indices,
@@ -785,33 +777,20 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
         ITYPE_t Y_start,
         ITYPE_t i,
         ITYPE_t j,
+        ITYPE_t n_Y,
         ITYPE_t thread_num=0,
     ) nogil:
         # Y_chunk_size is constant except for the last chunk that can be smaller.
         cdef:
-            # We need to find the chunk-relative index, i_c, j_c
-            # and also the total index i_t, j_t so that:
-            # i_t = X_start + i_c
-            # j_t = Y_start + j_c
-            ITYPE_t i_c = (i < X_start) * i + (i >= X_start) * (i - X_start)
-            ITYPE_t j_c = (j < Y_start) * j + (j >= Y_start) * (j - Y_start)
-
-            ITYPE_t i_t = X_start + i_c
-            ITYPE_t j_t = Y_start + j_c
-
-            ITYPE_t Y_chunk_size = (
-                (j_t <= self.Y_n_samples_fixed_size) * self.Y_n_samples_chunk
-                + (j_t > self.Y_n_samples_fixed_size) * self.Y_n_samples_last_chunk
-            )
             DTYPE_t dist_middle_term = (
-                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i_c * Y_chunk_size + j_c]
+                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * n_Y + j]
             )
         # Catastrophic cancellation might cause -0. to be present,
         # e.g. when computing d(x_i, y_i) when X is Y.
         return max(0.,
-            self.X_norm_squared[i_t]
+            self.X_norm_squared[i + X_start]
             + dist_middle_term
-            + self.Y_norm_squared[j_t]
+            + self.Y_norm_squared[j + Y_start]
         )
 
     @final
@@ -892,8 +871,11 @@ cdef class SparseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         ITYPE_t Y_start,
         ITYPE_t i,
         ITYPE_t j,
+        ITYPE_t n_Y,
         ITYPE_t thread_num=0,
     ) nogil:
+        i += X_start
+        j += Y_start
         return self.distance_metric.rdist_csr(
             x1_data=&self.X_data[0],
             x1_indices=self.X_indices,
@@ -965,10 +947,11 @@ cdef class DenseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         ITYPE_t Y_start,
         ITYPE_t i,
         ITYPE_t j,
+        ITYPE_t n_Y,
         ITYPE_t thread_num=0,
     ) nogil:
         # Swapping arguments on the same interface
-        return self.datasets_pair.surrogate_dist(Y_start, X_start, j, i)
+        return self.datasets_pair.surrogate_dist(Y_start, X_start, j, i, n_Y)
 
     @final
     cdef DTYPE_t dist(self, ITYPE_t i, ITYPE_t j) nogil:

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -584,12 +584,12 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
 
         self.use_squared_distances = use_squared_distances
 
-        if (
-            euclidean_kwargs is not None
-            and euclidean_kwargs.get("Y_norm_squared")
-        ):
+        euclidean_kwargs = euclidean_kwargs or {}
+        Y_norm_squared = euclidean_kwargs.pop("Y_norm_squared", None)
+
+        if Y_norm_squared is not None:
             self.Y_norm_squared = check_array(
-                euclidean_kwargs.pop("Y_norm_squared"),
+                Y_norm_squared,
                 ensure_2d=False,
                 input_name="Y_norm_squared",
                 dtype=np.float64,
@@ -600,12 +600,11 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
                 effective_n_threads,
             )
 
-        if (
-            euclidean_kwargs is not None
-            and euclidean_kwargs.get("X_norm_squared")
-        ):
+        X_norm_squared = euclidean_kwargs.pop("X_norm_squared", None)
+
+        if X_norm_squared is not None:
             self.X_norm_squared = check_array(
-                euclidean_kwargs.pop("X_norm_squared"),
+                X_norm_squared,
                 ensure_2d=False,
                 input_name="X_norm_squared",
                 dtype=np.float64,
@@ -629,7 +628,7 @@ cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasets
             self.Y_indptr,
             n_features=X.shape[1],
             effective_n_threads=effective_n_threads,
-            **(euclidean_kwargs or {}),
+            **(euclidean_kwargs),
         )
 
     @final

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -1026,7 +1026,7 @@ cdef class DenseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         ITYPE_t thread_num,
     ) nogil:
         # Swapping arguments on the same interface
-        return self.datasets_pair.surrogate_dist(Y_start, X_start, j, i, n_Y)
+        return self.datasets_pair.surrogate_dist(Y_start, X_start, j, i, n_Y, thread_num)
 
     @final
     cdef DTYPE_t dist(self, ITYPE_t i, ITYPE_t j) nogil:

--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -21,10 +21,17 @@ from ...utils._typedefs cimport DTYPE_t, ITYPE_t
 from ...metrics._dist_metrics cimport DistanceMetric
 
 from scipy.sparse import issparse, csr_matrix
+from ...utils import check_array
 from ...utils._typedefs import DTYPE, SPARSE_INDEX_TYPE
 
 cnp.import_array()
 {{for name_suffix, DistanceMetric, INPUT_DTYPE_t, INPUT_DTYPE in implementation_specific_values}}
+
+from ._middle_term_computer cimport (
+    DenseDenseMiddleTermComputer{{name_suffix}},
+    SparseSparseMiddleTermComputer{{name_suffix}},
+)
+from ._base cimport _sqeuclidean_row_norms{{name_suffix}}
 
 cdef class DatasetsPair{{name_suffix}}:
     """Abstract class which wraps a pair of datasets (X, Y).
@@ -62,6 +69,7 @@ cdef class DatasetsPair{{name_suffix}}:
         Y,
         str metric="euclidean",
         dict metric_kwargs=None,
+        dict euclidean_kwargs=None,
     ) -> DatasetsPair{{name_suffix}}:
         """Return the DatasetsPair implementation for the given arguments.
 
@@ -111,11 +119,57 @@ cdef class DatasetsPair{{name_suffix}}:
         X_is_sparse = issparse(X)
         Y_is_sparse = issparse(Y)
 
+        use_euclidean_specialization = (
+            metric in ("euclidean", "sqeuclidean")
+            and not (issparse(X) ^ issparse(Y))  # "^" is the XOR operator
+        )
+        if use_euclidean_specialization:
+            use_squared_distances = metric == "sqeuclidean"
+
         if not X_is_sparse and not Y_is_sparse:
+            if use_euclidean_specialization:
+                # Specialized implementation of {ArgKmin, RadiusNeighbors}
+                # for the Euclidean distance for the dense-dense case.
+                # This implementation computes the distances by chunk using
+                # a decomposition of the Squared Euclidean distance.
+                # This specialisation has an improved arithmetic intensity for both
+                # the dense and sparse settings, allowing in most case speed-ups of
+                # several orders of magnitude compared to the generic {ArgKmin, RadiusNeighbors}
+                # implementation.
+                # For more information see MiddleTermComputer.
+                return EuclideanDenseDenseDatasetsPair{{name_suffix}}(
+                    X, Y,
+                    distance_metric,
+                    use_squared_distances,
+                    **(euclidean_kwargs or {}),
+                )
+            # Fall back on a generic implementation that handles most scipy
+            # metrics by computing the distances between 2 vectors at a time.
             return DenseDenseDatasetsPair{{name_suffix}}(X, Y, distance_metric)
 
         if X_is_sparse and Y_is_sparse:
-            return SparseSparseDatasetsPair{{name_suffix}}(X, Y, distance_metric)
+            if use_euclidean_specialization:
+                # Specialized implementation of {ArgKmin, RadiusNeighbors}
+                # for the Euclidean distance for the sparse-sparse case.
+                # This implementation computes the distances by chunk using
+                # a decomposition of the Squared Euclidean distance.
+                # This specialisation has an improved arithmetic intensity for both
+                # the dense and sparse settings, allowing in most case speed-ups of
+                # several orders of magnitude compared to the generic {ArgKmin, RadiusNeighbors}
+                # implementation.
+                # For more information see MiddleTermComputer.
+                return EuclideanSparseSparseDatasetsPair{{name_suffix}}(
+                    X, Y,
+                    distance_metric,
+                    use_squared_distances,
+                    **(euclidean_kwargs or {}),
+                )
+            # Fall back on a generic implementation that handles most scipy
+            # metrics by computing the distances between 2 vectors at a time.
+            return SparseSparseDatasetsPair{{name_suffix}}(
+                X, Y,
+                distance_metric,
+            )
 
         if X_is_sparse and not Y_is_sparse:
             return SparseDenseDatasetsPair{{name_suffix}}(X, Y, distance_metric)
@@ -148,7 +202,7 @@ cdef class DatasetsPair{{name_suffix}}:
         # TODO: add "with gil: raise" here when supporting Cython 3.0
         return -999
 
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j) nogil:
+    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
         return self.dist(i, j)
 
     cdef DTYPE_t dist(self, ITYPE_t i, ITYPE_t j) nogil:
@@ -157,7 +211,61 @@ cdef class DatasetsPair{{name_suffix}}:
         # TODO: add "with gil: raise" here when supporting Cython 3.0
         return -1
 
-@final
+    cdef void _parallel_on_X_parallel_init(
+        self,
+        ITYPE_t thread_num,
+    ) nogil:
+        # This method must be overwritten in the Euclidean specialization only.
+        return
+
+    cdef void _parallel_on_X_init_chunk(
+        self,
+        ITYPE_t thread_num,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+    ) nogil:
+        # This method must be overwritten in the Euclidean specialization only.
+        return
+
+    cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        # This method must be overwritten in the Euclidean specialization only.
+        return
+
+    cdef void _parallel_on_Y_init(self) nogil:
+        # This method must be overwritten in the Euclidean specialization only.
+        return
+
+    cdef void _parallel_on_Y_parallel_init(
+        self,
+        ITYPE_t thread_num,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+    ) nogil:
+        # This method must be overwritten in the Euclidean specialization only.
+        return
+
+    cdef void _parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        # This method must be overwritten in the Euclidean specialization only.
+        return
+
+    cdef bint need_to_compute_exact_dist(self) nogil:
+        # This method must be overwritten in the Euclidean specialization only.
+        return True
+
 cdef class DenseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
     """Compute distances between row vectors of two arrays.
 
@@ -194,7 +302,7 @@ cdef class DenseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         return self.Y.shape[0]
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j) nogil:
+    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
         return self.distance_metric.rdist(&self.X[i, 0], &self.Y[j, 0], self.n_features)
 
     @final
@@ -203,6 +311,196 @@ cdef class DenseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
 
 
 @final
+cdef class EuclideanDenseDenseDatasetsPair{{name_suffix}}(DenseDenseDatasetsPair{{name_suffix}}):
+
+    def __init__(
+        self,
+        X,
+        Y,
+        {{DistanceMetric}} distance_metric,
+        bint use_squared_distances,
+        ITYPE_t X_n_chunks,
+        ITYPE_t Y_n_samples_chunk,
+        ITYPE_t Y_n_samples_last_chunk,
+        ITYPE_t effective_n_threads,
+        **euclidean_kwargs,
+    ):
+        super().__init__(X, Y, distance_metric)
+
+        # Used to compute the surrogate distance
+        self.X_n_chunks = X_n_chunks
+        self.Y_n_samples_chunk = Y_n_samples_chunk
+        self.Y_n_samples_last_chunk = Y_n_samples_last_chunk
+
+        self.use_squared_distances = use_squared_distances
+
+        Y_norm_squared = (euclidean_kwargs or {}).pop("Y_norm_squared")
+        if Y_norm_squared is not None:
+            self.Y_norm_squared = check_array(
+                Y_norm_squared,
+                ensure_2d=False,
+                input_name="Y_norm_squared",
+                dtype=np.float64,
+            )
+        else:
+            self.Y_norm_squared = _sqeuclidean_row_norms{{name_suffix}}(
+                Y,
+                effective_n_threads,
+            )
+
+        X_norm_squared = (euclidean_kwargs or {}).pop("X_norm_squared")
+        if X_norm_squared is not None:
+            self.X_norm_squared = check_array(
+                X_norm_squared,
+                ensure_2d=False,
+                input_name="X_norm_squared",
+                dtype=np.float64,
+            )
+        else:
+            # Do not recompute norms if datasets are identical.
+            self.X_norm_squared = (
+                self.Y_norm_squared if X is Y else
+                _sqeuclidean_row_norms{{name_suffix}}(
+                    X,
+                    effective_n_threads,
+                )
+            )
+
+        self.middle_term_computer = DenseDenseMiddleTermComputer{{name_suffix}}(
+            self.X,
+            self.Y,
+            n_features=X.shape[1],
+            effective_n_threads=effective_n_threads,
+            **(euclidean_kwargs or {}),
+        )
+
+    @final
+    cdef void _parallel_on_X_parallel_init(
+        self,
+        ITYPE_t thread_num,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_X_parallel_init(
+            self, thread_num
+        )
+        self.middle_term_computer._parallel_on_X_parallel_init(thread_num)
+
+    @final
+    cdef void _parallel_on_X_init_chunk(
+        self,
+        ITYPE_t thread_num,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_X_init_chunk(
+            self, thread_num, X_start, X_end
+        )
+        self.middle_term_computer._parallel_on_X_init_chunk(
+            thread_num,
+            X_start,
+            X_end,
+        )
+
+    @final
+    cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+            self, X_start, X_end, Y_start, Y_end, thread_num
+        )
+        self.middle_term_computer._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
+        self.middle_term_computer._compute_dist_middle_terms(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
+
+    @final
+    cdef void _parallel_on_Y_init(self) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_Y_init(self)
+        self.middle_term_computer._parallel_on_Y_init()
+
+    @final
+    cdef void _parallel_on_Y_parallel_init(
+        self,
+        ITYPE_t thread_num,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_Y_parallel_init(
+            self, thread_num, X_start, X_end
+        )
+        self.middle_term_computer._parallel_on_Y_parallel_init(
+            thread_num,
+            X_start,
+            X_end,
+        )
+
+    @final
+    cdef void _parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+            self, X_start, X_end, Y_start, Y_end, thread_num
+        )
+        self.middle_term_computer._parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
+        self.middle_term_computer._compute_dist_middle_terms(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
+
+    @final
+    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
+        cdef:
+            ITYPE_t Y_chunk_size = (
+                (i < (self.X_n_chunks - 1)) * self.Y_n_samples_chunk
+                + (i == (self.X_n_chunks - 1)) * self.Y_n_samples_last_chunk
+            )
+            DTYPE_t dist_middle_term = (
+                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * Y_chunk_size + j]
+            )
+        # Catastrophic cancellation might cause -0. to be present,
+        # e.g. when computing d(x_i, y_i) when X is Y.
+        return max(0.,
+            self.X_norm_squared[i]
+            + dist_middle_term
+            + self.Y_norm_squared[j]
+        )
+
+    @final
+    cdef bint need_to_compute_exact_dist(self) nogil:
+        # At that point `self.argkmin_distances` stores surrogate distances,
+        # which are in this case square euclidean distances.
+        # We only need to convert those values for the `metric='euclidean'` case.
+        return not self.use_squared_distances
+
+
 cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
     """Compute distances between vectors of two CSR matrices.
 
@@ -234,7 +532,7 @@ cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         return self.Y_indptr.shape[0] - 1
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j) nogil:
+    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
         return self.distance_metric.rdist_csr(
             x1_data=&self.X_data[0],
             x1_indices=self.X_indices,
@@ -260,6 +558,206 @@ cdef class SparseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
             x2_end=self.Y_indptr[j + 1],
             size=self.n_features,
         )
+
+
+@final
+cdef class EuclideanSparseSparseDatasetsPair{{name_suffix}}(SparseSparseDatasetsPair{{name_suffix}}):
+
+    def __init__(
+        self,
+        X,
+        Y,
+        {{DistanceMetric}} distance_metric,
+        bint use_squared_distances,
+        ITYPE_t X_n_chunks,
+        ITYPE_t Y_n_samples_chunk,
+        ITYPE_t Y_n_samples_last_chunk,
+        ITYPE_t effective_n_threads
+        **euclidean_kwargs,
+    ):
+        super().__init__(X, Y, distance_metric)
+
+        # Used to compute the surrogate distance.
+        self.X_n_chunks = X_n_chunks
+        self.Y_n_samples_chunk = Y_n_samples_chunk
+        self.Y_n_samples_last_chunk = Y_n_samples_last_chunk
+
+        self.use_squared_distances = use_squared_distances
+
+        if (
+            euclidean_kwargs is not None
+            and euclidean_kwargs.get("Y_norm_squared")
+        ):
+            self.Y_norm_squared = check_array(
+                euclidean_kwargs.pop("Y_norm_squared"),
+                ensure_2d=False,
+                input_name="Y_norm_squared",
+                dtype=np.float64,
+            )
+        else:
+            self.Y_norm_squared = _sqeuclidean_row_norms{{name_suffix}}(
+                Y,
+                effective_n_threads,
+            )
+
+        if (
+            euclidean_kwargs is not None
+            and euclidean_kwargs.get("X_norm_squared")
+        ):
+            self.X_norm_squared = check_array(
+                euclidean_kwargs.pop("X_norm_squared"),
+                ensure_2d=False,
+                input_name="X_norm_squared",
+                dtype=np.float64,
+            )
+        else:
+            # Do not recompute norms if datasets are identical.
+            self.X_norm_squared = (
+                self.Y_norm_squared if X is Y else
+                _sqeuclidean_row_norms{{name_suffix}}(
+                    X,
+                    effective_n_threads,
+                )
+            )
+
+        self.middle_term_computer = SparseSparseMiddleTermComputer{{name_suffix}}(
+            self.X_data,
+            self.X_indices,
+            self.X_indptr,
+            self.Y_data,
+            self.Y_indices,
+            self.Y_indptr,
+            n_features=X.shape[1],
+            effective_n_threads=effective_n_threads,
+            **(euclidean_kwargs or {}),
+        )
+
+    @final
+    cdef void _parallel_on_X_parallel_init(
+        self,
+        ITYPE_t thread_num,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_X_parallel_init(
+            self, thread_num
+        )
+        self.middle_term_computer._parallel_on_X_parallel_init(thread_num)
+
+    @final
+    cdef void _parallel_on_X_init_chunk(
+        self,
+        ITYPE_t thread_num,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_X_init_chunk(
+            self, thread_num, X_start, X_end
+        )
+        self.middle_term_computer._parallel_on_X_init_chunk(
+            thread_num,
+            X_start,
+            X_end,
+        )
+
+    @final
+    cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+            self, X_start, X_end, Y_start, Y_end, thread_num
+        )
+        self.middle_term_computer._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
+        self.middle_term_computer._compute_dist_middle_terms(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
+
+    @final
+    cdef void _parallel_on_Y_init(self) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_Y_init(self)
+        self.middle_term_computer._parallel_on_Y_init()
+
+    @final
+    cdef void _parallel_on_Y_parallel_init(
+        self,
+        ITYPE_t thread_num,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_Y_parallel_init(
+            self, thread_num, X_start, X_end
+        )
+        self.middle_term_computer._parallel_on_Y_parallel_init(
+            thread_num,
+            X_start,
+            X_end,
+        )
+
+    @final
+    cdef void _parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        DatasetsPair{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+            self, X_start, X_end, Y_start, Y_end, thread_num
+        )
+        self.middle_term_computer._parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
+        self.middle_term_computer._compute_dist_middle_terms(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
+
+    @final
+    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
+        # Y_chunk_size is constant except for the last chunk that can be smaller.
+        cdef:
+            ITYPE_t Y_chunk_size = (
+                (i < (self.X_n_chunks - 1)) * self.Y_n_samples_chunk
+                + (i == (self.X_n_chunks - 1)) * self.Y_n_samples_last_chunk
+            )
+            DTYPE_t dist_middle_term = (
+                self.middle_term_computer.dist_middle_terms_chunks[thread_num][i * Y_chunk_size + j]
+            )
+        # Catastrophic cancellation might cause -0. to be present,
+        # e.g. when computing d(x_i, y_i) when X is Y.
+        return max(0.,
+            self.X_norm_squared[i]
+            + dist_middle_term
+            + self.Y_norm_squared[j]
+        )
+
+    @final
+    cdef bint need_to_compute_exact_dist(self) nogil:
+        # At that point `self.argkmin_distances` stores surrogate distances,
+        # which are in this case square euclidean distances.
+        # We only need to convert those values for the `metric='euclidean'` case.
+        return not self.use_squared_distances
 
 
 @final
@@ -327,7 +825,7 @@ cdef class SparseDenseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         return self.n_Y
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j) nogil:
+    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
         return self.distance_metric.rdist_csr(
             x1_data=&self.X_data[0],
             x1_indices=self.X_indices,
@@ -393,7 +891,7 @@ cdef class DenseSparseDatasetsPair{{name_suffix}}(DatasetsPair{{name_suffix}}):
         return self.datasets_pair.n_samples_X()
 
     @final
-    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j) nogil:
+    cdef DTYPE_t surrogate_dist(self, ITYPE_t i, ITYPE_t j, ITYPE_t thread_num=0) nogil:
         # Swapping arguments on the same interface
         return self.datasets_pair.surrogate_dist(j, i)
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd.tp
@@ -150,11 +150,11 @@ cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_
 
 cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_suffix}}):
     cdef:
-        const DTYPE_t[:] X_data
+        const {{INPUT_DTYPE_t}}[:] X_data
         const SPARSE_INDEX_TYPE_t[:] X_indices
         const SPARSE_INDEX_TYPE_t[:] X_indptr
 
-        const DTYPE_t[:] Y_data
+        const {{INPUT_DTYPE_t}}[:] Y_data
         const SPARSE_INDEX_TYPE_t[:] Y_indices
         const SPARSE_INDEX_TYPE_t[:] Y_indptr
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd.tp
@@ -85,7 +85,7 @@ cdef class MiddleTermComputer{{name_suffix}}:
         ITYPE_t thread_num
     ) nogil
 
-    cdef DTYPE_t * _compute_dist_middle_terms(
+    cdef void _compute_dist_middle_terms(
         self,
         ITYPE_t X_start,
         ITYPE_t X_end,
@@ -138,7 +138,7 @@ cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_
         ITYPE_t thread_num
     ) nogil
 
-    cdef DTYPE_t * _compute_dist_middle_terms(
+    cdef void _compute_dist_middle_terms(
         self,
         ITYPE_t X_start,
         ITYPE_t X_end,
@@ -176,7 +176,7 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
         ITYPE_t thread_num
     ) nogil
 
-    cdef DTYPE_t * _compute_dist_middle_terms(
+    cdef void _compute_dist_middle_terms(
         self,
         ITYPE_t X_start,
         ITYPE_t X_end,

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd.tp
@@ -41,13 +41,11 @@ cdef void _middle_term_sparse_sparse_64(
 cdef class MiddleTermComputer{{name_suffix}}:
     cdef:
         ITYPE_t effective_n_threads
-        ITYPE_t chunks_n_threads
-        ITYPE_t dist_middle_terms_chunks_size
         ITYPE_t n_features
         ITYPE_t chunk_size
 
         # Buffers for the `-2 * X_c @ Y_c.T` term computed via GEMM
-        vector[vector[DTYPE_t]] dist_middle_terms_chunks
+        # vector[vector[DTYPE_t]] dist_middle_terms_chunks
 
     cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
         self,
@@ -92,6 +90,7 @@ cdef class MiddleTermComputer{{name_suffix}}:
         ITYPE_t Y_start,
         ITYPE_t Y_end,
         ITYPE_t thread_num,
+        DTYPE_t *dist_middle_term,
     ) nogil
 
 
@@ -145,6 +144,7 @@ cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_
         ITYPE_t Y_start,
         ITYPE_t Y_end,
         ITYPE_t thread_num,
+        DTYPE_t *dist_middle_term,
     ) nogil
 
 
@@ -183,6 +183,7 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
         ITYPE_t Y_start,
         ITYPE_t Y_end,
         ITYPE_t thread_num,
+        DTYPE_t *dist_middle_term,
     ) nogil
 
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
@@ -167,6 +167,7 @@ cdef class MiddleTermComputer{{name_suffix}}:
         return
 
 
+@final
 cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_suffix}}):
     """Computes the middle term of the Euclidean distance between two chunked dense matrices
     X_c and Y_c.
@@ -328,6 +329,7 @@ cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_
         _gemm(order, ta, tb, m, n, K, alpha, A, lda, B, ldb, beta, dist_middle_terms, ldc)
 
 
+@final
 cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_suffix}}):
     """Middle term of the Euclidean distance between two chunked CSR matrices.
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
@@ -167,7 +167,6 @@ cdef class MiddleTermComputer{{name_suffix}}:
         return
 
 
-@final
 cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_suffix}}):
     """Computes the middle term of the Euclidean distance between two chunked dense matrices
     X_c and Y_c.
@@ -329,7 +328,6 @@ cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_
         _gemm(order, ta, tb, m, n, K, alpha, A, lda, B, ldb, beta, dist_middle_terms, ldc)
 
 
-@final
 cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_suffix}}):
     """Middle term of the Euclidean distance between two chunked CSR matrices.
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
@@ -38,6 +38,9 @@ import numpy as np
 from scipy.sparse import issparse, csr_matrix
 from ...utils._typedefs import DTYPE, SPARSE_INDEX_TYPE
 
+
+{{for name_suffix, upcast_to_float64, INPUT_DTYPE_t, INPUT_DTYPE in implementation_specific_values}}
+
 # TODO: If possible optimize this routine to efficiently treat cases where
 # `n_samples_X << n_samples_Y` met in practise when X_test consists of a
 # few samples, and thus when there's a single chunk of X whose number of
@@ -46,13 +49,13 @@ from ...utils._typedefs import DTYPE, SPARSE_INDEX_TYPE
 # TODO: compare this routine with the similar ones in SciPy, especially
 # `csr_matmat` which might implement a better algorithm.
 # See: https://github.com/scipy/scipy/blob/e58292e066ba2cb2f3d1e0563ca9314ff1f4f311/scipy/sparse/sparsetools/csr.h#L603-L669  # noqa
-cdef void _middle_term_sparse_sparse_64(
-    const DTYPE_t[:] X_data,
+cdef void _middle_term_sparse_sparse_{{name_suffix}}(
+    const {{INPUT_DTYPE_t}}[:] X_data,
     const SPARSE_INDEX_TYPE_t[:] X_indices,
     const SPARSE_INDEX_TYPE_t[:] X_indptr,
     ITYPE_t X_start,
     ITYPE_t X_end,
-    const DTYPE_t[:] Y_data,
+    const {{INPUT_DTYPE_t}}[:] Y_data,
     const SPARSE_INDEX_TYPE_t[:] Y_indices,
     const SPARSE_INDEX_TYPE_t[:] Y_indptr,
     ITYPE_t Y_start,
@@ -77,9 +80,6 @@ cdef void _middle_term_sparse_sparse_64(
                     Y_j_col_idx = Y_indices[Y_j_ptr]
                     if X_i_col_idx == Y_j_col_idx:
                         D[k] += -2 * X_data[X_i_ptr] * Y_data[Y_j_ptr]
-
-
-{{for name_suffix, upcast_to_float64, INPUT_DTYPE_t, INPUT_DTYPE in implementation_specific_values}}
 
 
 cdef class MiddleTermComputer{{name_suffix}}:
@@ -350,10 +350,10 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
 
     def __init__(
         self,
-        const DTYPE_t[:] X_data,
+        const {{INPUT_DTYPE_t}}[:] X_data,
         const SPARSE_INDEX_TYPE_t[:] X_indices,
         const SPARSE_INDEX_TYPE_t[:] X_indptr,
-        const DTYPE_t[:] Y_data,
+        const {{INPUT_DTYPE_t}}[:] Y_data,
         const SPARSE_INDEX_TYPE_t[:] Y_indices,
         const SPARSE_INDEX_TYPE_t[:] Y_indptr,
         ITYPE_t effective_n_threads,
@@ -415,7 +415,7 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
                 self.dist_middle_terms_chunks[thread_num].data()
             )
 
-        _middle_term_sparse_sparse_64(
+        _middle_term_sparse_sparse_{{name_suffix}}(
             self.X_data,
             self.X_indices,
             self.X_indptr,

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
@@ -31,8 +31,8 @@ from ...utils._typedefs cimport DTYPE_t, ITYPE_t, SPARSE_INDEX_TYPE_t
 # Introduction in Cython:
 #
 # https://github.com/cython/cython/blob/05059e2a9b89bf6738a7750b905057e5b1e3fe2e/Cython/Includes/libcpp/algorithm.pxd#L50 #noqa
-cdef extern from "<algorithm>" namespace "std" nogil:
-    void fill[Iter, T](Iter first, Iter last, const T& value) except + #noqa
+# cdef extern from "<algorithm>" namespace "std" nogil:
+#    void fill[Iter, T](Iter first, Iter last, const T& value) except + #noqa
 
 import numpy as np
 from scipy.sparse import issparse, csr_matrix
@@ -103,18 +103,14 @@ cdef class MiddleTermComputer{{name_suffix}}:
     def __init__(
         self,
         ITYPE_t effective_n_threads,
-        ITYPE_t chunks_n_threads,
-        ITYPE_t dist_middle_terms_chunks_size,
         ITYPE_t n_features,
         ITYPE_t chunk_size,
     ):
         self.effective_n_threads = effective_n_threads
-        self.chunks_n_threads = chunks_n_threads
-        self.dist_middle_terms_chunks_size = dist_middle_terms_chunks_size
         self.n_features = n_features
         self.chunk_size = chunk_size
 
-        self.dist_middle_terms_chunks = vector[vector[DTYPE_t]](self.effective_n_threads)
+        #self.dist_middle_terms_chunks = vector[vector[DTYPE_t]](self.effective_n_threads)
 
     cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
         self,
@@ -127,7 +123,8 @@ cdef class MiddleTermComputer{{name_suffix}}:
         return
 
     cdef void _parallel_on_X_parallel_init(self, ITYPE_t thread_num) nogil:
-        self.dist_middle_terms_chunks[thread_num].resize(self.dist_middle_terms_chunks_size)
+        #    self.dist_middle_terms_chunks[thread_num].resize(self.dist_middle_terms_chunks_size)
+        return
 
     cdef void _parallel_on_X_init_chunk(
         self,
@@ -138,10 +135,7 @@ cdef class MiddleTermComputer{{name_suffix}}:
         return
 
     cdef void _parallel_on_Y_init(self) nogil:
-        for thread_num in range(self.chunks_n_threads):
-            self.dist_middle_terms_chunks[thread_num].resize(
-                self.dist_middle_terms_chunks_size
-            )
+        return
 
     cdef void _parallel_on_Y_parallel_init(
         self,
@@ -168,6 +162,7 @@ cdef class MiddleTermComputer{{name_suffix}}:
         ITYPE_t Y_start,
         ITYPE_t Y_end,
         ITYPE_t thread_num,
+        DTYPE_t *dist_middle_terms_chunks_size,
     ) nogil:
         return
 
@@ -187,15 +182,11 @@ cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_
         const {{INPUT_DTYPE_t}}[:, ::1] X,
         const {{INPUT_DTYPE_t}}[:, ::1] Y,
         ITYPE_t effective_n_threads,
-        ITYPE_t chunks_n_threads,
-        ITYPE_t dist_middle_terms_chunks_size,
         ITYPE_t n_features,
         ITYPE_t chunk_size,
     ):
         super().__init__(
             effective_n_threads,
-            chunks_n_threads,
-            dist_middle_terms_chunks_size,
             n_features,
             chunk_size,
         )
@@ -301,9 +292,10 @@ cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_
         ITYPE_t Y_start,
         ITYPE_t Y_end,
         ITYPE_t thread_num,
+        DTYPE_t *dist_middle_terms,
     ) nogil:
         cdef:
-            DTYPE_t *dist_middle_terms = self.dist_middle_terms_chunks[thread_num].data()
+            #DTYPE_t *dist_middle_terms = self.dist_middle_terms_chunks[thread_num].data()
 
             # Careful: LDA, LDB and LDC are given for F-ordered arrays
             # in BLAS documentations, for instance:
@@ -357,15 +349,11 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
         const SPARSE_INDEX_TYPE_t[:] Y_indices,
         const SPARSE_INDEX_TYPE_t[:] Y_indptr,
         ITYPE_t effective_n_threads,
-        ITYPE_t chunks_n_threads,
-        ITYPE_t dist_middle_terms_chunks_size,
         ITYPE_t n_features,
         ITYPE_t chunk_size,
     ):
         super().__init__(
             effective_n_threads,
-            chunks_n_threads,
-            dist_middle_terms_chunks_size,
             n_features,
             chunk_size,
         )
@@ -381,11 +369,12 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
         ITYPE_t thread_num,
     ) nogil:
         # Flush the thread dist_middle_terms_chunks to 0.0
-        fill(
-            self.dist_middle_terms_chunks[thread_num].begin(),
-            self.dist_middle_terms_chunks[thread_num].end(),
-            0.0,
-        )
+        #fill(
+        #    self.dist_middle_terms_chunks[thread_num].begin(),
+        #    self.dist_middle_terms_chunks[thread_num].end(),
+        #    0.0,
+        #)
+        return
 
     cdef void _parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
         self,
@@ -396,11 +385,12 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
         ITYPE_t thread_num,
     ) nogil:
         # Flush the thread dist_middle_terms_chunks to 0.0
-        fill(
-            self.dist_middle_terms_chunks[thread_num].begin(),
-            self.dist_middle_terms_chunks[thread_num].end(),
-            0.0,
-        )
+        #fill(
+        #    self.dist_middle_terms_chunks[thread_num].begin(),
+        #    self.dist_middle_terms_chunks[thread_num].end(),
+        #    0.0,
+        #)
+        return
 
     cdef void _compute_dist_middle_terms(
         self,
@@ -409,11 +399,12 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
         ITYPE_t Y_start,
         ITYPE_t Y_end,
         ITYPE_t thread_num,
+        DTYPE_t *dist_middle_terms,
     ) nogil:
-        cdef:
-            DTYPE_t *dist_middle_terms = (
-                self.dist_middle_terms_chunks[thread_num].data()
-            )
+        #cdef:
+        #    DTYPE_t *dist_middle_terms = (
+        #        self.dist_middle_terms_chunks[thread_num].data()
+        #    )
 
         _middle_term_sparse_sparse_{{name_suffix}}(
             self.X_data,

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
@@ -100,71 +100,6 @@ cdef class MiddleTermComputer{{name_suffix}}:
     the middle term, i.e. `- 2 X_c_i.Y_c_j^T`.
     """
 
-    @classmethod
-    def get_for(
-        cls,
-        X,
-        Y,
-        effective_n_threads,
-        chunks_n_threads,
-        dist_middle_terms_chunks_size,
-        n_features,
-        chunk_size,
-    ) -> MiddleTermComputer{{name_suffix}}:
-        """Return the DatasetsPair implementation for the given arguments.
-
-        Parameters
-        ----------
-        X : ndarray or CSR sparse matrix of shape (n_samples_X, n_features)
-            Input data.
-            If provided as a ndarray, it must be C-contiguous.
-
-        Y : ndarray or CSR sparse matrix of shape (n_samples_Y, n_features)
-            Input data.
-            If provided as a ndarray, it must be C-contiguous.
-
-        Returns
-        -------
-        middle_term_computer: MiddleTermComputer{{name_suffix}}
-            The suited MiddleTermComputer{{name_suffix}} implementation.
-        """
-        X_is_sparse = issparse(X)
-        Y_is_sparse = issparse(Y)
-
-        if not X_is_sparse and not Y_is_sparse:
-            return DenseDenseMiddleTermComputer{{name_suffix}}(
-                X,
-                Y,
-                effective_n_threads,
-                chunks_n_threads,
-                dist_middle_terms_chunks_size,
-                n_features,
-                chunk_size,
-            )
-        if X_is_sparse and Y_is_sparse:
-            return SparseSparseMiddleTermComputer{{name_suffix}}(
-                X,
-                Y,
-                effective_n_threads,
-                chunks_n_threads,
-                dist_middle_terms_chunks_size,
-                n_features,
-                chunk_size,
-            )
-
-        raise NotImplementedError(
-            "X and Y must be both CSR sparse matrices or both numpy arrays."
-        )
-
-
-    @classmethod
-    def unpack_csr_matrix(cls, X: csr_matrix):
-        """Ensure that the CSR matrix is indexed with SPARSE_INDEX_TYPE."""
-        X_data = np.asarray(X.data, dtype=DTYPE)
-        X_indices = np.asarray(X.indices, dtype=SPARSE_INDEX_TYPE)
-        X_indptr = np.asarray(X.indptr, dtype=SPARSE_INDEX_TYPE)
-        return X_data, X_indices, X_indptr
-
     def __init__(
         self,
         ITYPE_t effective_n_threads,
@@ -226,7 +161,7 @@ cdef class MiddleTermComputer{{name_suffix}}:
     ) nogil:
         return
 
-    cdef DTYPE_t * _compute_dist_middle_terms(
+    cdef void _compute_dist_middle_terms(
         self,
         ITYPE_t X_start,
         ITYPE_t X_end,
@@ -234,7 +169,7 @@ cdef class MiddleTermComputer{{name_suffix}}:
         ITYPE_t Y_end,
         ITYPE_t thread_num,
     ) nogil:
-        return NULL
+        return
 
 
 cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_suffix}}):
@@ -359,7 +294,7 @@ cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_
         return
 {{endif}}
 
-    cdef DTYPE_t * _compute_dist_middle_terms(
+    cdef void _compute_dist_middle_terms(
         self,
         ITYPE_t X_start,
         ITYPE_t X_end,
@@ -400,8 +335,6 @@ cdef class DenseDenseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_
         # dist_middle_terms = `-2 * X[X_start:X_end] @ Y[Y_start:Y_end].T`
         _gemm(order, ta, tb, m, n, K, alpha, A, lda, B, ldb, beta, dist_middle_terms, ldc)
 
-        return dist_middle_terms
-
 
 cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{name_suffix}}):
     """Middle term of the Euclidean distance between two chunked CSR matrices.
@@ -417,8 +350,12 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
 
     def __init__(
         self,
-        X,
-        Y,
+        const DTYPE_t[:] X_data,
+        const SPARSE_INDEX_TYPE_t[:] X_indices,
+        const SPARSE_INDEX_TYPE_t[:] X_indptr,
+        const DTYPE_t[:] Y_data,
+        const SPARSE_INDEX_TYPE_t[:] Y_indices,
+        const SPARSE_INDEX_TYPE_t[:] Y_indptr,
         ITYPE_t effective_n_threads,
         ITYPE_t chunks_n_threads,
         ITYPE_t dist_middle_terms_chunks_size,
@@ -432,8 +369,8 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
             n_features,
             chunk_size,
         )
-        self.X_data, self.X_indices, self.X_indptr = self.unpack_csr_matrix(X)
-        self.Y_data, self.Y_indices, self.Y_indptr = self.unpack_csr_matrix(Y)
+        self.X_data, self.X_indices, self.X_indptr = X_data, X_indices, X_indptr
+        self.Y_data, self.Y_indices, self.Y_indptr = Y_data, Y_indices, Y_indptr
 
     cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
         self,
@@ -465,7 +402,7 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
             0.0,
         )
 
-    cdef DTYPE_t * _compute_dist_middle_terms(
+    cdef void _compute_dist_middle_terms(
         self,
         ITYPE_t X_start,
         ITYPE_t X_end,
@@ -491,8 +428,6 @@ cdef class SparseSparseMiddleTermComputer{{name_suffix}}(MiddleTermComputer{{nam
             Y_end,
             dist_middle_terms,
         )
-
-        return dist_middle_terms
 
 
 {{endfor}}

--- a/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pxd.tp
@@ -29,7 +29,6 @@ cdef cnp.ndarray[object, ndim=1] coerce_vectors_to_nd_arrays(
 {{for name_suffix in ['64', '32']}}
 
 from ._base cimport BaseDistancesReduction{{name_suffix}}
-from ._middle_term_computer cimport MiddleTermComputer{{name_suffix}}
 
 cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
     """float{{name_suffix}} implementation of the RadiusNeighbors."""
@@ -76,15 +75,5 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
         ITYPE_t idx,
         ITYPE_t num_threads,
     ) nogil
-
-
-cdef class EuclideanRadiusNeighbors{{name_suffix}}(RadiusNeighbors{{name_suffix}}):
-    """EuclideanDistance-specialisation of RadiusNeighbors{{name_suffix}}."""
-    cdef:
-        MiddleTermComputer{{name_suffix}} middle_term_computer
-        const DTYPE_t[::1] X_norm_squared
-        const DTYPE_t[::1] Y_norm_squared
-
-        bint use_squared_distances
 
 {{endfor}}

--- a/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
@@ -14,7 +14,8 @@ from ...utils._vector_sentinel cimport vector_to_nd_array
 
 from numbers import Real
 from scipy.sparse import issparse
-from ...utils import check_array, check_scalar, _in_unstable_openblas_configuration
+# TODO: reintroduce _in_unstable... warnings
+from ...utils import check_scalar, _in_unstable_openblas_configuration
 from ...utils.fixes import threadpool_limits
 
 cnp.import_array()
@@ -43,15 +44,7 @@ cdef cnp.ndarray[object, ndim=1] coerce_vectors_to_nd_arrays(
 #####################
 {{for name_suffix in ['64', '32']}}
 
-from ._base cimport (
-    BaseDistancesReduction{{name_suffix}},
-    _sqeuclidean_row_norms{{name_suffix}}
-)
-
-from ._datasets_pair cimport DatasetsPair{{name_suffix}}
-
-from ._middle_term_computer cimport MiddleTermComputer{{name_suffix}}
-
+from ._base cimport BaseDistancesReduction{{name_suffix}}
 
 cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
     """float{{name_suffix}} implementation of the RadiusNeighbors."""
@@ -82,38 +75,15 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
 
         No instance should directly be created outside of this class method.
         """
-        if (
-            metric in ("euclidean", "sqeuclidean")
-            and not (issparse(X) ^ issparse(Y))  # "^" is XOR
-        ):
-            # Specialized implementation of RadiusNeighbors for the Euclidean
-            # distance for the dense-dense and sparse-sparse cases.
-            # This implementation computes the distances by chunk using
-            # a decomposition of the Squared Euclidean distance.
-            # This specialisation has an improved arithmetic intensity for both
-            # the dense and sparse settings, allowing in most case speed-ups of
-            # several orders of magnitude compared to the generic RadiusNeighbors
-            # implementation.
-            # For more information see MiddleTermComputer.
-            use_squared_distances = metric == "sqeuclidean"
-            pda = EuclideanRadiusNeighbors{{name_suffix}}(
-                X=X, Y=Y, radius=radius,
-                use_squared_distances=use_squared_distances,
-                chunk_size=chunk_size,
-                strategy=strategy,
-                sort_results=sort_results,
-                metric_kwargs=metric_kwargs,
-            )
-        else:
-             # Fall back on a generic implementation that handles most scipy
-             # metrics by computing the distances between 2 vectors at a time.
-            pda = RadiusNeighbors{{name_suffix}}(
-                datasets_pair=DatasetsPair{{name_suffix}}.get_for(X, Y, metric, metric_kwargs),
-                radius=radius,
-                chunk_size=chunk_size,
-                strategy=strategy,
-                sort_results=sort_results,
-            )
+        pda = RadiusNeighbors{{name_suffix}}(
+            X, Y,
+            radius=radius,
+            chunk_size=chunk_size,
+            strategy=strategy,
+            sort_results=sort_results,
+            metric=metric,
+            metric_kwargs=metric_kwargs,
+        )
 
         # Limit the number of threads in second level of nested parallelism for BLAS
         # to avoid threads over-subscription (in GEMM for instance).
@@ -128,14 +98,16 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
 
     def __init__(
         self,
-        DatasetsPair{{name_suffix}} datasets_pair,
+        X, Y,
         DTYPE_t radius,
         chunk_size=None,
         strategy=None,
         sort_results=False,
+        metric="euclidean",
+        metric_kwargs=None,
     ):
         super().__init__(
-            datasets_pair=datasets_pair,
+            X, Y,
             chunk_size=chunk_size,
             strategy=strategy,
         )
@@ -179,7 +151,7 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
 
         for i in range(X_start, X_end):
             for j in range(Y_start, Y_end):
-                r_dist_i_j = self.datasets_pair.surrogate_dist(i, j)
+                r_dist_i_j = self.datasets_pair.surrogate_dist(i, j, thread_num)
                 if r_dist_i_j <= self.r_radius:
                     deref(self.neigh_distances_chunks[thread_num])[i].push_back(r_dist_i_j)
                     deref(self.neigh_indices_chunks[thread_num])[i].push_back(j)
@@ -196,6 +168,14 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
 
         return coerce_vectors_to_nd_arrays(self.neigh_indices)
 
+    @final
+    cdef void _parallel_on_X_parallel_init(
+        self,
+        ITYPE_t thread_num
+    ) nogil:
+        self.datasets_pair._parallel_on_X_parallel_init(thread_num)
+
+    @final
     cdef void _parallel_on_X_init_chunk(
         self,
         ITYPE_t thread_num,
@@ -207,6 +187,20 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
         # thread vectors' pointers to the main vectors'.
         self.neigh_distances_chunks[thread_num] = self.neigh_distances
         self.neigh_indices_chunks[thread_num] = self.neigh_indices
+        self.datasets_pair._parallel_on_X_init_chunk(thread_num, X_start, X_end)
+
+    @final
+    cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        self.datasets_pair._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
+            X_start, X_end, Y_start, Y_end, thread_num,
+        )
 
     @final
     cdef void _parallel_on_X_prange_iter_finalize(
@@ -227,6 +221,7 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
                     deref(self.neigh_indices)[idx].size()
                 )
 
+    @final
     cdef void _parallel_on_Y_init(
         self,
     ) nogil:
@@ -238,6 +233,7 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
         for thread_num in range(self.chunks_n_threads):
             self.neigh_distances_chunks[thread_num] = make_shared[vector[vector[DTYPE_t]]](self.n_samples_X)
             self.neigh_indices_chunks[thread_num] = make_shared[vector[vector[ITYPE_t]]](self.n_samples_X)
+        self.datasets_pair._parallel_on_Y_init()
 
     @final
     cdef void _merge_vectors(
@@ -272,6 +268,33 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
             )
             last_element_idx += deref(self.neigh_distances_chunks[thread_num])[idx].size()
 
+    @final
+    cdef void _parallel_on_Y_parallel_init(
+        self,
+        ITYPE_t thread_num,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+    ) nogil:
+        self.datasets_pair._parallel_on_Y_parallel_init(thread_num, X_start, X_end)
+
+    @final
+    cdef void _parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+        self,
+        ITYPE_t X_start,
+        ITYPE_t X_end,
+        ITYPE_t Y_start,
+        ITYPE_t Y_end,
+        ITYPE_t thread_num,
+    ) nogil:
+        self.datasets_pair._parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
+            X_start,
+            X_end,
+            Y_start,
+            Y_end,
+            thread_num,
+        )
+
+    @final
     cdef void _parallel_on_Y_finalize(
         self,
     ) nogil:
@@ -304,220 +327,18 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
         """Convert rank-preserving distances to pairwise distances in parallel."""
         cdef:
             ITYPE_t i, j
-
-        for i in prange(self.n_samples_X, nogil=True, schedule='static',
-                        num_threads=self.effective_n_threads):
-            for j in range(deref(self.neigh_indices)[i].size()):
-                deref(self.neigh_distances)[i][j] = (
-                        self.datasets_pair.distance_metric._rdist_to_dist(
-                            # Guard against potential -0., causing nan production.
-                            max(deref(self.neigh_distances)[i][j], 0.)
-                        )
-                )
-
-
-cdef class EuclideanRadiusNeighbors{{name_suffix}}(RadiusNeighbors{{name_suffix}}):
-    """EuclideanDistance-specialisation of RadiusNeighbors{{name_suffix}}."""
-
-    @classmethod
-    def is_usable_for(cls, X, Y, metric) -> bool:
-        return (RadiusNeighbors{{name_suffix}}.is_usable_for(X, Y, metric)
-                and not _in_unstable_openblas_configuration())
-
-    def __init__(
-        self,
-        X,
-        Y,
-        DTYPE_t radius,
-        bint use_squared_distances=False,
-        chunk_size=None,
-        strategy=None,
-        sort_results=False,
-        metric_kwargs=None,
-    ):
-        if (
-            metric_kwargs is not None and
-            len(metric_kwargs) > 0 and (
-                "Y_norm_squared" not in metric_kwargs or
-                "X_norm_squared" not in metric_kwargs
+            bint need_to_compute_exact_dist = (
+                self.datasets_pair.need_to_compute_exact_dist()
             )
-        ):
-            warnings.warn(
-                f"Some metric_kwargs have been passed ({metric_kwargs}) but aren't "
-                f"usable for this case (EuclideanRadiusNeighbors64) and will be ignored.",
-                UserWarning,
-                stacklevel=3,
-            )
-
-        super().__init__(
-            # The datasets pair here is used for exact distances computations
-            datasets_pair=DatasetsPair{{name_suffix}}.get_for(X, Y, metric="euclidean"),
-            radius=radius,
-            chunk_size=chunk_size,
-            strategy=strategy,
-            sort_results=sort_results,
-        )
-        cdef:
-            ITYPE_t dist_middle_terms_chunks_size = self.Y_n_samples_chunk * self.X_n_samples_chunk
-
-        self.middle_term_computer = MiddleTermComputer{{name_suffix}}.get_for(
-            X,
-            Y,
-            self.effective_n_threads,
-            self.chunks_n_threads,
-            dist_middle_terms_chunks_size,
-            n_features=X.shape[1],
-            chunk_size=self.chunk_size,
-        )
-
-        if metric_kwargs is not None and "Y_norm_squared" in metric_kwargs:
-            self.Y_norm_squared = check_array(
-                metric_kwargs.pop("Y_norm_squared"),
-                ensure_2d=False,
-                input_name="Y_norm_squared",
-                dtype=np.float64,
-            )
-        else:
-            self.Y_norm_squared = _sqeuclidean_row_norms{{name_suffix}}(
-                Y,
-                self.effective_n_threads,
-            )
-
-        if metric_kwargs is not None and "X_norm_squared" in metric_kwargs:
-            self.X_norm_squared = check_array(
-                metric_kwargs.pop("X_norm_squared"),
-                ensure_2d=False,
-                input_name="X_norm_squared",
-                dtype=np.float64,
-            )
-        else:
-            # Do not recompute norms if datasets are identical.
-            self.X_norm_squared = (
-                self.Y_norm_squared if X is Y else
-                _sqeuclidean_row_norms{{name_suffix}}(
-                    X,
-                    self.effective_n_threads,
-                )
-            )
-
-        self.use_squared_distances = use_squared_distances
-
-        if use_squared_distances:
-            # In this specialisation and this setup, the value passed to the radius is
-            # already considered to be the adapted radius, so we overwrite it.
-            self.r_radius = radius
-
-    @final
-    cdef void _parallel_on_X_parallel_init(
-        self,
-        ITYPE_t thread_num,
-    ) nogil:
-        RadiusNeighbors{{name_suffix}}._parallel_on_X_parallel_init(self, thread_num)
-        self.middle_term_computer._parallel_on_X_parallel_init(thread_num)
-
-    @final
-    cdef void _parallel_on_X_init_chunk(
-        self,
-        ITYPE_t thread_num,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-    ) nogil:
-        RadiusNeighbors{{name_suffix}}._parallel_on_X_init_chunk(self, thread_num, X_start, X_end)
-        self.middle_term_computer._parallel_on_X_init_chunk(thread_num, X_start, X_end)
-
-    @final
-    cdef void _parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
-        self,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-        ITYPE_t Y_start,
-        ITYPE_t Y_end,
-        ITYPE_t thread_num,
-    ) nogil:
-        RadiusNeighbors{{name_suffix}}._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
-            self,
-            X_start, X_end,
-            Y_start, Y_end,
-            thread_num,
-        )
-        self.middle_term_computer._parallel_on_X_pre_compute_and_reduce_distances_on_chunks(
-            X_start, X_end, Y_start, Y_end, thread_num,
-        )
-
-    @final
-    cdef void _parallel_on_Y_init(
-        self,
-    ) nogil:
-        RadiusNeighbors{{name_suffix}}._parallel_on_Y_init(self)
-        self.middle_term_computer._parallel_on_Y_init()
-
-    @final
-    cdef void _parallel_on_Y_parallel_init(
-        self,
-        ITYPE_t thread_num,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-    ) nogil:
-        RadiusNeighbors{{name_suffix}}._parallel_on_Y_parallel_init(self, thread_num, X_start, X_end)
-        self.middle_term_computer._parallel_on_Y_parallel_init(thread_num, X_start, X_end)
-
-    @final
-    cdef void _parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
-        self,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-        ITYPE_t Y_start,
-        ITYPE_t Y_end,
-        ITYPE_t thread_num,
-    ) nogil:
-        RadiusNeighbors{{name_suffix}}._parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
-            self,
-            X_start, X_end,
-            Y_start, Y_end,
-            thread_num,
-        )
-        self.middle_term_computer._parallel_on_Y_pre_compute_and_reduce_distances_on_chunks(
-            X_start, X_end, Y_start, Y_end, thread_num
-        )
-
-    @final
-    cdef void compute_exact_distances(self) nogil:
-        if not self.use_squared_distances:
-            RadiusNeighbors{{name_suffix}}.compute_exact_distances(self)
-
-    @final
-    cdef void _compute_and_reduce_distances_on_chunks(
-        self,
-        ITYPE_t X_start,
-        ITYPE_t X_end,
-        ITYPE_t Y_start,
-        ITYPE_t Y_end,
-        ITYPE_t thread_num,
-    ) nogil:
-        cdef:
-            ITYPE_t i, j
-            DTYPE_t sqeuclidean_dist_i_j
-            ITYPE_t n_X = X_end - X_start
-            ITYPE_t n_Y = Y_end - Y_start
-            DTYPE_t *dist_middle_terms = self.middle_term_computer._compute_dist_middle_terms(
-                X_start, X_end, Y_start, Y_end, thread_num
-            )
-
-        # Pushing the distance and their associated indices in vectors.
-        for i in range(n_X):
-            for j in range(n_Y):
-                sqeuclidean_dist_i_j = (
-                    self.X_norm_squared[i + X_start]
-                    + dist_middle_terms[i * n_Y + j]
-                    + self.Y_norm_squared[j + Y_start]
-                )
-
-                # Catastrophic cancellation might cause -0. to be present,
-                # e.g. when computing d(x_i, y_i) when X is Y.
-                sqeuclidean_dist_i_j = max(0., sqeuclidean_dist_i_j)
-
-                if sqeuclidean_dist_i_j <= self.r_radius:
-                    deref(self.neigh_distances_chunks[thread_num])[i + X_start].push_back(sqeuclidean_dist_i_j)
-                    deref(self.neigh_indices_chunks[thread_num])[i + X_start].push_back(j + Y_start)
+        if need_to_compute_exact_dist:
+            for i in prange(self.n_samples_X, nogil=True, schedule='static',
+                            num_threads=self.effective_n_threads):
+                for j in range(deref(self.neigh_indices)[i].size()):
+                    deref(self.neigh_distances)[i][j] = (
+                            self.datasets_pair.distance_metric._rdist_to_dist(
+                                # Guard against potential -0., causing nan production.
+                                max(deref(self.neigh_distances)[i][j], 0.)
+                            )
+                    )
 
 {{endfor}}

--- a/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
@@ -148,10 +148,11 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
         cdef:
             ITYPE_t i, j
             DTYPE_t r_dist_i_j
+            ITYPE_t n_Y = Y_end - Y_start
 
         for i in range(X_start, X_end):
             for j in range(Y_start, Y_end):
-                r_dist_i_j = self.datasets_pair.surrogate_dist(X_start, Y_start, i, j, thread_num)
+                r_dist_i_j = self.datasets_pair.surrogate_dist(X_start, Y_start, i, j, n_Y, thread_num)
                 if r_dist_i_j <= self.r_radius:
                     deref(self.neigh_distances_chunks[thread_num])[i].push_back(r_dist_i_j)
                     deref(self.neigh_indices_chunks[thread_num])[i].push_back(j)

--- a/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
@@ -151,7 +151,7 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
 
         for i in range(X_start, X_end):
             for j in range(Y_start, Y_end):
-                r_dist_i_j = self.datasets_pair.surrogate_dist(i, j, thread_num)
+                r_dist_i_j = self.datasets_pair.surrogate_dist(X_start, Y_start, i, j, thread_num)
                 if r_dist_i_j <= self.r_radius:
                     deref(self.neigh_distances_chunks[thread_num])[i].push_back(r_dist_i_j)
                     deref(self.neigh_indices_chunks[thread_num])[i].push_back(j)

--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -625,7 +625,7 @@ def test_argkmin_factory_method_wrong_usages():
     message = (
         r"Some metric_kwargs have been passed \({'p': 3}\) but aren't usable for this"
         r" case \("
-        r"EuclideanArgKmin64."
+        r"euclidean."
     )
 
     with pytest.warns(UserWarning, match=message):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up of #25044
> Redesign DatasetsPair w.r.t the new MiddleTermComputer to remove the duplicated logic and to clarify responsibilities > (esp. squared euclidean norm computations)

#### What does this implement/fix? Explain your changes.

This PR removes the euclidean specialization logic from `EuclideanArgKmin` and `EuclideanRadiusNeighbors` to `Euclidean{DenseDense, SparseSparse}DatasetsPair`.

This is how `EuclideanArgKmin` and `EuclideanRadiusNeighbors` are currently tied to `MiddleTermComputer`:

![image (1)](https://user-images.githubusercontent.com/18560386/206990423-aac05d01-245c-4ffd-8e1c-477284a8c5c0.svg)

This is how this PR suggests removing `EuclideanArgKmin` and `EuclideanRadiusNeighbors` and introducing `Euclidean{DenseDense, SparseSparse}DatasetsPair` instead:

![image](https://user-images.githubusercontent.com/18560386/206989501-d66e2eb0-dc60-4729-babe-8d2822064a45.svg)

#### Any other comments?

**Done**
- `DatasetPairs` is instantiated during the `__init__` of `BaseDistancesReduction` because some parameters computed during the latter are needed in the former.
- `{DenseDense, SparseSparse}MiddleTermComputer` are instantiated directly during the `__init__` of `Euclidean{DenseDense, SparseSparse}DatasetsPair`, removing the need for a `get_for` classmethod to dispatch cases in `MiddleTermComputer`
- `parallel_on_{X, Y}_pre_compute_and_reduce_distances_on_chunks()` in `{ArgKmin, RadiusNeighbors}` computes and stores `dist_middle_term` within `MiddleTermComputer`.
- Calling `ArgKmin.surrogate_dist()` or `RadiusNeighbors.surrogate_dist()` performs a call to `DatasetsPair` and then to `MiddleTermComputer` to get the `dist_middle_term` quantity. 

**TODO**
- Make all tests pass (a lot of fails for now)
- Add some new tests as suggested in #25044

cc @jjerphan (and @Arnaud15 who is interested in this PR).

- See [this note](https://hackmd.io/ytpuYBmMTrOwmxC8Uw9r3Q?both) for more details on Euclidean Specialization (in french).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
