### PR TITLE
MAINT Define centralized generic, but with explicit precision, types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -275,7 +275,7 @@ extension_config = {
     ],
     "cluster": [
         {"sources": ["_dbscan_inner.pyx"], "language": "c++", "include_np": True},
-        {"sources": ["_hierarchical_fast.pyx"], "language": "c++"},
+        {"sources": ["_hierarchical_fast.pyx"], "language": "c++", "include_np": True},
         {"sources": ["_k_means_common.pyx"], "include_np": True},
         {"sources": ["_k_means_lloyd.pyx"], "include_np": True},
         {"sources": ["_k_means_elkan.pyx"], "include_np": True},

--- a/setup.py
+++ b/setup.py
@@ -275,7 +275,7 @@ extension_config = {
     ],
     "cluster": [
         {"sources": ["_dbscan_inner.pyx"], "language": "c++", "include_np": True},
-        {"sources": ["_hierarchical_fast.pyx"], "language": "c++", "include_np": True},
+        {"sources": ["_hierarchical_fast.pyx"], "language": "c++"},
         {"sources": ["_k_means_common.pyx"], "include_np": True},
         {"sources": ["_k_means_lloyd.pyx"], "include_np": True},
         {"sources": ["_k_means_elkan.pyx"], "include_np": True},

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -344,7 +344,7 @@ def ward_tree(X, *, connectivity=None, n_clusters=None, return_distance=False):
     if return_distance:
         distances = np.empty(n_nodes - n_samples)
 
-    not_visited = np.empty(n_nodes, dtype=np.int8, order="C")
+    not_visited = np.empty(n_nodes, dtype=bool, order="C")
 
     # recursive merge loop
     for k in range(n_samples, n_nodes):

--- a/sklearn/utils/_typedefs.pxd
+++ b/sklearn/utils/_typedefs.pxd
@@ -1,6 +1,28 @@
 #!python
 cimport numpy as cnp
 
+# Commonly used types
+# These are redefinitions of the ones defined by numpy and exposed by cython in
+# https://github.com/cython/cython/blob/master/Cython/Includes/numpy/__init__.pxd.
+# It will eventually avoid having to always include the numpy headers even when we
+# would only use it for the types. (TODO don't cimport numpy in this extension)
+# 
+# When used to declare variables that will receive values from numpy arrays, it
+# should match the dtype of the array. For example, to declare a variable that will
+# receive values from a numpy array of dtype np.float64, the type float64_t must be
+# used.
+#
+# TODO: Stop defining custom types locally of globally like DTYPE_t and friends and
+# use these consistantly throughout the codebase.
+ctypedef unsigned char bool_t
+ctypedef Py_ssize_t intp_t
+ctypedef size_t uintp_t
+ctypedef signed int int32_t
+ctypedef signed long long int64_t
+ctypedef float float32_t
+ctypedef double float64_t
+
+
 # Floating point/data type
 ctypedef cnp.float64_t DTYPE_t  # WARNING: should match DTYPE in typedefs.pyx
 

--- a/sklearn/utils/_typedefs.pxd
+++ b/sklearn/utils/_typedefs.pxd
@@ -2,7 +2,9 @@
 cimport numpy as cnp
 
 # Commonly used types
-# These are redefinitions of the ones defined by numpy and exposed by cython in
+# These are redefinitions of the ones defined by numpy in
+# https://github.com/numpy/numpy/blob/main/numpy/__init__.pxd
+# and exposed by cython in
 # https://github.com/cython/cython/blob/master/Cython/Includes/numpy/__init__.pxd.
 # It will eventually avoid having to always include the numpy headers even when we
 # would only use it for the types. (TODO don't cimport numpy in this extension)

--- a/sklearn/utils/_typedefs.pxd
+++ b/sklearn/utils/_typedefs.pxd
@@ -7,8 +7,9 @@ cimport numpy as cnp
 # and exposed by cython in
 # https://github.com/cython/cython/blob/master/Cython/Includes/numpy/__init__.pxd.
 # It will eventually avoid having to always include the numpy headers even when we
-# would only use it for the types. (TODO don't cimport numpy in this extension)
-# 
+# would only use it for the types.
+# TODO: don't cimport numpy in this extension.
+#
 # When used to declare variables that will receive values from numpy arrays, it
 # should match the dtype of the array. For example, to declare a variable that will
 # receive values from a numpy array of dtype np.float64, the type float64_t must be

--- a/sklearn/utils/_typedefs.pxd
+++ b/sklearn/utils/_typedefs.pxd
@@ -14,14 +14,11 @@ cimport numpy as cnp
 # receive values from a numpy array of dtype np.float64, the type float64_t must be
 # used.
 #
-# TODO: Stop defining custom types locally of globally like DTYPE_t and friends and
-# use these consistantly throughout the codebase.
+# TODO: Stop defining custom types locally or globally like DTYPE_t and friends and
+# use these consistently throughout the codebase.
+# NOTE: Extend this list as needed when converting more cython extensions.
 ctypedef unsigned char bool_t
 ctypedef Py_ssize_t intp_t
-ctypedef size_t uintp_t
-ctypedef signed int int32_t
-ctypedef signed long long int64_t
-ctypedef float float32_t
 ctypedef double float64_t
 
 


### PR DESCRIPTION
Towards #25572 

There seem to be a consensus to stop using the not very explicit types `DTYPE_t` and friends, which are sometimes defined globally, sometimes locally, with different meanings.

This PR defines the most common types we should need in `_typedefs.pxd`. The goal is that all cython extension cimport types from there. I also applied it to `_hierarchical.pyx` to illustrate it.

Note that as long as `_typedefs` cimports numpy, the numpy headers will be included in the extensions calling it.