### PR TITLE
MNT Refactors __reduce__ to parent Splitter

### DIFF
--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -91,6 +91,13 @@ cdef class Splitter:
     def __setstate__(self, d):
         pass
 
+    def __reduce__(self):
+        return (type(self), (self.criterion,
+                             self.max_features,
+                             self.min_samples_leaf,
+                             self.min_weight_leaf,
+                             self.random_state), self.__getstate__())
+
     cdef int init(
         self,
         object X,
@@ -240,13 +247,6 @@ cdef class BaseDenseSplitter(Splitter):
 
 cdef class BestSplitter(BaseDenseSplitter):
     """Splitter for finding the best split."""
-    def __reduce__(self):
-        return (BestSplitter, (self.criterion,
-                               self.max_features,
-                               self.min_samples_leaf,
-                               self.min_weight_leaf,
-                               self.random_state), self.__getstate__())
-
     cdef int node_split(self, double impurity, SplitRecord* split,
                         SIZE_t* n_constant_features) nogil except -1:
         """Find the best split on node samples[start:end]
@@ -553,13 +553,6 @@ cdef void heapsort(DTYPE_t* Xf, SIZE_t* samples, SIZE_t n) nogil:
 
 cdef class RandomSplitter(BaseDenseSplitter):
     """Splitter for finding the best random split."""
-    def __reduce__(self):
-        return (RandomSplitter, (self.criterion,
-                                 self.max_features,
-                                 self.min_samples_leaf,
-                                 self.min_weight_leaf,
-                                 self.random_state), self.__getstate__())
-
     cdef int node_split(self, double impurity, SplitRecord* split,
                         SIZE_t* n_constant_features) nogil except -1:
         """Find the best random split on node samples[start:end]
@@ -1057,14 +1050,6 @@ cdef inline void sparse_swap(SIZE_t[::1] index_to_samples, SIZE_t[::1] samples,
 
 cdef class BestSparseSplitter(BaseSparseSplitter):
     """Splitter for finding the best split, using the sparse data."""
-
-    def __reduce__(self):
-        return (BestSparseSplitter, (self.criterion,
-                                     self.max_features,
-                                     self.min_samples_leaf,
-                                     self.min_weight_leaf,
-                                     self.random_state), self.__getstate__())
-
     cdef int node_split(self, double impurity, SplitRecord* split,
                         SIZE_t* n_constant_features) nogil except -1:
         """Find the best split on node samples[start:end], using sparse features
@@ -1283,14 +1268,6 @@ cdef class BestSparseSplitter(BaseSparseSplitter):
 
 cdef class RandomSparseSplitter(BaseSparseSplitter):
     """Splitter for finding a random split, using the sparse data."""
-
-    def __reduce__(self):
-        return (RandomSparseSplitter, (self.criterion,
-                                       self.max_features,
-                                       self.min_samples_leaf,
-                                       self.min_weight_leaf,
-                                       self.random_state), self.__getstate__())
-
     cdef int node_split(self, double impurity, SplitRecord* split,
                         SIZE_t* n_constant_features) nogil except -1:
         """Find a random split on node samples[start:end], using sparse features


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Alternative to #25195

#### What does this implement/fix? Explain your changes.
This is a simpler version of #25195 by moving `__reduce__` up to the parent `Splitter` class.

#### Any other comments?
Unlike #25195, this PR is backward compatible with third party libraries that inherit from `Splitter` and has it's own `__cinit__`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
