### PR TITLE
MAINT always seed make_classification in tests

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -246,12 +246,15 @@ def test_multinomial_binary(solver):
     assert np.mean(pred == target) > 0.9
 
 
-def test_multinomial_binary_probabilities():
+def test_multinomial_binary_probabilities(global_random_seed):
     # Test multinomial LR gives expected probabilities based on the
     # decision function, for a binary problem.
-    X, y = make_classification(random_state=42)
+    X, y = make_classification(random_state=global_random_seed)
     clf = LogisticRegression(
-        multi_class="multinomial", solver="saga", tol=1e-3, random_state=42
+        multi_class="multinomial",
+        solver="saga",
+        tol=1e-3,
+        random_state=global_random_seed,
     )
     clf.fit(X, y)
 

--- a/sklearn/neighbors/tests/test_nca.py
+++ b/sklearn/neighbors/tests/test_nca.py
@@ -97,7 +97,7 @@ def test_finite_differences(global_random_seed):
     """
     # Initialize the transformation `M`, as well as `X` and `y` and `NCA`
     rng = np.random.RandomState(global_random_seed)
-    X, y = make_classification(global_random_seed)
+    X, y = make_classification(random_state=global_random_seed)
     M = rng.randn(rng.randint(1, X.shape[1] + 1), X.shape[1])
     nca = NeighborhoodComponentsAnalysis()
     nca.n_iter_ = 0
@@ -111,7 +111,7 @@ def test_finite_differences(global_random_seed):
 
     # compare the gradient to a finite difference approximation
     diff = check_grad(fun, grad, M.ravel())
-    assert diff == pytest.approx(0.0)
+    assert diff == pytest.approx(0.0, abs=1e-4)
 
 
 def test_params_validation():

--- a/sklearn/neighbors/tests/test_nca.py
+++ b/sklearn/neighbors/tests/test_nca.py
@@ -89,15 +89,15 @@ def test_toy_example_collapse_points():
     assert abs(loss_storer.loss + 1) < 1e-10
 
 
-def test_finite_differences():
+def test_finite_differences(global_random_seed):
     """Test gradient of loss function
 
     Assert that the gradient is almost equal to its finite differences
     approximation.
     """
     # Initialize the transformation `M`, as well as `X` and `y` and `NCA`
-    rng = np.random.RandomState(42)
-    X, y = make_classification()
+    rng = np.random.RandomState(global_random_seed)
+    X, y = make_classification(global_random_seed)
     M = rng.randn(rng.randint(1, X.shape[1] + 1), X.shape[1])
     nca = NeighborhoodComponentsAnalysis()
     nca.n_iter_ = 0
@@ -109,9 +109,9 @@ def test_finite_differences():
     def grad(M):
         return nca._loss_grad_lbfgs(M, X, mask)[1]
 
-    # compute relative error
-    rel_diff = check_grad(fun, grad, M.ravel()) / np.linalg.norm(grad(M))
-    np.testing.assert_almost_equal(rel_diff, 0.0, decimal=5)
+    # compare the gradient to a finite difference approximation
+    diff = check_grad(fun, grad, M.ravel())
+    assert diff == pytest.approx(0.0)
 
 
 def test_params_validation():

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -26,7 +26,11 @@ from sklearn.preprocessing import StandardScaler, MaxAbsScaler
 
 class DelegatorData:
     def __init__(
-        self, name, construct, skip_methods=(), fit_args=make_classification()
+        self,
+        name,
+        construct,
+        skip_methods=(),
+        fit_args=make_classification(random_state=0),
     ):
         self.name = name
         self.construct = construct


### PR DESCRIPTION
Follow-up on #25345 to:

- make sure all calls to `make_classification` in tests are seeded,
- use `global_random_seed` when appropriate.

I ran the impacted tests with `SKLEARN_TESTS_GLOBAL_RANDOM_SEED=all` locally.