### PR TITLE
DOC fix typo in euclidean_distances in `metrics/pairwise.py`

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -277,7 +277,7 @@ def euclidean_distances(
 
     See Also
     --------
-    paired_distances : Distances betweens pairs of elements of X and Y.
+    paired_distances : Distances between pairs of elements of X and Y.
 
     Notes
     -----


### PR DESCRIPTION

https://github.com/scikit-learn/scikit-learn/blob/9e08ed2279c80407f1d4c92a27279f73a2d08bb2/sklearn/metrics/pairwise.py#L280

Remove `s` from `betweens`.

`Distances betweens pairs of elements of X and Y. ` to
`Distances between pairs of elements of X and Y. `

#### Reference Issues/PRs

NA

#### What does this implement/fix? Explain your changes.

Fixes a typo.

#### Any other comments?

Thank you for your time to review this PR!