### PR TITLE
Add special case handling for default engine

### DIFF
--- a/sklearn/_engine/tests/test_engines.py
+++ b/sklearn/_engine/tests/test_engines.py
@@ -294,3 +294,24 @@ def test_missing_engine_raises():
     with config_context(engine_provider=(NeverAcceptsEngine, AlsoAlwaysAcceptsEngine)):
         engine = est._get_engine(X, reset=True)
         assert isinstance(engine, AlsoAlwaysAcceptsEngine)
+
+
+def test_default_engine_always_works():
+    """Check that an estimator that uses the default engine works, even when
+    no engines are explicitly configured.
+    """
+    # Values aren't important, just need something to pass as argument
+    # to _get_engine
+    X = [[1, 2], [3, 4]]
+
+    est = FakeEstimator()
+
+    with config_context(engine_provider=NeverAcceptsEngine):
+        engine = est._get_engine(X)
+        assert isinstance(engine, DefaultEngine)
+
+    assert est._engine_class == DefaultEngine
+
+    # With no explicit config, the default engine should still be selected
+    engine = est._get_engine(X)
+    assert isinstance(engine, DefaultEngine)

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1030,7 +1030,7 @@ class EngineAwareMixin:
             configured_providers = get_config()["engine_provider"]
             # Special case: the default engine can be selected
             # when no provider is explicitly configured and it is not an error
-            # to keep using it when nothing is explicitly configured
+            # to keep using it when nothing is explicitly configured.
             if (
                 self._engine_provider != "default"
                 and self._engine_provider not in configured_providers

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1028,7 +1028,13 @@ class EngineAwareMixin:
         """
         if hasattr(self, "_engine_provider") and not reset:
             configured_providers = get_config()["engine_provider"]
-            if self._engine_provider not in configured_providers:
+            # Dpecial case: the default engine can be selected
+            # when no provider is explicitly configured and it is not an error
+            # to keep using it when nothing is explicitly configured
+            if (
+                self._engine_provider != "default"
+                and self._engine_provider not in configured_providers
+            ):
                 raise RuntimeError(
                     f"Previously selected engine ({self._engine_provider}) is no longer"
                     " configured."

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1028,7 +1028,7 @@ class EngineAwareMixin:
         """
         if hasattr(self, "_engine_provider") and not reset:
             configured_providers = get_config()["engine_provider"]
-            # Dpecial case: the default engine can be selected
+            # Special case: the default engine can be selected
             # when no provider is explicitly configured and it is not an error
             # to keep using it when nothing is explicitly configured
             if (


### PR DESCRIPTION
This fixes the problem that if you did not configure a special engine provider, then you could not keep using the estimator. The logic needed an exception for the default engine.

This PR targets the "plugin engine" feature branch.

@fcharras @jjerphan @ogrisel 