### PR TITLE
CI Adapt handling of discarded fused typed memoryview

### DIFF
--- a/sklearn/datasets/_svmlight_format_fast.pyx
+++ b/sklearn/datasets/_svmlight_format_fast.pyx
@@ -187,6 +187,7 @@ def _dump_svmlight_file(
     bint y_is_sp,
 ):
     cdef bint X_is_integral
+    cdef bint query_id_is_not_empty = query_id.size > 0
     X_is_integral = X.dtype.kind == "i"
     if X_is_integral:
         value_pattern = "%d:%d"
@@ -198,7 +199,7 @@ def _dump_svmlight_file(
         label_pattern = "%.16g"
 
     line_pattern = "%s"
-    if query_id is not None:
+    if query_id_is_not_empty:
         line_pattern += " qid:%d"
     line_pattern += " %s\n"
 
@@ -246,7 +247,7 @@ def _dump_svmlight_file(
             else:
                 labels_str = label_pattern % y[i,0]
 
-        if query_id is not None:
+        if query_id_is_not_empty:
             feat = (labels_str, query_id[i], s)
         else:
             feat = (labels_str, s)

--- a/sklearn/datasets/_svmlight_format_io.py
+++ b/sklearn/datasets/_svmlight_format_io.py
@@ -506,18 +506,18 @@ def dump_svmlight_file(
         if hasattr(X, "sort_indices"):
             X.sort_indices()
 
-    if query_id is not None:
+    if query_id is None:
+        # NOTE: query_id is passed to Cython functions using a fused type on query_id.
+        # Yet as of Cython>=3.0, memory views can't be None otherwise the runtime
+        # would not known which concrete implementation to dispatch the Python call to.
+        # TODO: simplify interfaces and implementations in _svmlight_format_fast.pyx.
+        query_id = np.array([], dtype=np.int32)
+    else:
         query_id = np.asarray(query_id)
         if query_id.shape[0] != y.shape[0]:
             raise ValueError(
                 "expected query_id of shape (n_samples,), got %r" % (query_id.shape,)
             )
-    else:
-        # NOTE: query_id is passed to Cython functions using fuse type.
-        # Yet as of Cython>=3.0, memory views can't be None otherwise the runtime
-        # would not known which concrete implementation to dispatch the Python call to.
-        # TODO: simplify interfaces and implementations in _svmlight_format_fast.pyx.
-        query_id = np.array([], dtype=np.int32)
 
     one_based = not zero_based
 

--- a/sklearn/datasets/_svmlight_format_io.py
+++ b/sklearn/datasets/_svmlight_format_io.py
@@ -512,6 +512,12 @@ def dump_svmlight_file(
             raise ValueError(
                 "expected query_id of shape (n_samples,), got %r" % (query_id.shape,)
             )
+    else:
+        # NOTE: query_id is passed to Cython functions using fuse type.
+        # Yet as of Cython>=3.0, memory views can't be None otherwise the runtime
+        # would not known which concrete implementation to dispatch the Python call to.
+        # TODO: simplify interfaces and implementations in _svmlight_format_fast.pyx.
+        query_id = np.array([], dtype=np.int32)
 
     one_based = not zero_based
 


### PR DESCRIPTION
#### Reference Issues/PRs

Partially address #25202 by making the following tests pass on `[scipy-dev]`:

<details>
<summary>Resolved tests</summary>

```
 → pytest sklearn/datasets/tests/test_svmlight_format.py -v --lf                                                                                                                                                                                              
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.11.0, pytest-7.2.0, pluggy-1.0.0 -- /home/jjerphan/.local/share/miniconda3/envs/sk/bin/python3.11                                                                                                                                  
cachedir: .pytest_cache                                                                                                                                                                                                                                       
rootdir: /home/jjerphan/dev/scikit-learn, configfile: setup.cfg                                                                                                                                                                                               
plugins: anyio-3.6.2                                                                                                                                                                                                                                          
collected 57 items / 21 deselected / 36 selected                                                                                                                                                                                                              
run-last-failure: rerun previous 36 failures                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                              
sklearn/datasets/tests/test_svmlight_format.py::test_dump PASSED                                                                                                                                                                                       [  2%] 
sklearn/datasets/tests/test_svmlight_format.py::test_dump_multilabel PASSED                                                                                                                                                                            [  5%] 
sklearn/datasets/tests/test_svmlight_format.py::test_dump_concise PASSED                                                                                                                                                                               [  8%] 
sklearn/datasets/tests/test_svmlight_format.py::test_dump_comment PASSED                                                                                                                                                                               [ 11%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_zeros PASSED                                                                                                                                                                                 [ 13%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-13-0] PASSED                                                                                                                                                                  [ 16%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-13-0.1] PASSED                                                                                                                                                                [ 19%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-13-0.5] PASSED                                                                                                                                                                [ 22%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-13-0.99] PASSED                                                                                                                                                               [ 25%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-13-1] PASSED                                                                                                                                                                  [ 27%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-101-0] PASSED                                                                                                                                                                 [ 30%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-101-0.1] PASSED                                                                                                                                                               [ 33%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-101-0.5] PASSED                                                                                                                                                               [ 36%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-101-0.99] PASSED                                                                                                                                                              [ 38%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[2-101-1] PASSED                                                                                                                                                                 [ 41%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-13-0] PASSED                                                                                                                                                                  [ 44%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-13-0.1] PASSED                                                                                                                                                                [ 47%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-13-0.5] PASSED                                                                                                                                                                [ 50%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-13-0.99] PASSED                                                                                                                                                               [ 52%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-13-1] PASSED                                                                                                                                                                  [ 55%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-101-0] PASSED                                                                                                                                                                 [ 58%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-101-0.1] PASSED                                                                                                                                                               [ 61%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-101-0.5] PASSED                                                                                                                                                               [ 63%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-101-0.99] PASSED                                                                                                                                                              [ 66%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[7-101-1] PASSED                                                                                                                                                                 [ 69%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-13-0] PASSED                                                                                                                                                                 [ 72%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-13-0.1] PASSED                                                                                                                                                               [ 75%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-13-0.5] PASSED                                                                                                                                                               [ 77%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-13-0.99] PASSED                                                                                                                                                              [ 80%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-13-1] PASSED                                                                                                                                                                 [ 83%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-101-0] PASSED                                                                                                                                                                [ 86%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-101-0.1] PASSED                                                                                                                                                              [ 88%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-101-0.5] PASSED                                                                                                                                                              [ 91%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-101-0.99] PASSED                                                                                                                                                             [ 94%] 
sklearn/datasets/tests/test_svmlight_format.py::test_load_with_offsets[41-101-1] PASSED                                                                                                                                                                [ 97%] 
sklearn/datasets/tests/test_svmlight_format.py::test_multilabel_y_explicit_zeros PASSED                                                                                                                                                                [100%] 
                                                                                                                                                                                                                                                              
======================================================================================================= 36 passed, 21 deselected, 14 warnings in 0.11s =======================================================================================================
```

</details>

#### What does this implement/fix? Explain your changes.

As of Cython>=3.0, memory views can't be None otherwise the runtime would not know which concrete implementation to dispatch the Python call to.

This simply adapt a call to pass an empty numpy array to resolve the concrete implementation of Cython functions using fused-types.



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
