### PR TITLE
DOC: more didactic examples of bisecting kmeans.

### DIFF
--- a/examples/cluster/plot_bisect_kmeans.py
+++ b/examples/cluster/plot_bisect_kmeans.py
@@ -41,7 +41,7 @@ clustering_algorithms = {
 
 # Make subplots for each variant
 fig, axs = plt.subplots(
-    len(clustering_algorithms), len(n_clusters_list), figsize=(15, 5)
+    len(clustering_algorithms), len(n_clusters_list), figsize=(12, 5)
 )
 
 axs = axs.T

--- a/examples/cluster/plot_bisect_kmeans.py
+++ b/examples/cluster/plot_bisect_kmeans.py
@@ -6,9 +6,9 @@ Bisecting K-Means and Regular K-Means Performance Comparison
 This example shows differences between Regular K-Means algorithm and Bisecting K-Means.
 
 While K-Means clusterings are different when with increasing n_clusters,
-Bisecting K-Means clustering builds on top of the previous ones. As a
-result, it tends to create clusters that have a more consistent
-large-scale structure across the clusters.
+Bisecting K-Means clustering builds on top of the previous ones. As a result, it
+tends to create clusters that have a more regular large-scale structure. This
+difference can be visually observed: for all numbers of clusters, there is a
 
 This difference can visually be observed: for all numbers of clusters,
 there is a dividing line cutting the overall data cloud in two for

--- a/examples/cluster/plot_bisect_kmeans.py
+++ b/examples/cluster/plot_bisect_kmeans.py
@@ -6,7 +6,7 @@ Bisecting K-Means and Regular K-Means Performance Comparison
 This example shows differences between Regular K-Means algorithm and Bisecting K-Means.
 
 While K-Means clusterings are different when with increasing n_clusters,
-Bisecting K-Means clustering build on top of the previous ones. As a
+Bisecting K-Means clustering builds on top of the previous ones. As a
 result, it tends to create clusters that have a more consistent
 large-scale structure across the clusters.
 

--- a/examples/cluster/plot_bisect_kmeans.py
+++ b/examples/cluster/plot_bisect_kmeans.py
@@ -9,10 +9,8 @@ While K-Means clusterings are different when with increasing n_clusters,
 Bisecting K-Means clustering builds on top of the previous ones. As a result, it
 tends to create clusters that have a more regular large-scale structure. This
 difference can be visually observed: for all numbers of clusters, there is a
-
-dividing line cutting the overall data cloud in two for BisectingKMeans, whereas
-regular K-Means results into a `Voronoi cell partitioning
-<https://en.wikipedia.org/wiki/Voronoi_cell>`_.
+dividing line cutting the overall data cloud in two for BisectingKMeans, which is not
+present for regular K-Means.
 
 """
 import matplotlib.pyplot as plt

--- a/examples/cluster/plot_bisect_kmeans.py
+++ b/examples/cluster/plot_bisect_kmeans.py
@@ -5,7 +5,7 @@ Bisecting K-Means and Regular K-Means Performance Comparison
 
 This example shows differences between Regular K-Means algorithm and Bisecting K-Means.
 
-While K-Means clusterings are different when with increasing n_clusters,
+While K-Means clusterings are different when increasing n_clusters,
 Bisecting K-Means clustering builds on top of the previous ones. As a result, it
 tends to create clusters that have a more regular large-scale structure. This
 difference can be visually observed: for all numbers of clusters, there is a

--- a/examples/cluster/plot_bisect_kmeans.py
+++ b/examples/cluster/plot_bisect_kmeans.py
@@ -6,9 +6,13 @@ Bisecting K-Means and Regular K-Means Performance Comparison
 This example shows differences between Regular K-Means algorithm and Bisecting K-Means.
 
 While K-Means clusterings are different when with increasing n_clusters,
-Bisecting K-Means clustering build on top of the previous ones.
+Bisecting K-Means clustering build on top of the previous ones. As a
+result, it tends to create clusters that have a more consistent
+large-scale structure across the clusters.
 
-This difference can visually be observed.
+This difference can visually be observed: for all number of clusters,
+there is a dividing line cutting the overall data cloud in two for
+BisectingKMeans, but not for regular KMeans.
 
 """
 import matplotlib.pyplot as plt
@@ -21,13 +25,13 @@ print(__doc__)
 
 
 # Generate sample data
-n_samples = 1000
+n_samples = 10000
 random_state = 0
 
 X, _ = make_blobs(n_samples=n_samples, centers=2, random_state=random_state)
 
 # Number of cluster centers for KMeans and BisectingKMeans
-n_clusters_list = [2, 3, 4, 5]
+n_clusters_list = [4, 8, 16]
 
 # Algorithms to compare
 clustering_algorithms = {

--- a/examples/cluster/plot_bisect_kmeans.py
+++ b/examples/cluster/plot_bisect_kmeans.py
@@ -10,7 +10,7 @@ Bisecting K-Means clustering build on top of the previous ones. As a
 result, it tends to create clusters that have a more consistent
 large-scale structure across the clusters.
 
-This difference can visually be observed: for all number of clusters,
+This difference can visually be observed: for all numbers of clusters,
 there is a dividing line cutting the overall data cloud in two for
 BisectingKMeans, but not for regular KMeans.
 

--- a/examples/cluster/plot_bisect_kmeans.py
+++ b/examples/cluster/plot_bisect_kmeans.py
@@ -10,9 +10,9 @@ Bisecting K-Means clustering builds on top of the previous ones. As a result, it
 tends to create clusters that have a more regular large-scale structure. This
 difference can be visually observed: for all numbers of clusters, there is a
 
-This difference can visually be observed: for all numbers of clusters,
-there is a dividing line cutting the overall data cloud in two for
-BisectingKMeans, but not for regular KMeans.
+dividing line cutting the overall data cloud in two for BisectingKMeans, whereas
+regular K-Means results into a `Voronoi cell partitioning
+<https://en.wikipedia.org/wiki/Voronoi_cell>`_.
 
 """
 import matplotlib.pyplot as plt


### PR DESCRIPTION
This difference can better visually be observed: for all number of clusters, there is a dividing line cutting the overall data cloud in two for BisectingKMeans, but not for regular KMeans.


Before:
![image](https://user-images.githubusercontent.com/208217/214950959-f81bf657-258f-49eb-9847-b0c479676ab5.png)

After:
![image](https://user-images.githubusercontent.com/208217/214950842-f430f08d-6da0-4bca-94f5-006cd74c231f.png)

