### PR TITLE
MAINT Use memory views in _hashing_fast.pyx

### DIFF
--- a/sklearn/feature_extraction/_hashing_fast.pyx
+++ b/sklearn/feature_extraction/_hashing_fast.pyx
@@ -35,7 +35,7 @@ def transform(raw_X, Py_ssize_t n_features, dtype,
     # and values arrays ourselves. Use a Py_ssize_t capacity for safety.
     cdef Py_ssize_t capacity = 8192     # arbitrary
     cdef cnp.int64_t size = 0
-    cdef cnp.ndarray values = np.empty(capacity, dtype=dtype)
+    cdef double[:] values = np.empty(capacity, dtype=np.float64)
 
     for x in raw_X:
         for f, v in x:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards: #25484 


#### What does this implement/fix? Explain your changes.
- Replaced the single instance of cnp.ndarray with a memory view

#### Any other comments?
CC: @Vincent-Maladiere @jjerphan @adam2392 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
