### PR TITLE
DOC fix typo in doc/developers/contributing.rst (#25343)

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1412,7 +1412,7 @@ Reading the existing code base
 ==============================
 
 Reading and digesting an existing code base is always a difficult exercise
-that takes time and experience to main. Even though we try to write simple
+that takes time and experience to master. Even though we try to write simple
 code in general, understanding the code can seem overwhelming at first,
 given the sheer size of the project. Here is a list of tips that may help
 make this task easier and faster (in no particular order).


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #25343.


#### What does this implement/fix? Explain your changes.
Fixes a typo in the contributing docs - in the following sentence it changes `main` to `master`: 

'Reading and digesting an existing code base is always a difficult exercise that takes time and experience to main.'
