### PR TITLE
DOC Wrong rendering for sphinx's versionadded

### DIFF
--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -81,6 +81,7 @@ def fetch_kddcup99(
     data_home : str, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
+
         .. versionadded:: 0.19
 
     shuffle : bool, default=False

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -232,6 +232,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if the
         underlying estimators expose such an attribute when fit.
+
         .. versionadded:: 1.0
 
     See Also
@@ -534,6 +535,7 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if the
         underlying estimators expose such an attribute when fit.
+
         .. versionadded:: 1.0
 
     See Also


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I found some redenring bugs for versionadded and looking at the code it looked like we wer missing an enter.

#### Any other comments?

This PR should work for:
- [sklearn.datasets.fetch_kddcup99](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_kddcup99.html)
- [sklearn.ensemble.VotingClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.VotingClassifier.html)
- [sklearn.ensemble.VotingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.VotingRegressor.html)

But I didn't find the error for:
- [sklearn.ensemble.StackingClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.StackingClassifier.html)
- [sklearn.ensemble.StackingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.StackingRegressor.html)
