### PR TITLE
FIX Ensure dtype of categories is `object` for strings in `OneHotEncoder`

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -55,7 +55,6 @@ Changelog
   :pr:`24935` by :user:`Seladus <seladus>`, :user:`Guillaume Lemaitre <glemaitre>`, and
   :user:`Dea María Léon <deamarialeon>`.
 
-
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -42,6 +42,12 @@ Changelog
   `feature_union["scalar"]`) to access transformers by name. :pr:`25093` by
   `Thomas Fan`_.
 
+:mod:`sklearn.preprocessing`
+............................
+- |Fix| The `categories_` attribute of :class:`preprocessing.OneHotEncoder` now
+  always contains an array of `object`s when using predefined categories that
+  are strings. :pr:`25174` by :user:`Tim Head <betatim>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -19,6 +19,10 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
+- |Fix| The `categories_` attribute of :class:`preprocessing.OneHotEncoder` now
+  always contains an array of `object`s when using predefined categories that
+  are strings. :pr:`25174` by :user:`Tim Head <betatim>`.
+
 Changes impacting all modules
 -----------------------------
 
@@ -44,10 +48,6 @@ Changelog
 
 :mod:`sklearn.preprocessing`
 ............................
-- |Fix| The `categories_` attribute of :class:`preprocessing.OneHotEncoder` now
-  always contains an array of `object`s when using predefined categories that
-  are strings. :pr:`25174` by :user:`Tim Head <betatim>`.
-
 - |Enhancement| Added support for `sample_weight` in
   :class:`preprocessing.KBinsDiscretizer`. This allows specifying the parameter
   `sample_weight` for each sample to be used while fitting. The option is only

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -21,7 +21,8 @@ random sampling procedures.
 
 - |Fix| The `categories_` attribute of :class:`preprocessing.OneHotEncoder` now
   always contains an array of `object`s when using predefined categories that
-  are strings. :pr:`25174` by :user:`Tim Head <betatim>`.
+  are strings. Predefined categories encoded as bytes will no longer work
+  with `X` encoded as strings. :pr:`25174` by :user:`Tim Head <betatim>`.
 
 Changes impacting all modules
 -----------------------------

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -112,9 +112,9 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                     and Xi.dtype.kind != "S"
                 ):
                     msg = (
-                        f"Found incompatible types ('{type(cats[0]).__name__}' vs"
-                        f" '{type(Xi[0]).__name__}') between values and predefined"
-                        f" categories in column {i}."
+                        f"In column {i}, the predefined categories have type 'bytes'"
+                        " which is incompatible with values of type"
+                        f" '{type(Xi[0]).__name__}'."
                     )
                     raise ValueError(msg)
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -97,7 +97,12 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                 else:
                     cats = result
             else:
-                cats = np.array(self.categories[i], dtype=Xi.dtype)
+                if np.issubdtype(Xi.dtype, np.str_):
+                    Xi_dtype = object
+                else:
+                    Xi_dtype = Xi.dtype
+
+                cats = np.array(self.categories[i], dtype=Xi_dtype)
                 if Xi.dtype.kind not in "OUS":
                     sorted_cats = np.sort(cats)
                     error_msg = (

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -106,6 +106,17 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                     Xi_dtype = Xi.dtype
 
                 cats = np.array(self.categories[i], dtype=Xi_dtype)
+                if (
+                    cats.dtype == object
+                    and isinstance(cats[0], bytes)
+                    and Xi.dtype.kind != "S"
+                ):
+                    msg = (
+                        "Found incompatible types between values and predefined"
+                        " categories in column {0}.".format(i)
+                    )
+                    raise ValueError(msg)
+
                 if Xi.dtype.kind not in "OUS":
                     sorted_cats = np.sort(cats)
                     error_msg = (

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -98,6 +98,9 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                     cats = result
             else:
                 if np.issubdtype(Xi.dtype, np.str_):
+                    # Always convert string categories to objects to avoid
+                    # unexpected string truncation for longer category labels
+                    # passed in the constructor.
                     Xi_dtype = object
                 else:
                     Xi_dtype = Xi.dtype

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -112,8 +112,9 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                     and Xi.dtype.kind != "S"
                 ):
                     msg = (
-                        "Found incompatible types between values and predefined"
-                        " categories in column {0}.".format(i)
+                        f"Found incompatible types ('{type(cats[0]).__name__}' vs"
+                        f" '{type(Xi[0]).__name__}') between values and predefined"
+                        f" categories in column {i}."
                     )
                     raise ValueError(msg)
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1389,7 +1389,11 @@ def test_mixed_string_bytes_categoricals():
     ohe = OneHotEncoder(categories=categories, sparse_output=False)
 
     with pytest.raises(
-        ValueError, match="Found incompatible types between values and predefined"
+        ValueError,
+        match=(
+            "Found incompatible types ('bytes' vs 'str_') between values and predefined"
+            " categories in column 0."
+        ),
     ):
         ohe.fit(X)
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1388,7 +1388,7 @@ def test_mixed_string_bytes_categoricals():
     categories = [np.array(["b", "a"], dtype="S")]
     ohe = OneHotEncoder(categories=categories, sparse_output=False)
 
-    msg = (
+    msg = re.escape(
         "Found incompatible types ('bytes' vs 'str_') between values and predefined"
         " categories in column 0."
     )

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1346,7 +1346,7 @@ def test_one_hot_encoder_sparse_deprecated():
 
 # deliberately omit 'OS' as an invalid combo
 @pytest.mark.parametrize(
-    "input_dtype, category_dtype", ["OO", "OU", "UO", "UU", "SO", "SU", "SS"]
+    "input_dtype, category_dtype", ["OO", "OU", "UO", "UU", "US", "SO", "SU", "SS"]
 )
 @pytest.mark.parametrize("array_type", ["list", "array", "dataframe"])
 def test_encoders_string_categories(input_dtype, category_dtype, array_type):
@@ -1374,6 +1374,22 @@ def test_encoders_string_categories(input_dtype, category_dtype, array_type):
 
     expected = np.array([[1], [1], [0], [1]])
     assert_array_equal(X_trans, expected)
+
+
+def test_mixed_string_bytes_categoricals():
+    """Check that this mixture of predefined categries and X raises an error.
+
+    Categories defined as bytes can not easily be compared to data that is
+    a string.
+    """
+    # data as unicode
+    X = np.array([["b"], ["a"]], dtype="U")
+    # predefined categories as bytes
+    categories = [np.array(["b", "a"], dtype="S")]
+    ohe = OneHotEncoder(categories=categories, sparse_output=False)
+
+    with pytest.raises(ValueError, match="Found unknown categories"):
+        ohe.fit(X)
 
 
 @pytest.mark.parametrize("missing_value", [np.nan, None])
@@ -1956,4 +1972,3 @@ def test_predefined_categories_dtype():
     for n, cat in enumerate(enc.categories_):
         assert cat.dtype == object
         assert np.array_equal(categories[n], cat)
-

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1346,7 +1346,7 @@ def test_one_hot_encoder_sparse_deprecated():
 
 # deliberately omit 'OS' as an invalid combo
 @pytest.mark.parametrize(
-    "input_dtype, category_dtype", ["OO", "OU", "UO", "UU", "US", "SO", "SU", "SS"]
+    "input_dtype, category_dtype", ["OO", "OU", "UO", "UU", "SO", "SU", "SS"]
 )
 @pytest.mark.parametrize("array_type", ["list", "array", "dataframe"])
 def test_encoders_string_categories(input_dtype, category_dtype, array_type):
@@ -1973,4 +1973,4 @@ def test_predefined_categories_dtype():
     assert len(categories) == len(enc.categories_)
     for n, cat in enumerate(enc.categories_):
         assert cat.dtype == object
-        assert np.array_equal(categories[n], cat)
+        assert_array_equal(categories[n], cat)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1939,3 +1939,18 @@ def test_ordinal_set_output():
 
     assert_allclose(X_pandas.to_numpy(), X_default)
     assert_array_equal(ord_pandas.get_feature_names_out(), X_pandas.columns)
+
+
+def test_predefined_categories_dtype():
+    """Check that the categories_ dtype is `object` for string categories
+
+    Regression test for gh-25171.
+    """
+    categories = [["as", "mmas", "eas", "ras", "acs"], ["1", "2"]]
+
+    enc = OneHotEncoder(categories=categories)
+
+    enc.fit([["as", "1"]])
+
+    for cat in enc.categories_:
+        assert cat.dtype == object

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1388,7 +1388,9 @@ def test_mixed_string_bytes_categoricals():
     categories = [np.array(["b", "a"], dtype="S")]
     ohe = OneHotEncoder(categories=categories, sparse_output=False)
 
-    with pytest.raises(ValueError, match="Found unknown categories"):
+    with pytest.raises(
+        ValueError, match="Found incompatible types between values and predefined"
+    ):
         ohe.fit(X)
 
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1377,7 +1377,7 @@ def test_encoders_string_categories(input_dtype, category_dtype, array_type):
 
 
 def test_mixed_string_bytes_categoricals():
-    """Check that this mixture of predefined categries and X raises an error.
+    """Check that this mixture of predefined categories and X raises an error.
 
     Categories defined as bytes can not easily be compared to data that is
     a string.

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1389,8 +1389,8 @@ def test_mixed_string_bytes_categoricals():
     ohe = OneHotEncoder(categories=categories, sparse_output=False)
 
     msg = re.escape(
-        "Found incompatible types ('bytes' vs 'str_') between values and predefined"
-        " categories in column 0."
+        "In column 0, the predefined categories have type 'bytes' which is incompatible"
+        " with values of type 'str_'."
     )
 
     with pytest.raises(ValueError, match=msg):

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1346,7 +1346,7 @@ def test_one_hot_encoder_sparse_deprecated():
 
 # deliberately omit 'OS' as an invalid combo
 @pytest.mark.parametrize(
-    "input_dtype, category_dtype", ["OO", "OU", "UO", "UU", "US", "SO", "SU", "SS"]
+    "input_dtype, category_dtype", ["OO", "OU", "UO", "UU", "SO", "SU", "SS"]
 )
 @pytest.mark.parametrize("array_type", ["list", "array", "dataframe"])
 def test_encoders_string_categories(input_dtype, category_dtype, array_type):

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1952,5 +1952,8 @@ def test_predefined_categories_dtype():
 
     enc.fit([["as", "1"]])
 
-    for cat in enc.categories_:
+    assert len(categories) == len(enc.categories_)
+    for n, cat in enumerate(enc.categories_):
         assert cat.dtype == object
+        assert np.array_equal(categories[n], cat)
+

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1388,13 +1388,12 @@ def test_mixed_string_bytes_categoricals():
     categories = [np.array(["b", "a"], dtype="S")]
     ohe = OneHotEncoder(categories=categories, sparse_output=False)
 
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Found incompatible types ('bytes' vs 'str_') between values and predefined"
-            " categories in column 0."
-        ),
-    ):
+    msg = (
+        "Found incompatible types ('bytes' vs 'str_') between values and predefined"
+        " categories in column 0."
+    )
+
+    with pytest.raises(ValueError, match=msg):
         ohe.fit(X)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #25171

#### What does this implement/fix? Explain your changes.
This makes it so that the `enc.categories_` attribute of `OneHotEncoder` is contains an array of dtype `object` when using predefined categories that are strings. This makes it consistent with the dtype of `enc.categories_` when the categories are determine during `fit`. In general to compare a sequence of bytes to a string you need to assume an encoding, otherwise you can't really compare them. But I don't understand enough about the numpy type system to know if it would take care of this already? Ideas an input welcome.