### PR TITLE
MNT Reduces the number of runs for circleci redirector job

### DIFF
--- a/.github/workflows/artifact-redirector.yml
+++ b/.github/workflows/artifact-redirector.yml
@@ -1,7 +1,10 @@
+name: CircleCI artifacts redirector
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
+    # For testing this action on a fork, remove the "github.repository =="" condition.
+    if: "github.repository == 'scikit-learn/scikit-learn' && github.event.context == 'ci/circleci: doc'"
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step


### PR DESCRIPTION
This PR updates the redirector job with a name and reduces the number of runs with a `if` statement.

XREF: https://github.com/larsoner/circleci-artifacts-redirector-action#example-usage