### PR TITLE
TST Fixes set random seed for test_multinomial_binary_probabilities

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -249,8 +249,10 @@ def test_multinomial_binary(solver):
 def test_multinomial_binary_probabilities():
     # Test multinomial LR gives expected probabilities based on the
     # decision function, for a binary problem.
-    X, y = make_classification()
-    clf = LogisticRegression(multi_class="multinomial", solver="saga", tol=1e-3)
+    X, y = make_classification(random_state=42)
+    clf = LogisticRegression(
+        multi_class="multinomial", solver="saga", tol=1e-3, random_state=42
+    )
     clf.fit(X, y)
 
     decision = clf.decision_function(X)


### PR DESCRIPTION
This `test_multinomial_binary_probabilities` [failed](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=50719&view=logs&jobId=aabdcdc3-bb64-5414-b357-ed024fe8659e&j=aabdcdc3-bb64-5414-b357-ed024fe8659e&t=b7b3ba55-d585-563b-a032-f235636c22b0) in https://github.com/scikit-learn/scikit-learn/pull/25349 because of convergence issues. This PR stabilizes the test by setting the `random_state`.