### PR TITLE
DOC include a reference to `kernel_approximation` in SVC/SVR docstring

### DIFF
--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -559,7 +559,8 @@ class SVC(BaseSVC):
     beyond tens of thousands of samples. For large datasets
     consider using :class:`~sklearn.svm.LinearSVC` or
     :class:`~sklearn.linear_model.SGDClassifier` instead, possibly after a
-    :class:`~sklearn.kernel_approximation.Nystroem` transformer.
+    :class:`~sklearn.kernel_approximation.Nystroem` transformer or
+    other :ref:`kernel_approximation`.
 
     The multiclass support is handled according to a one-vs-one scheme.
 
@@ -1110,7 +1111,8 @@ class SVR(RegressorMixin, BaseLibSVM):
     to scale to datasets with more than a couple of 10000 samples. For large
     datasets consider using :class:`~sklearn.svm.LinearSVR` or
     :class:`~sklearn.linear_model.SGDRegressor` instead, possibly after a
-    :class:`~sklearn.kernel_approximation.Nystroem` transformer.
+    :class:`~sklearn.kernel_approximation.Nystroem` transformer or
+    other :ref:`kernel_approximation`.
 
     Read more in the :ref:`User Guide <svm_regression>`.
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #23524

#### What does this implement/fix? Explain your changes.
Includes a reference to `kernel_approximation` in the docstring.

#### Any other comments?