### PR TITLE
TST Actually compare feature importances when computed in parallel

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -329,6 +329,7 @@ def check_importances(name, criterion, dtype, tolerance):
     # Check with parallel
     importances = est.feature_importances_
     est.set_params(n_jobs=2)
+    est.fit(X, y)
     importances_parallel = est.feature_importances_
     assert_array_almost_equal(importances, importances_parallel)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Looks like the test was meant to compare feature importances with `n_jobs=1` and `n_jobs=2` but we were actually not calling `.fit` ...

Unless I am very tired and I am missing something subtle of course ...