### PR TITLE
DOC Move allowing pandas nullable dtypes to 1.2.2

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -79,6 +79,9 @@ Changelog
   non-finite validation with the Array API specification. :pr:`25619` by
   `Thomas Fan`_.
 
+- |Fix| :func:`utils.multiclass.type_of_target` can identify pandas
+  nullable data types as classification targets. :pr:`25638` by `Thomas Fan`_.
+
 .. _changes_1_2_1:
 
 Version 1.2.1

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -244,9 +244,6 @@ Changelog
   during `transform` with no prior call to `fit` or `fit_transform`.
   :pr:`25190` by :user:`Vincent Maladière <Vincent-Maladiere>`.
 
-- |Enhancement| :func:`utils.multiclass.type_of_target` can identify pandas
-  nullable data types as classification targets. :pr:`25638` by `Thomas Fan`_.
-
 :mod:`sklearn.semi_supervised`
 ..............................
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/issues/25578

#### What does this implement/fix? Explain your changes.
This PR moves the enhancement from #25638 as a bug fix to 1.2.2.

#### Any other comments?
I do not think this breaks any current behavior, so it makes sense to consider the patch a bug fix for 1.2.2.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
