### PR TITLE
MAINT Parameter Validation for metrics.precision_score()

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1904,6 +1904,23 @@ def class_likelihood_ratios(
     return positive_likelihood_ratio, negative_likelihood_ratio
 
 
+@validate_params(
+    {
+        "y_true": ["array-like", "sparse matrix"],
+        "y_pred": ["array-like", "sparse matrix"],
+        "labels": ["array-like", None],
+        "pos_label": [Real, str, "boolean", None],
+        "average": [
+            StrOptions({"micro", "macro", "samples", "weighted", "binary"}),
+            None,
+        ],
+        "sample_weight": ["array-like", None],
+        "zero_division": [
+            Options(Real, {0, 1}),
+            StrOptions({"warn"}),
+        ],
+    }
+)
 def precision_score(
     y_true,
     y_pred,

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -135,13 +135,13 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.mutual_info_score",
     "sklearn.metrics.pairwise.additive_chi2_kernel",
     "sklearn.metrics.precision_recall_fscore_support",
+    "sklearn.metrics.precision_score",
     "sklearn.metrics.r2_score",
     "sklearn.metrics.roc_curve",
     "sklearn.metrics.zero_one_loss",
     "sklearn.model_selection.train_test_split",
     "sklearn.random_projection.johnson_lindenstrauss_min_dim",
     "sklearn.svm.l1_min_c",
-    "sklearn.metrics.precision_score",
 ]
 
 

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -141,6 +141,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.model_selection.train_test_split",
     "sklearn.random_projection.johnson_lindenstrauss_min_dim",
     "sklearn.svm.l1_min_c",
+    "sklearn.metrics.precision_score",
 ]
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #24862 


#### What does this implement/fix? Explain your changes.
Includes parameter validation for `metrics.precision_score`

#### Any other comments?
Test passes `pytest -vl sklearn/tests/test_public_functions.py`
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
