### PR TITLE
FIX Fixes transform wrappig in _SetOutputMixin

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -20,7 +20,7 @@ Changelog
   :user:`Benjamin Bossan <BenjaminBossan>`.
 
 - |Fix| Inheriting from :class:`base.TransformerMixin` will only wrap the `transform`
-  method if the class defines `transform` itself. :pr:`xxxxx` by `Thomas Fan`_.
+  method if the class defines `transform` itself. :pr:`25295` by `Thomas Fan`_.
 
 :mod:`sklearn.linear_model`
 ...........................

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -19,6 +19,9 @@ Changelog
   certain estimators to be pickled when using Python 3.11. :pr:`25188` by
   :user:`Benjamin Bossan <BenjaminBossan>`.
 
+- |Fix| Inheriting from :class:`base.TransformerMixin` will only wrap the `transform`
+  method if the class defines `transform` itself. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -200,6 +200,10 @@ class _SetOutputMixin:
             if not hasattr(cls, method) or key not in auto_wrap_output_keys:
                 continue
             cls._sklearn_auto_wrap_output_keys.add(key)
+
+            # Only wrap methods defined by cls itself
+            if method not in cls.__dict__:
+                continue
             wrapped_method = _wrap_method_output(getattr(cls, method), key)
             setattr(cls, method, wrapped_method)
 

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -247,7 +247,7 @@ def test_set_output_mro():
 
     class Base(_SetOutputMixin):
         def transform(self, X):
-            return "Base"
+            return "Base"  # noqa
 
     class A(Base):
         pass

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -237,3 +237,26 @@ def test__wrap_in_pandas_container_column_errors():
     X_np = np.asarray([[1, 3], [2, 4], [3, 5]])
     X_wrapped = _wrap_in_pandas_container(X_np, columns=get_columns)
     assert_array_equal(X_wrapped.columns, range(X_np.shape[1]))
+
+
+def test_set_output_mro():
+    """Check that multi-inheritance resolves to the correct class method.
+
+    Non-regression test gh-25293.
+    """
+
+    class Base(_SetOutputMixin):
+        def transform(self, X):
+            return "Base"
+
+    class A(Base):
+        pass
+
+    class B(Base):
+        def transform(self, X):
+            return "B"
+
+    class C(A, B):
+        pass
+
+    assert C().transform(None) == "B"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/25293


#### What does this implement/fix? Explain your changes.
This PR forces `_SetOutputMixin` to wrap methods defined by the class.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
