### PR TITLE
FIX deprecate sample_weight in predict method of BaseKMeans

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -52,6 +52,13 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.cluster`
+......................
+
+- |API| The `sample_weight` parameter in `predict` method is now deprecated for
+  :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` and will be removed in v1.5.
+  :pr:`25251` by :user:`Gleb Levitski <glevv>`.
+
 :mod:`sklearn.decomposition`
 ............................
 - |Enhancement| :class:`decomposition.DictionaryLearning` now accepts the parameter

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -55,8 +55,9 @@ Changelog
 :mod:`sklearn.cluster`
 ......................
 
-- |API| The `sample_weight` parameter in `predict` method is now deprecated for
-  :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` and will be removed in v1.5.
+- |API| The `sample_weight` parameter in `predict` for
+  :meth:`cluster.KMeans.predict` and :meth:`cluster.MiniBatchKMeans.predict`
+  is now deprecated and will be removed in v1.5.
   :pr:`25251` by :user:`Gleb Levitski <glevv>`.
 
 :mod:`sklearn.decomposition`

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1049,8 +1049,8 @@ class _BaseKMeans(
             are assigned equal weight.
 
             .. deprecated:: 1.3
-           ``sample_weight`` was deprecated in version 1.3 and will be removed
-           in 1.5.
+               The parameter `sample_weight` is deprecated in version 1.3
+               and will be removed in 1.5.
 
         Returns
         -------

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1032,7 +1032,7 @@ class _BaseKMeans(
         """
         return self.fit(X, sample_weight=sample_weight).labels_
 
-    def predict(self, X, sample_weight=None):
+    def predict(self, X, sample_weight="deprecated"):
         """Predict the closest cluster each sample in X belongs to.
 
         In the vector quantization literature, `cluster_centers_` is called
@@ -1048,6 +1048,10 @@ class _BaseKMeans(
             The weights for each observation in X. If None, all observations
             are assigned equal weight.
 
+            .. deprecated:: 1.21
+           ``sample_weight`` was deprecated in version 1.21 and will be removed
+           in 1.23.
+
         Returns
         -------
         labels : ndarray of shape (n_samples,)
@@ -1056,7 +1060,15 @@ class _BaseKMeans(
         check_is_fitted(self)
 
         X = self._check_test_data(X)
-        sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
+        if sample_weight != "deprecated":
+            warnings.warn(
+                "'sample_weight' was deprecated in version 1.21 and "
+                "will be removed in 1.23.",
+                FutureWarning
+            )
+            sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
+        else:
+            sample_weight = None
 
         labels = _labels_inertia_threadpool_limit(
             X,

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1064,7 +1064,7 @@ class _BaseKMeans(
             warnings.warn(
                 "'sample_weight' was deprecated in version 1.3 and "
                 "will be removed in 1.5.",
-                FutureWarning
+                FutureWarning,
             )
             sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
         else:

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1068,7 +1068,7 @@ class _BaseKMeans(
             )
             sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
         else:
-            sample_weight = None
+            sample_weight = _check_sample_weight(None, X, dtype=X.dtype)
 
         labels = _labels_inertia_threadpool_limit(
             X,

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1048,9 +1048,9 @@ class _BaseKMeans(
             The weights for each observation in X. If None, all observations
             are assigned equal weight.
 
-            .. deprecated:: 1.21
-           ``sample_weight`` was deprecated in version 1.21 and will be removed
-           in 1.23.
+            .. deprecated:: 1.3
+           ``sample_weight`` was deprecated in version 1.3 and will be removed
+           in 1.5.
 
         Returns
         -------
@@ -1062,8 +1062,8 @@ class _BaseKMeans(
         X = self._check_test_data(X)
         if sample_weight != "deprecated":
             warnings.warn(
-                "'sample_weight' was deprecated in version 1.21 and "
-                "will be removed in 1.23.",
+                "'sample_weight' was deprecated in version 1.3 and "
+                "will be removed in 1.5.",
                 FutureWarning
             )
             sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -225,21 +225,11 @@ def test_algorithm_auto_full_deprecation_warning(algorithm):
         assert kmeans._algorithm == "lloyd"
 
 
-def test_predict_sample_weight_deprecation_warning(algorithm):
+@pytest.mark.parametrize("Estimator", [KMeans, MiniBatchKMeans])
+def test_predict_sample_weight_deprecation_warning(Estimator):
     X = np.random.rand(100, 2)
     sample_weight = np.random.uniform(size=100)
-    # test for kmeans
-    kmeans = KMeans()
-    kmeans.fit(X, sample_weight=sample_weight)
-    with pytest.warns(
-        FutureWarning,
-        match=(
-            "'sample_weight' was deprecated in version 1.3 and will be removed in 1.5.",
-        ),
-    ):
-        kmeans.predict(X, sample_weight=sample_weight)
-    # test for batch kmeans
-    kmeans = MiniBatchKMeans()
+    kmeans = Estimator()
     kmeans.fit(X, sample_weight=sample_weight)
     with pytest.warns(
         FutureWarning,

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -225,6 +225,33 @@ def test_algorithm_auto_full_deprecation_warning(algorithm):
         assert kmeans._algorithm == "lloyd"
 
 
+def test_predict_sample_weight_deprecation_warning(algorithm):
+    X = np.random.rand(100, 2)
+    sample_weight = np.random.uniform(size=100)
+    # test for kmeans
+    kmeans = KMeans()
+    kmeans.fit(X, sample_weight=sample_weight)
+    with pytest.warns(
+        FutureWarning,
+        match=(
+            "'sample_weight' was deprecated in version 1.3 and "
+            "will be removed in 1.5.",
+        ),
+    ):
+        kmeans.predict(X, sample_weight=sample_weight)
+    # test for batch kmeans
+    kmeans = MiniBatchKMeans()
+    kmeans.fit(X, sample_weight=sample_weight)
+    with pytest.warns(
+        FutureWarning,
+        match=(
+            "'sample_weight' was deprecated in version 1.3 and "
+            "will be removed in 1.5.",
+        ),
+    ):
+        kmeans.predict(X, sample_weight=sample_weight)
+
+
 def test_minibatch_update_consistency(global_random_seed):
     # Check that dense and sparse minibatch update give the same results
     rng = np.random.RandomState(global_random_seed)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -234,8 +234,7 @@ def test_predict_sample_weight_deprecation_warning(algorithm):
     with pytest.warns(
         FutureWarning,
         match=(
-            "'sample_weight' was deprecated in version 1.3 and "
-            "will be removed in 1.5.",
+            "'sample_weight' was deprecated in version 1.3 and will be removed in 1.5.",
         ),
     ):
         kmeans.predict(X, sample_weight=sample_weight)
@@ -245,8 +244,7 @@ def test_predict_sample_weight_deprecation_warning(algorithm):
     with pytest.warns(
         FutureWarning,
         match=(
-            "'sample_weight' was deprecated in version 1.3 and "
-            "will be removed in 1.5.",
+            "'sample_weight' was deprecated in version 1.3 and will be removed in 1.5.",
         ),
     ):
         kmeans.predict(X, sample_weight=sample_weight)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -232,7 +232,7 @@ def test_predict_sample_weight_deprecation_warning(Estimator):
     kmeans = Estimator()
     kmeans.fit(X, sample_weight=sample_weight)
     warn_msg = (
-        "'sample_weight' was deprecated in version 1.3 and will be removed in 1.5.",
+        "'sample_weight' was deprecated in version 1.3 and will be removed in 1.5."
     )
     with pytest.warns(FutureWarning, match=warn_msg):
         kmeans.predict(X, sample_weight=sample_weight)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -233,9 +233,7 @@ def test_predict_sample_weight_deprecation_warning(Estimator):
     kmeans.fit(X, sample_weight=sample_weight)
     with pytest.warns(
         FutureWarning,
-        match=(
-            "'sample_weight' was deprecated in version 1.3 and will be removed in 1.5.",
-        ),
+        match="'sample_weight' was deprecated in version 1.3 and will be removed in 1.5.",
     ):
         kmeans.predict(X, sample_weight=sample_weight)
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -231,10 +231,10 @@ def test_predict_sample_weight_deprecation_warning(Estimator):
     sample_weight = np.random.uniform(size=100)
     kmeans = Estimator()
     kmeans.fit(X, sample_weight=sample_weight)
-    with pytest.warns(
-        FutureWarning,
-        match="'sample_weight' was deprecated in version 1.3 and will be removed in 1.5.",
-    ):
+    warn_msg = (
+        "'sample_weight' was deprecated in version 1.3 and will be removed in 1.5.",
+    )
+    with pytest.warns(FutureWarning, match=warn_msg):
         kmeans.predict(X, sample_weight=sample_weight)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #25066

#### What does this implement/fix? Explain your changes.
Deprecation of `sample_weight` parameter in `predict` method for KMeans