### PR TITLE
FEA Add a private `check_array` with additional parameters

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -21,7 +21,7 @@ from .utils._tags import (
 )
 from .exceptions import InconsistentVersionWarning
 from .utils.validation import check_X_y
-from .utils.validation import check_array, _check_array
+from .utils.validation import _check_array
 from .utils.validation import _check_y
 from .utils.validation import _num_features
 from .utils.validation import _check_feature_names_in

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -21,7 +21,7 @@ from .utils._tags import (
 )
 from .exceptions import InconsistentVersionWarning
 from .utils.validation import check_X_y
-from .utils.validation import check_array
+from .utils.validation import check_array, _check_array
 from .utils.validation import _check_y
 from .utils.validation import _num_features
 from .utils.validation import _check_feature_names_in
@@ -574,7 +574,7 @@ class BaseEstimator:
         if no_val_X and no_val_y:
             raise ValueError("Validation should be done on X, y or both.")
         elif not no_val_X and no_val_y:
-            X = check_array(X, input_name="X", **check_params)
+            X = _check_array(X, input_name="X", **check_params)
             out = X
         elif no_val_X and not no_val_y:
             y = _check_y(y, **check_params)
@@ -588,10 +588,10 @@ class BaseEstimator:
                 check_X_params, check_y_params = validate_separately
                 if "estimator" not in check_X_params:
                     check_X_params = {**default_check_params, **check_X_params}
-                X = check_array(X, input_name="X", **check_X_params)
+                X = _check_array(X, input_name="X", **check_X_params)
                 if "estimator" not in check_y_params:
                     check_y_params = {**default_check_params, **check_y_params}
-                y = check_array(y, input_name="y", **check_y_params)
+                y = _check_array(y, input_name="y", **check_y_params)
             else:
                 X, y = check_X_y(X, y, **check_params)
             out = X, y

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1759,3 +1759,28 @@ def test_boolean_series_remains_boolean():
 
     assert res.dtype == expected.dtype
     assert_array_equal(res, expected)
+
+
+def test_custom_asarray():
+    """Check that a custom `asarray` function can be used during validation"""
+    est = BaseEstimator()
+
+    # This "special" asarray method converts elements of the input array
+    # to ints before creating a numpy array. Mostly so we can be sure it
+    # and not the standard asarray, was used for the data validation.
+    def my_asarray(array, copy=False, **kwargs):
+        converted = []
+        for row in array:
+            r = []
+            for element in row:
+                r.append(int(element))
+            converted.append(r)
+
+        if copy:
+            return np.array(converted, **kwargs)
+        else:
+            return np.asarray(converted, **kwargs)
+
+    x = est._validate_data([["1", "2", "3"], ["4", "5", "6"]], asarray=my_asarray)
+
+    assert x.dtype == int


### PR DESCRIPTION
To allow plugins or other users to pass in a custom `asarray` function an additional parameter is added to a private version of `check_array`. If the caller passes something, that callable is used instead of the default `np.asarray`. This is useful if you want to directly convert to a, say, cupy array. Without this parameter first a numpy array would be created which you then convert to a cupy array. This also makes it possible for cupy arrays to be passed in to `_validate_data`. This is useful for plugin authors who want to re-use the validation methods of scikit-learn, instead of having to maintain a copy of them.

The reason for the indirection is to avoid increasing the number of public parameters that need to then follow the deprecation policy.


#### Reference Issues/PRs
This is an attempt to closes #25433

#### What does this implement/fix? Explain your changes.
This implements the "add a private version with this additional parameter" idea from #25433.