### PR TITLE
FIX get config from dispatcher thread in delayed by default

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -13,19 +13,12 @@ Changes impacting all modules
 -----------------------------
 
 - |Fix| Fix a bug that was ignoring the global configuration in estimators using
-  `n_jobs > 1`. This bug was triggered for the tasks not dispatch by the main
+  `n_jobs > 1`. This bug was triggered for the tasks not dispatched by the main
   thread in `joblib` since :func:`sklearn.get_config` uses thread local configuration.
   :pr:`25242` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Changelog
 ---------
-
-:mod:`sklearn`
-..............
-
-- |Enhancement| :func:`sklearn.get_config` takes a parameter `thread` allowing to
-  retrieve the local configuration of this specific `thread`.
-  :pr:`25242` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.base`
 ...................

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -12,9 +12,11 @@ Version 1.2.1
 Changes impacting all modules
 -----------------------------
 
-- |Fix| Fix a bug that was ignoring the global configuration in estimators using
-  `n_jobs > 1`. This bug was triggered for the tasks not dispatched by the main
-  thread in `joblib` since :func:`sklearn.get_config` uses thread local configuration.
+- |Fix| Fix a bug where the current configuration was ignored in estimators using
+  `n_jobs > 1`. This bug was triggered for tasks dispatched by the ancillary
+  thread of `joblib` as :func:`sklearn.get_config` used to access an empty thread
+  local configuration instead of the configuration visible from the thread where
+  `delayed` was first called.
   :pr:`25242` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Changelog

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -9,8 +9,23 @@ Version 1.2.1
 
 **In Development**
 
+Changes impacting all modules
+-----------------------------
+
+- |Fix| Fix a bug that was ignoring the global configuration in estimators using
+  `n_jobs > 1`. This bug was triggered for the tasks not dispatch by the main
+  thread in `joblib` since :func:`sklearn.get_config` uses thread local configuration.
+  :pr:`25242` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Changelog
 ---------
+
+:mod:`sklearn`
+..............
+
+- |Enhancement| :func:`sklearn.get_config` takes a parameter `thread` allowing to
+  retrieve the local configuration of this specific `thread`.
+  :pr:`25242` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.base`
 ...................

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -25,8 +25,8 @@ def _get_threadlocal_config():
     """Get a threadlocal **mutable** configuration.
 
     If the configuration does not exist, copy the default global configuration.
-    The configuration is also registered to in a global dictionary where the
-    key is the thread id.
+    The configuration is also registered to a global dictionary where the keys
+    are weak references to the thread objects.
     """
     if not hasattr(_threadlocal, "global_config"):
         _threadlocal.global_config = _global_config_default.copy()
@@ -39,9 +39,9 @@ def get_config(thread=None):
 
     Parameters
     ----------
-    thread_id : int, default=None
-        The thread id from which to retrieve the configuration. If `None`,
-        the current thread id is used.
+    thread : Thread, default=None
+        The thread for which to retrieve the configuration. If None, the
+        configuration of the current thread is returned.
 
     Returns
     -------
@@ -55,9 +55,9 @@ def get_config(thread=None):
     """
     # Return a copy of the threadlocal configuration so that users will
     # not be able to modify the configuration with the returned dict.
+    threadlocal_config = _get_threadlocal_config()
     if thread is None:
-        return _get_threadlocal_config().copy()
-    _get_threadlocal_config()  # register the config to the thread if does not exist
+        return threadlocal_config.copy()
     return _thread_config[thread].copy()
 
 

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -37,14 +37,8 @@ def _get_thread_config(thread=None):
     return _thread_config[thread]
 
 
-def get_config(thread=None):
+def get_config():
     """Retrieve current values for configuration set by :func:`set_config`.
-
-    Parameters
-    ----------
-    thread : Thread, default=None
-        The thread for which to retrieve the configuration. If None, the
-        configuration of the current thread is returned.
 
     Returns
     -------
