### PR TITLE
DOC Specify behaviour of None for TfIdfVectorizer max_features parameter

### DIFF
--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1873,7 +1873,7 @@ class TfidfVectorizer(CountVectorizer):
 
     max_features : int, default=None
         If not None, build a vocabulary that only consider the top
-        max_features ordered by term frequency across the corpus.
+        `max_features` ordered by term frequency across the corpus.
         Otherwise, all features are used.
 
         This parameter is ignored if vocabulary is not None.

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1874,6 +1874,7 @@ class TfidfVectorizer(CountVectorizer):
     max_features : int, default=None
         If not None, build a vocabulary that only consider the top
         max_features ordered by term frequency across the corpus.
+        Otherwise, all features are used.
 
         This parameter is ignored if vocabulary is not None.
 


### PR DESCRIPTION
#### Reference Issues/PRs
Partially addresses #17295

#### What does this implement/fix? Explain your changes.
This PR specifies the meaning of `Y=None` in `max_features` parameter for the `TfidfVectorizer` class in `sklearn.feature_extraction.text`  module.