### PR TITLE
ENH Raise NotFittedError in get_feature_names_out for VotingClassifier and Voting Regressor

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -41,6 +41,8 @@ Changes impacting all modules
   raises a `NotFittedError` if the instance is not fitted. This ensures the error is
   consistent in all estimators with the `get_feature_names_out` method.
 
+  - :class:`ensemble.VotingClassifier`
+  - :class:`ensemble.VotingRegressor`
   - :class:`kernel_approximation.AdditiveChi2Sampler`
   - :class:`preprocessing.Binarizer`
   - :class:`preprocessing.MaxAbsScaler`
@@ -56,7 +58,7 @@ Changes impacting all modules
   The `NotFittedError` displays an informative message asking to fit the instance
   with the appropriate arguments.
 
-  :pr:`25294` by :user:`John Pangas <jpangas>` and :pr:`25291` by
+  :pr:`25294` by :user:`John Pangas <jpangas>` and :pr:`25291`, :pr:`xxxxx` by
   :user:`Rahil Parikh <rprkh>`.
 
 Changelog

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -452,6 +452,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         feature_names_out : ndarray of str objects
             Transformed feature names.
         """
+        check_is_fitted(self, "n_features_in_")
         if self.voting == "soft" and not self.flatten_transform:
             raise ValueError(
                 "get_feature_names_out is not supported when `voting='soft'` and "
@@ -647,6 +648,7 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         feature_names_out : ndarray of str objects
             Transformed feature names.
         """
+        check_is_fitted(self, "n_features_in_")
         _check_feature_names_in(self, input_features, generate_names=False)
         class_name = self.__class__.__name__.lower()
         return np.asarray(

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -486,8 +486,6 @@ WHITELISTED_FAILING_ESTIMATORS = [
     "StackingClassifier",
     "StackingRegressor",
     "VarianceThreshold",
-    "VotingClassifier",
-    "VotingRegressor",
 ]
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #24916

#### What does this implement/fix? Explain your changes.
Included `check_is_fitted` in `get_feature_names_out for` Voting Classifier and Voting Regressor

#### Any other comments?
Test passes `pytest -vsl sklearn/tests/test_common.py -k estimators_get_feature_names_out_error`