### PR TITLE
DOC Adds logo back to navbar

### DIFF
--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -21,8 +21,8 @@
   {% endblock %}
   <link rel="canonical" href="http://scikit-learn.org/stable/{{pagename}}.html" />
 
-  {% if favicon %}
-  <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
+  {% if favicon_url %}
+  <link rel="shortcut icon" href="{{ favicon_url|e }}"/>
   {% endif %}
 
   <link rel="stylesheet" href="{{ pathto('_static/css/vendor/bootstrap.min.css', 1) }}" type="text/css" />

--- a/doc/themes/scikit-learn-modern/nav.html
+++ b/doc/themes/scikit-learn-modern/nav.html
@@ -34,11 +34,11 @@
 
 <nav id="navbar" class="{{ nav_bar_class }} navbar navbar-expand-md navbar-light bg-light py-0">
   <div class="container-fluid {{ top_container_cls }} px-0">
-    {%- if logo %}
+    {%- if logo_url %}
       <a class="navbar-brand py-0" href="{{ pathto('index') }}">
         <img
           class="sk-brand-img"
-          src="{{ pathto('_static/' + logo, 1) }}"
+          src="{{ logo_url|e }}"
           alt="logo"/>
       </a>
     {%- endif %}


### PR DESCRIPTION
The `logo` is not appearing in the [navbar on dev](https://scikit-learn.org/dev/) because `logo` has been renamed to `logo_url` in Sphinx.

The same thing applies to the `favicon`.