### PR TITLE
DOC fix tiny formatting typo

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -120,7 +120,7 @@ enhance the functionality of scikit-learn's estimators.
   Scikit-learn pipelines to `ONNX <https://onnx.ai/>`_ for interchange and
   prediction.
 
-` `skops.io <https://skops.readthedocs.io/en/stable/persistence.html>`__ A
+- `skops.io <https://skops.readthedocs.io/en/stable/persistence.html>`__ A
   persistence model more secure than pickle, which can be used instead of
   pickle in most common cases.
 


### PR DESCRIPTION
Render the bullet for skops.io correctly (``` ` ```->`-`)

This was introduced in https://github.com/scikit-learn/scikit-learn/pull/25197/files#diff-3b9f7cbf0cc082344a96cdd4cfa90e7716b07da05aea633e9b80233095f851d0