### PR TITLE
CI Stablize build with random_state

### DIFF
--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -941,6 +941,7 @@ def test_mlp_warm_start_no_convergence(MLPEstimator, solver):
         warm_start=True,
         early_stopping=False,
         max_iter=10,
+        n_iter_no_change=np.inf,
         random_state=0,
     )
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -919,11 +919,7 @@ def test_preserve_feature_names(Estimator):
 def test_mlp_warm_start_with_early_stopping(MLPEstimator):
     """Check that early stopping works with warm start."""
     mlp = MLPEstimator(
-        max_iter=10,
-        random_state=0,
-        warm_start=True,
-        early_stopping=True,
-        random_state=0,
+        max_iter=10, random_state=0, warm_start=True, early_stopping=True
     )
     mlp.fit(X_iris, y_iris)
     n_validation_scores = len(mlp.validation_scores_)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -919,7 +919,11 @@ def test_preserve_feature_names(Estimator):
 def test_mlp_warm_start_with_early_stopping(MLPEstimator):
     """Check that early stopping works with warm start."""
     mlp = MLPEstimator(
-        max_iter=10, random_state=0, warm_start=True, early_stopping=True
+        max_iter=10,
+        random_state=0,
+        warm_start=True,
+        early_stopping=True,
+        random_state=0,
     )
     mlp.fit(X_iris, y_iris)
     n_validation_scores = len(mlp.validation_scores_)
@@ -937,7 +941,11 @@ def test_mlp_warm_start_no_convergence(MLPEstimator, solver):
     https://github.com/scikit-learn/scikit-learn/issues/24764
     """
     model = MLPEstimator(
-        solver=solver, warm_start=True, early_stopping=False, max_iter=10
+        solver=solver,
+        warm_start=True,
+        early_stopping=False,
+        max_iter=10,
+        random_state=0,
     )
 
     with pytest.warns(ConvergenceWarning):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/25699


#### What does this implement/fix? Explain your changes.
With `early_stopping=True` and solvers that use `random_state`, I can see the convergence warning not raising sometimes and causing the test to fail. This PR adds `random_state=0` to stabilize the test.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
