### PR TITLE
DOC improve the `warm_start` glossary entry

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1666,10 +1666,24 @@ functions or non-estimator constructors.
         in a subsequent call to :term:`fit`.
 
         Note that this is only applicable for some models and some
-        parameters, and even some orders of parameter values. For example,
-        ``warm_start`` may be used when building random forests to add more
-        trees to the forest (increasing ``n_estimators``) but not to reduce
-        their number.
+        parameters, and even some orders of parameter values. In general, there
+        is an interaction between ``warm_start`` and the parameter controlling
+        the number of iterations of the estimator.
+
+        With ensemble estimators (i.e. estimators imported from :mod:`ensemble`),
+        ``warm_start`` will interact with ``n_estimators`` or ``max_iter``.
+        For these models, the number of iterations, reported via
+        ``len(estiamtors_)`` or ``n_iter_``, corresponds the total number of
+        iterations/estimators learn since the intiailization of the model.
+        Thus, if a model was already initialized with `N`` estimators, and `fit`
+        is called with ``n_estimators`` or ``max_iter`` set to `M`, the model
+        will train `M - N` new estimators.
+
+        Other models have a different behavior. They all expose a ``max_iter``
+        parameter. The reported ``n_iter_`` corresponds to the number of
+        iteration done during the last call to ``fit`` and will be at most
+        ``max_iter``. Thus, we do not consider the state of the estimator since
+        the initialization.
 
         :term:`partial_fit` also retains the model between calls, but differs:
         with ``warm_start`` the parameters change and the data is

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1670,11 +1670,11 @@ functions or non-estimator constructors.
         is an interaction between ``warm_start`` and the parameter controlling
         the number of iterations of the estimator.
 
-        With ensemble estimators (i.e. estimators imported from :mod:`ensemble`),
+        For estimators imported from :mod:`ensemble`,
         ``warm_start`` will interact with ``n_estimators`` or ``max_iter``.
         For these models, the number of iterations, reported via
         ``len(estimators_)`` or ``n_iter_``, corresponds the total number of
-        estimators/iterations learn since the initialization of the model.
+        estimators/iterations learnt since the initialization of the model.
         Thus, if a model was already initialized with `N`` estimators, and `fit`
         is called with ``n_estimators`` or ``max_iter`` set to `M`, the model
         will train `M - N` new estimators.

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1679,11 +1679,11 @@ functions or non-estimator constructors.
         is called with ``n_estimators`` or ``max_iter`` set to `M`, the model
         will train `M - N` new estimators.
 
-        Other models have a different behavior. They all expose a ``max_iter``
-        parameter. The reported ``n_iter_`` corresponds to the number of
-        iteration done during the last call to ``fit`` and will be at most
-        ``max_iter``. Thus, we do not consider the state of the estimator since
-        the initialization.
+        Other models, usually using gradient-based solvers, have a different
+        behavior. They all expose a ``max_iter`` parameter. The reported
+        ``n_iter_`` corresponds to the number of iteration done during the last
+        call to ``fit`` and will be at most ``max_iter``. Thus, we do not
+        consider the state of the estimator since the initialization.
 
         :term:`partial_fit` also retains the model between calls, but differs:
         with ``warm_start`` the parameters change and the data is

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1673,8 +1673,8 @@ functions or non-estimator constructors.
         With ensemble estimators (i.e. estimators imported from :mod:`ensemble`),
         ``warm_start`` will interact with ``n_estimators`` or ``max_iter``.
         For these models, the number of iterations, reported via
-        ``len(estiamtors_)`` or ``n_iter_``, corresponds the total number of
-        iterations/estimators learn since the intiailization of the model.
+        ``len(estimators_)`` or ``n_iter_``, corresponds the total number of
+        estimators/iterations learn since the initialization of the model.
         Thus, if a model was already initialized with `N`` estimators, and `fit`
         is called with ``n_estimators`` or ``max_iter`` set to `M`, the model
         will train `M - N` new estimators.


### PR DESCRIPTION
Related #25522 

Improve the glossary entry for the term `warm_start` and more specifically about the meaning of `n_iter_`.