### PR TITLE
DOC add reference to skops's persistence

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -331,6 +331,7 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "joblib": ("https://joblib.readthedocs.io/en/latest/", None),
     "seaborn": ("https://seaborn.pydata.org/", None),
+    "skops": ("https://skops.readthedocs.io/en/stable/", None),
 }
 
 v = parse(release)

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -135,7 +135,7 @@ you can persist your models as explain in the `docs
 <https://skops.readthedocs.io/en/stable/persistence.html>`__ using
 :func:`skops.io.dump` and :func:`skops.io.dumps`::
 
-    >>> import skops.io as sio
+    >>> import skops.io as sio  # doctest:+SKIP
     >>> obj = sio.dumps(clf)
 
 And you can load them back using :func:`skops.io.load` and
@@ -144,12 +144,12 @@ trusted by you. You can get existing unknown types in a dumped object / file
 using :func:`skops.io.get_untrusted_types`, and after checking its contents,
 pass it to the load function::
 
-    >>> unknown_types = sio.get_untrusted_types(obj)
+    >>> unknown_types = sio.get_untrusted_types(obj)  # doctest:+SKIP
     >>> clf = sio.loads(obj, trusted=unknown_types)
 
 If you trust the source of the file / object, you can pass ``trusted=True``:
 
-    >>> clf = sio.loads(obj, trusted=True)
+    >>> clf = sio.loads(obj, trusted=True)  # doctest:+SKIP
 
 Please report issues and feature requests related to this format on the `skops
 issue tracker <https://github.com/skops-dev/skops/issues>`__.

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -104,8 +104,8 @@ you can persist your models as explain in the `docs
 <https://skops.readthedocs.io/en/stable/persistence.html>`__ using
 :func:`skops.io.dump` and :func:`skops.io.dumps`::
 
-    >>> import skops.io as sio  # doctest:+SKIP
-    >>> obj = sio.dumps(clf)  # doctest:+SKIP
+    import skops.io as sio
+    obj = sio.dumps(clf)
 
 And you can load them back using :func:`skops.io.load` and
 :func:`skops.io.loads`. However, you need to specify the types which are
@@ -113,12 +113,12 @@ trusted by you. You can get existing unknown types in a dumped object / file
 using :func:`skops.io.get_untrusted_types`, and after checking its contents,
 pass it to the load function::
 
-    >>> unknown_types = sio.get_untrusted_types(obj)  # doctest:+SKIP
-    >>> clf = sio.loads(obj, trusted=unknown_types)  # doctest:+SKIP
+    unknown_types = sio.get_untrusted_types(obj)
+    clf = sio.loads(obj, trusted=unknown_types)
 
-If you trust the source of the file / object, you can pass ``trusted=True``:
+If you trust the source of the file / object, you can pass ``trusted=True``::
 
-    >>> clf = sio.loads(obj, trusted=True)  # doctest:+SKIP
+    clf = sio.loads(obj, trusted=True)
 
 Please report issues and feature requests related to this format on the `skops
 issue tracker <https://github.com/skops-dev/skops/issues>`__.

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -92,7 +92,6 @@ serialization methods, please refer to this
 `talk by Alex Gaynor
 <https://pyvideo.org/video/2566/pickles-are-for-delis-not-software>`_.
 
-
 Interoperable formats
 ---------------------
 
@@ -124,7 +123,6 @@ not help in production when performance is critical.
 To convert scikit-learn model to PMML you can use for example `sklearn2pmml
 <https://github.com/jpmml/sklearn2pmml>`_ distributed under the Affero GPLv3
 license.
-
 
 A more secure format: `skops`
 -----------------------------

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -92,6 +92,7 @@ serialization methods, please refer to this
 `talk by Alex Gaynor
 <https://pyvideo.org/video/2566/pickles-are-for-delis-not-software>`_.
 
+
 Interoperable formats
 ---------------------
 
@@ -123,3 +124,34 @@ not help in production when performance is critical.
 To convert scikit-learn model to PMML you can use for example `sklearn2pmml
 <https://github.com/jpmml/sklearn2pmml>`_ distributed under the Affero GPLv3
 license.
+
+
+A more secure format: `skops`
+-----------------------------
+
+`skops <https://skops.readthedocs.io/en/stable/>`__ provides a more secure
+format via the :mod:`skops.io` module. It avoids using :mod:`pickle` and only
+loads files which have types and references to functions which are trusted
+either by default or by the user. The API is very similar to ``pickle``, and
+you can persist your models as explain in the `docs
+<https://skops.readthedocs.io/en/stable/persistence.html>`__ using
+:func:`skops.io.dump` and :func:`skops.io.dumps`::
+
+    >>> import skops.io as sio
+    >>> obj = sio.dumps(clf)
+
+And you can load them back using :func:`skops.io.load` and
+:func:`skops.io.loads`. However, you need to specify the types which are
+trusted by you. You can get existing unknown types in a dumped object / file
+using :func:`skops.io.get_untrusted_types`, and after checking its contents,
+pass it to the load function::
+
+    >>> unknown_types = sio.get_untrusted_types(obj)
+    >>> clf = sio.loads(obj, trusted=unknown_types)
+
+If you trust the source of the file / object, you can pass ``trusted=True``:
+
+    >>> clf = sio.loads(obj, trusted=True)
+
+Please report issues and feature requests related to this format on the `skops
+issue tracker <https://github.com/skops-dev/skops/issues>`__.

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -92,6 +92,37 @@ serialization methods, please refer to this
 `talk by Alex Gaynor
 <https://pyvideo.org/video/2566/pickles-are-for-delis-not-software>`_.
 
