### PR TITLE
FIX make IsotonicRegression predict NumPy array

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -2,6 +2,39 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_1_2_2:
+
+Version 1.2.2
+=============
+
+**In development**
+
+The following estimators and functions, when fit with the same data and
+parameters, may produce different models from the previous version. This often
+occurs due to changes in the modelling logic (bug fixes or enhancements), or in
+random sampling procedures.
+
+Changed models
+--------------
+
+-
+
+Changes impacting all modules
+-----------------------------
+
+-
+
+Changelog
+---------
+
+:mod:`sklearn.isotonic`
+.......................
+
+- |Fix| Fixes a bug in :class:`isotonic.IsotonicRegression` where
+  :meth:`isotonic.IsotonicRegression.predict` would return a pandas DataFrame
+  when `set_output` would be fixed to `"pandas"`.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 .. _changes_1_2_1:
 
 Version 1.2.1

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -32,7 +32,7 @@ Changelog
 
 - |Fix| Fixes a bug in :class:`isotonic.IsotonicRegression` where
   :meth:`isotonic.IsotonicRegression.predict` would return a pandas DataFrame
-  when `set_output` would be fixed to `"pandas"`.
+  when the global configuration sets `transform_output="pandas"`.
   :pr:`25500` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 .. _changes_1_2_1:

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -33,7 +33,7 @@ Changelog
 - |Fix| Fixes a bug in :class:`isotonic.IsotonicRegression` where
   :meth:`isotonic.IsotonicRegression.predict` would return a pandas DataFrame
   when `set_output` would be fixed to `"pandas"`.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`25500` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 .. _changes_1_2_1:
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -361,6 +361,15 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         return self
 
     def _transform(self, T):
+        """`_transform` is called by both `transform` and `predict` methods.
+
+        Since `transform` is wrapped to output arrays of specific types (e.g.
+        NumPy arrays, pandas DataFrame), we cannot make `predict` call `transform`
+        directly.
+
+        The above behaviour could be changed in the future, if we decide to output
+        other type of arrays when calling `predict`.
+        """
         if hasattr(self, "X_thresholds_"):
             dtype = self.X_thresholds_.dtype
         else:

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -360,23 +360,7 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         self._build_f(X, y)
         return self
 
-    def transform(self, T):
-        """Transform new data by linear interpolation.
-
-        Parameters
-        ----------
-        T : array-like of shape (n_samples,) or (n_samples, 1)
-            Data to transform.
-
-            .. versionchanged:: 0.24
-               Also accepts 2d array with 1 feature.
-
-        Returns
-        -------
-        y_pred : ndarray of shape (n_samples,)
-            The transformed data.
-        """
-
+    def _transform(self, T):
         if hasattr(self, "X_thresholds_"):
             dtype = self.X_thresholds_.dtype
         else:
@@ -397,6 +381,24 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
 
         return res
 
+    def transform(self, T):
+        """Transform new data by linear interpolation.
+
+        Parameters
+        ----------
+        T : array-like of shape (n_samples,) or (n_samples, 1)
+            Data to transform.
+
+            .. versionchanged:: 0.24
+               Also accepts 2d array with 1 feature.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            The transformed data.
+        """
+        return self._transform(T)
+
     def predict(self, T):
         """Predict new data by linear interpolation.
 
@@ -410,7 +412,7 @@ class IsotonicRegression(RegressorMixin, TransformerMixin, BaseEstimator):
         y_pred : ndarray of shape (n_samples,)
             Transformed data.
         """
-        return self.transform(T)
+        return self._transform(T)
 
     # We implement get_feature_names_out here instead of using
     # `ClassNamePrefixFeaturesOutMixin`` because `input_features` are ignored.

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -5,6 +5,7 @@ import copy
 
 import pytest
 
+import sklearn
 from sklearn.datasets import make_regression
 from sklearn.isotonic import (
     check_increasing,
@@ -680,3 +681,24 @@ def test_get_feature_names_out(shape):
     assert isinstance(names, np.ndarray)
     assert names.dtype == object
     assert_array_equal(["isotonicregression0"], names)
+
+
+def test_isotonic_regression_output_predict():
+    """Check that `predict` does return the expected output type.
+
+    We need to check that `transform` will output a DataFrame and a NumPy array
+    when we set `transform_output` to `pandas`.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/25499
+    """
+    pd = pytest.importorskip("pandas")
+    X, y = make_regression(n_samples=10, n_features=1, random_state=42)
+    regressor = IsotonicRegression()
+    with sklearn.config_context(transform_output="pandas"):
+        regressor.fit(X, y)
+        X_trans = regressor.transform(X)
+        y_pred = regressor.predict(X)
+
+    assert isinstance(X_trans, pd.DataFrame)
+    assert isinstance(y_pred, np.ndarray)


### PR DESCRIPTION
closes #25499 

Make sure that `IsotonicRegression` outputs NumPy array when calling `predict`.
Since `predict` was calling `transform` then the wrapper setting the type of output was also called.

Here, we make a private `_transform` method, called by both `predict` and `transform`. We, therefore, avoid calling the output wrapper.