### PR TITLE
CI Fixes linux ARM CI on CirrusCI

### DIFF
--- a/build_tools/cirrus/arm_tests.yml
+++ b/build_tools/cirrus/arm_tests.yml
@@ -12,6 +12,7 @@ linux_aarch64_test_task:
     OPENBLAS_NUM_THREADS: 2
     LOCK_FILE: build_tools/cirrus/py39_conda_forge_linux-aarch64_conda.lock
     CONDA_PKGS_DIRS: /root/.conda/pkgs
+    HOME: /  # $HOME is not defined in image and is required to install mambaforge
   ccache_cache:
     folder: /root/.cache/ccache
   conda_cache:


### PR DESCRIPTION
This PR fixes the ARM CI on CirrusCI by adding `HOME` to the env. `$HOME` is not defined in the image which causes the mambaforge install to fail. 