### PR TITLE
MAINT Parameters validation for sklearn.model_selection.check_cv

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2402,6 +2402,13 @@ class _CVIterableWrapper(BaseCrossValidator):
             yield train, test
 
 
+@validate_params(
+    {
+        "cv": ["cv_object"],
+        "y": ["array-like", None],
+        "classifier": ["boolean"],
+    }
+)
 def check_cv(cv=5, y=None, *, classifier=False):
     """Input checker utility for building a cross-validator.
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2402,13 +2402,9 @@ class _CVIterableWrapper(BaseCrossValidator):
             yield train, test
 
 
-@validate_params(
-    {
-        "cv": ["cv_object"],
-        "y": ["array-like", None],
-        "classifier": ["boolean"],
-    }
-)
+@validate_params({
+    "cv": ["cv_object"], "y": ["array-like", None], "classifier": ["boolean"]
+})
 def check_cv(cv=5, y=None, *, classifier=False):
     """Input checker utility for building a cross-validator.
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2456,13 +2456,7 @@ def check_cv(cv=5, y=None, *, classifier=False):
         else:
             return KFold(cv)
 
-    if not hasattr(cv, "split") or isinstance(cv, str):
-        if not isinstance(cv, Iterable) or isinstance(cv, str):
-            raise ValueError(
-                "Expected cv as an integer, cross-validation "
-                "object (from sklearn.model_selection) "
-                "or an iterable. Got %s." % cv
-            )
+    if not hasattr(cv, "split"):
         return _CVIterableWrapper(cv)
 
     return cv  # New style cv objects are passed without any modification

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -119,6 +119,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.r2_score",
     "sklearn.metrics.roc_curve",
     "sklearn.metrics.zero_one_loss",
+    "sklearn.model_selection.check_cv",
     "sklearn.model_selection.train_test_split",
     "sklearn.svm.l1_min_c",
 ]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24862 


#### What does this implement/fix? Explain your changes.
Parameter validation for `model_selection.check_cv`.


#### Any other comments?
The `"cv_object"` check for `cv` should be the correct check for this param. This check catches something more wrt the previous implementation which could have let something like `cv=-1` pass, since this value error would have been caught by `_BaseKFold`.
Also removes some additional checks which aren't required anymore thanks to `"cv_object"`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
