### PR TITLE
TST reduce warnings in test_logistic.py

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1380,13 +1380,13 @@ def test_elastic_net_coeffs():
     C = 2.0
     l1_ratio = 0.5
     coeffs = list()
-    for penalty in ("elasticnet", "l1", "l2"):
+    for penalty, ratio in (("elasticnet", l1_ratio), ("l1", None), ("l2", None)):
         lr = LogisticRegression(
             penalty=penalty,
             C=C,
             solver="saga",
             random_state=0,
-            l1_ratio=l1_ratio,
+            l1_ratio=ratio,
             tol=1e-3,
             max_iter=200,
         )
@@ -1807,7 +1807,7 @@ def test_penalty_none(solver):
     #   non-default value.
     # - Make sure setting penalty=None is equivalent to setting C=np.inf with
     #   l2 penalty.
-    X, y = make_classification(n_samples=1000, random_state=0)
+    X, y = make_classification(n_samples=1000, n_redundant=0, random_state=0)
 
     msg = "Setting penalty=None will ignore the C"
     lr = LogisticRegression(penalty=None, solver=solver, C=4)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #24819.

#### What does this implement/fix? Explain your changes.
This let's `pytest -x -Werror sklearn/linear_model/tests/test_logistic.py` run without error on my machine and setup.