### PR TITLE
FIX use const memory views in hist_gradient_boosting predictor

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
@@ -14,7 +14,7 @@ from ._bitset cimport in_bitset_2d_memoryview
 
 
 def _predict_from_raw_data(  # raw data = non-binned data
-        node_struct [:] nodes,
+        const node_struct [:] nodes,
         const X_DTYPE_C [:, :] numeric_data,
         const BITSET_INNER_DTYPE_C [:, ::1] raw_left_cat_bitsets,
         const BITSET_INNER_DTYPE_C [:, ::1] known_cat_bitsets,
@@ -34,7 +34,7 @@ def _predict_from_raw_data(  # raw data = non-binned data
 
 
 cdef inline Y_DTYPE_C _predict_one_from_raw_data(
-        node_struct [:] nodes,
+        const node_struct [:] nodes,
         const X_DTYPE_C [:, :] numeric_data,
         const BITSET_INNER_DTYPE_C [:, ::1] raw_left_cat_bitsets,
         const BITSET_INNER_DTYPE_C [:, ::1] known_cat_bitsets,

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1165,15 +1165,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         return averaged_predictions
 
     def _more_tags(self):
-        return {
-            "allow_nan": True,
-            "_xfail_checks": {
-                "check_estimators_pickle": (
-                    "The memory views of the nodes parameter need to be defined"
-                    "as read only in the Cython implementation."
-                ),
-            },
-        }
+        return {"allow_nan": True}
 
     @abstractmethod
     def _get_loss(self, sample_weight):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up of: #25624

#### What does this implement/fix? Explain your changes.
- Removes the error when predicting through hist_gradient_boosting after loading from a read only buffer
- It uses const memory views for the nodes parameter in the required places.

#### Any other comments?
CC: @jjerphan @betatim 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
