### PR TITLE
MAINT exclude cirrus.star from MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ recursive-exclude maint_tools *
 recursive-exclude benchmarks *
 recursive-exclude .binder *
 recursive-exclude .circleci *
+exclude .cirrus.star
 exclude .codecov.yml
 exclude .git-blame-ignore-revs
 exclude .mailmap


### PR DESCRIPTION
closes #25183

I assume that we should exclude `.cirrus.star` in the `MANIFEST.in` to avoid the error.