### PR TITLE
MAINT Parameters validation for sklearn.metrics.det_curve

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -392,6 +392,15 @@ def confusion_matrix(
     return cm
 
 
+@validate_params(
+    {
+        "y_true": ["array-like", "sparse matrix"],
+        "y_pred": ["array-like", "sparse matrix"],
+        "sample_weight": ["array-like", None],
+        "labels": ["array-like", None],
+        "samplewise": ["boolean"],
+    }
+)
 def multilabel_confusion_matrix(
     y_true, y_pred, *, sample_weight=None, labels=None, samplewise=False
 ):

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -34,7 +34,7 @@ from ..utils import column_or_1d, check_array
 from ..utils.multiclass import type_of_target
 from ..utils.extmath import stable_cumsum
 from ..utils.sparsefuncs import count_nonzero
-from ..utils._param_validation import Interval, validate_params
+from ..utils._param_validation import validate_params
 from ..exceptions import UndefinedMetricWarning
 from ..preprocessing import label_binarize
 from ..utils._encode import _encode, _unique
@@ -243,7 +243,7 @@ def average_precision_score(
     {
         "y_true": ["array-like"],
         "y_score": ["array-like"],
-        "pos_label": [Interval(Integral, str, None, closed="left"), None],
+        "pos_label": [Integral, str, None],
         "sample_weight": ["array-like", None],
     }
 )

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -21,7 +21,7 @@ the lower the better.
 
 import warnings
 from functools import partial
-from numbers import Real
+from numbers import Real, Integral
 
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
@@ -34,7 +34,7 @@ from ..utils import column_or_1d, check_array
 from ..utils.multiclass import type_of_target
 from ..utils.extmath import stable_cumsum
 from ..utils.sparsefuncs import count_nonzero
-from ..utils._param_validation import validate_params
+from ..utils._param_validation import Interval, validate_params
 from ..exceptions import UndefinedMetricWarning
 from ..preprocessing import label_binarize
 from ..utils._encode import _encode, _unique
@@ -239,6 +239,14 @@ def average_precision_score(
     )
 
 
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_score": ["array-like"],
+        "pos_label": ["array-like", None],
+        "sample_weight": [Interval(Integral, 1, None, closed="left"), None],
+    }
+)
 def det_curve(y_true, y_score, pos_label=None, sample_weight=None):
     """Compute error rates for different probability thresholds.
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -243,8 +243,8 @@ def average_precision_score(
     {
         "y_true": ["array-like"],
         "y_score": ["array-like"],
-        "pos_label": ["array-like", None],
-        "sample_weight": [Interval(Integral, 1, None, closed="left"), None],
+        "pos_label": [Interval(Integral, str, None, closed="left"), None],
+        "sample_weight": ["array-like", None],
     }
 )
 def det_curve(y_true, y_score, pos_label=None, sample_weight=None):

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -107,7 +107,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.auc",
     "sklearn.metrics.cohen_kappa_score",
     "sklearn.metrics.confusion_matrix",
-    "sklearn.metrics.det_curve"
+    "sklearn.metrics.det_curve",
     "sklearn.metrics.mean_absolute_error",
     "sklearn.metrics.mean_tweedie_deviance",
     "sklearn.metrics.multilabel_confusion_matrix",

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -107,6 +107,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.auc",
     "sklearn.metrics.cohen_kappa_score",
     "sklearn.metrics.confusion_matrix",
+    "sklearn.metrics.det_curve"
     "sklearn.metrics.mean_absolute_error",
     "sklearn.metrics.mean_tweedie_deviance",
     "sklearn.metrics.multilabel_confusion_matrix",

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -109,7 +109,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.confusion_matrix",
     "sklearn.metrics.mean_absolute_error",
     "sklearn.metrics.mean_tweedie_deviance",
-    "sklearn.metrics.multilabel_confusion_matrix"
+    "sklearn.metrics.multilabel_confusion_matrix",
     "sklearn.metrics.mutual_info_score",
     "sklearn.metrics.r2_score",
     "sklearn.metrics.roc_curve",

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -109,6 +109,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.confusion_matrix",
     "sklearn.metrics.mean_absolute_error",
     "sklearn.metrics.mean_tweedie_deviance",
+    "sklearn.metrics.multilabel_confusion_matrix"
     "sklearn.metrics.mutual_info_score",
     "sklearn.metrics.r2_score",
     "sklearn.metrics.roc_curve",


### PR DESCRIPTION
Reference Issues/PRs

Towards #24862 
What does this implement/fix? Explain your changes.

Added the validate_params decorator for sklearn.metrics.det_curve