### PR TITLE
ENH KBinsDiscretizer sample_weight support for kmeans strategy

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -89,9 +89,9 @@ Changelog
 - |Enhancement| Added support for `sample_weight` in
   :class:`preprocessing.KBinsDiscretizer`. This allows specifying the parameter
   `sample_weight` for each sample to be used while fitting. The option is only
-  available when `strategy` is set to `quantile`.
+  available when `strategy` is set to `quantile` and `kmeans`.
   :pr:`24935` by :user:`Seladus <seladus>`, :user:`Guillaume Lemaitre <glemaitre>`, and
-  :user:`Dea María Léon <deamarialeon>`.
+  :user:`Dea María Léon <deamarialeon>`, :pr:`25257` by :user:`Gleb Levitski <glevv>`.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -243,8 +243,8 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         elif sample_weight is not None and self.strategy == "uniform":
             raise ValueError(
-                "`sample_weight` was provided but it can only be "
-                "used with strategy='quantile'. Got strategy="
+                "`sample_weight` was provided but it cannot be "
+                "used with strategy='uniform'. Got strategy="
                 f"{self.strategy!r} instead."
             )
 
@@ -291,7 +291,9 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
                 # 1D k-means procedure
                 km = KMeans(n_clusters=n_bins[jj], init=init, n_init=1)
-                centers = km.fit(column[:, None], sample_weight).cluster_centers_[:, 0]
+                centers = km.fit(
+                    column[:, None], sample_weight=sample_weight
+                ).cluster_centers_[:, 0]
                 # Must sort, centers may be unsorted even with sorted init
                 centers.sort()
                 bin_edges[jj] = (centers[1:] + centers[:-1]) * 0.5

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -241,7 +241,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                 '`subsample` must be used with `strategy="quantile"`.'
             )
 
-        elif sample_weight is not None and self.strategy != "quantile":
+        elif sample_weight is not None and self.strategy == "uniform":
             raise ValueError(
                 "`sample_weight` was provided but it can only be "
                 "used with strategy='quantile'. Got strategy="
@@ -291,7 +291,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
                 # 1D k-means procedure
                 km = KMeans(n_clusters=n_bins[jj], init=init, n_init=1)
-                centers = km.fit(column[:, None]).cluster_centers_[:, 0]
+                centers = km.fit(column[:, None], sample_weight).cluster_centers_[:, 0]
                 # Must sort, centers may be unsorted even with sorted init
                 centers.sort()
                 bin_edges[jj] = (centers[1:] + centers[:-1]) * 0.5

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -37,6 +37,16 @@ X = [[-2, 1.5, -4, -1], [-1, 2.5, -3, -0.5], [0, 3.5, -2, 0.5], [1, 4.5, -1, 2]]
             [[0, 0, 0, 0], [0, 0, 0, 0], [1, 1, 1, 1], [1, 1, 1, 1]],
             [0, 1, 1, 1],
         ),
+        (
+            "kmeans",
+            [[0, 0, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1], [2, 2, 2, 2]],
+            [1, 0, 2, 1],
+        ),
+        (
+            "kmeans",
+            [[0, 0, 0, 0], [0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]],
+            [1, 1, 1, 1],
+        ),
     ],
 )
 def test_fit_transform(strategy, expected, sample_weight):
@@ -51,7 +61,7 @@ def test_valid_n_bins():
     assert KBinsDiscretizer(n_bins=2).fit(X).n_bins_.dtype == np.dtype(int)
 
 
-@pytest.mark.parametrize("strategy", ["uniform", "kmeans"])
+@pytest.mark.parametrize("strategy", ["uniform"])
 def test_kbinsdiscretizer_wrong_strategy_with_weights(strategy):
     """Check that we raise an error when the wrong strategy is used."""
     sample_weight = np.ones(shape=(len(X)))
@@ -130,6 +140,11 @@ def test_invalid_n_bins_array():
         #       `sample_weight = [1, 1, 1, 1]` are currently not equivalent.
         #       This problem has been adressed in issue :
         #       https://github.com/scikit-learn/scikit-learn/issues/17370
+        (
+            "kmeans",
+            [[0, 0, 0, 0], [0, 1, 1, 0], [1, 1, 1, 1], [1, 2, 2, 2]],
+            [1, 0, 2, 1],
+        ),
     ],
 )
 def test_fit_transform_n_bins_array(strategy, expected, sample_weight):
@@ -157,9 +172,10 @@ def test_kbinsdiscretizer_effect_sample_weight():
     assert_allclose(est.transform(X), [[0.0], [1.0], [2.0], [2.0], [2.0], [2.0]])
 
 
-def test_kbinsdiscretizer_no_mutating_sample_weight():
+@pytest.mark.parametrize("strategy", ["kmeans", "quantile"])
+def test_kbinsdiscretizer_no_mutating_sample_weight(strategy):
     """Make sure that `sample_weight` is not changed in place."""
-    est = KBinsDiscretizer(n_bins=3, encode="ordinal", strategy="quantile")
+    est = KBinsDiscretizer(n_bins=3, encode="ordinal", strategy=strategy)
     sample_weight = np.array([1, 3, 1, 2], dtype=np.float64)
     sample_weight_copy = np.copy(sample_weight)
     est.fit(X, sample_weight=sample_weight)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -40,7 +40,7 @@ X = [[-2, 1.5, -4, -1], [-1, 2.5, -3, -0.5], [0, 3.5, -2, 0.5], [1, 4.5, -1, 2]]
         (
             "kmeans",
             [[0, 0, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1], [2, 2, 2, 2]],
-            [1, 0, 2, 1],
+            [1, 0, 3, 1],
         ),
         (
             "kmeans",
@@ -67,7 +67,7 @@ def test_kbinsdiscretizer_wrong_strategy_with_weights(strategy):
     sample_weight = np.ones(shape=(len(X)))
     est = KBinsDiscretizer(n_bins=3, strategy=strategy)
     err_msg = (
-        "`sample_weight` was provided but it can only be used with strategy='quantile'."
+        "`sample_weight` was provided but it cannot be used with strategy='uniform'."
     )
     with pytest.raises(ValueError, match=err_msg):
         est.fit(X, sample_weight=sample_weight)
@@ -143,7 +143,7 @@ def test_invalid_n_bins_array():
         (
             "kmeans",
             [[0, 0, 0, 0], [0, 1, 1, 0], [1, 1, 1, 1], [1, 2, 2, 2]],
-            [1, 0, 2, 1],
+            [1, 0, 3, 1],
         ),
     ],
 )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #25231

#### What does this implement/fix? Explain your changes.
Adding support for `sample_weight` parameter when `strategy='kmeans'` in `KBinsDiscretizer`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
