### PR TITLE
CI Remove unused env var

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,6 @@ jobs:
         LOCK_FILE: './build_tools/azure/pylatest_pip_scipy_dev_linux-64_conda.lock'
         CHECK_WARNINGS: 'true'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        TEST_DOCSTRINGS: 'true'
         # Tests that require large downloads over the networks are skipped in CI.
         # Here we make sure, that they are still run on a regular basis.
         SKLEARN_SKIP_NETWORK_TESTS: '0'
@@ -201,7 +200,6 @@ jobs:
         DISTRIB: 'conda-pip-latest'
         LOCK_FILE: './build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        TEST_DOCSTRINGS: 'true'
         CHECK_WARNINGS: 'true'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '3'  # non-default seed
 

--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -22,7 +22,6 @@ jobs:
     SKLEARN_SKIP_NETWORK_TESTS: '1'
     PYTEST_XDIST_VERSION: 'latest'
     COVERAGE: 'false'
-    TEST_DOCSTRINGS: 'false'
     # Set in azure-pipelines.yml
     DISTRIB: ''
     DOCKER_CONTAINER: ''

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -24,7 +24,6 @@ jobs:
     CCACHE_COMPRESS: '1'
     PYTEST_XDIST_VERSION: 'latest'
     COVERAGE: 'true'
-    TEST_DOCSTRINGS: 'false'
     CREATE_ISSUE_ON_TRACKER: 'true'
     SHOW_SHORT_SUMMARY: 'false'
   strategy:


### PR DESCRIPTION
The env var `TEST_DOCSTRINGS` seems to have no impact. Despite defaulting to `false` and only set to `true` in 2 jobs, the docstrings are actually tested in almost all jobs (except windows and linux docker).

What controls that is in fact `addopts = --doctest-modules` in `setup.cfg`.
I'm not sure how they are disable on windows and linux docker but it probably has to do with `sklearn/conftest.py` ?

Anyway, this env var is not used anywhere in the project: these are all the 4 occurences. Just to be safe I also checked that it's not an env var that pytest would use.