### PR TITLE
TST Sets random_state for test_logistic.py

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1,6 +1,7 @@
 import itertools
 import os
 import warnings
+from functools import partial
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 from numpy.testing import assert_array_almost_equal, assert_array_equal
@@ -28,13 +29,16 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model._logistic import (
     _log_reg_scoring_path,
     _logistic_regression_path,
-    LogisticRegression,
-    LogisticRegressionCV,
+    LogisticRegression as LogisticRegressionDefault,
+    LogisticRegressionCV as LogisticRegressionCVDefault,
 )
 
 pytestmark = pytest.mark.filterwarnings(
     "error::sklearn.exceptions.ConvergenceWarning:sklearn.*"
 )
+# Fixing random_state helps prevent ConvergenceWarnings
+LogisticRegression = partial(LogisticRegressionDefault, random_state=0)
+LogisticRegressionCV = partial(LogisticRegressionCVDefault, random_state=0)
 
 
 SOLVERS = ("lbfgs", "liblinear", "newton-cg", "newton-cholesky", "sag", "saga")


### PR DESCRIPTION
As observed in https://github.com/scikit-learn/scikit-learn/pull/25445#issuecomment-1398632465, not setting the `random_state` can lead to convergence warnings for solvers that shuffle the data. In `test_logistic.py`, the `ConvergenceWarnings` are turned into errors, which can be unstable for package managers testing the code.

This PR sets the random state for all `LogisticRegression` and `LogisticRegressionCV` estimators in the test fail to try to prevent the convergence warnings. Note that the call can still change the `random_state` themselves:

```python
from sklearn.linear_model import LogisticRegression as LogisticRegressionDefault
from functools import partial

LogisticRegression = partial(LogisticRegression, random_state=0)

lr = LogisticRegression(random_state=20)
print(lr.random_state)
# 20
```