### PR TITLE
FIX `transform_output` set in `config_context` not preserved in the Transformer object?

### DIFF
--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -175,6 +175,12 @@ class _SetOutputMixin:
     `auto_wrap_output_keys` is the default value.
     """
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        transform_output = get_config()["transform_output"]
+        if transform_output != "default":
+            self.set_output(transform=transform_output)
+
     def __init_subclass__(cls, auto_wrap_output_keys=("transform",), **kwargs):
         super().__init_subclass__(**kwargs)
 

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -174,6 +174,12 @@ def test__get_output_config():
         config = _get_output_config("transform", est)
         assert config["dense"] == "default"
 
+    with config_context(transform_output="pandas"):
+        est = EstimatorWithSetOutput()
+    config = _get_output_config("transform", est)
+    assert config["dense"] == "pandas"
+
+    est = EstimatorWithSetOutput()
     est.set_output(transform="pandas")
     config = _get_output_config("transform", est)
     assert config["dense"] == "pandas"


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes: https://github.com/scikit-learn/scikit-learn/issues/25287


#### What does this implement/fix? Explain your changes.

Implements the idea from https://github.com/scikit-learn/scikit-learn/issues/25287, to provide a default init `_SetOutputMixin` to capture the `transform_output` if not `default`. But I'm obviously open to suggestions for better solution, and I'm happy to adjust this PR.
