### PR TITLE
MAINT Parameters validation for metrics.mean_absolute_percentage_error()

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -305,6 +305,14 @@ def mean_pinball_loss(
     return np.average(output_errors, weights=multioutput)
 
 
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+        "multioutput": [StrOptions({"raw_values", "uniform_average"}), "array-like"],
+    }
+)
 def mean_absolute_percentage_error(
     y_true, y_pred, *, sample_weight=None, multioutput="uniform_average"
 ):

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -127,6 +127,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.log_loss",
     "sklearn.metrics.max_error",
     "sklearn.metrics.mean_absolute_error",
+    "sklearn.metrics.mean_absolute_percentage_error",
     "sklearn.metrics.mean_pinball_loss",
     "sklearn.metrics.mean_squared_error",
     "sklearn.metrics.mean_tweedie_deviance",


### PR DESCRIPTION
Towards #24862

* Added parameter validation for `metrics.mean_absolute_percentage_error`
* Added test for `metrics.mean_absolute_percentage_error`