### PR TITLE
MAINT Parameters validation for sklearn.metrics.multilabel_confusion_matrix

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -392,6 +392,15 @@ def confusion_matrix(
     return cm
 
 
+@validate_params(
+    {
+        "y_true": ["array-like", "sparse matrix"],
+        "y_pred": ["array-like", "sparse matrix"],
+        "sample_weight": ["array-like", None],
+        "labels": ["array-like", None],
+        "samplewise": ["boolean"],
+    }
+)
 def multilabel_confusion_matrix(
     y_true, y_pred, *, sample_weight=None, labels=None, samplewise=False
 ):

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -109,7 +109,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.confusion_matrix",
     "sklearn.metrics.mean_absolute_error",
     "sklearn.metrics.mean_tweedie_deviance",
-    "sklearn.metrics.multilabel_confusion_matrix"
+    "sklearn.metrics.multilabel_confusion_matrix",
     "sklearn.metrics.mutual_info_score",
     "sklearn.metrics.r2_score",
     "sklearn.metrics.roc_curve",

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -109,6 +109,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.confusion_matrix",
     "sklearn.metrics.mean_absolute_error",
     "sklearn.metrics.mean_tweedie_deviance",
+    "sklearn.metrics.multilabel_confusion_matrix"
     "sklearn.metrics.mutual_info_score",
     "sklearn.metrics.r2_score",
     "sklearn.metrics.roc_curve",


### PR DESCRIPTION
Reference Issues/PRs

Towards #24862 
What does this implement/fix? Explain your changes.

Added the validate_params decorator for sklearn.metrics.multilabel_confusion_matrix