### PR TITLE
MAINT fix typo in _t_sne.py and _middle_term_computer.pyx.tp

### DIFF
--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -566,7 +566,7 @@ class TSNE(BaseEstimator):
         is used in other manifold learning algorithms. Larger datasets
         usually require a larger perplexity. Consider selecting a value
         between 5 and 50. Different values can result in significantly
-        different results. The perplexity must be less that the number
+        different results. The perplexity must be less than the number
         of samples.
 
     early_exaggeration : float, default=12.0

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
@@ -41,7 +41,7 @@ from ...utils._typedefs import DTYPE, SPARSE_INDEX_TYPE
 # TODO: If possible optimize this routine to efficiently treat cases where
 # `n_samples_X << n_samples_Y` met in practise when X_test consists of a
 # few samples, and thus when there's a single chunk of X whose number of
-# samples is less that the default chunk size.
+# samples is less than the default chunk size.
 
 # TODO: compare this routine with the similar ones in SciPy, especially
 # `csr_matmat` which might implement a better algorithm.


### PR DESCRIPTION
Fixed a typo that appears in `_t_sne.py` and `_middle_term_computer.pyx.tp`: "less than" instead of "less that".