### PR TITLE
DOC Fix typo in alpha parameter description

### DIFF
--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -962,9 +962,8 @@ class SGDClassifier(BaseSGDClassifier):
 
     alpha : float, default=0.0001
         Constant that multiplies the regularization term. The higher the
-        value, the stronger the regularization.
-        Also used to compute the learning rate when set to `learning_rate` is
-        set to 'optimal'.
+        value, the stronger the regularization. Also used to compute the
+        learning rate when `learning_rate` is set to 'optimal'.
         Values must be in the range `[0.0, inf)`.
 
     l1_ratio : float, default=0.15


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixes a typo in the parameter description.