### PR TITLE
MAINT Remove -Wsign-compare warnings when compiling sklearn.tree._tree

### DIFF
--- a/sklearn/tree/_tree.pxd
+++ b/sklearn/tree/_tree.pxd
@@ -60,7 +60,7 @@ cdef class Tree:
                           SIZE_t n_node_samples,
                           double weighted_n_node_samples) nogil except -1
     cdef int _resize(self, SIZE_t capacity) nogil except -1
-    cdef int _resize_c(self, size_t capacity=*) nogil except -1
+    cdef int _resize_c(self, SIZE_t capacity=*) nogil except -1
 
     cdef cnp.ndarray _get_value_ndarray(self)
     cdef cnp.ndarray _get_node_ndarray(self)

--- a/sklearn/tree/_tree.pxd
+++ b/sklearn/tree/_tree.pxd
@@ -60,7 +60,7 @@ cdef class Tree:
                           SIZE_t n_node_samples,
                           double weighted_n_node_samples) nogil except -1
     cdef int _resize(self, SIZE_t capacity) nogil except -1
-    cdef int _resize_c(self, SIZE_t capacity=*) nogil except -1
+    cdef int _resize_c(self, size_t capacity=*) nogil except -1
 
     cdef cnp.ndarray _get_value_ndarray(self)
     cdef cnp.ndarray _get_node_ndarray(self)

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -13,6 +13,7 @@
 # License: BSD 3 clause
 
 from cpython cimport Py_INCREF, PyObject, PyTypeObject
+from cython cimport floating
 
 from libc.stdlib cimport free
 from libc.string cimport memcpy
@@ -243,7 +244,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                                          split.threshold, impurity, n_node_samples,
                                          weighted_n_node_samples)
 
-                if node_id == SIZE_MAX:
+                if <size_t> node_id == SIZE_MAX:
                     rc = -1
                     break
 
@@ -473,7 +474,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
                                  is_left, is_leaf,
                                  split.feature, split.threshold, impurity, n_node_samples,
                                  weighted_n_node_samples)
-        if node_id == SIZE_MAX:
+        if <size_t> node_id == SIZE_MAX:
             return -1
 
         # compute values also for split nodes (might become leafs later).
@@ -709,7 +710,7 @@ cdef class Tree:
         if capacity == self.capacity and self.nodes != NULL:
             return 0
 
-        if capacity == SIZE_MAX:
+        if <size_t> capacity == SIZE_MAX:
             if self.capacity == 0:
                 capacity = 3  # default initial value
             else:
@@ -1769,7 +1770,7 @@ cdef _build_pruned_tree(
                 node.impurity, node.n_node_samples,
                 node.weighted_n_node_samples)
 
-            if new_node_id == SIZE_MAX:
+            if <size_t> new_node_id == SIZE_MAX:
                 rc = -1
                 break
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -13,7 +13,6 @@
 # License: BSD 3 clause
 
 from cpython cimport Py_INCREF, PyObject, PyTypeObject
-from cython cimport floating
 
 from libc.stdlib cimport free
 from libc.string cimport memcpy

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -17,7 +17,7 @@ from cpython cimport Py_INCREF, PyObject, PyTypeObject
 from libc.stdlib cimport free
 from libc.string cimport memcpy
 from libc.string cimport memset
-from libc.stdint cimport SIZE_MAX
+from libc.stdint cimport INTPTR_MAX
 from libcpp.vector cimport vector
 from libcpp.algorithm cimport pop_heap
 from libcpp.algorithm cimport push_heap
@@ -180,7 +180,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
         cdef SIZE_t n_node_samples = splitter.n_samples
         cdef double weighted_n_node_samples
         cdef SplitRecord split
-        cdef size_t node_id
+        cdef SIZE_t node_id
 
         cdef double impurity = INFINITY
         cdef SIZE_t n_constant_features
@@ -243,7 +243,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                                          split.threshold, impurity, n_node_samples,
                                          weighted_n_node_samples)
 
-                if node_id == SIZE_MAX:
+                if node_id == INTPTR_MAX:
                     rc = -1
                     break
 
@@ -440,7 +440,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
                                     FrontierRecord* res) nogil except -1:
         """Adds node w/ partition ``[start, end)`` to the frontier. """
         cdef SplitRecord split
-        cdef size_t node_id
+        cdef SIZE_t node_id
         cdef SIZE_t n_node_samples
         cdef SIZE_t n_constant_features = 0
         cdef double min_impurity_decrease = self.min_impurity_decrease
@@ -473,7 +473,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
                                  is_left, is_leaf,
                                  split.feature, split.threshold, impurity, n_node_samples,
                                  weighted_n_node_samples)
-        if node_id == SIZE_MAX:
+        if node_id == INTPTR_MAX:
             return -1
 
         # compute values also for split nodes (might become leafs later).
@@ -700,7 +700,7 @@ cdef class Tree:
             with gil:
                 raise MemoryError()
 