@@ -58,7 +52,7 @@ def get_config(thread=None):
     """
     # Return a copy of the configuration so that users will not be able to
     # modify the configuration with the returned dict.
-    return _get_thread_config(thread=thread).copy()
+    return _get_thread_config().copy()
 
 
 def set_config(

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -1,9 +1,11 @@
 """Global configuration state and functions for management
 """
 import os
-from contextlib import contextmanager as contextmanager
 import threading
-import weakref
+
+from contextlib import contextmanager as contextmanager
+from typing import Dict
+from weakref import WeakKeyDictionary
 
 _global_config_default = {
     "assume_finite": bool(os.environ.get("SKLEARN_ASSUME_FINITE", False)),
@@ -18,7 +20,7 @@ _global_config_default = {
     "transform_output": "default",
 }
 _threadlocal = threading.local()
-_thread_config = weakref.WeakKeyDictionary()  # type: ignore
+_thread_config = WeakKeyDictionary()  # type: WeakKeyDictionary[threading.Thread, Dict]
 
 
 def _get_threadlocal_config():

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -4,7 +4,7 @@ import os
 import threading
 
 from contextlib import contextmanager as contextmanager
-from typing import Dict
+from typing import Dict  # noqa
 from weakref import WeakKeyDictionary
 
 _global_config_default = {

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -3,7 +3,7 @@
 import os
 import threading
 
-from contextlib import contextmanager as contextmanager
+from contextlib import contextmanager
 from typing import Dict  # noqa
 from weakref import WeakKeyDictionary
 

--- a/sklearn/tests/test_config.py
+++ b/sklearn/tests/test_config.py
@@ -5,6 +5,8 @@ from concurrent.futures import ThreadPoolExecutor
 from joblib import Parallel
 import pytest
 
+from sklearn._config import _get_thread_config
+
 from sklearn import get_config, set_config, config_context
 from sklearn.utils.fixes import delayed
 
@@ -149,19 +151,19 @@ def test_config_threadsafe():
     assert items == [False, True, False, True]
 
 
-def test_get_config_thread_dependent():
+def test_get_thread_config():
     """Check that we can retrieve the config file from a specific thread."""
 
     def set_definitive_assume_finite(assume_finite, sleep_duration):
         set_config(assume_finite=assume_finite)
         time.sleep(sleep_duration)
-        return get_config()["assume_finite"]
+        return _get_thread_config()["assume_finite"]
 
     thread = threading.Thread(target=set_definitive_assume_finite, args=(True, 0.1))
     thread.start()
     thread.join()
 
-    thread_specific_config = get_config(thread=thread)
+    thread_specific_config = _get_thread_config(thread=thread)
     assert thread_specific_config["assume_finite"] is True
-    main_thread_config = get_config()
+    main_thread_config = _get_thread_config()
     assert main_thread_config["assume_finite"] is False

--- a/sklearn/tests/test_config.py
+++ b/sklearn/tests/test_config.py
@@ -165,13 +165,3 @@ def test_get_config_thread_dependent():
     assert thread_specific_config["assume_finite"] is True
     main_thread_config = get_config()
     assert main_thread_config["assume_finite"] is False
-
-    # check that we have 2 threads registered in the thread config dictionary
-    from sklearn._config import _thread_config
-
-    assert len(_thread_config) == 2
-
-    # delete the thread and check that the dictionary does keep a reference to it
-    # since we use a weakref dictionary
-    del thread
-    assert len(_thread_config) == 1

--- a/sklearn/tests/test_config.py
+++ b/sklearn/tests/test_config.py
@@ -152,14 +152,9 @@ def test_config_threadsafe():
 
 
 def test_get_thread_config():
-    """Check that we can retrieve the config file from a specific thread."""
+    """Check that we can retrieve the config from a specific thread."""
 
-    def set_definitive_assume_finite(assume_finite, sleep_duration):
-        set_config(assume_finite=assume_finite)
-        time.sleep(sleep_duration)
-        return _get_thread_config()["assume_finite"]
-
-    thread = threading.Thread(target=set_definitive_assume_finite, args=(True, 0.1))
+    thread = threading.Thread(target=set_config, kwargs={"assume_finite": True})
     thread.start()
     thread.join()
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -108,8 +108,13 @@ else:
 
 
 # remove when https://github.com/joblib/joblib/issues/1071 is fixed
-def delayed(func, thread=threading.current_thread()):
+def delayed(func):
     """Decorator used to capture the arguments of a function."""
+    return _delayed(func)
+
+
+def _delayed(func, thread=threading.current_thread()):
+    """Private function to expose the thread argument."""
 
     def decorate(func):
         @functools.wraps(func)

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -21,7 +21,7 @@ import numpy as np
 import scipy
 import scipy.stats
 import threadpoolctl
-from .._config import config_context, get_config
+from .._config import config_context, _get_thread_config
 from ..externals._packaging.version import parse as parse_version
 
 
@@ -131,7 +131,7 @@ class _FuncWrapper:
 
     def __init__(self, function, thread):
         self.function = function
-        self.config = get_config(thread=thread)
+        self.config = _get_thread_config(thread=thread)
         update_wrapper(self, self.function)
 
     def __call__(self, *args, **kwargs):

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -108,13 +108,13 @@ else:
 
 
 # remove when https://github.com/joblib/joblib/issues/1071 is fixed
-def delayed(func, thread_id=threading.get_ident()):
+def delayed(func, thread=threading.current_thread()):
     """Decorator used to capture the arguments of a function."""
 
     def decorate(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            return _FuncWrapper(func, thread_id=thread_id), args, kwargs
+            return _FuncWrapper(func, thread=thread), args, kwargs
 
         return wrapper
 
@@ -124,9 +124,9 @@ def delayed(func, thread_id=threading.get_ident()):
 class _FuncWrapper:
     """ "Load the global configuration before calling the function."""
 
