### PR TITLE
DOC document how to generate a valid CIRCLE_CI_TOKEN

### DIFF
--- a/.github/workflows/trigger-hosting.yml
+++ b/.github/workflows/trigger-hosting.yml
@@ -21,6 +21,14 @@ jobs:
       - name: Trigger hosting jobs
         run: bash build_tools/github/trigger_hosting.sh
         env:
+          # Note: the CIRCLE_CI_TOKEN needs to be a user token instead of a
+          # project-wide token created using:
+          #
+          # https://support.circleci.com/hc/en-us/articles/360050351292-How-to-Trigger-a-Workflow-via-CircleCI-API-v2
+          #
+          # At the time of writing, secrets.CIRCLE_CI_TOKEN is valued with a
+          # token created using the ogrisel circleci account using:
+          # https://app.circleci.com/settings/user/tokens
           CIRCLE_CI_TOKEN: ${{ secrets.CIRCLE_CI_TOKEN }}
           EVENT: ${{ github.event.workflow_run.event }}
           RUN_ID: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
We started getting a permission denied message when running `build_tools/github/trigger_hosting.sh` on all new builds:

```
curl --request POST --url https://circleci.com/api/v2/project/gh/scikit-learn/scikit-learn/pipeline --header 'Circle-Token: ***' --header 'content-type: application/json' --header 'x-attribution-actor-id: github_actions' --header 'x-attribution-login: github_actions' --data '{"branch":"main","parameters":{"GITHUB_RUN_URL":"https://nightly.link/scikit-learn/scikit-learn/actions/runs/3872020543"}}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
{
100   159  100    37  100   122    323   1067 --:--:-- --:--:-- --:--:--  1407
  "message" : "Permission denied"
}
```

see for instance: https://github.com/scikit-learn/scikit-learn/actions/runs/3872313863/jobs/6601020506

I updated the github actions secret with a new personal circle ci token generated using my account. This PR adds a comment to the config file to make this more explicit.