### PR TITLE
FIX Conditionally resolve metric deprecated by SciPy

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1661,7 +1661,7 @@ _VALID_METRICS = [
 # but to `sklearn.metrics.DistanceMetric`.
 _SCIPY_DEPRECATED_METRICS = (
     # Kulsinski has been deprecated in SciPy 1.8 and removed in SciPy 1.11.
-    *(["kulsinski"] if sp_version >= parse_version("1.11") else ()),
+    *(["kulsinski"] if sp_version >= parse_version("1.8") else ()),
 )
 
 _NAN_METRICS = ["nan_euclidean"]

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -2068,8 +2068,6 @@ PAIRWISE_BOOLEAN_FUNCTIONS = [
     "dice",
     "jaccard",
     # Kulsinski has been deprecated in SciPy 1.8 and removed in SciPy 1.11.
-    # If it is not included in this list, it will not be supported via
-    # scipy.spatial.distance but it will via sklearn.metrics.DistanceMetric.
     # TODO: remove this line once only scipy>=1.11 is supported.
     *(["kulsinski"] if sp_version < parse_version("1.11") else ()),
     "matching",

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -2069,7 +2069,7 @@ PAIRWISE_BOOLEAN_FUNCTIONS = [
     "jaccard",
     # Kulsinski has been deprecated in SciPy 1.8 and removed in SciPy 1.11.
     # TODO: remove this line once only scipy>=1.11 is supported.
-    *(["kulsinski"] if sp_version < parse_version("1.11") else ()),
+    *(["kulsinski"] if sp_version < parse_version("1.11.0.dev") else ()),
     "matching",
     "rogerstanimoto",
     "russellrao",

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -131,6 +131,9 @@ def test_cdist(metric_param_grid, X, Y):
     "X_bool, Y_bool", [(X_bool, Y_bool), (X_bool_mmap, Y_bool_mmap)]
 )
 def test_cdist_bool_metric(metric, X_bool, Y_bool):
+    if metric == "kulsinski" and sp_version >= parse_version("1.11.0.dev"):
+        pytest.skip("Kulsinski has been removed in SciPy 1.11.")
+
     D_scipy_cdist = cdist(X_bool, Y_bool, metric)
 
     dm = DistanceMetric.get_metric(metric)
@@ -251,6 +254,9 @@ def test_distance_metrics_dtype_consistency(metric_param_grid):
 @pytest.mark.parametrize("metric", BOOL_METRICS)
 @pytest.mark.parametrize("X_bool", [X_bool, X_bool_mmap])
 def test_pdist_bool_metrics(metric, X_bool):
+    if metric == "kulsinski" and sp_version >= parse_version("1.11.0.dev"):
+        pytest.skip("Kulsinski has been removed in SciPy 1.11.")
+
     D_scipy_pdist = cdist(X_bool, X_bool, metric)
     dm = DistanceMetric.get_metric(metric)
     D_sklearn = dm.pairwise(X_bool)
@@ -293,6 +299,9 @@ def test_pickle(writable_kwargs, metric_param_grid, X):
 @pytest.mark.parametrize("metric", BOOL_METRICS)
 @pytest.mark.parametrize("X_bool", [X_bool, X_bool_mmap])
 def test_pickle_bool_metrics(metric, X_bool):
+    if metric == "kulsinski" and sp_version >= parse_version("1.11"):
+        pytest.skip("Kulsinski has been removed in SciPy 1.11.")
+
     dm = DistanceMetric.get_metric(metric)
     D1 = dm.pairwise(X_bool)
     dm2 = pickle.loads(pickle.dumps(dm))


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #25202.
Alternative to #25212.

#### What does this implement/fix? Explain your changes.

SciPy might deprecated some distance metrics overtime, so with need to have condtional fallback for deprecated metrics. This is currently the case for `"kulsinski"`.

This adds a fallback on `DistanceMetric{,32}`.

Note that for now, the newly introduced
`DistanceMetric{,32}` fallback has precedence over the `scipy.spatial.distance` fallback, but this must not be the case.

One way to remove this precedence would be to check for metric inclusion in a list equals to
`scipy.spatial.distance._METRICS_NAMES` (which can't be imported unfortunately :slightly_frowning_face:  ).

Hence the proposed `_SCIPY_DEPRECATED_METRICS`.

#### Any other comments?

I guess we need to coordinate with the team of SciPy to correctly address distance metric resolution on the long term. What do you think?