### PR TITLE
TST check error consistency when calling get_feature_names_out on unfitted estimator

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -462,15 +462,59 @@ ESTIMATORS_WITH_GET_FEATURE_NAMES_OUT = [
     est for est in _tested_estimators() if hasattr(est, "get_feature_names_out")
 ]
 
+WHITELISTED_FAILING_ESTIMATORS = [
+    "AdditiveChi2Sampler",
+    "Binarizer",
+    "DictVectorizer",
+    "GaussianRandomProjection",
+    "GenericUnivariateSelect",
+    "IterativeImputer",
+    "IsotonicRegression",
+    "KBinsDiscretizer",
+    "KNNImputer",
+    "MaxAbsScaler",
+    "MinMaxScaler",
+    "MissingIndicator",
+    "Normalizer",
+    "OrdinalEncoder",
+    "PowerTransformer",
+    "QuantileTransformer",
+    "RFE",
+    "RFECV",
+    "RobustScaler",
+    "SelectFdr",
+    "SelectFpr",
+    "SelectFromModel",
+    "SelectFwe",
+    "SelectKBest",
+    "SelectPercentile",
+    "SequentialFeatureSelector",
+    "SimpleImputer",
+    "SparseRandomProjection",
+    "SplineTransformer",
+    "StackingClassifier",
+    "StackingRegressor",
+    "StandardScaler",
+    "TfidfTransformer",
+    "VarianceThreshold",
+    "VotingClassifier",
+    "VotingRegressor",
+]
+
 
 @pytest.mark.parametrize(
     "estimator", ESTIMATORS_WITH_GET_FEATURE_NAMES_OUT, ids=_get_check_estimator_ids
 )
 def test_estimators_get_feature_names_out_error(estimator):
+    estimator_name = estimator.__class__.__name__
+    if estimator_name in WHITELISTED_FAILING_ESTIMATORS:
+        return pytest.xfail(
+            reason=f"{estimator_name} is not failing with a consistent NotFittedError"
+        )
     _set_checking_parameters(estimator)
 
     with ignore_warnings(category=(FutureWarning)):
-        check_get_feature_names_out_error(estimator.__class__.__name__, estimator)
+        check_get_feature_names_out_error(estimator_name, estimator)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -81,6 +81,7 @@ from sklearn.utils.estimator_checks import (
     check_set_output_transform,
     check_set_output_transform_pandas,
     check_global_ouptut_transform_pandas,
+    check_get_feature_names_out_error,
 )
 
 
@@ -455,6 +456,21 @@ def test_transformers_get_feature_names_out(transformer):
         check_transformer_get_feature_names_out_pandas(
             transformer.__class__.__name__, transformer
         )
+
+
+ESTIMATORS_WITH_GET_FEATURE_NAMES_OUT = [
+    est for est in _tested_estimators() if hasattr(est, "get_feature_names_out")
+]
+
+
+@pytest.mark.parametrize(
+    "estimator", ESTIMATORS_WITH_GET_FEATURE_NAMES_OUT, ids=_get_check_estimator_ids
+)
+def test_estimators_get_feature_names_out_error(estimator):
+    _set_checking_parameters(estimator)
+
+    with ignore_warnings(category=(FutureWarning)):
+        check_get_feature_names_out_error(estimator.__class__.__name__, estimator)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -512,9 +512,7 @@ def test_estimators_get_feature_names_out_error(estimator):
             reason=f"{estimator_name} is not failing with a consistent NotFittedError"
         )
     _set_checking_parameters(estimator)
-
-    with ignore_warnings(category=(FutureWarning)):
-        check_get_feature_names_out_error(estimator_name, estimator)
+    check_get_feature_names_out_error(estimator_name, estimator)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2590,7 +2590,7 @@ def check_classifiers_multilabel_output_format_decision_function(name, classifie
     )
 
 
-@ignore_warnings
+@ignore_warnings(category=FutureWarning)
 def check_get_feature_names_out_error(name, estimator_orig):
     """Check the error raised by get_feature_names_out when called before fit.
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2590,6 +2590,22 @@ def check_classifiers_multilabel_output_format_decision_function(name, classifie
     )
 
 
+@ignore_warnings
+def check_get_feature_names_out_error(name, estimator_orig):
+    """Check the error raised by get_feature_names_out when called before fit.
+
+    Unfitted estimators with get_feature_names_out should raise a NotFittedError.
+    """
+
+    estimator = clone(estimator_orig)
+    err_msg = (
+        f"Estimator {name} should have raised a NotFitted error when fit is called"
+        " before get_feature_names_out"
+    )
+    with raises(NotFittedError, err_msg=err_msg):
+        estimator.get_feature_names_out()
+
+
 @ignore_warnings(category=FutureWarning)
 def check_estimators_fit_returns_self(name, estimator_orig, readonly_memmap=False):
     """Check if self is returned when calling fit."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
In issue #24916 , we want to make error messages uniform when calling `get_feature_names_out` before `fit`. To adhere to the uniformity, it was agreed that all estimators should raise a `NotFittedError` if they are unfitted. 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
To solve the issue, we first needed to identify the estimators that don't raise a `NotFittedError`. Therefore, this PR proposes tests that check if a `NotFittedError` is raised in estimators with `get_feature_names_out`.

#### Any other comments?
For a particular estimator, the test will pass if a `NotFittedError` is raised by `get_feature_names_out` and will fail if any other type of error/exception is raised.
In case the test fails, it will show the estimator, the error and which parts of the code led to the error being raised.
The command below can be used to run the tests that check errors generated when `get_feature_names_out` is called before `fit` in all estimators:
`pytest -vsl sklearn/tests/test_common.py -k estimators_get_feature_names_out_error`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
