### PR TITLE
FIX Fixes check_array nonfinite checks with ArrayAPI specification

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -65,6 +65,13 @@ Changelog
   when the global configuration sets `transform_output="pandas"`.
   :pr:`25500` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+:mod:`sklearn.utils`
+....................
+
+- |Fix| Fixes a bug in :func:`utils.check_array` which now correctly performs
+  non-finite validation with the Array API specification. :pr:`xxxxx` by
+  `Thomas Fan`_.
+
 .. _changes_1_2_1:
 
 Version 1.2.1

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -69,7 +69,7 @@ Changelog
 ....................
 
 - |Fix| Fixes a bug in :func:`utils.check_array` which now correctly performs
-  non-finite validation with the Array API specification. :pr:`xxxxx` by
+  non-finite validation with the Array API specification. :pr:`25619` by
   `Thomas Fan`_.
 
 .. _changes_1_2_1:

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1765,7 +1765,7 @@ def test_boolean_series_remains_boolean():
 @pytest.mark.parametrize("array_namespace", ["numpy.array_api", "cupy.array_api"])
 def test_check_array_array_api_has_non_finite(array_namespace):
     """Checks that Array API arrays checks non-finite correctly."""
-    xp = pytest.importorskip("numpy.array_api")
+    xp = pytest.importorskip(array_namespace)
 
     X_nan = xp.asarray([[xp.nan, 1, 0], [0, xp.nan, 3]], dtype=xp.float32)
     with config_context(array_api_dispatch=True):

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -13,6 +13,7 @@ from pytest import importorskip
 import numpy as np
 import scipy.sparse as sp
 
+from sklearn._config import config_context
 from sklearn.utils._testing import assert_no_warnings
 from sklearn.utils._testing import ignore_warnings
 from sklearn.utils._testing import SkipTest
@@ -1759,3 +1760,19 @@ def test_boolean_series_remains_boolean():
 
     assert res.dtype == expected.dtype
     assert_array_equal(res, expected)
+
+
+@pytest.mark.parametrize("array_namespace", ["numpy.array_api", "cupy.array_api"])
+def test_check_array_array_api_has_non_finite(array_namespace):
+    """Checks that Array API arrays checks non-finite correctly."""
+    xp = pytest.importorskip("numpy.array_api")
+
+    X_nan = xp.asarray([[xp.nan, 1, 0], [0, xp.nan, 3]], dtype=xp.float32)
+    with config_context(array_api_dispatch=True):
+        with pytest.raises(ValueError, match="Input contains NaN."):
+            check_array(X_nan)
+
+    X_inf = xp.asarray([[xp.inf, 1, 0], [0, xp.inf, 3]], dtype=xp.float32)
+    with config_context(array_api_dispatch=True):
+        with pytest.raises(ValueError, match="infinity or a value too large"):
+            check_array(X_inf)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -131,8 +131,8 @@ def _assert_all_finite(
         has_nan_error = False if allow_nan else out == FiniteStatus.has_nan
         has_inf = out == FiniteStatus.has_infinite
     else:
-        has_inf = np.isinf(X).any()
-        has_nan_error = False if allow_nan else xp.isnan(X).any()
+        has_inf = xp.any(xp.isinf(X))
+        has_nan_error = False if allow_nan else xp.any(xp.isnan(X))
     if has_inf or has_nan_error:
         if has_nan_error:
             type_err = "NaN"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Noticed this issue while reviewing #25617

#### What does this implement/fix? Explain your changes.
This PR corrects `_assert_all_finite` so that it calls the ArrayAPI functions in the namespace.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
