### PR TITLE
FIX BisectingKMeans crashes randomly

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -27,6 +27,13 @@ Changes impacting all modules
 Changelog
 ---------
 
+:mod:`sklearn.cluster`
+......................
+
+- |Fix| Fixed a bug in :class:`cluster.BisectingKMeans`, preventing `fit` to randomly
+  fail due to a permutation of the labels when running multiple inits.
+  :pr:`25563` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 :mod:`sklearn.isotonic`
 .......................
 

--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -337,7 +337,7 @@ class BisectingKMeans(_BaseKMeans):
                 X, best_centers, best_labels, sample_weight
             )
         else:  # bisecting_strategy == "largest_cluster"
-            scores = np.bincount(best_labels)
+            scores = np.bincount(best_labels, minlength=2)
 
         cluster_to_bisect.split(best_labels, best_centers, scores)
 

--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -337,6 +337,8 @@ class BisectingKMeans(_BaseKMeans):
                 X, best_centers, best_labels, sample_weight
             )
         else:  # bisecting_strategy == "largest_cluster"
+            # Using minlength to make sure that we have the counts for both labels even
+            # if all samples are labelled 0.
             scores = np.bincount(best_labels, minlength=2)
 
         cluster_to_bisect.split(best_labels, best_centers, scores)


### PR DESCRIPTION
Fixes #25505

BisectingKMeans can fail randomly if the labels are permuted for some init, because
`np.bincount([1,1,1])` returns an array with the counts for 0 and 1, while
`np.bincount([0,0,0]` returns an array with the counts for 0 only.
We need to set minlength to ensure that we have the counts for the 2 labels.

It's quite hard to test since it triggers randomly.