### PR TITLE
FIX Raise appropriate attribute error in ensemble

### DIFF
--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -187,6 +187,12 @@ class BaseEnsemble(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
     @property
     def estimator_(self):
         """Estimator used to grow the ensemble."""
+        # Raise an attribute error for subclasses of that are not meant to
+        # expose an estimator_ attribute.
+        if not hasattr(self, "_estimator"):
+            raise AttributeError(
+                f"{self.__class__.__name__!r} object has no attribute 'estimator_'"
+            )
         return self._estimator
 
     def _make_estimator(self, append=True, random_state=None):

--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -161,16 +161,16 @@ class BaseEnsemble(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             )
 
         if self.estimator is not None:
-            self._estimator = self.estimator
+            self.estimator_ = self.estimator
         elif self.base_estimator not in [None, "deprecated"]:
             warnings.warn(
                 "`base_estimator` was renamed to `estimator` in version 1.2 and "
                 "will be removed in 1.4.",
                 FutureWarning,
             )
-            self._estimator = self.base_estimator
+            self.estimator_ = self.base_estimator
         else:
-            self._estimator = default
+            self.estimator_ = default
 
     # TODO(1.4): remove
     # mypy error: Decorated property not supported
@@ -181,19 +181,7 @@ class BaseEnsemble(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
     @property
     def base_estimator_(self):
         """Estimator used to grow the ensemble."""
-        return self._estimator
-
-    # TODO(1.4): remove
-    @property
-    def estimator_(self):
-        """Estimator used to grow the ensemble."""
-        # Raise an attribute error for subclasses of that are not meant to
-        # expose an estimator_ attribute.
-        if not hasattr(self, "_estimator"):
-            raise AttributeError(
-                f"{self.__class__.__name__!r} object has no attribute 'estimator_'"
-            )
-        return self._estimator
+        return self.estimator_
 
     def _make_estimator(self, append=True, random_state=None):
         """Make and configure a copy of the `estimator_` attribute.

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -140,5 +140,4 @@ def test_estimator_attribute_error(model):
     y = [0, 1]
     model.fit(X, y)
 
-    with pytest.raises(AttributeError, match="has no attribute 'estimator_'"):
-        model.estimator_
+    assert not hasattr(model, "estimator_")

--- a/sklearn/ensemble/tests/test_base.py
+++ b/sklearn/ensemble/tests/test_base.py
@@ -12,10 +12,12 @@ from sklearn.datasets import load_iris
 from sklearn.ensemble import BaggingClassifier
 from sklearn.ensemble._base import _set_random_states
 from sklearn.linear_model import Perceptron
+from sklearn.linear_model import Ridge, LogisticRegression
 from collections import OrderedDict
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 from sklearn.pipeline import Pipeline
 from sklearn.feature_selection import SelectFromModel
+from sklearn import ensemble
 
 
 def test_base():
@@ -117,3 +119,26 @@ def test_validate_estimator_value_error():
     err_msg = "Both `estimator` and `base_estimator` were set. Only set `estimator`."
     with pytest.raises(ValueError, match=err_msg):
         model.fit(X, y)
+
+
+# TODO(1.4): remove
+@pytest.mark.parametrize(
+    "model",
+    [
+        ensemble.GradientBoostingClassifier(),
+        ensemble.GradientBoostingRegressor(),
+        ensemble.HistGradientBoostingClassifier(),
+        ensemble.HistGradientBoostingRegressor(),
+        ensemble.VotingClassifier(
+            [("a", LogisticRegression()), ("b", LogisticRegression())]
+        ),
+        ensemble.VotingRegressor([("a", Ridge()), ("b", Ridge())]),
+    ],
+)
+def test_estimator_attribute_error(model):
+    X = [[1], [2]]
+    y = [0, 1]
+    model.fit(X, y)
+
+    with pytest.raises(AttributeError, match="has no attribute 'estimator_'"):
+        model.estimator_


### PR DESCRIPTION
closes https://github.com/scikit-learn/scikit-learn/issues/25588

As a side effect of the deprecation of ``base_estimator``, trying to access the `estimator_` attribute of the ensemble estimators that are not meant to expose it raise an attribute error for ``_estimator`` instead of ``estimator_``.

This PR fixes the error message, knowing that all this will be removed in 1.4.

I don't think this requires a change log entry