### PR TITLE
CI Update nogil lock file

### DIFF
--- a/build_tools/azure/python_nogil_lock.txt
+++ b/build_tools/azure/python_nogil_lock.txt
@@ -27,7 +27,7 @@ kiwisolver==1.4.4
     # via matplotlib
 matplotlib==3.6.2
     # via -r /scikit-learn/build_tools/azure/python_nogil_requirements.txt
-numpy==1.22.3
+numpy==1.24.0
     # via
     #   -r /scikit-learn/build_tools/azure/python_nogil_requirements.txt
     #   contourpy

--- a/build_tools/azure/python_nogil_requirements.txt
+++ b/build_tools/azure/python_nogil_requirements.txt
@@ -6,9 +6,7 @@
 # the latest cython will be picked up from PyPI, rather than the one from the
 # python-nogil index
 matplotlib
-# XXX temporary pin for numpy see
-# https://github.com/scikit-learn/scikit-learn/pull/25437 for more details
-numpy==1.22.3
+numpy
 scipy
 cython
 joblib


### PR DESCRIPTION
This is a follow-up of https://github.com/scikit-learn/scikit-learn/pull/25437 now that numpy 1.24.0 for nogil has been patched.

See https://github.com/colesbury/nogil/issues/102 for more details.