### PR TITLE
MAINT update sklearn-ci email to ci@scikit-learn.org

### DIFF
--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -56,7 +56,7 @@ then
 	git rm -rf $dir/ && rm -rf $dir/
 fi
 cp -R $GENERATED_DOC_DIR $dir
-git config user.email "olivier.grisel+sklearn-ci@gmail.com"
+git config user.email "ci@scikit-learn.org"
 git config user.name $USERNAME
 git config push.default matching
 git add -f $dir/


### PR DESCRIPTION
I created a new email alias on our DNS config for scikit-learn.org on gandi.net instead of using my personal email address.

The `sklearn-ci` is used to push the generated documentation from circle ci workers to the github.com/scikit-learn/scikit-learn.github.io repo.

At the moment I am the only one on the alias but I would be glad to add any other volunteer maintainer to it to increase the bus factor for the management of this technical account (e.g. for password resets).