### PR TITLE
TST Allow callables as valid parameter regarding cloning estimator

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3299,6 +3299,7 @@ def check_parameters_default_constructible(name, Estimator):
                 type,
                 types.FunctionType,
                 joblib.Memory,
+                np.core._multiarray_umath._ArrayFunctionDispatcher,
             }
             # Any numpy numeric such as np.int32.
             allowed_types.update(np.core.numerictypes.allTypes.values())

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3297,12 +3297,18 @@ def check_parameters_default_constructible(name, Estimator):
                 type(None),
                 type,
             }
-
             # Any numpy numeric such as np.int32.
             allowed_types.update(np.core.numerictypes.allTypes.values())
 
-            allowed_value = type(init_param.default) in allowed_types or callable(
-                init_param.default
+            allowed_value = (
+                type(init_param.default) in allowed_types
+                or
+                # Although callables are mutable, we accept them as argument
+                # default value and trust that neither the implementation of
+                # the callable nor of the estimator changes the state of the
+                # callable, which is needed for consistency regarding
+                # pickling and unpickling objects.
+                callable(init_param.default)
             )
 
             assert allowed_value, (

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3306,18 +3306,15 @@ def check_parameters_default_constructible(name, Estimator):
                 # Although callables are mutable, we accept them as argument
                 # default value and trust that neither the implementation of
                 # the callable nor of the estimator changes the state of the
-                # callable, which is needed for consistency regarding
-                # pickling and unpickling objects.
+                # callable.
                 callable(init_param.default)
             )
 
             assert allowed_value, (
                 f"Parameter '{init_param.name}' of estimator "
                 f"'{Estimator.__name__}' is of type "
-                f"{type(init_param.default).__name__} which is not "
-                "allowed. All init parameters have to be immutable to "
-                "make cloning possible. Therefore we restrict the set of "
-                "legal types to "
+                f"{type(init_param.default).__name__} which is not allowed. "
+                f"'{init_param.name}' must be a callable or must be of type "
                 f"{set(type.__name__ for type in allowed_types)}."
             )
             if init_param.name not in params.keys():

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1,4 +1,3 @@
-import types
 import warnings
 import pickle
 import re
@@ -52,12 +51,11 @@ from ..pipeline import make_pipeline
 from ..exceptions import DataConversionWarning
 from ..exceptions import NotFittedError
 from ..exceptions import SkipTestWarning
-from ..externals._packaging.version import parse
 from ..model_selection import train_test_split
 from ..model_selection import ShuffleSplit
 from ..model_selection._validation import _safe_split
 from ..metrics.pairwise import rbf_kernel, linear_kernel, pairwise_distances
-from ..utils.fixes import sp_version, np_base_version
+from ..utils.fixes import sp_version
 from ..utils.fixes import parse_version
 from ..utils.validation import check_is_fitted
 from ..utils._param_validation import make_constraint
@@ -3298,20 +3296,16 @@ def check_parameters_default_constructible(name, Estimator):
                 tuple,
                 type(None),
                 type,
-                types.FunctionType,
-                joblib.Memory,
             }
-
-            if np_base_version > parse("1.24"):
-                # This is a workaround to support the change of type for NumPy function,
-                # which appeared in 1.25.0.dev.
-                # See: https://github.com/scikit-learn/scikit-learn/pull/25498
-                # TODO: Remove this branch once NumPy resolved the issue.
-                allowed_types.add(np.core._multiarray_umath._ArrayFunctionDispatcher)
 
             # Any numpy numeric such as np.int32.
             allowed_types.update(np.core.numerictypes.allTypes.values())
-            assert type(init_param.default) in allowed_types, (
+
+            allowed_value = type(init_param.default) in allowed_types or callable(
+                init_param.default
+            )
+
+            assert allowed_value, (
                 f"Parameter '{init_param.name}' of estimator "
                 f"'{Estimator.__name__}' is of type "
                 f"{type(init_param.default).__name__} which is not "

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -57,7 +57,7 @@ from ..model_selection import train_test_split
 from ..model_selection import ShuffleSplit
 from ..model_selection._validation import _safe_split
 from ..metrics.pairwise import rbf_kernel, linear_kernel, pairwise_distances
-from ..utils.fixes import sp_version, np_version
+from ..utils.fixes import sp_version, np_base_version
 from ..utils.fixes import parse_version
 from ..utils.validation import check_is_fitted
 from ..utils._param_validation import make_constraint
@@ -3302,7 +3302,7 @@ def check_parameters_default_constructible(name, Estimator):
                 joblib.Memory,
             }
 
-            if np_version > parse("1.24"):
+            if np_base_version > parse("1.24"):
                 # This is a workaround to support the change of type for NumPy function,
                 # which appeared in 1.25.0.dev.
                 # See: https://github.com/scikit-learn/scikit-learn/pull/25498

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -26,7 +26,6 @@ from ..externals._packaging.version import parse as parse_version
 np_version = parse_version(np.__version__)
 sp_version = parse_version(scipy.__version__)
 sp_base_version = parse_version(sp_version.base_version)
-np_base_version = parse_version(np_version.base_version)
 
 
 if sp_version >= parse_version("1.4"):

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -26,6 +26,7 @@ from ..externals._packaging.version import parse as parse_version
 np_version = parse_version(np.__version__)
 sp_version = parse_version(scipy.__version__)
 sp_base_version = parse_version(sp_version.base_version)
+np_base_version = parse_version(np_version.base_version)
 
 
 if sp_version >= parse_version("1.4"):


### PR DESCRIPTION
#### Reference Issues/PRs

Closes https://github.com/scikit-learn/scikit-learn/issues/25202.

Closes https://github.com/scikit-learn/scikit-learn/issues/25467.

#### What does this implement/fix? Explain your changes.

The behavior in NumPy slightly have changed with https://github.com/numpy/numpy/pull/23039/, and the type of NumPy functions (like np.mean) isn't `function` but `np._ArrayFunctionDispatcher`.

<details>
<summary>See the change of behavior</summary>

---

```python
import numpy as np
np.mean
```
With `numpy==1.24.1`:
```
function
```

With `numpy==1.25.0.dev0+363.gbb2769e12`:
```
numpy._ArrayFunctionDispatcher
```

---

</details>



This makes some test fail.

This commit makes accepting `np._ArrayFunctionDispatcher` as an allowed type

#### Any other comments?

