### PR TITLE
MNT Enable O3 optimization for trees

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -418,10 +418,15 @@ extension_config = {
         },
     ],
     "tree": [
-        {"sources": ["_tree.pyx"], "language": "c++", "include_np": True},
-        {"sources": ["_splitter.pyx"], "include_np": True},
-        {"sources": ["_criterion.pyx"], "include_np": True},
-        {"sources": ["_utils.pyx"], "include_np": True},
+        {
+            "sources": ["_tree.pyx"],
+            "language": "c++",
+            "include_np": True,
+            "optimization_level": "O3",
+        },
+        {"sources": ["_splitter.pyx"], "include_np": True, "optimization_level": "O3"},
+        {"sources": ["_criterion.pyx"], "include_np": True, "optimization_level": "O3"},
+        {"sources": ["_utils.pyx"], "include_np": True, "optimization_level": "O3"},
     ],
     "utils": [
         {"sources": ["sparsefuncs_fast.pyx"], "include_np": True},
@@ -503,15 +508,14 @@ def configure_extension_modules():
 
     is_pypy = platform.python_implementation() == "PyPy"
     np_include = numpy.get_include()
+    default_optimization_level = "O2"
 
-    optimization_level = "O2"
     if os.name == "posix":
-        default_extra_compile_args = [f"-{optimization_level}"]
         default_libraries = ["m"]
     else:
-        default_extra_compile_args = [f"/{optimization_level}"]
         default_libraries = []
 
+    default_extra_compile_args = []
     build_with_debug_symbols = (
         os.environ.get("SKLEARN_BUILD_ENABLE_DEBUG_SYMBOLS", "0") != "0"
     )
@@ -574,6 +578,14 @@ def configure_extension_modules():
             extra_compile_args = (
                 extension.get("extra_compile_args", []) + default_extra_compile_args
             )
+            optimization_level = extension.get(
+                "optimization_level", default_optimization_level
+            )
+            if os.name == "posix":
+                extra_compile_args.append(f"-{optimization_level}")
+            else:
+                extra_compile_args.append(f"/{optimization_level}")
+
             libraries_ext = extension.get("libraries", []) + default_libraries
 
             new_ext = Extension(


### PR DESCRIPTION
This PR re-enables O3 optimization for trees, because there is a measurable difference between O2 and O3. Here is the result of the ASV benchmark with random forest:

```bash
export SKLBENCH_PROFILE=large_scale
asv continuous  -b RandomForestClassifierBenchmark.time_fit main tree_o3
asv compare main tree_o3
```

```
       before           after         ratio
     [ce00ba81]       [40141f9d]
     <main>       <tree_o3>
       25.5±0.05s       23.5±0.07s     0.92  ensemble.RandomForestClassifierBenchmark.time_fit('dense', 1)
       28.5±0.04s       28.3±0.02s     0.99  ensemble.RandomForestClassifierBenchmark.time_fit('sparse', 1)
```

Note that O3 was enabled by default for trees in `1.1.X`: https://github.com/scikit-learn/scikit-learn/blob/1.1.X/sklearn/tree/setup.py