### PR TITLE
MNT Use set/get_state instead of reduce in tree splitter

### DIFF
--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -49,9 +49,9 @@ cdef class Splitter:
     sparse and dense data, one split at a time.
     """
 
-    def __cinit__(self, Criterion criterion, SIZE_t max_features,
-                  SIZE_t min_samples_leaf, double min_weight_leaf,
-                  object random_state):
+    def __init__(self, Criterion criterion, SIZE_t max_features,
+                 SIZE_t min_samples_leaf, double min_weight_leaf,
+                 object random_state):
         """
         Parameters
         ----------
@@ -94,12 +94,12 @@ cdef class Splitter:
             "random_state": self.random_state,
         }
 
-    def __setstate__(self, d):
-        self.criterion = d["criterion"]
-        self.max_features = d["max_features"]
-        self.min_samples_leaf = d["min_samples_leaf"]
-        self.min_weight_leaf = d["min_weight_leaf"]
-        self.random_state = d["random_state"]
+    def __setstate__(self, state):
+        self.criterion = state["criterion"]
+        self.max_features = state["max_features"]
+        self.min_samples_leaf = state["min_samples_leaf"]
+        self.min_weight_leaf = state["min_weight_leaf"]
+        self.random_state = state["random_state"]
 
     cdef int init(
         self,
@@ -754,12 +754,6 @@ cdef class BaseSparseSplitter(Splitter):
 
     cdef SIZE_t[::1] index_to_samples
     cdef SIZE_t[::1] sorted_samples
-
-    def __cinit__(self, Criterion criterion, SIZE_t max_features,
-                  SIZE_t min_samples_leaf, double min_weight_leaf,
-                  object random_state):
-        # Parent __cinit__ is automatically called
-        self.n_total_samples = 0
 
     cdef int init(
         self,

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -86,10 +86,20 @@ cdef class Splitter:
         self.random_state = random_state
 
     def __getstate__(self):
-        return {}
+        return {
+            "criterion": self.criterion,
+            "max_features": self.max_features,
+            "min_samples_leaf": self.min_samples_leaf,
+            "min_weight_leaf": self.min_weight_leaf,
+            "random_state": self.random_state,
+        }
 
     def __setstate__(self, d):
-        pass
+        self.criterion = d["criterion"]
+        self.max_features = d["max_features"]
+        self.min_samples_leaf = d["min_samples_leaf"]
+        self.min_weight_leaf = d["min_weight_leaf"]
+        self.random_state = d["random_state"]
 
     cdef int init(
         self,
@@ -240,13 +250,6 @@ cdef class BaseDenseSplitter(Splitter):
 
 cdef class BestSplitter(BaseDenseSplitter):
     """Splitter for finding the best split."""
-    def __reduce__(self):
-        return (BestSplitter, (self.criterion,
-                               self.max_features,
-                               self.min_samples_leaf,
-                               self.min_weight_leaf,
-                               self.random_state), self.__getstate__())
-
     cdef int node_split(self, double impurity, SplitRecord* split,
                         SIZE_t* n_constant_features) nogil except -1:
         """Find the best split on node samples[start:end]
@@ -553,13 +556,6 @@ cdef void heapsort(DTYPE_t* Xf, SIZE_t* samples, SIZE_t n) nogil:
 
 cdef class RandomSplitter(BaseDenseSplitter):
     """Splitter for finding the best random split."""
-    def __reduce__(self):
-        return (RandomSplitter, (self.criterion,
-                                 self.max_features,
-                                 self.min_samples_leaf,
-                                 self.min_weight_leaf,
-                                 self.random_state), self.__getstate__())
-
     cdef int node_split(self, double impurity, SplitRecord* split,
                         SIZE_t* n_constant_features) nogil except -1:
         """Find the best random split on node samples[start:end]
@@ -1057,14 +1053,6 @@ cdef inline void sparse_swap(SIZE_t[::1] index_to_samples, SIZE_t[::1] samples,
 
 cdef class BestSparseSplitter(BaseSparseSplitter):
     """Splitter for finding the best split, using the sparse data."""
-
-    def __reduce__(self):
-        return (BestSparseSplitter, (self.criterion,
-                                     self.max_features,
-                                     self.min_samples_leaf,
-                                     self.min_weight_leaf,
-                                     self.random_state), self.__getstate__())
-
     cdef int node_split(self, double impurity, SplitRecord* split,
                         SIZE_t* n_constant_features) nogil except -1:
         """Find the best split on node samples[start:end], using sparse features
@@ -1283,14 +1271,6 @@ cdef class BestSparseSplitter(BaseSparseSplitter):
 
 cdef class RandomSparseSplitter(BaseSparseSplitter):
     """Splitter for finding a random split, using the sparse data."""
-
-    def __reduce__(self):
-        return (RandomSparseSplitter, (self.criterion,
-                                       self.max_features,
-                                       self.min_samples_leaf,
-                                       self.min_weight_leaf,
-                                       self.random_state), self.__getstate__())
-
     cdef int node_split(self, double impurity, SplitRecord* split,
                         SIZE_t* n_constant_features) nogil except -1:
         """Find a random split on node samples[start:end], using sparse features

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -3,7 +3,7 @@ Testing for the tree module (sklearn.tree).
 """
 import copy
 import pickle
-from itertools import product
+from itertools import product, chain
 import struct
 import io
 import copyreg
@@ -59,6 +59,7 @@ from sklearn.tree._classes import CRITERIA_REG
 from sklearn import datasets
 
 from sklearn.utils import compute_sample_weight
+from sklearn.tree._classes import DENSE_SPLITTERS, SPARSE_SPLITTERS
 
 
 CLF_CRITERIONS = ("gini", "log_loss")
@@ -2371,3 +2372,20 @@ def test_max_features_auto_deprecated():
         )
         with pytest.warns(FutureWarning, match=msg):
             tree.fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "Splitter", chain(DENSE_SPLITTERS.values(), SPARSE_SPLITTERS.values())
+)
+def test_splitter_serializable(Splitter):
+    """Check that splitters are serializable."""
+    rng = np.random.RandomState(42)
+    max_features = 10
+    n_outputs, n_classes = 2, np.array([3, 2], dtype=np.intp)
+
+    criterion = CRITERIA_CLF["gini"](n_outputs, n_classes)
+    splitter = Splitter(criterion, max_features, 5, 0.5, rng)
+    splitter_serialize = pickle.dumps(splitter)
+
+    splitter_back = pickle.loads(splitter_serialize)
+    assert splitter_back.max_features == max_features

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2389,3 +2389,4 @@ def test_splitter_serializable(Splitter):
 
     splitter_back = pickle.loads(splitter_serialize)
     assert splitter_back.max_features == max_features
+    assert isinstance(splitter_back, Splitter)


### PR DESCRIPTION
I think the tree splitters do not need their own custom `__reduce__` method and can use `__getstate__` and `__setstate__`. This is consistent with [Python's docs](https://docs.python.org/3/library/pickle.html#object.__setstate__), which recommends using `__getstate__` and `__setstate__` when possible.