### PR TITLE
CI Only run cirrus on the scikit-learn repo

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -6,8 +6,8 @@ load("cirrus", "env", "fs", "http")
 def main(ctx):
     # Only run for scikit-learn/scikit-learn. For debugging on a fork, you can
     # comment out the following condition.
-    # if env.get("CIRRUS_REPO_FULL_NAME") != "scikit-learn/scikit-learn":
-    #    return []
+    if env.get("CIRRUS_REPO_FULL_NAME") != "scikit-learn/scikit-learn":
+        return []
 
     arm_wheel_yaml = "build_tools/cirrus/arm_wheel.yml"
 


### PR DESCRIPTION
This PR forces the cirrus build to only run on the `scikit-learn/scikit-learn` repo and not forks.