### PR TITLE
DOC Unify usage of 'w.r.t.' abbreviations in docstrings

### DIFF
--- a/doc/common_pitfalls.rst
+++ b/doc/common_pitfalls.rst
@@ -243,7 +243,7 @@ Some scikit-learn objects are inherently random. These are usually estimators
 splitters (e.g. :class:`~sklearn.model_selection.KFold`). The randomness of
 these objects is controlled via their `random_state` parameter, as described
 in the :term:`Glossary <random_state>`. This section expands on the glossary
-entry, and describes good practices and common pitfalls w.r.t. to this
+entry, and describes good practices and common pitfalls w.r.t. this
 subtle parameter.
 
 .. note:: Recommendation summary

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -681,7 +681,7 @@ class ClassifierMixin:
         Returns
         -------
         score : float
-            Mean accuracy of ``self.predict(X)`` wrt. `y`.
+            Mean accuracy of ``self.predict(X)`` w.r.t. `y`.
         """
         from .metrics import accuracy_score
 
@@ -725,7 +725,7 @@ class RegressorMixin:
         Returns
         -------
         score : float
-            :math:`R^2` of ``self.predict(X)`` wrt. `y`.
+            :math:`R^2` of ``self.predict(X)`` w.r.t. `y`.
 
         Notes
         -----

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -435,7 +435,7 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
         Returns
         -------
         score : float
-            Mean accuracy of self.predict(X) wrt. y.
+            Mean accuracy of self.predict(X) w.r.t. y.
         """
         if X is None:
             X = np.zeros(shape=(len(y), 1))
@@ -667,7 +667,7 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         Returns
         -------
         score : float
-            R^2 of `self.predict(X)` wrt. y.
+            R^2 of `self.predict(X)` w.r.t. y.
         """
         if X is None:
             X = np.zeros(shape=(len(y), 1))

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -88,7 +88,7 @@ class NewtonSolver(ABC):
         Newton step.
 
     gradient : ndarray of shape coef.shape
-        Gradient of the loss wrt. the coefficients.
+        Gradient of the loss w.r.t. the coefficients.
 
     gradient_old : ndarray of shape coef.shape
         Gradient of previous iteration.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -2087,7 +2087,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
         Returns
         -------
         score : float
-            Score of self.predict(X) wrt. y.
+            Score of self.predict(X) w.r.t. y.
         """
         scoring = self.scoring or "accuracy"
         scoring = get_scorer(scoring)

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2164,8 +2164,8 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
 
 def _validate_shuffle_split(n_samples, test_size, train_size, default_test_size=None):
     """
-    Validation helper to check if the test/test sizes are meaningful wrt to the
-    size of the data (n_samples)
+    Validation helper to check if the test/test sizes are meaningful w.r.t. the
+    size of the data (n_samples).
     """
     if test_size is None and train_size is None:
         test_size = default_test_size

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -240,7 +240,7 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features), default=None
             The query sample or samples to compute the Local Outlier Factor
-            w.r.t. to the training samples.
+            w.r.t. the training samples.
 
         y : Ignored
             Not used, present for API consistency by convention.
@@ -343,7 +343,7 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             The query sample or samples to compute the Local Outlier Factor
-            w.r.t. to the training samples.
+            w.r.t. the training samples.
 
         Returns
         -------
@@ -361,7 +361,7 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features), default=None
             The query sample or samples to compute the Local Outlier Factor
-            w.r.t. to the training samples. If None, makes prediction on the
+            w.r.t. the training samples. If None, makes prediction on the
             training data without considering them as their own neighbors.
 
         Returns

--- a/sklearn/neighbors/_quad_tree.pyx
+++ b/sklearn/neighbors/_quad_tree.pyx
@@ -426,7 +426,7 @@ cdef class _QuadTree:
 
         # Check whether we can use this node as a summary
         # It's a summary node if the angular size as measured from the point
-        # is relatively small (w.r.t. to theta) or if it is a leaf node.
+        # is relatively small (w.r.t. theta) or if it is a leaf node.
         # If it can be summarized, we use the cell center of mass
         # Otherwise, we go a higher level of resolution and into the leaves.
         if cell.is_leaf or (


### PR DESCRIPTION
#### Reference Issues/PRs
No issues in existence.
Fix is too small for an issue, I guess...

#### What does this implement/fix? Explain your changes.
In several Python files the docstrings have a diverse way of using the abbreviation w.r.t. (with respect to).
One can find 'w.r.t.', 'wrt' and 'wrt.' with a trailing dot.
Furthermore, at several places the 'to' part of 'w.r.t.' is duplicated as in 

'[...] w.r.t. to the training samples [...]'

All occurrence should be one valid version of this abbreviation.
Although 'wrt' and 'w.r.t.' are known, I used 'w.r.t.' at all places as used in most papers as well.
After my fix no diverse versions can be found by grep anymore:

$ git grep "w\.r\.t\. to"
$ git grep "wrt to"
$ git grep "wrt\."
$ git grep "wrt\. to"
$ 

#### Any other comments?
