### PR TITLE
DOC Fix typo in parameter description of KMeans

### DIFF
--- a/examples/cluster/plot_kmeans_digits.py
+++ b/examples/cluster/plot_kmeans_digits.py
@@ -114,7 +114,7 @@ def bench_k_means(kmeans, name, data, labels):
 #
 # We will compare three approaches:
 #
-# * an initialization using `kmeans++`. This method is stochastic and we will
+# * an initialization using `k-means++`. This method is stochastic and we will
 #   run the initialization 4 times;
 # * a random initialization. This method is stochastic as well and we will run
 #   the initialization 4 times;

--- a/examples/cluster/plot_kmeans_plusplus.py
+++ b/examples/cluster/plot_kmeans_plusplus.py
@@ -23,7 +23,7 @@ X, y_true = make_blobs(
 )
 X = X[:, ::-1]
 
-# Calculate seeds from kmeans++
+# Calculate seeds from k-means++
 centers_init, indices = kmeans_plusplus(X, n_clusters=4, random_state=0)
 
 # Plot init seeds along side sample data

--- a/examples/cluster/plot_kmeans_stability_low_dim_dense.py
+++ b/examples/cluster/plot_kmeans_stability_low_dim_dense.py
@@ -10,7 +10,7 @@ distances to the nearest cluster center).
 
 The first plot shows the best inertia reached for each combination
 of the model (``KMeans`` or ``MiniBatchKMeans``), and the init method
-(``init="random"`` or ``init="kmeans++"``) for increasing values of the
+(``init="random"`` or ``init="k-means++"``) for increasing values of the
 ``n_init`` parameter that controls the number of initializations.
 
 The second plot demonstrates one single run of the ``MiniBatchKMeans``

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -345,7 +345,7 @@ def k_means(
         n_init consecutive runs in terms of inertia.
 
         When `n_init='auto'`, the number of runs depends on the value of init:
-        10 if using `init='random'`, 1 if using `init='kmeans++'`.
+        10 if using `init='random'`, 1 if using `init='k-means++'`.
 
         .. versionadded:: 1.2
            Added 'auto' option for `n_init`.
@@ -1206,7 +1206,7 @@ class KMeans(_BaseKMeans):
         high-dimensional problems (see :ref:`kmeans_sparse_high_dim`).
 
         When `n_init='auto'`, the number of runs depends on the value of init:
-        10 if using `init='random'`, 1 if using `init='kmeans++'`.
+        10 if using `init='random'`, 1 if using `init='k-means++'`.
 
         .. versionadded:: 1.2
            Added 'auto' option for `n_init`.
@@ -1734,7 +1734,7 @@ class MiniBatchKMeans(_BaseKMeans):
         :ref:`kmeans_sparse_high_dim`).
 
         When `n_init='auto'`, the number of runs depends on the value of init:
-        3 if using `init='random'`, 1 if using `init='kmeans++'`.
+        3 if using `init='random'`, 1 if using `init='k-means++'`.
 
         .. versionadded:: 1.2
            Added 'auto' option for `n_init`.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None. It's just a typo and not related to other issues.

#### What does this implement/fix? Explain your changes.
Change `init='kmeans++'` to `init='k-means++'` in description of `KMeans`

#### Any other comments?
Thank you! :)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