-    cdef int _resize_c(self, SIZE_t capacity=SIZE_MAX) nogil except -1:
+    cdef int _resize_c(self, SIZE_t capacity=INTPTR_MAX) nogil except -1:
         """Guts of _resize
 
         Returns -1 in case of failure to allocate memory (and raise MemoryError)
@@ -709,7 +709,7 @@ cdef class Tree:
         if capacity == self.capacity and self.nodes != NULL:
             return 0
 
-        if <size_t> capacity == SIZE_MAX:
+        if capacity == INTPTR_MAX:
             if self.capacity == 0:
                 capacity = 3  # default initial value
             else:
@@ -745,7 +745,7 @@ cdef class Tree:
 
         if node_id >= self.capacity:
             if self._resize_c() != 0:
-                return SIZE_MAX
+                return INTPTR_MAX
 
         cdef Node* node = &self.nodes[node_id]
         node.impurity = impurity
@@ -1731,7 +1731,7 @@ cdef _build_pruned_tree(
 
     cdef:
         SIZE_t orig_node_id
-        size_t new_node_id
+        SIZE_t new_node_id
         SIZE_t depth
         SIZE_t parent
         bint is_left
@@ -1769,7 +1769,7 @@ cdef _build_pruned_tree(
                 node.impurity, node.n_node_samples,
                 node.weighted_n_node_samples)
 
-            if new_node_id == SIZE_MAX:
+            if new_node_id == INTPTR_MAX:
                 rc = -1
                 break
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -181,7 +181,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
         cdef SIZE_t n_node_samples = splitter.n_samples
         cdef double weighted_n_node_samples
         cdef SplitRecord split
-        cdef SIZE_t node_id
+        cdef size_t node_id
 
         cdef double impurity = INFINITY
         cdef SIZE_t n_constant_features
@@ -244,7 +244,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                                          split.threshold, impurity, n_node_samples,
                                          weighted_n_node_samples)
 
-                if <size_t> node_id == SIZE_MAX:
+                if node_id == SIZE_MAX:
                     rc = -1
                     break
 
@@ -441,7 +441,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
                                     FrontierRecord* res) nogil except -1:
         """Adds node w/ partition ``[start, end)`` to the frontier. """
         cdef SplitRecord split
-        cdef SIZE_t node_id
+        cdef size_t node_id
         cdef SIZE_t n_node_samples
         cdef SIZE_t n_constant_features = 0
         cdef double min_impurity_decrease = self.min_impurity_decrease
@@ -474,7 +474,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
                                  is_left, is_leaf,
                                  split.feature, split.threshold, impurity, n_node_samples,
                                  weighted_n_node_samples)
-        if <size_t> node_id == SIZE_MAX:
+        if node_id == SIZE_MAX:
             return -1
 
         # compute values also for split nodes (might become leafs later).
@@ -701,7 +701,7 @@ cdef class Tree:
             with gil:
                 raise MemoryError()
 
-    cdef int _resize_c(self, SIZE_t capacity=SIZE_MAX) nogil except -1:
+    cdef int _resize_c(self, size_t capacity=SIZE_MAX) nogil except -1:
         """Guts of _resize
 
         Returns -1 in case of failure to allocate memory (and raise MemoryError)
@@ -710,7 +710,7 @@ cdef class Tree:
         if capacity == self.capacity and self.nodes != NULL:
             return 0
 
-        if <size_t> capacity == SIZE_MAX:
+        if capacity == SIZE_MAX:
             if self.capacity == 0:
                 capacity = 3  # default initial value
             else:
@@ -1732,7 +1732,7 @@ cdef _build_pruned_tree(
 
     cdef:
         SIZE_t orig_node_id
-        SIZE_t new_node_id
+        size_t new_node_id
         SIZE_t depth
         SIZE_t parent
         bint is_left
@@ -1770,7 +1770,7 @@ cdef _build_pruned_tree(
                 node.impurity, node.n_node_samples,
                 node.weighted_n_node_samples)
 
-            if <size_t> new_node_id == SIZE_MAX:
+            if new_node_id == SIZE_MAX:
                 rc = -1
                 break
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -700,7 +700,7 @@ cdef class Tree:
             with gil:
                 raise MemoryError()
 
-    cdef int _resize_c(self, size_t capacity=SIZE_MAX) nogil except -1:
+    cdef int _resize_c(self, SIZE_t capacity=SIZE_MAX) nogil except -1:
         """Guts of _resize
 
         Returns -1 in case of failure to allocate memory (and raise MemoryError)
@@ -709,7 +709,7 @@ cdef class Tree:
         if capacity == self.capacity and self.nodes != NULL:
             return 0
 
-        if capacity == SIZE_MAX:
+        if <size_t> capacity == SIZE_MAX:
             if self.capacity == 0:
                 capacity = 3  # default initial value
             else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards: #24875 

#### What does this implement/fix? Explain your changes.
- Removed sign compare warnings in _tree.pyx by casting the related conditionals to <size_t>

#### Any other comments?
CC: @jjerphan @glemaitre @jeremiedbb 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
