### PR TITLE
DOC update the documentation of fit of stateless transformers

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -751,11 +751,11 @@ General Concepts
     stateless
         An estimator is stateless if it does not store any information that is
         obtained during :term:`fit`. This information can be either parameters
-        :term:`learned` during :term:`fit` or statistics computed from the
+        learned during :term:`fit` or statistics computed from the
         training data. An estimator is stateless if it has no :term:`attributes`
-        apart from ones set in :term:`__init__`. Calling :term:`fit` for these
+        apart from ones set in `__init__`. Calling :term:`fit` for these
         estimators will only validate the public :term:`attributes` passed
-        in :term:`__init__`.
+        in `__init__`.
 
     supervised
     supervised learning

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -748,6 +748,15 @@ General Concepts
         possible (i.e. if an estimator does not / cannot support sparse
         matrices).
 
+    stateless
+        An estimator is stateless if it does not store any information that is
+        obtained during :term:`fit`. This information can be either parameters
+        :term:`learned` during :term:`fit` or statistics computed from the
+        training data. An estimator is stateless if it has no :term:`attributes`
+        apart from ones set in :term:`__init__`. Calling :term:`fit` for these
+        estimators will only validate the public :term:`attributes` passed
+        in :term:`__init__`.
+
     supervised
     supervised learning
         Learning where the expected prediction (label or ground truth) is

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -73,9 +73,10 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
 
     Notes
     -----
-    This estimator is stateless and does not need to be fitted. However, we
-    recommend to call :meth:`fit_transform` instead of :meth:`transform`, as
-    parameter validation is only performed in :meth:`fit`.
+    This estimator is :term:`stateless` and does not need to be fitted.
+    However, we recommend to call :meth:`fit_transform` instead of
+    :meth:`transform`, as parameter validation is only performed in
+    :meth:`fit`.
 
     Examples
     --------

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -103,10 +103,10 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         self.alternate_sign = alternate_sign
 
     def fit(self, X=None, y=None):
-        """No-op.
+        """Only validates estimator's parameters.
 
-        This method doesn't do anything. It exists purely for compatibility
-        with the scikit-learn transformer API.
+        This method allows to: (i) validate the estimator's parameters and
+        (ii) be consistent with the scikit-learn transformer API.
 
         Parameters
         ----------

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -74,8 +74,8 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
     Notes
     -----
     This estimator is stateless and does not need to be fitted. However, we
-    advice to class :meth:`fit_transform` instead of only :meth:`transform` to
-    benefit from the parameters validation that only happens in :meth:`fit`.
+    recommend to call :meth:`fit_transform` instead of :meth:`transform`, as
+    parameter validation is only performed in :meth:`fit`.
 
     Examples
     --------

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -71,6 +71,12 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
     DictVectorizer : Vectorizes string-valued features using a hash table.
     sklearn.preprocessing.OneHotEncoder : Handles nominal/categorical features.
 
