### PR TITLE
Multiclass monotonic_cst for HistGradientBoostingClassifier

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -1,6 +1,7 @@
 import re
 import numpy as np
 import pytest
+from sklearn.base import clone
 
 from sklearn.ensemble._hist_gradient_boosting.grower import TreeGrower
 from sklearn.ensemble._hist_gradient_boosting.common import G_H_DTYPE
@@ -325,14 +326,7 @@ def test_monotonic_multiclass_classification(global_random_seed, use_feature_nam
 
     # TODO: use_feature_names=True is not tested yet
 
-    clf_cst = HistGradientBoostingClassifier(
-        learning_rate=1.0,
-        max_iter=5,
-        min_samples_leaf=1,
-        max_leaf_nodes=5,
-        monotonic_cst=monotonic_cst,
-        random_state=global_random_seed,
-    )
+    clf_cst = clone(clf).set_params(monotonic_cst=monotonic_cst)
     clf_cst.fit(X, y)
 
     # Feature 0


### PR DESCRIPTION
I think it should be quite easy to implement and I believe it will be useful for the R&D work we currently conduct with @Vincent-Maladiere on predictive competing risk analysis (a variant of survival analysis with mutually exclusive event types).

But more generally, I think it might be useful for some users doing regular multiclass classification.

## TODO:

- [x] test for `monotonic_cst` passed as a 2D integer array
- [ ] test for `monotonic_cst` passed as a dict with feature names
- [x] actual implementation
- [ ] update the documentation / docstring
- [ ] do we need an example? Any suggestions welcome, in particular if you have idea of a multiclass classification dataset from OpenML where monotonic constraints would naturally be useful.
