### PR TITLE
CI Open issue when arm wheel fails on CirrusCI

### DIFF
--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -14,6 +14,10 @@ macos_arm64_wheel_task:
     CIBW_BUILD_VERBOSITY: 1
     PATH: $HOME/mambaforge/bin/:$PATH
     CONDA_HOME: $HOME/mambaforge
+    # Upload tokens have been encrypted via the CirrusCI interface:
+    # https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
+    # See `maint_tools/update_tracking_issue.py` for details on the permissions the token requires.
+    BOT_GITHUB_TOKEN: ENCRYPTED[9b50205e2693f9e4ce9a3f0fcb897a259289062fda2f5a3b8aaa6c56d839e0854a15872f894a70fca337dd4787274e0f]
   matrix:
     - env:
         CIBW_BUILD: cp38-macosx_arm64
@@ -30,6 +34,11 @@ macos_arm64_wheel_task:
 
   cibuildwheel_script:
     - bash build_tools/wheels/build_wheels.sh
+    - bash build_tools/cirrus/update_tracking_issue.sh true
+
+  on_failure:
+    update_tracker_script:
+      - bash build_tools/cirrus/update_tracking_issue.sh false
 
   wheels_artifacts:
     path: "wheelhouse/*"
@@ -53,6 +62,10 @@ linux_arm64_wheel_task:
     CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
     CIBW_TEST_REQUIRES: pytest pandas threadpoolctl pytest-xdist
     CIBW_BUILD_VERBOSITY: 1
+    # Upload tokens have been encrypted via the CirrusCI interface:
+    # https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
+    # See `maint_tools/update_tracking_issue.py` for details on the permissions the token requires.
+    BOT_GITHUB_TOKEN: ENCRYPTED[9b50205e2693f9e4ce9a3f0fcb897a259289062fda2f5a3b8aaa6c56d839e0854a15872f894a70fca337dd4787274e0f]
   matrix:
     - env:
         CIBW_BUILD: cp38-manylinux_aarch64
@@ -66,6 +79,11 @@ linux_arm64_wheel_task:
   cibuildwheel_script:
     - apt install -y python3 python-is-python3
     - bash build_tools/wheels/build_wheels.sh
+    - bash build_tools/cirrus/update_tracking_issue.sh true
+
+  on_failure:
+    update_tracker_script:
+      - bash build_tools/cirrus/update_tracking_issue.sh false
 
   wheels_artifacts:
     path: "wheelhouse/*"

--- a/build_tools/cirrus/update_tracking_issue.sh
+++ b/build_tools/cirrus/update_tracking_issue.sh
@@ -4,6 +4,7 @@ if [[ "$CIRRUS_CRON" != "nightly" ]]; then
     exit 0
 fi
 
+# TEST_PASSED is either "true" or "false"
 TEST_PASSED="$1"
 
 python -m venv .venv

--- a/build_tools/cirrus/update_tracking_issue.sh
+++ b/build_tools/cirrus/update_tracking_issue.sh
@@ -1,0 +1,20 @@
+# Update tracking issue if Cirrus fails nightly job
+
+if [[ "$CIRRUS_CRON" != "nightly" ]]; then
+    exit 0
+fi
+
+TEST_PASSED="$1"
+
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install defusedxml PyGithub
+
+LINK_TO_RUN="https://cirrus-ci.com/build/$CIRRUS_BUILD_ID"
+
+python maint_tools/update_tracking_issue.py \
+    $BOT_GITHUB_TOKEN \
+    $CIRRUS_TASK_NAME \
+    $CIRRUS_REPO_FULL_NAME \
+    $LINK_TO_RUN \
+    --tests-passed $TEST_PASSED


### PR DESCRIPTION
This PR enables CirrusCI ARM wheels jobs to open a issue if they were to fail.

I tried a few methods to get this to work that does not require giving a token to the build job, but they were too complex and changes the UX for when the jobs failed.