### PR TITLE
FIX Compute covariance matrix for centered complex inputs

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -104,6 +104,13 @@ Changelog
   is now deprecated and will be removed in v1.5.
   :pr:`25251` by :user:`Gleb Levitski <glevv>`.
 
+:mod:`sklearn.covariance`
+.........................
+
+- |Fix| :func:`covariance.empirical_covariance` now estimates the covariance
+  instead of pseudo-covariance for centered complex inputs.
+  :pr:`25520` by :user:`Quentin Barthélemy <qbarthelemy>`.
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -95,7 +95,7 @@ def empirical_covariance(X, *, assume_centered=False):
         )
 
     if assume_centered:
-        covariance = np.dot(X.T, X) / X.shape[0]
+        covariance = np.dot(X.T, X.conj()) / X.shape[0]
     else:
         covariance = np.cov(X.T, bias=1)
 

--- a/sklearn/covariance/tests/test_covariance.py
+++ b/sklearn/covariance/tests/test_covariance.py
@@ -79,6 +79,14 @@ def test_covariance():
     cov.fit(X)
     assert_array_equal(cov.location_, np.zeros(X.shape[1]))
 
+    # test centered complex case
+    rng = np.random.RandomState(0)
+    X_complex = rng.randn(10, 3) + 1.0j * rng.randn(10, 3)
+    X_complex -= np.mean(X_complex, axis=0, keepdims=True)
+    emp_cov_true = empirical_covariance(X_complex, assume_centered=True)
+    emp_cov_false = empirical_covariance(X_complex, assume_centered=False)
+    assert_array_almost_equal(emp_cov_true, emp_cov_false)
+
 
 def test_shrunk_covariance():
     # Tests ShrunkCovariance module on a simple dataset.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #25519, computing covariance (instead of pseudo-covariance) for centered complex inputs.

#### What does this implement/fix? Explain your changes.

It simply adds complex conjugate `.conj()` when estimating the covariance matrix.

Contrary to the example described in the issue, example below is OK.
```
import numpy as np
from numpy.testing import assert_array_almost_equal


def empirical_covariance_new(X, *, assume_centered=False):
    if assume_centered:
        covariance = np.dot(X.T, X.conj()) / X.shape[0]
    else:
        covariance = np.cov(X.T, bias=1)
    return covariance


n_samples, n_features = 100, 2
rs = np.random.RandomState(2023)
X = rs.randn(n_samples, n_features) + 1.0j * rs.randn(n_samples, n_features)
X -= np.mean(X, axis=0, keepdims=True)

C3 = empirical_covariance_new(X, assume_centered=True)
C4 = empirical_covariance_new(X, assume_centered=False)
assert_array_almost_equal(C3, C4)
```