+    Notes
+    -----
+    This estimator is stateless and does not need to be fitted. However, we
+    advice to class :meth:`fit_transform` instead of only :meth:`transform` to
+    benefit from the parameters validation that only happens in :meth:`fit`.
+
     Examples
     --------
     >>> from sklearn.feature_extraction import FeatureHasher

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -724,6 +724,12 @@ class HashingVectorizer(
     TfidfVectorizer : Convert a collection of raw documents to a matrix of
         TF-IDF features.
 
+    Notes
+    -----
+    This estimator is stateless and does not need to be fitted. However, we
+    advice to class :meth:`fit_transform` instead of only :meth:`transform` to
+    benefit from the parameters validation that only happens in :meth:`fit`.
+
     Examples
     --------
     >>> from sklearn.feature_extraction.text import HashingVectorizer

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -727,8 +727,8 @@ class HashingVectorizer(
     Notes
     -----
     This estimator is stateless and does not need to be fitted. However, we
-    advice to class :meth:`fit_transform` instead of only :meth:`transform` to
-    benefit from the parameters validation that only happens in :meth:`fit`.
+    recommend to call :meth:`fit_transform` instead of :meth:`transform`, as
+    parameter validation is only performed in :meth:`fit`.
 
     Examples
     --------

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -796,10 +796,10 @@ class HashingVectorizer(
         self.dtype = dtype
 
     def partial_fit(self, X, y=None):
-        """No-op: this transformer is stateless.
+        """Only validates estimator's parameters.
 
-        This method is just there to mark the fact that this transformer
-        can work in a streaming setup.
+        This method allows to: (i) validate the estimator's parameters and
+        (ii) be consistent with the scikit-learn transformer API.
 
         Parameters
         ----------
@@ -819,7 +819,10 @@ class HashingVectorizer(
         return self
 
     def fit(self, X, y=None):
-        """No-op: this transformer is stateless.
+        """Only validates estimator's parameters.
+
+        This method allows to: (i) validate the estimator's parameters and
+        (ii) be consistent with the scikit-learn transformer API.
 
         Parameters
         ----------

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -726,9 +726,10 @@ class HashingVectorizer(
 
     Notes
     -----
-    This estimator is stateless and does not need to be fitted. However, we
-    recommend to call :meth:`fit_transform` instead of :meth:`transform`, as
-    parameter validation is only performed in :meth:`fit`.
+    This estimator is :term:`stateless` and does not need to be fitted.
+    However, we recommend to call :meth:`fit_transform` instead of
+    :meth:`transform`, as parameter validation is only performed in
+    :meth:`fit`.
 
     Examples
     --------

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1942,10 +1942,10 @@ class Normalizer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         self.copy = copy
 
     def fit(self, X, y=None):
-        """Do nothing and return the estimator unchanged.
+        """Only validates estimator's parameters.
 
-        This method is just there to implement the usual API and hence
-        work in pipelines.
+        This method allows to: (i) validate the estimator's parameters and
+        (ii) be consistent with the scikit-learn transformer API.
 
         Parameters
         ----------
@@ -2116,10 +2116,10 @@ class Binarizer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         self.copy = copy
 
     def fit(self, X, y=None):
-        """Do nothing and return the estimator unchanged.
+        """Only validates estimator's parameters.
 
-        This method is just there to implement the usual API and hence
-        work in pipelines.
+        This method allows to: (i) validate the estimator's parameters and
+        (ii) be consistent with the scikit-learn transformer API.
 
         Parameters
         ----------

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1911,8 +1911,8 @@ class Normalizer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     Notes
     -----
     This estimator is stateless and does not need to be fitted. However, we
-    advice to class :meth:`fit_transform` instead of only :meth:`transform` to
-    benefit from the parameters validation that only happens in :meth:`fit`.
+    recommend to call :meth:`fit_transform` instead of :meth:`transform`, as
+    parameter validation is only performed in :meth:`fit`.
 
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py
@@ -2090,8 +2090,8 @@ class Binarizer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     to update by the :class:`Binarizer` class.
 
     This estimator is stateless and does not need to be fitted. However, we
-    advice to class :meth:`fit_transform` instead of only :meth:`transform` to
-    benefit from the parameters validation that only happens in :meth:`fit`.
+    recommend to call :meth:`fit_transform` instead of :meth:`transform`, as
+    parameter validation is only performed in :meth:`fit`.
 
     Examples
     --------

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1910,8 +1910,9 @@ class Normalizer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
     Notes
     -----
-    This estimator is stateless (besides constructor parameters), the
-    fit method does nothing but is useful when used in a pipeline.
+    This estimator is stateless and does not need to be fitted. However, we
+    advice to class :meth:`fit_transform` instead of only :meth:`transform` to
+    benefit from the parameters validation that only happens in :meth:`fit`.
 
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py
@@ -2086,10 +2087,11 @@ class Binarizer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     Notes
     -----
     If the input is a sparse matrix, only the non-zero values are subject
-    to update by the Binarizer class.
+    to update by the :class:`Binarizer` class.
 
-    This estimator is stateless (besides constructor parameters), the
-    fit method does nothing but is useful when used in a pipeline.
+    This estimator is stateless and does not need to be fitted. However, we
+    advice to class :meth:`fit_transform` instead of only :meth:`transform` to
+    benefit from the parameters validation that only happens in :meth:`fit`.
 
     Examples
     --------

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1910,9 +1910,10 @@ class Normalizer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
     Notes
     -----
-    This estimator is stateless and does not need to be fitted. However, we
-    recommend to call :meth:`fit_transform` instead of :meth:`transform`, as
-    parameter validation is only performed in :meth:`fit`.
+    This estimator is :term:`stateless` and does not need to be fitted.
+    However, we recommend to call :meth:`fit_transform` instead of
+    :meth:`transform`, as parameter validation is only performed in
+    :meth:`fit`.
 
     For a comparison of the different scalers, transformers, and normalizers,
     see :ref:`examples/preprocessing/plot_all_scaling.py
@@ -2089,9 +2090,10 @@ class Binarizer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
     If the input is a sparse matrix, only the non-zero values are subject
     to update by the :class:`Binarizer` class.
 
-    This estimator is stateless and does not need to be fitted. However, we
-    recommend to call :meth:`fit_transform` instead of :meth:`transform`, as
-    parameter validation is only performed in :meth:`fit`.
+    This estimator is :term:`stateless` and does not need to be fitted.
+    However, we recommend to call :meth:`fit_transform` instead of
+    :meth:`transform`, as parameter validation is only performed in
+    :meth:`fit`.
 
     Examples
     --------


### PR DESCRIPTION
Update the docstring of the stateless transformers to indicate the parameter validation.
Add indication that it only happens when `fit` is called and advice to always call `fit_transform` instead of only `transform`.