### PR TITLE
Test kmeans predict label equality up to a permutation

### DIFF
--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -646,7 +646,8 @@ def test_kmeans_predict(
 
     # re-predict labels for training set using fit_predict
     pred = km.fit_predict(X)
-    assert_array_equal(pred, labels)
+    # check same labels up to a permutation
+    assert_allclose(v_measure_score(pred, labels), 1.0)
 
     # predict centroid labels
     pred = km.predict(km.cluster_centers_)


### PR DESCRIPTION
While working on a plugin for kmeans I've had a marginal case (running this test with a GPU backend that doesn't support float64 and internally fallback on float32 computations ~in this case it's expected to have some tests with float64 input fail due to numerical errors) that caused the test `test_kmeans_predict` to fail.

But after closer inspection I saw that the labels are good up to a permutation, so here is this PR to make the test pass even if labels are permuted in the `fit`.

We've discussed before that it's ok to have the tests pass up to a permutation on labels (and having this behavior seems to be wished for more than the opposite, judging by the history of other tests in the same file), and I had also had a similar PR merged before that: https://github.com/scikit-learn/scikit-learn/pull/24779

Here it's maybe less obvious since it means two successive calls to the lloyd algorithm can give slightly different results because of numerical errors.  Is it necessarily a bug in my backend ?

WDYT ?
