### PR TITLE
FIX Improves error message in partial_fit when early_stopping=True

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -199,7 +199,7 @@ Changelog
 
 - |Fix| Improves error message in :class:`neural_network.MLPClassifier` and
   :class:`neural_network.MLPRegressor`, when `early_stopping=True` and
-  :meth:`partial_fit` is called. :pr:`xxxxx` by `Thomas Fan`_.
+  :meth:`partial_fit` is called. :pr:`25694` by `Thomas Fan`_.
 
 :mod:`sklearn.preprocessing`
 ............................

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -197,6 +197,10 @@ Changelog
   no longer raise warnings when fitting data with feature names.
   :pr:`24873` by :user:`Tim Head <betatim>`.
 
+- |Fix| Improves error message in :class:`neural_network.MLPClassifier` and
+  :class:`neural_network.MLPRegressor`, when `early_stopping=True` and
+  :meth:`partial_fit` is called. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -575,7 +575,9 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
                 )
 
         # early_stopping in partial_fit doesn't make sense
-        early_stopping = self.early_stopping and not incremental
+        if self.early_stopping and incremental:
+            raise ValueError("partial_fit does not support early_stopping=True")
+        early_stopping = self.early_stopping
         if early_stopping:
             # don't stratify in multilabel classification
             should_stratify = is_classifier(self) and self.n_outputs_ == 1

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -956,7 +956,7 @@ def test_mlp_partial_fit_after_fit(MLPEstimator):
 
     Non-regression test for gh-25693.
     """
-    mlp = MLPREstimator(early_stopping=True, random_state=0).fit(X_iris, y_iris)
+    mlp = MLPEstimator(early_stopping=True, random_state=0).fit(X_iris, y_iris)
 
     msg = "partial_fit does not support early_stopping=True"
     with pytest.raises(ValueError, match=msg):

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -956,7 +956,7 @@ def test_mlp_partial_fit_after_fit(MLPEstimator):
 
     Non-regression test for gh-25693.
     """
-    mlp = MLPRegressor(early_stopping=True, random_state=0).fit(X_iris, y_iris)
+    mlp = MLPREstimator(early_stopping=True, random_state=0).fit(X_iris, y_iris)
 
     msg = "partial_fit does not support early_stopping=True"
     with pytest.raises(ValueError, match=msg):

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -948,3 +948,16 @@ def test_mlp_warm_start_no_convergence(MLPEstimator, solver):
     with pytest.warns(ConvergenceWarning):
         model.fit(X_iris, y_iris)
     assert model.n_iter_ == 20
+
+
+@pytest.mark.parametrize("MLPEstimator", [MLPClassifier, MLPRegressor])
+def test_mlp_partial_fit_after_fit(MLPEstimator):
+    """Check partial fit does not fail after fit when early_stopping=True.
+
+    Non-regression test for gh-25693.
+    """
+    mlp = MLPRegressor(early_stopping=True, random_state=0).fit(X_iris, y_iris)
+
+    msg = "partial_fit does not support early_stopping=True"
+    with pytest.raises(ValueError, match=msg):
+        mlp.partial_fit(X_iris, y_iris)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #25693


#### What does this implement/fix? Explain your changes.
This PR raises when `partial_fit` is called when `early_stopping=True` rather than switch to `early_stopping=False` automatically.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
