### PR TITLE
GOV Propose 3 Basic Roles

### DIFF
--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -68,7 +68,8 @@ Therefore, core contributors are given the following rights:
 
 New core contributors can be nominated by any existing core contributor.
 Once they have been nominated, there will be a vote by the current core contributors.
-Voting on new core contributors is one of the few activities that takes place on the project's private management list.
+Voting on new core contributors is one of the few activities that takes place on the
+project's private management list.
 While it is expected that most votes will be unanimous, a two-thirds majority of the
 cast votes is needed for acceptance of the candidate as new core contributor.
 The vote needs to be open for at least 2 and at most 4 weeks.
@@ -80,7 +81,8 @@ As *ultima ratio*, the technical committee is allowed to call for a vote to with
 the core contributor role from a current member.
 A 3/4 majority of all current core contributors is needed that this vote passes.
 It is open for exactly 4 weeks and is done on a private list.
-Core contributors that step back can, if they want to, be listed as emeritus core contributors on the public website.
+Core contributors that step back can, if they want to, be listed as emeritus core
+contributors on the public website.
 
 The list of core contributors, active and emeritus (with dates at
 which they became active) is public on the scikit-learn website.

--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -30,7 +30,7 @@ invest time and energy to improve the project for the greater community.
 Anyone can become a contributor, and contributions can take many forms:
 coding, reviewing pull request, communications, organization, triaging, replying
 to mails in the mailing list, etc.
-Every contributor is welcome to participate in `monthly core developer meetings
+Every contributor is welcome to participate in `monthly core contributor meetings
 <https://github.com/scikit-learn/administrative/tree/master/meeting_notes>`_.
 More details can be found in the :ref:`contributors guide <contributing>`.
 
@@ -87,6 +87,7 @@ which they became active) is public on the scikit-learn website.
 
 # TODO: remove/replace .. _communication_team:
 # TODO: replace core developer by core contributor in all files.
+# TODO: what to do with members of the contributor experience team, communication team?
 
 Technical Committee
 -------------------
@@ -96,10 +97,10 @@ participate in strategic planning, and approve changes to the governance model.
 The purpose of the TC is to ensure a smooth progress from the big-picture
 perspective. Indeed changes that impact the full project require a synthetic
 analysis and a consensus that is both explicit and informed. In cases that the
-core developer community (which includes the TC members) fails to reach such a
+core contributor community (which includes the TC members) fails to reach such a
 consensus in the required time frame, the TC is the entity to resolve the
 issue.
-Membership of the TC is by nomination by a core developer. A nomination will
+Membership of the TC is by nomination by a core contributor. A nomination will
 result in discussion which cannot take more than a month and then a vote by
 the core contributors which will stay open for a week. TC membership votes are
 subject to a two-third majority of all cast votes as well as a simple majority
@@ -122,8 +123,8 @@ Occasionally, sensitive discussion occurs on a private list.
 
 Scikit-learn uses a "consensus seeking" process for making decisions. The group
 tries to find a resolution that has no open objections among core contributors.
-At any point during the discussion, any core-developer can call for a vote, which will
-conclude one month from the call for the vote. Any vote must be backed by a
+At any point during the discussion, any core contributor can call for a vote, which
+will conclude one month from the call for the vote. Any vote must be backed by a
 :ref:`SLEP <slep>`. If no option can gather two thirds of the votes cast, the
 decision is escalated to the TC, which in turn will use consensus seeking with
 the fallback option of a simple majority vote if no consensus can be found
@@ -135,13 +136,13 @@ are made according to the following rules:
 
 * **Minor Documentation changes**, such as typo fixes, or addition / correction of a
   sentence, but no change of the scikit-learn.org landing page or the “about”
