### PR TITLE
MAINT Remove -Wcpp warnings when compiling sklearn.neighbors._quad_tree

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.neighbors._ball_tree",
     "sklearn.neighbors._kd_tree",
     "sklearn.neighbors._partition_nodes",
+    "sklearn.neighbors._quad_tree",
     "sklearn.tree._splitter",
     "sklearn.tree._utils",
     "sklearn.utils._cython_blas",

--- a/sklearn/neighbors/_quad_tree.pxd
+++ b/sklearn/neighbors/_quad_tree.pxd
@@ -93,4 +93,4 @@ cdef class _QuadTree:
     cdef int _resize(self, SIZE_t capacity) nogil except -1
     cdef int _resize_c(self, SIZE_t capacity=*) nogil except -1
     cdef int _get_cell(self, DTYPE_t[3] point, SIZE_t cell_id=*) nogil except -1
-    cdef cnp.ndarray _get_cell_ndarray(self)
+    cdef Cell[:] _get_cell_ndarray(self)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24875 

#### What does this implement/fix? Explain your changes.
- Use memory views in place of cnp.ndarray in sklearn.neighbors._quad_tree

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
