### PR TITLE
Added support for ZCA whitening algorithm in _fastica.py

### DIFF
--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -257,10 +257,10 @@ def fastica(
         Algorithm to use for whitening.
 
         - "pca" (Principal Component Analysis) enables pre-ICA
-        dimensionality reduction.
+          dimensionality reduction.
 
         - "zca" (Zero-Phase Component Analysis) yields whitened data
-        which is as close as possible to the original data.
+          which is as close as possible to the original data.
 
     random_state : int, RandomState instance or None, default=None
         Used to initialize ``w_init`` when not specified, with a
@@ -431,10 +431,10 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         Algorithm to use for whitening.
 
         - "pca" (Principal Component Analysis) enables pre-ICA
-        dimensionality reduction.
+          dimensionality reduction.
 
         - "zca" (Zero-Phase Component Analysis) yields whitened data
-        which is as close as possible to the original data.
+          which is as close as possible to the original data.
 
     random_state : int, RandomState instance or None, default=None
         Used to initialize ``w_init`` when not specified, with a

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -181,17 +181,6 @@ def test_fastica_simple(add_noise, global_random_seed, global_dtype):
         ica.fit(m.T)
 
 
-def test_fastica_nowhiten():
-    m = [[0, 1], [1, 0]]
-
-    # test for issue #697
-    ica = FastICA(n_components=1, whiten=False, random_state=0)
-    warn_msg = "Ignoring n_components with whiten=False."
-    with pytest.warns(UserWarning, match=warn_msg):
-        ica.fit(m)
-    assert hasattr(ica, "mixing_")
-
-
 def test_fastica_convergence_fail():
     # Test the FastICA algorithm on very simple data
     # (see test_non_square_fastica).
@@ -326,7 +315,7 @@ def test_fit_transform(global_random_seed, global_dtype):
         ("arbitrary-variance", 10, (10, 10)),
         ("unit-variance", 5, (10, 5)),
         ("unit-variance", 10, (10, 10)),
-        (False, 5, (10, 10)),
+        (False, 5, (10, 5)),
         (False, 10, (10, 10)),
     ],
 )


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR implements the Zero-Phase Component Analysis whitening method, as per Eq. 35 (p. 422) in Hyvarinen et al.'s [Independent component analysis: algorithms and applications](https://doi.org/10.1016/S0893-6080(00)00026-5). It can be selected via an additional parameter `whiten_alg` in `__init__`. 

#### Any other comments?
Unlike PCA, ZCA whitening does not allow dimensionality reduction, thus with the previous implementation it wasn't possible to extract fewer components than observed features.
Therefore, I've also modified the weight initialization to take into account non-square weight matrices. I've tested the correctness of the implementation visually, on noisy mixture with more observed features than source components.

#### Update
I had to delete `test_fastica_nowhiten`, since with my implementation is possible to extract less sources than features of the whitened data (i.e., it accounts for non-square matrices). For the same reason, I modified `test_inverse_transform`.