### PR TITLE
ENH Raise NotFittedError in get_feature_names_out for AdditiveChi2Sampler

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -41,6 +41,7 @@ Changes impacting all modules
   raises a `NotFittedError` if the instance is not fitted. This ensures the error is 
   consistent in all estimators with the `get_feature_names_out` method.
 
+  - :class:`kernel_approximation.AdditiveChi2Sampler`
   - :class:`sklearn.preprocessing.Binarizer`
   - :class:`sklearn.preprocessing.MaxAbsScaler`
   - :class:`sklearn.preprocessing.MinMaxScaler`
@@ -55,7 +56,8 @@ Changes impacting all modules
   The `NotFittedError` displays an informative message asking to fit the instance 
   with the appropriate arguments.
 
-  :pr:`25294` by :user:`John Pangas <jpangas>`.
+  :pr:`25294` by :user:`John Pangas <jpangas>` and :pr:`25291` by
+  :user:`Rahil Parikh <rprkh>`.
 
 Changelog
 ---------

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -743,6 +743,7 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
         feature_names_out : ndarray of str objects
             Transformed feature names.
         """
+        check_is_fitted(self, "n_features_in_")
         input_features = _check_feature_names_in(
             self, input_features, generate_names=True
         )

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -463,7 +463,6 @@ ESTIMATORS_WITH_GET_FEATURE_NAMES_OUT = [
 ]
 
 WHITELISTED_FAILING_ESTIMATORS = [
-    "AdditiveChi2Sampler",
     "DictVectorizer",
     "GaussianRandomProjection",
     "GenericUnivariateSelect",


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #24916

#### What does this implement/fix? Explain your changes.
Included `check_is_fitted` in `get_feature_names_out` for AdditiveChi2Sampler

#### Any other comments?
Test passes `pytest -vsl sklearn/tests/test_common.py -k estimators_get_feature_names_out_error`