### PR TITLE
MAINT Parameters validation for cluster.ward_tree

### DIFF
--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -178,7 +178,7 @@ def _single_linkage_tree(
 @validate_params(
     {
         "X": ["array-like"],
-        "connectivity": ["sparse matrix", None],
+        "connectivity": ["array-like", "sparse matrix", None],
         "n_clusters": [Interval(Integral, 1, None, closed="left"), None],
         "return_distance": ["boolean"],
     }

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -178,7 +178,7 @@ def _single_linkage_tree(
 @validate_params(
     {
         "X": ["array-like"],
-        "connectivity": ["array-like", "sparse matrix", None],
+        "connectivity": ["sparse matrix", None],
         "n_clusters": [Interval(Integral, 1, None, closed="left"), None],
         "return_distance": ["boolean"],
     }

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -23,7 +23,13 @@ from ..metrics._dist_metrics import METRIC_MAPPING
 from ..utils import check_array
 from ..utils._fast_dict import IntFloatDict
 from ..utils.graph import _fix_connected_components
-from ..utils._param_validation import Hidden, Interval, StrOptions, HasMethods
+from ..utils._param_validation import (
+    Hidden,
+    Interval,
+    StrOptions,
+    HasMethods,
+    validate_params,
+)
 from ..utils.validation import check_memory
 
 # mypy error: Module 'sklearn.cluster' has no attribute '_hierarchical_fast'
@@ -169,6 +175,14 @@ def _single_linkage_tree(
 # Hierarchical tree building functions
 
 
+@validate_params(
+    {
+        "X": ["array-like"],
+        "connectivity": ["array-like", "sparse matrix", None],
+        "n_clusters": [Interval(Integral, 1, None, closed="left"), None],
+        "return_distance": ["boolean"],
+    }
+)
 def ward_tree(X, *, connectivity=None, n_clusters=None, return_distance=False):
     """Ward clustering based on a Feature matrix.
 

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -201,7 +201,7 @@ def ward_tree(X, *, connectivity=None, n_clusters=None, return_distance=False):
     X : array-like of shape (n_samples, n_features)
         Feature matrix representing `n_samples` samples to be clustered.
 
-    connectivity : sparse matrix, default=None
+    connectivity : {array-like, sparse matrix}, default=None
         Connectivity matrix. Defines for each sample the neighboring samples
         following a given structure of the data. The matrix is assumed to
         be symmetric and only the upper triangular half is used.

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -98,6 +98,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.cluster.compute_optics_graph",
     "sklearn.cluster.estimate_bandwidth",
     "sklearn.cluster.kmeans_plusplus",
+    "sklearn.cluster.ward_tree",
     "sklearn.covariance.empirical_covariance",
     "sklearn.covariance.shrunk_covariance",
     "sklearn.datasets.fetch_california_housing",


### PR DESCRIPTION
#### Reference Issues/PRs
Towards https://github.com/scikit-learn/scikit-learn/issues/24862

#### What does this implement/fix? Explain your changes.
This PR adds automatic parameter validation for sklearn.cluster.ward_tree

#### Any other comments?
I looked for tests within the function that could be removed, but they are not 'simple' tests - i.e. they depend on the input data.

I also ran `pytest -vl sklearn/tests/test_public_functions.py` and all tests pass (see screenshot below):

<img width="1174" alt="Screenshot 2023-01-12 at 19 05 48" src="https://user-images.githubusercontent.com/36704697/212207351-52d2c861-2ae5-43d4-a9b1-cc80de2f4ba7.png">
