### PR TITLE
FIX error when deserialzing a Tree instance from a read only buffer

### DIFF
--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -708,8 +708,8 @@ cdef class Tree:
         if self._resize_c(self.capacity) != 0:
             raise MemoryError("resizing tree to %d" % self.capacity)
 
-        cdef Node[::1] node_memory_view = node_ndarray
-        cdef DOUBLE_t[:, :, ::1] value_memory_view = value_ndarray
+        cdef const Node[::1] node_memory_view = node_ndarray
+        cdef const DOUBLE_t[:, :, ::1] value_memory_view = value_ndarray
         nodes = memcpy(self.nodes, &node_memory_view[0],
                        self.capacity * sizeof(Node))
         value = memcpy(self.value, &value_memory_view[0, 0, 0],

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -708,11 +708,9 @@ cdef class Tree:
         if self._resize_c(self.capacity) != 0:
             raise MemoryError("resizing tree to %d" % self.capacity)
 
-        cdef const Node[::1] node_memory_view = node_ndarray
-        cdef const DOUBLE_t[:, :, ::1] value_memory_view = value_ndarray
-        nodes = memcpy(self.nodes, &node_memory_view[0],
+        nodes = memcpy(self.nodes, cnp.PyArray_DATA(node_ndarray),
                        self.capacity * sizeof(Node))
-        value = memcpy(self.value, &value_memory_view[0, 0, 0],
+        value = memcpy(self.value, cnp.PyArray_DATA(value_ndarray),
                        self.capacity * self.value_stride * sizeof(double))
 
     cdef int _resize(self, SIZE_t capacity) nogil except -1:

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2418,4 +2418,10 @@ def test_tree_deserialization_from_read_only_buffer(tmpdir):
     clf.fit(X_small, y_small)
 
     joblib.dump(clf, pickle_path)
-    joblib.load(pickle_path, mmap_mode="r")
+    loaded_clf = joblib.load(pickle_path, mmap_mode="r")
+
+    assert_tree_equal(
+        loaded_clf.tree_,
+        clf.tree_,
+        "The trees of the original and loaded classifiers are not equal.",
+    )

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -21,8 +21,6 @@ from joblib.numpy_pickle import NumpyPickler
 from sklearn.random_projection import _sparse_random_matrix
 
 from sklearn.dummy import DummyRegressor
-from sklearn.datasets import fetch_california_housing
-from sklearn.inspection import PartialDependenceDisplay
 
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import mean_squared_error
@@ -62,6 +60,7 @@ from sklearn import datasets
 
 from sklearn.utils import compute_sample_weight
 from sklearn.tree._classes import DENSE_SPLITTERS, SPARSE_SPLITTERS
+
 
 CLF_CRITERIONS = ("gini", "log_loss")
 REG_CRITERIONS = ("squared_error", "absolute_error", "friedman_mse", "poisson")
@@ -2409,23 +2408,14 @@ def test_splitter_serializable(Splitter):
     assert isinstance(splitter_back, Splitter)
 
 
-def test_tree_deserialization_from_read_only_buffer():
+def test_tree_deserialization_from_read_only_buffer(tmpdir):
     # Non-regression test for the issue:
     # https://github.com/scikit-learn/scikit-learn/issues/25584
     # This test helps to ensure that the Tree module is able to
     # successfully deserialize data from read only buffers.
-    X, y = fetch_california_housing(return_X_y=True, as_frame=True)
-    features = ["MedInc", "AveOccup", "HouseAge", "AveRooms"]
-    est = DecisionTreeRegressor()
-    est.fit(X, y)
+    pickle_path = str(tmpdir.join("clf.joblib"))
+    clf = DecisionTreeClassifier(random_state=0)
+    clf.fit(X_small, y_small)
 
-    PartialDependenceDisplay.from_estimator(
-        est,
-        X,
-        features,
-        kind="individual",
-        subsample=50,
-        n_jobs=3,
-        grid_resolution=20,
-        random_state=0,
-    )
+    joblib.dump(clf, pickle_path)
+    joblib.load(pickle_path, mmap_mode="r")

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2409,10 +2409,10 @@ def test_splitter_serializable(Splitter):
 
 
 def test_tree_deserialization_from_read_only_buffer(tmpdir):
-    # Non-regression test for the issue:
-    # https://github.com/scikit-learn/scikit-learn/issues/25584
-    # This test helps to ensure that the Tree module is able to
-    # successfully deserialize data from read only buffers.
+    """Check that Trees can be deserialized with read only buffers.
+
+    Non-regression test for gh-25584.
+    """
     pickle_path = str(tmpdir.join("clf.joblib"))
     clf = DecisionTreeClassifier(random_state=0)
     clf.fit(X_small, y_small)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes: #25584

#### What does this implement/fix? Explain your changes.
- Makes the memory views inside the Tree __setstate__ method to be const
- Adds a non regression test to ensure that a Tree can be deserialized from data that has a read only buffer.

#### Any other comments?
CC: @ogrisel 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
