### PR TITLE
DOC Improve visibility of warning message on example "Pitfalls in the interpretation of coefficients of linear models"

### DIFF
--- a/examples/inspection/plot_causal_interpretation.py
+++ b/examples/inspection/plot_causal_interpretation.py
@@ -124,8 +124,7 @@ coef = pd.concat(
 ax = coef.plot.barh()
 ax.set_xlabel("Coefficient values")
 ax.set_title("Coefficients of the linear regression including the ability features")
-plt.tight_layout()
-plt.show()
+_ = plt.tight_layout()
 
 # %%
 # Income prediction with partial observations
@@ -158,6 +157,8 @@ coef = pd.concat(
 ax = coef.plot.barh()
 ax.set_xlabel("Coefficient values")
 _ = ax.set_title("Coefficients of the linear regression excluding the ability feature")
+plt.tight_layout()
+plt.show()
 
 # %%
 # To compensate for the omitted variable, the model inflates the coefficient of

--- a/examples/inspection/plot_linear_model_coefficient_interpretation.py
+++ b/examples/inspection/plot_linear_model_coefficient_interpretation.py
@@ -19,6 +19,16 @@ This example will provide some hints in interpreting coefficient in linear
 models, pointing at problems that arise when either the linear model is not
 appropriate to describe the dataset, or when features are correlated.
 
+.. note::
+
+    Keep in mind that the features `X` and the outcome `y` are in general the
+    result of a data generating process that is unknown to us. Machine learning
+    models are trained to approximate the unobserved mathematical function that
+    links `X` to `y` from sample data. As a result, any interpretation made
+    about a model may not necessarily generalize to the true data generating
+    process. This is especially true when the model is of bad quality or when
+    the sample data is not representative of the population.
+
 We will use data from the `"Current Population Survey"
 <https://www.openml.org/d/534>`_ from 1985 to predict
 wage as a function of various features such as experience, age, or education.
@@ -728,18 +738,6 @@ plt.subplots_adjust(left=0.3)
 #
 # See the :ref:`sphx_glr_auto_examples_inspection_plot_causal_interpretation.py`
 # for a simulated case of ability OVB.
-#
-# Warning: data and model quality
-# -------------------------------
-#
-# Keep in mind that the outcome `y` and features `X` are the product
-# of a data generating process that is hidden from us. Machine
-# learning models are trained to approximate the unobserved
-# mathematical function that links `X` to `y` from sample data. As a
-# result, any interpretation made about a model may not necessarily
-# generalize to the true data generating process. This is especially
-# true when the model is of bad quality or when the sample data is
-# not representative of the population.
 #
 # Lessons learned
 # ---------------

--- a/examples/inspection/plot_linear_model_coefficient_interpretation.py
+++ b/examples/inspection/plot_linear_model_coefficient_interpretation.py
@@ -3,17 +3,16 @@
 Common pitfalls in the interpretation of coefficients of linear models
 ======================================================================
 
-In linear models, the target value is modeled as
-a linear combination of the features (see the :ref:`linear_model` User Guide
-section for a description of a set of linear models available in
-scikit-learn).
-Coefficients in multiple linear models represent the relationship between the
-given feature, :math:`X_i` and the target, :math:`y`, assuming that all the
-other features remain constant (`conditional dependence
-<https://en.wikipedia.org/wiki/Conditional_dependence>`_).
-This is different from plotting :math:`X_i` versus :math:`y` and fitting a
-linear relationship: in that case all possible values of the other features are
-taken into account in the estimation (marginal dependence).
+In linear models, the target value is modeled as a linear combination of the
+features (see the :ref:`linear_model` User Guide section for a description of a
+set of linear models available in scikit-learn). Coefficients in multiple linear
+models represent the relationship between the given feature, :math:`X_i` and the
+target, :math:`y`, assuming that all the other features remain constant
+(`conditional dependence
+<https://en.wikipedia.org/wiki/Conditional_dependence>`_). This is different
+from plotting :math:`X_i` versus :math:`y` and fitting a linear relationship: in
+that case all possible values of the other features are taken into account in
+the estimation (marginal dependence).
 
 This example will provide some hints in interpreting coefficient in linear
 models, pointing at problems that arise when either the linear model is not
@@ -21,17 +20,18 @@ appropriate to describe the dataset, or when features are correlated.
 
 .. note::
 
-    Keep in mind that the features `X` and the outcome `y` are in general the
-    result of a data generating process that is unknown to us. Machine learning
-    models are trained to approximate the unobserved mathematical function that
-    links `X` to `y` from sample data. As a result, any interpretation made
-    about a model may not necessarily generalize to the true data generating
-    process. This is especially true when the model is of bad quality or when
-    the sample data is not representative of the population.
+    Keep in mind that the features :math:`X` and the outcome :math:`y` are in
+    general the result of a data generating process that is unknown to us.
+    Machine learning models are trained to approximate the unobserved
+    mathematical function that links :math:`X` to :math:`y` from sample data. As
+    a result, any interpretation made about a model may not necessarily
+    generalize to the true data generating process. This is especially true when
+    the model is of bad quality or when the sample data is not representative of
+    the population.
 
 We will use data from the `"Current Population Survey"
-<https://www.openml.org/d/534>`_ from 1985 to predict
-wage as a function of various features such as experience, age, or education.
+<https://www.openml.org/d/534>`_ from 1985 to predict wage as a function of
+various features such as experience, age, or education.
 
 .. contents::
    :local:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

See #20451.

#### What does this implement/fix? Explain your changes.

As mentioned in [this comment](https://github.com/scikit-learn/scikit-learn/pull/20451#discussion_r1040749057), the warning message introduced in #20451 is quite relevant for passing the intended messages of the example. Therefore it would gain visibility if stated in the header instead of appearing in a section at the end of the example.

#### Any other comments?

I also took the opportunity to fix the second plot in [Failure of Machine Learning to infer causal effects notebook](https://scikit-learn.org/dev/auto_examples/inspection/plot_causal_interpretation.html), which was not rendering properly.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
