### PR TITLE
MNT Remove allowed type for check_parameters_default_constructible

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3298,7 +3298,6 @@ def check_parameters_default_constructible(name, Estimator):
                 type(None),
                 type,
                 types.FunctionType,
-                joblib.Memory,
             }
             # Any numpy numeric such as np.int32.
             allowed_types.update(np.core.numerictypes.allTypes.values())


### PR DESCRIPTION
It seems like allowing `joblib.Memory` as default argument is not used anywhere. Let's see if the CI agrees.