-    def __init__(self, function, thread_id=None):
+    def __init__(self, function, thread):
         self.function = function
-        self.config = get_config(thread_id=thread_id)
+        self.config = get_config(thread=thread)
         update_wrapper(self, self.function)
 
     def __call__(self, *args, **kwargs):

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -15,7 +15,7 @@ from joblib import Parallel
 import sklearn
 from sklearn.utils._testing import assert_array_equal
 
-from sklearn.utils.fixes import _object_dtype_isnan, delayed, loguniform
+from sklearn.utils.fixes import _delayed, _object_dtype_isnan, loguniform
 
 
 @pytest.mark.parametrize("dtype, val", ([object, 1], [object, "a"], [float, 1]))
@@ -52,7 +52,7 @@ def test_loguniform(low, high, base):
 
 
 def test_delayed_fetching_right_config():
-    """Check that `delayed` function fetches the right config associated to
+    """Check that `_delayed` function fetches the right config associated to
     the main thread.
 
     Non-regression test for:
@@ -68,7 +68,7 @@ def test_delayed_fetching_right_config():
     # parameters defined within the context manager
     with sklearn.config_context(working_memory=123):
         results = Parallel(n_jobs=2, pre_dispatch=4)(
-            delayed(get_working_memory)() for _ in range(n_iter)
+            _delayed(get_working_memory)() for _ in range(n_iter)
         )
 
     assert results == [123] * n_iter
@@ -79,7 +79,7 @@ def test_delayed_fetching_right_config():
     local_thread.join()
     with sklearn.config_context(working_memory=123):
         results = Parallel(n_jobs=2, pre_dispatch=4)(
-            delayed(get_working_memory, thread=local_thread)() for _ in range(n_iter)
+            _delayed(get_working_memory, thread=local_thread)() for _ in range(n_iter)
         )
 
     assert results == [get_working_memory()] * n_iter


### PR DESCRIPTION
closes #25239

`delayed` function wrap the function and fetch the global configuration. However, this "global" dictionary is local to the specific thread that dispatches the job. Therefore, we can end-up with a default "global" config instead of the configuration defined in the main thread.

The solution here is to add a parameter to `delayed`, defaulting to the main thread, to retrieve the configuration associated with the main thread.