### PR TITLE
DOC: fix typo in California Housing dataset description

### DIFF
--- a/sklearn/datasets/descr/california_housing.rst
+++ b/sklearn/datasets/descr/california_housing.rst
@@ -32,9 +32,9 @@ block group. A block group is the smallest geographical unit for which the U.S.
 Census Bureau publishes sample data (a block group typically has a population
 of 600 to 3,000 people).
 
-An household is a group of people residing within a home. Since the average
+A household is a group of people residing within a home. Since the average
 number of rooms and bedrooms in this dataset are provided per household, these
-columns may take surpinsingly large values for block groups with few households
+columns may take surprisingly large values for block groups with few households
 and many empty houses, such as vacation resorts.
 
 It can be downloaded/loaded using the


### PR DESCRIPTION


#### Reference Issues/PRs
None. Just noticed a mild typo when swapping out the Boston housing for California housing in a tutorial I was developing.

#### What does this implement/fix? Explain your changes.
Typo in California housing description file.

#### Any other comments?
Thanks for a great library! Please let me know if there is anything additional to do while I'm in these files.

Happy to do what I can to make this correct/easy to reveiew.

Thanks!