### PR TITLE
CI Adds permissions to workflows that use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/artifact-redirector.yml
+++ b/.github/workflows/artifact-redirector.yml
@@ -1,6 +1,9 @@
 name: CircleCI artifacts redirector
 on: [status]
 
+# Restrict the permissions granted to the use of secrets.GITHUB_TOKEN in this
+# github actions workflow:
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
   statuses: write
 

--- a/.github/workflows/artifact-redirector.yml
+++ b/.github/workflows/artifact-redirector.yml
@@ -1,5 +1,9 @@
 name: CircleCI artifacts redirector
 on: [status]
+
+permissions:
+  statuses: write
+
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,3 +1,4 @@
+
 name: Assign
 on:
   issue_comment:
@@ -14,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     # Note that string comparisons is not case sensitive.
     if: >-
-      startsWith(github.event.comment.body, '/take')
-      && !github.event.issue.assignee
+       startsWith(github.event.comment.body, '/take')
+       && !github.event.issue.assignee
     steps:
       - run: |
           echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: created
 
+permissions:
+  issues: write
+
 jobs:
   one:
     runs-on: ubuntu-latest

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,9 +1,11 @@
-
 name: Assign
 on:
   issue_comment:
     types: created
 
+# Restrict the permissions granted to the use of secrets.GITHUB_TOKEN in this
+# github actions workflow:
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
   issues: write
 
@@ -12,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     # Note that string comparisons is not case sensitive.
     if: >-
-       startsWith(github.event.comment.body, '/take')
-       && !github.event.issue.assignee
+      startsWith(github.event.comment.body, '/take')
+      && !github.event.issue.assignee
     steps:
       - run: |
           echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"

--- a/.github/workflows/labeler-module.yml
+++ b/.github/workflows/labeler-module.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [opened]
 
+# Restrict the permissions granted to the use of secrets.GITHUB_TOKEN in this
+# github actions workflow:
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/labeler-module.yml
+++ b/.github/workflows/labeler-module.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler-title-regex.yml
+++ b/.github/workflows/labeler-title-regex.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [opened, edited]
 
+# Restrict the permissions granted to the use of secrets.GITHUB_TOKEN in this
+# github actions workflow:
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/unassign.yml
+++ b/.github/workflows/unassign.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: unassigned
 
+# Restrict the permissions granted to the use of secrets.GITHUB_TOKEN in this
+# github actions workflow:
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
   issues: write
 

--- a/.github/workflows/unassign.yml
+++ b/.github/workflows/unassign.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: unassigned
 
+permissions:
+  issues: write
+
 jobs:
   one:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds permissions to the GitHub workflows that use `secrets.GITHUB_TOKEN`. I determined the permissions by looking over https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28 and seeing what calls are made by looking at the source code.

- For `circleci-artifacts-redirector`, the [source](https://github.com/larsoner/circleci-artifacts-redirector-action/blob/bcd0879bbcfd8e15b24dc4069c7a43ccd15c03cc/index.js#L83-L91) needs write access to the commit status.
- For `thomasjpfan/labeler`, the [source](https://github.com/thomasjpfan/labeler/blob/master/src/main.ts) writes to the pull request and reads `contents` to get the labels.
- For the bash scripts, the API calls are directly in the workflow.