### PR TITLE
MAINT Clean dead code in build helpers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ class build_ext_subclass(build_ext):
                 print(f"Using old NumPy C API (version 1.7) for extension {ext.name}")
 
         if sklearn._OPENMP_SUPPORTED:
-            openmp_flag = get_openmp_flag(self.compiler)
+            openmp_flag = get_openmp_flag()
 
             for e in self.extensions:
                 e.extra_compile_args += openmp_flag

--- a/sklearn/_build_utils/openmp_helpers.py
+++ b/sklearn/_build_utils/openmp_helpers.py
@@ -12,12 +12,7 @@ import warnings
 from .pre_build_helpers import compile_test_program
 
 
-def get_openmp_flag(compiler):
-    if hasattr(compiler, "compiler"):
-        compiler = compiler.compiler[0]
-    else:
-        compiler = compiler.__class__.__name__
-
+def get_openmp_flag():
     if sys.platform == "win32":
         return ["/openmp"]
     elif sys.platform == "darwin" and "openmp" in os.getenv("CPPFLAGS", ""):
@@ -66,7 +61,7 @@ def check_openmp_support():
             if flag.startswith(("-L", "-Wl,-rpath", "-l", "-Wl,--sysroot=/"))
         ]
 
-    extra_postargs = get_openmp_flag
+    extra_postargs = get_openmp_flag()
 
     openmp_exception = None
     try:

--- a/sklearn/_build_utils/pre_build_helpers.py
+++ b/sklearn/_build_utils/pre_build_helpers.py
@@ -10,17 +10,10 @@ import subprocess
 from setuptools.command.build_ext import customize_compiler, new_compiler
 
 
-def compile_test_program(code, extra_preargs=[], extra_postargs=[]):
+def compile_test_program(code, extra_preargs=None, extra_postargs=None):
     """Check that some C code can be compiled and run"""
     ccompiler = new_compiler()
     customize_compiler(ccompiler)
-
-    # extra_(pre/post)args can be a callable to make it possible to get its
-    # value from the compiler
-    if callable(extra_preargs):
-        extra_preargs = extra_preargs(ccompiler)
-    if callable(extra_postargs):
-        extra_postargs = extra_postargs(ccompiler)
 
     start_dir = os.path.abspath(".")
 


### PR DESCRIPTION
before dropping distutils, `get_openmp_flags` needed to know the compiler in some situations but that's no longer the case.