### PR TITLE
MNT Add parameter allow_nd for y

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -642,7 +642,6 @@ def check_array(
     estimator=None,
     input_name="",
 ):
-
     """Input validation on an array, list, sparse matrix or similar.
 
     By default, the input is checked to be a non-empty 2D array containing
@@ -1119,7 +1118,13 @@ def check_X_y(
         input_name="X",
     )
 
-    y = _check_y(y, multi_output=multi_output, y_numeric=y_numeric, estimator=estimator, allow_nd=allow_nd)
+    y = _check_y(
+        y,
+        multi_output=multi_output,
+        y_numeric=y_numeric,
+        estimator=estimator,
+        allow_nd=allow_nd,
+    )
 
     check_consistent_length(X, y)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1119,14 +1119,14 @@ def check_X_y(
         input_name="X",
     )
 
-    y = _check_y(y, multi_output=multi_output, y_numeric=y_numeric, estimator=estimator)
+    y = _check_y(y, multi_output=multi_output, y_numeric=y_numeric, estimator=estimator, allow_nd=allow_nd)
 
     check_consistent_length(X, y)
 
     return X, y
 
 
-def _check_y(y, multi_output=False, y_numeric=False, estimator=None):
+def _check_y(y, multi_output=False, y_numeric=False, estimator=None, allow_nd=False):
     """Isolated part of check_X_y dedicated to y validation"""
     if multi_output:
         y = check_array(
@@ -1137,6 +1137,7 @@ def _check_y(y, multi_output=False, y_numeric=False, estimator=None):
             dtype=None,
             input_name="y",
             estimator=estimator,
+            allow_nd=allow_nd,
         )
     else:
         estimator_name = _check_estimator_name(estimator)


### PR DESCRIPTION
This PR adds the parameter allow_nd for the function `_check_y`. The reason is that I am currently trying to make a sklearn compatible estimator that does multi-label hierarchical classification and 3D y is necessary for my use-case. If there is a particular reason why this multi-dimension cannot be enabled for y, please disregard this PR.