### PR TITLE
MAINT Parameters validation for cluster.compute_optics_graph

### DIFF
--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -425,14 +425,14 @@ def _compute_core_distances_(X, neighbors, min_samples, working_memory):
 
 @validate_params(
     {
-        "X": [np.ndarray],
+        "X": [np.ndarray, "sparse matrix"],
         "min_samples": [
-            Interval(Integral, 1, None, closed="left"),
+            Interval(Integral, 2, None, closed="left"),
             Interval(Real, 0, 1, closed="both"),
         ],
         "max_eps": [Interval(Real, 0, None, closed="both")],
         "metric": [StrOptions(set(_VALID_METRICS) | {"precomputed"}), callable],
-        "p": [Interval(Real, 1, None, closed="left")],
+        "p": [Interval(Real, 0, None, closed="right"), None],
         "metric_params": [dict, None],
         "algorithm": [StrOptions({"auto", "brute", "ball_tree", "kd_tree"})],
         "leaf_size": [Interval(Integral, 1, None, closed="left")],
@@ -448,7 +448,7 @@ def compute_optics_graph(
 
     Parameters
     ----------
-    X : ndarray of shape (n_samples, n_features), or \
+    X : {ndarray, sparse matrix} of shape (n_samples, n_features), or \
             (n_samples, n_samples) if metric='precomputed'
         A feature array, or array of distances between samples if
         metric='precomputed'.

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -423,6 +423,22 @@ def _compute_core_distances_(X, neighbors, min_samples, working_memory):
     return core_distances
 
 
+@validate_params(
+    {
+        "X": [np.ndarray],
+        "min_samples": [
+            Interval(Integral, 1, None, closed="left"),
+            Interval(Real, 0, 1, closed="both")
+        ],
+        "max_eps": [Interval(Real, 0, None, closed="both")],
+        "metric": [StrOptions(set(_VALID_METRICS) | {"precomputed"}), callable],
+        "p": [Interval(Real, 1, None, closed="left")],
+        "metric_params": [dict, None],
+        "algorithm": [StrOptions({"auto", "brute", "ball_tree", "kd_tree"})],
+        "leaf_size": [Interval(Integral, 1, None, closed="left")],
+        "n_jobs": [Integral, None],
+    }
+)
 def compute_optics_graph(
     X, *, min_samples, max_eps, metric, p, metric_params, algorithm, leaf_size, n_jobs
 ):

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -428,7 +428,7 @@ def _compute_core_distances_(X, neighbors, min_samples, working_memory):
         "X": [np.ndarray],
         "min_samples": [
             Interval(Integral, 1, None, closed="left"),
-            Interval(Real, 0, 1, closed="both")
+            Interval(Real, 0, 1, closed="both"),
         ],
         "max_eps": [Interval(Real, 0, None, closed="both")],
         "metric": [StrOptions(set(_VALID_METRICS) | {"precomputed"}), callable],

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -95,6 +95,7 @@ def _check_function_param_validation(
 
 PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.cluster.cluster_optics_dbscan",
+    "sklearn.cluster.compute_optics_graph"
     "sklearn.cluster.estimate_bandwidth",
     "sklearn.cluster.kmeans_plusplus",
     "sklearn.covariance.empirical_covariance",

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -95,7 +95,7 @@ def _check_function_param_validation(
 
 PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.cluster.cluster_optics_dbscan",
-    "sklearn.cluster.compute_optics_graph"
+    "sklearn.cluster.compute_optics_graph",
     "sklearn.cluster.estimate_bandwidth",
     "sklearn.cluster.kmeans_plusplus",
     "sklearn.covariance.empirical_covariance",

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -85,7 +85,7 @@ def _check_function_param_validation(
 
         for constraint in constraints:
             try:
-                bad_value = generate_invalid_param_val(constraint)
+                bad_value = generate_invalid_param_val(constraint, constraints)
             except NotImplementedError:
                 continue
 

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -886,6 +886,11 @@ def generate_valid_param(constraint):
         if constraint.type is np.ndarray:
             # special case for ndarray since it can't be instantiated without arguments
             return np.array([1, 2, 3])
+        
+        if constraint.type in (Integral, Real):
+            # special case for Integral and Real since they are abstract classes
+            return 1
+
         return constraint.type()
 
     if isinstance(constraint, _Booleans):

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -886,7 +886,7 @@ def generate_valid_param(constraint):
         if constraint.type is np.ndarray:
             # special case for ndarray since it can't be instantiated without arguments
             return np.array([1, 2, 3])
-        
+
         if constraint.type in (Integral, Real):
             # special case for Integral and Real since they are abstract classes
             return 1


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #24862 

#### What does this implement/fix? Explain your changes.
Parameter validation for `cluster.compute_optics_graph`.

#### Any other comments?
I am not sure if I have done the params validation for `X` well, because if `metric='precomputed'`, then the array is a feature array or array of distances. 

Also, I think there may be an error in the parameter constraints in the `Optics` class: 
The integer interval for `min_samples` does not match the documentation of the parameter. 
I don't know if am mistaken, just asking to be sure. 
