### PR TITLE
FIX Add stride to `y` in `_ger_memview`

### DIFF
--- a/sklearn/utils/_cython_blas.pyx
+++ b/sklearn/utils/_cython_blas.pyx
@@ -165,7 +165,7 @@ cdef void _ger(BLAS_Order order, int m, int n, floating alpha, floating *x,
             dger(&m, &n, &alpha, x, &incx, y, &incy, A, &lda)
 
 
-cpdef _ger_memview(floating alpha, floating[::1] x, floating[::] y,
+cpdef _ger_memview(floating alpha, floating[::1] x, floating[::1] y,
                    floating[:, :] A):
     cdef:
         int m = A.shape[0]


### PR DESCRIPTION
There was a missing `1` in the striding of `y` in `_ger_memview`. This adds it.

<hr>

For more context the increment of `y` (`incy`) is `1` below

https://github.com/scikit-learn/scikit-learn/blob/b0e6ee4671bca17e565a78c6aae6cc817f4f7ee4/sklearn/utils/_cython_blas.pyx#L176

Note `incy` follows `y` in the signature definition

https://github.com/scikit-learn/scikit-learn/blob/b0e6ee4671bca17e565a78c6aae6cc817f4f7ee4/sklearn/utils/_cython_blas.pyx#L153-L154