### PR TITLE
Allow tuple for ColumnTransformer 'transformers' parameter

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -21,7 +21,7 @@ from ..preprocessing import FunctionTransformer
 from ..utils import Bunch
 from ..utils import _safe_indexing
 from ..utils import _get_column_indices
-from ..utils._param_validation import HasMethods, Interval, StrOptions
+from ..utils._param_validation import HasMethods, Interval, StrOptions, Hidden
 from ..utils._set_output import _get_output_config, _safe_set_output
 from ..utils import check_pandas_support
 from ..utils.metaestimators import _BaseComposition
@@ -215,7 +215,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     _required_parameters = ["transformers"]
 
     _parameter_constraints: dict = {
-        "transformers": [list],
+        "transformers": [list, Hidden(tuple)],
         "remainder": [
             StrOptions({"drop", "passthrough"}),
             HasMethods(["fit", "transform"]),

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -137,6 +137,23 @@ def test_column_transformer():
     assert len(both.transformers_) == 1
 
 
+def test_column_transformer_tuple_transformers_parameter():
+    X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
+
+    transformers = [("trans1", Trans(), [0]), ("trans2", Trans(), [1])]
+
+    ct_with_list = ColumnTransformer(transformers)
+    ct_with_tuple = ColumnTransformer(tuple(transformers))
+
+    assert_array_equal(
+        ct_with_list.fit_transform(X_array), ct_with_tuple.fit_transform(X_array)
+    )
+    assert_array_equal(
+        ct_with_list.fit(X_array).transform(X_array),
+        ct_with_tuple.fit(X_array).transform(X_array),
+    )
+
+
 def test_column_transformer_dataframe():
     pd = pytest.importorskip("pandas")
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Add `Hidden(tuple)` to `ColumnTransformer` `transformers` parameters as suggested in https://github.com/scikit-learn/scikit-learn/pull/25137#discussion_r1044820875

Turns out `tuple` is actually used in the `plot_set_output.py` example:
https://github.com/scikit-learn/scikit-learn/blob/ce89a4ff155cf1ec06e991a2910ca3b3c0224394/examples/miscellaneous/plot_set_output.py#L87-L99

And #25137 broke the doc build: https://github.com/scikit-learn/scikit-learn/actions/runs/3733396516/jobs/6334138907

The other errors in the doc build are likely due to side-effect of `plot_set_output.py` failing before it can revert the output to the default. I'll trigger a full doc build in this PR to make sure of this.

