### PR TITLE
ENH Let csr_row_norms support multi-thread

### DIFF
--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -36,7 +36,7 @@ def csr_row_norms(X):
 def _sqeuclidean_row_norms_sparse(
     const floating[::1] X_data,
     const integral[::1] X_indptr,
-    const integral[::1] n_threads,
+    const int n_threads,
 ):
     cdef:
         integral n_samples = X_indptr.shape[0] - 1

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -29,7 +29,7 @@ def csr_row_norms(X):
     """Squared L2 norm of each row in CSR matrix X."""
     if X.dtype not in [np.float32, np.float64]:
         X = X.astype(np.float64)
-        n_threads = _openmp_effective_n_threads()
+    n_threads = _openmp_effective_n_threads()
     return _sqeuclidean_row_norms_sparse(X.data, X.indptr, n_threads)
 
 

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -12,6 +12,7 @@ from libc.math cimport fabs, sqrt
 cimport numpy as cnp
 import numpy as np
 from cython cimport floating
+from cython.parallel cimport prange
 from numpy.math cimport isnan
 
 from sklearn.utils._openmp_helpers import _openmp_effective_n_threads

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -37,7 +37,7 @@ def csr_row_norms(X):
 def _sqeuclidean_row_norms_sparse(
     const floating[::1] X_data,
     const integral[::1] X_indptr,
-    const int n_threads,
+    int n_threads,
 ):
     cdef:
         integral n_samples = X_indptr.shape[0] - 1

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -46,7 +46,7 @@ def _sqeuclidean_row_norms_sparse(
 
     dtype = np.float32 if floating is float else np.float64
 
-    cdef floating[::1] norms = np.zeros(n_samples, dtype=dtype)
+    cdef floating[::1] squared_row_norms = np.zeros(n_samples, dtype=dtype)
 
     for i in prange(n_samples, schedule='static', nogil=True, num_threads=n_threads):
         for j in range(X_indptr[i], X_indptr[i + 1]):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Follows #24426.

#### What does this implement/fix? Explain your changes.

- Allows for multi-thread support of the `csr_row_norms` function;
- removes unused variable `X_indices`;
- renames private function to something more explicit.

#### Any other comments?

This is a first step towards removing a redundant routine as mentioned [in this comment](https://github.com/scikit-learn/scikit-learn/pull/24426#pullrequestreview-1270714169).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
