### PR TITLE
Extract patches 2d 0 bug

### DIFF
--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -266,7 +266,7 @@ def _compute_n_patches(i_h, i_w, p_h, p_w, max_patches=None):
     n_w = i_w - p_w + 1
     all_patches = n_h * n_w
 
-    if max_patches:
+    if max_patches is not None:
         if isinstance(max_patches, (Integral)) and max_patches < all_patches:
             return max_patches
         elif isinstance(max_patches, (Integral)) and max_patches >= all_patches:
@@ -419,7 +419,7 @@ def extract_patches_2d(image, patch_size, *, max_patches=None, random_state=None
     )
 
     n_patches = _compute_n_patches(i_h, i_w, p_h, p_w, max_patches)
-    if max_patches:
+    if max_patches is not None:
         rng = check_random_state(random_state)
         i_s = rng.randint(i_h - p_h + 1, size=n_patches)
         j_s = rng.randint(i_w - p_w + 1, size=n_patches)

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -356,6 +356,7 @@ def test_extract_patches_square():
     patches = _extract_patches(face, patch_shape=p)
     assert patches.shape == (expected_n_patches[0], expected_n_patches[1], p, p)
 
+
 def test_width_patch():
     # width and height of the patch should be less than the image
     x = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -364,8 +365,9 @@ def test_width_patch():
     with pytest.raises(ValueError):
         extract_patches_2d(x, (1, 4))
 
+
 def test_extract_patches_2d_max_patches_0():
     x = np.arange(9).reshape(3, 3)
-    patches = extract_patches_2d(x, (2, 2), max_patches = 0)
+    patches = extract_patches_2d(x, (2, 2), max_patches=0)
     expected_n_patches = 0
     assert expected_n_patches == patches.shape[0]

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -356,7 +356,6 @@ def test_extract_patches_square():
     patches = _extract_patches(face, patch_shape=p)
     assert patches.shape == (expected_n_patches[0], expected_n_patches[1], p, p)
 
-
 def test_width_patch():
     # width and height of the patch should be less than the image
     x = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -364,3 +363,9 @@ def test_width_patch():
         extract_patches_2d(x, (4, 1))
     with pytest.raises(ValueError):
         extract_patches_2d(x, (1, 4))
+
+def test_extract_patches_2d_max_patches_0():
+    x = np.arange(9).reshape(3, 3)
+    patches = extract_patches_2d(x, (2, 2), max_patches = 0)
+    expected_n_patches = 0
+    assert expected_n_patches == patches.shape[0]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #25161


#### What does this implement/fix? Explain your changes.
Makes it so that calling sklearn.feature_extraction.image.extract_patches_2d with the parameter max_patches = 0 returns an empty array (0 patches) instead of an array with all possible patches.

#### Any other comments?
Marked as [WIP] since more changes had to be made than discussed in the original issue: a similar `if max_patches` check that was made in `_compute_n_patches` and was causing the problem in #25161 is made in `extract_patches_2d` and causes the same problem (so it was changed aswell). Furthermore, with the code changes in this PR an RNG check is made even when `max_patches` is 0, which I think is redundant:
``` Python
if max_patches is not None:
    rng = check_random_state(random_state)
    i_s = rng.randint(i_h - p_h + 1, size=n_patches)
    j_s = rng.randint(i_w - p_w + 1, size=n_patches)
    patches = extracted_patches[i_s, j_s, 0]
else:
    patches = extracted_patches
``` 
Maybe we should add a special case where `max_patches = 0` to remove the redundant RNG check ?

In PR #25149, 0 is set as an illegal parameter for the function so if we go ahead with the change I'll change the PR to reflect that.

Lastly, I'd love any feedback about the test I added since this is the first time I'm writing a test!




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
