### PR TITLE
FIX Add `sample_weight` deprecation to engine

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -426,6 +426,12 @@ class KMeansCythonEngine:
 
     def prepare_prediction(self, X, sample_weight):
         X = self.estimator._check_test_data(X)
+
+        # The deprecation check and raising the warning happens in the estimator,
+        # so we just have to handle the case of a string being passed in.
+        if sample_weight == "deprecated":
+            sample_weight = None
+
         sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
         return X, sample_weight
 
@@ -1687,6 +1693,14 @@ class KMeans(_BaseKMeans, EngineAwareMixin):
             Index of the cluster each sample belongs to.
         """
         check_is_fitted(self)
+
+        if not (isinstance(sample_weight, str) and sample_weight == "deprecated"):
+            warnings.warn(
+                "'sample_weight' was deprecated in version 1.3 and "
+                "will be removed in 1.5.",
+                FutureWarning,
+            )
+
         engine = self._get_engine(X, sample_weight=sample_weight)
         X, sample_weight = engine.prepare_prediction(X, sample_weight)
         return engine.get_labels(X, sample_weight)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This adds the deprecation from #25251 to the engine based `KMeans`.

I think it makes sense to handle the deprecation warning at the level of the estimator, but delegate the handling of the special `"deprecated"` value and calling `_check_sample_weight` to the engine. This means engine authors have to think about the fact that parameters might get deprecated and how to deal with that (write their engine so it can handle/expects `"deprecated"` as a parameter value??).

#### Any other comments?

This branch targets the `feature/engine-api` branch
