### PR TITLE
TST use global_random_seed in sklearn/cluster/tests/test_hierarchical.py

### DIFF
--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -50,9 +50,9 @@ from sklearn.utils._testing import assert_array_equal
 from sklearn.datasets import make_moons, make_circles
 
 
-def test_linkage_misc():
+def test_linkage_misc(global_random_seed):
     # Misc tests on linkage
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     X = rng.normal(size=(5, 5))
 
     with pytest.raises(ValueError):
@@ -280,9 +280,9 @@ def test_agglomerative_clustering_memory_mapped():
     AgglomerativeClustering(metric="euclidean", linkage="single").fit(Xmm)
 
 
-def test_ward_agglomeration():
+def test_ward_agglomeration(global_random_seed):
     # Check that we obtain the correct solution in a simplistic case
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
     mask = np.ones([10, 10], dtype=bool)
     X = rng.randn(50, 100)
     connectivity = grid_to_graph(*mask.shape)
@@ -468,13 +468,13 @@ def test_connectivity_propagation():
     ward.fit(X)
 
 
-def test_ward_tree_children_order():
+def test_ward_tree_children_order(global_random_seed):
     # Check that children are ordered in the same way for both structured and
     # unstructured versions of ward_tree.
 
     # test on five random datasets
     n, p = 10, 5
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
 
     connectivity = np.ones((n, n))
     for i in range(5):
@@ -764,8 +764,8 @@ def test_agglomerative_clustering_with_distance_threshold(linkage):
         assert np.array_equiv(clusters_produced, clusters_at_threshold)
 
 
-def test_small_distance_threshold():
-    rng = np.random.RandomState(0)
+def test_small_distance_threshold(global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     n_samples = 10
     X = rng.randint(-300, 300, size=(n_samples, 3))
     # this should result in all data in their own clusters, given that
@@ -781,8 +781,8 @@ def test_small_distance_threshold():
     assert clustering.n_clusters_ == n_samples
 
 
-def test_cluster_distances_with_distance_threshold():
-    rng = np.random.RandomState(0)
+def test_cluster_distances_with_distance_threshold(global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     n_samples = 100
     X = rng.randint(-10, 10, size=(n_samples, 3))
     # check the distances within the clusters and with other clusters

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -50,9 +50,9 @@ from sklearn.utils._testing import assert_array_equal
 from sklearn.datasets import make_moons, make_circles
 
 
-def test_linkage_misc(global_random_seed):
+def test_linkage_misc():
     # Misc tests on linkage
-    rng = np.random.RandomState(global_random_seed)
+    rng = np.random.RandomState(42)
     X = rng.normal(size=(5, 5))
 
     with pytest.raises(ValueError):
@@ -330,10 +330,10 @@ def assess_same_labelling(cut1, cut2):
     assert (co_clust[0] == co_clust[1]).all()
 
 
-def test_sparse_scikit_vs_scipy():
+def test_sparse_scikit_vs_scipy(global_random_seed):
     # Test scikit linkage with full connectivity (i.e. unstructured) vs scipy
     n, p, k = 10, 5, 3
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
 
     # Not using a lil_matrix here, just to check that non sparse
     # matrices are well handled
@@ -370,10 +370,9 @@ def test_sparse_scikit_vs_scipy():
 
 # Make sure our custom mst_linkage_core gives
 # the same results as scipy's builtin
-@pytest.mark.parametrize("seed", range(5))
-def test_vector_scikit_single_vs_scipy_single(seed):
+def test_vector_scikit_single_vs_scipy_single(global_random_seed):
     n_samples, n_features, n_clusters = 10, 5, 3
-    rng = np.random.RandomState(seed)
+    rng = np.random.RandomState(global_random_seed)
     X = 0.1 * rng.normal(size=(n_samples, n_features))
     X -= 4.0 * np.arange(n_samples)[:, np.newaxis]
     X -= X.mean(axis=1)[:, np.newaxis]
@@ -488,13 +487,13 @@ def test_ward_tree_children_order(global_random_seed):
         assert_array_equal(out_unstructured[0], out_structured[0])
 
 
-def test_ward_linkage_tree_return_distance():
+def test_ward_linkage_tree_return_distance(global_random_seed):
     # Test return_distance option on linkage and ward trees
 
     # test that return_distance when set true, gives same
     # output on both structured and unstructured clustering.
     n, p = 10, 5
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
 
     connectivity = np.ones((n, n))
     for i in range(5):
@@ -726,10 +725,10 @@ def test_affinity_passed_to_fix_connectivity():
 
 
 @pytest.mark.parametrize("linkage", ["ward", "complete", "average"])
-def test_agglomerative_clustering_with_distance_threshold(linkage):
+def test_agglomerative_clustering_with_distance_threshold(linkage, global_random_seed):
     # Check that we obtain the correct number of clusters with
     # agglomerative clustering with distance_threshold.
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
     mask = np.ones([10, 10], dtype=bool)
     n_samples = 100
     X = rng.randn(n_samples, 50)

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -176,10 +176,10 @@ def test_agglomerative_clustering_distances(
         assert not hasattr(clustering, "distances_")
 
 
-def test_agglomerative_clustering():
+def test_agglomerative_clustering(global_random_seed):
     # Check that we obtain the correct number of clusters with
     # agglomerative clustering.
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
     mask = np.ones([10, 10], dtype=bool)
     n_samples = 100
     X = rng.randn(n_samples, 50)


### PR DESCRIPTION
#### Reference Issues/PRs
towards #22827


#### What does this implement/fix? Explain your changes.
I used the global_random_seed fixture in the `sklearn/cluster/tests/test_hierarchical.py` module where I thought it's appropriate in accordance with the description of the referenced issue. 

A few comments about tests where I at first thought the global_random_seed fixture would be useful but didn't apply it:
 
`test_agglomerative_clustering_memory_mapped` and `test_mst_linkage_core_memory_mapped`.
In the documentation of the numpy `memmap` function on which these tests are based it is said, "Memory-mapped files are used for accessing small segments of large files on disk, without reading the entire file into memory." (for reference see [here](https://numpy.org/doc/stable/reference/generated/numpy.memmap.html)). Therefore I thought the global_random_seed fixture could be useful in these two tests because changing the seed might result in a different small segment being chosen (but I'm not sure if this is correct). When I applied this fixture to these two tests, all tests passed but the former test ran in 1.83 s on my machine (Apple M1 Pro) and the latter ran in 14 s. Because of the rather long run time, I didn't apply the fixture in these tests.

I also tried applying the fixture to the function `test_ward_linkage_tree_return_distance` and all tests ran successfully. However, the run time on my machine was 1.4 s and I therefore decided against applying this fixture here. 

#### Any other comments?
#PyLadiesParis
I started working on this issue during the PyLadies Paris scikit-learn sprint on 8 Dec 2022. 