### PR TITLE
MNT Remove unneeded computation in random sparse tree splitter

### DIFF
--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -1459,10 +1459,6 @@ cdef class RandomSparseSplitter(BaseSparseSplitter):
 
             if current_proxy_improvement > best_proxy_improvement:
                 best_proxy_improvement = current_proxy_improvement
-                self.criterion.children_impurity(&current.impurity_left,
-                                                 &current.impurity_right)
-                current.improvement = self.criterion.impurity_improvement(
-                    impurity, current.impurity_left, current.impurity_right)
                 best = current
 
         # Reorganize into samples[start:best.pos] + samples[best.pos:end]


### PR DESCRIPTION
The random splitter does not need to compute the actual improvement when it finds an improvement through the proxy. The actual improvement will be computed later for the best split:

https://github.com/scikit-learn/scikit-learn/blob/12176efa867a066032883733aa115fd31db5ee8a/sklearn/tree/_splitter.pyx#L1479-L1482

With this PR, the sparse case will consistent with what the random dense splitter does:

https://github.com/scikit-learn/scikit-learn/blob/12176efa867a066032883733aa115fd31db5ee8a/sklearn/tree/_splitter.pyx#L711-L713