### PR TITLE
CI fix test in scipy-dev build following deprecation of array elementwise comparison with string

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1060,7 +1060,7 @@ class _BaseKMeans(
         check_is_fitted(self)
 
         X = self._check_test_data(X)
-        if sample_weight != "deprecated":
+        if not (isinstance(sample_weight, str) and sample_weight == "deprecated"):
             warnings.warn(
                 "'sample_weight' was deprecated in version 1.3 and "
                 "will be removed in 1.5.",


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This fixes one of the issue seen in https://github.com/scikit-learn/scikit-learn/issues/25202

In numpy dev version, this is now an error.

```py
import numpy as np
arr = np.array([1, 2])

bool(arr != 'deprecated')
```

With this PR the following pytest command passes:
```
pytest sklearn/cluster/tests/test_k_means.py -k sample_weight_deprecation
```