+
+A more secure format: `skops`
+.............................
+
+`skops <https://skops.readthedocs.io/en/stable/>`__ provides a more secure
+format via the :mod:`skops.io` module. It avoids using :mod:`pickle` and only
+loads files which have types and references to functions which are trusted
+either by default or by the user. The API is very similar to ``pickle``, and
+you can persist your models as explain in the `docs
+<https://skops.readthedocs.io/en/stable/persistence.html>`__ using
+:func:`skops.io.dump` and :func:`skops.io.dumps`::
+
+    >>> import skops.io as sio  # doctest:+SKIP
+    >>> obj = sio.dumps(clf)  # doctest:+SKIP
+
+And you can load them back using :func:`skops.io.load` and
+:func:`skops.io.loads`. However, you need to specify the types which are
+trusted by you. You can get existing unknown types in a dumped object / file
+using :func:`skops.io.get_untrusted_types`, and after checking its contents,
+pass it to the load function::
+
+    >>> unknown_types = sio.get_untrusted_types(obj)  # doctest:+SKIP
+    >>> clf = sio.loads(obj, trusted=unknown_types)  # doctest:+SKIP
+
+If you trust the source of the file / object, you can pass ``trusted=True``:
+
+    >>> clf = sio.loads(obj, trusted=True)  # doctest:+SKIP
+
+Please report issues and feature requests related to this format on the `skops
+issue tracker <https://github.com/skops-dev/skops/issues>`__.
+
 Interoperable formats
 ---------------------
 
@@ -123,33 +154,3 @@ not help in production when performance is critical.
 To convert scikit-learn model to PMML you can use for example `sklearn2pmml
 <https://github.com/jpmml/sklearn2pmml>`_ distributed under the Affero GPLv3
 license.
-
-A more secure format: `skops`
------------------------------
-
-`skops <https://skops.readthedocs.io/en/stable/>`__ provides a more secure
-format via the :mod:`skops.io` module. It avoids using :mod:`pickle` and only
-loads files which have types and references to functions which are trusted
-either by default or by the user. The API is very similar to ``pickle``, and
-you can persist your models as explain in the `docs
-<https://skops.readthedocs.io/en/stable/persistence.html>`__ using
-:func:`skops.io.dump` and :func:`skops.io.dumps`::
-
-    >>> import skops.io as sio  # doctest:+SKIP
-    >>> obj = sio.dumps(clf)  # doctest:+SKIP
-
-And you can load them back using :func:`skops.io.load` and
-:func:`skops.io.loads`. However, you need to specify the types which are
-trusted by you. You can get existing unknown types in a dumped object / file
-using :func:`skops.io.get_untrusted_types`, and after checking its contents,
-pass it to the load function::
-
-    >>> unknown_types = sio.get_untrusted_types(obj)  # doctest:+SKIP
-    >>> clf = sio.loads(obj, trusted=unknown_types)  # doctest:+SKIP
-
-If you trust the source of the file / object, you can pass ``trusted=True``:
-
-    >>> clf = sio.loads(obj, trusted=True)  # doctest:+SKIP
-
-Please report issues and feature requests related to this format on the `skops
-issue tracker <https://github.com/skops-dev/skops/issues>`__.

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -136,7 +136,7 @@ you can persist your models as explain in the `docs
 :func:`skops.io.dump` and :func:`skops.io.dumps`::
 
     >>> import skops.io as sio  # doctest:+SKIP
-    >>> obj = sio.dumps(clf)
+    >>> obj = sio.dumps(clf)  # doctest:+SKIP
 
 And you can load them back using :func:`skops.io.load` and
 :func:`skops.io.loads`. However, you need to specify the types which are
@@ -145,7 +145,7 @@ using :func:`skops.io.get_untrusted_types`, and after checking its contents,
 pass it to the load function::
 
     >>> unknown_types = sio.get_untrusted_types(obj)  # doctest:+SKIP
-    >>> clf = sio.loads(obj, trusted=unknown_types)
+    >>> clf = sio.loads(obj, trusted=unknown_types)  # doctest:+SKIP
 
 If you trust the source of the file / object, you can pass ``trusted=True``:
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -115,6 +115,10 @@ enhance the functionality of scikit-learn's estimators.
   Scikit-learn pipelines to `ONNX <https://onnx.ai/>`_ for interchange and
   prediction.
 
+` `skops.io <https://skops.readthedocs.io/en/stable/persistence.html>`__ A
+  persistence model more secure than pickle, which can be used instead of
+  pickle in most common cases.
+
 - `sklearn2pmml <https://github.com/jpmml/sklearn2pmml>`_
   Serialization of a wide variety of scikit-learn estimators and transformers
   into PMML with the help of `JPMML-SkLearn <https://github.com/jpmml/jpmml-sklearn>`_


### PR DESCRIPTION
This PR proposes to add a reference to skops's persistence as an alternative.

It would certainly also help us figure out more bugs and improve the persistence implementation.

I'm open to comments on whether this is the right time to add this here or not, and whether there is anything we need to do in the immediate future on the skops side.

cc @BenjaminBossan @thomasjpfan @glemaitre 