### PR TITLE
CI Upload ARM wheels from CirrusCI to nightly and staging index

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -221,5 +221,6 @@ jobs:
           # Secret variables need to be mapped to environment variables explicitly
           SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN }}
           SCIKIT_LEARN_STAGING_UPLOAD_TOKEN: ${{ secrets.SCIKIT_LEARN_STAGING_UPLOAD_TOKEN }}
+          ARTIFACTS_PATH: dist/artifact
         # Force a replacement if the remote file already exists
         run: bash build_tools/github/upload_anaconda.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -103,20 +103,6 @@ jobs:
             python: 311
             platform_id: macosx_x86_64
 
-          # MacOS arm64
-          - os: macos-latest
-            python: 38
-            platform_id: macosx_arm64
-          - os: macos-latest
-            python: 39
-            platform_id: macosx_arm64
-          - os: macos-latest
-            python: 310
-            platform_id: macosx_arm64
-          - os: macos-latest
-            python: 311
-            platform_id: macosx_arm64
-
     steps:
       - name: Checkout scikit-learn
         uses: actions/checkout@v3

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -81,6 +81,7 @@ wheels_upload_task:
   only_if: $CIRRUS_PR == ""
   env:
     # XXX: Need to encrypt keys in the CirrusCI interface
+    # https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
     # SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[...]
     # SCIKIT_LEARN_STAGING_UPLOAD_TOKEN: ENCRYPTED[...]
     ARTIFACTS_PATH: wheelhouse

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -69,3 +69,31 @@ linux_arm64_wheel_task:
 
   wheels_artifacts:
     path: "wheelhouse/*"
+
+
+wheels_upload_task:
+  depends_on:
+    - macos_arm64_wheel
+    - linux_arm64_wheel
+  container:
+    image: continuumio/miniconda3:22.11.1
+  # Artifacts are not uploaded on PRs
+  only_if: $CIRRUS_PR == ""
+  env:
+    # XXX: Need to encrypt keys in the CirrusCI interface
+    # SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[...]
+    # SCIKIT_LEARN_STAGING_UPLOAD_TOKEN: ENCRYPTED[...]
+    ARTIFACTS_PATH: wheelhouse
+  upload_script: |
+    conda install curl unzip -y
+
+    if [[ "$CIRRUS_CRON" == "nightly" ]]; then
+      export GITHUB_EVENT_NAME="schedule"
+    fi
+
+    # Download and show wheels
+    curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
+    unzip wheels.zip
+    ls wheelhouse
+
+    bash build_tools/github/upload_anaconda.sh

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -80,7 +80,7 @@ wheels_upload_task:
   # Artifacts are not uploaded on PRs
   only_if: $CIRRUS_PR == ""
   env:
-    # XXX: Need to encrypt keys in the CirrusCI interface
+    # Upload tokens have been encrypted via the CirrusCI interface:
     # https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
     SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[8f20120b18a07d8a11192b98bff1f562883558e1f4c53f8ead1577113785a4105ee6f14ad9b5dacf1803c19c4913fe1c]
     SCIKIT_LEARN_STAGING_UPLOAD_TOKEN: ENCRYPTED[8fade46af37fa645e57bd1ee21683337aa369ba56f6307ce13889f1e74df94e5bdd21d323baac21e332fd87b8949659a]

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -82,8 +82,8 @@ wheels_upload_task:
   env:
     # XXX: Need to encrypt keys in the CirrusCI interface
     # https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
-    # SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[...]
-    # SCIKIT_LEARN_STAGING_UPLOAD_TOKEN: ENCRYPTED[...]
+    SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN: ENCRYPTED[8f20120b18a07d8a11192b98bff1f562883558e1f4c53f8ead1577113785a4105ee6f14ad9b5dacf1803c19c4913fe1c]
+    SCIKIT_LEARN_STAGING_UPLOAD_TOKEN: ENCRYPTED[8fade46af37fa645e57bd1ee21683337aa369ba56f6307ce13889f1e74df94e5bdd21d323baac21e332fd87b8949659a]
     ARTIFACTS_PATH: wheelhouse
   upload_script: |
     conda install curl unzip -y

--- a/build_tools/github/check_wheels.py
+++ b/build_tools/github/check_wheels.py
@@ -14,14 +14,13 @@ n_wheels = len(build_matrix)
 # plus one more for the sdist
 n_wheels += 1
 
-# aarch64 builds from travis
-travis_config_path = Path.cwd() / ".travis.yml"
-with travis_config_path.open("r") as f:
-    travis_config = yaml.safe_load(f)
+# arm64 builds from cirrus
+cirrus_path = Path.cwd() / "build_tools" / "cirrus" / "arm_wheel.yml"
+with cirrus_path.open("r") as f:
+    cirrus_config = yaml.safe_load(f)
 
-jobs = travis_config["jobs"]["include"]
-travis_builds = [j for j in jobs if any("CIBW_BUILD" in env for env in j["env"])]
-n_wheels += len(travis_builds)
+n_wheels += len(cirrus_config["macos_arm64_wheel_task"]["matrix"])
+n_wheels += len(cirrus_config["linux_arm64_wheel_task"]["matrix"])
 
 dist_files = list(Path("dist").glob("**/*"))
 n_dist_files = len(dist_files)

--- a/build_tools/github/upload_anaconda.sh
+++ b/build_tools/github/upload_anaconda.sh
@@ -18,5 +18,5 @@ source activate upload
 conda install -y anaconda-client
 
 # Force a replacement if the remote file already exists
-anaconda -t $ANACONDA_TOKEN upload --force -u $ANACONDA_ORG dist/artifact/*
+anaconda -t $ANACONDA_TOKEN upload --force -u $ANACONDA_ORG $ARTIFACTS_PATH/*
 echo "Index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"


### PR DESCRIPTION
This PR enables the ARM wheels build on CirrusCI to be uploaded to the staging and nightly index.

The instructions for adding the encrypted keys to CirrusCI are available here: https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables