### PR TITLE
CI Allow cirrus arm tests to run with cd build commit tag

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -30,6 +30,6 @@ def main(ctx):
         return []
 
     if "[cd build]" in commit_msg or "[cd build cirrus]" in commit_msg:
-        return fs.read(arm_wheel_yaml)
+        return fs.read(arm_wheel_yaml) + fs.read(arm_tests_yaml)
 
     return fs.read(arm_tests_yaml)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Issue observed in https://github.com/scikit-learn/scikit-learn/pull/25513

#### What does this implement/fix? Explain your changes.
This PR allows the Linux arm build to run when the commit is tagged with `[cd build]`.

Previously tagging with `[cd build]` would only trigger the build the wheels, which also tests on all supported Python versions, but the normal Linux ARM tests **did not** run. The `arm_tests_yaml` is a Linux ARM test environment similar to the Azure CI jobs and nothing to do with wheel building. With this PR, the Linux ARM test will run all the time, independent of any tag.

Concretely, looking at the [Cirrus job](https://cirrus-ci.com/build/6402402991996928) for this PR, the jobs tagged with `CIBW_BUILD` are the wheel builds and `linux_aarch64_test` is the Linux ARM test.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
