### PR TITLE
BLD Support Cython annotation via an environment variable

### DIFF
--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -71,6 +71,11 @@ def cythonize_extensions(extension):
         os.environ.get("SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES", "0") != "0"
     )
 
+    # Additional checks for Cython
+    generate_cython_annotations = (
+        os.environ.get("SKLEARN_GENERATE_CYTHON_ANNOTATIONS", "0") != "0"
+    )
+
     compiler_directives = {
         "language_level": 3,
         "boundscheck": cython_enable_debug_directives,
@@ -102,6 +107,7 @@ def cythonize_extensions(extension):
             "SKLEARN_OPENMP_PARALLELISM_ENABLED": sklearn._OPENMP_SUPPORTED
         },
         compiler_directives=compiler_directives,
+        annotate=generate_cython_annotations,
     )
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

None.

#### What does this implement/fix? Explain your changes.

This allows generating HTML annotated reports of Cython source at compile time if the `SKLEARN_GENERATE_CYTHON_ANNOTATIONS` environment variable is set and different than `0`.

#### Any other comments?
Co-authored-by: Vincent M <maladiere.vincent@yahoo.fr>
