### PR TITLE
CI Add linter display name in Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,7 @@ jobs:
       displayName: Install linters
     - bash: |
         ./build_tools/linting.sh
+      displayName: Run linters
 
 - template: build_tools/azure/posix.yml
   parameters:


### PR DESCRIPTION
Follow up of https://github.com/scikit-learn/scikit-learn/pull/25475

This adds a display name to be more explicit than the default "Bash" name: 
![image](https://user-images.githubusercontent.com/1680079/214844888-3907bdba-afde-4204-9b0b-3977fd390e88.png)
