### PR TITLE
MAINT use ArgKmin in OutputCodeClassifier

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -19,6 +19,11 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
+- |Enhancement| :meth:`multiclass.OutputCodeClassifier.predict` now uses a more
+  efficient pairwise distance reduction. As a consequence, the tie-breaking
+  strategy is different and thus the predicted labels may be different.
+  :pr:`25196` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Changes impacting all modules
 -----------------------------
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -44,7 +44,7 @@ from .base import BaseEstimator, ClassifierMixin, clone, is_classifier
 from .base import MultiOutputMixin
 from .base import MetaEstimatorMixin, is_regressor
 from .preprocessing import LabelBinarizer
-from .metrics.pairwise import euclidean_distances
+from .metrics._pairwise_distances_reduction import ArgKmin
 from .utils import check_random_state
 from .utils._param_validation import HasMethods, Interval
 from .utils._tags import _safe_tags
@@ -1039,6 +1039,16 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
             Predicted multi-class targets.
         """
         check_is_fitted(self)
-        Y = np.array([_predict_binary(e, X) for e in self.estimators_]).T
-        pred = euclidean_distances(Y, self.code_book_).argmin(axis=1)
+        # ArgKmin only accept C-contiguous array. The aggregated predictions need to be
+        # transposed. We therefore create a F-contiguous array to avoid a copy and have
+        # a C-contiguous array after the transpose operation.
+        Y = np.array([_predict_binary(e, X) for e in self.estimators_], order="F").T
+        pred = ArgKmin.compute(
+            Y,
+            self.code_book_,
+            k=1,
+            metric="euclidean",
+            strategy="auto",
+            return_distance=False,
+        ).ravel()
         return self.classes_[pred]

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -860,8 +860,8 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
     classifiers are used to project new points in the class space and the class
     closest to the points is chosen. The main advantage of these strategies is
     that the number of classifiers used can be controlled by the user, either
-    for compressing the model (0 < code_size < 1) or for making the model more
-    robust to errors (code_size > 1). See the documentation for more details.
+    for compressing the model (0 < `code_size` < 1) or for making the model more
+    robust to errors (`code_size` > 1). See the documentation for more details.
 
     Read more in the :ref:`User Guide <ecoc>`.
 
@@ -1000,12 +1000,12 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         # FIXME: there are more elaborate methods than generating the codebook
         # randomly.
         self.code_book_ = random_state.uniform(size=(n_classes, code_size_))
-        self.code_book_[self.code_book_ > 0.5] = 1
+        self.code_book_[self.code_book_ > 0.5] = 1.0
 
         if hasattr(self.estimator, "decision_function"):
-            self.code_book_[self.code_book_ != 1] = -1
+            self.code_book_[self.code_book_ != 1] = -1.0
         else:
-            self.code_book_[self.code_book_ != 1] = 0
+            self.code_book_[self.code_book_ != 1] = 0.0
 
         classes_index = {c: i for i, c in enumerate(self.classes_)}
 
@@ -1042,6 +1042,10 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
         # ArgKmin only accepts C-contiguous array. The aggregated predictions need to be
         # transposed. We therefore create a F-contiguous array to avoid a copy and have
         # a C-contiguous array after the transpose operation.
-        Y = np.array([_predict_binary(e, X) for e in self.estimators_], order="F").T
+        Y = np.array(
+            [_predict_binary(e, X) for e in self.estimators_],
+            order="F",
+            dtype=np.float64,
+        ).T
         pred = pairwise_distances_argmin(Y, self.code_book_, metric="euclidean")
         return self.classes_[pred]

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -44,7 +44,7 @@ from .base import BaseEstimator, ClassifierMixin, clone, is_classifier
 from .base import MultiOutputMixin
 from .base import MetaEstimatorMixin, is_regressor
 from .preprocessing import LabelBinarizer
-from .metrics._pairwise_distances_reduction import ArgKmin
+from .metrics.pairwise import pairwise_distances_argmin
 from .utils import check_random_state
 from .utils._param_validation import HasMethods, Interval
 from .utils._tags import _safe_tags
@@ -1039,16 +1039,9 @@ class OutputCodeClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
             Predicted multi-class targets.
         """
         check_is_fitted(self)
-        # ArgKmin only accept C-contiguous array. The aggregated predictions need to be
+        # ArgKmin only accepts C-contiguous array. The aggregated predictions need to be
         # transposed. We therefore create a F-contiguous array to avoid a copy and have
         # a C-contiguous array after the transpose operation.
         Y = np.array([_predict_binary(e, X) for e in self.estimators_], order="F").T
-        pred = ArgKmin.compute(
-            Y,
-            self.code_book_,
-            k=1,
-            metric="euclidean",
-            strategy="auto",
-            return_distance=False,
-        ).ravel()
+        pred = pairwise_distances_argmin(Y, self.code_book_, metric="euclidean")
         return self.classes_[pred]

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -922,3 +922,11 @@ def test_ovo_consistent_binary_classification():
     ovo.fit(X, y)
 
     assert_array_equal(clf.predict(X), ovo.predict(X))
+
+
+def test_xxx():
+    X, y = iris.data, iris.target
+    ecoc = OutputCodeClassifier(
+        estimator=DecisionTreeClassifier(max_depth=2, random_state=0), random_state=0
+    )
+    ecoc.fit(X, y).predict(X)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -922,9 +922,3 @@ def test_ovo_consistent_binary_classification():
     ovo.fit(X, y)
 
     assert_array_equal(clf.predict(X), ovo.predict(X))
-
-
-def test_xxx():
-    X, y = iris.data, iris.target
-    model = OutputCodeClassifier(estimator=DecisionTreeClassifier(random_state=0))
-    model.fit(X, y).predict(X[:5])

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -922,11 +922,3 @@ def test_ovo_consistent_binary_classification():
     ovo.fit(X, y)
 
     assert_array_equal(clf.predict(X), ovo.predict(X))
-
-
-def test_xxx():
-    X, y = iris.data, iris.target
-    ecoc = OutputCodeClassifier(
-        estimator=DecisionTreeClassifier(max_depth=2, random_state=0), random_state=0
-    )
-    ecoc.fit(X, y).predict(X)

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -922,3 +922,9 @@ def test_ovo_consistent_binary_classification():
     ovo.fit(X, y)
 
     assert_array_equal(clf.predict(X), ovo.predict(X))
+
+
+def test_xxx():
+    X, y = iris.data, iris.target
+    model = OutputCodeClassifier(estimator=DecisionTreeClassifier(random_state=0))
+    model.fit(X, y).predict(X[:5])


### PR DESCRIPTION
Make the code using `ArgKmin` instead of `euclidean_distance`. The reason will be linked to https://github.com/scikit-learn/scikit-learn/pull/25148 where I suspect that we should implement an L1 distance (city-block) as stated in the original paper.

As a first step, we can use the `ArgKmin` implementation that provides to switch distance and it is optimum since we apply a reduction.