### PR TITLE
MAINT Parameters validation for metrics.precision_recall_curve()

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -814,6 +814,14 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     return fps, tps, y_score[threshold_idxs]
 
 
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "probas_pred": ["array-like"],
+        "pos_label": [Real, str, "boolean", None],
+        "sample_weight": ["array-like", None],
+    }
+)
 def precision_recall_curve(y_true, probas_pred, *, pos_label=None, sample_weight=None):
     """Compute precision-recall pairs for different probability thresholds.
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -847,11 +847,11 @@ def precision_recall_curve(y_true, probas_pred, *, pos_label=None, sample_weight
 
     Parameters
     ----------
-    y_true : ndarray of shape (n_samples,)
+    y_true : array-like of shape (n_samples,)
         True binary labels. If labels are not either {-1, 1} or {0, 1}, then
         pos_label should be explicitly given.
 
-    probas_pred : ndarray of shape (n_samples,)
+    probas_pred : array-like of shape (n_samples,)
         Target scores, can either be probability estimates of the positive
         class, or non-thresholded measure of decisions (as returned by
         `decision_function` on some classifiers).

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -134,6 +134,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.multilabel_confusion_matrix",
     "sklearn.metrics.mutual_info_score",
     "sklearn.metrics.pairwise.additive_chi2_kernel",
+    "sklearn.metrics.precision_recall_curve",
     "sklearn.metrics.precision_recall_fscore_support",
     "sklearn.metrics.r2_score",
     "sklearn.metrics.roc_curve",


### PR DESCRIPTION
Towards #24862

* Added parameter validation for `metrics.precision_recall_curve`
* Added test for `metrics.precision_recall_curve` in `test_public_functions.py`