-  page: Requires +1 by a core developer, no -1 by a core developer (lazy
+  page: Requires +1 by a core contributor, no -1 by a core contributor (lazy
   consensus), happens on the issue or pull request page. Core contributors are
   expected to give “reasonable time” to others to give their opinion on the pull
   request if they're not confident others would agree.
 
 * **Code changes and major documentation changes**
-  require +1 by two core contributors, no -1 by a core developer (lazy
+  require +1 by two core contributors, no -1 by a core contributor (lazy
   consensus), happens on the issue of pull-request page.
 
 * **Changes to the API principles and changes to dependencies or supported

--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -1,7 +1,7 @@
 .. _governance:
 
 ===========================================
-Scikit-learn governance and decision-making
+Scikit-learn Governance and Decision-Making
 ===========================================
 
 The purpose of this document is to formalize the governance process used by the
@@ -11,90 +11,86 @@ This document establishes a decision-making structure that takes into account
 feedback from all members of the community and strives to find consensus, while
 avoiding any deadlocks.
 
-This is a meritocratic, consensus-based community project. Anyone with an
-interest in the project can join the community, contribute to the project
-design and participate in the decision making process. This document describes
+This is a meritocratic, consensus-based community project with democratic elements.
+Anyone with an interest in the project can join the community, contribute to the
+project design and participate in the decision-making process. This document describes
 how that participation takes place and how to set about earning merit within
 the project community.
 
 Roles And Responsibilities
 ==========================
 
+There are three basic roles.
+
 Contributors
 ------------
 
-Contributors are community members who contribute in concrete ways to the
-project. Anyone can become a contributor, and contributions can take many forms
-– not only code – as detailed in the :ref:`contributors guide <contributing>`.
-
-Contributor Experience Team
----------------------------
-
-The contributor experience team is composed of community members who have permission on
-github to label and close issues. :ref:`Their work <bug_triaging>` is
-crucial to improve the communication in the project and limit the crowding
-of the issue tracker.
-
-Similarly to what has been decided in the `python project
-<https://devguide.python.org/triage/triage-team/#becoming-a-member-of-the-python-triage-team>`_,
-any contributor may become a member of the scikit-learn contributor experience team,
-after showing some continuity in participating to scikit-learn
-development (with pull requests and reviews).
-Any core developer or member of the contributor experience team is welcome to propose a
-scikit-learn contributor to join the contributor experience team. Other core developers
-are then consulted: while it is expected that most acceptances will be
-unanimous, a two-thirds majority is enough.
-Every new member of the contributor experience team will be announced in the mailing
-list. Members of the team are welcome to participate in `monthly core developer meetings
+Contributors are persons who contribute in concrete ways to the project, i.e. they
+invest time and energy to improve the project for the greater community.
+Anyone can become a contributor, and contributions can take many forms:
+coding, reviewing pull request, communications, organization, triaging, replying
+to mails in the mailing list, etc.
+Every contributor is welcome to participate in `monthly core developer meetings
 <https://github.com/scikit-learn/administrative/tree/master/meeting_notes>`_.
+More details can be found in the :ref:`contributors guide <contributing>`.
 
-.. _communication_team:
+Core Contributors
+-----------------
 
-Communication team
--------------------
+Core contributors are persons who have shown that they are dedicated to the continued
+development of the project through ongoing engagement with the community.
+They have shown that they can be trusted to maintain scikit-learn with care.
+Core contributors are expected to invest continued time and energy in the project.
+This includes selectively (not cumulatively):
 
-Members of the communication team help with outreach and communication
-for scikit-learn. The goal of the team is to develop public awareness of
-scikit-learn, of its features and usage, as well as branding.
+  - Ensure the maintenance of scikit-learn
+  - Help other contributors to engage in the project and to carry on with their project
+    related activities.
+  - Conduct public relations work
+  - Fundraising
+  - Triage github issues and pull requests
+  - Review code
+  - Contribute code
+  - Create a common development roadmap
 
-For this, they can operate the scikit-learn accounts on various social
-networks and produce materials.
+Therefore, core contributors are given the following rights:
 
-Every new communicator will be announced in the mailing list.
-Communicators are welcome to participate in `monthly core developer meetings
-<https://github.com/scikit-learn/administrative/tree/master/meeting_notes>`_.
+  - Call for votes and cast votes according to the decision-making process as detailed
+    below.
+  - Be involved in deciding major changes to the API and the governance.
+  - Direct access to the project's GitHub repository and joining as organization member
+    in the scikit-learn `GitHub organization
+    <https://github.com/orgs/scikit-learn/people>`_.
+    This right might not be exercised for security reasons, but it may be claimed at
+    any time.
+  - Cast a vote for, i.e. approve, or cast a vote against pull-requests.
+  - Merge pull-requests.
 
-Core developers
----------------
+New core contributors can be nominated by any existing core contributor.
+Once they have been nominated, there will be a vote by the current core contributors.
+Voting on new core contributors is one of the few activities that takes place on the project's private management list.
+While it is expected that most votes will be unanimous, a two-thirds majority of the
+cast votes is needed for acceptance of the candidate as new core contributor.
+The vote needs to be open for at least 2 and at most 4 weeks.
 
-Core developers are community members who have shown that they are dedicated to
-the continued development of the project through ongoing engagement with the
-community. They have shown they can be trusted to maintain scikit-learn with
-care. Being a core developer allows contributors to more easily carry on
-with their project related activities by giving them direct access to the
-project's repository and is represented as being an organization member on the
-scikit-learn `GitHub organization <https://github.com/orgs/scikit-learn/people>`_.
-Core developers are expected to review code
-contributions, can merge approved pull requests, can cast votes for and against
-merging a pull-request, and can be involved in deciding major changes to the
-API.
+Core contributors can step back from their role and privileges at any time.
+If they have not reasonably contributed to the project in the past 12 months, they will
+be kindly asked to step back by the technical committee.
+As *ultima ratio*, the technical committee is allowed to call for a vote to withdraw
+the core contributor role from a current member.
+A 3/4 majority of all current core contributors is needed that this vote passes.
+It is open for exactly 4 weeks and is done on a private list.
+Core contributors that step back can, if they want to, be listed as emeritus core contributors on the public website.
 
-New core developers can be nominated by any existing core developers. Once they
-have been nominated, there will be a vote by the current core developers.
-Voting on new core developers is one of the few activities that takes place on
-the project's private management list. While it is expected that most votes
-will be unanimous, a two-thirds majority of the cast votes is enough. The vote
-needs to be open for at least 1 week.
-
-Core developers that have not contributed to the project (commits or GitHub
-comments) in the past 12 months will be asked if they want to become emeritus
-core developers and recant their commit and voting rights until they become
-active again. The list of core developers, active and emeritus (with dates at
+The list of core contributor, active and emeritus (with dates at
 which they became active) is public on the scikit-learn website.
+
+# TODO: remove/replace .. _communication_team:
+# TODO: replace core developer by core contributor
 
 Technical Committee
 -------------------
-The Technical Committee (TC) members are core developers who have additional
+The Technical Committee (TC) members are core contributor who have additional
 responsibilities to ensure the smooth running of the project. TC members are expected to
 participate in strategic planning, and approve changes to the governance model.
 The purpose of the TC is to ensure a smooth progress from the big-picture
@@ -105,7 +101,7 @@ consensus in the required time frame, the TC is the entity to resolve the
 issue.
 Membership of the TC is by nomination by a core developer. A nomination will
 result in discussion which cannot take more than a month and then a vote by
-the core developers which will stay open for a week. TC membership votes are
+the core contributor which will stay open for a week. TC membership votes are
 subject to a two-third majority of all cast votes as well as a simple majority
 approval of all the current TC members. TC members who do not actively engage
 with the TC duties are expected to resign.
@@ -116,7 +112,7 @@ The Technical Committee of scikit-learn consists of :user:`Thomas Fan
 <amueller>`, :user:`Joel Nothman <jnothman>` and :user:`Gaël Varoquaux
 <GaelVaroquaux>`.
 
-Decision Making Process
+Decision-Making Process
 =======================
 Decisions about the future of the project are made through discussion with all
 members of the community. All non-sensitive project management discussion takes
@@ -125,35 +121,35 @@ and the `issue tracker <https://github.com/scikit-learn/scikit-learn/issues>`_.
 Occasionally, sensitive discussion occurs on a private list.
 
 Scikit-learn uses a "consensus seeking" process for making decisions. The group
-tries to find a resolution that has no open objections among core developers.
+tries to find a resolution that has no open objections among core contributor.
 At any point during the discussion, any core-developer can call for a vote, which will
 conclude one month from the call for the vote. Any vote must be backed by a
 :ref:`SLEP <slep>`. If no option can gather two thirds of the votes cast, the
 decision is escalated to the TC, which in turn will use consensus seeking with
 the fallback option of a simple majority vote if no consensus can be found
-within a month. This is what we hereafter may refer to as "**the decision making
+within a month. This is what we hereafter may refer to as "**the decision-making
 process**".
 
-Decisions (in addition to adding core developers and TC membership as above)
+Decisions (in addition to adding core contributor and TC membership as above)
 are made according to the following rules:
 
 * **Minor Documentation changes**, such as typo fixes, or addition / correction of a
   sentence, but no change of the scikit-learn.org landing page or the “about”
   page: Requires +1 by a core developer, no -1 by a core developer (lazy
-  consensus), happens on the issue or pull request page. Core developers are
+  consensus), happens on the issue or pull request page. Core contributor are
   expected to give “reasonable time” to others to give their opinion on the pull
   request if they're not confident others would agree.
 
 * **Code changes and major documentation changes**
-  require +1 by two core developers, no -1 by a core developer (lazy
+  require +1 by two core contributor, no -1 by a core developer (lazy
   consensus), happens on the issue of pull-request page.
 
 * **Changes to the API principles and changes to dependencies or supported
   versions** happen via a :ref:`slep` and follows the decision-making process outlined above.
 
 If a veto -1 vote is cast on a lazy consensus, the proposer can appeal to the
-community and core developers and the change can be approved or rejected using
-the decision making procedure outlined above.
+community and core contributor and the change can be approved or rejected using
+the decision-making procedure outlined above.
 
 Governance Model Changes
 ------------------------

--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -82,15 +82,15 @@ A 3/4 majority of all current core contributors is needed that this vote passes.
 It is open for exactly 4 weeks and is done on a private list.
 Core contributors that step back can, if they want to, be listed as emeritus core contributors on the public website.
 
-The list of core contributor, active and emeritus (with dates at
+The list of core contributors, active and emeritus (with dates at
 which they became active) is public on the scikit-learn website.
 
 # TODO: remove/replace .. _communication_team:
-# TODO: replace core developer by core contributor
+# TODO: replace core developer by core contributor in all files.
 
 Technical Committee
 -------------------
-The Technical Committee (TC) members are core contributor who have additional
+The Technical Committee (TC) members are core contributors who have additional
 responsibilities to ensure the smooth running of the project. TC members are expected to
 participate in strategic planning, and approve changes to the governance model.
 The purpose of the TC is to ensure a smooth progress from the big-picture
@@ -101,7 +101,7 @@ consensus in the required time frame, the TC is the entity to resolve the
 issue.
 Membership of the TC is by nomination by a core developer. A nomination will
 result in discussion which cannot take more than a month and then a vote by
-the core contributor which will stay open for a week. TC membership votes are
+the core contributors which will stay open for a week. TC membership votes are
 subject to a two-third majority of all cast votes as well as a simple majority
 approval of all the current TC members. TC members who do not actively engage
 with the TC duties are expected to resign.
@@ -121,7 +121,7 @@ and the `issue tracker <https://github.com/scikit-learn/scikit-learn/issues>`_.
 Occasionally, sensitive discussion occurs on a private list.
 
 Scikit-learn uses a "consensus seeking" process for making decisions. The group
-tries to find a resolution that has no open objections among core contributor.
+tries to find a resolution that has no open objections among core contributors.
 At any point during the discussion, any core-developer can call for a vote, which will
 conclude one month from the call for the vote. Any vote must be backed by a
 :ref:`SLEP <slep>`. If no option can gather two thirds of the votes cast, the
@@ -130,25 +130,25 @@ the fallback option of a simple majority vote if no consensus can be found
 within a month. This is what we hereafter may refer to as "**the decision-making
 process**".
 
-Decisions (in addition to adding core contributor and TC membership as above)
+Decisions (in addition to adding core contributors and TC membership as above)
 are made according to the following rules:
 
 * **Minor Documentation changes**, such as typo fixes, or addition / correction of a
   sentence, but no change of the scikit-learn.org landing page or the “about”
   page: Requires +1 by a core developer, no -1 by a core developer (lazy
-  consensus), happens on the issue or pull request page. Core contributor are
+  consensus), happens on the issue or pull request page. Core contributors are
   expected to give “reasonable time” to others to give their opinion on the pull
   request if they're not confident others would agree.
 
 * **Code changes and major documentation changes**
-  require +1 by two core contributor, no -1 by a core developer (lazy
+  require +1 by two core contributors, no -1 by a core developer (lazy
   consensus), happens on the issue of pull-request page.
 
 * **Changes to the API principles and changes to dependencies or supported
   versions** happen via a :ref:`slep` and follows the decision-making process outlined above.
 
 If a veto -1 vote is cast on a lazy consensus, the proposer can appeal to the
-community and core contributor and the change can be approved or rejected using
+community and core contributors and the change can be approved or rejected using
 the decision-making procedure outlined above.
 
 Governance Model Changes


### PR DESCRIPTION
# Governance Change
According to [SLEP020](https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep020/proposal.html), see also #25663, this PR proposes a change of the scikit-learn governance.

## Abstract
The governance structure gets more democratic elements and only three different roles are established. This way, all contributions, e.g. "beyond code", are recognized equally and get the same rights and obligations.

## Proposed Roles
Three basic roles replace all other roles:
- Contributor
- Core Contributor
- Member of the Technical Committee (unchanged)

@scikit-learn/core-devs @scikit-learn/contributor-experience-team @scikit-learn/communication-team ping