### PR TITLE
FIX fix pickling for empty object with Python 3.11+

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -12,6 +12,13 @@ Version 1.2.1
 Changelog
 ---------
 
+:mod:`sklearn.base`
+...................
+
+- |Fix| Fix a regression in ``BaseEstimator.__getstate__`` that would prevent
+  certain estimators to be pickled when using Python 3.11. :pr:`25188` by
+  :user:`Benjamin Bossan <BenjaminBossan>`.
+
 :mod:`sklearn.utils`
 ....................
 

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -15,7 +15,7 @@ Changelog
 :mod:`sklearn.base`
 ...................
 
-- |Fix| Fix a regression in ``BaseEstimator.__getstate__`` that would prevent
+- |Fix| Fix a regression in `BaseEstimator.__getstate__` that would prevent
   certain estimators to be pickled when using Python 3.11. :pr:`25188` by
   :user:`Benjamin Bossan <BenjaminBossan>`.
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -274,6 +274,8 @@ class BaseEstimator:
         try:
             state = super().__getstate__()
             if state is None:
+                # For Python 3.11+, empty instance (no `__slots__`,
+                # and `__dict__`) will return a state equal to `None`.
                 state = self.__dict__.copy()
         except AttributeError:
             state = self.__dict__.copy()

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -273,7 +273,11 @@ class BaseEstimator:
     def __getstate__(self):
         try:
             state = super().__getstate__()
+            if state is None:
+                state = self.__dict__.copy()
         except AttributeError:
+            # TODO: Remove once Python < 3.11 is dropped, as there will never be
+            # an AttributeError
             state = self.__dict__.copy()
 
         if type(self).__module__.startswith("sklearn."):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -271,6 +271,12 @@ class BaseEstimator:
         return repr_
 
     def __getstate__(self):
+        if hasattr(self, "__slots__"):
+            raise TypeError(
+                "You cannot use `__slots__` in objects inheriting from "
+                "`sklearn.base.BaseEstimator`"
+            )
+
         try:
             state = super().__getstate__()
             if state is None:

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -271,7 +271,7 @@ class BaseEstimator:
         return repr_
 
     def __getstate__(self):
-        if hasattr(self, "__slots__"):
+        if getattr(self, "__slots__", None):
             raise TypeError(
                 "You cannot use `__slots__` in objects inheriting from "
                 "`sklearn.base.BaseEstimator`"

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -278,6 +278,7 @@ class BaseEstimator:
                 # and `__dict__`) will return a state equal to `None`.
                 state = self.__dict__.copy()
         except AttributeError:
+            # Python < 3.11
             state = self.__dict__.copy()
 
         if type(self).__module__.startswith("sklearn."):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -276,8 +276,6 @@ class BaseEstimator:
             if state is None:
                 state = self.__dict__.copy()
         except AttributeError:
-            # TODO: Remove once Python < 3.11 is dropped, as there will never be
-            # an AttributeError
             state = self.__dict__.copy()
 
         if type(self).__module__.startswith("sklearn."):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -274,7 +274,7 @@ class BaseEstimator:
         if getattr(self, "__slots__", None):
             raise TypeError(
                 "You cannot use `__slots__` in objects inheriting from "
-                "`sklearn.base.BaseEstimator`"
+                "`sklearn.base.BaseEstimator`."
             )
 
         try:

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -699,3 +699,12 @@ def test_base_estimator_empty_instance_dict():
     state = BaseEstimator().__getstate__()
     expected = {"_sklearn_version": sklearn.__version__}
     assert state == expected
+
+
+def test_base_estimator_pickleable():
+    # Since Python 3.11, Python objects have a __getstate__ method by default
+    # that returns None if the instance dict is empty. See #25188.
+
+    # This would raise an error before the bugfix because BaseEstimator's
+    # __dict__ is empty
+    pickle.loads(pickle.dumps(BaseEstimator()))

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -692,7 +692,6 @@ def test_estimator_empty_instance_dict(estimator):
 
     Python 3.11+ changed behaviour by returning ``None`` instead of raising an
     ``AttributeError``. Non-regression test for gh-25188.
-
     """
     state = estimator.__getstate__()
     expected = {"_sklearn_version": sklearn.__version__}

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -679,7 +679,7 @@ def test_clone_keeps_output_config():
 
 def test_parent_object_empty_instance_dict():
     # Since Python 3.11, Python objects have a __getstate__ method by default
-    # that returns None if the instance dict is empty
+    # that returns None if the instance dict is empty. See #25188.
     class Empty:
         pass
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -693,7 +693,7 @@ def test_parent_object_empty_instance_dict():
 
 def test_base_estimator_empty_instance_dict():
     # Since Python 3.11, Python objects have a __getstate__ method by default
-    # that returns None if the instance dict is empty
+    # that returns None if the instance dict is empty. See #25188.
 
     # this should not raise
     state = BaseEstimator().__getstate__()

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -702,7 +702,7 @@ def test_estimator_empty_instance_dict(estimator):
 
 
 def test_estimator_getstate_using_slots_error_message():
-    """Using a BaseEstimator with __slots__ is not supported"""
+    """Using a `BaseEstimator` with `__slots__` is not supported."""
 
     class WithSlots:
         __slots__ = ("x",)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -675,3 +675,27 @@ def test_clone_keeps_output_config():
     ss_clone = clone(ss)
     config_clone = _get_output_config("transform", ss_clone)
     assert config == config_clone
+
+
+def test_parent_object_empty_instance_dict():
+    # Since Python 3.11, Python objects have a __getstate__ method by default
+    # that returns None if the instance dict is empty
+    class Empty:
+        pass
+
+    class Estimator(Empty, BaseEstimator):
+        pass
+
+    state = Estimator().__getstate__()
+    expected = {"_sklearn_version": sklearn.__version__}
+    assert state == expected
+
+
+def test_base_estimator_empty_instance_dict():
+    # Since Python 3.11, Python objects have a __getstate__ method by default
+    # that returns None if the instance dict is empty
+
+    # this should not raise
+    state = BaseEstimator().__getstate__()
+    expected = {"_sklearn_version": sklearn.__version__}
+    assert state == expected


### PR DESCRIPTION
As discussed with @adrinjalali 

Since Python 3.11, objects have a `__getstate__` method by default:

https://github.com/python/cpython/issues/70766

Therefore, the exception in `BaseEstimator.__getstate__` will no longer be raised, thus not falling back on using the object's `__dict__`:

https://github.com/scikit-learn/scikit-learn/blob/dc580a8ef5ee2a8aea80498388690e2213118efd/sklearn/base.py#L274-L280

If the instance dict of the object is empty, the return value will, however, be `None`. Therefore, the line below calling `state.items()` results in an error.

In this bugfix, it is checked if the state is `None` and if it is, the object's `__dict__` is used (which should always be empty).

Not addressed in this PR is how to deal with slots (see also discussion in #10079). When there are `__slots__`, `__getstate__` will actually return a tuple, as documented [here](https://docs.python.org/3/library/pickle.html#object.__getstate__).

The user would thus still get an indiscriptive error message.